### PR TITLE
ARROW-10765: [Rust] Optimize take string for non-null arrays

### DIFF
--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -365,43 +365,81 @@ where
         .unwrap();
 
     let num_bytes = bit_util::ceil(data_len, 8);
-    let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-    let null_slice = null_buf.data_mut();
 
+    let null_count = array.null_count();
     let mut offsets = Vec::with_capacity(data_len + 1);
     let mut values = Vec::with_capacity(data_len);
     let mut length_so_far = OffsetSize::zero();
 
-    offsets.push(length_so_far);
-    for i in 0..data_len {
-        let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
-            ArrowError::ComputeError("Cast to usize failed".to_string())
-        })?;
+    let nulls;
+    if null_count == 0 && indices.null_count() == 0 {
+        for i in 0..data_len {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
 
-        if array.is_valid(index) && indices.is_valid(i) {
             let s = array.value(index);
 
             length_so_far += OffsetSize::from_usize(s.len()).unwrap();
             values.extend_from_slice(s.as_bytes());
-        } else {
-            // set null bit
-            bit_util::unset_bit(null_slice, i);
+            offsets.push(length_so_far);
         }
+        nulls = None
+    } else if null_count == 0 {
+        for i in 0..data_len {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
+
+            if indices.is_valid(i) {
+                let s = array.value(index);
+
+                length_so_far += OffsetSize::from_usize(s.len()).unwrap();
+                values.extend_from_slice(s.as_bytes());
+            }
+            offsets.push(length_so_far);
+        }
+        nulls = None
+    } else {
+        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
+        let null_slice = null_buf.data_mut();
+
         offsets.push(length_so_far);
+        for i in 0..data_len {
+            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                ArrowError::ComputeError("Cast to usize failed".to_string())
+            })?;
+
+            if array.is_valid(index) && indices.is_valid(i) {
+                let s = array.value(index);
+
+                length_so_far += OffsetSize::from_usize(s.len()).unwrap();
+                values.extend_from_slice(s.as_bytes());
+            } else {
+                // set null bit
+                bit_util::unset_bit(null_slice, i);
+            }
+            offsets.push(length_so_far);
+        }
+
+        nulls = match indices.data_ref().null_buffer() {
+            Some(buffer) => {
+                Some(buffer_bin_and(buffer, 0, &null_buf.freeze(), 0, data_len))
+            }
+            None => Some(null_buf.freeze()),
+        };
     }
 
-    let nulls = match indices.data_ref().null_buffer() {
-        Some(buffer) => buffer_bin_and(buffer, 0, &null_buf.freeze(), 0, data_len),
-        None => null_buf.freeze(),
-    };
-
-    let data = ArrayData::builder(<OffsetSize as StringOffsetSizeTrait>::DATA_TYPE)
+    let mut data = ArrayData::builder(<OffsetSize as StringOffsetSizeTrait>::DATA_TYPE)
         .len(data_len)
-        .null_bit_buffer(nulls)
         .add_buffer(Buffer::from(offsets.to_byte_slice()))
-        .add_buffer(Buffer::from(&values[..]))
-        .build();
-    Ok(Arc::new(GenericStringArray::<OffsetSize>::from(data)))
+        .add_buffer(Buffer::from(&values[..]));
+    if let Some(null_buffer) = nulls {
+        data = data.add_buffer(null_buffer);
+    }
+    Ok(Arc::new(GenericStringArray::<OffsetSize>::from(
+        data.build(),
+    )))
 }
 
 /// `take` implementation for list arrays

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -370,6 +370,7 @@ where
     let mut offsets = Vec::with_capacity(data_len + 1);
     let mut values = Vec::with_capacity(data_len);
     let mut length_so_far = OffsetSize::zero();
+    offsets.push(length_so_far);
 
     let nulls;
     if null_count == 0 && indices.null_count() == 0 {
@@ -399,12 +400,11 @@ where
             }
             offsets.push(length_so_far);
         }
-        nulls = None
+        nulls = indices.data_ref().null_buffer().cloned();
     } else {
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
         let null_slice = null_buf.data_mut();
 
-        offsets.push(length_so_far);
         for i in 0..data_len {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
                 ArrowError::ComputeError("Cast to usize failed".to_string())

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -435,7 +435,7 @@ where
         .add_buffer(Buffer::from(offsets.to_byte_slice()))
         .add_buffer(Buffer::from(&values[..]));
     if let Some(null_buffer) = nulls {
-        data = data.add_buffer(null_buffer);
+        data = data.null_bit_buffer(null_buffer);
     }
     Ok(Arc::new(GenericStringArray::<OffsetSize>::from(
         data.build(),

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -389,10 +389,11 @@ where
     } else if null_count == 0 {
         for i in 0..data_len {
             if indices.is_valid(i) {
-                let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
-                    ArrowError::ComputeError("Cast to usize failed".to_string())
-                })?;
-    
+                let index =
+                    ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                        ArrowError::ComputeError("Cast to usize failed".to_string())
+                    })?;
+
                 let s = array.value(index);
 
                 length_so_far += OffsetSize::from_usize(s.len()).unwrap();

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -388,11 +388,11 @@ where
         nulls = None
     } else if null_count == 0 {
         for i in 0..data_len {
-            let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
-                ArrowError::ComputeError("Cast to usize failed".to_string())
-            })?;
-
             if indices.is_valid(i) {
+                let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+                    ArrowError::ComputeError("Cast to usize failed".to_string())
+                })?;
+    
                 let s = array.value(index);
 
                 length_so_far += OffsetSize::from_usize(s.len()).unwrap();


### PR DESCRIPTION
Simarly as in https://github.com/apache/arrow/pull/8795 we can optimize take for strings for non-null arrays as well.

```
Benchmarking take str 512: Collecting 100 samples in estimated 5.0028 s (3.0M it                                                                                take str 512            time:   [1.6526 us 1.6593 us 1.6663 us]
                        change: [-42.763% -42.500% -42.200%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking take str 1024: Collecting 100 samples in estimated 5.0104 s (1.6M i                                                                                take str 1024           time:   [2.9526 us 2.9550 us 2.9576 us]
                        change: [-39.657% -39.134% -38.514%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high severe

Benchmarking take str nulls 512: Collecting 100 samples in estimated 5.0001 s (1                                                                                take str nulls 512      time:   [3.2271 us 3.2319 us 3.2371 us]
                        change: [-30.930% -30.716% -30.495%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Benchmarking take str nulls 1024: Collecting 100 samples in estimated 5.0320 s (                                                                                take str nulls 1024     time:   [7.6034 us 7.6135 us 7.6240 us]
                        change: [-22.503% -22.027% -21.564%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
```