### PR TITLE
ARROW-10749: [C++] Incorrect string format for Datum with the collection type

### DIFF
--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -220,6 +220,7 @@ std::string Datum::ToString() const {
         }
         ss << values[i].ToString();
       }
+      ss << ')';
       return ss.str();
     }
     default:
@@ -229,14 +230,12 @@ std::string Datum::ToString() const {
 }
 
 ValueDescr::Shape GetBroadcastShape(const std::vector<ValueDescr>& args) {
-  ValueDescr::Shape shape = ValueDescr::SCALAR;
   for (const auto& descr : args) {
     if (descr.shape == ValueDescr::ARRAY) {
-      shape = ValueDescr::ARRAY;
-      break;
+      return ValueDescr::ARRAY;
     }
   }
-  return shape;
+  return ValueDescr::SCALAR;
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/datum_test.cc
+++ b/cpp/src/arrow/datum_test.cc
@@ -132,8 +132,17 @@ TEST(Datum, ToString) {
 
   Datum v1(arr);
   Datum v2(std::make_shared<Int8Scalar>(1));
+
+  std::vector<Datum> vec1 = {v1};
+  Datum v3(vec1);
+
+  std::vector<Datum> vec2 = {v1, v2};
+  Datum v4(vec2);
+
   ASSERT_EQ("Array", v1.ToString());
   ASSERT_EQ("Scalar", v2.ToString());
+  ASSERT_EQ("Collection(Array)", v3.ToString());
+  ASSERT_EQ("Collection(Array, Scalar)", v4.ToString());
 }
 
 TEST(ValueDescr, Basics) {


### PR DESCRIPTION
The current format looks like this: `Collection(...`, the right embrace is omitted.