### PR TITLE
ARROW-10740: [Rust][DataFusion] Remove redundant clones found by clippy

### DIFF
--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -241,7 +241,7 @@ mod tests {
         ]));
 
         let batch = RecordBatch::try_new(
-            schema1.clone(),
+            schema1,
             vec![
                 Arc::new(Int32Array::from(vec![1, 2, 3])),
                 Arc::new(Int32Array::from(vec![4, 5, 6])),

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -210,11 +210,11 @@ impl ExecutionContext {
 
         let table_scan = LogicalPlan::CsvScan {
             path: filename.to_string(),
-            schema: csv.schema().clone(),
+            schema: csv.schema(),
             has_header: options.has_header,
             delimiter: Some(options.delimiter),
             projection: None,
-            projected_schema: csv.schema().clone(),
+            projected_schema: csv.schema(),
         };
 
         Ok(Arc::new(DataFrameImpl::new(
@@ -229,9 +229,9 @@ impl ExecutionContext {
 
         let table_scan = LogicalPlan::ParquetScan {
             path: filename.to_string(),
-            schema: parquet.schema().clone(),
+            schema: parquet.schema(),
             projection: None,
-            projected_schema: parquet.schema().clone(),
+            projected_schema: parquet.schema(),
         };
 
         Ok(Arc::new(DataFrameImpl::new(
@@ -245,7 +245,7 @@ impl ExecutionContext {
         &mut self,
         provider: Arc<dyn TableProvider + Send + Sync>,
     ) -> Result<Arc<dyn DataFrame>> {
-        let schema = provider.schema().clone();
+        let schema = provider.schema();
         let table_scan = LogicalPlan::TableScan {
             schema_name: "".to_string(),
             source: TableSource::FromProvider(provider),
@@ -297,7 +297,7 @@ impl ExecutionContext {
     pub fn table(&mut self, table_name: &str) -> Result<Arc<dyn DataFrame>> {
         match self.state.datasources.get(table_name) {
             Some(provider) => {
-                let schema = provider.schema().clone();
+                let schema = provider.schema();
                 let table_scan = LogicalPlan::TableScan {
                     schema_name: "".to_string(),
                     source: TableSource::FromContext(table_name.to_string()),
@@ -530,7 +530,7 @@ pub struct ExecutionContextState {
 
 impl SchemaProvider for ExecutionContextState {
     fn get_table_meta(&self, name: &str) -> Option<SchemaRef> {
-        self.datasources.get(name).map(|ds| ds.schema().clone())
+        self.datasources.get(name).map(|ds| ds.schema())
     }
 
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
@@ -554,9 +554,10 @@ impl FunctionRegistry for ExecutionContextState {
     fn udf(&self, name: &str) -> Result<&ScalarUDF> {
         let result = self.scalar_functions.get(name);
         if result.is_none() {
-            Err(DataFusionError::Plan(
-                format!("There is no UDF named \"{}\" in the registry", name).to_string(),
-            ))
+            Err(DataFusionError::Plan(format!(
+                "There is no UDF named \"{}\" in the registry",
+                name
+            )))
         } else {
             Ok(result.unwrap())
         }
@@ -565,10 +566,10 @@ impl FunctionRegistry for ExecutionContextState {
     fn udaf(&self, name: &str) -> Result<&AggregateUDF> {
         let result = self.aggregate_functions.get(name);
         if result.is_none() {
-            Err(DataFusionError::Plan(
-                format!("There is no UDAF named \"{}\" in the registry", name)
-                    .to_string(),
-            ))
+            Err(DataFusionError::Plan(format!(
+                "There is no UDAF named \"{}\" in the registry",
+                name
+            )))
         } else {
             Ok(result.unwrap())
         }

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -203,7 +203,7 @@ mod tests {
             count(col("c12")),
         ];
 
-        let df = df.aggregate(group_expr.clone(), aggr_expr.clone())?;
+        let df = df.aggregate(group_expr, aggr_expr)?;
 
         let plan = df.to_logical_plan();
 

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -40,7 +40,6 @@
     clippy::new_without_default,
     clippy::or_fun_call,
     clippy::ptr_arg,
-    clippy::redundant_clone,
     clippy::redundant_field_names,
     clippy::redundant_static_lifetimes,
     clippy::redundant_pattern_matching,

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -92,7 +92,7 @@ impl LogicalPlanBuilder {
     /// Scan a Parquet data source
     pub fn scan_parquet(path: &str, projection: Option<Vec<usize>>) -> Result<Self> {
         let p = ParquetTable::try_new(path)?;
-        let schema = p.schema().clone();
+        let schema = p.schema();
 
         let projected_schema = projection
             .clone()

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -305,32 +305,32 @@ impl Expr {
 
     /// Equal
     pub fn eq(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::Eq, other.clone())
+        binary_expr(self.clone(), Operator::Eq, other)
     }
 
     /// Not equal
     pub fn not_eq(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::NotEq, other.clone())
+        binary_expr(self.clone(), Operator::NotEq, other)
     }
 
     /// Greater than
     pub fn gt(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::Gt, other.clone())
+        binary_expr(self.clone(), Operator::Gt, other)
     }
 
     /// Greater than or equal to
     pub fn gt_eq(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::GtEq, other.clone())
+        binary_expr(self.clone(), Operator::GtEq, other)
     }
 
     /// Less than
     pub fn lt(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::Lt, other.clone())
+        binary_expr(self.clone(), Operator::Lt, other)
     }
 
     /// Less than or equal to
     pub fn lt_eq(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::LtEq, other.clone())
+        binary_expr(self.clone(), Operator::LtEq, other)
     }
 
     /// And
@@ -350,17 +350,17 @@ impl Expr {
 
     /// Calculate the modulus of two expressions
     pub fn modulus(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::Modulus, other.clone())
+        binary_expr(self.clone(), Operator::Modulus, other)
     }
 
     /// like (string) another expression
     pub fn like(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::Like, other.clone())
+        binary_expr(self.clone(), Operator::Like, other)
     }
 
     /// not like another expression
     pub fn not_like(&self, other: Expr) -> Expr {
-        binary_expr(self.clone(), Operator::NotLike, other.clone())
+        binary_expr(self.clone(), Operator::NotLike, other)
     }
 
     /// Alias
@@ -807,13 +807,13 @@ fn create_name(e: &Expr, input_schema: &Schema) -> Result<String> {
         } => {
             let mut name = "CASE ".to_string();
             if let Some(e) = expr {
-                name += &format!("{:?} ", e).to_string();
+                name += &format!("{:?} ", e);
             }
             for (w, t) in when_then_expr {
-                name += &format!("WHEN {:?} THEN {:?} ", w, t).to_string();
+                name += &format!("WHEN {:?} THEN {:?} ", w, t);
             }
             if let Some(e) = else_expr {
-                name += &format!("ELSE {:?} ", e).to_string();
+                name += &format!("ELSE {:?} ", e);
             }
             name += "END";
             Ok(name)

--- a/rust/datafusion/src/logical_plan/operators.rs
+++ b/rust/datafusion/src/logical_plan/operators.rs
@@ -81,7 +81,7 @@ impl ops::Add for Expr {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        binary_expr(self.clone(), Operator::Plus, rhs.clone())
+        binary_expr(self, Operator::Plus, rhs)
     }
 }
 
@@ -89,7 +89,7 @@ impl ops::Sub for Expr {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        binary_expr(self.clone(), Operator::Minus, rhs.clone())
+        binary_expr(self, Operator::Minus, rhs)
     }
 }
 
@@ -97,7 +97,7 @@ impl ops::Mul for Expr {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        binary_expr(self.clone(), Operator::Multiply, rhs.clone())
+        binary_expr(self, Operator::Multiply, rhs)
     }
 }
 
@@ -105,7 +105,7 @@ impl ops::Div for Expr {
     type Output = Self;
 
     fn div(self, rhs: Self) -> Self {
-        binary_expr(self.clone(), Operator::Divide, rhs.clone())
+        binary_expr(self, Operator::Divide, rhs)
     }
 }
 

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -99,7 +99,7 @@ fn issue_filters(
 
     // add a new filter node with the predicates
     let plan = LogicalPlan::Filter {
-        predicate: predicate.clone(),
+        predicate,
         input: Arc::new(plan.clone()),
     };
 

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -252,7 +252,7 @@ impl CsvStream {
         let file = File::open(filename)?;
         let reader = csv::Reader::new(
             file,
-            schema.clone(),
+            schema,
             has_header,
             delimiter,
             batch_size,

--- a/rust/datafusion/src/physical_plan/empty.rs
+++ b/rust/datafusion/src/physical_plan/empty.rs
@@ -125,7 +125,7 @@ mod tests {
     async fn empty() -> Result<()> {
         let schema = test::aggr_test_schema();
 
-        let empty = EmptyExec::new(false, schema);
+        let empty = EmptyExec::new(false, schema.clone());
         assert_eq!(empty.schema(), schema);
 
         // we should have no results

--- a/rust/datafusion/src/physical_plan/empty.rs
+++ b/rust/datafusion/src/physical_plan/empty.rs
@@ -125,7 +125,7 @@ mod tests {
     async fn empty() -> Result<()> {
         let schema = test::aggr_test_schema();
 
-        let empty = EmptyExec::new(false, schema.clone());
+        let empty = EmptyExec::new(false, schema);
         assert_eq!(empty.schema(), schema);
 
         // we should have no results
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn with_new_children() -> Result<()> {
         let schema = test::aggr_test_schema();
-        let empty = EmptyExec::new(false, schema.clone());
+        let empty = EmptyExec::new(false, schema);
 
         let empty2 = empty.with_new_children(vec![])?;
         assert_eq!(empty.schema(), empty2.schema());
@@ -155,7 +155,7 @@ mod tests {
     #[tokio::test]
     async fn invalid_execute() -> Result<()> {
         let schema = test::aggr_test_schema();
-        let empty = EmptyExec::new(false, schema.clone());
+        let empty = EmptyExec::new(false, schema);
 
         // ask for the wrong partition
         assert!(empty.execute(1).await.is_err());

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2513,7 +2513,7 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("dict", dict_type.clone(), true),
-            Field::new("str", string_type.clone(), true),
+            Field::new("str", string_type, true),
         ]));
 
         let batch = RecordBatch::try_new(
@@ -2656,7 +2656,7 @@ mod tests {
         generic_test_cast!(
             Int64Array,
             DataType::Int64,
-            original.clone(),
+            original,
             TimestampNanosecondArray,
             DataType::Timestamp(TimeUnit::Nanosecond, None),
             expected
@@ -3199,8 +3199,8 @@ mod tests {
 
         // should handle have negative values in result (for signed)
         apply_arithmetic::<Int32Type>(
-            schema.clone(),
-            vec![b.clone(), a.clone()],
+            schema,
+            vec![b, a],
             Operator::Minus,
             Int32Array::from(vec![0, 0, -1, -4, -11]),
         )?;
@@ -3314,7 +3314,7 @@ mod tests {
     fn is_null_op() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
         let a = StringArray::from(vec![Some("foo"), None]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 
         // expression: "a is null"
         let expr = is_null(col("a")).unwrap();
@@ -3335,7 +3335,7 @@ mod tests {
     fn is_not_null_op() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
         let a = StringArray::from(vec![Some("foo"), None]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 
         // expression: "a is not null"
         let expr = is_not_null(col("a")).unwrap();
@@ -3479,7 +3479,7 @@ mod tests {
     fn case_test_batch() -> Result<RecordBatch> {
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
         let a = StringArray::from(vec![Some("foo"), Some("baz"), None, Some("bar")]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
         Ok(batch)
     }
 }

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2645,7 +2645,7 @@ mod tests {
         );
         Ok(())
     }
-
+    #[allow(clippy::redundant_clone)]
     #[test]
     fn test_cast_i64_t64() -> Result<()> {
         let original = vec![1, 2, 3, 4, 5];

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2277,10 +2277,8 @@ mod tests {
         ]);
         let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let b = Int32Array::from(vec![1, 2, 4, 8, 16]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema.clone()),
-            vec![Arc::new(a), Arc::new(b)],
-        )?;
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b"
         let lt = binary_simple(col("a"), Operator::Lt, col("b"));
@@ -2307,10 +2305,8 @@ mod tests {
         ]);
         let a = Int32Array::from(vec![2, 4, 6, 8, 10]);
         let b = Int32Array::from(vec![2, 5, 4, 8, 8]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema.clone()),
-            vec![Arc::new(a), Arc::new(b)],
-        )?;
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b OR a == b"
         let expr = binary_simple(
@@ -2340,7 +2336,7 @@ mod tests {
         // create an arbitrary record bacth
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let a = Int32Array::from(vec![Some(1), None, Some(3), Some(4), Some(5)]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 
         // create and evaluate a literal expression
         let literal_expr = lit(ScalarValue::from(42i32));
@@ -2373,10 +2369,8 @@ mod tests {
             ]);
             let a = $A_ARRAY::from($A_VEC);
             let b = $B_ARRAY::from($B_VEC);
-            let batch = RecordBatch::try_new(
-                Arc::new(schema.clone()),
-                vec![Arc::new(a), Arc::new(b)],
-            )?;
+            let batch =
+                RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
 
             // verify that we can construct the expression
             let expression = binary(col("a"), $OP, col("b"), &schema)?;
@@ -2593,8 +2587,7 @@ mod tests {
         ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
             let a = $A_ARRAY::from($A_VEC);
-            let batch =
-                RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
 
             // verify that we can construct the expression
             let expression = cast(col("a"), &schema, $TYPE)?;

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2656,7 +2656,7 @@ mod tests {
         generic_test_cast!(
             Int64Array,
             DataType::Int64,
-            original,
+            original.clone(),
             TimestampNanosecondArray,
             DataType::Timestamp(TimeUnit::Nanosecond, None),
             expected

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2278,7 +2278,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let b = Int32Array::from(vec![1, 2, 4, 8, 16]);
         let batch =
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
+            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b"
         let lt = binary_simple(col("a"), Operator::Lt, col("b"));
@@ -2306,7 +2306,7 @@ mod tests {
         let a = Int32Array::from(vec![2, 4, 6, 8, 10]);
         let b = Int32Array::from(vec![2, 5, 4, 8, 8]);
         let batch =
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
+            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b OR a == b"
         let expr = binary_simple(
@@ -2370,7 +2370,7 @@ mod tests {
             let a = $A_ARRAY::from($A_VEC);
             let b = $B_ARRAY::from($B_VEC);
             let batch =
-                RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
+                RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
 
             // verify that we can construct the expression
             let expression = binary(col("a"), $OP, col("b"), &schema)?;
@@ -2587,7 +2587,7 @@ mod tests {
         ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
             let a = $A_ARRAY::from($A_VEC);
-            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
+            let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
             // verify that we can construct the expression
             let expression = cast(col("a"), &schema, $TYPE)?;

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2369,8 +2369,10 @@ mod tests {
             ]);
             let a = $A_ARRAY::from($A_VEC);
             let b = $B_ARRAY::from($B_VEC);
-            let batch =
-                RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
+            let batch = RecordBatch::try_new(
+                Arc::new(schema.clone()),
+                vec![Arc::new(a), Arc::new(b)],
+            )?;
 
             // verify that we can construct the expression
             let expression = binary(col("a"), $OP, col("b"), &schema)?;
@@ -2587,7 +2589,8 @@ mod tests {
         ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
             let a = $A_ARRAY::from($A_VEC);
-            let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
+            let batch =
+                RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
             // verify that we can construct the expression
             let expression = cast(col("a"), &schema, $TYPE)?;

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1334,8 +1334,7 @@ fn common_binary_type(
             format!(
                 "'{:?} {} {:?}' can't be evaluated because there isn't a common type to coerce the types to",
                 lhs_type, op, rhs_type
-            )
-            .to_string(),
+            ),
         )),
         Some(t) => Ok(t)
     }
@@ -1602,8 +1601,7 @@ pub fn not(
             format!(
                 "NOT '{:?}' can't be evaluated because the expression's type is {:?}, not boolean",
                 arg, data_type,
-            )
-            .to_string(),
+            ),
         ))
     } else {
         Ok(Arc::new(NotExpr::new(arg)))

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2278,7 +2278,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let b = Int32Array::from(vec![1, 2, 4, 8, 16]);
         let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b"
         let lt = binary_simple(col("a"), Operator::Lt, col("b"));
@@ -2306,7 +2306,7 @@ mod tests {
         let a = Int32Array::from(vec![2, 4, 6, 8, 10]);
         let b = Int32Array::from(vec![2, 5, 4, 8, 8]);
         let batch =
-            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a), Arc::new(b)])?;
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)])?;
 
         // expression: "a < b OR a == b"
         let expr = binary_simple(
@@ -2512,7 +2512,7 @@ mod tests {
             StringArray::from(vec![Some("not one"), Some("two"), None, Some("four")]);
 
         let schema = Arc::new(Schema::new(vec![
-            Field::new("dict", dict_type.clone(), true),
+            Field::new("dict", dict_type, true),
             Field::new("str", string_type, true),
         ]));
 

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -54,7 +54,7 @@ impl FilterExec {
     ) -> Result<Self> {
         match predicate.data_type(input.schema().as_ref())? {
             DataType::Boolean => Ok(Self {
-                predicate: predicate.clone(),
+                predicate,
                 input: input.clone(),
             }),
             other => Err(DataFusionError::Plan(format!(

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -464,7 +464,7 @@ mod tests {
 
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Array,
-            &vec![lit(value1.clone()), lit(value2.clone())],
+            &vec![lit(value1), lit(value2)],
             &schema,
         )?;
 

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -179,9 +179,10 @@ pub fn return_type(
     if arg_types.len() == 0 {
         // functions currently cannot be evaluated without arguments, as they can't
         // know the number of rows to return.
-        return Err(DataFusionError::Plan(
-            format!("Function '{}' requires at least one argument", fun).to_string(),
-        ));
+        return Err(DataFusionError::Plan(format!(
+            "Function '{}' requires at least one argument",
+            fun
+        )));
     }
 
     // the return type of the built in function. Eventually there

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -808,7 +808,7 @@ mod tests {
                 )
                 .unwrap(),
                 RecordBatch::try_new(
-                    schema.clone(),
+                    schema,
                     vec![
                         Arc::new(UInt32Array::from(vec![2, 3, 3, 4])),
                         Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0, 4.0])),

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -180,7 +180,7 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> RecordBatch {
         .map(|i| limit(batch.column(i), n))
         .collect();
 
-    RecordBatch::try_new(batch.schema().clone(), limited_columns).unwrap()
+    RecordBatch::try_new(batch.schema(), limited_columns).unwrap()
 }
 
 /// A Limit stream limits the stream to up to `limit` rows.
@@ -231,7 +231,7 @@ impl Stream for LimitStream {
 impl RecordBatchStream for LimitStream {
     /// Get the schema
     fn schema(&self) -> SchemaRef {
-        self.input.schema().clone()
+        self.input.schema()
     }
 }
 

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -117,8 +117,8 @@ impl MemoryStream {
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         Ok(Self {
-            data: data.clone(),
-            schema: schema.clone(),
+            data,
+            schema,
             projection,
             index: 0,
         })

--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -141,7 +141,7 @@ impl ExecutionPlan for MergeExec {
 
                 Ok(Box::pin(MergeStream {
                     input: receiver,
-                    schema: self.schema().clone(),
+                    schema: self.schema(),
                 }))
             }
         }

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -181,7 +181,7 @@ fn read_file(
     let file_reader = Arc::new(SerializedFileReader::new(file)?);
     let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
     let mut batch_reader =
-        arrow_reader.get_record_reader_by_columns(projection.clone(), batch_size)?;
+        arrow_reader.get_record_reader_by_columns(projection, batch_size)?;
     loop {
         match batch_reader.next() {
             Some(Ok(batch)) => send_result(&response_tx, Some(Ok(batch)))?,

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -190,7 +190,7 @@ impl DefaultPhysicalPlanner {
             )?)),
             LogicalPlan::Projection { input, expr, .. } => {
                 let input = self.create_physical_plan(input, ctx_state)?;
-                let input_schema = input.as_ref().schema().clone();
+                let input_schema = input.as_ref().schema();
                 let runtime_expr = expr
                     .iter()
                     .map(|e| {
@@ -210,7 +210,7 @@ impl DefaultPhysicalPlanner {
             } => {
                 // Initially need to perform the aggregate and then merge the partitions
                 let input = self.create_physical_plan(input, ctx_state)?;
-                let input_schema = input.as_ref().schema().clone();
+                let input_schema = input.as_ref().schema();
 
                 let groups = group_expr
                     .iter()
@@ -253,14 +253,14 @@ impl DefaultPhysicalPlanner {
                 input, predicate, ..
             } => {
                 let input = self.create_physical_plan(input, ctx_state)?;
-                let input_schema = input.as_ref().schema().clone();
+                let input_schema = input.as_ref().schema();
                 let runtime_expr =
                     self.create_physical_expr(predicate, &input_schema, ctx_state)?;
                 Ok(Arc::new(FilterExec::try_new(runtime_expr, input)?))
             }
             LogicalPlan::Sort { expr, input, .. } => {
                 let input = self.create_physical_plan(input, ctx_state)?;
-                let input_schema = input.as_ref().schema().clone();
+                let input_schema = input.as_ref().schema();
 
                 let sort_expr = expr
                     .iter()

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -75,7 +75,7 @@ impl ExecutionPlan for SortExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.input.schema().clone()
+        self.input.schema()
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {

--- a/rust/datafusion/src/physical_plan/udaf.rs
+++ b/rust/datafusion/src/physical_plan/udaf.rs
@@ -112,7 +112,7 @@ pub fn create_aggregate_expr(
         fun: fun.clone(),
         args: args.clone(),
         data_type: (fun.return_type)(&arg_types)?.as_ref().clone(),
-        name: name.clone(),
+        name,
     }))
 }
 

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -45,7 +45,7 @@ pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
         ],
     )
     .unwrap();
-    let provider = MemTable::new(dual_schema.clone(), vec![vec![batch.clone()]]).unwrap();
+    let provider = MemTable::new(dual_schema.clone(), vec![vec![batch]]).unwrap();
     Box::new(provider)
 }
 
@@ -262,7 +262,7 @@ pub fn build_table_i32(
     ]);
 
     RecordBatch::try_new(
-        Arc::new(schema.clone()),
+        Arc::new(schema),
         vec![
             Arc::new(Int32Array::from(a.1.clone())),
             Arc::new(Int32Array::from(b.1.clone())),

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -45,7 +45,7 @@ pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
         ],
     )
     .unwrap();
-    let provider = MemTable::new(dual_schema.clone(), vec![vec![batch]]).unwrap();
+    let provider = MemTable::new(dual_schema, vec![vec![batch]]).unwrap();
     Box::new(provider)
 }
 


### PR DESCRIPTION
I think this clippy warning is useful to have in CI and reduces noise in the code (and maybe some small performance or compile time wins).