### PR TITLE
ARROW-10759: [Rust][DataFusion] Implement string to date cast

### DIFF
--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -70,6 +70,8 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
 
         (_, Boolean) => DataType::is_numeric(from_type),
         (Boolean, _) => DataType::is_numeric(to_type) || to_type == &Utf8,
+
+        (Utf8, Date32(DateUnit::Day)) => true,
         (Utf8, _) => DataType::is_numeric(to_type),
         (_, Utf8) => DataType::is_numeric(from_type) || from_type == &Binary,
 
@@ -376,6 +378,27 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             Int64 => cast_string_to_numeric::<Int64Type>(array),
             Float32 => cast_string_to_numeric::<Float32Type>(array),
             Float64 => cast_string_to_numeric::<Float64Type>(array),
+            Date32(DateUnit::Day) => {
+                use chrono::{NaiveDate, NaiveTime};
+                let zero_time = NaiveTime::from_hms(0, 0, 0);
+                let string_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+                let mut builder = PrimitiveBuilder::<Date32Type>::new(string_array.len());
+                for i in 0..string_array.len() {
+                    if string_array.is_null(i) {
+                        builder.append_null()?;
+                    } else {
+                        match NaiveDate::parse_from_str(string_array.value(i), "%Y-%m-%d")
+                        {
+                            Ok(date) => builder.append_value(
+                                (date.and_time(zero_time).timestamp() / SECONDS_IN_DAY)
+                                    as i32,
+                            )?,
+                            Err(_) => builder.append_null()?, // not a valid date
+                        };
+                    }
+                }
+                Ok(Arc::new(builder.finish()) as ArrayRef)
+            }
             _ => Err(ArrowError::ComputeError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
@@ -2718,6 +2741,42 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn test_cast_utf8_to_date32() {
+        use chrono::{NaiveDate, NaiveTime};
+
+        let a = StringArray::from(vec![
+            "2000-01-01",
+            "2000-2-2",
+            "2000-00-00",
+            "2000-01-01T12:00:00",
+            "2000",
+        ]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Date32(DateUnit::Day)).unwrap();
+        let c = b.as_any().downcast_ref::<Date32Array>().unwrap();
+
+        let zero_time = NaiveTime::from_hms(0, 0, 0);
+
+        let date_value = (NaiveDate::from_ymd(2000, 1, 1)
+            .and_time(zero_time)
+            .timestamp()
+            / SECONDS_IN_DAY) as i32;
+        assert_eq!(true, c.is_valid(0));
+        assert_eq!(date_value, c.value(0));
+
+        let date_value = (NaiveDate::from_ymd(2000, 2, 2)
+            .and_time(zero_time)
+            .timestamp()
+            / SECONDS_IN_DAY) as i32;
+        assert_eq!(true, c.is_valid(1));
+        assert_eq!(date_value, c.value(1));
+
+        assert_eq!(false, c.is_valid(2));
+        assert_eq!(false, c.is_valid(3));
+        assert_eq!(false, c.is_valid(4));
     }
 
     #[test]

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -201,7 +201,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
             SQLDataType::Float(_) => Ok(DataType::Float32),
             SQLDataType::Real | SQLDataType::Double => Ok(DataType::Float64),
             SQLDataType::Boolean => Ok(DataType::Boolean),
-            SQLDataType::Date => Ok(DataType::Date64(DateUnit::Day)),
+            SQLDataType::Date => Ok(DataType::Date32(DateUnit::Day)),
             SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
             SQLDataType::Timestamp => Ok(DataType::Date64(DateUnit::Millisecond)),
             _ => Err(DataFusionError::NotImplemented(format!(
@@ -763,6 +763,7 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
         SQLDataType::Double => Ok(DataType::Float64),
         SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        SQLDataType::Date => Ok(DataType::Date32(DateUnit::Day)),
         other => Err(DataFusionError::NotImplemented(format!(
             "Unsupported SQL type {:?}",
             other
@@ -830,6 +831,18 @@ mod tests {
 
         let expected = "Projection: #state\
             \n  Filter: #birth_date Lt CAST(Int64(158412331400600000) AS Timestamp(Nanosecond, None))\
+            \n    TableScan: person projection=None";
+
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn test_date_filter() {
+        let sql =
+            "SELECT state FROM person WHERE birth_date < CAST ('2020-01-01' as date)";
+
+        let expected = "Projection: #state\
+            \n  Filter: #birth_date Lt CAST(Utf8(\"2020-01-01\") AS Date32(Day))\
             \n    TableScan: person projection=None";
 
         quick_test(sql, expected);


### PR DESCRIPTION
This PR implements casting string (Utf8) to date (Date32(Day)) for a more user-friendly and readable way for creating date literals in SQL queries using an expression such as `CAST('2019-01-01' AS DATE)`