### PR TITLE
ARROW-10772: [Rust] Speed up take by writing to buffer

### DIFF
--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -223,12 +223,12 @@ where
 
     if null_count == 0 {
         // Take indices without null checking
-        for i in 0..data_len {
+        for (i, elem) in data.iter_mut().enumerate() {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
                 ArrowError::ComputeError("Cast to usize failed".to_string())
             })?;
 
-            data[i] = array.value(index);
+            *elem = array.value(index);
         }
         nulls = indices.data_ref().null_buffer().cloned();
     } else {
@@ -237,7 +237,7 @@ where
 
         let null_slice = null_buf.data_mut();
 
-        for i in 0..data_len {
+        for (i, elem) in data.iter_mut().enumerate() {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
                 ArrowError::ComputeError("Cast to usize failed".to_string())
             })?;
@@ -246,7 +246,7 @@ where
                 bit_util::unset_bit(null_slice, i);
             }
 
-            data[i] = array.value(index);
+            *elem = array.value(index);
         }
         nulls = match indices.data_ref().null_buffer() {
             Some(buffer) => Some(buffer_bin_and(

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -205,6 +205,7 @@ fn take_primitive<T, I>(
 ) -> Result<ArrayRef>
 where
     T: ArrowPrimitiveType,
+    T::Native: num::Num,
     I: ArrowNumericType,
     I::Native: ToPrimitive,
 {
@@ -214,9 +215,10 @@ where
 
     let null_count = array.null_count();
 
-    // This iteration is implemented with a while loop, rather than a
-    // map()/collect(), since the while loop performs better in the benchmarks.
-    let mut new_values: Vec<T::Native> = Vec::with_capacity(data_len);
+    let mut buffer = MutableBuffer::new(data_len * std::mem::size_of::<T::Native>());
+    buffer.resize(data_len * std::mem::size_of::<T::Native>());
+    let data = buffer.typed_data_mut();
+
     let nulls;
 
     if null_count == 0 {
@@ -226,7 +228,7 @@ where
                 ArrowError::ComputeError("Cast to usize failed".to_string())
             })?;
 
-            new_values.push(array.value(index));
+            data[i] = array.value(index);
         }
         nulls = indices.data_ref().null_buffer().cloned();
     } else {
@@ -244,7 +246,7 @@ where
                 bit_util::unset_bit(null_slice, i);
             }
 
-            new_values.push(array.value(index));
+            data[i] = array.value(index);
         }
         nulls = match indices.data_ref().null_buffer() {
             Some(buffer) => Some(buffer_bin_and(
@@ -264,7 +266,7 @@ where
         None,
         nulls,
         0,
-        vec![Buffer::from(new_values.to_byte_slice())],
+        vec![buffer.freeze()],
         vec![],
     );
     Ok(Arc::new(PrimitiveArray::<T>::from(Arc::new(data))))
@@ -469,6 +471,7 @@ where
 fn take_dict<T, I>(values: &ArrayRef, indices: &PrimitiveArray<I>) -> Result<ArrayRef>
 where
     T: ArrowPrimitiveType,
+    T::Native: num::Num,
     I: ArrowNumericType,
     I::Native: ToPrimitive,
 {


### PR DESCRIPTION
This speeds up `take` a bit more by creating / writing to a buffer directly instead of creating an intermediate Vec. Quite some kernels could benefit from a similar change.

@jorgecarleitao I don't know whether this is the correct/easiest way of doing this currently?
I also think it is related to your PR/discussion about using `Vec` . 

Local benchmark results:
```
Benchmarking take i32 512: Collecting 100 samples in estimated 5.0027 s (5.8M it                                                                                
take i32 512            time:   [782.83 ns 835.58 ns 901.10 ns]
                        change: [-38.602% -34.097% -29.230%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

Benchmarking take i32 1024: Collecting 100 samples in estimated 5.0024 s (3.1M i                                                                                
take i32 1024           time:   [1.4874 us 1.5975 us 1.7365 us]
                        change: [-39.280% -32.409% -24.891%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high severe

Benchmarking take i32 nulls 512: Collecting 100 samples in estimated 5.0003 s (5                                                                                
take i32 nulls 512      time:   [887.77 ns 942.04 ns 1.0056 us]
                        change: [-37.017% -32.331% -27.416%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe

Benchmarking take i32 nulls 1024: Collecting 100 samples in estimated 5.0005 s (                                                                                
take i32 nulls 1024     time:   [1.4689 us 1.5630 us 1.6789 us]
                        change: [-35.852% -30.746% -25.307%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
```