### PR TITLE
ARROW-10779: [Java] Fix writeNull method in UnionListWriter

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -47,6 +47,7 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   protected ${listName}Vector vector;
   protected PromotableWriter writer;
   private boolean inStruct = false;
+  private boolean listStarted = false;
   private String structName;
   <#if listName == "LargeList">
   private static final long OFFSET_WIDTH = 8;
@@ -180,24 +181,28 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   public void startList() {
     vector.startNewValue(idx());
     writer.setPosition(checkedCastToInt(vector.getOffsetBuffer().getLong(((long) idx() + 1L) * OFFSET_WIDTH)));
+    listStarted = true;
   }
 
   @Override
   public void endList() {
     vector.getOffsetBuffer().setLong(((long) idx() + 1L) * OFFSET_WIDTH, writer.idx());
     setPosition(idx() + 1);
+    listStarted = false;
   }
   <#else>
   @Override
   public void startList() {
     vector.startNewValue(idx());
     writer.setPosition(vector.getOffsetBuffer().getInt((idx() + 1) * OFFSET_WIDTH));
+    listStarted = true;
   }
 
   @Override
   public void endList() {
     vector.getOffsetBuffer().setInt((idx() + 1) * OFFSET_WIDTH, writer.idx());
     setPosition(idx() + 1);
+    listStarted = false;
   }
   </#if>
 
@@ -226,7 +231,11 @@ public class Union${listName}Writer extends AbstractFieldWriter {
 
   @Override
   public void writeNull() {
-    writer.writeNull();
+    if (!listStarted){
+      vector.setNull(idx());
+    } else {
+      writer.writeNull();
+    }
   }
 
   public void writeDecimal(long start, ArrowBuf buffer, ArrowType arrowType) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -921,6 +921,24 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
   }
 
   /**
+   * Sets list at index to be null.
+   * @param index position in vector
+   */
+  public void setNull(int index) {
+    while (index >= getValidityAndOffsetValueCapacity()) {
+      reallocValidityAndOffsetBuffers();
+    }
+    if (lastSet >= index) {
+      lastSet = index - 1;
+    }
+    for (int i = lastSet + 1; i <= index; i++) {
+      final int currentOffset = offsetBuffer.getInt(i * OFFSET_WIDTH);
+      offsetBuffer.setInt((i + 1) * OFFSET_WIDTH, currentOffset);
+    }
+    BitVectorHelper.unsetBit(validityBuffer, index);
+  }
+
+  /**
    * Start a new value in the list vector.
    *
    * @param index index of the value to start

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -795,6 +795,24 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   /**
+   * Sets list at index to be null.
+   * @param index position in vector
+   */
+  public void setNull(int index) {
+    while (index >= getValidityAndOffsetValueCapacity()) {
+      reallocValidityAndOffsetBuffers();
+    }
+    if (lastSet >= index) {
+      lastSet = index - 1;
+    }
+    for (int i = lastSet + 1; i <= index; i++) {
+      final int currentOffset = offsetBuffer.getInt(i * OFFSET_WIDTH);
+      offsetBuffer.setInt((i + 1) * OFFSET_WIDTH, currentOffset);
+    }
+    BitVectorHelper.unsetBit(validityBuffer, index);
+  }
+
+  /**
    * Start a new value in the list vector.
    *
    * @param index index of the value to start

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -225,6 +225,10 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
 
   @Override
   public void writeNull() {
+    FieldWriter w = getWriter();
+    if (w != null) {
+      w.writeNull();
+    }
     setPosition(idx() + 1);
   }
 


### PR DESCRIPTION
UnionListWriter#writeNull currently increments the index in the inner writer and doesn't unset the validity at the particular index. So if the validity at that index was already set (like due to overwriting on an existing vector) an empty list is created at that instead instead of null