### PR TITLE
ARROW-10801: [Rust] [Flight] Support sending FlightData for Dictionaries with that of a RecordBatch

### DIFF
--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -42,7 +42,8 @@ pub fn flight_data_from_arrow_batch(
     batch: &RecordBatch,
     options: &IpcWriteOptions,
 ) -> FlightData {
-    let data = writer::record_batch_to_bytes(batch, &options);
+    let data_gen = writer::IpcDataGenerator::default();
+    let data = data_gen.record_batch_to_bytes(batch, &options);
     FlightData {
         flight_descriptor: None,
         app_metadata: vec![],

--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -67,8 +67,11 @@ pub fn flight_schema_from_arrow_schema(
     schema: &Schema,
     options: &IpcWriteOptions,
 ) -> SchemaResult {
+    let data_gen = writer::IpcDataGenerator::default();
+    let schema_bytes = data_gen.schema_to_bytes(schema, &options);
+
     SchemaResult {
-        schema: writer::schema_to_bytes(schema, &options).ipc_message,
+        schema: schema_bytes.ipc_message,
     }
 }
 
@@ -88,7 +91,8 @@ pub fn flight_data_from_arrow_schema(
     schema: &Schema,
     options: &IpcWriteOptions,
 ) -> FlightData {
-    let schema = writer::schema_to_bytes(schema, &options);
+    let data_gen = writer::IpcDataGenerator::default();
+    let schema = data_gen.schema_to_bytes(schema, &options);
     FlightData {
         flight_descriptor: None,
         app_metadata: vec![],

--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -26,30 +26,40 @@ use arrow::error::{ArrowError, Result};
 use arrow::ipc::{convert, reader, writer, writer::IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 
-/// Convert a `RecordBatch` to `FlightData` by converting the header and body to bytes
+/// Convert a `RecordBatch` to a vector of `FlightData` representing the bytes of the dictionaries
+/// and values. This can't be a `From` implementation because neither `RecordBatch` nor `Vec` are
+/// implemented in this crate.
 ///
 /// Note: This implicitly uses the default `IpcWriteOptions`. To configure options,
 /// use `flight_data_from_arrow_batch()`
-impl From<&RecordBatch> for FlightData {
-    fn from(batch: &RecordBatch) -> Self {
-        let options = IpcWriteOptions::default();
-        flight_data_from_arrow_batch(batch, &options)
-    }
+pub fn convert_to_flight_data(batch: &RecordBatch) -> Vec<FlightData> {
+    let options = IpcWriteOptions::default();
+    flight_data_from_arrow_batch(batch, &options)
 }
 
-/// Convert a `RecordBatch` to `FlightData` by converting the header and body to bytes
+/// Convert a `RecordBatch` to a vector of `FlightData` representing the bytes of the dictionaries
+/// and values
 pub fn flight_data_from_arrow_batch(
     batch: &RecordBatch,
     options: &IpcWriteOptions,
-) -> FlightData {
+) -> Vec<FlightData> {
     let data_gen = writer::IpcDataGenerator::default();
-    let data = data_gen.record_batch_to_bytes(batch, &options);
-    FlightData {
-        flight_descriptor: None,
-        app_metadata: vec![],
-        data_header: data.ipc_message,
-        data_body: data.arrow_data,
-    }
+    let mut dictionary_tracker = writer::DictionaryTracker::new(false);
+
+    let (encoded_dictionaries, encoded_batch) = data_gen
+        .encoded_batch(batch, &mut dictionary_tracker, &options)
+        .expect("DictionaryTracker configured above to not error on replacement");
+
+    encoded_dictionaries
+        .into_iter()
+        .chain(std::iter::once(encoded_batch))
+        .map(|data| FlightData {
+            flight_descriptor: None,
+            app_metadata: vec![],
+            data_header: data.ipc_message,
+            data_body: data.arrow_data,
+        })
+        .collect()
 }
 
 /// Convert a `Schema` to `SchemaResult` by converting to an IPC message

--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -27,17 +27,6 @@ use arrow::ipc::{convert, reader, writer, writer::IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 
 /// Convert a `RecordBatch` to a vector of `FlightData` representing the bytes of the dictionaries
-/// and values. This can't be a `From` implementation because neither `RecordBatch` nor `Vec` are
-/// implemented in this crate.
-///
-/// Note: This implicitly uses the default `IpcWriteOptions`. To configure options,
-/// use `flight_data_from_arrow_batch()`
-pub fn convert_to_flight_data(batch: &RecordBatch) -> Vec<FlightData> {
-    let options = IpcWriteOptions::default();
-    flight_data_from_arrow_batch(batch, &options)
-}
-
-/// Convert a `RecordBatch` to a vector of `FlightData` representing the bytes of the dictionaries
 /// and values
 pub fn flight_data_from_arrow_batch(
     batch: &RecordBatch,
@@ -63,17 +52,6 @@ pub fn flight_data_from_arrow_batch(
 }
 
 /// Convert a `Schema` to `SchemaResult` by converting to an IPC message
-///
-/// Note: This implicitly uses the default `IpcWriteOptions`. To configure options,
-/// use `flight_schema_from_arrow_schema()`
-impl From<&Schema> for SchemaResult {
-    fn from(schema: &Schema) -> Self {
-        let options = IpcWriteOptions::default();
-        flight_schema_from_arrow_schema(schema, &options)
-    }
-}
-
-/// Convert a `Schema` to `SchemaResult` by converting to an IPC message
 pub fn flight_schema_from_arrow_schema(
     schema: &Schema,
     options: &IpcWriteOptions,
@@ -83,17 +61,6 @@ pub fn flight_schema_from_arrow_schema(
 
     SchemaResult {
         schema: schema_bytes.ipc_message,
-    }
-}
-
-/// Convert a `Schema` to `FlightData` by converting to an IPC message
-///
-/// Note: This implicitly uses the default `IpcWriteOptions`. To configure options,
-/// use `flight_data_from_arrow_schema()`
-impl From<&Schema> for FlightData {
-    fn from(schema: &Schema) -> Self {
-        let options = writer::IpcWriteOptions::default();
-        flight_data_from_arrow_schema(schema, &options)
     }
 }
 

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -542,29 +542,6 @@ pub struct EncodedData {
     pub arrow_data: Vec<u8>,
 }
 
-enum Message<'a> {
-    Schema(&'a Schema, &'a IpcWriteOptions),
-    RecordBatch(&'a RecordBatch, &'a IpcWriteOptions),
-    DictionaryBatch(i64, &'a ArrayDataRef, &'a IpcWriteOptions),
-}
-
-impl<'a> Message<'a> {
-    /// Encode message to a ipc::Message and return data as bytes
-    fn encode(&'a self, data_gen: &IpcDataGenerator) -> EncodedData {
-        match self {
-            Message::Schema(schema, options) => {
-                data_gen.schema_to_bytes(*schema, *options)
-            }
-            Message::RecordBatch(batch, options) => {
-                data_gen.record_batch_to_bytes(*batch, *options)
-            }
-            Message::DictionaryBatch(dict_id, array_data, options) => {
-                data_gen.dictionary_batch_to_bytes(*dict_id, *array_data, *options)
-            }
-        }
-    }
-}
-
 /// Write a message's IPC data and buffers, returning metadata and buffer data lengths written
 fn write_message<W: Write>(
     mut writer: &mut BufWriter<W>,

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -168,7 +168,7 @@ impl IpcDataGenerator {
 
     /// Write a `RecordBatch` into two sets of bytes, one for the header (ipc::Message) and the
     /// other for the batch's data
-    pub fn record_batch_to_bytes(
+    fn record_batch_to_bytes(
         &self,
         batch: &RecordBatch,
         write_options: &IpcWriteOptions,
@@ -222,7 +222,7 @@ impl IpcDataGenerator {
 
     /// Write dictionary values into two sets of bytes, one for the header (ipc::Message) and the
     /// other for the data
-    pub fn dictionary_batch_to_bytes(
+    fn dictionary_batch_to_bytes(
         &self,
         dict_id: i64,
         array_data: &ArrayDataRef,

--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -114,7 +114,11 @@ impl FlightService for FlightServiceImpl {
 
                 let mut batches: Vec<Result<FlightData, Status>> = results
                     .iter()
-                    .map(|batch| Ok(FlightData::from(batch)))
+                    .flat_map(|batch| {
+                        let flight_data =
+                            arrow_flight::utils::convert_to_flight_data(batch);
+                        flight_data.into_iter().map(Ok)
+                    })
                     .collect();
 
                 // append batch vector to schema vector, so that the first message sent is the schema

--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -66,7 +66,13 @@ impl FlightService for FlightServiceImpl {
 
         let table = ParquetTable::try_new(&request.path[0]).unwrap();
 
-        Ok(Response::new(SchemaResult::from(table.schema().as_ref())))
+        let options = arrow::ipc::writer::IpcWriteOptions::default();
+        let schema_result = arrow_flight::utils::flight_schema_from_arrow_schema(
+            table.schema().as_ref(),
+            &options,
+        );
+
+        Ok(Response::new(schema_result))
     }
 
     async fn do_get(
@@ -108,15 +114,24 @@ impl FlightService for FlightServiceImpl {
                 }
 
                 // add an initial FlightData message that sends schema
+                let options = arrow::ipc::writer::IpcWriteOptions::default();
                 let schema = plan.schema();
+                let schema_flight_data =
+                    arrow_flight::utils::flight_data_from_arrow_schema(
+                        schema.as_ref(),
+                        &options,
+                    );
+
                 let mut flights: Vec<Result<FlightData, Status>> =
-                    vec![Ok(FlightData::from(schema.as_ref()))];
+                    vec![Ok(schema_flight_data)];
 
                 let mut batches: Vec<Result<FlightData, Status>> = results
                     .iter()
                     .flat_map(|batch| {
                         let flight_data =
-                            arrow_flight::utils::convert_to_flight_data(batch);
+                            arrow_flight::utils::flight_data_from_arrow_batch(
+                                batch, &options,
+                            );
                         flight_data.into_iter().map(Ok)
                     })
                     .collect();

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -205,7 +205,8 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Option<Schema> {
 /// Encodes the Arrow schema into the IPC format, and base64 encodes it
 fn encode_arrow_schema(schema: &Schema) -> String {
     let options = writer::IpcWriteOptions::default();
-    let mut serialized_schema = arrow::ipc::writer::schema_to_bytes(&schema, &options);
+    let data_gen = arrow::ipc::writer::IpcDataGenerator::default();
+    let mut serialized_schema = data_gen.schema_to_bytes(&schema, &options);
 
     // manually prepending the length to the schema as arrow uses the legacy IPC format
     // TODO: change after addressing ARROW-9777


### PR DESCRIPTION
This PR contains a series of refactorings to extract code from the IPC `FileWriter` and `StreamWriter` that generates `EncodedData` instances. I highly recommend reviewing commit-by-commit, I tried to make the changes fairly mechanical and easy to understand at each step.

With those refactorings, it becomes easier to reuse the code with Flight too, so that when we're generating `FlightData` for a `RecordBatch`, we get the `FlightData` for the batch's dictionaries too.

This will help in getting the Flight integration tests that include dictionaries to pass... I'm also having some unrelated protocol problems over in [this PR I'm working on](https://github.com/apache/arrow/pull/8641) but this work will help there.