### PR TITLE
PARQUET-1566: [C++] Indicate if null count, distinct count are present in column statistics

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -115,14 +115,17 @@ static std::shared_ptr<Statistics> MakeTypedColumnStats(
         descr, metadata.statistics.min_value, metadata.statistics.max_value,
         metadata.num_values - metadata.statistics.null_count,
         metadata.statistics.null_count, metadata.statistics.distinct_count,
-        metadata.statistics.__isset.max_value || metadata.statistics.__isset.min_value);
+        metadata.statistics.__isset.max_value || metadata.statistics.__isset.min_value,
+        metadata.statistics.__isset.null_count,
+        metadata.statistics.__isset.distinct_count);
   }
   // Default behavior
   return MakeStatistics<DType>(
       descr, metadata.statistics.min, metadata.statistics.max,
       metadata.num_values - metadata.statistics.null_count,
       metadata.statistics.null_count, metadata.statistics.distinct_count,
-      metadata.statistics.__isset.max || metadata.statistics.__isset.min);
+      metadata.statistics.__isset.max || metadata.statistics.__isset.min,
+      metadata.statistics.__isset.null_count, metadata.statistics.__isset.distinct_count);
 }
 
 std::shared_ptr<Statistics> MakeColumnStats(const format::ColumnMetaData& meta_data,

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -374,6 +374,8 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     auto comp = Comparator::Make(descr);
     comparator_ = std::static_pointer_cast<TypedComparator<DType>>(comp);
     Reset();
+    has_null_count_ = true;
+    has_distinct_count_ = true;
   }
 
   TypedStatisticsImpl(const T& min, const T& max, int64_t num_values, int64_t null_count,
@@ -393,11 +395,15 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   TypedStatisticsImpl(const ColumnDescriptor* descr, const std::string& encoded_min,
                       const std::string& encoded_max, int64_t num_values,
                       int64_t null_count, int64_t distinct_count, bool has_min_max,
-                      MemoryPool* pool)
+                      bool has_null_count, bool has_distinct_count, MemoryPool* pool)
       : TypedStatisticsImpl(descr, pool) {
     IncrementNumValues(num_values);
-    IncrementNullCount(null_count);
-    IncrementDistinctCount(distinct_count);
+    if (has_null_count_) {
+      IncrementNullCount(null_count);
+    }
+    if (has_distinct_count) {
+      IncrementDistinctCount(distinct_count);
+    }
 
     if (!encoded_min.empty()) {
       PlainDecode(encoded_min, &min_);
@@ -408,7 +414,9 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     has_min_max_ = has_min_max;
   }
 
+  bool HasDistinctCount() const override { return has_distinct_count_; };
   bool HasMinMax() const override { return has_min_max_; }
+  bool HasNullCount() const override { return has_null_count_; };
 
   bool Equals(const Statistics& raw_other) const override {
     if (physical_type() != raw_other.physical_type()) return false;
@@ -427,6 +435,8 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   void Reset() override {
     ResetCounts();
     has_min_max_ = false;
+    has_distinct_count_ = false;
+    has_null_count_ = false;
   }
 
   void SetMinMax(const T& arg_min, const T& arg_max) override {
@@ -434,9 +444,16 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
 
   void Merge(const TypedStatistics<DType>& other) override {
-    this->MergeCounts(other);
-    if (!other.HasMinMax()) return;
-    SetMinMax(other.min(), other.max());
+    this->num_values_ += other.num_values();
+    if (other.HasNullCount()) {
+      this->statistics_.null_count += other.null_count();
+    }
+    if (other.HasDistinctCount()) {
+      this->statistics_.distinct_count += other.distinct_count();
+    }
+    if (other.HasMinMax()) {
+      SetMinMax(other.min(), other.max());
+    }
   }
 
   void Update(const T* values, int64_t num_not_null, int64_t num_null) override;
@@ -480,7 +497,9 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
       s.set_min(this->EncodeMin());
       s.set_max(this->EncodeMax());
     }
-    s.set_null_count(this->null_count());
+    if (HasNullCount()) {
+      s.set_null_count(this->null_count());
+    }
     return s;
   }
 
@@ -491,6 +510,8 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
  private:
   const ColumnDescriptor* descr_;
   bool has_min_max_ = false;
+  bool has_null_count_ = false;
+  bool has_distinct_count_ = false;
   T min_;
   T max_;
   ::arrow::MemoryPool* pool_;
@@ -504,16 +525,16 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
 
   void Copy(const T& src, T* dst, ResizableBuffer*) { *dst = src; }
 
-  void IncrementNullCount(int64_t n) { statistics_.null_count += n; }
+  void IncrementNullCount(int64_t n) {
+    statistics_.null_count += n;
+    has_null_count_ = true;
+  }
 
   void IncrementNumValues(int64_t n) { num_values_ += n; }
 
-  void IncrementDistinctCount(int64_t n) { statistics_.distinct_count += n; }
-
-  void MergeCounts(const Statistics& other) {
-    this->statistics_.null_count += other.null_count();
-    this->statistics_.distinct_count += other.distinct_count();
-    this->num_values_ += other.num_values();
+  void IncrementDistinctCount(int64_t n) {
+    statistics_.distinct_count += n;
+    has_distinct_count_ = true;
   }
 
   void ResetCounts() {
@@ -741,12 +762,13 @@ std::shared_ptr<Statistics> Statistics::Make(const ColumnDescriptor* descr,
                                              const std::string& encoded_max,
                                              int64_t num_values, int64_t null_count,
                                              int64_t distinct_count, bool has_min_max,
+                                             bool has_null_count, bool has_distinct_count,
                                              ::arrow::MemoryPool* pool) {
 #define MAKE_STATS(CAP_TYPE, KLASS)                                              \
   case Type::CAP_TYPE:                                                           \
     return std::make_shared<TypedStatisticsImpl<KLASS>>(                         \
         descr, encoded_min, encoded_max, num_values, null_count, distinct_count, \
-        has_min_max, pool)
+        has_min_max, has_null_count, has_distinct_count, pool)
 
   switch (descr->physical_type()) {
     MAKE_STATS(BOOLEAN, BooleanType);

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -206,8 +206,8 @@ class PARQUET_EXPORT Statistics {
   /// \param[in] null_count number of null values
   /// \param[in] distinct_count number of distinct values
   /// \param[in] has_min_max whether the min/max statistics are set
-  /// \param[in] has_null_count whether the min/max statistics are set
-  /// \param[in] has_distinct_count whether the min/max statistics are set
+  /// \param[in] has_null_count whether the null_count statistics are set
+  /// \param[in] has_distinct_count whether the distinct_count statistics are set
   /// \param[in] pool a memory pool to use for any memory allocations, optional
   static std::shared_ptr<Statistics> Make(
       const ColumnDescriptor* descr, const std::string& encoded_min,

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -206,15 +206,24 @@ class PARQUET_EXPORT Statistics {
   /// \param[in] null_count number of null values
   /// \param[in] distinct_count number of distinct values
   /// \param[in] has_min_max whether the min/max statistics are set
+  /// \param[in] has_null_count whether the min/max statistics are set
+  /// \param[in] has_distinct_count whether the min/max statistics are set
   /// \param[in] pool a memory pool to use for any memory allocations, optional
   static std::shared_ptr<Statistics> Make(
       const ColumnDescriptor* descr, const std::string& encoded_min,
       const std::string& encoded_max, int64_t num_values, int64_t null_count,
-      int64_t distinct_count, bool has_min_max,
+      int64_t distinct_count, bool has_min_max, bool has_null_count,
+      bool has_distinct_count,
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+  /// \brief Return true if the count of null values is set
+  virtual bool HasNullCount() const = 0;
 
   /// \brief The number of null values, may not be set
   virtual int64_t null_count() const = 0;
+
+  /// \brief Return true if the count of distinct values is set
+  virtual bool HasDistinctCount() const = 0;
 
   /// \brief The number of distinct values, may not be set
   virtual int64_t distinct_count() const = 0;
@@ -323,11 +332,11 @@ template <typename DType>
 std::shared_ptr<TypedStatistics<DType>> MakeStatistics(
     const ColumnDescriptor* descr, const std::string& encoded_min,
     const std::string& encoded_max, int64_t num_values, int64_t null_count,
-    int64_t distinct_count, bool has_min_max,
-    ::arrow::MemoryPool* pool = ::arrow::default_memory_pool()) {
-  return std::static_pointer_cast<TypedStatistics<DType>>(
-      Statistics::Make(descr, encoded_min, encoded_max, num_values, null_count,
-                       distinct_count, has_min_max, pool));
+    int64_t distinct_count, bool has_min_max, bool has_null_count,
+    bool has_distinct_count, ::arrow::MemoryPool* pool = ::arrow::default_memory_pool()) {
+  return std::static_pointer_cast<TypedStatistics<DType>>(Statistics::Make(
+      descr, encoded_min, encoded_max, num_values, null_count, distinct_count,
+      has_min_max, has_null_count, has_distinct_count, pool));
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -272,7 +272,7 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
 
     auto statistics2 =
         MakeStatistics<TestType>(this->schema_.Column(0), encoded_min, encoded_max,
-                                 this->values_.size(), 0, 0, true);
+                                 this->values_.size(), 0, 0, true, true, true);
 
     auto statistics3 = MakeStatistics<TestType>(this->schema_.Column(0));
     std::vector<uint8_t> valid_bits(
@@ -302,6 +302,7 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
     statistics->Reset();
     ASSERT_EQ(0, statistics->null_count());
     ASSERT_EQ(0, statistics->num_values());
+    ASSERT_EQ(0, statistics->distinct_count());
     ASSERT_EQ("", statistics->EncodeMin());
     ASSERT_EQ("", statistics->EncodeMax());
   }
@@ -473,7 +474,7 @@ void TestStatistics<ByteArrayType>::TestMinMaxEncode() {
 
   auto statistics2 =
       MakeStatistics<ByteArrayType>(this->schema_.Column(0), encoded_min, encoded_max,
-                                    this->values_.size(), 0, 0, true);
+                                    this->values_.size(), 0, 0, true, true, true);
 
   ASSERT_EQ(encoded_min, statistics2->EncodeMin());
   ASSERT_EQ(encoded_max, statistics2->EncodeMax());


### PR DESCRIPTION
This PR adds flags and convenience methods to toggle between presence/absence of `distinct_count` and `null_count` column statistics when reading/writing Parquet files.