### PR TITLE
ARROW-10833: [Python] Allow pyarrow to be compiled on NumPy <1.16.6 and work on 1.20+

### DIFF
--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -67,7 +67,7 @@ NumPyBuffer::~NumPyBuffer() {
 namespace {
 
 Status GetTensorType(PyObject* dtype, std::shared_ptr<DataType>* out) {
-  if (!PyArray_DescrCheck(dtype)) {
+  if (!PyObject_TypeCheck(dtype, &PyArrayDescr_Type)) {
     return Status::TypeError("Did not pass numpy.dtype object");
   }
   PyArray_Descr* descr = reinterpret_cast<PyArray_Descr*>(dtype);
@@ -123,7 +123,7 @@ Status GetNumPyType(const DataType& type, int* type_num) {
 }  // namespace
 
 Status NumPyDtypeToArrow(PyObject* dtype, std::shared_ptr<DataType>* out) {
-  if (!PyArray_DescrCheck(dtype)) {
+  if (!PyObject_TypeCheck(dtype, &PyArrayDescr_Type)) {
     return Status::TypeError("Did not pass numpy.dtype object");
   }
   PyArray_Descr* descr = reinterpret_cast<PyArray_Descr*>(dtype);

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -736,7 +736,7 @@ Status NumPyConverter::Visit(const StructType& type) {
       }
       PyArray_Descr* sub_dtype =
           reinterpret_cast<PyArray_Descr*>(PyTuple_GET_ITEM(tup, 0));
-      DCHECK(PyArray_DescrCheck(sub_dtype));
+      DCHECK(PyObject_TypeCheck(sub_dtype, &PyArrayDescr_Type));
       int offset = static_cast<int>(PyLong_AsLong(PyTuple_GET_ITEM(tup, 1)));
       RETURN_IF_PYERROR();
       Py_INCREF(sub_dtype); /* PyArray_GetField() steals ref */


### PR DESCRIPTION
NumPy before `1.16.6` had a faulty macro which now finally (in NumPy 1.20)
will lead to actually wrong results (it will always return False) even
when the dtype is a NumPy dtype.

This fixes it by avoiding the macro, the macro itself is fixed in
NumPy 1.16.6+, but this ensures that for the time being you can
compile using an older NumPy versions.

Since this breaks PyArrow, my best suggestion is that NumPy could wait
for its final 1.20 release until after PyArrow had a chance to do a
bug-fix release that includes this fix.

---

xref: https://github.com/numpy/numpy/issues/17913