### PR TITLE
ARROW-10745: [Rust] Directly allocate padding bytes in filter context

### DIFF
--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -324,10 +324,12 @@ impl FilterContext {
 
         let filter_bytes = filter_buffer.data();
 
-        // transmute filter_bytes to &[u64]
-        let mut u64_buffer = MutableBuffer::new(filter_bytes.len());
         // add to the resulting len so is is a multiple of the size of u64
         let pad_addional_len = (8 - filter_bytes.len() % 8) % 8;
+
+        // transmute filter_bytes to &[u64]
+        let mut u64_buffer = MutableBuffer::new(filter_bytes.len() + pad_addional_len);
+
         u64_buffer.extend_from_slice(filter_bytes);
         u64_buffer.extend_from_slice(&vec![0; pad_addional_len]);
         let mut filter_u64 = u64_buffer.typed_data_mut::<u64>().to_owned();

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -325,7 +325,7 @@ impl FilterContext {
         let filter_bytes = filter_buffer.data();
 
         // add to the resulting len so is is a multiple of the size of u64
-        let pad_addional_len = (8 - filter_bytes.len() % 8) % 8;
+        let pad_addional_len = 8 - filter_bytes.len() % 8;
 
         // transmute filter_bytes to &[u64]
         let mut u64_buffer = MutableBuffer::new(filter_bytes.len() + pad_addional_len);


### PR DESCRIPTION
A thing I noticed while going through some code. 

When creating a`MutableBuffer` here only `filter_bytes.len()` are being allocated, but the capacity can afterwards being increased when adding bytes using `extend_from_slice`.

This changes it to allocate those bytes directly.