### PR TITLE
ARROW-10742: [Python] Check mask when creating array from numpy

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -240,7 +240,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
 
         if mask is not None:
             if mask.dtype != np.bool_:
-                raise ValueError("Mask must be boolean dtype")
+                raise TypeError("Mask must be boolean dtype")
             if mask.ndim != 1:
                 raise ValueError("Mask must be 1D array")
             if len(values) != len(mask):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -238,6 +238,15 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 mask = None if values.mask is np.ma.nomask else values.mask
                 values = values.data
 
+        if mask is not None:
+            if mask.dtype != np.bool_:
+                raise ValueError("Mask must be boolean dtype")
+            if mask.ndim != 1:
+                raise ValueError("Mask must be 1D array")
+            if len(values) != len(mask):
+                raise ValueError(
+                    "Mask is a different length from sequence being converted")
+
         if hasattr(values, '__arrow_array__'):
             return _handle_arrow_array_protocol(values, type, mask, size)
         elif pandas_api.is_categorical(values):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2565,16 +2565,26 @@ def test_array_masked():
 def test_array_invalid_mask_raises():
     # ARROW-10742
     cases = [
-        ([1, 2], np.array([False, False], dtype="O"), "must be boolean dtype"),
-        ([1, 2], np.array([[False], [False]]), "must be 1D array"),
-        ([1, 2, 3], np.array([False, False]), "different length"),
-        (np.array([1, 2]), np.array([False, False],
-                                    dtype="O"), "must be boolean dtype"),
-        (np.array([1, 2]), np.array([[False], [False]]), "must be 1D array"),
-        (np.array([1, 2, 3]), np.array([False, False]), "different length"),
+        ([1, 2], np.array([False, False], dtype="O"),
+         pa.ArrowInvalid, "must be boolean dtype"),
+
+        ([1, 2], np.array([[False], [False]]),
+         pa.ArrowInvalid, "must be 1D array"),
+
+        ([1, 2, 3], np.array([False, False]),
+         pa.ArrowInvalid, "different length"),
+
+        (np.array([1, 2]), np.array([False, False], dtype="O"),
+         TypeError, "must be boolean dtype"),
+
+        (np.array([1, 2]), np.array([[False], [False]]),
+         ValueError, "must be 1D array"),
+
+        (np.array([1, 2, 3]), np.array([False, False]),
+         ValueError, "different length"),
     ]
-    for obj, mask, msg in cases:
-        with pytest.raises(ValueError, match=msg):
+    for obj, mask, ex, msg in cases:
+        with pytest.raises(ex, match=msg):
             pa.array(obj, mask=mask)
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2562,6 +2562,22 @@ def test_array_masked():
     assert arr.type == pa.int64()
 
 
+def test_array_invalid_mask_raises():
+    # ARROW-10742
+    cases = [
+        ([1, 2], np.array([False, False], dtype="O"), "must be boolean dtype"),
+        ([1, 2], np.array([[False], [False]]), "must be 1D array"),
+        ([1, 2, 3], np.array([False, False]), "different length"),
+        (np.array([1, 2]), np.array([False, False],
+                                    dtype="O"), "must be boolean dtype"),
+        (np.array([1, 2]), np.array([[False], [False]]), "must be 1D array"),
+        (np.array([1, 2, 3]), np.array([False, False]), "different length"),
+    ]
+    for obj, mask, msg in cases:
+        with pytest.raises(ValueError, match=msg):
+            pa.array(obj, mask=mask)
+
+
 def test_array_from_large_pyints():
     # ARROW-5430
     with pytest.raises(OverflowError):


### PR DESCRIPTION
This change adds checks so that the same exceptions are raised when creating an array with a mask using a python sequence or a numpy array.