### PR TITLE
ARROW-10812: [Rust] Make BooleanArray not a PrimitiveArray

### DIFF
--- a/rust/arrow/benches/csv_writer.rs
+++ b/rust/arrow/benches/csv_writer.rs
@@ -46,7 +46,7 @@ fn record_batches_to_csv() {
         Some(-556132.25),
     ]);
     let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-    let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+    let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
 
     let b = RecordBatch::try_new(
         Arc::new(schema),

--- a/rust/arrow/benches/take_kernels.rs
+++ b/rust/arrow/benches/take_kernels.rs
@@ -47,6 +47,20 @@ where
     Arc::new(array) as ArrayRef
 }
 
+// cast array from specified primitive array type to desired data type
+fn create_boolean(size: usize) -> ArrayRef
+where
+    Standard: Distribution<bool>,
+{
+    let array: BooleanArray = seedable_rng()
+        .sample_iter(&Standard)
+        .take(size)
+        .map(Some)
+        .collect();
+
+    Arc::new(array) as ArrayRef
+}
+
 fn create_strings(size: usize, null_density: f32) -> ArrayRef {
     let rng = &mut seedable_rng();
 
@@ -101,23 +115,23 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_take(&values, &indices))
     });
 
-    let values = create_primitive::<BooleanType>(512);
+    let values = create_boolean(512);
     let indices = create_random_index(512, 0.0);
     c.bench_function("take bool 512", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
-    let values = create_primitive::<BooleanType>(1024);
+    let values = create_boolean(1024);
     let indices = create_random_index(1024, 0.0);
     c.bench_function("take bool 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
 
-    let values = create_primitive::<BooleanType>(512);
+    let values = create_boolean(512);
     let indices = create_random_index(512, 0.5);
     c.bench_function("take bool nulls 512", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
-    let values = create_primitive::<BooleanType>(1024);
+    let values = create_boolean(1024);
     let indices = create_random_index(1024, 0.5);
     c.bench_function("take bool nulls 1024", |b| {
         b.iter(|| bench_take(&values, &indices))

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -136,31 +136,7 @@ impl From<Vec<bool>> for BooleanArray {
 
 impl From<Vec<Option<bool>>> for BooleanArray {
     fn from(data: Vec<Option<bool>>) -> Self {
-        let data_len = data.len();
-        let num_byte = bit_util::ceil(data_len, 8);
-        let mut null_buf = MutableBuffer::new_null(data.len());
-        let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
-
-        {
-            let null_slice = null_buf.data_mut();
-            let val_slice = val_buf.data_mut();
-
-            for (i, v) in data.iter().enumerate() {
-                if let Some(b) = v {
-                    bit_util::set_bit(null_slice, i);
-                    if *b {
-                        bit_util::set_bit(val_slice, i);
-                    }
-                }
-            }
-        }
-
-        let array_data = ArrayData::builder(DataType::Boolean)
-            .len(data_len)
-            .add_buffer(val_buf.freeze())
-            .null_bit_buffer(null_buf.freeze())
-            .build();
-        BooleanArray::from(array_data)
+        BooleanArray::from_iter(data.iter())
     }
 }
 

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -1,0 +1,331 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::borrow::Borrow;
+use std::iter::{FromIterator, IntoIterator};
+use std::mem;
+use std::{any::Any, fmt};
+use std::{convert::From, sync::Arc};
+
+use super::*;
+use super::{array::print_long_array, raw_pointer::RawPtrBox};
+use crate::buffer::{Buffer, MutableBuffer};
+use crate::memory;
+use crate::util::bit_util;
+
+/// Array of bools
+pub struct BooleanArray {
+    data: ArrayDataRef,
+    /// Pointer to the value array. The lifetime of this must be <= to the value buffer
+    /// stored in `data`, so it's safe to store.
+    raw_values: RawPtrBox<u8>,
+}
+
+impl fmt::Debug for BooleanArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BooleanArray\n[\n")?;
+        print_long_array(self, f, |array, index, f| {
+            fmt::Debug::fmt(&array.value(index), f)
+        })?;
+        write!(f, "]")
+    }
+}
+
+impl BooleanArray {
+    /// Returns the length of this array.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns whether this array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns a raw pointer to the values of this array.
+    pub fn raw_values(&self) -> *const u8 {
+        unsafe { self.raw_values.get().add(self.data.offset()) }
+    }
+
+    /// Returns a slice for the given offset and length
+    ///
+    /// Note this doesn't do any bound checking, for performance reason.
+    pub fn value_slice(&self, offset: usize, len: usize) -> &[u8] {
+        let raw =
+            unsafe { std::slice::from_raw_parts(self.raw_values().add(offset), len) };
+        &raw[..]
+    }
+
+    // Returns a new boolean array builder
+    pub fn builder(capacity: usize) -> BooleanBuilder {
+        BooleanBuilder::new(capacity)
+    }
+
+    /// Returns a `Buffer` holding all the values of this array.
+    ///
+    /// Note this doesn't take the offset of this array into account.
+    pub fn values(&self) -> Buffer {
+        self.data.buffers()[0].clone()
+    }
+
+    /// Returns the boolean value at index `i`.
+    ///
+    /// Note this doesn't do any bound checking, for performance reason.
+    pub fn value(&self, i: usize) -> bool {
+        let offset = i + self.offset();
+        unsafe { bit_util::get_bit_raw(self.raw_values.get() as *const u8, offset) }
+    }
+}
+
+impl Array for BooleanArray {
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    fn data(&self) -> ArrayDataRef {
+        self.data.clone()
+    }
+
+    fn data_ref(&self) -> &ArrayDataRef {
+        &self.data
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [BooleanArray].
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [BooleanArray].
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
+    }
+}
+
+impl From<Vec<bool>> for BooleanArray {
+    fn from(data: Vec<bool>) -> Self {
+        let mut mut_buf = MutableBuffer::new_null(data.len());
+        {
+            let mut_slice = mut_buf.data_mut();
+            for (i, b) in data.iter().enumerate() {
+                if *b {
+                    bit_util::set_bit(mut_slice, i);
+                }
+            }
+        }
+        let array_data = ArrayData::builder(DataType::Boolean)
+            .len(data.len())
+            .add_buffer(mut_buf.freeze())
+            .build();
+        BooleanArray::from(array_data)
+    }
+}
+
+impl From<Vec<Option<bool>>> for BooleanArray {
+    fn from(data: Vec<Option<bool>>) -> Self {
+        let data_len = data.len();
+        let num_byte = bit_util::ceil(data_len, 8);
+        let mut null_buf = MutableBuffer::new_null(data.len());
+        let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
+
+        {
+            let null_slice = null_buf.data_mut();
+            let val_slice = val_buf.data_mut();
+
+            for (i, v) in data.iter().enumerate() {
+                if let Some(b) = v {
+                    bit_util::set_bit(null_slice, i);
+                    if *b {
+                        bit_util::set_bit(val_slice, i);
+                    }
+                }
+            }
+        }
+
+        let array_data = ArrayData::builder(DataType::Boolean)
+            .len(data_len)
+            .add_buffer(val_buf.freeze())
+            .null_bit_buffer(null_buf.freeze())
+            .build();
+        BooleanArray::from(array_data)
+    }
+}
+
+impl From<ArrayDataRef> for BooleanArray {
+    fn from(data: ArrayDataRef) -> Self {
+        assert_eq!(
+            data.buffers().len(),
+            1,
+            "BooleanArray data should contain a single buffer only (values buffer)"
+        );
+        let raw_values = data.buffers()[0].raw_data();
+        assert!(
+            memory::is_aligned::<u8>(raw_values, mem::align_of::<bool>()),
+            "memory is not aligned"
+        );
+        Self {
+            data,
+            raw_values: RawPtrBox::new(raw_values as *const u8),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a BooleanArray {
+    type Item = Option<bool>;
+    type IntoIter = BooleanIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BooleanIter::<'a>::new(self)
+    }
+}
+
+impl<'a> BooleanArray {
+    /// constructs a new iterator
+    pub fn iter(&'a self) -> BooleanIter<'a> {
+        BooleanIter::<'a>::new(&self)
+    }
+}
+
+impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let (_, data_len) = iter.size_hint();
+        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
+
+        let num_bytes = bit_util::ceil(data_len, 8);
+        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+        let mut val_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+
+        let data = unsafe {
+            std::slice::from_raw_parts_mut(val_buf.raw_data_mut(), val_buf.capacity())
+        };
+
+        let null_slice = null_buf.data_mut();
+        iter.enumerate().for_each(|(i, item)| {
+            if let Some(a) = item.borrow() {
+                bit_util::set_bit(null_slice, i);
+                if *a {
+                    bit_util::set_bit(data, i);
+                }
+            }
+        });
+
+        let data = ArrayData::new(
+            DataType::Boolean,
+            data_len,
+            None,
+            Some(null_buf.freeze()),
+            0,
+            vec![val_buf.freeze()],
+            vec![],
+        );
+        BooleanArray::from(Arc::new(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::buffer::Buffer;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_boolean_fmt_debug() {
+        let arr = BooleanArray::from(vec![true, false, false]);
+        assert_eq!(
+            "BooleanArray\n[\n  true,\n  false,\n  false,\n]",
+            format!("{:?}", arr)
+        );
+    }
+
+    #[test]
+    fn test_boolean_with_null_fmt_debug() {
+        let mut builder = BooleanArray::builder(3);
+        builder.append_value(true).unwrap();
+        builder.append_null().unwrap();
+        builder.append_value(false).unwrap();
+        let arr = builder.finish();
+        assert_eq!(
+            "BooleanArray\n[\n  true,\n  null,\n  false,\n]",
+            format!("{:?}", arr)
+        );
+    }
+
+    #[test]
+    fn test_boolean_array_from_vec() {
+        let buf = Buffer::from([10_u8]);
+        let arr = BooleanArray::from(vec![false, true, false, true]);
+        assert_eq!(buf, arr.values());
+        assert_eq!(4, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(0, arr.null_count());
+        for i in 0..4 {
+            assert!(!arr.is_null(i));
+            assert!(arr.is_valid(i));
+            assert_eq!(i == 1 || i == 3, arr.value(i), "failed at {}", i)
+        }
+    }
+
+    #[test]
+    fn test_boolean_array_from_vec_option() {
+        let buf = Buffer::from([10_u8]);
+        let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
+        assert_eq!(buf, arr.values());
+        assert_eq!(4, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        for i in 0..4 {
+            if i == 2 {
+                assert!(arr.is_null(i));
+                assert!(!arr.is_valid(i));
+            } else {
+                assert!(!arr.is_null(i));
+                assert!(arr.is_valid(i));
+                assert_eq!(i == 1 || i == 3, arr.value(i), "failed at {}", i)
+            }
+        }
+    }
+
+    #[test]
+    fn test_boolean_array_builder() {
+        // Test building a boolean array with ArrayData builder and offset
+        // 000011011
+        let buf = Buffer::from([27_u8]);
+        let buf2 = buf.clone();
+        let data = ArrayData::builder(DataType::Boolean)
+            .len(5)
+            .offset(2)
+            .add_buffer(buf)
+            .build();
+        let arr = BooleanArray::from(data);
+        assert_eq!(buf2, arr.values());
+        assert_eq!(5, arr.len());
+        assert_eq!(2, arr.offset());
+        assert_eq!(0, arr.null_count());
+        for i in 0..3 {
+            assert_eq!(i != 0, arr.value(i), "failed at {}", i);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "BooleanArray data should contain a single buffer only \
+                               (values buffer)")]
+    fn test_boolean_array_invalid_buffer_len() {
+        let data = ArrayData::builder(DataType::Boolean).len(5).build();
+        BooleanArray::from(data);
+    }
+}

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -94,7 +94,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// Note this doesn't do any bound checking, for performance reason.
     pub fn value(&self, i: usize) -> T::Native {
         let offset = i + self.offset();
-        unsafe { T::index(self.raw_values.get(), offset) }
+        unsafe { *self.raw_values.get().add(offset) }
     }
 }
 

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -422,56 +422,6 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
     }
 }
 
-/// Constructs a boolean array from a vector. Should only be used for testing.
-impl From<Vec<bool>> for BooleanArray {
-    fn from(data: Vec<bool>) -> Self {
-        let mut mut_buf = MutableBuffer::new_null(data.len());
-        {
-            let mut_slice = mut_buf.data_mut();
-            for (i, b) in data.iter().enumerate() {
-                if *b {
-                    bit_util::set_bit(mut_slice, i);
-                }
-            }
-        }
-        let array_data = ArrayData::builder(DataType::Boolean)
-            .len(data.len())
-            .add_buffer(mut_buf.freeze())
-            .build();
-        BooleanArray::from(array_data)
-    }
-}
-
-impl From<Vec<Option<bool>>> for BooleanArray {
-    fn from(data: Vec<Option<bool>>) -> Self {
-        let data_len = data.len();
-        let num_byte = bit_util::ceil(data_len, 8);
-        let mut null_buf = MutableBuffer::new_null(data.len());
-        let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
-
-        {
-            let null_slice = null_buf.data_mut();
-            let val_slice = val_buf.data_mut();
-
-            for (i, v) in data.iter().enumerate() {
-                if let Some(b) = v {
-                    bit_util::set_bit(null_slice, i);
-                    if *b {
-                        bit_util::set_bit(val_slice, i);
-                    }
-                }
-            }
-        }
-
-        let array_data = ArrayData::builder(DataType::Boolean)
-            .len(data_len)
-            .add_buffer(val_buf.freeze())
-            .null_bit_buffer(null_buf.freeze())
-            .build();
-        BooleanArray::from(array_data)
-    }
-}
-
 /// Constructs a `PrimitiveArray` from an array data reference.
 impl<T: ArrowPrimitiveType> From<ArrayDataRef> for PrimitiveArray<T> {
     fn from(data: ArrayDataRef) -> Self {
@@ -835,28 +785,6 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_fmt_debug() {
-        let arr = BooleanArray::from(vec![true, false, false]);
-        assert_eq!(
-            "PrimitiveArray<Boolean>\n[\n  true,\n  false,\n  false,\n]",
-            format!("{:?}", arr)
-        );
-    }
-
-    #[test]
-    fn test_boolean_with_null_fmt_debug() {
-        let mut builder = BooleanArray::builder(3);
-        builder.append_value(true).unwrap();
-        builder.append_null().unwrap();
-        builder.append_value(false).unwrap();
-        let arr = builder.finish();
-        assert_eq!(
-            "PrimitiveArray<Boolean>\n[\n  true,\n  null,\n  false,\n]",
-            format!("{:?}", arr)
-        );
-    }
-
-    #[test]
     fn test_timestamp_fmt_debug() {
         let arr: PrimitiveArray<TimestampMillisecondType> =
             TimestampMillisecondArray::from_vec(vec![1546214400000, 1546214400000], None);
@@ -909,70 +837,6 @@ mod tests {
     fn test_primitive_array_invalid_buffer_len() {
         let data = ArrayData::builder(DataType::Int32).len(5).build();
         Int32Array::from(data);
-    }
-
-    #[test]
-    fn test_boolean_array_from_vec() {
-        let buf = Buffer::from([10_u8]);
-        let arr = BooleanArray::from(vec![false, true, false, true]);
-        assert_eq!(buf, arr.values());
-        assert_eq!(4, arr.len());
-        assert_eq!(0, arr.offset());
-        assert_eq!(0, arr.null_count());
-        for i in 0..4 {
-            assert!(!arr.is_null(i));
-            assert!(arr.is_valid(i));
-            assert_eq!(i == 1 || i == 3, arr.value(i), "failed at {}", i)
-        }
-    }
-
-    #[test]
-    fn test_boolean_array_from_vec_option() {
-        let buf = Buffer::from([10_u8]);
-        let arr = BooleanArray::from(vec![Some(false), Some(true), None, Some(true)]);
-        assert_eq!(buf, arr.values());
-        assert_eq!(4, arr.len());
-        assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
-        for i in 0..4 {
-            if i == 2 {
-                assert!(arr.is_null(i));
-                assert!(!arr.is_valid(i));
-            } else {
-                assert!(!arr.is_null(i));
-                assert!(arr.is_valid(i));
-                assert_eq!(i == 1 || i == 3, arr.value(i), "failed at {}", i)
-            }
-        }
-    }
-
-    #[test]
-    fn test_boolean_array_builder() {
-        // Test building a boolean array with ArrayData builder and offset
-        // 000011011
-        let buf = Buffer::from([27_u8]);
-        let buf2 = buf.clone();
-        let data = ArrayData::builder(DataType::Boolean)
-            .len(5)
-            .offset(2)
-            .add_buffer(buf)
-            .build();
-        let arr = BooleanArray::from(data);
-        assert_eq!(buf2, arr.values());
-        assert_eq!(5, arr.len());
-        assert_eq!(2, arr.offset());
-        assert_eq!(0, arr.null_count());
-        for i in 0..3 {
-            assert_eq!(i != 0, arr.value(i), "failed at {}", i);
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "PrimitiveArray data should contain a single buffer only \
-                               (values buffer)")]
-    fn test_boolean_array_invalid_buffer_len() {
-        let data = ArrayData::builder(DataType::Boolean).len(5).build();
-        BooleanArray::from(data);
     }
 
     #[test]

--- a/rust/arrow/src/array/array_union.rs
+++ b/rust/arrow/src/array/array_union.rs
@@ -430,15 +430,13 @@ mod tests {
     fn test_dense_mixed() {
         let mut builder = UnionBuilder::new_dense(7);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", false).unwrap();
         builder.append::<Int64Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         builder.append::<Int64Type>("c", 5).unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         let union = builder.build().unwrap();
 
-        assert_eq!(7, union.len());
+        assert_eq!(5, union.len());
         for i in 0..union.len() {
             let slot = union.value(i);
             assert_eq!(false, union.is_null(i));
@@ -450,40 +448,28 @@ mod tests {
                     assert_eq!(1_i32, value);
                 }
                 1 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(false, value);
-                }
-                2 => {
                     let slot = slot.as_any().downcast_ref::<Int64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(3_i64, value);
                 }
-                3 => {
+                2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);
                 }
-                4 => {
+                3 => {
                     let slot = slot.as_any().downcast_ref::<Int64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(5_i64, value);
                 }
-                5 => {
+                4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
-                }
-                6 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(true, value);
                 }
                 _ => unreachable!(),
             }
@@ -494,15 +480,13 @@ mod tests {
     fn test_dense_mixed_with_nulls() {
         let mut builder = UnionBuilder::new_dense(7);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", false).unwrap();
         builder.append::<Int64Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 10).unwrap();
         builder.append_null().unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         let union = builder.build().unwrap();
 
-        assert_eq!(7, union.len());
+        assert_eq!(5, union.len());
         for i in 0..union.len() {
             let slot = union.value(i);
             match i {
@@ -514,40 +498,26 @@ mod tests {
                     assert_eq!(1_i32, value);
                 }
                 1 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(false, union.is_null(i));
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(false, value);
-                }
-                2 => {
                     let slot = slot.as_any().downcast_ref::<Int64Array>().unwrap();
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(3_i64, value);
                 }
-                3 => {
+                2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(10_i32, value);
                 }
-                4 => assert!(union.is_null(i)),
-                5 => {
+                3 => assert!(union.is_null(i)),
+                4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
-                }
-                6 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(false, union.is_null(i));
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(true, value);
                 }
                 _ => unreachable!(),
             }
@@ -558,15 +528,13 @@ mod tests {
     fn test_dense_mixed_with_nulls_and_offset() {
         let mut builder = UnionBuilder::new_dense(7);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", false).unwrap();
         builder.append::<Int64Type>("c", 3).unwrap();
         builder.append::<Int32Type>("a", 10).unwrap();
         builder.append_null().unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         let union = builder.build().unwrap();
 
-        let slice = union.slice(3, 3);
+        let slice = union.slice(2, 3);
         let new_union = slice.as_any().downcast_ref::<UnionArray>().unwrap();
 
         assert_eq!(3, new_union.len());
@@ -739,17 +707,15 @@ mod tests {
 
     #[test]
     fn test_sparse_mixed() {
-        let mut builder = UnionBuilder::new_sparse(7);
+        let mut builder = UnionBuilder::new_sparse(5);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         builder.append::<Float64Type>("c", 3.0).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         builder.append::<Float64Type>("c", 5.0).unwrap();
         builder.append::<Int32Type>("a", 6).unwrap();
-        builder.append::<BooleanType>("b", false).unwrap();
         let union = builder.build().unwrap();
 
-        let expected_type_ids = vec![0_i8, 1, 2, 0, 2, 0, 1];
+        let expected_type_ids = vec![0_i8, 1, 0, 1, 0];
 
         // Check type ids
         assert_eq!(
@@ -774,40 +740,28 @@ mod tests {
                     assert_eq!(1_i32, value);
                 }
                 1 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(true, value);
-                }
-                2 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(value - 3_f64 < f64::EPSILON);
                 }
-                3 => {
+                2 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(4_i32, value);
                 }
-                4 => {
+                3 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(5_f64 - value < f64::EPSILON);
                 }
-                5 => {
+                4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert_eq!(6_i32, value);
-                }
-                6 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(false, value);
                 }
                 _ => unreachable!(),
             }
@@ -816,15 +770,14 @@ mod tests {
 
     #[test]
     fn test_sparse_mixed_with_nulls() {
-        let mut builder = UnionBuilder::new_sparse(7);
+        let mut builder = UnionBuilder::new_sparse(5);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         builder.append_null().unwrap();
         builder.append::<Float64Type>("c", 3.0).unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         let union = builder.build().unwrap();
 
-        let expected_type_ids = vec![0_i8, 1, 0, 2, 0];
+        let expected_type_ids = vec![0_i8, 0, 1, 0];
 
         // Check type ids
         assert_eq!(
@@ -848,22 +801,15 @@ mod tests {
                     let value = slot.value(0);
                     assert_eq!(1_i32, value);
                 }
-                1 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(false, union.is_null(i));
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(true, value);
-                }
-                2 => assert!(union.is_null(i)),
-                3 => {
+                1 => assert!(union.is_null(i)),
+                2 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(value - 3_f64 < f64::EPSILON);
                 }
-                4 => {
+                3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
@@ -877,39 +823,31 @@ mod tests {
 
     #[test]
     fn test_sparse_mixed_with_nulls_and_offset() {
-        let mut builder = UnionBuilder::new_sparse(7);
+        let mut builder = UnionBuilder::new_sparse(5);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", true).unwrap();
         builder.append_null().unwrap();
         builder.append::<Float64Type>("c", 3.0).unwrap();
         builder.append_null().unwrap();
         builder.append::<Int32Type>("a", 4).unwrap();
         let union = builder.build().unwrap();
 
-        let slice = union.slice(1, 5);
+        let slice = union.slice(1, 4);
         let new_union = slice.as_any().downcast_ref::<UnionArray>().unwrap();
 
-        assert_eq!(5, new_union.len());
+        assert_eq!(4, new_union.len());
         for i in 0..new_union.len() {
             let slot = new_union.value(i);
             match i {
-                0 => {
-                    let slot = slot.as_any().downcast_ref::<BooleanArray>().unwrap();
-                    assert_eq!(false, new_union.is_null(i));
-                    assert_eq!(slot.len(), 1);
-                    let value = slot.value(0);
-                    assert_eq!(true, value);
-                }
-                1 => assert!(new_union.is_null(i)),
-                2 => {
+                0 => assert!(new_union.is_null(i)),
+                1 => {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(false, new_union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
                     assert!(value - 3_f64 < f64::EPSILON);
                 }
-                3 => assert!(new_union.is_null(i)),
-                4 => {
+                2 => assert!(new_union.is_null(i)),
+                3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
                     assert_eq!(false, new_union.is_null(i));
                     assert_eq!(slot.len(), 1);

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -272,8 +272,8 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     }
 
     fn capacity(&self) -> usize {
-        let bit_capacity = self.buffer.capacity() * 8;
-        bit_capacity / T::get_bit_width()
+        let bit_capacity = self.buffer.capacity();
+        bit_capacity / T::get_byte_width()
     }
 
     #[inline]
@@ -705,7 +705,7 @@ impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveBuilder<T> {
         self.values_builder.reserve(total_len);
         self.bitmap_builder.reserve(total_len);
 
-        let mul = T::get_bit_width() / 8;
+        let mul = T::get_byte_width();
         for array in data {
             let len = array.len();
             if len == 0 {

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -254,15 +254,7 @@ pub trait BufferBuilderTrait<T: ArrowPrimitiveType> {
 impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn new(capacity: usize) -> Self {
-        let buffer = if matches!(T::DATA_TYPE, DataType::Boolean) {
-            let byte_capacity = bit_util::ceil(capacity, 8);
-            let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
-            let mut buffer = MutableBuffer::new(actual_capacity);
-            buffer.set_null_bits(0, actual_capacity);
-            buffer
-        } else {
-            MutableBuffer::new(capacity * mem::size_of::<T::Native>())
-        };
+        let buffer = MutableBuffer::new(capacity * mem::size_of::<T::Native>());
 
         Self {
             buffer,
@@ -286,11 +278,7 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
 
     #[inline]
     fn advance(&mut self, i: usize) -> Result<()> {
-        let new_buffer_len = if matches!(T::DATA_TYPE, DataType::Boolean) {
-            bit_util::ceil(self.len + i, 8)
-        } else {
-            (self.len + i) * mem::size_of::<T::Native>()
-        };
+        let new_buffer_len = (self.len + i) * mem::size_of::<T::Native>();
         self.buffer.resize(new_buffer_len);
         self.len += i;
         Ok(())
@@ -299,54 +287,22 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     #[inline]
     fn reserve(&mut self, n: usize) {
         let new_capacity = self.len + n;
-        if matches!(T::DATA_TYPE, DataType::Boolean) {
-            if new_capacity > self.capacity() {
-                let new_byte_capacity = bit_util::ceil(new_capacity, 8);
-                let existing_capacity = self.buffer.capacity();
-                let new_capacity = self.buffer.reserve(new_byte_capacity);
-                self.buffer
-                    .set_null_bits(existing_capacity, new_capacity - existing_capacity);
-            }
-        } else {
-            let byte_capacity = mem::size_of::<T::Native>() * new_capacity;
-            self.buffer.reserve(byte_capacity);
-        }
+        let byte_capacity = mem::size_of::<T::Native>() * new_capacity;
+        self.buffer.reserve(byte_capacity);
     }
 
     #[inline]
     fn append(&mut self, v: T::Native) -> Result<()> {
         self.reserve(1);
-        if matches!(T::DATA_TYPE, DataType::Boolean) {
-            if v != T::default_value() {
-                unsafe {
-                    bit_util::set_bit_raw(self.buffer.raw_data_mut(), self.len);
-                }
-            }
-            self.len += 1;
-        } else {
-            self.write_bytes(v.to_byte_slice(), 1);
-        }
+        self.write_bytes(v.to_byte_slice(), 1);
         Ok(())
     }
 
     #[inline]
     fn append_n(&mut self, n: usize, v: T::Native) -> Result<()> {
         self.reserve(n);
-        if matches!(T::DATA_TYPE, DataType::Boolean) {
-            if n != 0 && v != T::default_value() {
-                let data = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        self.buffer.raw_data_mut(),
-                        self.buffer.capacity(),
-                    )
-                };
-                (self.len..self.len + n).for_each(|i| bit_util::set_bit(data, i))
-            }
-            self.len += n;
-        } else {
-            for _ in 0..n {
-                self.write_bytes(v.to_byte_slice(), 1);
-            }
+        for _ in 0..n {
+            self.write_bytes(v.to_byte_slice(), 1);
         }
         Ok(())
     }
@@ -356,40 +312,127 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
         let array_slots = slice.len();
         self.reserve(array_slots);
 
-        if matches!(T::DATA_TYPE, DataType::Boolean) {
-            for v in slice {
-                if *v != T::default_value() {
-                    // For performance the `len` of the buffer is not
-                    // updated on each append but is updated in the
-                    // `freeze` method instead.
-                    unsafe {
-                        bit_util::set_bit_raw(self.buffer.raw_data_mut(), self.len);
-                    }
-                }
-                self.len += 1;
-            }
-            Ok(())
-        } else {
-            self.write_bytes(slice.to_byte_slice(), array_slots);
-            Ok(())
-        }
+        self.write_bytes(slice.to_byte_slice(), array_slots);
+        Ok(())
     }
 
     #[inline]
     fn finish(&mut self) -> Buffer {
-        if matches!(T::DATA_TYPE, DataType::Boolean) {
-            // `append` does not update the buffer's `len` so do it before `freeze` is called.
-            let new_buffer_len = bit_util::ceil(self.len, 8);
-            debug_assert!(new_buffer_len >= self.buffer.len());
-            let mut buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
-            self.len = 0;
-            buf.resize(new_buffer_len);
-            buf.freeze()
-        } else {
-            let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
-            self.len = 0;
-            buf.freeze()
+        let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
+        self.len = 0;
+        buf.freeze()
+    }
+}
+
+#[derive(Debug)]
+pub struct BooleanBufferBuilder {
+    buffer: MutableBuffer,
+    len: usize,
+}
+
+impl BooleanBufferBuilder {
+    #[inline]
+    pub fn new(capacity: usize) -> Self {
+        let byte_capacity = bit_util::ceil(capacity, 8);
+        let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
+        let mut buffer = MutableBuffer::new(actual_capacity);
+        buffer.set_null_bits(0, actual_capacity);
+
+        Self { buffer, len: 0 }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.buffer.capacity() * 8
+    }
+
+    #[inline]
+    pub fn advance(&mut self, i: usize) -> Result<()> {
+        let new_buffer_len = bit_util::ceil(self.len + i, 8);
+        self.buffer.resize(new_buffer_len);
+        self.len += i;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, n: usize) {
+        let new_capacity = self.len + n;
+        if new_capacity > self.capacity() {
+            let new_byte_capacity = bit_util::ceil(new_capacity, 8);
+            let existing_capacity = self.buffer.capacity();
+            let new_capacity = self.buffer.reserve(new_byte_capacity);
+            self.buffer
+                .set_null_bits(existing_capacity, new_capacity - existing_capacity);
         }
+    }
+
+    #[inline]
+    pub fn append(&mut self, v: bool) -> Result<()> {
+        self.reserve(1);
+        if v {
+            let data = unsafe {
+                std::slice::from_raw_parts_mut(
+                    self.buffer.raw_data_mut(),
+                    self.buffer.capacity(),
+                )
+            };
+            bit_util::set_bit(data, self.len);
+        }
+        self.len += 1;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn append_n(&mut self, n: usize, v: bool) -> Result<()> {
+        self.reserve(n);
+        if n != 0 && v {
+            let data = unsafe {
+                std::slice::from_raw_parts_mut(
+                    self.buffer.raw_data_mut(),
+                    self.buffer.capacity(),
+                )
+            };
+            (self.len..self.len + n).for_each(|i| bit_util::set_bit(data, i))
+        }
+        self.len += n;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn append_slice(&mut self, slice: &[bool]) -> Result<()> {
+        let array_slots = slice.len();
+        self.reserve(array_slots);
+
+        for v in slice {
+            if *v {
+                // For performance the `len` of the buffer is not
+                // updated on each append but is updated in the
+                // `freeze` method instead.
+                unsafe {
+                    bit_util::set_bit_raw(self.buffer.raw_data_mut(), self.len);
+                }
+            }
+            self.len += 1;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn finish(&mut self) -> Buffer {
+        // `append` does not update the buffer's `len` so do it before `freeze` is called.
+        let new_buffer_len = bit_util::ceil(self.len, 8);
+        debug_assert!(new_buffer_len >= self.buffer.len());
+        let mut buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
+        self.len = 0;
+        buf.resize(new_buffer_len);
+        buf.freeze()
     }
 }
 
@@ -440,6 +483,169 @@ pub trait ArrayBuilder: Any {
 
     /// Returns the boxed builder as a box of `Any`.
     fn into_box_any(self: Box<Self>) -> Box<Any>;
+}
+
+///  Array builder for fixed-width primitive types
+#[derive(Debug)]
+pub struct BooleanBuilder {
+    values_builder: BooleanBufferBuilder,
+    bitmap_builder: BooleanBufferBuilder,
+}
+
+impl BooleanBuilder {
+    /// Creates a new primitive array builder
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            values_builder: BooleanBufferBuilder::new(capacity),
+            bitmap_builder: BooleanBufferBuilder::new(capacity),
+        }
+    }
+
+    /// Returns the capacity of this builder measured in slots of type `T`
+    pub fn capacity(&self) -> usize {
+        self.values_builder.capacity()
+    }
+
+    /// Appends a value of type `T` into the builder
+    pub fn append_value(&mut self, v: bool) -> Result<()> {
+        self.bitmap_builder.append(true)?;
+        self.values_builder.append(v)?;
+        Ok(())
+    }
+
+    /// Appends a null slot into the builder
+    pub fn append_null(&mut self) -> Result<()> {
+        self.bitmap_builder.append(false)?;
+        self.values_builder.advance(1)?;
+        Ok(())
+    }
+
+    /// Appends an `Option<T>` into the builder
+    pub fn append_option(&mut self, v: Option<bool>) -> Result<()> {
+        match v {
+            None => self.append_null()?,
+            Some(v) => self.append_value(v)?,
+        };
+        Ok(())
+    }
+
+    /// Appends a slice of type `T` into the builder
+    pub fn append_slice(&mut self, v: &[bool]) -> Result<()> {
+        self.bitmap_builder.append_n(v.len(), true)?;
+        self.values_builder.append_slice(v)?;
+        Ok(())
+    }
+
+    /// Appends values from a slice of type `T` and a validity boolean slice
+    pub fn append_values(&mut self, values: &[bool], is_valid: &[bool]) -> Result<()> {
+        if values.len() != is_valid.len() {
+            return Err(ArrowError::InvalidArgumentError(
+                "Value and validity lengths must be equal".to_string(),
+            ));
+        }
+        self.bitmap_builder.append_slice(is_valid)?;
+        self.values_builder.append_slice(values)
+    }
+
+    /// Builds the [BooleanArray] and reset this builder.
+    pub fn finish(&mut self) -> BooleanArray {
+        let len = self.len();
+        let null_bit_buffer = self.bitmap_builder.finish();
+        let null_count = len - null_bit_buffer.count_set_bits();
+        let mut builder = ArrayData::builder(DataType::Boolean)
+            .len(len)
+            .add_buffer(self.values_builder.finish());
+        if null_count > 0 {
+            builder = builder
+                .null_count(null_count)
+                .null_bit_buffer(null_bit_buffer);
+        }
+        let data = builder.build();
+        BooleanArray::from(data)
+    }
+}
+
+impl ArrayBuilder for BooleanBuilder {
+    /// Returns the builder as a non-mutable `Any` reference.
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    /// Returns the builder as a mutable `Any` reference.
+    fn as_any_mut(&mut self) -> &mut Any {
+        self
+    }
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+
+    /// Returns the number of array slots in the builder
+    fn len(&self) -> usize {
+        self.values_builder.len
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.values_builder.is_empty()
+    }
+
+    /// Appends data from other arrays into the builder
+    ///
+    /// This is most useful when concatenating arrays of the same type into a builder.
+    fn append_data(&mut self, data: &[ArrayDataRef]) -> Result<()> {
+        // validate arraydata and reserve memory
+        let mut total_len = 0;
+        for array in data {
+            if array.data_type() != &self.data_type() {
+                return Err(ArrowError::InvalidArgumentError(
+                    "Cannot append data to builder if data types are different"
+                        .to_string(),
+                ));
+            }
+            if array.buffers().len() != 1 {
+                return Err(ArrowError::InvalidArgumentError(
+                    "Primitive arrays should have 1 buffer".to_string(),
+                ));
+            }
+            total_len += array.len();
+        }
+        // reserve memory
+        self.values_builder.reserve(total_len);
+        self.bitmap_builder.reserve(total_len);
+
+        for array in data {
+            let len = array.len();
+            if len == 0 {
+                continue;
+            }
+
+            // booleans are bit-packed, thus we iterate through the array
+            let array = BooleanArray::from(array.clone());
+            for i in 0..len {
+                self.values_builder.append(array.value(i))?;
+            }
+
+            for i in 0..len {
+                // account for offset as `ArrayData` does not
+                self.bitmap_builder.append(array.is_valid(i))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the data type of the builder
+    ///
+    /// This is used for validating array data types in `append_data`
+    fn data_type(&self) -> DataType {
+        DataType::Boolean
+    }
+
+    /// Builds the array and reset this builder.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
+    }
 }
 
 ///  Array builder for fixed-width primitive types
@@ -2403,7 +2609,6 @@ impl FieldData {
     fn append_null_dynamic(&mut self) -> Result<()> {
         match self.data_type {
             DataType::Null => unimplemented!(),
-            DataType::Boolean => self.append_null::<BooleanType>()?,
             DataType::Int8 => self.append_null::<Int8Type>()?,
             DataType::Int16 => self.append_null::<Int16Type>()?,
             DataType::Int32

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -272,8 +272,8 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
     }
 
     fn capacity(&self) -> usize {
-        let bit_capacity = self.buffer.capacity();
-        bit_capacity / T::get_byte_width()
+        let byte_capacity = self.buffer.capacity();
+        byte_capacity / T::get_byte_width()
     }
 
     #[inline]

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -20,9 +20,9 @@
 //! depend on dynamic casting of `Array`.
 
 use super::{
-    Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray, FixedSizeBinaryArray,
-    GenericBinaryArray, GenericListArray, GenericStringArray, NullArray, OffsetSizeTrait,
-    PrimitiveArray, StringOffsetSizeTrait, StructArray,
+    Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
+    FixedSizeBinaryArray, GenericBinaryArray, GenericListArray, GenericStringArray,
+    NullArray, OffsetSizeTrait, PrimitiveArray, StringOffsetSizeTrait, StructArray,
 };
 
 use crate::{

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -20,7 +20,7 @@
 //! depend on dynamic casting of `Array`.
 
 use super::{
-    Array, ArrayData, BinaryOffsetSizeTrait, DecimalArray, FixedSizeBinaryArray,
+    Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray, FixedSizeBinaryArray,
     GenericBinaryArray, GenericListArray, GenericStringArray, NullArray, OffsetSizeTrait,
     PrimitiveArray, StringOffsetSizeTrait, StructArray,
 };
@@ -76,6 +76,12 @@ impl PartialEq for NullArray {
 
 impl<T: ArrowPrimitiveType> PartialEq for PrimitiveArray<T> {
     fn eq(&self, other: &PrimitiveArray<T>) -> bool {
+        equal(self.data().as_ref(), other.data().as_ref())
+    }
+}
+
+impl PartialEq for BooleanArray {
+    fn eq(&self, other: &BooleanArray) -> bool {
         equal(self.data().as_ref(), other.data().as_ref())
     }
 }

--- a/rust/arrow/src/array/equal_json.rs
+++ b/rust/arrow/src/array/equal_json.rs
@@ -49,6 +49,20 @@ impl<T: ArrowPrimitiveType> JsonEqual for PrimitiveArray<T> {
     }
 }
 
+/// Implement array equals for numeric type
+impl JsonEqual for BooleanArray {
+    fn equals_json(&self, json: &[&Value]) -> bool {
+        if self.len() != json.len() {
+            return false;
+        }
+
+        (0..self.len()).all(|i| match json[i] {
+            Value::Null => self.is_null(i),
+            v => self.is_valid(i) && Some(v) == self.value(i).into_json_value().as_ref(),
+        })
+    }
+}
+
 impl<T: ArrowPrimitiveType> PartialEq<Value> for PrimitiveArray<T> {
     fn eq(&self, json: &Value) -> bool {
         match json {

--- a/rust/arrow/src/array/equal_json.rs
+++ b/rust/arrow/src/array/equal_json.rs
@@ -38,28 +38,28 @@ pub trait JsonEqual {
 /// Implement array equals for numeric type
 impl<T: ArrowPrimitiveType> JsonEqual for PrimitiveArray<T> {
     fn equals_json(&self, json: &[&Value]) -> bool {
-        if self.len() != json.len() {
-            return false;
-        }
-
-        (0..self.len()).all(|i| match json[i] {
-            Value::Null => self.is_null(i),
-            v => self.is_valid(i) && Some(v) == self.value(i).into_json_value().as_ref(),
-        })
+        self.len() == json.len()
+            && (0..self.len()).all(|i| match json[i] {
+                Value::Null => self.is_null(i),
+                v => {
+                    self.is_valid(i)
+                        && Some(v) == self.value(i).into_json_value().as_ref()
+                }
+            })
     }
 }
 
 /// Implement array equals for numeric type
 impl JsonEqual for BooleanArray {
     fn equals_json(&self, json: &[&Value]) -> bool {
-        if self.len() != json.len() {
-            return false;
-        }
-
-        (0..self.len()).all(|i| match json[i] {
-            Value::Null => self.is_null(i),
-            v => self.is_valid(i) && Some(v) == self.value(i).into_json_value().as_ref(),
-        })
+        self.len() == json.len()
+            && (0..self.len()).all(|i| match json[i] {
+                Value::Null => self.is_null(i),
+                v => {
+                    self.is_valid(i)
+                        && Some(v) == self.value(i).into_json_value().as_ref()
+                }
+            })
     }
 }
 

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -18,11 +18,11 @@
 use crate::datatypes::ArrowPrimitiveType;
 
 use super::{
-    Array, BinaryOffsetSizeTrait, GenericBinaryArray, GenericStringArray, PrimitiveArray,
-    StringOffsetSizeTrait,
+    Array, BinaryOffsetSizeTrait, BooleanArray, GenericBinaryArray, GenericStringArray,
+    PrimitiveArray, StringOffsetSizeTrait,
 };
 
-/// an iterator that returns Some(T) or None, that can be used on any non-boolean PrimitiveArray
+/// an iterator that returns Some(T) or None, that can be used on any PrimitiveArray
 // Note: This implementation is based on std's [Vec]s' [IntoIter].
 #[derive(Debug)]
 pub struct PrimitiveIter<'a, T: ArrowPrimitiveType> {
@@ -80,6 +80,65 @@ impl<'a, T: ArrowPrimitiveType> std::iter::DoubleEndedIterator for PrimitiveIter
 
 /// all arrays have known size.
 impl<'a, T: ArrowPrimitiveType> std::iter::ExactSizeIterator for PrimitiveIter<'a, T> {}
+
+/// an iterator that returns Some(bool) or None.
+// Note: This implementation is based on std's [Vec]s' [IntoIter].
+#[derive(Debug)]
+pub struct BooleanIter<'a> {
+    array: &'a BooleanArray,
+    current: usize,
+    current_end: usize,
+}
+
+impl<'a> BooleanIter<'a> {
+    /// create a new iterator
+    pub fn new(array: &'a BooleanArray) -> Self {
+        BooleanIter {
+            array,
+            current: 0,
+            current_end: array.len(),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for BooleanIter<'a> {
+    type Item = Option<bool>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.current_end {
+            None
+        } else if self.array.is_null(self.current) {
+            self.current += 1;
+            Some(None)
+        } else {
+            let old = self.current;
+            self.current += 1;
+            Some(Some(self.array.value(old)))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.array.len(), Some(self.array.len()))
+    }
+}
+
+impl<'a> std::iter::DoubleEndedIterator for BooleanIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.current_end == self.current {
+            None
+        } else {
+            self.current_end -= 1;
+            Some(if self.array.is_null(self.current_end) {
+                None
+            } else {
+                Some(self.array.value(self.current_end))
+            })
+        }
+    }
+}
+
+/// all arrays have known size.
+impl<'a> std::iter::ExactSizeIterator for BooleanIter<'a> {}
 
 /// an iterator that returns `Some(&str)` or `None`, for string arrays
 #[derive(Debug)]

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -242,7 +242,7 @@ impl<'a, T: BinaryOffsetSizeTrait> std::iter::ExactSizeIterator
 mod tests {
     use std::sync::Arc;
 
-    use crate::array::{ArrayRef, BinaryArray, Int32Array, StringArray};
+    use crate::array::{ArrayRef, BinaryArray, BooleanArray, Int32Array, StringArray};
 
     #[test]
     fn test_primitive_array_iter_round_trip() {
@@ -309,6 +309,16 @@ mod tests {
 
         // to and from iter
         let result: BinaryArray = array.iter().collect();
+
+        assert_eq!(result, array);
+    }
+
+    #[test]
+    fn test_boolean_array_iter_round_trip() {
+        let array = BooleanArray::from(vec![Some(true), None, Some(false)]);
+
+        // to and from iter
+        let result: BooleanArray = array.iter().collect();
 
         assert_eq!(result, array);
     }

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -84,6 +84,7 @@
 #[allow(clippy::module_inception)]
 mod array;
 mod array_binary;
+mod array_boolean;
 mod array_dictionary;
 mod array_list;
 mod array_primitive;
@@ -116,6 +117,7 @@ pub use self::array_binary::BinaryArray;
 pub use self::array_binary::DecimalArray;
 pub use self::array_binary::FixedSizeBinaryArray;
 pub use self::array_binary::LargeBinaryArray;
+pub use self::array_boolean::BooleanArray;
 pub use self::array_dictionary::DictionaryArray;
 pub use self::array_list::FixedSizeListArray;
 pub use self::array_list::LargeListArray;
@@ -129,7 +131,6 @@ pub use self::null::NullArray;
 
 pub use self::array::make_array;
 
-pub type BooleanArray = PrimitiveArray<BooleanType>;
 pub type Int8Array = PrimitiveArray<Int8Type>;
 pub type Int16Array = PrimitiveArray<Int16Type>;
 pub type Int32Array = PrimitiveArray<Int32Type>;
@@ -176,10 +177,10 @@ pub use self::array_string::StringOffsetSizeTrait;
 
 // --------------------- Array Builder ---------------------
 
+pub use self::builder::BooleanBufferBuilder;
 pub use self::builder::BufferBuilder;
 pub use self::builder::BufferBuilderTrait;
 
-pub type BooleanBufferBuilder = BufferBuilder<BooleanType>;
 pub type Int8BufferBuilder = BufferBuilder<Int8Type>;
 pub type Int16BufferBuilder = BufferBuilder<Int16Type>;
 pub type Int32BufferBuilder = BufferBuilder<Int32Type>;
@@ -210,6 +211,7 @@ pub type DurationNanosecondBufferBuilder = BufferBuilder<DurationNanosecondType>
 
 pub use self::builder::ArrayBuilder;
 pub use self::builder::BinaryBuilder;
+pub use self::builder::BooleanBuilder;
 pub use self::builder::DecimalBuilder;
 pub use self::builder::FixedSizeBinaryBuilder;
 pub use self::builder::FixedSizeListBuilder;
@@ -224,7 +226,6 @@ pub use self::builder::StringDictionaryBuilder;
 pub use self::builder::StructBuilder;
 pub use self::builder::UnionBuilder;
 
-pub type BooleanBuilder = PrimitiveBuilder<BooleanType>;
 pub type Int8Builder = PrimitiveBuilder<Int8Type>;
 pub type Int16Builder = PrimitiveBuilder<Int16Type>;
 pub type Int32Builder = PrimitiveBuilder<Int32Type>;

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -51,6 +51,12 @@ where
     Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
+fn compare_boolean<'a>(left: &'a Array, right: &'a Array) -> DynComparator<'a> {
+    let left = left.as_any().downcast_ref::<BooleanArray>().unwrap();
+    let right = right.as_any().downcast_ref::<BooleanArray>().unwrap();
+    Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
+}
+
 fn compare_float<'a, T: ArrowPrimitiveType>(
     left: &'a Array,
     right: &'a Array,
@@ -129,7 +135,7 @@ pub fn build_compare<'a>(left: &'a Array, right: &'a Array) -> Result<DynCompara
                 "Can't compare arrays of different types".to_string(),
             ));
         }
-        (Boolean, Boolean) => compare_primitives::<BooleanType>(left, right),
+        (Boolean, Boolean) => compare_boolean(left, right),
         (UInt8, UInt8) => compare_primitives::<UInt8Type>(left, right),
         (UInt16, UInt16) => compare_primitives::<UInt16Type>(left, right),
         (UInt32, UInt32) => compare_primitives::<UInt32Type>(left, right),

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -297,12 +297,7 @@ where
         left_data
             .buffers()
             .iter()
-            .map(|buf| {
-                buf.bit_slice(
-                    left.offset() * T::get_bit_width(),
-                    left.len() * T::get_bit_width(),
-                )
-            })
+            .map(|buf| buf.slice(left.offset() * T::get_byte_width()))
             .collect::<Vec<_>>()
     };
 

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -2979,7 +2979,7 @@ mod tests {
     fn make_union_array() -> UnionArray {
         let mut builder = UnionBuilder::new_dense(7);
         builder.append::<Int32Type>("a", 1).unwrap();
-        builder.append::<BooleanType>("b", false).unwrap();
+        builder.append::<Int64Type>("b", 2).unwrap();
         builder.build().unwrap()
     }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use crate::array::*;
 use crate::buffer::{Buffer, MutableBuffer};
 use crate::compute::util::combine_option_bitmap;
-use crate::datatypes::{ArrowNumericType, BooleanType, DataType};
+use crate::datatypes::{ArrowNumericType, DataType};
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
 
@@ -61,7 +61,7 @@ macro_rules! compare_op {
             vec![result.finish()],
             vec![],
         );
-        Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+        Ok(BooleanArray::from(Arc::new(data)))
     }};
 }
 
@@ -82,7 +82,7 @@ macro_rules! compare_op_scalar {
             vec![result.finish()],
             vec![],
         );
-        Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+        Ok(BooleanArray::from(Arc::new(data)))
     }};
 }
 
@@ -152,7 +152,7 @@ pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray
         vec![result.finish()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 fn is_like_pattern(c: char) -> bool {
@@ -203,7 +203,7 @@ pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray>
         vec![result.finish()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
@@ -248,7 +248,7 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
         vec![result.finish()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 pub fn nlike_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray> {
@@ -294,7 +294,7 @@ pub fn nlike_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray
         vec![result.finish()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 pub fn eq_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
@@ -402,7 +402,7 @@ where
         vec![result.freeze()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 /// Helper function to perform boolean lambda function on values from an array and a scalar value using
@@ -453,7 +453,7 @@ where
         vec![result.freeze()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 /// Perform `left == right` operation on two arrays.
@@ -703,7 +703,7 @@ where
         vec![bool_buf.freeze()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 /// Checks if a `GenericListArray` contains a value in the `GenericStringArray`
@@ -761,7 +761,7 @@ where
         vec![bool_buf.freeze()],
         vec![],
     );
-    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    Ok(BooleanArray::from(Arc::new(data)))
 }
 
 // create a buffer and fill it with valid bits

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -58,7 +58,7 @@ pub fn concat(array_list: &[ArrayRef]) -> Result<ArrayRef> {
             Ok(ArrayBuilder::finish(&mut builder))
         }
         DataType::Boolean => {
-            let mut builder = PrimitiveArray::<BooleanType>::builder(0);
+            let mut builder = BooleanArray::builder(0);
             builder.append_data(array_data_list)?;
             Ok(ArrayBuilder::finish(&mut builder))
         }
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_concat_boolean_primitive_arrays() -> Result<()> {
         let arr = concat(&[
-            Arc::new(PrimitiveArray::<BooleanType>::from(vec![
+            Arc::new(BooleanArray::from(vec![
                 Some(true),
                 Some(true),
                 Some(false),
@@ -279,7 +279,7 @@ mod tests {
                 None,
                 Some(false),
             ])) as ArrayRef,
-            Arc::new(PrimitiveArray::<BooleanType>::from(vec![
+            Arc::new(BooleanArray::from(vec![
                 None,
                 Some(false),
                 Some(true),
@@ -287,7 +287,7 @@ mod tests {
             ])) as ArrayRef,
         ])?;
 
-        let expected_output = Arc::new(PrimitiveArray::<BooleanType>::from(vec![
+        let expected_output = Arc::new(BooleanArray::from(vec![
             Some(true),
             Some(true),
             Some(false),

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -94,9 +94,7 @@ pub fn sort_to_indices(
     let (v, n) = partition_validity(values);
 
     match values.data_type() {
-        DataType::Boolean => {
-            sort_primitive::<BooleanType>(values, v, n, vec![], &options)
-        }
+        DataType::Boolean => sort_boolean(values, v, n, vec![], &options),
         DataType::Int8 => sort_primitive::<Int8Type>(values, v, n, vec![], &options),
         DataType::Int16 => sort_primitive::<Int16Type>(values, v, n, vec![], &options),
         DataType::Int32 => sort_primitive::<Int32Type>(values, v, n, vec![], &options),
@@ -220,6 +218,72 @@ impl Default for SortOptions {
             nulls_first: true,
         }
     }
+}
+
+/// Sort primitive values
+fn sort_boolean(
+    values: &ArrayRef,
+    value_indices: Vec<u32>,
+    null_indices: Vec<u32>,
+    nan_indices: Vec<u32>,
+    options: &SortOptions,
+) -> Result<UInt32Array> {
+    let values = values
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .expect("Unable to downcast to boolean array");
+    let descending = options.descending;
+
+    // create tuples that are used for sorting
+    let mut valids = value_indices
+        .into_iter()
+        .map(|index| (index, values.value(index as usize)))
+        .collect::<Vec<(u32, bool)>>();
+
+    let mut nulls = null_indices;
+    let mut nans = nan_indices;
+
+    let valids_len = valids.len();
+    let nulls_len = nulls.len();
+    let nans_len = nans.len();
+
+    if !descending {
+        valids.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("unexpected NaN"));
+    } else {
+        valids.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("unexpected NaN").reverse());
+        // reverse to keep a stable ordering
+        nans.reverse();
+        nulls.reverse();
+    }
+
+    // collect results directly into a buffer instead of a vec to avoid another aligned allocation
+    let mut result = MutableBuffer::new(values.len() * std::mem::size_of::<u32>());
+    // sets len to capacity so we can access the whole buffer as a typed slice
+    result.resize(values.len() * std::mem::size_of::<u32>());
+    let result_slice: &mut [u32] = result.typed_data_mut();
+
+    debug_assert_eq!(result_slice.len(), nulls_len + nans_len + valids_len);
+
+    if options.nulls_first {
+        result_slice[0..nulls_len].copy_from_slice(&nulls);
+        insert_valid_and_nan_values(result_slice, nulls_len, valids, nans, descending);
+    } else {
+        // nulls last
+        insert_valid_and_nan_values(result_slice, 0, valids, nans, descending);
+        result_slice[valids_len + nans_len..].copy_from_slice(nulls.as_slice())
+    }
+
+    let result_data = Arc::new(ArrayData::new(
+        DataType::UInt32,
+        values.len(),
+        Some(0),
+        None,
+        0,
+        vec![result.freeze()],
+        vec![],
+    ));
+
+    Ok(UInt32Array::from(result_data))
 }
 
 /// Sort primitive values
@@ -560,6 +624,17 @@ mod tests {
     use std::iter::FromIterator;
     use std::sync::Arc;
 
+    fn test_sort_to_indices_boolean_arrays(
+        data: Vec<Option<bool>>,
+        options: Option<SortOptions>,
+        expected_data: Vec<u32>,
+    ) {
+        let output = BooleanArray::from(data);
+        let expected = UInt32Array::from(expected_data);
+        let output = sort_to_indices(&(Arc::new(output) as ArrayRef), options).unwrap();
+        assert_eq!(output, expected)
+    }
+
     fn test_sort_to_indices_primitive_arrays<T>(
         data: Vec<Option<T::Native>>,
         options: Option<SortOptions>,
@@ -825,16 +900,19 @@ mod tests {
             }),
             vec![5, 0, 2, 1, 4, 3],
         );
+    }
 
+    #[test]
+    fn test_sort_boolean() {
         // boolean
-        test_sort_to_indices_primitive_arrays::<BooleanType>(
+        test_sort_to_indices_boolean_arrays(
             vec![None, Some(false), Some(true), Some(true), Some(false), None],
             None,
             vec![0, 5, 1, 4, 2, 3],
         );
 
         // boolean, descending
-        test_sort_to_indices_primitive_arrays::<BooleanType>(
+        test_sort_to_indices_boolean_arrays(
             vec![None, Some(false), Some(true), Some(true), Some(false), None],
             Some(SortOptions {
                 descending: true,
@@ -844,7 +922,7 @@ mod tests {
         );
 
         // boolean, descending, nulls first
-        test_sort_to_indices_primitive_arrays::<BooleanType>(
+        test_sort_to_indices_boolean_arrays(
             vec![None, Some(false), Some(true), Some(true), Some(false), None],
             Some(SortOptions {
                 descending: true,

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -564,6 +564,18 @@ where
 mod tests {
     use super::*;
 
+    fn test_take_boolean_arrays(
+        data: Vec<Option<bool>>,
+        index: &UInt32Array,
+        options: Option<TakeOptions>,
+        expected_data: Vec<Option<bool>>,
+    ) {
+        let output = BooleanArray::from(data);
+        let expected = Arc::new(BooleanArray::from(expected_data)) as ArrayRef;
+        let output = take(&(Arc::new(output) as ArrayRef), index, options).unwrap();
+        assert_eq!(&output, &expected)
+    }
+
     fn test_take_primitive_arrays<T>(
         data: Vec<Option<T::Native>>,
         index: &UInt32Array,
@@ -825,7 +837,7 @@ mod tests {
     fn test_take_primitive_bool() {
         let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(2)]);
         // boolean
-        test_take_primitive_arrays::<BooleanType>(
+        test_take_boolean_arrays(
             vec![Some(false), None, Some(true), Some(false), None],
             &index,
             None,

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -48,7 +48,7 @@
 //!     Some(-556132.25),
 //! ]);
 //! let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-//! let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+//! let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
 //!
 //! let batch = RecordBatch::try_new(
 //!     Arc::new(schema),
@@ -415,7 +415,7 @@ mod tests {
             Some(-556132.25),
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-        let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+        let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
         let c5 = TimestampMillisecondArray::from_opt_vec(
             vec![None, Some(1555584887378), Some(1555555555555)],
             None,
@@ -482,7 +482,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             Some(-556132.25),
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-        let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+        let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
         let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
 
         let batch = RecordBatch::try_new(
@@ -543,7 +543,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             Some(-556132.25),
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-        let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+        let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
         let c5 = TimestampMillisecondArray::from_opt_vec(
             vec![None, Some(1555584887378), Some(1555555555555)],
             None,

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -219,9 +219,9 @@ pub trait ArrowPrimitiveType: 'static {
     /// the corresponding Arrow data type of this primitive type.
     const DATA_TYPE: DataType;
 
-    /// Returns the bit width of this primitive type.
-    fn get_bit_width() -> usize {
-        size_of::<Self::Native>() * 8
+    /// Returns the byte width of this primitive type.
+    fn get_byte_width() -> usize {
+        size_of::<Self::Native>()
     }
 
     /// Returns a default value of this primitive type.
@@ -229,15 +229,6 @@ pub trait ArrowPrimitiveType: 'static {
     /// This is useful for aggregate array ops like `sum()`, `mean()`.
     fn default_value() -> Self::Native {
         Default::default()
-    }
-
-    /// Returns a value offset from the given pointer by the given index. The default
-    /// implementation (used for all non-boolean types) is simply equivalent to pointer-arithmetic.
-    /// # Safety
-    /// Just like array-access in C: the raw_ptr must be the start of a valid array, and the index
-    /// must be less than the size of the array.
-    unsafe fn index(raw_ptr: *const Self::Native, i: usize) -> Self::Native {
-        *(raw_ptr.add(i))
     }
 }
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -41,7 +41,6 @@ use serde_json::{
 };
 
 use crate::error::{ArrowError, Result};
-use crate::util::bit_util;
 
 /// The set of datatypes that are supported by this implementation of Apache Arrow.
 ///
@@ -377,20 +376,8 @@ impl ArrowNativeType for f64 {
 #[derive(Debug)]
 pub struct BooleanType {}
 
-impl ArrowPrimitiveType for BooleanType {
-    type Native = bool;
-    const DATA_TYPE: DataType = DataType::Boolean;
-
-    fn get_bit_width() -> usize {
-        1
-    }
-
-    /// # Safety
-    /// The pointer must be part of a bit-packed boolean array, and the index must be less than the
-    /// size of the array.
-    unsafe fn index(raw_ptr: *const Self::Native, i: usize) -> Self::Native {
-        bit_util::get_bit_raw(raw_ptr as *const u8, i)
-    }
+impl BooleanType {
+    pub const DATA_TYPE: DataType = DataType::Boolean;
 }
 
 macro_rules! make_type {

--- a/rust/arrow/src/util/string_writer.rs
+++ b/rust/arrow/src/util/string_writer.rs
@@ -47,7 +47,7 @@
 //!     Some(-556132.25),
 //! ]);
 //! let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
-//! let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+//! let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
 //!
 //! let batch = RecordBatch::try_new(
 //!     Arc::new(schema),

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -25,10 +25,10 @@ use std::vec::Vec;
 
 use arrow::array::{
     Array, ArrayData, ArrayDataBuilder, ArrayDataRef, ArrayRef, BinaryArray,
-    BinaryBuilder, BooleanBufferBuilder, BufferBuilderTrait, FixedSizeBinaryArray,
-    FixedSizeBinaryBuilder, GenericListArray, Int16BufferBuilder, ListBuilder,
-    OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
-    StructArray,
+    BinaryBuilder, BooleanArray, BooleanBufferBuilder, BufferBuilderTrait,
+    FixedSizeBinaryArray, FixedSizeBinaryBuilder, GenericListArray, Int16BufferBuilder,
+    ListBuilder, OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray,
+    StringBuilder, StructArray,
 };
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::datatypes::{
@@ -305,8 +305,7 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
 
         let array = match T::get_physical_type() {
             PhysicalType::BOOLEAN => {
-                Arc::new(PrimitiveArray::<ArrowBooleanType>::from(array_data.build()))
-                    as ArrayRef
+                Arc::new(BooleanArray::from(array_data.build())) as ArrayRef
             }
             PhysicalType::INT32 => {
                 Arc::new(PrimitiveArray::<ArrowInt32Type>::from(array_data.build()))
@@ -627,7 +626,8 @@ fn build_empty_list_array(item_type: ArrowType) -> Result<ArrayRef> {
             build_empty_list_array_with_primitive_items!(ArrowFloat64Type)
         }
         ArrowType::Boolean => {
-            build_empty_list_array_with_primitive_items!(ArrowBooleanType)
+            //build_empty_list_array_with_primitive_items!(ArrowBooleanType)
+            todo!()
         }
         ArrowType::Date32(_) => {
             build_empty_list_array_with_primitive_items!(ArrowDate32Type)
@@ -772,7 +772,8 @@ fn remove_indices(
             remove_primitive_array_indices!(arr, ArrowFloat64Type, indices)
         }
         ArrowType::Boolean => {
-            remove_primitive_array_indices!(arr, ArrowBooleanType, indices)
+            todo!()
+            //remove_primitive_array_indices!(arr, ArrowBooleanType, indices)
         }
         ArrowType::Date32(_) => {
             remove_primitive_array_indices!(arr, ArrowDate32Type, indices)

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -25,7 +25,7 @@ use crate::column::{page::PageReader, reader::ColumnReaderImpl};
 use crate::data_type::DataType;
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
-use arrow::array::{BooleanBufferBuilder, BufferBuilderTrait};
+use arrow::array::BooleanBufferBuilder;
 use arrow::bitmap::Bitmap;
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::memory;


### PR DESCRIPTION
This PR creates a new struct `BooleanArray`, that replaces `PrimitiveArray<BooleanType>`, so that we do not have to consider the differences between being bit-packed and non-bit packed.

This difference is causing a significant performance degradation described on ARROW-10453 and #8837 .

This usage of different logic is already observed in most of our kernels, as the code for byte-width and bit-packed is almost always different, due to how offsets are computed. With this PR, that offset computation no longer depends on bit-packed vs non-bit-packed.

IMPORTANT: this removed support from Boolean array to UnionArray, as `UnionArray` currently only supports `PrimitiveType`.

Micro benchmarks (worse to best, statistically insignificant ignored):

|  benchmark | variation |
|-------------- | -------------- | 
| min nulls 512 | 33.7 | 
| record_batches_to_csv | 23.1 | 
| array_string_from_vec 256 | 5.6 | 
| array_string_from_vec 512 | 5.2 | 
| take bool nulls 512 | 4.9 | 
| cast int32 to int64 512 | 2.5 | 
| equal_512 | 2.3 | 
| filter u8 very low selectivity | 2.2 | 
| array_slice 512 | 2.1 | 
| take bool nulls 1024 | 2.0 | 
| cast int64 to int32 512 | 1.6 | 
| min 512 | 1.6 | 
| take i32 512 | 1.1 | 
| add 512 | 1.1 | 
| array_slice 2048 | 1.0 | 
| length | 1.0 | 
| filter u8 low selectivity | 0.9 | 
| filter u8 high selectivity | 0.9 | 
| array_string_from_vec 128 | 0.9 | 
| cast int32 to float64 512 | 0.9 | 
| cast timestamp_ms to i64 512 | 0.8 | 
| take str null indices 512 | 0.6 | 
| sum 512 | 0.4 | 
| filter context u8 very low selectivity | -0.7 | 
| take i32 1024 | -0.9 | 
| filter context f32 very low selectivity | -0.9 | 
| cast float64 to float32 512 | -1.0 | 
| equal_nulls_512 | -1.0 | 
| cast time32s to time32ms 512 | -1.1 | 
| sort 2^12 | -1.2 | 
| struct_array_from_vec 128 | -1.4 | 
| array_from_vec 256 | -1.4 | 
| array_from_vec 128 | -1.5 | 
| filter context u8 high selectivity | -1.6 | 
| limit 512, 512 | -1.7 | 
| equal_string_nulls_512 | -1.8 | 
| take i32 nulls 1024 | -1.8 | 
| struct_array_from_vec 512 | -1.9 | 
| filter context f32 high selectivity | -2.0 | 
| cast timestamp_ms to timestamp_ns 512 | -2.2 | 
| take i32 nulls 512 | -2.3 | 
| buffer_bit_ops or | -2.4 | 
| array_from_vec 512 | -2.6 | 
| cast float64 to uint64 512 | -2.7 | 
| take str 512 | -2.8 | 
| min nulls string 512 | -3.1 | 
| cast int32 to int32 512 | -3.3 | 
| array_slice 128 | -3.3 | 
| filter context u8 w NULLs very low selectivity | -3.3 | 
| buffer_bit_ops and | -3.4 | 
| struct_array_from_vec 256 | -4.2 | 
| cast int32 to uint32 512 | -4.5 | 
| multiply 512 | -5.2 | 
| equal_string_512 | -5.5 | 
| take str null values null indices 1024 | -6.8 | 
| sum nulls 512 | -13.3 | 
| add_nulls_512 | -17.6 | 
| like_utf8 scalar contains | -17.8 | 
| nlike_utf8 scalar contains | -17.9 | 
| nlike_utf8 scalar complex | -24.6 | 
| like_utf8 scalar complex | -25.2 | 
| cast time64ns to time32s 512 | -42.7 | 
| cast date64 to date32 512 | -49.1 | 
| cast date32 to date64 512 | -50.7 | 
| nlike_utf8 scalar starts with | -51.1 | 
| nlike_utf8 scalar ends with | -55.1 | 
| like_utf8 scalar ends with | -55.5 | 
| like_utf8 scalar starts with | -56.3 | 
| nlike_utf8 scalar equals | -67.8 | 
| like_utf8 scalar equals | -74.2 | 
| eq Float32 | -75.7 | 
| gt_eq Float32 | -76.1 | 
| lt_eq Float32 | -76.5 | 
| not | -77.1 | 
| and | -78.6 | 
| or | -78.7 | 
| lt_eq scalar Float32 | -79.4 | 
| eq scalar Float32 | -82.1 | 
| neq Float32 | -82.1 | 
| lt scalar Float32 | -82.1 | 
| lt Float32 | -82.3 | 
| gt Float32 | -82.4 | 
| gt_eq scalar Float32 | -82.4 | 
| neq scalar Float32 | -82.6 | 
| gt scalar Float32 | -84.7 |
