### PR TITLE
ARROW-10807: [Rust][DataFusion] Avoid double hashing

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -45,6 +45,7 @@ cli = ["rustyline"]
 
 [dependencies]
 ahash = "0.6"
+hashbrown = "0.9"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", features = ["prettyprint"] }
 parquet = { path = "../parquet", version = "3.0.0-SNAPSHOT", features = ["arrow"] }
 sqlparser = "0.6.1"

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#![feature(hash_raw_entry)]
 #![warn(missing_docs)]
 // Clippy lints, some should be disabled incrementally
 #![allow(

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+#![feature(hash_raw_entry)]
 #![warn(missing_docs)]
 // Clippy lints, some should be disabled incrementally
 #![allow(

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -253,6 +253,10 @@ fn group_aggregate_batch(
     // 1.1 construct the key from the group values
     // 1.2 construct the mapping key if it does not exist
     // 1.3 add the row' index to `indices`
+
+    // Make sure we can create the accumulators or otherwise return an error
+    create_accumulators(aggr_expr)?;
+
     for row in 0..batch.num_rows() {
         // 1.1
         create_key(&group_values, row, &mut key)
@@ -260,10 +264,12 @@ fn group_aggregate_batch(
         accumulators
             .raw_entry_mut()
             .from_key(&key)
+            // 1.3
             .and_modify(|_, (_, v)| v.push(row as u32))
+            // 1.2
             .or_insert_with(|| {
-                let accumulator_set = create_accumulators(aggr_expr)
-                    .expect("Couldn't generate accumulators");
+                // We can safely unwrap here as we checked we can create an accumulator before
+                let accumulator_set = create_accumulators(aggr_expr).unwrap();
                 (key.clone(), (accumulator_set, Box::new(vec![row as u32])))
             });
     }

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -47,7 +47,7 @@ use super::{
     SendableRecordBatchStream,
 };
 use ahash::RandomState;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use async_trait::async_trait;
 

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -255,7 +255,7 @@ fn group_aggregate_batch(
     // 1.3 add the row' index to `indices`
 
     // Make sure we can create the accumulators or otherwise return an error
-    create_accumulators(aggr_expr)?;
+    create_accumulators(aggr_expr).map_err(DataFusionError::into_arrow_external_error)?;
 
     for row in 0..batch.num_rows() {
         // 1.1

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -215,12 +215,10 @@ fn update_hash(
     for row in 0..batch.num_rows() {
         create_key(&keys_values, row, &mut key)?;
 
-        hash
-        .raw_entry_mut()
-        .from_key(&key)
-        .and_modify(|_, v| v.push((index, row)))
-        .or_insert_with(|| (key.clone(),  vec![(index, row)]));
-
+        hash.raw_entry_mut()
+            .from_key(&key)
+            .and_modify(|_, v| v.push((index, row)))
+            .or_insert_with(|| (key.clone(), vec![(index, row)]));
     }
     Ok(())
 }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -214,12 +214,13 @@ fn update_hash(
     // update the hash map
     for row in 0..batch.num_rows() {
         create_key(&keys_values, row, &mut key)?;
-        match hash.get_mut(&key) {
-            Some(v) => v.push((index, row)),
-            None => {
-                hash.insert(key.clone(), vec![(index, row)]);
-            }
-        };
+
+        hash
+        .raw_entry_mut()
+        .from_key(&key)
+        .and_modify(|_, v| v.push((index, row)))
+        .or_insert_with(|| (key.clone(),  vec![(index, row)]));
+
     }
     Ok(())
 }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -19,13 +19,11 @@
 //! into a set of partitions.
 
 use std::sync::Arc;
-use std::{
-    any::Any,
-    collections::{HashMap, HashSet},
-};
+use std::{any::Any, collections::HashSet};
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt, TryStreamExt};
+use hashbrown::HashMap;
 
 use arrow::array::{make_array, Array, MutableArrayData};
 use arrow::datatypes::{Schema, SchemaRef};


### PR DESCRIPTION
This PR shows one area for improvement in the hash join and aggregates. Currently the key is hashed twice by first looking up the key, and then inserting (which hashes the same key again) or mutating the value. This particularly is expensive with lots of distinct keys (ie most joins or aggregates on some high cardinality identifier).
Using the unstable `hash_raw_entry` (or api in hashbrown) api we can avoid this, and get some speedup somewhere between 50-100ms (mostly in the hash join) for the tpch query 12.

~~We could also use the hashbrown crate (which rust std lib also uses) instead to avoid needing a unstable feature.~~ did that

This brings the query tpc-h 12 times down from > 1500ms locally to:
```
Query 12 iteration 0 took 1399 ms
Query 12 iteration 1 took 1398 ms
Query 12 iteration 2 took 1402 ms
Query 12 iteration 3 took 1407 ms
Query 12 iteration 4 took 1409 ms
Query 12 iteration 5 took 1406 ms
Query 12 iteration 6 took 1414 ms
Query 12 iteration 7 took 1416 ms
Query 12 iteration 8 took 1423 ms
Query 12 iteration 9 took 1430 ms
```

FYI @jorgecarleitao @andygrove 