### PR TITLE
ARROW-10268: [Rust] Write out non-nested dictionaries in the IPC format

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1577,13 +1577,11 @@ def get_generated_json_files(tempdir=None):
 
         # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
         generate_dictionary_case()
-        .skip_category('Go')
-        .skip_category('Rust'),
+        .skip_category('Go'),
 
         generate_dictionary_unsigned_case()
         .skip_category('Go')     # TODO(ARROW-9378)
-        .skip_category('Java')   # TODO(ARROW-9377)
-        .skip_category('Rust'),  # TODO(ARROW-9379)
+        .skip_category('Java'),  # TODO(ARROW-9377)
 
         generate_nested_dictionary_case()
         .skip_category('Go')

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -509,19 +509,22 @@ fn write_array_data(
         offset = write_buffer(buffer, &mut buffers, &mut arrow_data, offset);
     });
 
-    // recursively write out nested structures
-    array_data.child_data().iter().for_each(|data_ref| {
-        // write the nested data (e.g list data)
-        offset = write_array_data(
-            data_ref,
-            &mut buffers,
-            &mut arrow_data,
-            &mut nodes,
-            offset,
-            data_ref.len(),
-            data_ref.null_count(),
-        );
-    });
+    if !matches!(array_data.data_type(), DataType::Dictionary(_, _)) {
+        // recursively write out nested structures
+        array_data.child_data().iter().for_each(|data_ref| {
+            // write the nested data (e.g list data)
+            offset = write_array_data(
+                data_ref,
+                &mut buffers,
+                &mut arrow_data,
+                &mut nodes,
+                offset,
+                data_ref.len(),
+                data_ref.null_count(),
+            );
+        });
+    }
+
     offset
 }
 

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -20,11 +20,12 @@
 //! The `FileWriter` and `StreamWriter` have similar interfaces,
 //! however the `FileWriter` expects a reader that supports `Seek`ing
 
+use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 
 use flatbuffers::FlatBufferBuilder;
 
-use crate::array::ArrayDataRef;
+use crate::array::{ArrayDataRef, ArrayRef};
 use crate::buffer::{Buffer, MutableBuffer};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
@@ -112,6 +113,8 @@ pub struct FileWriter<W: Write> {
     record_blocks: Vec<ipc::Block>,
     /// Whether the writer footer has been written, and the writer is finished
     finished: bool,
+    /// Keeps track of dictionaries that have been written
+    last_written_dictionaries: HashMap<i64, ArrayRef>,
 }
 
 impl<W: Write> FileWriter<W> {
@@ -143,6 +146,7 @@ impl<W: Write> FileWriter<W> {
             dictionary_blocks: vec![],
             record_blocks: vec![],
             finished: false,
+            last_written_dictionaries: HashMap::new(),
         })
     }
 
@@ -153,6 +157,7 @@ impl<W: Write> FileWriter<W> {
                 "Cannot write record batch to file writer as it is closed".to_string(),
             ));
         }
+        self.write_dictionaries(&batch)?;
         let message = Message::RecordBatch(batch, &self.write_options);
         let (meta, data) =
             write_message(&mut self.writer, &message, &self.write_options)?;
@@ -164,6 +169,51 @@ impl<W: Write> FileWriter<W> {
         );
         self.record_blocks.push(block);
         self.block_offsets += meta + data;
+        Ok(())
+    }
+
+    fn write_dictionaries(&mut self, batch: &RecordBatch) -> Result<()> {
+        // TODO: handle nested dictionaries
+
+        let schema = batch.schema();
+        for (i, field) in schema.fields().iter().enumerate() {
+            let column = batch.column(i);
+
+            if let DataType::Dictionary(_key_type, _value_type) = column.data_type() {
+                let dict_id = field.dict_id();
+                let dict_data = column.data();
+                let dict_values = &dict_data.child_data()[0];
+
+                // If a dictionary with this id was already emitted, check if it was the same.
+                if let Some(last_dictionary) =
+                    self.last_written_dictionaries.get(&dict_id)
+                {
+                    if last_dictionary.data().child_data()[0] == *dict_values {
+                        // Same dictionary values => no need to emit it again
+                        continue;
+                    } else {
+                        return Err(ArrowError::InvalidArgumentError(
+                            "Dictionary replacement detected when writing IPC file format. \
+                             Arrow IPC files only support a single dictionary for a given field \
+                             across all batches.".to_string()));
+                    }
+                }
+
+                self.last_written_dictionaries
+                    .insert(dict_id, column.clone());
+
+                let message =
+                    Message::DictionaryBatch(dict_id, dict_values, &self.write_options);
+
+                let (meta, data) =
+                    write_message(&mut self.writer, &message, &self.write_options)?;
+
+                let block =
+                    ipc::Block::new(self.block_offsets as i64, meta as i32, data as i64);
+                self.dictionary_blocks.push(block);
+                self.block_offsets += meta + data;
+            }
+        }
         Ok(())
     }
 
@@ -216,6 +266,8 @@ pub struct StreamWriter<W: Write> {
     schema: Schema,
     /// Whether the writer footer has been written, and the writer is finished
     finished: bool,
+    /// Keeps track of dictionaries that have been written
+    last_written_dictionaries: HashMap<i64, ArrayRef>,
 }
 
 impl<W: Write> StreamWriter<W> {
@@ -239,6 +291,7 @@ impl<W: Write> StreamWriter<W> {
             write_options,
             schema: schema.clone(),
             finished: false,
+            last_written_dictionaries: HashMap::new(),
         })
     }
 
@@ -249,8 +302,44 @@ impl<W: Write> StreamWriter<W> {
                 "Cannot write record batch to stream writer as it is closed".to_string(),
             ));
         }
+        self.write_dictionaries(&batch)?;
+
         let message = Message::RecordBatch(batch, &self.write_options);
         write_message(&mut self.writer, &message, &self.write_options)?;
+        Ok(())
+    }
+
+    fn write_dictionaries(&mut self, batch: &RecordBatch) -> Result<()> {
+        // TODO: handle nested dictionaries
+
+        let schema = batch.schema();
+        for (i, field) in schema.fields().iter().enumerate() {
+            let column = batch.column(i);
+
+            if let DataType::Dictionary(_key_type, _value_type) = column.data_type() {
+                let dict_id = field.dict_id();
+                let dict_data = column.data();
+                let dict_values = &dict_data.child_data()[0];
+
+                // If a dictionary with this id was already emitted, check if it was the same.
+                if let Some(last_dictionary) =
+                    self.last_written_dictionaries.get(&dict_id)
+                {
+                    if last_dictionary.data().child_data()[0] == *dict_values {
+                        // Same dictionary values => no need to emit it again
+                        continue;
+                    }
+                }
+
+                self.last_written_dictionaries
+                    .insert(dict_id, column.clone());
+
+                let message =
+                    Message::DictionaryBatch(dict_id, dict_values, &self.write_options);
+
+                write_message(&mut self.writer, &message, &self.write_options)?;
+            }
+        }
         Ok(())
     }
 
@@ -307,7 +396,7 @@ pub fn schema_to_bytes(schema: &Schema, write_options: &IpcWriteOptions) -> Enco
 enum Message<'a> {
     Schema(&'a Schema, &'a IpcWriteOptions),
     RecordBatch(&'a RecordBatch, &'a IpcWriteOptions),
-    DictionaryBatch(&'a IpcWriteOptions),
+    DictionaryBatch(i64, &'a ArrayDataRef, &'a IpcWriteOptions),
 }
 
 impl<'a> Message<'a> {
@@ -318,8 +407,8 @@ impl<'a> Message<'a> {
             Message::RecordBatch(batch, options) => {
                 record_batch_to_bytes(*batch, *options)
             }
-            Message::DictionaryBatch(_) => {
-                unimplemented!("Writing dictionary batches not implemented")
+            Message::DictionaryBatch(dict_id, array_data, options) => {
+                dictionary_batch_to_bytes(*dict_id, *array_data, *options)
             }
         }
     }
@@ -431,6 +520,65 @@ pub fn record_batch_to_bytes(
     message.add_bodyLength(arrow_data.len() as i64);
     message.add_header(root);
     let root = message.finish();
+    fbb.finish(root, None);
+    let finished_data = fbb.finished_data();
+
+    EncodedData {
+        ipc_message: finished_data.to_vec(),
+        arrow_data,
+    }
+}
+
+/// Write dictionary values into a tuple of bytes, one for the header (ipc::Message) and the other for the data
+pub fn dictionary_batch_to_bytes(
+    dict_id: i64,
+    array_data: &ArrayDataRef,
+    write_options: &IpcWriteOptions,
+) -> EncodedData {
+    let mut fbb = FlatBufferBuilder::new();
+
+    let mut nodes: Vec<ipc::FieldNode> = vec![];
+    let mut buffers: Vec<ipc::Buffer> = vec![];
+    let mut arrow_data: Vec<u8> = vec![];
+
+    write_array_data(
+        &array_data,
+        &mut buffers,
+        &mut arrow_data,
+        &mut nodes,
+        0,
+        array_data.len(),
+        array_data.null_count(),
+    );
+
+    // write data
+    let buffers = fbb.create_vector(&buffers);
+    let nodes = fbb.create_vector(&nodes);
+
+    let root = {
+        let mut batch_builder = ipc::RecordBatchBuilder::new(&mut fbb);
+        batch_builder.add_length(array_data.len() as i64);
+        batch_builder.add_nodes(nodes);
+        batch_builder.add_buffers(buffers);
+        batch_builder.finish()
+    };
+
+    let root = {
+        let mut batch_builder = ipc::DictionaryBatchBuilder::new(&mut fbb);
+        batch_builder.add_id(dict_id);
+        batch_builder.add_data(root);
+        batch_builder.finish().as_union_value()
+    };
+
+    let root = {
+        let mut message_builder = ipc::MessageBuilder::new(&mut fbb);
+        message_builder.add_version(write_options.metadata_version);
+        message_builder.add_header_type(ipc::MessageHeader::DictionaryBatch);
+        message_builder.add_bodyLength(arrow_data.len() as i64);
+        message_builder.add_header(root);
+        message_builder.finish()
+    };
+
     fbb.finish(root, None);
     let finished_data = fbb.finished_data();
 
@@ -668,6 +816,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
+            "generated_dictionary",
             "generated_nested",
             "generated_primitive_no_batches",
             "generated_primitive_zerolength",
@@ -711,6 +860,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
+            "generated_dictionary",
             "generated_nested",
             "generated_primitive_no_batches",
             "generated_primitive_zerolength",

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -25,11 +25,7 @@ use arrow::ipc::writer::StreamWriter;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
-    eprintln!("{:?}", args);
-
     let filename = &args[1];
-    eprintln!("Reading from Arrow file {}", filename);
-
     let f = File::open(filename)?;
     let reader = BufReader::new(f);
     let mut reader = FileReader::try_new(reader)?;
@@ -42,8 +38,6 @@ fn main() -> Result<()> {
         writer.write(&batch)
     })?;
     writer.finish()?;
-
-    eprintln!("Completed without error");
 
     Ok(())
 }

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -90,12 +90,6 @@ fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()>
     let arrow_file = File::create(arrow_name)?;
     let mut writer = FileWriter::try_new(arrow_file, &json_file.schema)?;
 
-    if !json_file.dictionaries.is_empty() {
-        return Err(ArrowError::JsonError(
-            "Writing dictionaries not yet supported".to_string(),
-        ));
-    }
-
     for b in json_file.batches {
         writer.write(&b)?;
     }
@@ -704,7 +698,8 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
 struct ArrowFile {
     schema: Schema,
     // we can evolve this into a concrete Arrow type
-    dictionaries: HashMap<i64, ArrowJsonDictionaryBatch>,
+    // this is temporarily not being read from
+    _dictionaries: HashMap<i64, ArrowJsonDictionaryBatch>,
     batches: Vec<RecordBatch>,
 }
 
@@ -735,7 +730,7 @@ fn read_json_file(json_name: &str) -> Result<ArrowFile> {
     }
     Ok(ArrowFile {
         schema,
-        dictionaries,
+        _dictionaries: dictionaries,
         batches,
     })
 }

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -536,6 +536,8 @@ fn dictionary_array_from_json(
         | DataType::UInt16
         | DataType::UInt32
         | DataType::UInt64 => {
+            let null_buf = create_null_buf(&json_col);
+
             // build the key data into a buffer, then construct values separately
             let key_field = Field::new_dict(
                 "key",
@@ -555,6 +557,7 @@ fn dictionary_array_from_json(
             let dict_data = ArrayData::builder(field.data_type().clone())
                 .len(keys.len())
                 .add_buffer(keys.data().buffers()[0].clone())
+                .null_bit_buffer(null_buf)
                 .add_child_data(values.data())
                 .build();
 

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
@@ -39,9 +38,6 @@ use arrow::{
 };
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    eprintln!("{:?}", args);
-
     let matches = App::new("rust arrow-json-integration-test")
         .arg(Arg::with_name("integration")
             .long("integration"))

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::io;
 
 use arrow::error::Result;
@@ -23,9 +22,6 @@ use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    eprintln!("{:?}", args);
-
     let mut arrow_stream_reader = StreamReader::try_new(io::stdin())?;
     let schema = arrow_stream_reader.schema();
 
@@ -33,8 +29,6 @@ fn main() -> Result<()> {
 
     arrow_stream_reader.try_for_each(|batch| writer.write(&batch?))?;
     writer.finish()?;
-
-    eprintln!("Completed without error");
 
     Ok(())
 }


### PR DESCRIPTION
This adds support for writing non-nested dictionaries in the IPC format in Rust.

The first commit in this PR is sort of a bug fix related to correctly supporting dictionaries, but I wanted to draw attention to it specifically and make sure I'm handling that case correctly.

The second commit is the majority of the new functionality.

The third commit removes the TODO assertion in the integration test tool that errored if dictionaries were encountered in the JSON... which means nothing is reading from the `dictionaries` field of the `ArrowFile` struct. This might mean it can be removed? Or perhaps I'm missing something, or something isn't yet implemented?

The fourth commit fixes an issue when the integration testing tool reads JSON files with dictionaries; the null bit buffers weren't being set. This didn't matter when testing Rust-to-Rust as neither side was setting the null bit buffers, so the columns were equal, but this does matter when testing dictionaries with another language and Rust.

The fifth commit enables the dictionary and unsigned dictionary integration tests for Rust, but doesn't enable the nested dictionary test as that isn't working yet.

The sixth commit makes the Rust integration testing tool less noisy-- it was printing more output than the other languages' integration testing tools. Let me know if this should be done a different way.

