### PR TITLE
ARROW-10732: [Rust] [DataFusion] Integrate DFSchema as a step towards supporting qualified column names

### DIFF
--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -19,8 +19,7 @@
 
 use crate::arrow::record_batch::RecordBatch;
 use crate::error::Result;
-use crate::logical_plan::{Expr, FunctionRegistry, JoinType, LogicalPlan};
-use arrow::datatypes::Schema;
+use crate::logical_plan::{DFSchema, Expr, FunctionRegistry, JoinType, LogicalPlan};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -201,7 +200,7 @@ pub trait DataFrame {
     /// # Ok(())
     /// # }
     /// ```
-    fn schema(&self) -> &Schema;
+    fn schema(&self) -> &DFSchema;
 
     /// Return the logical plan represented by this DataFrame.
     fn to_logical_plan(&self) -> LogicalPlan;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -407,11 +407,8 @@ impl ExecutionContext {
             let filename = format!("part-{}.parquet", i);
             let path = Path::new(&path).join(&filename);
             let file = fs::File::create(path)?;
-            let mut writer = ArrowWriter::try_new(
-                file.try_clone().unwrap(),
-                plan.schema().as_ref().to_owned().into(),
-                None,
-            )?;
+            let mut writer =
+                ArrowWriter::try_new(file.try_clone().unwrap(), plan.schema(), None)?;
             let stream = plan.execute(i).await?;
 
             stream

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -35,7 +35,7 @@ use crate::datasource::TableProvider;
 use crate::error::{DataFusionError, Result};
 use crate::execution::dataframe_impl::DataFrameImpl;
 use crate::logical_plan::{
-    FunctionRegistry, LogicalPlan, LogicalPlanBuilder, TableSource,
+    DFSchema, DFSchemaRef, FunctionRegistry, LogicalPlan, LogicalPlanBuilder, TableSource,
 };
 use crate::optimizer::filter_push_down::FilterPushDown;
 use crate::optimizer::optimizer::OptimizerRule;
@@ -140,7 +140,7 @@ impl ExecutionContext {
                         name,
                         location,
                         CsvReadOptions::new()
-                            .schema(&schema)
+                            .schema(&schema.as_ref().to_owned().into())
                             .has_header(*has_header),
                     )?;
                     let plan = LogicalPlanBuilder::empty(false).build()?;
@@ -214,7 +214,7 @@ impl ExecutionContext {
             has_header: options.has_header,
             delimiter: Some(options.delimiter),
             projection: None,
-            projected_schema: csv.schema(),
+            projected_schema: Arc::new(DFSchema::from(&csv.schema())?),
         };
 
         Ok(Arc::new(DataFrameImpl::new(
@@ -231,7 +231,7 @@ impl ExecutionContext {
             path: filename.to_string(),
             schema: parquet.schema(),
             projection: None,
-            projected_schema: parquet.schema(),
+            projected_schema: Arc::new(DFSchema::from(&parquet.schema())?),
         };
 
         Ok(Arc::new(DataFrameImpl::new(
@@ -250,7 +250,7 @@ impl ExecutionContext {
             schema_name: "".to_string(),
             source: TableSource::FromProvider(provider),
             table_schema: schema.clone(),
-            projected_schema: schema,
+            projected_schema: DFSchemaRef::new(DFSchema::from(&schema)?),
             projection: None,
         };
         Ok(Arc::new(DataFrameImpl::new(
@@ -302,7 +302,7 @@ impl ExecutionContext {
                     schema_name: "".to_string(),
                     source: TableSource::FromContext(table_name.to_string()),
                     table_schema: schema.clone(),
-                    projected_schema: schema,
+                    projected_schema: DFSchemaRef::new(DFSchema::from(&schema)?),
                     projection: None,
                 };
                 Ok(Arc::new(DataFrameImpl::new(
@@ -407,8 +407,11 @@ impl ExecutionContext {
             let filename = format!("part-{}.parquet", i);
             let path = Path::new(&path).join(&filename);
             let file = fs::File::create(path)?;
-            let mut writer =
-                ArrowWriter::try_new(file.try_clone().unwrap(), plan.schema(), None)?;
+            let mut writer = ArrowWriter::try_new(
+                file.try_clone().unwrap(),
+                plan.schema().as_ref().to_owned().into(),
+                None,
+            )?;
             let stream = plan.execute(i).await?;
 
             stream
@@ -758,7 +761,7 @@ mod tests {
             )?]],
             schema: schema.clone(),
             projection: None,
-            projected_schema: schema.clone(),
+            projected_schema: DFSchemaRef::new(DFSchema::from(&schema)?),
         })
         .project(vec![col("b")])?
         .build()?;

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -24,9 +24,8 @@ use crate::dataframe::*;
 use crate::error::Result;
 use crate::execution::context::{ExecutionContext, ExecutionContextState};
 use crate::logical_plan::{
-    col, Expr, FunctionRegistry, JoinType, LogicalPlan, LogicalPlanBuilder,
+    col, DFSchema, Expr, FunctionRegistry, JoinType, LogicalPlan, LogicalPlanBuilder,
 };
-use arrow::datatypes::Schema;
 
 use async_trait::async_trait;
 
@@ -50,18 +49,12 @@ impl DataFrameImpl {
 impl DataFrame for DataFrameImpl {
     /// Apply a projection based on a list of column names
     fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<dyn DataFrame>> {
-        let exprs = columns
+        let fields = columns
             .iter()
-            .map(|name| {
-                self.plan
-                    .schema()
-                    // take the index to ensure that the column exists in the schema
-                    .index_of(name.to_owned())
-                    .and_then(|_| Ok(col(name)))
-                    .map_err(|e| e.into())
-            })
+            .map(|name| self.plan.schema().field_with_unqualified_name(name))
             .collect::<Result<Vec<_>>>()?;
-        self.select(exprs)
+        let expr = fields.iter().map(|f| col(f.name())).collect();
+        self.select(expr)
     }
 
     /// Create a projection based on arbitrary expressions
@@ -133,7 +126,7 @@ impl DataFrame for DataFrameImpl {
     }
 
     /// Returns the schema from the logical plan
-    fn schema(&self) -> &Schema {
+    fn schema(&self) -> &DFSchema {
         self.plan.schema()
     }
 
@@ -332,7 +325,7 @@ mod tests {
         ctx.register_csv(
             "aggregate_test_100",
             &format!("{}/csv/aggregate_test_100.csv", testdata),
-            CsvReadOptions::new().schema(&schema),
+            CsvReadOptions::new().schema(&schema.as_ref().to_owned().into()),
         )?;
         Ok(())
     }

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -325,7 +325,7 @@ mod tests {
         ctx.register_csv(
             "aggregate_test_100",
             &format!("{}/csv/aggregate_test_100.csv", testdata),
-            CsvReadOptions::new().schema(&schema.as_ref().to_owned().into()),
+            CsvReadOptions::new().schema(&schema.as_ref()),
         )?;
         Ok(())
     }

--- a/rust/datafusion/src/logical_plan/display.rs
+++ b/rust/datafusion/src/logical_plan/display.rs
@@ -62,7 +62,11 @@ impl<'a, 'b> PlanVisitor for IndentVisitor<'a, 'b> {
 
         write!(self.f, "{}", plan.display())?;
         if self.with_schema {
-            write!(self.f, " {}", display_schema(plan.schema()))?;
+            write!(
+                self.f,
+                " {}",
+                display_schema(&plan.schema().as_ref().to_owned().into())
+            )?;
         }
 
         self.indent += 1;
@@ -202,7 +206,7 @@ impl<'a, 'b> PlanVisitor for GraphvizVisitor<'a, 'b> {
             format!(
                 "{}\\nSchema: {}",
                 plan.display(),
-                display_schema(plan.schema())
+                display_schema(&plan.schema().as_ref().to_owned().into())
             )
         } else {
             format!("{}", plan.display())

--- a/rust/datafusion/src/logical_plan/extension.rs
+++ b/rust/datafusion/src/logical_plan/extension.rs
@@ -17,7 +17,7 @@
 
 //! This module defines the interface for logical nodes
 use super::{Expr, LogicalPlan};
-use arrow::datatypes::SchemaRef;
+use crate::logical_plan::DFSchemaRef;
 use std::{any::Any, collections::HashSet, fmt, sync::Arc};
 
 /// This defines the interface for `LogicalPlan` nodes that can be
@@ -34,7 +34,7 @@ pub trait UserDefinedLogicalNode: fmt::Debug {
     fn inputs(&self) -> Vec<&LogicalPlan>;
 
     /// Return the output schema of this logical plan node
-    fn schema(&self) -> &SchemaRef;
+    fn schema(&self) -> &DFSchemaRef;
 
     /// returns all expressions in the current logical plan node. This
     /// should not include expressions of any inputs (aka

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -31,6 +31,7 @@ use crate::sql::parser::FileType;
 use super::display::{GraphvizVisitor, IndentVisitor};
 use super::expr::Expr;
 use super::extension::UserDefinedLogicalNode;
+use crate::logical_plan::dfschema::DFSchemaRef;
 
 /// Describes the source of the table, either registered on the context or by reference
 #[derive(Clone)]
@@ -70,7 +71,7 @@ pub enum LogicalPlan {
         /// The incoming logical plan
         input: Arc<LogicalPlan>,
         /// The schema description of the output
-        schema: SchemaRef,
+        schema: DFSchemaRef,
     },
     /// Filters rows from its input that do not match an
     /// expression (essentially a WHERE clause with a predicate
@@ -96,7 +97,7 @@ pub enum LogicalPlan {
         /// Aggregate expressions
         aggr_expr: Vec<Expr>,
         /// The schema description of the aggregate output
-        schema: SchemaRef,
+        schema: DFSchemaRef,
     },
     /// Sorts its input according to a list of sort expressions.
     Sort {
@@ -116,7 +117,7 @@ pub enum LogicalPlan {
         /// Join type
         join_type: JoinType,
         /// The output schema, containing fields from the left and right inputs
-        schema: SchemaRef,
+        schema: DFSchemaRef,
     },
     /// Produces rows from a table provider by reference or from the context
     TableScan {
@@ -129,7 +130,7 @@ pub enum LogicalPlan {
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The schema description of the output
-        projected_schema: SchemaRef,
+        projected_schema: DFSchemaRef,
     },
     /// Produces rows that come from a `Vec` of in memory `RecordBatch`es
     InMemoryScan {
@@ -140,7 +141,7 @@ pub enum LogicalPlan {
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The schema description of the output
-        projected_schema: SchemaRef,
+        projected_schema: DFSchemaRef,
     },
     /// Produces rows by scanning Parquet file(s)
     ParquetScan {
@@ -151,7 +152,7 @@ pub enum LogicalPlan {
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The schema description of the output
-        projected_schema: SchemaRef,
+        projected_schema: DFSchemaRef,
     },
     /// Produces rows by scanning a CSV file(s)
     CsvScan {
@@ -166,14 +167,14 @@ pub enum LogicalPlan {
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The schema description of the output
-        projected_schema: SchemaRef,
+        projected_schema: DFSchemaRef,
     },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {
         /// Whether to produce a placeholder row
         produce_one_row: bool,
         /// The schema description of the output
-        schema: SchemaRef,
+        schema: DFSchemaRef,
     },
     /// Produces the first `n` tuples from its input and discards the rest.
     Limit {
@@ -185,7 +186,7 @@ pub enum LogicalPlan {
     /// Creates an external table.
     CreateExternalTable {
         /// The table schema
-        schema: SchemaRef,
+        schema: DFSchemaRef,
         /// The table name
         name: String,
         /// The physical location
@@ -205,7 +206,7 @@ pub enum LogicalPlan {
         /// Represent the various stages plans have gone through
         stringified_plans: Vec<StringifiedPlan>,
         /// The output schema of the explain (2 columns of text)
-        schema: SchemaRef,
+        schema: DFSchemaRef,
     },
     /// Extension operator defined outside of DataFusion
     Extension {
@@ -216,7 +217,7 @@ pub enum LogicalPlan {
 
 impl LogicalPlan {
     /// Get a reference to the logical plan's schema
-    pub fn schema(&self) -> &SchemaRef {
+    pub fn schema(&self) -> &DFSchemaRef {
         match self {
             LogicalPlan::EmptyRelation { schema, .. } => &schema,
             LogicalPlan::InMemoryScan {

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -14,11 +14,9 @@
 
 //! Filter Push Down optimizer rule ensures that filters are applied as early as possible in the plan
 
-use arrow::datatypes::Schema;
-
 use crate::error::Result;
-use crate::logical_plan::Expr;
 use crate::logical_plan::{and, LogicalPlan};
+use crate::logical_plan::{DFSchema, Expr};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
 use std::{
@@ -87,8 +85,8 @@ fn get_predicates<'a>(
 // Note that a predicate can be both pushed to the left and to the right.
 fn get_join_predicates<'a>(
     state: &'a State,
-    left: &Schema,
-    right: &Schema,
+    left: &DFSchema,
+    right: &DFSchema,
 ) -> (
     Vec<&'a HashSet<String>>,
     Vec<&'a HashSet<String>>,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -19,11 +19,13 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow::datatypes::{Schema, SchemaRef};
+use arrow::datatypes::Schema;
 
 use super::optimizer::OptimizerRule;
 use crate::error::{DataFusionError, Result};
-use crate::logical_plan::{Expr, LogicalPlan, PlanType, StringifiedPlan};
+use crate::logical_plan::{
+    DFSchema, DFSchemaRef, Expr, LogicalPlan, PlanType, StringifiedPlan,
+};
 use crate::prelude::{col, lit};
 use crate::scalar::ScalarValue;
 
@@ -117,13 +119,11 @@ pub fn optimize_explain(
         PlanType::OptimizedLogicalPlan { optimizer_name },
         format!("{:#?}", plan),
     ));
-    let schema = SchemaRef::new(schema.clone());
-
     Ok(LogicalPlan::Explain {
         verbose,
         plan,
         stringified_plans,
-        schema,
+        schema: DFSchemaRef::new(DFSchema::from(schema)?),
     })
 }
 
@@ -429,7 +429,7 @@ mod tests {
             true,
             &empty_plan,
             &vec![StringifiedPlan::new(PlanType::LogicalPlan, "...")],
-            &*schema,
+            schema.as_ref(),
         )?;
 
         match &optimized_explain {

--- a/rust/datafusion/src/test/user_defined.rs
+++ b/rust/datafusion/src/test/user_defined.rs
@@ -23,9 +23,7 @@ use std::{
     sync::Arc,
 };
 
-use arrow::datatypes::SchemaRef;
-
-use crate::logical_plan::{Expr, LogicalPlan, UserDefinedLogicalNode};
+use crate::logical_plan::{DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode};
 
 /// Create a new user defined plan node, for testing
 pub fn new(input: LogicalPlan) -> LogicalPlan {
@@ -52,7 +50,7 @@ impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
         vec![&self.input]
     }
 
-    fn schema(&self) -> &SchemaRef {
+    fn schema(&self) -> &DFSchemaRef {
         self.input.schema()
     }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -32,7 +32,7 @@ use arrow::{
 use datafusion::datasource::{csv::CsvReadOptions, MemTable};
 use datafusion::error::Result;
 use datafusion::execution::context::ExecutionContext;
-use datafusion::logical_plan::LogicalPlan;
+use datafusion::logical_plan::{DFSchema, LogicalPlan};
 use datafusion::prelude::create_udf;
 
 #[tokio::test]
@@ -1350,7 +1350,10 @@ async fn execute(ctx: &mut ExecutionContext, sql: &str) -> Vec<Vec<String>> {
     let results = ctx.collect(plan).await.expect(&msg);
 
     assert_eq!(logical_schema.as_ref(), optimized_logical_schema.as_ref());
-    assert_eq!(logical_schema.as_ref(), physical_schema.as_ref());
+    assert_eq!(
+        logical_schema.as_ref(),
+        &DFSchema::from(physical_schema.as_ref()).unwrap()
+    );
 
     result_vec(&results)
 }

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -85,6 +85,7 @@ use std::task::{Context, Poll};
 use std::{any::Any, collections::BTreeMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
+use datafusion::logical_plan::DFSchemaRef;
 
 /// Execute the specified sql and return the resulting record batches
 /// pretty printed as a String.
@@ -246,7 +247,7 @@ impl OptimizerRule for TopKOptimizerRule {
                     *verbose,
                     &*plan,
                     stringified_plans,
-                    &*schema,
+                    &schema.as_ref().to_owned().into(),
                 )
             }
             _ => {}
@@ -288,7 +289,7 @@ impl UserDefinedLogicalNode for TopKPlanNode {
     }
 
     /// Schema for TopK is the same as the input
-    fn schema(&self) -> &SchemaRef {
+    fn schema(&self) -> &DFSchemaRef {
         self.input.schema()
     }
 


### PR DESCRIPTION
This PR builds on https://github.com/apache/arrow/pull/8840 and integrates DFSchema with the DataFusion query planning, optimization, and execution code.

This was a pretty large refactor unfortunately and I don't really see a way to break this down into smaller PRs.

There should be no functional changes in this PR. Fields are looked up using `field_with_unqualified_name` and I will file a separate PR to add support for referencing qualified field names.

Note that I had to update `PhysicalExpr.evaluate()` to pass in the input schema since we can no longer rely on the schema from the Arrow `RecordBatch` (because it loses the qualifiers). The other methods on `PhysicalExpr` already required the input schema, so this seems consistent at least, because we now always use the schema from the plan.

The rest of the changes are updating the query planning, optimization, and execution to use `DFSchema` instead of `Schema`.

Design Document: https://docs.google.com/document/d/1BFo7ruJayCulAHLa9-noaHXbgcaAH_4LuOJFGJnDHkc/edit#heading=h.3japu7255aut