### PR TITLE
ARROW-10721: [C#][CI] Use .NET 3.1 by default

### DIFF
--- a/.env
+++ b/.env
@@ -39,7 +39,7 @@ TURBODBC=latest
 KARTOTHEK=latest
 HDFS=2.9.2
 SPARK=master
-DOTNET=2.1
+DOTNET=3.1
 R=4.0
 ARROW_R_DEV=TRUE
 # These correspond to images on Docker Hub that contain R, e.g. rhub/ubuntu-gcc-release:latest

--- a/ci/docker/ubuntu-18.04-csharp.dockerfile
+++ b/ci/docker/ubuntu-18.04-csharp.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG platform=bionic
-ARG dotnet=2.1
+ARG dotnet=3.1
 FROM mcr.microsoft.com/dotnet/core/sdk:${dotnet}-${platform}
 
 RUN dotnet tool install --tool-path /usr/local/bin sourcelink


### PR DESCRIPTION
We upgraded our .NET version by b8e021c17f88ea979f440c7207866250ceca4843.