### PR TITLE
ARROW-10710: [Rust] Revert tokio upgrade, go back to 0.2

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -31,7 +31,7 @@ tonic = "0.3"
 bytes = "0.5"
 prost = "0.6"
 prost-derive = "0.6"
-tokio = {version = "0.3", features = ["macros"]}
+tokio = { version = "0.2", features = ["macros"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -30,5 +30,5 @@ arrow = { path = "../arrow" }
 parquet = { path = "../parquet" }
 datafusion = { path = "../datafusion" }
 structopt = { version = "0.3", default-features = false }
-tokio = { version = "0.3", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "0.2", features = ["macros"] }
 futures = "0.3"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -30,5 +30,5 @@ arrow = { path = "../arrow" }
 parquet = { path = "../parquet" }
 datafusion = { path = "../datafusion" }
 structopt = { version = "0.3", default-features = false }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"] }
 futures = "0.3"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -57,7 +57,7 @@ chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"] }
 
 [dev-dependencies]
 rand = "0.7"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -57,7 +57,7 @@ chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
-tokio = { version = "0.3", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "0.2", features = ["macros"] }
 
 [dev-dependencies]
 rand = "0.7"

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -41,7 +41,7 @@ use datafusion::error::Result;
 use datafusion::execution::context::ExecutionContext;
 
 fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
-    let rt = Runtime::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
 
     // execute the query
     let df = ctx.lock().unwrap().sql(&sql).unwrap();

--- a/rust/datafusion/benches/math_query_sql.rs
+++ b/rust/datafusion/benches/math_query_sql.rs
@@ -37,7 +37,7 @@ use datafusion::datasource::MemTable;
 use datafusion::execution::context::ExecutionContext;
 
 fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
-    let rt = Runtime::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
 
     // execute the query
     let df = ctx.lock().unwrap().sql(&sql).unwrap();

--- a/rust/datafusion/benches/sort_limit_query_sql.rs
+++ b/rust/datafusion/benches/sort_limit_query_sql.rs
@@ -33,7 +33,7 @@ use datafusion::execution::context::ExecutionContext;
 use tokio::runtime::Runtime;
 
 fn query(ctx: Arc<Mutex<ExecutionContext>>, sql: &str) {
-    let rt = Runtime::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
 
     // execute the query
     let df = ctx.lock().unwrap().sql(&sql).unwrap();
@@ -67,7 +67,7 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
     )
     .unwrap();
 
-    let rt = Runtime::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
 
     let ctx_holder: Arc<Mutex<Vec<Arc<Mutex<ExecutionContext>>>>> =
         Arc::new(Mutex::new(vec![]));


### PR DESCRIPTION
## Changes 

This PR backs out the version upgrade to tokio done in https://github.com/apache/arrow/pull/8697 and also partly by @andygrove  in #8734 (see comment https://github.com/apache/arrow/pull/8697#issuecomment-732936572 by @rdettai for more details).

## Rationale:

It seems as if the new version of tokio (0.3) has some fairly substantial changes, and some of the higher level libraries built on top of tokio that are used in the flight implementation do not yet support version 0.3 of tokio. This results in parts of the code (flight server) using the older version of tokio and parts of the code (datafusion) using newer versions of tokio which causes ... issues. 

This issue can be seen in the flight example linked in https://issues.apache.org/jira/browse/ARROW-10710 and I saw it when I tried to upgrade to latest arrow in https://github.com/influxdata/influxdb_iox

For example, https://crates.io/crates/tonic appears to require tokio < 0.3

<img width="350" alt="Screen Shot 2020-11-25 at 7 10 21 AM" src="https://user-images.githubusercontent.com/490673/100227458-2eabbb00-2eef-11eb-82a8-eb11dad03bc2.png">



cc @Dandandan  and @nevi-me 

