### PR TITLE
ARROW-10798: [CI] Made certain workflows be less triggered on changes of dockerfiles

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -21,7 +21,7 @@ on:
   push:
     paths:
       - '.github/workflows/cpp.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/*cpp*'
       - 'ci/scripts/cpp_*'
       - 'ci/scripts/msys2_*'
       - 'ci/scripts/util_*'
@@ -30,7 +30,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/cpp.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/*cpp*'
       - 'ci/scripts/cpp_*'
       - 'ci/scripts/msys2_*'
       - 'ci/scripts/util_*'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,6 @@ on:
     paths:
       - '.github/workflows/go.yml'
       - 'ci/docker/*_go.dockerfile'
-      - 'ci/docker/**'
       - 'ci/scripts/go_*'
       - 'go/**'
 

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -21,7 +21,7 @@ on:
   push:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/docker/linux-apt-jni.dockerfile'
+      - 'ci/docker/*-jni.dockerfile'
       - 'ci/scripts/cpp_build.sh'
       - 'ci/scripts/java_*'
       - 'cpp/**'
@@ -29,7 +29,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/docker/linux-apt-jni.dockerfile'
+      - 'ci/docker/*-jni.dockerfile'
       - 'ci/scripts/cpp_build.sh'
       - 'ci/scripts/java_*'
       - 'cpp/**'

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -21,7 +21,7 @@ on:
   push:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-jni.dockerfile'
       - 'ci/scripts/cpp_build.sh'
       - 'ci/scripts/java_*'
       - 'cpp/**'
@@ -29,7 +29,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-jni.dockerfile'
       - 'ci/scripts/cpp_build.sh'
       - 'ci/scripts/java_*'
       - 'cpp/**'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -25,7 +25,8 @@ on:
       - 'ci/scripts/cpp_*.sh'
       - 'ci/scripts/PKGBUILD'
       - 'ci/etc/rprofile'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-r.dockerfile'
+      - 'ci/docker/linux-r.dockerfile'
       - 'cpp/**'
       - 'r/**'
   pull_request:
@@ -35,7 +36,8 @@ on:
       - 'ci/scripts/cpp_*.sh'
       - 'ci/scripts/PKGBUILD'
       - 'ci/etc/rprofile'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-r.dockerfile'
+      - 'ci/docker/linux-r.dockerfile'
       - 'cpp/**'
       - 'r/**'
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -25,8 +25,7 @@ on:
       - 'ci/scripts/cpp_*.sh'
       - 'ci/scripts/PKGBUILD'
       - 'ci/etc/rprofile'
-      - 'ci/docker/linux-apt-r.dockerfile'
-      - 'ci/docker/linux-r.dockerfile'
+      - 'ci/docker/*-r.dockerfile'
       - 'cpp/**'
       - 'r/**'
   pull_request:
@@ -36,8 +35,7 @@ on:
       - 'ci/scripts/cpp_*.sh'
       - 'ci/scripts/PKGBUILD'
       - 'ci/etc/rprofile'
-      - 'ci/docker/linux-apt-r.dockerfile'
-      - 'ci/docker/linux-r.dockerfile'
+      - 'ci/docker/*-r.dockerfile'
       - 'cpp/**'
       - 'r/**'
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ on:
   push:
     paths:
       - '.github/workflows/ruby.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-ruby.dockerfile'
       - 'ci/scripts/c_glib_*'
       - 'ci/scripts/cpp_*'
       - 'ci/scripts/msys2_*'
@@ -33,7 +33,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/ruby.yml'
-      - 'ci/docker/**'
+      - 'ci/docker/linux-apt-ruby.dockerfile'
       - 'ci/scripts/c_glib_*'
       - 'ci/scripts/cpp_*'
       - 'ci/scripts/msys2_*'


### PR DESCRIPTION
This PR restricts some CI workflows from getting triggered when _any_ dockerfile changes, thereby reducing the workload on our queue when someone modifies a dockerfile.

This is particularly important when testing the CI itself, as devs will trigger multiple runs of the CI for single change of a single dockerfile, which triggers the execution of a large number of workflows.