### PR TITLE
ARROW-10830 [Rust] avoid hard crash in json reader

### DIFF
--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -472,7 +472,9 @@ impl<R: Read> Reader<R> {
         for _ in 0..self.batch_size {
             let bytes_read = self.reader.read_line(&mut line)?;
             if bytes_read > 0 {
-                rows.push(serde_json::from_str(&line).expect("Not valid JSON"));
+                rows.push(serde_json::from_str(&line).map_err(|e| {
+                    ArrowError::JsonError(format!("Not valid JSON: {}", e))
+                })?);
                 line = String::new();
             } else {
                 break;


### PR DESCRIPTION
return parsing error to caller instead