### PR TITLE
ARROW-10767: [Rust] Speed up sum with nulls (non-simd)

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -156,10 +156,13 @@ where
             data_chunks
                 .zip(bit_chunks.iter())
                 .for_each(|(chunk, mask)| {
-                    chunk.iter().enumerate().for_each(|(i, value)| {
-                        if (mask & (1 << i)) != 0 {
+                    // index_mask has value 1 << i in the loop
+                    let mut index_mask = 1;
+                    chunk.iter().for_each(|value| {
+                        if (mask & index_mask) != 0 {
                             sum = sum + *value;
                         }
+                        index_mask <<= 1;
                     });
                 });
 


### PR DESCRIPTION
Speeds up sum kernel with nulls by simplifying mask calculation in inner loop.


```
sum nulls 512           time:   [227.43 ns 227.73 ns 228.09 ns]                          
                        change: [-53.623% -53.506% -53.391%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```