### PR TITLE
ARROW-10776: [C++] Allow STL iteration over concrete primitive arrays

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -621,12 +621,13 @@ add_arrow_test(table_test
 
 add_arrow_test(tensor_test)
 add_arrow_test(sparse_tensor_test)
-add_arrow_test(stl_iterator_test)
 
+set(STL_TEST_SRCS stl_iterator_test.cc)
 if(ARROW_COMPUTE)
   # This unit test uses compute code
-  add_arrow_test(stl_test)
+  list(APPEND STL_TEST_SRCS stl_test.cc)
 endif()
+add_arrow_test(stl_test SOURCES ${STL_TEST_SRCS})
 
 add_arrow_benchmark(builder_benchmark)
 add_arrow_benchmark(compare_benchmark)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -621,6 +621,7 @@ add_arrow_test(table_test
 
 add_arrow_test(tensor_test)
 add_arrow_test(sparse_tensor_test)
+add_arrow_test(stl_iterator_test)
 
 if(ARROW_COMPUTE)
   # This unit test uses compute code

--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -28,6 +28,7 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
 #include "arrow/buffer.h"
+#include "arrow/stl_iterator.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/macros.h"
@@ -46,6 +47,7 @@ class BaseBinaryArray : public FlatArray {
  public:
   using TypeClass = TYPE;
   using offset_type = typename TypeClass::offset_type;
+  using IteratorType = stl::ArrayIterator<BaseBinaryArray<TYPE>>;
 
   /// Return the pointer to the given elements bytes
   // XXX should GetValue(int64_t i) return a string_view?
@@ -114,6 +116,10 @@ class BaseBinaryArray : public FlatArray {
       return 0;
     }
   }
+
+  IteratorType begin() { return IteratorType(*this); }
+
+  IteratorType end() { return IteratorType(*this, length()); }
 
  protected:
   // For subclasses
@@ -203,6 +209,7 @@ class ARROW_EXPORT LargeStringArray : public LargeBinaryArray {
 class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
  public:
   using TypeClass = FixedSizeBinaryType;
+  using IteratorType = stl::ArrayIterator<FixedSizeBinaryArray>;
 
   explicit FixedSizeBinaryArray(const std::shared_ptr<ArrayData>& data);
 
@@ -223,6 +230,10 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
   int32_t byte_width() const { return byte_width_; }
 
   const uint8_t* raw_values() const { return raw_values_ + data_->offset * byte_width_; }
+
+  IteratorType begin() { return IteratorType(*this); }
+
+  IteratorType end() { return IteratorType(*this, length()); }
 
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data) {

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -25,6 +25,7 @@
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
+#include "arrow/stl_iterator.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"  // IWYU pragma: export
 #include "arrow/type_traits.h"
@@ -40,6 +41,7 @@ class NumericArray : public PrimitiveArray {
  public:
   using TypeClass = TYPE;
   using value_type = typename TypeClass::c_type;
+  using IteratorType = stl::ArrayIterator<NumericArray<TYPE>>;
 
   explicit NumericArray(const std::shared_ptr<ArrayData>& data) : PrimitiveArray(data) {}
 
@@ -62,6 +64,10 @@ class NumericArray : public PrimitiveArray {
   // For API compatibility with BinaryArray etc.
   value_type GetView(int64_t i) const { return Value(i); }
 
+  IteratorType begin() { return IteratorType(*this); }
+
+  IteratorType end() { return IteratorType(*this, length()); }
+
  protected:
   using PrimitiveArray::PrimitiveArray;
 };
@@ -70,6 +76,7 @@ class NumericArray : public PrimitiveArray {
 class ARROW_EXPORT BooleanArray : public PrimitiveArray {
  public:
   using TypeClass = BooleanType;
+  using IteratorType = stl::ArrayIterator<BooleanArray>;
 
   explicit BooleanArray(const std::shared_ptr<ArrayData>& data);
 
@@ -91,6 +98,10 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
   /// \brief Return the number of true (1) values among the valid
   /// values. Result is not cached.
   int64_t true_count() const;
+
+  IteratorType begin() { return IteratorType(*this); }
+
+  IteratorType end() { return IteratorType(*this, length()); }
 
  protected:
   using PrimitiveArray::PrimitiveArray;

--- a/cpp/src/arrow/stl_iterator.h
+++ b/cpp/src/arrow/stl_iterator.h
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <utility>
+
+#include "arrow/type_fwd.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/optional.h"
+
+namespace arrow {
+namespace stl {
+
+namespace detail {
+
+template <typename ArrayType>
+struct DefaultValueAccessor {
+  using ValueType = decltype(std::declval<ArrayType>().GetView(0));
+
+  ValueType operator()(const ArrayType& array, int64_t index) {
+    return array.GetView(index);
+  }
+};
+
+}  // namespace detail
+
+template <typename ArrayType,
+          typename ValueAccessor = detail::DefaultValueAccessor<ArrayType>>
+class ArrayIterator {
+ public:
+  using value_type =
+      arrow::util::optional<decltype(ValueAccessor()(std::declval<ArrayType>(), 0))>;
+  using difference_type = int64_t;
+  using iterator_category = std::random_access_iterator_tag;
+
+  // Some algorithms need to default-construct an iterator
+  ArrayIterator() : array_(NULLPTR), index_(0) {}
+
+  explicit ArrayIterator(const ArrayType& array, int64_t index = 0)
+      : array_(&array), index_(index) {}
+
+  // Value access
+  value_type operator*() const {
+    return array_->IsNull(index_) ? value_type{} : array_->GetView(index_);
+  }
+
+  value_type operator[](difference_type n) const {
+    return array_->IsNull(index_ + n) ? value_type{} : array_->GetView(index_ + n);
+  }
+
+  int64_t index() const { return index_; }
+
+  // Forward / backward
+  ArrayIterator& operator++() {
+    ++index_;
+    return *this;
+  }
+  ArrayIterator& operator--() {
+    --index_;
+    return *this;
+  }
+  ArrayIterator operator++(int) {
+    ArrayIterator tmp(*this);
+    ++index_;
+    return tmp;
+  }
+  ArrayIterator operator--(int) {
+    ArrayIterator tmp(*this);
+    --index_;
+    return tmp;
+  }
+
+  // Arithmetic
+  difference_type operator-(const ArrayIterator& other) const {
+    return index_ - other.index_;
+  }
+  ArrayIterator operator+(difference_type n) const {
+    return ArrayIterator(*array_, index_ + n);
+  }
+  ArrayIterator operator-(difference_type n) const {
+    return ArrayIterator(*array_, index_ - n);
+  }
+  friend inline ArrayIterator operator+(difference_type diff,
+                                        const ArrayIterator& other) {
+    return ArrayIterator(*other.array_, diff + other.index_);
+  }
+  friend inline ArrayIterator operator-(difference_type diff,
+                                        const ArrayIterator& other) {
+    return ArrayIterator(*other.array_, diff - other.index_);
+  }
+  ArrayIterator& operator+=(difference_type n) {
+    index_ += n;
+    return *this;
+  }
+  ArrayIterator& operator-=(difference_type n) {
+    index_ -= n;
+    return *this;
+  }
+
+  // Comparisons
+  bool operator==(const ArrayIterator& other) const { return index_ == other.index_; }
+  bool operator!=(const ArrayIterator& other) const { return index_ != other.index_; }
+  bool operator<(const ArrayIterator& other) const { return index_ < other.index_; }
+  bool operator>(const ArrayIterator& other) const { return index_ > other.index_; }
+  bool operator<=(const ArrayIterator& other) const { return index_ <= other.index_; }
+  bool operator>=(const ArrayIterator& other) const { return index_ >= other.index_; }
+
+ private:
+  const ArrayType* array_;
+  int64_t index_;
+};
+
+}  // namespace stl
+}  // namespace arrow
+
+namespace std {
+
+template <typename ArrayType>
+struct iterator_traits<::arrow::stl::ArrayIterator<ArrayType>> {
+  using IteratorType = ::arrow::stl::ArrayIterator<ArrayType>;
+  using difference_type = typename IteratorType::difference_type;
+  using value_type = typename IteratorType::value_type;
+  using iterator_category = typename IteratorType::iterator_category;
+};
+
+}  // namespace std

--- a/cpp/src/arrow/stl_iterator.h
+++ b/cpp/src/arrow/stl_iterator.h
@@ -45,8 +45,7 @@ template <typename ArrayType,
           typename ValueAccessor = detail::DefaultValueAccessor<ArrayType>>
 class ArrayIterator {
  public:
-  using value_type =
-      arrow::util::optional<decltype(ValueAccessor()(std::declval<ArrayType>(), 0))>;
+  using value_type = arrow::util::optional<typename ValueAccessor::ValueType>;
   using difference_type = int64_t;
   using iterator_category = std::random_access_iterator_tag;
 

--- a/cpp/src/arrow/stl_iterator_test.cc
+++ b/cpp/src/arrow/stl_iterator_test.cc
@@ -1,0 +1,263 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "arrow/stl.h"
+#include "arrow/stl_iterator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
+using util::nullopt;
+using util::optional;
+
+namespace stl {
+
+template <typename T>
+void AssertOptionalEquals(optional<T> value, T expected) {
+  ASSERT_TRUE(value.has_value());
+  ASSERT_EQ(*value, expected);
+}
+
+template <typename T>
+void AssertOptionalEmpty(optional<T> value) {
+  ASSERT_FALSE(value.has_value());
+}
+
+TEST(ArrayIterator, Basics) {
+  auto array =
+      checked_pointer_cast<Int32Array>(ArrayFromJSON(int32(), "[4, 5, null, 6]"));
+
+  ArrayIterator<Int32Array> it(*array);
+  optional<int32_t> v = *it;
+  AssertOptionalEquals(v, 4);
+  AssertOptionalEquals(it[0], 4);
+  ++it;
+  AssertOptionalEquals(it[0], 5);
+  AssertOptionalEquals(*it, 5);
+  AssertOptionalEmpty(it[1]);
+  AssertOptionalEquals(it[2], 6);
+}
+
+TEST(ArrayIterator, Arithmetic) {
+  auto array = checked_pointer_cast<Int32Array>(
+      ArrayFromJSON(int32(), "[4, 5, null, 6, null, 7]"));
+
+  ArrayIterator<Int32Array> it(*array);
+  auto it2 = it + 2;
+  AssertOptionalEquals(*it, 4);
+  AssertOptionalEmpty(*it2);
+  ASSERT_EQ(it2 - it, 2);
+  ASSERT_EQ(it - it2, -2);
+  auto it3 = it++;
+  ASSERT_EQ(it2 - it, 1);
+  ASSERT_EQ(it2 - it3, 2);
+  AssertOptionalEquals(*it3, 4);
+  AssertOptionalEquals(*it, 5);
+  auto it4 = ++it;
+  AssertOptionalEmpty(*it);
+  AssertOptionalEmpty(*it4);
+  ASSERT_EQ(it2 - it, 0);
+  ASSERT_EQ(it2 - it4, 0);
+  auto it5 = it + 3;
+  AssertOptionalEquals(*it5, 7);
+  AssertOptionalEquals(*(it5 - 2), 6);
+  AssertOptionalEquals(*(it5 + (-2)), 6);
+  auto it6 = (--it5)--;
+  AssertOptionalEmpty(*it6);
+  AssertOptionalEquals(*it5, 6);
+  ASSERT_EQ(it6 - it5, 1);
+}
+
+TEST(ArrayIterator, Comparison) {
+  auto array = checked_pointer_cast<Int32Array>(
+      ArrayFromJSON(int32(), "[4, 5, null, 6, null, 7]"));
+
+  auto it = ArrayIterator<Int32Array>(*array) + 2;
+  auto it2 = ArrayIterator<Int32Array>(*array) + 2;
+  auto it3 = ArrayIterator<Int32Array>(*array) + 4;
+
+  ASSERT_TRUE(it == it2);
+  ASSERT_TRUE(it <= it2);
+  ASSERT_TRUE(it >= it2);
+  ASSERT_FALSE(it != it2);
+  ASSERT_FALSE(it < it2);
+  ASSERT_FALSE(it > it2);
+
+  ASSERT_FALSE(it == it3);
+  ASSERT_TRUE(it <= it3);
+  ASSERT_FALSE(it >= it3);
+  ASSERT_TRUE(it != it3);
+  ASSERT_TRUE(it < it3);
+  ASSERT_FALSE(it > it3);
+}
+
+TEST(ArrayIterator, BeginEnd) {
+  auto array =
+      checked_pointer_cast<Int32Array>(ArrayFromJSON(int32(), "[4, 5, null, 6]"));
+  std::vector<optional<int32_t>> values;
+  for (auto it = array->begin(); it != array->end(); ++it) {
+    values.push_back(*it);
+  }
+  std::vector<optional<int32_t>> expected{4, 5, {}, 6};
+  ASSERT_EQ(values, expected);
+}
+
+TEST(ArrayIterator, RangeFor) {
+  auto array =
+      checked_pointer_cast<Int32Array>(ArrayFromJSON(int32(), "[4, 5, null, 6]"));
+  std::vector<optional<int32_t>> values;
+  for (const auto v : *array) {
+    values.push_back(v);
+  }
+  std::vector<optional<int32_t>> expected{4, 5, {}, 6};
+  ASSERT_EQ(values, expected);
+}
+
+TEST(ArrayIterator, String) {
+  auto array = checked_pointer_cast<StringArray>(
+      ArrayFromJSON(utf8(), R"(["foo", "bar", null, "quux"])"));
+  std::vector<optional<util::string_view>> values;
+  for (const auto v : *array) {
+    values.push_back(v);
+  }
+  std::vector<optional<util::string_view>> expected{"foo", "bar", {}, "quux"};
+  ASSERT_EQ(values, expected);
+}
+
+TEST(ArrayIterator, Boolean) {
+  auto array = checked_pointer_cast<BooleanArray>(
+      ArrayFromJSON(boolean(), "[true, null, null, false]"));
+  std::vector<optional<bool>> values;
+  for (const auto v : *array) {
+    values.push_back(v);
+  }
+  std::vector<optional<bool>> expected{true, {}, {}, false};
+  ASSERT_EQ(values, expected);
+}
+
+TEST(ArrayIterator, FixedSizeBinary) {
+  auto array = checked_pointer_cast<FixedSizeBinaryArray>(
+      ArrayFromJSON(fixed_size_binary(3), R"(["foo", "bar", null, "quu"])"));
+  std::vector<optional<util::string_view>> values;
+  for (const auto v : *array) {
+    values.push_back(v);
+  }
+  std::vector<optional<util::string_view>> expected{"foo", "bar", {}, "quu"};
+  ASSERT_EQ(values, expected);
+}
+
+// Test compatibility with various STL algorithms
+
+TEST(ArrayIterator, StdFind) {
+  auto array = checked_pointer_cast<StringArray>(
+      ArrayFromJSON(utf8(), R"(["foo", "bar", null, "quux"])"));
+
+  auto it = std::find(array->begin(), array->end(), "bar");
+  ASSERT_EQ(it.index(), 1);
+  it = std::find(array->begin(), array->end(), nullopt);
+  ASSERT_EQ(it.index(), 2);
+  it = std::find(array->begin(), array->end(), "zzz");
+  ASSERT_EQ(it, array->end());
+}
+
+TEST(ArrayIterator, StdCountIf) {
+  auto array = checked_pointer_cast<BooleanArray>(
+      ArrayFromJSON(boolean(), "[true, null, null, false]"));
+
+  auto n = std::count_if(array->begin(), array->end(),
+                         [](optional<bool> v) { return !v.has_value(); });
+  ASSERT_EQ(n, 2);
+}
+
+TEST(ArrayIterator, StdCopy) {
+  auto array = checked_pointer_cast<BooleanArray>(
+      ArrayFromJSON(boolean(), "[true, null, null, false]"));
+  std::vector<optional<bool>> values;
+  std::copy(array->begin() + 1, array->end(), std::back_inserter(values));
+  std::vector<optional<bool>> expected{{}, {}, false};
+  ASSERT_EQ(values, expected);
+}
+
+TEST(ArrayIterator, StdPartitionPoint) {
+  auto array = checked_pointer_cast<DoubleArray>(
+      ArrayFromJSON(float64(), "[4.5, 2.5, 1e100, 3, null, null, null, null, null]"));
+  auto it = std::partition_point(array->begin(), array->end(),
+                                 [](optional<double> v) { return v.has_value(); });
+  ASSERT_EQ(it.index(), 4);
+  AssertOptionalEmpty(*it);
+
+  array =
+      checked_pointer_cast<DoubleArray>(ArrayFromJSON(float64(), "[null, null, null]"));
+  it = std::partition_point(array->begin(), array->end(),
+                            [](optional<double> v) { return v.has_value(); });
+  ASSERT_EQ(it, array->begin());
+  it = std::partition_point(array->begin(), array->end(),
+                            [](optional<double> v) { return !v.has_value(); });
+  ASSERT_EQ(it, array->end());
+}
+
+TEST(ArrayIterator, StdEqualRange) {
+  auto array = checked_pointer_cast<Int8Array>(
+      ArrayFromJSON(int8(), "[1, 4, 5, 5, 5, 7, 8, null, null, null]"));
+  auto cmp_lt = [](optional<int8_t> u, optional<int8_t> v) {
+    return u.has_value() && (!v.has_value() || *u < *v);
+  };
+
+  auto pair = std::equal_range(array->begin(), array->end(), nullopt, cmp_lt);
+  ASSERT_EQ(pair.first, array->end() - 3);
+  ASSERT_EQ(pair.second, array->end());
+  pair = std::equal_range(array->begin(), array->end(), 6, cmp_lt);
+  ASSERT_EQ(pair.first, array->begin() + 5);
+  ASSERT_EQ(pair.second, pair.first);
+  pair = std::equal_range(array->begin(), array->end(), 5, cmp_lt);
+  ASSERT_EQ(pair.first, array->begin() + 2);
+  ASSERT_EQ(pair.second, array->begin() + 5);
+  pair = std::equal_range(array->begin(), array->end(), 1, cmp_lt);
+  ASSERT_EQ(pair.first, array->begin());
+  ASSERT_EQ(pair.second, array->begin() + 1);
+  pair = std::equal_range(array->begin(), array->end(), 0, cmp_lt);
+  ASSERT_EQ(pair.first, array->begin());
+  ASSERT_EQ(pair.second, pair.first);
+}
+
+TEST(ArrayIterator, StdMerge) {
+  auto array1 = checked_pointer_cast<Int8Array>(
+      ArrayFromJSON(int8(), "[1, 4, 5, 5, 7, null, null, null]"));
+  auto array2 =
+      checked_pointer_cast<Int8Array>(ArrayFromJSON(int8(), "[-1, 3, 3, 6, 42]"));
+  auto cmp_lt = [](optional<int8_t> u, optional<int8_t> v) {
+    return u.has_value() && (!v.has_value() || *u < *v);
+  };
+
+  std::vector<optional<int8_t>> values;
+  std::merge(array1->begin(), array1->end(), array2->begin(), array2->end(),
+             std::back_inserter(values), cmp_lt);
+  std::vector<optional<int8_t>> expected{-1, 1, 3, 3, 4, 5, 5, 6, 7, 42, {}, {}, {}};
+  ASSERT_EQ(values, expected);
+}
+
+}  // namespace stl
+}  // namespace arrow

--- a/cpp/src/arrow/stl_iterator_test.cc
+++ b/cpp/src/arrow/stl_iterator_test.cc
@@ -41,13 +41,13 @@ TEST(ArrayIterator, Basics) {
 
   ArrayIterator<Int32Array> it(*array);
   optional<int32_t> v = *it;
-  ASSERT_EQ(*v, 4);
-  ASSERT_EQ(*it[0], 4);
+  ASSERT_EQ(v, 4);
+  ASSERT_EQ(it[0], 4);
   ++it;
-  ASSERT_EQ(*it[0], 5);
-  ASSERT_EQ(**it, 5);
+  ASSERT_EQ(it[0], 5);
+  ASSERT_EQ(*it, 5);
   ASSERT_EQ(it[1], nullopt);
-  ASSERT_EQ(*it[2], 6);
+  ASSERT_EQ(it[2], 6);
 }
 
 TEST(ArrayIterator, Arithmetic) {
@@ -56,27 +56,27 @@ TEST(ArrayIterator, Arithmetic) {
 
   ArrayIterator<Int32Array> it(*array);
   auto it2 = it + 2;
-  ASSERT_EQ(**it, 4);
+  ASSERT_EQ(*it, 4);
   ASSERT_EQ(*it2, nullopt);
   ASSERT_EQ(it2 - it, 2);
   ASSERT_EQ(it - it2, -2);
   auto it3 = it++;
   ASSERT_EQ(it2 - it, 1);
   ASSERT_EQ(it2 - it3, 2);
-  ASSERT_EQ(**it3, 4);
-  ASSERT_EQ(**it, 5);
+  ASSERT_EQ(*it3, 4);
+  ASSERT_EQ(*it, 5);
   auto it4 = ++it;
   ASSERT_EQ(*it, nullopt);
   ASSERT_EQ(*it4, nullopt);
   ASSERT_EQ(it2 - it, 0);
   ASSERT_EQ(it2 - it4, 0);
   auto it5 = it + 3;
-  ASSERT_EQ(**it5, 7);
-  ASSERT_EQ(**(it5 - 2), 6);
-  ASSERT_EQ(**(it5 + (-2)), 6);
+  ASSERT_EQ(*it5, 7);
+  ASSERT_EQ(*(it5 - 2), 6);
+  ASSERT_EQ(*(it5 + (-2)), 6);
   auto it6 = (--it5)--;
   ASSERT_EQ(*it6, nullopt);
-  ASSERT_EQ(**it5, 6);
+  ASSERT_EQ(*it5, 6);
   ASSERT_EQ(it6 - it5, 1);
 }
 

--- a/cpp/src/arrow/stl_iterator_test.cc
+++ b/cpp/src/arrow/stl_iterator_test.cc
@@ -35,30 +35,19 @@ using util::optional;
 
 namespace stl {
 
-template <typename T>
-void AssertOptionalEquals(optional<T> value, T expected) {
-  ASSERT_TRUE(value.has_value());
-  ASSERT_EQ(*value, expected);
-}
-
-template <typename T>
-void AssertOptionalEmpty(optional<T> value) {
-  ASSERT_FALSE(value.has_value());
-}
-
 TEST(ArrayIterator, Basics) {
   auto array =
       checked_pointer_cast<Int32Array>(ArrayFromJSON(int32(), "[4, 5, null, 6]"));
 
   ArrayIterator<Int32Array> it(*array);
   optional<int32_t> v = *it;
-  AssertOptionalEquals(v, 4);
-  AssertOptionalEquals(it[0], 4);
+  ASSERT_EQ(*v, 4);
+  ASSERT_EQ(*it[0], 4);
   ++it;
-  AssertOptionalEquals(it[0], 5);
-  AssertOptionalEquals(*it, 5);
-  AssertOptionalEmpty(it[1]);
-  AssertOptionalEquals(it[2], 6);
+  ASSERT_EQ(*it[0], 5);
+  ASSERT_EQ(**it, 5);
+  ASSERT_EQ(it[1], nullopt);
+  ASSERT_EQ(*it[2], 6);
 }
 
 TEST(ArrayIterator, Arithmetic) {
@@ -67,27 +56,27 @@ TEST(ArrayIterator, Arithmetic) {
 
   ArrayIterator<Int32Array> it(*array);
   auto it2 = it + 2;
-  AssertOptionalEquals(*it, 4);
-  AssertOptionalEmpty(*it2);
+  ASSERT_EQ(**it, 4);
+  ASSERT_EQ(*it2, nullopt);
   ASSERT_EQ(it2 - it, 2);
   ASSERT_EQ(it - it2, -2);
   auto it3 = it++;
   ASSERT_EQ(it2 - it, 1);
   ASSERT_EQ(it2 - it3, 2);
-  AssertOptionalEquals(*it3, 4);
-  AssertOptionalEquals(*it, 5);
+  ASSERT_EQ(**it3, 4);
+  ASSERT_EQ(**it, 5);
   auto it4 = ++it;
-  AssertOptionalEmpty(*it);
-  AssertOptionalEmpty(*it4);
+  ASSERT_EQ(*it, nullopt);
+  ASSERT_EQ(*it4, nullopt);
   ASSERT_EQ(it2 - it, 0);
   ASSERT_EQ(it2 - it4, 0);
   auto it5 = it + 3;
-  AssertOptionalEquals(*it5, 7);
-  AssertOptionalEquals(*(it5 - 2), 6);
-  AssertOptionalEquals(*(it5 + (-2)), 6);
+  ASSERT_EQ(**it5, 7);
+  ASSERT_EQ(**(it5 - 2), 6);
+  ASSERT_EQ(**(it5 + (-2)), 6);
   auto it6 = (--it5)--;
-  AssertOptionalEmpty(*it6);
-  AssertOptionalEquals(*it5, 6);
+  ASSERT_EQ(*it6, nullopt);
+  ASSERT_EQ(**it5, 6);
   ASSERT_EQ(it6 - it5, 1);
 }
 
@@ -207,7 +196,7 @@ TEST(ArrayIterator, StdPartitionPoint) {
   auto it = std::partition_point(array->begin(), array->end(),
                                  [](optional<double> v) { return v.has_value(); });
   ASSERT_EQ(it.index(), 4);
-  AssertOptionalEmpty(*it);
+  ASSERT_EQ(*it, nullopt);
 
   array =
       checked_pointer_cast<DoubleArray>(ArrayFromJSON(float64(), "[null, null, null]"));

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -479,4 +479,17 @@ void PrintTo(const basic_string_view<Char, Traits>& view, std::ostream* os) {
 }
 
 }  // namespace sv_lite
+namespace optional_lite {
+
+template <typename T>
+void PrintTo(const optional<T>& opt, std::ostream* os) {
+  if (opt.has_value()) {
+    *os << "{" << *opt << "}";
+  } else {
+    *os << "nullopt";
+  }
+}
+
+}  // namespace optional_lite
 }  // namespace nonstd
+

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -479,17 +479,21 @@ void PrintTo(const basic_string_view<Char, Traits>& view, std::ostream* os) {
 }
 
 }  // namespace sv_lite
+
 namespace optional_lite {
 
 template <typename T>
 void PrintTo(const optional<T>& opt, std::ostream* os) {
   if (opt.has_value()) {
-    *os << "{" << *opt << "}";
+    *os << "{";
+    ::testing::internal::UniversalPrint(*opt, os);
+    *os << "}";
   } else {
     *os << "nullopt";
   }
 }
 
+inline void PrintTo(const decltype(nullopt)&, std::ostream* os) { *os << "nullopt"; }
+
 }  // namespace optional_lite
 }  // namespace nonstd
-


### PR DESCRIPTION
This is a useful primitive when maximum performance isn't required, for example when testing.