### PR TITLE
ARROW-10712: [Rust] Add tests to TPC-H benchmarks

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -353,3 +353,36 @@ fn get_schema(table: &str) -> Schema {
         _ => unimplemented!(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[tokio::test]
+    async fn q1() -> Result<()> {
+        verify_query(1).await
+    }
+
+    #[tokio::test]
+    async fn q12() -> Result<()> {
+        verify_query(12).await
+    }
+
+    async fn verify_query(n: usize) -> Result<()> {
+        if let Ok(path) = env::var("TPCH_DATA") {
+            let opt = BenchmarkOpt {
+                query: n,
+                debug: false,
+                iterations: 1,
+                concurrency: 2,
+                batch_size: 4096,
+                path: PathBuf::from(path),
+                file_format: "tbl".to_string(),
+                mem_table: false,
+            };
+            benchmark(opt).await?
+        }
+        Ok(())
+    }
+}

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -383,6 +383,9 @@ mod tests {
             };
             benchmark(opt).await?
         }
+        } else {
+            println!("TPCH_DATA environment variable not set, skipping test")
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This adds tests to the TPC-H benchmark suite that only run if the `TPCH_DATA` environment variable exists and points to a directory containing `tbl` files.

This is useful when running tests locally and adds a mechanism that we could leverage in CI. We could have a docker image container that includes the data generator and generate the SF=1 data set before running the cargo tests.