### PR TITLE
ARROW-10703: [Rust] [DataFusion] Make join not collect on every right part

### DIFF
--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -82,7 +82,7 @@ mod tests {
         let table = load_table("alltypes_plain.parquet")?;
         let projection = None;
         let exec = table.scan(&projection, 2)?;
-        let stream = exec.execute(0).await?;
+        let stream = &mut exec.execute().await?[0];
 
         let count = stream
             .map(|batch| {
@@ -303,8 +303,9 @@ mod tests {
         projection: &Option<Vec<usize>>,
     ) -> Result<RecordBatch> {
         let exec = table.scan(projection, 1024)?;
-        let mut it = exec.execute(0).await?;
-        it.next()
+        let stream = &mut exec.execute().await?[0];
+        stream
+            .next()
             .await
             .expect("should have received at least one batch")
             .map_err(|e| e.into())

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -80,7 +80,7 @@ impl RecordBatchStream for SizedRecordBatchStream {
 }
 
 /// Create a vector of record batches from a stream
-pub async fn collect(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
+pub async fn collect(stream: &mut SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
     stream
         .try_collect::<Vec<_>>()
         .await

--- a/rust/datafusion/src/physical_plan/explain.rs
+++ b/rust/datafusion/src/physical_plan/explain.rs
@@ -89,14 +89,7 @@ impl ExecutionPlan for ExplainExec {
         }
     }
 
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
-        if 0 != partition {
-            return Err(DataFusionError::Internal(format!(
-                "ExplainExec invalid partition {}",
-                partition
-            )));
-        }
-
+    async fn execute(&self) -> Result<Vec<SendableRecordBatchStream>> {
         let mut type_builder = StringBuilder::new(self.stringified_plans.len());
         let mut plan_builder = StringBuilder::new(self.stringified_plans.len());
 
@@ -113,9 +106,9 @@ impl ExecutionPlan for ExplainExec {
             ],
         )?;
 
-        Ok(Box::pin(SizedRecordBatchStream::new(
+        Ok(vec![Box::pin(SizedRecordBatchStream::new(
             self.schema.clone(),
             vec![Arc::new(record_batch)],
-        )))
+        ))])
     }
 }

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -73,12 +73,17 @@ impl ExecutionPlan for MemoryExec {
         )))
     }
 
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
-        Ok(Box::pin(MemoryStream::try_new(
-            self.partitions[partition].clone(),
-            self.schema.clone(),
-            self.projection.clone(),
-        )?))
+    async fn execute(&self) -> Result<Vec<SendableRecordBatchStream>> {
+        self.partitions
+            .iter()
+            .map(|part| {
+                Ok(Box::pin(MemoryStream::try_new(
+                    part.clone(),
+                    self.schema.clone(),
+                    self.projection.clone(),
+                )?) as SendableRecordBatchStream)
+            })
+            .collect()
     }
 }
 

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -80,8 +80,9 @@ pub trait ExecutionPlan: Debug + Send + Sync {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
-    /// creates an iterator
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream>;
+    /// creates a vector of streams of [RecordBatch]es, each stream corresponding
+    /// to a part of the partition.
+    async fn execute(&self) -> Result<Vec<SendableRecordBatchStream>>;
 }
 
 /// Partitioning schemes supported by operators.

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -835,7 +835,7 @@ mod tests {
             unimplemented!("NoOpExecutionPlan::with_new_children");
         }
 
-        async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchStream> {
+        async fn execute(&self) -> Result<Vec<SendableRecordBatchStream>> {
             unimplemented!("NoOpExecutionPlan::execute");
         }
     }

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -122,8 +122,8 @@ impl ExecutionPlan for CustomExecutionPlan {
             ))
         }
     }
-    async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchStream> {
-        Ok(Box::pin(TestCustomRecordBatchStream { nb_batch: 1 }))
+    async fn execute(&self) -> Result<Vec<SendableRecordBatchStream>> {
+        Ok(vec![Box::pin(TestCustomRecordBatchStream { nb_batch: 1 })])
     }
 }
 


### PR DESCRIPTION
This is a draft proposal to address a limitation on which the join currently computes the left side (build) on every part of the right (probe).

@alamb and @andygrove , I am not sure if this is right from the execution's point of view. the idea here is to leverage the notion that as long as it has all the information it requires, a node can always return all its streams simply by iterating on them. We can scrap this if it does not feel right.

Note that this makes `Merge` to not `Plan::execute` inside of a `spawn`. I am not sure if this has non trivial consequences.