### PR TITLE
ARROW-10724: [Dev Tools] Added labeler to PRs that need rebase.

### DIFF
--- a/.github/workflows/dev_labeler_pr_rebase.yml
+++ b/.github/workflows/dev_labeler_pr_rebase.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR rebase needed labeler
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checks if PR needs rebase
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "needs-rebase"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This is a proposal to have a github action that automatically adds labels to PRs that need rebase.

We have been adding these labels manually in Rust PRs, as it is easier to filter for PRs that need an action from the contributor before merging.

By doing this systematically, we do not need to maintain these labels ourselves.

Note that this action takes seconds to complete.