### PR TITLE
ARROW-10842 [Rust] decouple IO from json reader, fix crash during json schema inference with invalid json

### DIFF
--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -543,10 +543,7 @@ impl Decoder {
     }
 
     /// Read the next batch of records
-    pub fn next_batch<'a, 'b, I>(
-        &'a self,
-        value_iter: &'b mut I,
-    ) -> Result<Option<RecordBatch>>
+    pub fn next_batch<I>(&self, value_iter: &mut I) -> Result<Option<RecordBatch>>
     where
         I: Iterator<Item = Result<Value>>,
     {


### PR DESCRIPTION
Other related changes:

 * reuse the same IO code between schema inference and record batch reader.
 * reuse string buffer to avoid repeatitive memory allocation
 * ignore new lines when reading json records
 * avoid hard crash during JSON schema inference caused by invalid json