### PR TITLE
ARROW-10627: [Rust] Loosen cfg restrictions for wasm32

### DIFF
--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -564,10 +564,9 @@ pub(super) fn buffer_bin_and(
     }
 }
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(any(feature = "simd", feature = "avx512"))
-))]
+// Note: do not target specific features like x86 without considering
+// other targets like wasm32, as those would fail to build
+#[cfg(all(not(any(feature = "simd", feature = "avx512"))))]
 pub(super) fn buffer_bin_and(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -674,10 +673,7 @@ pub(super) fn buffer_bin_or(
     }
 }
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(any(feature = "simd", feature = "avx512"))
-))]
+#[cfg(all(not(any(feature = "simd", feature = "avx512"))))]
 pub(super) fn buffer_bin_or(
     left: &Buffer,
     left_offset_in_bits: usize,


### PR DESCRIPTION
One of our recent changes made compiling under non-x86/amd64 platforms to return errors.
This removes those restrictions as a quick fix.

I'm a bit wary of introducing `wasm32` targets into CI for now, as the tests don't yet work, and we would just increase CI time for everyone.
There is also a separate JIRA for this work, so I'm not including it here.