### PR TITLE
ARROW-10763: [Rust] Speed up take for primitive / boolean for non-null arrays

### DIFF
--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -212,39 +212,57 @@ where
 
     let array = values.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
-    let num_bytes = bit_util::ceil(data_len, 8);
-    let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-
-    let null_slice = null_buf.data_mut();
+    let null_count = array.null_count();
 
     // This iteration is implemented with a while loop, rather than a
     // map()/collect(), since the while loop performs better in the benchmarks.
     let mut new_values: Vec<T::Native> = Vec::with_capacity(data_len);
-    let mut i = 0;
-    while i < data_len {
-        let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
-            ArrowError::ComputeError("Cast to usize failed".to_string())
-        })?;
+    let nulls;
 
-        if array.is_null(index) {
-            bit_util::unset_bit(null_slice, i);
+    if null_count == 0 {
+        // Just taking indices without null checking
+        for i in 0..data_len {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
+
+            new_values.push(array.value(index));
         }
+        nulls = indices.data_ref().null_buffer().cloned();
+    } else {
+        let num_bytes = bit_util::ceil(data_len, 8);
+        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
 
-        new_values.push(array.value(index));
+        let null_slice = null_buf.data_mut();
 
-        i += 1;
+        for i in 0..data_len {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
+
+            if array.is_null(index) {
+                bit_util::unset_bit(null_slice, i);
+            }
+
+            new_values.push(array.value(index));
+        }
+        nulls = match indices.data_ref().null_buffer() {
+            Some(buffer) => Some(buffer_bin_and(
+                buffer,
+                0,
+                &null_buf.freeze(),
+                0,
+                indices.len(),
+            )),
+            None => Some(null_buf.freeze()),
+        };
     }
-
-    let nulls = match indices.data_ref().null_buffer() {
-        Some(buffer) => buffer_bin_and(buffer, 0, &null_buf.freeze(), 0, indices.len()),
-        None => null_buf.freeze(),
-    };
 
     let data = ArrayData::new(
         T::DATA_TYPE,
         indices.len(),
         None,
-        Some(nulls),
+        nulls,
         0,
         vec![Buffer::from(new_values.to_byte_slice())],
         vec![],

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -220,7 +220,7 @@ where
     let nulls;
 
     if null_count == 0 {
-        // Just taking indices without null checking
+        // Take indices without null checking
         for i in 0..data_len {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
                 ArrowError::ComputeError("Cast to usize failed".to_string())
@@ -284,36 +284,62 @@ where
     let array = values.as_any().downcast_ref::<BooleanArray>().unwrap();
 
     let num_byte = bit_util::ceil(data_len, 8);
-    let mut null_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, true);
     let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
 
-    let null_slice = null_buf.data_mut();
     let val_slice = val_buf.data_mut();
 
-    (0..data_len).try_for_each::<_, Result<()>>(|i| {
-        let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
-            ArrowError::ComputeError("Cast to usize failed".to_string())
+    let null_count = array.null_count();
+
+    let nulls;
+    if null_count == 0 {
+        (0..data_len).try_for_each::<_, Result<()>>(|i| {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
+
+            if array.value(index) {
+                bit_util::set_bit(val_slice, i);
+            }
+
+            Ok(())
         })?;
 
-        if array.is_null(index) {
-            bit_util::unset_bit(null_slice, i);
-        } else if array.value(index) {
-            bit_util::set_bit(val_slice, i);
-        }
+        nulls = indices.data_ref().null_buffer().cloned();
+    } else {
+        let mut null_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, true);
+        let null_slice = null_buf.data_mut();
 
-        Ok(())
-    })?;
+        (0..data_len).try_for_each::<_, Result<()>>(|i| {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
 
-    let nulls = match indices.data_ref().null_buffer() {
-        Some(buffer) => buffer_bin_and(buffer, 0, &null_buf.freeze(), 0, indices.len()),
-        None => null_buf.freeze(),
-    };
+            if array.is_null(index) {
+                bit_util::unset_bit(null_slice, i);
+            } else if array.value(index) {
+                bit_util::set_bit(val_slice, i);
+            }
+
+            Ok(())
+        })?;
+
+        nulls = match indices.data_ref().null_buffer() {
+            Some(buffer) => Some(buffer_bin_and(
+                buffer,
+                0,
+                &null_buf.freeze(),
+                0,
+                indices.len(),
+            )),
+            None => Some(null_buf.freeze()),
+        };
+    }
 
     let data = ArrayData::new(
         DataType::Boolean,
         indices.len(),
         None,
-        Some(nulls),
+        nulls,
         0,
         vec![val_buf.freeze()],
         vec![],


### PR DESCRIPTION
This PR significantly speeds up the take (primitive and boolean) kernels for non-null arrays (even more if indices contain nulls)


```
take i32 512            time:   [1.1847 us 1.1879 us 1.1915 us]
                        change: [-47.038% -46.813% -46.609%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking take i32 1024: Collecting 100 samples in estimated 5.0083 s (2.2M i                                                                                take i32 1024           time:   [2.2183 us 2.2255 us 2.2330 us]
                        change: [-48.699% -47.683% -46.797%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild

Benchmarking take i32 nulls 512: Collecting 100 samples in estimated 5.0016 s (3                                                                                take i32 nulls 512      time:   [1.2828 us 1.2882 us 1.2941 us]
                        change: [-44.592% -44.377% -44.178%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  6 (6.00%) high mild
  4 (4.00%) high severe

Benchmarking take i32 nulls 1024: Collecting 100 samples in estimated 5.0112 s (                                                                                take i32 nulls 1024     time:   [2.3798 us 2.3846 us 2.3894 us]
                        change: [-41.139% -40.735% -40.358%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild

Benchmarking take bool 512: Collecting 100 samples in estimated 5.0061 s (3.6M i                                                                                take bool 512           time:   [1.3864 us 1.3937 us 1.4009 us]
                        change: [-38.319% -38.028% -37.734%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

Benchmarking take bool 1024: Collecting 100 samples in estimated 5.0006 s (2.0M                                                                                 take bool 1024          time:   [2.4654 us 2.4722 us 2.4790 us]
                        change: [-36.041% -35.820% -35.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking take bool nulls 512: Collecting 100 samples in estimated 5.0002 s (                                                                                take bool nulls 512     time:   [1.1865 us 1.1901 us 1.1939 us]
                        change: [-66.326% -65.988% -65.656%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking take bool nulls 1024: Collecting 100 samples in estimated 5.0098 s                                                                                 take bool nulls 1024    time:   [2.0748 us 2.0814 us 2.0889 us]
                        change: [-73.180% -73.053% -72.925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```