### PR TITLE
ARROW-10810: [Rust] Speed up comparison kernels

### DIFF
--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -47,9 +47,19 @@ macro_rules! compare_op {
         let null_bit_buffer =
             combine_option_bitmap($left.data_ref(), $right.data_ref(), $left.len())?;
 
-        let mut result = BooleanBufferBuilder::new($left.len());
+        let byte_capacity = bit_util::ceil($left.len(), 8);
+        let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
+        let mut buffer = MutableBuffer::new(actual_capacity);
+        buffer.resize(byte_capacity);
+        buffer.set_null_bits(0, actual_capacity);
+
+        let data = buffer.raw_data_mut();
         for i in 0..$left.len() {
-            result.append($op($left.value(i), $right.value(i)))?;
+            if $op($left.value(i), $right.value(i)) {
+                unsafe {
+                    bit_util::set_bit_raw(data, i);
+                }
+            }
         }
 
         let data = ArrayData::new(
@@ -58,7 +68,7 @@ macro_rules! compare_op {
             None,
             null_bit_buffer,
             0,
-            vec![result.finish()],
+            vec![buffer.freeze()],
             vec![],
         );
         Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
@@ -68,8 +78,13 @@ macro_rules! compare_op {
 macro_rules! compare_op_scalar {
     ($left: expr, $right:expr, $op:expr) => {{
         let null_bit_buffer = $left.data().null_buffer().cloned();
-        let mut result = MutableBuffer::new($left.len());
-        let data = result.raw_data_mut();
+        let byte_capacity = bit_util::ceil($left.len(), 8);
+        let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
+        let mut buffer = MutableBuffer::new(actual_capacity);
+        buffer.resize(byte_capacity);
+
+        buffer.set_null_bits(0, actual_capacity);
+        let data = buffer.raw_data_mut();
         for i in 0..$left.len() {
             if $op($left.value(i), $right) {
                 unsafe {
@@ -84,7 +99,7 @@ macro_rules! compare_op_scalar {
             None,
             null_bit_buffer,
             0,
-            vec![result.freeze()],
+            vec![buffer.freeze()],
             vec![],
         );
         Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -51,7 +51,6 @@ macro_rules! compare_op {
         let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
         let mut buffer = MutableBuffer::new(actual_capacity);
         buffer.resize(byte_capacity);
-        buffer.set_null_bits(0, actual_capacity);
 
         let data = buffer.raw_data_mut();
         for i in 0..$left.len() {
@@ -83,7 +82,6 @@ macro_rules! compare_op_scalar {
         let mut buffer = MutableBuffer::new(actual_capacity);
         buffer.resize(byte_capacity);
 
-        buffer.set_null_bits(0, actual_capacity);
         let data = buffer.raw_data_mut();
         for i in 0..$left.len() {
             if $op($left.value(i), $right) {


### PR DESCRIPTION
This PR speeds up the (non-simd) comparison kernels by ~8 times:

Together with https://github.com/apache/arrow/pull/8832 brings even more improvements to query 12 (~1400 -> ~1250ms) 

```
Query 12 iteration 0 took 1233 ms
Query 12 iteration 1 took 1233 ms
Query 12 iteration 2 took 1235 ms
Query 12 iteration 3 took 1235 ms
Query 12 iteration 4 took 1297 ms
Query 12 iteration 5 took 1246 ms
Query 12 iteration 6 took 1257 ms
Query 12 iteration 7 took 1250 ms
Query 12 iteration 8 took 1265 ms
Query 12 iteration 9 took 1279 ms
```


```
eq Float32              time:   [105.96 us 106.01 us 106.06 us]                       
                        change: [-82.463% -82.423% -82.378%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  3 (3.00%) high severe

eq scalar Float32       time:   [61.439 us 61.530 us 61.662 us]                              
                        change: [-88.282% -88.255% -88.221%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe

neq Float32             time:   [71.018 us 71.080 us 71.144 us]                        
                        change: [-86.580% -86.563% -86.546%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

neq scalar Float32      time:   [68.706 us 68.773 us 68.838 us]                               
                        change: [-86.207% -86.188% -86.171%] (p = 0.00 < 0.05)
                        Performance has improved.

lt Float32              time:   [70.655 us 70.703 us 70.753 us]                       
                        change: [-85.629% -85.617% -85.604%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

lt scalar Float32       time:   [50.626 us 50.664 us 50.698 us]                               
                        change: [-89.802% -89.764% -89.731%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

lt_eq Float32           time:   [101.34 us 101.43 us 101.51 us]                          
                        change: [-82.825% -82.797% -82.767%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

lt_eq scalar Float32    time:   [68.894 us 68.913 us 68.933 us]                                 
                        change: [-86.575% -86.557% -86.538%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild

gt Float32              time:   [71.260 us 71.332 us 71.400 us]                       
                        change: [-87.481% -87.450% -87.418%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

gt scalar Float32       time:   [38.852 us 38.888 us 38.929 us]                               
                        change: [-91.745% -91.733% -91.721%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  11 (11.00%) high mild
  1 (1.00%) high severe

gt_eq Float32           time:   [99.404 us 99.451 us 99.503 us]                          
                        change: [-80.870% -80.848% -80.827%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

gt_eq scalar Float32    time:   [55.892 us 55.926 us 55.963 us]                                 
                        change: [-88.783% -88.751% -88.727%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```