### PR TITLE
ARROW-10838: [Rust] [CI] Add arrow build targeting wasm32

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -350,3 +350,45 @@ jobs:
           pip install maturin==0.8.2 toml==0.10.1 pyarrow==1.0.0
           maturin develop
           python -m unittest discover tests
+
+  # test the arrow crate builds against wasm32 in stable rust
+  wasm32-build:
+    name: AMD64 Debian 10 Rust ${{ matrix.rust }} test arrow wasm32
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [nightly-2020-11-24]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
+        PARQUET_TEST_DATA: /__w/arrow/arrow/cpp/submodules/parquet-testing/data
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache-${{ matrix.rust }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          default: true
+          override: true
+          components: rustfmt
+          target: wasm32-unknown-unknown
+      - name: Build arrow crate
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cd rust/arrow
+          cargo build --target wasm32-unknown-unknown


### PR DESCRIPTION
This is a requirement fielded to merge #7767, and so I though about adding it to our CI.

I am not sure whether this is exactly what we need to test #7767, and so I would like to request help from @paddyhoran and @rj-atw here.

NOTE: this is built on top of #8821 . Only the last commit is relevant. Basically, this runs

```
rustup add target wasm32-unknown-unknown
cd rust/arrow
cargo build --target wasm32-unknown-unknown
```

Note that this does not actually run the tests yet. I think that that is #7767 's goal.
