### PR TITLE
ARROW-10940: [Rust] Extend sort kernel to ListArray

### DIFF
--- a/rust/arrow/src/array/cast.rs
+++ b/rust/arrow/src/array/cast.rs
@@ -40,6 +40,12 @@ where
         .expect("Unable to downcast to dictionary array")
 }
 
+pub fn as_list_array(arr: &ArrayRef) -> &ListArray {
+    arr.as_any()
+        .downcast_ref::<ListArray>()
+        .expect("Unable to downcast to list array")
+}
+
 macro_rules! array_downcast_fn {
     ($name: ident, $arrty: ty, $arrty_str:expr) => {
         #[doc = "Force downcast ArrayRef to "]

--- a/rust/arrow/src/array/cast.rs
+++ b/rust/arrow/src/array/cast.rs
@@ -40,9 +40,9 @@ where
         .expect("Unable to downcast to dictionary array")
 }
 
-pub fn as_list_array(arr: &ArrayRef) -> &ListArray {
+pub fn as_list_array<S: OffsetSizeTrait>(arr: &ArrayRef) -> &GenericListArray<S> {
     arr.as_any()
-        .downcast_ref::<ListArray>()
+        .downcast_ref::<GenericListArray<S>>()
         .expect("Unable to downcast to list array")
 }
 

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -271,8 +271,8 @@ pub use self::ord::{build_compare, DynComparator};
 // --------------------- Array downcast helper functions ---------------------
 
 pub use self::cast::{
-    as_boolean_array, as_dictionary_array, as_largestring_array, as_null_array,
-    as_primitive_array, as_string_array,
+    as_boolean_array, as_dictionary_array, as_largestring_array, as_list_array,
+    as_null_array, as_primitive_array, as_string_array,
 };
 
 // ------------------------------ C Data Interface ---------------------------

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -816,10 +816,9 @@ mod tests {
         let mut values = vec![];
 
         for array in data {
-            array.and_then(|mut array| {
+            if let Some(mut array) = array {
                 values.append(&mut array);
-                Some(())
-            });
+            }
             offset.push(values.len() as i64);
         }
         let num_item = offset.len() - 1;
@@ -845,8 +844,8 @@ mod tests {
 
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(num_item)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
         Arc::new(GenericListArray::<S>::from(list_data))
     }
@@ -873,11 +872,10 @@ mod tests {
         // for LargeList
         let list_data_type =
             DataType::LargeList(Box::new(Field::new("item", DataType::Int64, false)));
-        let input = make_var_sized_list_array::<i64, T>(data.clone(), &list_data_type);
+        let input = make_var_sized_list_array::<i64, T>(data, &list_data_type);
         let sorted = sort(&(input as ArrayRef), options).unwrap();
-        let expected =
-            make_var_sized_list_array::<i64, T>(expected_data.clone(), &list_data_type)
-                as ArrayRef;
+        let expected = make_var_sized_list_array::<i64, T>(expected_data, &list_data_type)
+            as ArrayRef;
 
         assert_eq!(&sorted, &expected);
     }

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -854,30 +854,19 @@ mod tests {
         }
 
         // for List
-        let list_data_type =
-            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
-        let input = Arc::new(build_generic_list_nullable::<i32, T>(
-            data.clone(),
-            &list_data_type,
-        ));
+        let input = Arc::new(build_generic_list_nullable::<i32, T>(data.clone()));
         let sorted = sort(&(input as ArrayRef), options).unwrap();
-        let expected = Arc::new(build_generic_list_nullable::<i32, T>(
-            expected_data.clone(),
-            &list_data_type,
-        )) as ArrayRef;
+        let expected =
+            Arc::new(build_generic_list_nullable::<i32, T>(expected_data.clone()))
+                as ArrayRef;
 
         assert_eq!(&sorted, &expected);
 
         // for LargeList
-        let list_data_type =
-            DataType::LargeList(Box::new(Field::new("item", DataType::Int64, false)));
-        let input =
-            Arc::new(build_generic_list_nullable::<i64, T>(data, &list_data_type));
+        let input = Arc::new(build_generic_list_nullable::<i64, T>(data));
         let sorted = sort(&(input as ArrayRef), options).unwrap();
-        let expected = Arc::new(build_generic_list_nullable::<i64, T>(
-            expected_data,
-            &list_data_type,
-        )) as ArrayRef;
+        let expected =
+            Arc::new(build_generic_list_nullable::<i64, T>(expected_data)) as ArrayRef;
 
         assert_eq!(&sorted, &expected);
     }
@@ -1550,6 +1539,28 @@ mod tests {
                 Some(vec![Some(4), Some(3), Some(2), Some(1)]),
             ],
             None,
+        );
+
+        test_sort_list_arrays::<Int32Type>(
+            vec![
+                None,
+                Some(vec![Some(4), None, Some(2)]),
+                Some(vec![Some(2), Some(3), Some(4)]),
+                None,
+                Some(vec![Some(3), Some(3), None]),
+            ],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: false,
+            }),
+            vec![
+                Some(vec![Some(2), Some(3), Some(4)]),
+                Some(vec![Some(3), Some(3), None]),
+                Some(vec![Some(4), None, Some(2)]),
+                None,
+                None,
+            ],
+            Some(3),
         );
     }
 

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -556,6 +556,7 @@ where
     Ok(UInt32Array::from(valid_indices))
 }
 
+/// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).
 fn cmp_array(a: &Array, b: &Array) -> Ordering {
     let cmp_op = build_compare(a, b).unwrap();
     let length = a.len().max(b.len());

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -617,7 +617,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::util::tests::build_fixed_size_list;
+    use crate::compute::util::tests::build_fixed_size_list_nullable;
 
     fn test_take_boolean_arrays(
         data: Vec<Option<bool>>,
@@ -1158,12 +1158,12 @@ mod tests {
         let indices = UInt32Array::from(indices);
 
         let input_array: ArrayRef =
-            Arc::new(build_fixed_size_list::<T>(input_data, length));
+            Arc::new(build_fixed_size_list_nullable::<T>(input_data, length));
 
         let output = take_fixed_size_list(&input_array, &indices, length as u32).unwrap();
 
         let expected: ArrayRef =
-            Arc::new(build_fixed_size_list::<T>(expected_data, length));
+            Arc::new(build_fixed_size_list_nullable::<T>(expected_data, length));
 
         assert_eq!(&output, &expected)
     }

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -148,7 +148,7 @@ where
         DataType::List(_) => take_list::<_, Int32Type>(values, indices),
         DataType::LargeList(_) => take_list::<_, Int64Type>(values, indices),
         DataType::FixedSizeList(_, length) => {
-            take_fixed_size_list(values, indices, *length)
+            take_fixed_size_list(values, indices, *length as u32)
         }
         DataType::Struct(fields) => {
             let struct_: &StructArray =
@@ -541,23 +541,19 @@ where
 fn take_fixed_size_list<IndexType>(
     values: &ArrayRef,
     indices: &PrimitiveArray<IndexType>,
-    length: <Int32Type as ArrowPrimitiveType>::Native,
+    length: <UInt32Type as ArrowPrimitiveType>::Native,
 ) -> Result<ArrayRef>
 where
     IndexType: ArrowNumericType,
     IndexType::Native: ToPrimitive,
 {
-    let indices = indices
-        .as_any()
-        .downcast_ref::<PrimitiveArray<Int32Type>>()
-        .expect("FixedSizeListArray's indices type should be 32-bit signed integer");
     let list = values
         .as_any()
         .downcast_ref::<FixedSizeListArray>()
         .unwrap();
 
-    let list_indices = take_value_indices_from_fixed_size_list(list, indices, length);
-    let taken = take_impl::<Int32Type>(&list.values(), &list_indices, None)?;
+    let list_indices = take_value_indices_from_fixed_size_list(list, indices, length)?;
+    let taken = take_impl::<UInt32Type>(&list.values(), &list_indices, None)?;
 
     // determine null count and null buffer, which are a function of `values` and `indices`
     let mut null_count = 0;
@@ -566,7 +562,10 @@ where
     let null_slice = null_buf.data_mut();
 
     for i in 0..indices.len() {
-        if !indices.is_valid(i) || list.is_null(indices.value(i) as usize) {
+        let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
+            ArrowError::ComputeError("Cast to usize failed".to_string())
+        })?;
+        if !indices.is_valid(i) || list.is_null(index) {
             bit_util::unset_bit(null_slice, i);
             null_count += 1;
         }
@@ -1150,18 +1149,18 @@ mod tests {
     fn do_take_fixed_size_list_test<T>(
         length: <Int32Type as ArrowPrimitiveType>::Native,
         input_data: Vec<Option<Vec<Option<T::Native>>>>,
-        indices: Vec<<Int32Type as ArrowPrimitiveType>::Native>,
+        indices: Vec<<UInt32Type as ArrowPrimitiveType>::Native>,
         expected_data: Vec<Option<Vec<Option<T::Native>>>>,
     ) where
         T: ArrowPrimitiveType,
         PrimitiveArray<T>: From<Vec<Option<T::Native>>>,
     {
-        let indices = Int32Array::from(indices);
+        let indices = UInt32Array::from(indices);
 
         let input_array: ArrayRef =
             Arc::new(build_fixed_size_list::<T>(input_data, length));
 
-        let output = take_fixed_size_list(&input_array, &indices, length).unwrap();
+        let output = take_fixed_size_list(&input_array, &indices, length as u32).unwrap();
 
         let expected: ArrayRef =
             Arc::new(build_fixed_size_list::<T>(expected_data, length));


### PR DESCRIPTION
This supports sort on `GenericListArray` and `FixedSizeListArray`.