### PR TITLE
ARROW-10809: [C++] Use Datum for SortIndices() input

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -62,10 +62,10 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
   return result.make_array();
 }
 
-Result<std::shared_ptr<Array>> SortIndices(const Table& table, const SortOptions& options,
+Result<std::shared_ptr<Array>> SortIndices(const Datum& datum, const SortOptions& options,
                                            ExecContext* ctx) {
   ARROW_ASSIGN_OR_RAISE(Datum result,
-                        CallFunction("sort_indices", {Datum(table)}, &options, ctx));
+                        CallFunction("sort_indices", {datum}, &options, ctx));
   return result.make_array();
 }
 

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -222,15 +222,16 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
                                            SortOrder order = SortOrder::Ascending,
                                            ExecContext* ctx = NULLPTR);
 
-/// \brief Returns the indices that would sort a table in the
-/// specified order.
+/// \brief Returns the indices that would sort an input in the
+/// specified order. Input is one of array, chunked array record batch
+/// or table.
 ///
-/// Perform an indirect sort of table. The output array will contain
-/// indices that would sort a table, which would be the same length as
-/// input. Nulls will be stably partitioned to the end of the output
-/// regardless of order.
+/// Perform an indirect sort of input. The output array will contain
+/// indices that would sort an input, which would be the same length
+/// as input. Nulls will be stably partitioned to the end of the
+/// output regardless of order.
 ///
-/// For example given table = {
+/// For example given input (table) = {
 /// "column1": [[null,   1], [   3, null, 2, 1]],
 /// "column2": [[   5], [3,   null, null, 5, 5]],
 /// } and options = {
@@ -238,12 +239,12 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
 /// {"column2", SortOrder::Descending},
 /// }, the output will be [5, 1, 4, 2, 0, 3].
 ///
-/// \param[in] table table to sort
+/// \param[in] datum array, chunked array, record batch or table to sort
 /// \param[in] options options
 /// \param[in] ctx the function execution context, optional
 /// \return offsets indices that would sort a table
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> SortIndices(const Table& table, const SortOptions& options,
+Result<std::shared_ptr<Array>> SortIndices(const Datum& datum, const SortOptions& options,
                                            ExecContext* ctx = NULLPTR);
 
 /// \brief Compute unique elements from an array-like object

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -94,7 +94,7 @@ static void TableSortIndicesBenchmark(benchmark::State& state,
                                       const std::shared_ptr<Table>& table,
                                       const SortOptions& options) {
   for (auto _ : state) {
-    ABORT_NOT_OK(SortIndices(*table, options).status());
+    ABORT_NOT_OK(SortIndices(Datum(*table), options).status());
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -549,7 +549,7 @@ class TestTableSortIndices : public ::testing::Test {
  protected:
   void AssertSortIndices(const std::shared_ptr<Table> table, const SortOptions& options,
                          const std::shared_ptr<Array> expected) {
-    ASSERT_OK_AND_ASSIGN(auto actual, SortIndices(*table, options));
+    ASSERT_OK_AND_ASSIGN(auto actual, SortIndices(Datum(*table), options));
     AssertArraysEqual(*expected, *actual);
   }
 
@@ -774,7 +774,7 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
     TableBatchReader reader(*table);
     reader.set_chunksize((length + num_chunks - 1) / num_chunks);
     ASSERT_OK_AND_ASSIGN(auto chunked_table, Table::FromRecordBatchReader(&reader));
-    ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(*chunked_table, options));
+    ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*chunked_table), options));
     Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
   }
 }


### PR DESCRIPTION
Because we migrated to Datum-based version for Take() in 1.0.0. New
API should follow the convention.

We keep SortIndices(Array) and SortIndices(ChunkedArray) to provide
easy to use shortcut. SortIndices(Datum) uses SortOptions but
SortIndices(Array) and SortIndices(ChunkedArray) need only
SortOrder. If we provide only SortIndices(Datum), users need to create
SortOptions even when they just want to specify order.