### PR TITLE
ARROW-10729: [Rust] [DataFusion] Add SQL support for JOIN using implicit syntax

### DIFF
--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -789,8 +789,8 @@ fn remove_join_expressions(
                 let r = remove_join_expressions(right, join_columns)?;
                 match (l, r) {
                     (Some(ll), Some(rr)) => Ok(Some(and(ll, rr))),
-                    (Some(ll), _) => Ok(Some(ll.clone())),
-                    (_, Some(rr)) => Ok(Some(rr.clone())),
+                    (Some(ll), _) => Ok(Some(ll)),
+                    (_, Some(rr)) => Ok(Some(rr)),
                     _ => Ok(None),
                 }
             }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -333,6 +333,8 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                 let join_schema = Schema::new(fields);
 
                 let filter_expr = self.sql_to_rex(predicate_expr, &join_schema)?;
+
+                // look for expressions of the form `<column> = <column>`
                 let mut possible_join_keys = vec![];
                 extract_possible_join_keys(&filter_expr, &mut possible_join_keys)?;
 
@@ -769,8 +771,8 @@ fn remove_join_expressions(expr: &Expr) -> Result<Option<Expr>> {
                 let r = remove_join_expressions(right)?;
                 match (l, r) {
                     (Some(ll), Some(rr)) => Ok(Some(and(ll, rr))),
-                    (Some(expr), _) => Ok(Some(expr.clone())),
-                    (_, Some(expr)) => Ok(Some(expr.clone())),
+                    (Some(ll), _) => Ok(Some(ll.clone())),
+                    (_, Some(rr)) => Ok(Some(rr.clone())),
                     _ => Ok(None),
                 }
             }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -372,7 +372,11 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                         }
                         left
                     }
-                    _ => return Err(DataFusionError::NotImplemented("TBD".to_string())),
+                    _ => {
+                        return Err(DataFusionError::NotImplemented(
+                            "Cartesian joins are not supported".to_string(),
+                        ))
+                    }
                 }
             }
         };

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1065,6 +1065,7 @@ async fn equijoin_implicit_syntax() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore] // see https://issues.apache.org/jira/browse/ARROW-10760
 async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
     let mut ctx = create_join_context()?;
     let sql = "SELECT t1_id, t1_name, t2_name \

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1065,7 +1065,6 @@ async fn equijoin_implicit_syntax() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore] // see https://issues.apache.org/jira/browse/ARROW-10760
 async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
     let mut ctx = create_join_context()?;
     let sql = "SELECT t1_id, t1_name, t2_name \

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1049,6 +1049,36 @@ async fn equijoin() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn equijoin_implicit_syntax() -> Result<()> {
+    let mut ctx = create_join_context()?;
+    let sql =
+        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t1_id = t2_id ORDER BY t1_id";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["11", "a", "z"],
+        vec!["22", "b", "y"],
+        vec!["44", "d", "x"],
+    ];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn equijoin_implicit_syntax_reversed() -> Result<()> {
+    let mut ctx = create_join_context()?;
+    let sql =
+        "SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["11", "a", "z"],
+        vec!["22", "b", "y"],
+        vec!["44", "d", "x"],
+    ];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
 fn create_join_context() -> Result<ExecutionContext> {
     let mut ctx = ExecutionContext::new();
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1065,6 +1065,26 @@ async fn equijoin_implicit_syntax() -> Result<()> {
 }
 
 #[tokio::test]
+async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
+    let mut ctx = create_join_context()?;
+    let sql =
+        "SELECT t1_id, t1_name, t2_name \
+        FROM t1, t2 \
+        WHERE t1_id > 0 \
+        AND t1_id = t2_id \
+        AND t2_id < 99 \
+        ORDER BY t1_id";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["11", "a", "z"],
+        vec!["22", "b", "y"],
+        vec!["44", "d", "x"],
+    ];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn equijoin_implicit_syntax_reversed() -> Result<()> {
     let mut ctx = create_join_context()?;
     let sql =

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1067,8 +1067,7 @@ async fn equijoin_implicit_syntax() -> Result<()> {
 #[tokio::test]
 async fn equijoin_implicit_syntax_with_filter() -> Result<()> {
     let mut ctx = create_join_context()?;
-    let sql =
-        "SELECT t1_id, t1_name, t2_name \
+    let sql = "SELECT t1_id, t1_name, t2_name \
         FROM t1, t2 \
         WHERE t1_id > 0 \
         AND t1_id = t2_id \

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1079,6 +1079,18 @@ async fn equijoin_implicit_syntax_reversed() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn cartesian_join() -> Result<()> {
+    let ctx = create_join_context()?;
+    let sql = "SELECT t1_id, t1_name, t2_name FROM t1, t2 ORDER BY t1_id";
+    let maybe_plan = ctx.create_logical_plan(&sql);
+    assert_eq!(
+        "This feature is not implemented: Cartesian joins are not supported",
+        &format!("{}", maybe_plan.err().unwrap())
+    );
+    Ok(())
+}
+
 fn create_join_context() -> Result<ExecutionContext> {
     let mut ctx = ExecutionContext::new();
 


### PR DESCRIPTION
Adds support for SQL joins using the implicit syntax where the "ON" conditions are part of the WHERE clause.

For example:

```sql
SELECT t1_id, t1_name, t2_name FROM t1, t2 WHERE t2_id = t1_id ORDER BY t1_id
```