### PR TITLE
ARROW-6883: [C++][Python] Allow writing dictionary deltas

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -222,29 +222,31 @@ bool Array::ApproxEquals(const std::shared_ptr<Array>& arr,
 }
 
 bool Array::RangeEquals(const Array& other, int64_t start_idx, int64_t end_idx,
-                        int64_t other_start_idx) const {
-  return ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx);
+                        int64_t other_start_idx, const EqualOptions& opts) const {
+  return ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx, opts);
 }
 
 bool Array::RangeEquals(const std::shared_ptr<Array>& other, int64_t start_idx,
-                        int64_t end_idx, int64_t other_start_idx) const {
+                        int64_t end_idx, int64_t other_start_idx,
+                        const EqualOptions& opts) const {
   if (!other) {
     return false;
   }
-  return ArrayRangeEquals(*this, *other, start_idx, end_idx, other_start_idx);
+  return ArrayRangeEquals(*this, *other, start_idx, end_idx, other_start_idx, opts);
 }
 
 bool Array::RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_idx,
-                        const Array& other) const {
-  return ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx);
+                        const Array& other, const EqualOptions& opts) const {
+  return ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx, opts);
 }
 
 bool Array::RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_idx,
-                        const std::shared_ptr<Array>& other) const {
+                        const std::shared_ptr<Array>& other,
+                        const EqualOptions& opts) const {
   if (!other) {
     return false;
   }
-  return ArrayRangeEquals(*this, *other, start_idx, end_idx, other_start_idx);
+  return ArrayRangeEquals(*this, *other, start_idx, end_idx, other_start_idx, opts);
 }
 
 std::shared_ptr<Array> Array::Slice(int64_t offset, int64_t length) const {

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -119,13 +119,17 @@ class ARROW_EXPORT Array {
   /// Compare if the range of slots specified are equal for the given array and
   /// this array.  end_idx exclusive.  This methods does not bounds check.
   bool RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_idx,
-                   const Array& other) const;
+                   const Array& other,
+                   const EqualOptions& = EqualOptions::Defaults()) const;
   bool RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_idx,
-                   const std::shared_ptr<Array>& other) const;
+                   const std::shared_ptr<Array>& other,
+                   const EqualOptions& = EqualOptions::Defaults()) const;
   bool RangeEquals(const Array& other, int64_t start_idx, int64_t end_idx,
-                   int64_t other_start_idx) const;
+                   int64_t other_start_idx,
+                   const EqualOptions& = EqualOptions::Defaults()) const;
   bool RangeEquals(const std::shared_ptr<Array>& other, int64_t start_idx,
-                   int64_t end_idx, int64_t other_start_idx) const;
+                   int64_t end_idx, int64_t other_start_idx,
+                   const EqualOptions& = EqualOptions::Defaults()) const;
 
   Status Accept(ArrayVisitor* visitor) const;
 

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -664,12 +664,14 @@ class GrpcStreamWriter : public FlightStreamWriter {
     }
     return Status::OK();
   }
+
   Status WriteWithMetadata(const RecordBatch& batch,
                            std::shared_ptr<Buffer> app_metadata) override {
     RETURN_NOT_OK(CheckStarted());
     app_metadata_ = app_metadata;
     return batch_writer_->WriteRecordBatch(batch);
   }
+
   Status DoneWriting() override {
     // Do not CheckStarted - DoneWriting applies to data and metadata
     if (batch_writer_) {
@@ -683,6 +685,7 @@ class GrpcStreamWriter : public FlightStreamWriter {
     }
     return writer_->DoneWriting();
   }
+
   Status Close() override {
     // Do not CheckStarted - Close applies to data and metadata
     if (batch_writer_ && !writer_closed_) {
@@ -696,6 +699,11 @@ class GrpcStreamWriter : public FlightStreamWriter {
       return writer_->Finish(batch_writer_->Close());
     }
     return writer_->Finish(Status::OK());
+  }
+
+  ipc::WriteStats stats() const override {
+    ARROW_CHECK_NE(batch_writer_, nullptr);
+    return batch_writer_->stats();
   }
 
  private:

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -65,6 +65,20 @@ struct ARROW_EXPORT IpcWriteOptions {
   /// like compression
   bool use_threads = true;
 
+  /// \brief Whether to emit dictionary deltas
+  ///
+  /// If false, a changed dictionary for a given field will emit a full
+  /// dictionary replacement.
+  /// If true, a changed dictionary will be compared against the previous
+  /// version. If possible, a dictionary delta will be omitted, otherwise
+  /// a full dictionary replacement.
+  ///
+  /// Default is false to maximize stream compatibility.
+  ///
+  /// Also, note that if a changed dictionary is a nested dictionary,
+  /// then a delta is never emitted, for compatibility with the read path.
+  bool emit_dictionary_deltas = false;
+
   /// \brief Format version to use for IPC messages and their metadata.
   ///
   /// Presently using V5 version (readable by 1.0.0 and later).

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1142,20 +1142,16 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
   };
 
  public:
-  explicit StreamDecoderImpl(std::shared_ptr<Listener> listener,
-                             const IpcReadOptions& options)
-      : MessageDecoderListener(),
-        listener_(std::move(listener)),
-        options_(options),
+  explicit StreamDecoderImpl(std::shared_ptr<Listener> listener, IpcReadOptions options)
+      : listener_(std::move(listener)),
+        options_(std::move(options)),
         state_(State::SCHEMA),
         message_decoder_(std::shared_ptr<StreamDecoderImpl>(this, [](void*) {}),
                          options_.memory_pool),
-        field_inclusion_mask_(),
-        n_required_dictionaries_(0),
-        dictionary_memo_(),
-        schema_() {}
+        n_required_dictionaries_(0) {}
 
   Status OnMessageDecoded(std::unique_ptr<Message> message) override {
+    ++stats_.num_messages;
     switch (state_) {
       case State::SCHEMA:
         ARROW_RETURN_NOT_OK(OnSchemaMessageDecoded(std::move(message)));
@@ -1188,6 +1184,8 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
   std::shared_ptr<Schema> schema() const { return out_schema_; }
 
   int64_t next_required_size() const { return message_decoder_.next_required_size(); }
+
+  ReadStats stats() const { return stats_; }
 
  private:
   Status OnSchemaMessageDecoded(std::unique_ptr<Message> message) {
@@ -1229,30 +1227,42 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
           auto batch,
           ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
                                   &dictionary_memo_, options_, reader.get()));
+      ++stats_.num_record_batches;
       return listener_->OnRecordBatchDecoded(std::move(batch));
     }
   }
 
   // Read dictionary from dictionary batch
   Status ReadDictionary(const Message& message) {
-    // TODO accumulate and expose ReadStats
-    DictionaryKind unused_kind;
-    return ::arrow::ipc::ReadDictionary(message, &dictionary_memo_, options_,
-                                        &unused_kind);
+    DictionaryKind kind;
+    RETURN_NOT_OK(
+        ::arrow::ipc::ReadDictionary(message, &dictionary_memo_, options_, &kind));
+    ++stats_.num_dictionary_batches;
+    switch (kind) {
+      case DictionaryKind::New:
+        break;
+      case DictionaryKind::Delta:
+        ++stats_.num_dictionary_deltas;
+        break;
+      case DictionaryKind::Replacement:
+        ++stats_.num_replaced_dictionaries;
+        break;
+    }
+    return Status::OK();
   }
 
   std::shared_ptr<Listener> listener_;
-  IpcReadOptions options_;
+  const IpcReadOptions options_;
   State state_;
   MessageDecoder message_decoder_;
   std::vector<bool> field_inclusion_mask_;
   int n_required_dictionaries_;
   DictionaryMemo dictionary_memo_;
   std::shared_ptr<Schema> schema_, out_schema_;
+  ReadStats stats_;
 };
 
-StreamDecoder::StreamDecoder(std::shared_ptr<Listener> listener,
-                             const IpcReadOptions& options) {
+StreamDecoder::StreamDecoder(std::shared_ptr<Listener> listener, IpcReadOptions options) {
   impl_.reset(new StreamDecoderImpl(std::move(listener), options));
 }
 
@@ -1268,6 +1278,8 @@ Status StreamDecoder::Consume(std::shared_ptr<Buffer> buffer) {
 std::shared_ptr<Schema> StreamDecoder::schema() const { return impl_->schema(); }
 
 int64_t StreamDecoder::next_required_size() const { return impl_->next_required_size(); }
+
+ReadStats StreamDecoder::stats() const { return impl_->stats(); }
 
 Result<std::shared_ptr<Schema>> ReadSchema(io::InputStream* stream,
                                            DictionaryMemo* dictionary_memo) {

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -267,7 +267,7 @@ class ARROW_EXPORT StreamDecoder {
   /// Listener::OnRecordBatchDecoded() to receive decoded record batches
   /// \param[in] options any IPC reading options (optional)
   StreamDecoder(std::shared_ptr<Listener> listener,
-                const IpcReadOptions& options = IpcReadOptions::Defaults());
+                IpcReadOptions options = IpcReadOptions::Defaults());
 
   virtual ~StreamDecoder();
 
@@ -359,6 +359,9 @@ class ARROW_EXPORT StreamDecoder {
   /// \return the number of bytes needed to advance the state of the
   /// decoder
   int64_t next_required_size() const;
+
+  /// \brief Return current read statistics
+  ReadStats stats() const;
 
  private:
   class StreamDecoderImpl;

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -60,6 +60,23 @@ struct IpcPayload {
   int64_t body_length = 0;
 };
 
+struct WriteStats {
+  /// Number of IPC messages written.
+  int64_t num_messages = 0;
+  /// Number of record batches written.
+  int64_t num_record_batches = 0;
+  /// Number of dictionary batches written.
+  ///
+  /// Note: num_dictionary_batches >= num_dictionary_deltas + num_replaced_dictionaries
+  int64_t num_dictionary_batches = 0;
+
+  /// Number of dictionary deltas written.
+  int64_t num_dictionary_deltas = 0;
+  /// Number of replaced dictionaries (i.e. where a dictionary batch replaces
+  /// an existing dictionary with an unrelated new dictionary).
+  int64_t num_replaced_dictionaries = 0;
+};
+
 /// \class RecordBatchWriter
 /// \brief Abstract interface for writing a stream of record batches
 class ARROW_EXPORT RecordBatchWriter {
@@ -87,6 +104,9 @@ class ARROW_EXPORT RecordBatchWriter {
   ///
   /// \return Status
   virtual Status Close() = 0;
+
+  /// \brief Return current write statistics
+  virtual WriteStats stats() const = 0;
 };
 
 /// Create a new IPC stream writer from stream sink and schema. User is

--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -118,7 +118,7 @@ IPC Format
 +-----------------------------+-------+-------+-------+------------+-------+-------+
 | Replacement dictionaries    | ✓     | ✓     |       |            |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+
-| Delta dictionaries          |       |       |       |            |       |       |
+| Delta dictionaries          | ✓ (1) |       |       |            |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+
 | Tensors                     | ✓     |       |       |            |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+
@@ -126,6 +126,13 @@ IPC Format
 +-----------------------------+-------+-------+-------+------------+-------+-------+
 | Custom schema metadata      | ✓     | ✓     |       |            |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+
+
+Notes:
+
+* \(1) Delta dictionaries not supported on nested dictionaries
+
+.. seealso::
+   The :ref:`format-ipc` specification.
 
 
 Flight RPC
@@ -175,6 +182,22 @@ C Data Interface
 
 .. seealso::
    The :ref:`C Data Interface <c-data-interface>` specification.
+
+
+C Stream Interface (experimental)
+=================================
+
++-----------------------------+-------+--------+
+| Feature                     | C++   | Python |
+|                             |       |        |
++=============================+=======+========+
+| Stream export               | ✓     | ✓      |
++-----------------------------+-------+--------+
+| Stream import               | ✓     | ✓      |
++-----------------------------+-------+--------+
+
+.. seealso::
+   The :ref:`C Stream Interface <c-stream-interface>` specification.
 
 
 Third-Party Data Formats

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from collections import namedtuple
 import warnings
 
 
@@ -45,6 +46,44 @@ cdef CMetadataVersion _unwrap_metadata_version(
     raise ValueError("Not a metadata version: " + repr(version))
 
 
+_WriteStats = namedtuple(
+    'WriteStats',
+    ('num_messages', 'num_record_batches', 'num_dictionary_batches',
+     'num_dictionary_deltas', 'num_replaced_dictionaries'))
+
+
+class WriteStats(_WriteStats):
+    """IPC write statistics
+    """
+    __slots__ = ()
+
+
+@staticmethod
+cdef _wrap_write_stats(CIpcWriteStats c):
+    return WriteStats(c.num_messages, c.num_record_batches,
+                      c.num_dictionary_batches, c.num_dictionary_deltas,
+                      c.num_replaced_dictionaries)
+
+
+_ReadStats = namedtuple(
+    'ReadStats',
+    ('num_messages', 'num_record_batches', 'num_dictionary_batches',
+     'num_dictionary_deltas', 'num_replaced_dictionaries'))
+
+
+class ReadStats(_ReadStats):
+    """IPC write statistics
+    """
+    __slots__ = ()
+
+
+@staticmethod
+cdef _wrap_read_stats(CIpcReadStats c):
+    return ReadStats(c.num_messages, c.num_record_batches,
+                     c.num_dictionary_batches, c.num_dictionary_deltas,
+                     c.num_replaced_dictionaries)
+
+
 cdef class IpcWriteOptions(_Weakrefable):
     """Serialization options for the IPC format.
 
@@ -61,6 +100,9 @@ cdef class IpcWriteOptions(_Weakrefable):
     use_threads: bool
         Whether to use the global CPU thread pool to parallelize any
         computational tasks like compression.
+    emit_dictionary_deltas: bool
+        Whether to emit dictionary deltas.  Default is false for maximum
+        stream compatibility.
     """
     __slots__ = ()
 
@@ -68,13 +110,14 @@ cdef class IpcWriteOptions(_Weakrefable):
 
     def __init__(self, *, metadata_version=MetadataVersion.V5,
                  use_legacy_format=False, compression=None,
-                 bint use_threads=True):
+                 bint use_threads=True, bint emit_dictionary_deltas=False):
         self.c_options = CIpcWriteOptions.Defaults()
         self.use_legacy_format = use_legacy_format
         self.metadata_version = metadata_version
         if compression is not None:
             self.compression = compression
         self.use_threads = use_threads
+        self.emit_dictionary_deltas = emit_dictionary_deltas
 
     @property
     def use_legacy_format(self):
@@ -114,6 +157,14 @@ cdef class IpcWriteOptions(_Weakrefable):
     @use_threads.setter
     def use_threads(self, bint value):
         self.c_options.use_threads = value
+
+    @property
+    def emit_dictionary_deltas(self):
+        return self.c_options.emit_dictionary_deltas
+
+    @emit_dictionary_deltas.setter
+    def emit_dictionary_deltas(self, bint value):
+        self.c_options.emit_dictionary_deltas = value
 
 
 cdef class Message(_Weakrefable):
@@ -356,6 +407,15 @@ cdef class _CRecordBatchWriter(_Weakrefable):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    @property
+    def stats(self):
+        """
+        Current IPC write statistics.
+        """
+        if not self.writer:
+            raise ValueError("Operation on closed writer")
+        return _wrap_write_stats(self.writer.get().stats())
+
 
 cdef class _RecordBatchStreamWriter(_CRecordBatchWriter):
     cdef:
@@ -568,6 +628,7 @@ cdef class _RecordBatchStreamReader(RecordBatchReader):
     cdef:
         shared_ptr[CInputStream] in_stream
         CIpcReadOptions options
+        CRecordBatchStreamReader* stream_reader
 
     def __cinit__(self):
         pass
@@ -577,6 +638,16 @@ cdef class _RecordBatchStreamReader(RecordBatchReader):
         with nogil:
             self.reader = GetResultValue(CRecordBatchStreamReader.Open(
                 self.in_stream, self.options))
+            self.stream_reader = <CRecordBatchStreamReader*> self.reader.get()
+
+    @property
+    def stats(self):
+        """
+        Current IPC read statistics.
+        """
+        if not self.reader:
+            raise ValueError("Operation on closed reader")
+        return _wrap_read_stats(self.stream_reader.stats())
 
 
 cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
@@ -677,6 +748,15 @@ cdef class _RecordBatchFileReader(_Weakrefable):
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
+
+    @property
+    def stats(self):
+        """
+        Current IPC read statistics.
+        """
+        if not self.reader:
+            raise ValueError("Operation on closed reader")
+        return _wrap_read_stats(self.reader.get().stats())
 
 
 def get_tensor_size(Tensor tensor):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -21,7 +21,8 @@ import os
 
 import pyarrow as pa
 
-from pyarrow.lib import (IpcWriteOptions, Message, MessageReader,  # noqa
+from pyarrow.lib import (IpcWriteOptions, ReadStats, WriteStats,  # noqa
+                         Message, MessageReader,
                          RecordBatchReader, _ReadPandasMixin,
                          MetadataVersion,
                          read_message, read_record_batch, read_schema,


### PR DESCRIPTION
* Add an ipc::IpcWriteOptions member to govern emission of dictionary deltas.

  If the option is enabled, deltas are detected by checking whether the new
  dictionary starts with the last emitted one for the same field.
  However, for nested dictionaries, deltas are not emitted for the outer dictionary,
  as the read path doesn't support it.

* Add a stats() method to ipc::StreamDecoder

* Expose the IPC statistics in Python, and add tests