### PR TITLE
ARROW-10769: [Rust] Revert "ARROW-10656: [Rust] Use DataType comparison without values"

### DIFF
--- a/rust/arrow/examples/builders.rs
+++ b/rust/arrow/examples/builders.rs
@@ -25,9 +25,7 @@ use arrow::array::{
     StringArray, StructArray,
 };
 use arrow::buffer::Buffer;
-use arrow::datatypes::{
-    DataType, Date64Type, Field, NullableDataType, Time64NanosecondType, ToByteSlice,
-};
+use arrow::datatypes::{DataType, Date64Type, Field, Time64NanosecondType, ToByteSlice};
 
 fn main() {
     // Primitive Arrays
@@ -102,7 +100,7 @@ fn main() {
 
     // Construct a list array from the above two
     let list_data_type =
-        DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+        DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
     let list_data = ArrayData::builder(list_data_type)
         .len(3)
         .add_buffer(value_offsets)

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -596,7 +596,7 @@ impl Array for DecimalArray {
 
 #[cfg(test)]
 mod tests {
-    use crate::datatypes::NullableDataType;
+    use crate::datatypes::Field;
 
     use super::*;
 
@@ -908,7 +908,7 @@ mod tests {
             .build();
 
         let array_data = ArrayData::builder(DataType::FixedSizeList(
-            Box::new(NullableDataType::new(DataType::Binary, false)),
+            Box::new(Field::new("item", DataType::Binary, false)),
             4,
         ))
         .len(3)

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -297,12 +297,15 @@ impl fmt::Debug for FixedSizeListArray {
 #[cfg(test)]
 mod tests {
     use crate::{
-        array::ArrayData, array::Int32Array, buffer::Buffer, datatypes::ToByteSlice,
-        memory, util::bit_util,
+        array::ArrayData,
+        array::Int32Array,
+        buffer::Buffer,
+        datatypes::{Field, ToByteSlice},
+        memory,
+        util::bit_util,
     };
 
     use super::*;
-    use crate::datatypes::NullableDataType;
 
     #[test]
     fn test_list_array() {
@@ -318,7 +321,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(3)
             .add_buffer(value_offsets.clone())
@@ -388,7 +391,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(3)
             .add_buffer(value_offsets.clone())
@@ -454,7 +457,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::FixedSizeList(
-            Box::new(NullableDataType::new(DataType::Int32, false)),
+            Box::new(Field::new("item", DataType::Int32, false)),
             3,
         );
         let list_data = ArrayData::builder(list_data_type.clone())
@@ -523,7 +526,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::FixedSizeList(
-            Box::new(NullableDataType::new(DataType::Int32, false)),
+            Box::new(Field::new("item", DataType::Int32, false)),
             3,
         );
         let list_data = ArrayData::builder(list_data_type)
@@ -557,7 +560,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(9)
             .add_buffer(value_offsets)
@@ -622,7 +625,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(9)
             .add_buffer(value_offsets)
@@ -685,7 +688,7 @@ mod tests {
 
         // Construct a fixed size list array from the above two
         let list_data_type = DataType::FixedSizeList(
-            Box::new(NullableDataType::new(DataType::Int32, false)),
+            Box::new(Field::new("item", DataType::Int32, false)),
             2,
         );
         let list_data = ArrayData::builder(list_data_type)
@@ -736,7 +739,7 @@ mod tests {
             .add_buffer(Buffer::from(&[0, 1, 2, 3, 4, 5, 6, 7].to_byte_slice()))
             .build();
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_child_data(value_data)
@@ -751,7 +754,7 @@ mod tests {
     fn test_list_array_invalid_child_array_len() {
         let value_offsets = Buffer::from(&[0, 2, 5, 7].to_byte_slice());
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -770,7 +773,7 @@ mod tests {
         let value_offsets = Buffer::from(&[2, 2, 5, 7].to_byte_slice());
 
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -802,7 +805,7 @@ mod tests {
             .build();
 
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .add_buffer(buf2)
             .add_child_data(value_data)

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -764,7 +764,8 @@ where
     ///
     /// This is used for validating array data types in `append_data`
     fn data_type(&self) -> DataType {
-        DataType::List(Box::new(NullableDataType::new(
+        DataType::List(Box::new(Field::new(
+            "item",
             self.values_builder.data_type(),
             true,
         )))
@@ -833,7 +834,8 @@ where
         let null_bit_buffer = self.bitmap_builder.finish();
         let nulls = null_bit_buffer.count_set_bits();
         self.offsets_builder.append(0).unwrap();
-        let data = ArrayData::builder(DataType::List(Box::new(NullableDataType::new(
+        let data = ArrayData::builder(DataType::List(Box::new(Field::new(
+            "item",
             values_data.data_type().clone(),
             true, // TODO: find a consistent way of getting this
         ))))
@@ -974,7 +976,8 @@ where
     ///
     /// This is used for validating array data types in `append_data`
     fn data_type(&self) -> DataType {
-        DataType::LargeList(Box::new(NullableDataType::new(
+        DataType::LargeList(Box::new(Field::new(
+            "item",
             self.values_builder.data_type(),
             true,
         )))
@@ -1043,9 +1046,11 @@ where
         let null_bit_buffer = self.bitmap_builder.finish();
         let nulls = null_bit_buffer.count_set_bits();
         self.offsets_builder.append(0).unwrap();
-        let data = ArrayData::builder(DataType::LargeList(Box::new(
-            NullableDataType::new(values_data.data_type().clone(), true),
-        )))
+        let data = ArrayData::builder(DataType::LargeList(Box::new(Field::new(
+            "item",
+            values_data.data_type().clone(),
+            true,
+        ))))
         .len(len)
         .null_count(len - nulls)
         .add_buffer(offset_buffer)
@@ -1153,7 +1158,7 @@ where
     /// This is used for validating array data types in `append_data`
     fn data_type(&self) -> DataType {
         DataType::FixedSizeList(
-            Box::new(NullableDataType::new(self.values_builder.data_type(), true)),
+            Box::new(Field::new("item", self.values_builder.data_type(), true)),
             self.list_len,
         )
     }
@@ -1232,7 +1237,7 @@ where
         let null_bit_buffer = self.bitmap_builder.finish();
         let nulls = null_bit_buffer.count_set_bits();
         let data = ArrayData::builder(DataType::FixedSizeList(
-            Box::new(NullableDataType::new(values_data.data_type().clone(), true)),
+            Box::new(Field::new("item", values_data.data_type().clone(), true)),
             self.list_len,
         ))
         .len(len)
@@ -1453,10 +1458,7 @@ fn append_binary_data(
                 )) as ArrayDataRef;
 
                 Arc::new(ArrayData::new(
-                    DataType::List(Box::new(NullableDataType::new(
-                        DataType::UInt8,
-                        true,
-                    ))),
+                    DataType::List(Box::new(Field::new("item", DataType::UInt8, true))),
                     array.len(),
                     None,
                     array.null_buffer().cloned(),
@@ -1508,7 +1510,8 @@ fn append_large_binary_data(
                 )) as ArrayDataRef;
 
                 Arc::new(ArrayData::new(
-                    DataType::LargeList(Box::new(NullableDataType::new(
+                    DataType::LargeList(Box::new(Field::new(
+                        "item",
                         DataType::UInt8,
                         true,
                     ))),
@@ -1610,7 +1613,7 @@ impl ArrayBuilder for FixedSizeBinaryBuilder {
             )) as ArrayDataRef;
             let list_data = Arc::new(ArrayData::new(
                 DataType::FixedSizeList(
-                    Box::new(NullableDataType::new(DataType::UInt8, true)),
+                    Box::new(Field::new("item", DataType::UInt8, true)),
                     self.builder.list_len,
                 ),
                 array.len(),
@@ -1696,7 +1699,7 @@ impl ArrayBuilder for DecimalBuilder {
             )) as ArrayDataRef;
             let list_data = Arc::new(ArrayData::new(
                 DataType::FixedSizeList(
-                    Box::new(NullableDataType::new(DataType::UInt8, true)),
+                    Box::new(Field::new("item", DataType::UInt8, true)),
                     self.builder.list_len,
                 ),
                 array.len(),
@@ -3817,13 +3820,13 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Data type List(NullableDataType { data_type: Int64, nullable: true }) is not currently supported"
+        expected = "Data type List(Field { name: \"item\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false }) is not currently supported"
     )]
     fn test_struct_array_builder_from_schema_unsupported_type() {
         let mut fields = Vec::new();
         fields.push(Field::new("f1", DataType::Int16, false));
         let list_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int64, true)));
+            DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
         fields.push(Field::new("f2", list_type, false));
 
         let _ = StructBuilder::from_fields(fields, 5);
@@ -4122,7 +4125,7 @@ mod tests {
         let list_value_offsets =
             Buffer::from(&[0, 3, 5, 11, 13, 13, 15, 15, 17].to_byte_slice());
         let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(NullableDataType::new(DataType::Int64, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
             8,
             None,
             None,
@@ -4208,7 +4211,7 @@ mod tests {
             &[0, 3, 5, 5, 13, 15, 15, 15, 19, 19, 19, 19, 23].to_byte_slice(),
         );
         let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(NullableDataType::new(DataType::Int64, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
             12,
             None,
             None,
@@ -4250,7 +4253,7 @@ mod tests {
         ]);
         let list_value_offsets = Buffer::from(&[0, 2, 3, 6].to_byte_slice());
         let list_data = ArrayData::new(
-            DataType::List(Box::new(NullableDataType::new(DataType::Utf8, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
             3,
             None,
             None,
@@ -4285,7 +4288,7 @@ mod tests {
         ]);
         let list_value_offsets = Buffer::from(&[0, 2, 2, 4, 5, 8, 9, 12].to_byte_slice());
         let expected_list_data = ArrayData::new(
-            DataType::List(Box::new(NullableDataType::new(DataType::Utf8, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
             7,
             None,
             None, // is this correct?
@@ -4374,7 +4377,7 @@ mod tests {
         ]);
         let expected_list_data = ArrayData::new(
             DataType::FixedSizeList(
-                Box::new(NullableDataType::new(DataType::UInt16, true)),
+                Box::new(Field::new("item", DataType::UInt16, true)),
                 2,
             ),
             12,
@@ -4447,7 +4450,7 @@ mod tests {
         ]);
         let expected_list_data = ArrayData::new(
             DataType::FixedSizeList(
-                Box::new(NullableDataType::new(DataType::UInt8, true)),
+                Box::new(Field::new("item", DataType::UInt8, true)),
                 2,
             ),
             12,

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -1237,7 +1237,7 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(
             &array,
-            &DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
         )
         .unwrap();
         assert_eq!(5, b.len());
@@ -1267,7 +1267,7 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(
             &array,
-            &DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
         )
         .unwrap();
         assert_eq!(5, b.len());
@@ -1300,7 +1300,7 @@ mod tests {
         let array = array.slice(2, 4);
         let b = cast(
             &array,
-            &DataType::List(Box::new(NullableDataType::new(DataType::Float64, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
         )
         .unwrap();
         assert_eq!(4, b.len());
@@ -1377,7 +1377,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -1387,7 +1387,7 @@ mod tests {
 
         let cast_array = cast(
             &list_array,
-            &DataType::List(Box::new(NullableDataType::new(DataType::UInt16, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::UInt16, true))),
         )
         .unwrap();
         // 3 negative values should get lost when casting to unsigned,
@@ -1436,7 +1436,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -1446,7 +1446,8 @@ mod tests {
 
         cast(
             &list_array,
-            &DataType::List(Box::new(NullableDataType::new(
+            &DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Timestamp(TimeUnit::Microsecond, None),
                 true,
             ))),
@@ -2853,7 +2854,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -2875,7 +2876,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
@@ -2895,7 +2896,7 @@ mod tests {
 
         // Construct a fixed size list array from the above two
         let list_data_type = DataType::FixedSizeList(
-            Box::new(NullableDataType::new(DataType::Int32, true)),
+            Box::new(Field::new("item", DataType::Int32, true)),
             2,
         );
         let list_data = ArrayData::builder(list_data_type)
@@ -2988,12 +2989,12 @@ mod tests {
             LargeBinary,
             Utf8,
             LargeUtf8,
-            List(Box::new(NullableDataType::new(DataType::Int8, true))),
-            List(Box::new(NullableDataType::new(DataType::Utf8, true))),
-            FixedSizeList(Box::new(NullableDataType::new(DataType::Int8, true)), 10),
-            FixedSizeList(Box::new(NullableDataType::new(DataType::Utf8, false)), 10),
-            LargeList(Box::new(NullableDataType::new(DataType::Int8, true))),
-            LargeList(Box::new(NullableDataType::new(DataType::Utf8, false))),
+            List(Box::new(Field::new("item", DataType::Int8, true))),
+            List(Box::new(Field::new("item", DataType::Utf8, true))),
+            FixedSizeList(Box::new(Field::new("item", DataType::Int8, true)), 10),
+            FixedSizeList(Box::new(Field::new("item", DataType::Utf8, false)), 10),
+            LargeList(Box::new(Field::new("item", DataType::Int8, true))),
+            LargeList(Box::new(Field::new("item", DataType::Utf8, false))),
             Struct(vec![
                 Field::new("f1", DataType::Int32, false),
                 Field::new("f2", DataType::Utf8, true),

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -776,8 +776,8 @@ fn new_all_set_buffer(len: usize) -> Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Int32Array;
-    use crate::datatypes::{Int8Type, NullableDataType, ToByteSlice};
+    use crate::datatypes::{Int8Type, ToByteSlice};
+    use crate::{array::Int32Array, datatypes::Field};
 
     #[test]
     fn test_primitive_array_eq() {
@@ -1046,7 +1046,7 @@ mod tests {
         .data();
         let value_offsets = Buffer::from(&[0i64, 3, 6, 6, 9].to_byte_slice());
         let list_data_type =
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(4)
             .add_buffer(value_offsets)

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -1080,7 +1080,7 @@ mod tests {
         let value_offsets = Buffer::from(&[0i64, 3, 6, 8, 8].to_byte_slice());
 
         let list_data_type =
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(4)
             .add_buffer(value_offsets)

--- a/rust/arrow/src/compute/kernels/limit.rs
+++ b/rust/arrow/src/compute/kernels/limit.rs
@@ -35,7 +35,7 @@ mod tests {
     use super::*;
     use crate::array::*;
     use crate::buffer::Buffer;
-    use crate::datatypes::{DataType, Field, NullableDataType, ToByteSlice};
+    use crate::datatypes::{DataType, Field, ToByteSlice};
     use crate::util::bit_util;
 
     use std::sync::Arc;
@@ -110,7 +110,7 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(9)
             .add_buffer(value_offsets)

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -810,9 +810,11 @@ mod tests {
             let value_offsets: [$offset_type; 4] = [0, 3, 6, 8];
             let value_offsets = Buffer::from(&value_offsets.to_byte_slice());
             // Construct a list array from the above two
-            let list_data_type = DataType::$list_data_type(Box::new(
-                NullableDataType::new(DataType::Int32, false),
-            ));
+            let list_data_type = DataType::$list_data_type(Box::new(Field::new(
+                "item",
+                DataType::Int32,
+                false,
+            )));
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(3)
                 .add_buffer(value_offsets)
@@ -881,9 +883,11 @@ mod tests {
             let value_offsets: [$offset_type; 5] = [0, 3, 6, 7, 9];
             let value_offsets = Buffer::from(&value_offsets.to_byte_slice());
             // Construct a list array from the above two
-            let list_data_type = DataType::$list_data_type(Box::new(
-                NullableDataType::new(DataType::Int32, false),
-            ));
+            let list_data_type = DataType::$list_data_type(Box::new(Field::new(
+                "item",
+                DataType::Int32,
+                false,
+            )));
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
@@ -952,9 +956,11 @@ mod tests {
             let value_offsets: [$offset_type; 5] = [0, 3, 6, 6, 8];
             let value_offsets = Buffer::from(&value_offsets.to_byte_slice());
             // Construct a list array from the above two
-            let list_data_type = DataType::$list_data_type(Box::new(
-                NullableDataType::new(DataType::Int32, false),
-            ));
+            let list_data_type = DataType::$list_data_type(Box::new(Field::new(
+                "item",
+                DataType::Int32,
+                false,
+            )));
             let list_data = ArrayData::builder(list_data_type.clone())
                 .len(4)
                 .add_buffer(value_offsets)
@@ -1045,7 +1051,7 @@ mod tests {
         let value_offsets = Buffer::from(&[0, 3, 6, 8].to_byte_slice());
         // Construct a list array from the above two
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, false)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -321,7 +321,7 @@ mod tests {
     #[test]
     fn test_take_value_index_from_list() {
         let list = build_list(
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
             Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
             vec![0i32, 2i32, 5i32, 10i32],
         );
@@ -337,7 +337,7 @@ mod tests {
     #[test]
     fn test_take_value_index_from_large_list() {
         let list = build_list(
-            DataType::LargeList(Box::new(NullableDataType::new(DataType::Int32, false))),
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false))),
             Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
             vec![0i64, 2i64, 5i64, 10i64],
         );

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -89,7 +89,7 @@ fn create_array(
             buffer_index += 2;
             array
         }
-        List(ref type_ctx) | LargeList(ref type_ctx) => {
+        List(ref list_field) | LargeList(ref list_field) => {
             let list_node = &nodes[node_index];
             let list_buffers: Vec<Buffer> = buffers[buffer_index..buffer_index + 2]
                 .iter()
@@ -99,7 +99,7 @@ fn create_array(
             buffer_index += 2;
             let triple = create_array(
                 nodes,
-                type_ctx.data_type(),
+                list_field.data_type(),
                 data,
                 buffers,
                 dictionaries,

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -66,16 +66,20 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
         1 => Ok(dt[0].clone()),
         2 => {
             // there can be a case where a list and scalar both exist
-            if dt.contains(&&DataType::List(Box::new(NullableDataType::new(
+            if dt.contains(&&DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Float64,
                 true,
-            )))) || dt.contains(&&DataType::List(Box::new(NullableDataType::new(
+            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Int64,
                 true,
-            )))) || dt.contains(&&DataType::List(Box::new(NullableDataType::new(
+            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Boolean,
                 true,
-            )))) || dt.contains(&&DataType::List(Box::new(NullableDataType::new(
+            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Utf8,
                 true,
             )))) {
@@ -86,12 +90,14 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
                 match (dt[0], dt[1]) {
                     (t1, DataType::List(e)) if e.data_type() == &DataType::Float64 => {
                         if t1 == &DataType::Float64 {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 DataType::Float64,
                                 true,
                             ))))
                         } else {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 coerce_data_type(vec![t1, &DataType::Float64])?,
                                 true,
                             ))))
@@ -99,12 +105,14 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
                     }
                     (t1, DataType::List(e)) if e.data_type() == &DataType::Int64 => {
                         if t1 == &DataType::Int64 {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 DataType::Int64,
                                 true,
                             ))))
                         } else {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 coerce_data_type(vec![t1, &DataType::Int64])?,
                                 true,
                             ))))
@@ -112,12 +120,14 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
                     }
                     (t1, DataType::List(e)) if e.data_type() == &DataType::Boolean => {
                         if t1 == &DataType::Boolean {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 DataType::Boolean,
                                 true,
                             ))))
                         } else {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 coerce_data_type(vec![t1, &DataType::Boolean])?,
                                 true,
                             ))))
@@ -125,12 +135,14 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
                     }
                     (t1, DataType::List(e)) if e.data_type() == &DataType::Utf8 => {
                         if t1 == &DataType::Utf8 {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 DataType::Utf8,
                                 true,
                             ))))
                         } else {
-                            Ok(DataType::List(Box::new(NullableDataType::new(
+                            Ok(DataType::List(Box::new(Field::new(
+                                "item",
                                 coerce_data_type(vec![t1, &DataType::Utf8])?,
                                 true,
                             ))))
@@ -150,7 +162,8 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
         _ => {
             // TODO(nevi_me) It's possible to have [float, int, list(float)], which should
             // return list(float). Will hash this out later
-            Ok(DataType::List(Box::new(NullableDataType::new(
+            Ok(DataType::List(Box::new(Field::new(
+                "item",
                 DataType::Utf8,
                 true,
             ))))
@@ -291,13 +304,13 @@ pub fn infer_json_schema<R: Read>(
                                         if values.contains_key(k) {
                                             let x = values.get_mut(k).unwrap();
                                             x.insert(DataType::List(Box::new(
-                                                NullableDataType::new(dt, true),
+                                                Field::new("item", dt, true),
                                             )));
                                         } else {
                                             // create hashset and add value type
                                             let mut hs = HashSet::new();
                                             hs.insert(DataType::List(Box::new(
-                                                NullableDataType::new(dt, true),
+                                                Field::new("item", dt, true),
                                             )));
                                             values.insert(k.to_string(), hs);
                                         }
@@ -1422,12 +1435,12 @@ mod tests {
         assert_eq!(&DataType::Int64, a.1.data_type());
         let b = schema.column_with_name("b").unwrap();
         assert_eq!(
-            &DataType::List(Box::new(NullableDataType::new(DataType::Float64, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
             b.1.data_type()
         );
         let c = schema.column_with_name("c").unwrap();
         assert_eq!(
-            &DataType::List(Box::new(NullableDataType::new(DataType::Boolean, true))),
+            &DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
             c.1.data_type()
         );
         let d = schema.column_with_name("d").unwrap();
@@ -1480,35 +1493,35 @@ mod tests {
         use crate::datatypes::DataType::*;
 
         assert_eq!(
-            List(Box::new(NullableDataType::new(Float64, true))),
+            List(Box::new(Field::new("item", Float64, true))),
             coerce_data_type(vec![
                 &Float64,
-                &List(Box::new(NullableDataType::new(Float64, true)))
+                &List(Box::new(Field::new("item", Float64, true)))
             ])
             .unwrap()
         );
         assert_eq!(
-            List(Box::new(NullableDataType::new(Float64, true))),
+            List(Box::new(Field::new("item", Float64, true))),
             coerce_data_type(vec![
                 &Float64,
-                &List(Box::new(NullableDataType::new(Int64, true)))
+                &List(Box::new(Field::new("item", Int64, true)))
             ])
             .unwrap()
         );
         assert_eq!(
-            List(Box::new(NullableDataType::new(Int64, true))),
+            List(Box::new(Field::new("item", Int64, true))),
             coerce_data_type(vec![
                 &Int64,
-                &List(Box::new(NullableDataType::new(Int64, true)))
+                &List(Box::new(Field::new("item", Int64, true)))
             ])
             .unwrap()
         );
         // boolean and number are incompatible, return utf8
         assert_eq!(
-            List(Box::new(NullableDataType::new(Utf8, true))),
+            List(Box::new(Field::new("item", Utf8, true))),
             coerce_data_type(vec![
                 &Boolean,
-                &List(Box::new(NullableDataType::new(Float64, true)))
+                &List(Box::new(Field::new("item", Float64, true)))
             ])
             .unwrap()
         );
@@ -1541,17 +1554,17 @@ mod tests {
             assert_eq!(&DataType::Int64, a.1.data_type());
             let b = schema.column_with_name("b").unwrap();
             assert_eq!(
-                &DataType::List(Box::new(NullableDataType::new(DataType::Float64, true))),
+                &DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
                 b.1.data_type()
             );
             let c = schema.column_with_name("c").unwrap();
             assert_eq!(
-                &DataType::List(Box::new(NullableDataType::new(DataType::Boolean, true))),
+                &DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
                 c.1.data_type()
             );
             let d = schema.column_with_name("d").unwrap();
             assert_eq!(
-                &DataType::List(Box::new(NullableDataType::new(DataType::Utf8, true))),
+                &DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
                 d.1.data_type()
             );
 
@@ -1791,7 +1804,8 @@ mod tests {
     fn test_list_of_string_dictionary_from_json() {
         let schema = Schema::new(vec![Field::new(
             "events",
-            List(Box::new(NullableDataType::new(
+            List(Box::new(Field::new(
+                "item",
                 Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Utf8)),
                 true,
             ))),
@@ -1814,7 +1828,8 @@ mod tests {
 
         let events = schema.column_with_name("events").unwrap();
         assert_eq!(
-            &List(Box::new(NullableDataType::new(
+            &List(Box::new(Field::new(
+                "item",
                 Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Utf8)),
                 true
             ))),
@@ -1848,7 +1863,8 @@ mod tests {
     fn test_list_of_string_dictionary_from_json_with_nulls() {
         let schema = Schema::new(vec![Field::new(
             "events",
-            List(Box::new(NullableDataType::new(
+            List(Box::new(Field::new(
+                "item",
                 Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Utf8)),
                 true,
             ))),
@@ -1873,7 +1889,8 @@ mod tests {
 
         let events = schema.column_with_name("events").unwrap();
         assert_eq!(
-            &List(Box::new(NullableDataType::new(
+            &List(Box::new(Field::new(
+                "item",
                 Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Utf8)),
                 true
             ))),
@@ -2014,17 +2031,17 @@ mod tests {
             Field::new("a", DataType::Int64, true),
             Field::new(
                 "b",
-                DataType::List(Box::new(NullableDataType::new(DataType::Float64, true))),
+                DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
                 true,
             ),
             Field::new(
                 "c",
-                DataType::List(Box::new(NullableDataType::new(DataType::Boolean, true))),
+                DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
                 true,
             ),
             Field::new(
                 "d",
-                DataType::List(Box::new(NullableDataType::new(DataType::Utf8, true))),
+                DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
                 true,
             ),
         ]);

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -299,42 +299,6 @@ mod tests {
     }
 
     #[test]
-    fn create_record_batch_with_matching_nested_type() {
-        let schema = Schema::new(vec![Field::new(
-            "list",
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
-            false,
-        )]);
-
-        let child_data = Int32Array::from(vec![0, 1, 2, 3, 4, 5]);
-        let child_data_ref = Arc::new(ArrayData::new(
-            DataType::Int32,
-            6,
-            None,
-            None,
-            0,
-            vec![child_data.data_ref().buffers()[0].clone()],
-            vec![],
-        ));
-
-        let offsets = UInt64Array::from(vec![0, 2, 4]);
-        let array_data = Arc::new(ArrayData::new(
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
-            3,
-            None,
-            None,
-            0,
-            vec![offsets.data_ref().buffers()[0].clone()],
-            vec![child_data_ref],
-        ));
-
-        let list_array = Arc::new(ListArray::from(array_data));
-
-        let result = RecordBatch::try_new(Arc::new(schema), vec![list_array]);
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn create_record_batch_from_struct_array() {
         let boolean_data = ArrayData::builder(DataType::Boolean)
             .len(4)

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -688,7 +688,11 @@ mod tests {
             Field::new("c3", DataType::Utf8, true),
             Field::new(
                 "c4",
-                DataType::List(Box::new(NullableDataType::new(DataType::Int32, false))),
+                DataType::List(Box::new(Field::new(
+                    "custom_item",
+                    DataType::Int32,
+                    false,
+                ))),
                 true,
             ),
         ]);
@@ -758,7 +762,7 @@ mod tests {
             Field::new("utf8s", DataType::Utf8, true),
             Field::new(
                 "lists",
-                DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
+                DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
                 true,
             ),
             Field::new(
@@ -835,7 +839,7 @@ mod tests {
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);
         let value_offsets = Buffer::from(&[0, 3, 4, 4].to_byte_slice());
         let list_data_type =
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true)));
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)

--- a/rust/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/rust/datafusion/src/physical_plan/distinct_expressions.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
 
-use arrow::datatypes::{DataType, Field, NullableDataType};
+use arrow::datatypes::{DataType, Field};
 
 use ahash::RandomState;
 use std::collections::HashSet;
@@ -81,10 +81,7 @@ impl AggregateExpr for DistinctCount {
             .map(|data_type| {
                 Field::new(
                     &format_state_name(&self.name, "count distinct"),
-                    DataType::List(Box::new(NullableDataType::new(
-                        data_type.clone(),
-                        true,
-                    ))),
+                    DataType::List(Box::new(Field::new("item", data_type.clone(), true))),
                     false,
                 )
             })

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -39,12 +39,11 @@ use crate::physical_plan::datetime_expressions;
 use crate::physical_plan::expressions::{nullif_func, SUPPORTED_NULLIF_TYPES};
 use crate::physical_plan::math_expressions;
 use crate::physical_plan::string_expressions;
-use arrow::datatypes::NullableDataType;
 use arrow::{
     array::ArrayRef,
     compute::kernels::length::length,
     datatypes::TimeUnit,
-    datatypes::{DataType, Schema},
+    datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
 use fmt::{Debug, Formatter};
@@ -208,7 +207,7 @@ pub fn return_type(
             Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
         }
         BuiltinScalarFunction::Array => Ok(DataType::FixedSizeList(
-            Box::new(NullableDataType::new(arg_types[0].clone(), true)),
+            Box::new(Field::new("item", arg_types[0].clone(), true)),
             arg_types.len() as i32,
         )),
         BuiltinScalarFunction::NullIf => {
@@ -485,10 +484,7 @@ mod tests {
         assert_eq!(
             expr.data_type(&schema)?,
             // type equals to a common coercion
-            DataType::FixedSizeList(
-                Box::new(NullableDataType::new(expected_type, true)),
-                2
-            )
+            DataType::FixedSizeList(Box::new(Field::new("item", expected_type, true)), 2)
         );
 
         // evaluate works

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -786,7 +786,7 @@ mod tests {
         };
         let plan = planner.create_physical_plan(&logical_plan, &ctx_state);
 
-        let expected_error = "Extension planner for NoOp created an ExecutionPlan with mismatched schema. LogicalPlan schema: Schema { fields: [Field { name: \"a\", data_type: NullableDataType { data_type: Int32, nullable: false }, dict_id: 0, dict_is_ordered: false }], metadata: {} }, ExecutionPlan schema: Schema { fields: [Field { name: \"b\", data_type: NullableDataType { data_type: Int32, nullable: false }, dict_id: 0, dict_is_ordered: false }], metadata: {} }";
+        let expected_error = "Extension planner for NoOp created an ExecutionPlan with mismatched schema. LogicalPlan schema: Schema { fields: [Field { name: \"a\", data_type: Int32, nullable: false, dict_id: 0, dict_is_ordered: false }], metadata: {} }, ExecutionPlan schema: Schema { fields: [Field { name: \"b\", data_type: Int32, nullable: false, dict_id: 0, dict_is_ordered: false }], metadata: {} }";
 
         match plan {
             Ok(_) => assert!(false, "Expected planning failure"),

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -23,7 +23,10 @@ use arrow::array::{
     Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder, UInt16Builder,
     UInt32Builder, UInt64Builder, UInt8Builder,
 };
-use arrow::{array::ArrayRef, datatypes::DataType};
+use arrow::{
+    array::ArrayRef,
+    datatypes::{DataType, Field},
+};
 use arrow::{
     array::{
         Array, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array,
@@ -34,7 +37,6 @@ use arrow::{
 };
 
 use crate::error::{DataFusionError, Result};
-use arrow::datatypes::NullableDataType;
 
 /// Represents a dynamically typed, nullable single value.
 /// This is the single-valued counter-part of arrow’s `Array`.
@@ -134,7 +136,7 @@ impl ScalarValue {
             ScalarValue::Utf8(_) => DataType::Utf8,
             ScalarValue::LargeUtf8(_) => DataType::LargeUtf8,
             ScalarValue::List(_, data_type) => {
-                DataType::List(Box::new(NullableDataType::new(data_type.clone(), true)))
+                DataType::List(Box::new(Field::new("item", data_type.clone(), true)))
             }
             ScalarValue::Date32(_) => DataType::Date32(DateUnit::Day),
         }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -25,7 +25,7 @@ extern crate datafusion;
 use arrow::{array::*, datatypes::TimeUnit};
 use arrow::{datatypes::Int32Type, datatypes::Int64Type, record_batch::RecordBatch};
 use arrow::{
-    datatypes::{DataType, Field, NullableDataType, Schema, SchemaRef},
+    datatypes::{DataType, Field, Schema, SchemaRef},
     util::display::array_value_to_string,
 };
 
@@ -142,12 +142,12 @@ async fn parquet_list_columns() {
     let schema = Arc::new(Schema::new(vec![
         Field::new(
             "int64_list",
-            DataType::List(Box::new(NullableDataType::new(DataType::Int64, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Int64, true))),
             true,
         ),
         Field::new(
             "utf8_list",
-            DataType::List(Box::new(NullableDataType::new(DataType::Utf8, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
             true,
         ),
     ]));

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -408,14 +408,9 @@ fn array_from_json(
             }
             Ok(Arc::new(b.finish()))
         }
-        DataType::List(type_ctx) => {
+        DataType::List(child_field) => {
             let null_buf = create_null_buf(&json_col);
             let children = json_col.children.clone().unwrap();
-            let child_field = Field::new(
-                "element",
-                type_ctx.data_type().clone(),
-                type_ctx.is_nullable(),
-            );
             let child_array = array_from_json(
                 &child_field,
                 children.get(0).unwrap().clone(),
@@ -436,14 +431,9 @@ fn array_from_json(
                 .build();
             Ok(Arc::new(ListArray::from(list_data)))
         }
-        DataType::LargeList(type_ctx) => {
+        DataType::LargeList(child_field) => {
             let null_buf = create_null_buf(&json_col);
             let children = json_col.children.clone().unwrap();
-            let child_field = Field::new(
-                "element",
-                type_ctx.data_type().clone(),
-                type_ctx.is_nullable(),
-            );
             let child_array = array_from_json(
                 &child_field,
                 children.get(0).unwrap().clone(),
@@ -468,13 +458,8 @@ fn array_from_json(
                 .build();
             Ok(Arc::new(LargeListArray::from(list_data)))
         }
-        DataType::FixedSizeList(type_ctx, _) => {
+        DataType::FixedSizeList(child_field, _) => {
             let children = json_col.children.clone().unwrap();
-            let child_field = Field::new(
-                "element",
-                type_ctx.data_type().clone(),
-                type_ctx.is_nullable(),
-            );
             let child_array = array_from_json(
                 &child_field,
                 children.get(0).unwrap().clone(),
@@ -495,8 +480,8 @@ fn array_from_json(
                 .len(json_col.count)
                 .null_bit_buffer(null_buf);
 
-            for (f, col) in fields.iter().zip(json_col.children.unwrap()) {
-                let array = array_from_json(f, col, dictionaries)?;
+            for (field, col) in fields.iter().zip(json_col.children.unwrap()) {
+                let array = array_from_json(field, col, dictionaries)?;
                 array_data = array_data.add_child_data(array.data());
             }
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -40,7 +40,7 @@ use arrow::datatypes::{
     DurationSecondType as ArrowDurationSecondType, Field,
     Float32Type as ArrowFloat32Type, Float64Type as ArrowFloat64Type,
     Int16Type as ArrowInt16Type, Int32Type as ArrowInt32Type,
-    Int64Type as ArrowInt64Type, Int8Type as ArrowInt8Type, NullableDataType, Schema,
+    Int64Type as ArrowInt64Type, Int8Type as ArrowInt8Type, Schema,
     Time32MillisecondType as ArrowTime32MillisecondType,
     Time32SecondType as ArrowTime32SecondType,
     Time64MicrosecondType as ArrowTime64MicrosecondType,
@@ -1347,7 +1347,8 @@ impl<'a> TypeVisitor<Option<Box<dyn ArrayReader>>, &'a ArrayReaderBuilderContext
                     .ok()
                     .map(|f| f.data_type().to_owned())
                     .unwrap_or_else(|| {
-                        ArrowType::List(Box::new(NullableDataType::new(
+                        ArrowType::List(Box::new(Field::new(
+                            list_type.name(),
                             item_reader_type.clone(),
                             list_type.is_optional(),
                         )))
@@ -1627,7 +1628,7 @@ mod tests {
     };
     use arrow::datatypes::{
         ArrowPrimitiveType, DataType as ArrowType, Date32Type as ArrowDate32, Field,
-        Int32Type as ArrowInt32, Int64Type as ArrowInt64, NullableDataType,
+        Int32Type as ArrowInt32, Int64Type as ArrowInt64,
         Time32MillisecondType as ArrowTime32MillisecondArray,
         Time64MicrosecondType as ArrowTime64MicrosecondArray,
         TimestampMicrosecondType as ArrowTimestampMicrosecondType,
@@ -2310,7 +2311,7 @@ mod tests {
 
         let mut list_array_reader = ListArrayReader::<i32>::new(
             Box::new(item_array_reader),
-            ArrowType::List(Box::new(NullableDataType::new(ArrowType::Int32, false))),
+            ArrowType::List(Box::new(Field::new("item", ArrowType::Int32, true))),
             ArrowType::Int32,
             1,
             1,
@@ -2364,7 +2365,7 @@ mod tests {
 
         let mut list_array_reader = ListArrayReader::<i64>::new(
             Box::new(item_array_reader),
-            ArrowType::LargeList(Box::new(NullableDataType::new(ArrowType::Int32, true))),
+            ArrowType::LargeList(Box::new(Field::new("item", ArrowType::Int32, true))),
             ArrowType::Int32,
             1,
             1,

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -688,8 +688,8 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::*;
+    use arrow::datatypes::ToByteSlice;
     use arrow::datatypes::{DataType, Field, Schema, UInt32Type, UInt8Type};
-    use arrow::datatypes::{NullableDataType, ToByteSlice};
     use arrow::record_batch::RecordBatch;
 
     use crate::arrow::{ArrowReader, ParquetFileArrowReader};
@@ -776,7 +776,7 @@ mod tests {
         // define schema
         let schema = Schema::new(vec![Field::new(
             "a",
-            DataType::List(Box::new(NullableDataType::new(DataType::Int32, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
             false,
         )]);
 
@@ -789,9 +789,11 @@ mod tests {
             arrow::buffer::Buffer::from(&[0, 1, 3, 3, 6, 10].to_byte_slice());
 
         // Construct a list array from the above two
-        let a_list_data = ArrayData::builder(DataType::List(Box::new(
-            NullableDataType::new(DataType::Int32, true),
-        )))
+        let a_list_data = ArrayData::builder(DataType::List(Box::new(Field::new(
+            "items",
+            DataType::Int32,
+            true,
+        ))))
         .len(5)
         .add_buffer(a_value_offsets)
         .add_child_data(a_values.data())
@@ -874,7 +876,7 @@ mod tests {
         let struct_field_f = Field::new("f", DataType::Float32, true);
         let struct_field_g = Field::new(
             "g",
-            DataType::List(Box::new(NullableDataType::new(DataType::Int16, false))),
+            DataType::List(Box::new(Field::new("items", DataType::Int16, false))),
             false,
         );
         let struct_field_e = Field::new(
@@ -1295,9 +1297,11 @@ mod tests {
         let a_values = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let a_value_offsets =
             arrow::buffer::Buffer::from(&[0, 1, 3, 3, 6, 10].to_byte_slice());
-        let a_list_data = ArrayData::builder(DataType::List(Box::new(
-            NullableDataType::new(DataType::Int32, true),
-        )))
+        let a_list_data = ArrayData::builder(DataType::List(Box::new(Field::new(
+            "item",
+            DataType::Int32,
+            true,
+        ))))
         .len(5)
         .add_buffer(a_value_offsets)
         .add_child_data(a_values.data())
@@ -1318,9 +1322,11 @@ mod tests {
         let a_values = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         let a_value_offsets =
             arrow::buffer::Buffer::from(&[0i64, 1, 3, 3, 6, 10].to_byte_slice());
-        let a_list_data = ArrayData::builder(DataType::LargeList(Box::new(
-            NullableDataType::new(DataType::Int32, true),
-        )))
+        let a_list_data = ArrayData::builder(DataType::LargeList(Box::new(Field::new(
+            "large_item",
+            DataType::Int32,
+            true,
+        ))))
         .len(5)
         .add_buffer(a_value_offsets)
         .add_child_data(a_values.data())


### PR DESCRIPTION
This reverts commit 71e2cb255671ad98616fbca710cdb1b968580849.