### PR TITLE
ARROW-10803: Support R >= 3.3 and add CI

### DIFF
--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -60,7 +60,7 @@ fi
 # Make sure we aren't writing to the home dir (CRAN _hates_ this but there is no official check)
 BEFORE=$(ls -alh ~/)
 
-${R_BIN} -e "as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
+SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   if (as_cran) {
     rcmdcheck::rcmdcheck(args = c('--as-cran', '--run-donttest'), error_on = 'warning', check_dir = 'check')
   } else {
@@ -73,6 +73,7 @@ ${R_BIN} -e "as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     }
     rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')
   }"
+${R_BIN} < $SCRIPT
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -73,7 +73,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     }
     rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')
   }"
-echo "$SCRIPT" | ${R_BIN}
+echo "$SCRIPT" | ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -73,7 +73,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     }
     rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')
   }"
-${R_BIN} < $SCRIPT
+echo "$SCRIPT" | ${R_BIN}
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -35,8 +35,9 @@ jobs:
         r_version:
           # We test devel, release, and oldrel in regular CI.
           # This is for older versions
-          - "3.1"
-          - "3.2"
+          # - "3.1"
+          # - "3.2"
+          # rcmdcheck package depends on digest, which depends on R >= 3.3
           - "3.3"
           - "3.4"
           - "3.5"

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -35,9 +35,7 @@ jobs:
         r_version:
           # We test devel, release, and oldrel in regular CI.
           # This is for older versions
-          # - "3.1"
-          # - "3.2"
-          # rcmdcheck package depends on digest, which depends on R >= 3.3
+          # rlang and vctrs depend on R >= 3.3
           - "3.3"
           - "3.4"
           - "3.5"

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE: must set "Crossbow" as name to have the badge links working in the
+# github comment reports!
+name: Crossbow
+
+on:
+  push:
+    branches:
+      - "*-github-*"
+
+jobs:
+  r-versions:
+    name: "rstudio/r-base:{{ MATRIX }}-bionic"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # See https://hub.docker.com/r/rstudio/r-base
+        r_version:
+          # We test devel, release, and oldrel in regular CI.
+          # This is for older versions
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "3.5"
+    env:
+      R_ORG: "rstudio"
+      R_IMAGE: "r-base"
+      R_TAG: "{{ MATRIX }}-bionic"
+      ARROW_R_DEV: "FALSE"
+    steps:
+      - name: Checkout Arrow
+        run: |
+          git clone --no-checkout {{ arrow.remote }} arrow
+          git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
+          git -C arrow checkout FETCH_HEAD
+          git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: cd arrow && ci/scripts/util_checkout.sh
+      - name: Docker Pull
+        shell: bash
+        run: cd arrow && docker-compose pull --ignore-pull-failures r
+      - name: Docker Build
+        shell: bash
+        run: cd arrow && docker-compose build r
+      - name: Docker Run
+        shell: bash
+        run: cd arrow && docker-compose run r
+      - name: Dump install logs
+        run: cat arrow/r/check/arrow.Rcheck/00install.out
+        if: always()

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -43,7 +43,7 @@ jobs:
       R_ORG: "rstudio"
       R_IMAGE: "r-base"
       R_TAG: "{{ MATRIX }}-bionic"
-      ARROW_R_DEV: "FALSE"
+      ARROW_R_DEV: "TRUE"
     steps:
       - name: Checkout Arrow
         run: |

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1753,6 +1753,12 @@ tasks:
     params:
       MATRIX: "${{ matrix.r_image }}"
 
+  test-r-versions:
+    ci: github
+    template: r/github.linux.versions.yml
+    params:
+      MATRIX: "${{ matrix.r_version }}"
+
   test-r-rhub-ubuntu-gcc-release:
     ci: azure
     template: r/azure.linux.yml

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -14,7 +14,7 @@ Description: 'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
     language-independent columnar memory format for flat and hierarchical data,
     organized for efficient analytic operations on modern hardware. This
     package provides an interface to the 'Arrow C++' library.
-Depends: R (>= 3.1)
+Depends: R (>= 3.3)
 License: Apache License (>= 2.0)
 URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
 BugReports: https://issues.apache.org/jira/projects/ARROW/issues

--- a/r/configure
+++ b/r/configure
@@ -164,6 +164,8 @@ fi
 # Test configuration
 CXXCPP="`${R_HOME}/bin/R CMD config CXX11` -E"
 if [ $? -eq 0 ]; then
+  # Great, CXX11 exists for this version of R (current);
+  # now let's set the other two variables
   CXX11FLAGS=`"${R_HOME}"/bin/R CMD config CXX11FLAGS`
   CXX11STD=`"${R_HOME}"/bin/R CMD config CXX11STD`
 else

--- a/r/configure
+++ b/r/configure
@@ -151,12 +151,6 @@ else
   fi
 fi
 
-# Find compiler
-CXXCPP="`${R_HOME}/bin/R CMD config CXX11` -E"
-CXX11FLAGS=`"${R_HOME}"/bin/R CMD config CXX11FLAGS`
-CXX11STD=`"${R_HOME}"/bin/R CMD config CXX11STD`
-CPPFLAGS=`"${R_HOME}"/bin/R CMD config CPPFLAGS`
-
 # If libarrow uses the old GLIBCXX ABI, so we have to use it too
 if [ "$ARROW_USE_OLD_CXXABI" ]; then
   PKG_CFLAGS="$PKG_CFLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
@@ -168,6 +162,17 @@ if [ "$ARROW_R_CXXFLAGS" ]; then
 fi
 
 # Test configuration
+CXXCPP="`${R_HOME}/bin/R CMD config CXX11` -E"
+if [ $? -eq 0 ]; then
+  CXX11FLAGS=`"${R_HOME}"/bin/R CMD config CXX11FLAGS`
+  CXX11STD=`"${R_HOME}"/bin/R CMD config CXX11STD`
+else
+  # For compatibility with R < 3.4, when these were called CXX1X
+  CXXCPP="`${R_HOME}/bin/R CMD config CXX1X` -E"
+  CXX11FLAGS=`"${R_HOME}"/bin/R CMD config CXX1XFLAGS`
+  CXX11STD=`"${R_HOME}"/bin/R CMD config CXX1XSTD`
+fi
+CPPFLAGS=`"${R_HOME}"/bin/R CMD config CPPFLAGS`
 TEST_CMD="${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX11FLAGS} ${CXX11STD} -xc++ -"
 echo "#include $PKG_TEST_HEADER" | ${TEST_CMD} >/dev/null 2>&1
 

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -53,6 +53,17 @@ std::shared_ptr<arrow::Array> Array__from_vector(SEXP x, SEXP type);
 std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP, SEXP);
 arrow::MemoryPool* gc_memory_pool();
 
+#if (R_VERSION < R_Version(3, 5, 0))
+#define LOGICAL_RO(x) ((const int*)LOGICAL(x))
+#define INTEGER_RO(x) ((const int*)INTEGER(x))
+#define REAL_RO(x) ((const double*)REAL(x))
+#define COMPLEX_RO(x) ((const Rcomplex*)COMPLEX(x))
+#define STRING_PTR_RO(x) ((const SEXP*)STRING_PTR(x))
+#define RAW_RO(x) ((const Rbyte*)RAW(x))
+#define DATAPTR_RO(x) ((const void*)STRING_PTR(x))
+#define DATAPTR(x) (void*)STRING_PTR(x)
+#endif
+
 namespace arrow {
 
 static inline void StopIfNotOk(const Status& status) {

--- a/r/src/imports.cpp
+++ b/r/src/imports.cpp
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <R_ext/Rdynload.h>  // for R_GetCCallable
 #include <Rdefines.h>
-#include <R_ext/Rdynload.h> // for R_GetCCallable
 
 namespace vctrs {
 struct vctrs_api_ptrs_t {

--- a/r/src/imports.cpp
+++ b/r/src/imports.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <Rdefines.h>
+#include <R_ext/Rdynload.h> // for R_GetCCallable
 
 namespace vctrs {
 struct vctrs_api_ptrs_t {

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -21,6 +21,11 @@ dst_dir <- paste0("libarrow/arrow-", VERSION)
 
 arrow_repo <- "https://dl.bintray.com/ursalabs/arrow-r/libarrow/"
 
+if (getRversion() < 3.4 && is.null(getOption("download.file.method"))) {
+  # default method doesn't work on R 3.3; default changed to libcurl in 3.4
+  options(download.file.method = "libcurl")
+}
+
 options(.arrow.cleanup = character()) # To collect dirs to rm on exit
 on.exit(unlink(getOption(".arrow.cleanup")))
 

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -22,8 +22,8 @@ dst_dir <- paste0("libarrow/arrow-", VERSION)
 arrow_repo <- "https://dl.bintray.com/ursalabs/arrow-r/libarrow/"
 
 if (getRversion() < 3.4 && is.null(getOption("download.file.method"))) {
-  # default method doesn't work on R 3.3; default changed to libcurl in 3.4
-  options(download.file.method = "libcurl")
+  # default method doesn't work on R 3.3, nor does libcurl
+  options(download.file.method = "wget")
 }
 
 options(.arrow.cleanup = character()) # To collect dirs to rm on exit

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -301,8 +301,12 @@ build_libarrow <- function(src_dir, dst_dir) {
   options(.arrow.cleanup = c(getOption(".arrow.cleanup"), build_dir))
 
   R_CMD_config <- function(var) {
-    # cf. tools::Rcmd, introduced R 3.3
-    system2(file.path(R.home("bin"), "R"), c("CMD", "config", var), stdout = TRUE)
+    if (getRversion() < 3.4) {
+      # var names were called CXX1X instead of CXX11
+      var <- sub("^CXX11", "CXX1X", var)
+    }
+    # tools::Rcmd introduced R 3.3
+    tools::Rcmd(paste("config", var), stdout = TRUE)
   }
   env_var_list <- c(
     SOURCE_DIR = src_dir,
@@ -339,7 +343,7 @@ ensure_cmake <- function() {
   if (is.null(cmake)) {
     # If not found, download it
     cat("**** cmake\n")
-    CMAKE_VERSION <- Sys.getenv("CMAKE_VERSION", "3.18.1")
+    CMAKE_VERSION <- Sys.getenv("CMAKE_VERSION", "3.19.2")
     cmake_binary_url <- paste0(
       "https://github.com/Kitware/CMake/releases/download/v", CMAKE_VERSION,
       "/cmake-", CMAKE_VERSION, "-Linux-x86_64.tar.gz"


### PR DESCRIPTION
Includes fixes for compiling on R 3.4 and R 3.3, plus a crossbow job to build on old R versions