### PR TITLE
ARROW-10751: [C++] Add RE2 to minimal build example

### DIFF
--- a/cpp/examples/minimal_build/system_dependency.dockerfile
+++ b/cpp/examples/minimal_build/system_dependency.dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update -y -q && \
       liblz4-dev \
       libprotobuf-dev \
       libprotoc-dev \
+      libre2-dev \
       libsnappy-dev \
       libthrift-dev \
       libutf8proc-dev \


### PR DESCRIPTION
Because we require RE2 with ARROW_COMPUTE by default.

See also: ARROW-10541 and #8756