### PR TITLE
ARROW-10753: [Rust] [DataFusion] Fix parsing of negative numbers in DataFusion

### DIFF
--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -274,9 +274,7 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
         DataType::FixedSizeList(_, _) => {}
         DataType::Union(_) => {}
         */
-        _ => {
-            todo!("Take and filter operations still not supported for this datatype")
-        }
+        _ => todo!("Take and filter operations still not supported for this datatype"),
     })
 }
 

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -52,6 +52,7 @@
     clippy::useless_format,
     clippy::zero_prefixed_literal
 )]
+#![feature(box_patterns)]
 
 //! DataFusion is an extensible query execution framework that uses
 //! [Apache Arrow](https://arrow.apache.org) as its in-memory format.

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -52,7 +52,6 @@
     clippy::useless_format,
     clippy::zero_prefixed_literal
 )]
-#![feature(box_patterns)]
 
 //! DataFusion is an extensible query execution framework that uses
 //! [Apache Arrow](https://arrow.apache.org) as its in-memory format.

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -644,7 +644,10 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                 },
                 (UnaryOperator::Minus, box SQLExpr::Value(Value::Number(n))) =>
                     // Parse negative numbers properly
-                    Ok(lit(-n.parse::<f64>().unwrap())),
+                    match n.parse::<i64>() {
+                        Ok(n) => Ok(lit(-n)),
+                        Err(_) => Ok(lit(-n.parse::<f64>().unwrap())),
+                    },
                 _ => Err(DataFusionError::Internal(format!(
                     "SQL binary operator cannot be interpreted as a unary operator"
                 ))),

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -638,11 +638,11 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                 Ok(Expr::IsNotNull(Box::new(self.sql_to_rex(expr, schema)?)))
             }
 
-            SQLExpr::UnaryOp { ref op, ref expr } => match (op, expr) {
+            SQLExpr::UnaryOp { ref op, ref expr } => match (op, &**expr) {
                 (UnaryOperator::Not, _) => {
                     Ok(Expr::Not(Box::new(self.sql_to_rex(expr, schema)?)))
                 },
-                (UnaryOperator::Minus, box SQLExpr::Value(Value::Number(n))) =>
+                (UnaryOperator::Minus, SQLExpr::Value(Value::Number(n))) =>
                     // Parse negative numbers properly
                     match n.parse::<i64>() {
                         Ok(n) => Ok(lit(-n)),

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -638,16 +638,18 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                 Ok(Expr::IsNotNull(Box::new(self.sql_to_rex(expr, schema)?)))
             }
 
-            SQLExpr::UnaryOp { ref op, ref expr } => match (op, &**expr) {
+            SQLExpr::UnaryOp { ref op, ref expr } => match (op, expr.as_ref()) {
                 (UnaryOperator::Not, _) => {
                     Ok(Expr::Not(Box::new(self.sql_to_rex(expr, schema)?)))
-                },
+                }
                 (UnaryOperator::Minus, SQLExpr::Value(Value::Number(n))) =>
-                    // Parse negative numbers properly
+                // Parse negative numbers properly
+                {
                     match n.parse::<i64>() {
                         Ok(n) => Ok(lit(-n)),
                         Err(_) => Ok(lit(-n.parse::<f64>().unwrap())),
-                    },
+                    }
+                }
                 _ => Err(DataFusionError::Internal(format!(
                     "SQL binary operator cannot be interpreted as a unary operator"
                 ))),

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -638,10 +638,13 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                 Ok(Expr::IsNotNull(Box::new(self.sql_to_rex(expr, schema)?)))
             }
 
-            SQLExpr::UnaryOp { ref op, ref expr } => match *op {
-                UnaryOperator::Not => {
+            SQLExpr::UnaryOp { ref op, ref expr } => match (op, expr) {
+                (UnaryOperator::Not, _) => {
                     Ok(Expr::Not(Box::new(self.sql_to_rex(expr, schema)?)))
-                }
+                },
+                (UnaryOperator::Minus, box SQLExpr::Value(Value::Number(n))) =>
+                    // Parse negative numbers properly
+                    Ok(lit(-n.parse::<f64>().unwrap())),
                 _ => Err(DataFusionError::Internal(format!(
                     "SQL binary operator cannot be interpreted as a unary operator"
                 ))),

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1512,6 +1512,18 @@ async fn query_where_neg_num() -> Result<()> {
         vec!["4", "39363"],
     ];
     assert_eq!(expected, actual);
+
+    // Also check floating point neg numbers
+    let sql = "select c7, c8 from aggregate_test_100 where c7 >= -2.9 and c7 < 10";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["7", "45465"],
+        vec!["5", "40622"],
+        vec!["0", "61069"],
+        vec!["2", "20120"],
+        vec!["4", "39363"],
+    ];
+    assert_eq!(expected, actual);
     Ok(())
 }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1497,6 +1497,25 @@ async fn csv_query_sum_cast() {
 }
 
 #[tokio::test]
+async fn query_where_neg_num() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv_by_sql(&mut ctx).await;
+
+    // Negative numbers do not parse correctly as of Arrow 2.0.0
+    let sql = "select c7, c8 from aggregate_test_100 where c7 >= -2 and c7 < 10";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["7", "45465"],
+        vec!["5", "40622"],
+        vec!["0", "61069"],
+        vec!["2", "20120"],
+        vec!["4", "39363"],
+    ];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn like() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;


### PR DESCRIPTION
Currently, DataFusion SQL statements that compare negative numbers result in an exception, as negative numbers are incorrectly parsed.  The error thrown is `InternalError("SQL binary operator cannot be interpreted as a unary operator")`

This PR adds a quick fix in SQL planner.rs, to parse SQL of the form ` UnaryOp { op: Minus, expr: Value(Number("1")) } } ` etc from SQL such as `WHERE col1 >= -1` to allow proper evaluation of the above SQL as a literal number.
