### PR TITLE
ARROW-10795: [Rust] Optimize specialization for datatypes

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -254,7 +254,6 @@ pub trait BufferBuilderTrait<T: ArrowPrimitiveType> {
 impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn new(capacity: usize) -> Self {
-        
         let buffer = if matches!(T::DATA_TYPE, DataType::Boolean) {
             let byte_capacity = bit_util::ceil(capacity, 8);
             let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -254,7 +254,8 @@ pub trait BufferBuilderTrait<T: ArrowPrimitiveType> {
 impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn new(capacity: usize) -> Self {
-        let buffer = if T::DATA_TYPE == DataType::Boolean {
+        
+        let buffer = if matches!(T::DATA_TYPE, DataType::Boolean) {
             let byte_capacity = bit_util::ceil(capacity, 8);
             let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
             let mut buffer = MutableBuffer::new(actual_capacity);
@@ -286,7 +287,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
 
     #[inline]
     fn advance(&mut self, i: usize) -> Result<()> {
-        let new_buffer_len = if T::DATA_TYPE == DataType::Boolean {
+        let new_buffer_len = if matches!(T::DATA_TYPE, DataType::Boolean) {
             bit_util::ceil(self.len + i, 8)
         } else {
             (self.len + i) * mem::size_of::<T::Native>()
@@ -299,7 +300,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn reserve(&mut self, n: usize) {
         let new_capacity = self.len + n;
-        if T::DATA_TYPE == DataType::Boolean {
+        if matches!(T::DATA_TYPE, DataType::Boolean) {
             if new_capacity > self.capacity() {
                 let new_byte_capacity = bit_util::ceil(new_capacity, 8);
                 let existing_capacity = self.buffer.capacity();
@@ -316,7 +317,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn append(&mut self, v: T::Native) -> Result<()> {
         self.reserve(1);
-        if T::DATA_TYPE == DataType::Boolean {
+        if matches!(T::DATA_TYPE, DataType::Boolean) {
             if v != T::default_value() {
                 unsafe {
                     bit_util::set_bit_raw(self.buffer.raw_data_mut(), self.len);
@@ -332,7 +333,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn append_n(&mut self, n: usize, v: T::Native) -> Result<()> {
         self.reserve(n);
-        if T::DATA_TYPE == DataType::Boolean {
+        if matches!(T::DATA_TYPE, DataType::Boolean) {
             if n != 0 && v != T::default_value() {
                 let data = unsafe {
                     std::slice::from_raw_parts_mut(
@@ -356,7 +357,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
         let array_slots = slice.len();
         self.reserve(array_slots);
 
-        if T::DATA_TYPE == DataType::Boolean {
+        if matches!(T::DATA_TYPE, DataType::Boolean) {
             for v in slice {
                 if *v != T::default_value() {
                     // For performance the `len` of the buffer is not
@@ -377,7 +378,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
 
     #[inline]
     fn finish(&mut self) -> Buffer {
-        if T::DATA_TYPE == DataType::Boolean {
+        if matches!(T::DATA_TYPE, DataType::Boolean) {
             // `append` does not update the buffer's `len` so do it before `freeze` is called.
             let new_buffer_len = bit_util::ceil(self.len, 8);
             debug_assert!(new_buffer_len >= self.buffer.len());

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -47,7 +47,7 @@ fn partition_nan<T: ArrowPrimitiveType>(
     v: Vec<u32>,
 ) -> (Vec<u32>, Vec<u32>) {
     // partition by nan for float types
-    if T::DATA_TYPE == DataType::Float32 {
+    if matches!(T::DATA_TYPE, DataType::Float32) {
         // T::Native has no `is_nan` and thus we need to downcast
         let array = array
             .as_any()
@@ -60,7 +60,7 @@ fn partition_nan<T: ArrowPrimitiveType>(
         } else {
             (v, vec![])
         }
-    } else if T::DATA_TYPE == DataType::Float64 {
+    } else if matches!(T::DATA_TYPE, DataType::Float64) {
         let array = array
             .as_any()
             .downcast_ref::<Float64Array>()


### PR DESCRIPTION
This PR fixes the specialization around data types.

I found during profiling that the compiler doesn't remove the `if T::DATA_TYPE == DataType::Boolean` (and corresponding `PartialEq` implementation) and accounts for around ~6.5%(!) of the instruction fetches (mostly related to `append` which makes sense).

Using pattern matching instead of using `==` seems to fix this issue and brings the query from ~1700ms to ~1500ms.

This could also explain part of the overhead I saw of buffer builder vs mutable buffer and `Vec` when working on earlier PRs.

Benchmark results for query 12:
```
Query 12 iteration 0 took 1500 ms
Query 12 iteration 1 took 1499 ms
Query 12 iteration 2 took 1502 ms
Query 12 iteration 3 took 1506 ms
Query 12 iteration 4 took 1500 ms
Query 12 iteration 5 took 1497 ms
Query 12 iteration 6 took 1501 ms
Query 12 iteration 7 took 1500 ms
Query 12 iteration 8 took 1501 ms
Query 12 iteration 9 took 1498 ms
Query 12 iteration 10 took 1500 ms
Query 12 iteration 11 took 1498 ms
Query 12 iteration 12 took 1502 ms
Query 12 iteration 13 took 1499 ms
Query 12 iteration 14 took 1497 ms
Query 12 iteration 15 took 1497 ms
Query 12 iteration 16 took 1500 ms
Query 12 iteration 17 took 1496 ms
Query 12 iteration 18 took 1499 ms
Query 12 iteration 19 took 1493 ms
```

Master:

```
Query 12 iteration 0 took 1762 ms
Query 12 iteration 1 took 1734 ms
Query 12 iteration 2 took 1734 ms
Query 12 iteration 3 took 1730 ms
Query 12 iteration 4 took 1731 ms
Query 12 iteration 5 took 1758 ms
Query 12 iteration 6 took 1727 ms
Query 12 iteration 7 took 1727 ms
Query 12 iteration 8 took 1727 ms
Query 12 iteration 9 took 1730 ms
Query 12 iteration 10 took 1719 ms
Query 12 iteration 11 took 1731 ms
Query 12 iteration 12 took 1735 ms
Query 12 iteration 13 took 1724 ms
Query 12 iteration 14 took 1713 ms
Query 12 iteration 15 took 1712 ms
Query 12 iteration 16 took 1729 ms
Query 12 iteration 17 took 1721 ms
Query 12 iteration 18 took 1713 ms
Query 12 iteration 19 took 1710 ms
```

