### PR TITLE
ARROW-10791: [Rust] StreamReader, read_dictionary duplicating schema info

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1648,6 +1648,15 @@ impl Schema {
         Ok(&self.fields[self.index_of(name)?])
     }
 
+    /// Returns a vector of immutable references to all `Field` instances selected by
+    /// the dictionary ID they use
+    pub fn fields_with_dict_id(&self, dict_id: i64) -> Vec<&Field> {
+        self.fields
+            .iter()
+            .filter(|f| f.dict_id() == Some(dict_id))
+            .collect()
+    }
+
     /// Find the index of the column with the given name
     pub fn index_of(&self, name: &str) -> Result<usize> {
         for i in 0..self.fields.len() {
@@ -2573,6 +2582,20 @@ mod tests {
             "last_name"
         );
         schema.field_with_name("nickname").unwrap();
+    }
+
+    #[test]
+    fn schema_field_with_dict_id() {
+        let schema = person_schema();
+
+        let fields_dict_123: Vec<_> = schema
+            .fields_with_dict_id(123)
+            .iter()
+            .map(|f| f.name())
+            .collect();
+        assert_eq!(fields_dict_123, vec!["interests"]);
+
+        assert!(schema.fields_with_dict_id(456).is_empty());
     }
 
     #[test]

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -291,8 +291,12 @@ pub(crate) fn build_field<'a>(
     let fb_dictionary = if let Dictionary(index_type, _) = field.data_type() {
         Some(get_fb_dictionary(
             index_type,
-            field.dict_id(),
-            field.dict_is_ordered(),
+            field
+                .dict_id()
+                .expect("All Dictionary types have `dict_id`"),
+            field
+                .dict_is_ordered()
+                .expect("All Dictionary types have `dict_is_ordered`"),
             fbb,
         ))
     } else {

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -180,7 +180,9 @@ impl<W: Write> FileWriter<W> {
             let column = batch.column(i);
 
             if let DataType::Dictionary(_key_type, _value_type) = column.data_type() {
-                let dict_id = field.dict_id();
+                let dict_id = field
+                    .dict_id()
+                    .expect("All Dictionary types have `dict_id`");
                 let dict_data = column.data();
                 let dict_values = &dict_data.child_data()[0];
 
@@ -317,7 +319,9 @@ impl<W: Write> StreamWriter<W> {
             let column = batch.column(i);
 
             if let DataType::Dictionary(_key_type, _value_type) = column.data_type() {
-                let dict_id = field.dict_id();
+                let dict_id = field
+                    .dict_id()
+                    .expect("All Dictionary types have `dict_id`");
                 let dict_data = column.data();
                 let dict_values = &dict_data.child_data()[0];
 

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -489,7 +489,12 @@ fn array_from_json(
             Ok(Arc::new(array))
         }
         DataType::Dictionary(key_type, value_type) => {
-            let dict_id = field.dict_id();
+            let dict_id = field.dict_id().ok_or_else(|| {
+                ArrowError::JsonError(format!(
+                    "Unable to find dict_id for field {:?}",
+                    field
+                ))
+            })?;
             // find dictionary
             let dictionary = dictionaries
                 .ok_or_else(|| {
@@ -539,8 +544,12 @@ fn dictionary_array_from_json(
                 "key",
                 dict_key.clone(),
                 field.is_nullable(),
-                field.dict_id(),
-                field.dict_is_ordered(),
+                field
+                    .dict_id()
+                    .expect("Dictionary fields must have a dict_id value"),
+                field
+                    .dict_is_ordered()
+                    .expect("Dictionary fields must have a dict_is_ordered value"),
             );
             let keys = array_from_json(&key_field, json_col, None)?;
             // note: not enough info on nullability of dictionary


### PR DESCRIPTION
The purpose of this PR is refactoring `read_dictionary` to only need one kind of `Schema`, which lets us then remove the `find_dictionary_field` function and the `ipc_schema` field on `StreamReader` by adding a way to look up schema fields that use a particular dictionary by ID.

I'm also resubmitting a change to the `dict_id`/`dict_is_ordered` methods on `Field`; I had submitted this to @nevi-me to become part of #8200 but it looks like it got lost in a rebase or something? I think it's more correct to only return values if the fields have a dictionary as their datatype.

