### PR TITLE
ARROW-10789: [Rust][DataFusion] Make TableProvider dynamically typed

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use arrow::datatypes::SchemaRef;
+use std::any::Any;
 use std::string::String;
 use std::sync::Arc;
 
@@ -79,6 +80,10 @@ impl CsvFile {
 }
 
 impl TableProvider for CsvFile {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -17,6 +17,7 @@
 
 //! Data source traits
 
+use std::any::Any;
 use std::sync::Arc;
 
 use crate::arrow::datatypes::SchemaRef;
@@ -25,6 +26,10 @@ use crate::physical_plan::ExecutionPlan;
 
 /// Source table
 pub trait TableProvider {
+    /// Returns the table provider as [`Any`](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
     /// Get a reference to the schema for this table
     fn schema(&self) -> SchemaRef;
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -19,6 +19,7 @@
 //! queried by DataFusion. This allows data to be pre-loaded into memory and then
 //! repeatedly queried without incurring additional file I/O overhead.
 
+use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
@@ -85,6 +86,10 @@ impl MemTable {
 }
 
 impl TableProvider for MemTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -17,6 +17,7 @@
 
 //! Parquet data source
 
+use std::any::Any;
 use std::string::String;
 use std::sync::Arc;
 
@@ -46,6 +47,10 @@ impl ParquetTable {
 }
 
 impl TableProvider for ParquetTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     /// Get the schema for this parquet file.
     fn schema(&self) -> SchemaRef {
         self.schema.clone()

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -128,11 +128,14 @@ impl ExecutionPlan for CustomExecutionPlan {
 }
 
 impl TableProvider for CustomTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn schema(&self) -> SchemaRef {
         TEST_CUSTOM_SCHEMA_REF!()
     }
 
-    /// Create an ExecutionPlan that will scan the table.
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,


### PR DESCRIPTION
> The `TableProvider` trait can be used to provide custom datasources to the query plan. It can be useful for usecases like plan serialization to be able to downcast to the concrete implementation, the same way it is done for the `ExecutionPlan` trait.

https://issues.apache.org/jira/browse/ARROW-10789