### PR TITLE
ARROW-10774: [R] Set minimum cpp11 version

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     rmarkdown,
     testthat,
     tibble
-LinkingTo: cpp11
+LinkingTo: cpp11 (>= 0.2.0)
 Collate:
     'enums.R'
     'arrow-package.R'


### PR DESCRIPTION
R arrow doesn't compile with cpp11 0.1. 

https://issues.apache.org/jira/browse/ARROW-10774