### PR TITLE
ARROW-10711: [CI] Remove set-env from auto-tune to work with new GHA settings

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -72,16 +72,16 @@ jobs:
             git diff --name-only HEAD..upstream/master | grep -e "$1" >/dev/null 2>&1
           }
           if changed '^r/.*\.R$'; then
-            echo "::set-env name=R_DOCS::true"
+            echo "R_DOCS=true" >> $GITHUB_ENV
           fi
           if changed 'cmake' || changed 'CMake'; then
-            echo "::set-env name=CMAKE_FORMAT::true"
+            echo "CMAKE_FORMAT=true" >> $GITHUB_ENV
           fi
           if changed '^cpp/src'; then
-            echo "::set-env name=CLANG_FORMAT_CPP::true"
+            echo "CLANG_FORMAT_CPP=true" >> $GITHUB_ENV
           fi
           if changed '^r/src'; then
-            echo "::set-env name=CLANG_FORMAT_R::true"
+            echo "CLANG_FORMAT_R=true" >> $GITHUB_ENV
           fi
       - name: Run cmake_format
         if: env.CMAKE_FORMAT == 'true' || endsWith(github.event.comment.body, 'everything')


### PR DESCRIPTION
See also https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Tested in https://github.com/xhochy/arrow/pull/8