### PR TITLE
ARROW-10854: [Rust] [DataFusion] Simplify logical plan scans

### DIFF
--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -149,7 +149,7 @@ fn create_context(
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, partitions)?;
+    let provider = MemTable::try_new(schema, partitions)?;
     ctx.register_table("t", Box::new(provider));
 
     Ok(Arc::new(Mutex::new(ctx)))

--- a/rust/datafusion/benches/filter_query_sql.rs
+++ b/rust/datafusion/benches/filter_query_sql.rs
@@ -61,7 +61,7 @@ fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContex
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![batches])?;
+    let provider = MemTable::try_new(schema, vec![batches])?;
     ctx.register_table("t", Box::new(provider));
 
     Ok(ctx)

--- a/rust/datafusion/benches/math_query_sql.rs
+++ b/rust/datafusion/benches/math_query_sql.rs
@@ -71,7 +71,7 @@ fn create_context(
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![batches])?;
+    let provider = MemTable::try_new(schema, vec![batches])?;
     ctx.register_table("t", Box::new(provider));
 
     Ok(Arc::new(Mutex::new(ctx)))

--- a/rust/datafusion/examples/dataframe_in_memory.rs
+++ b/rust/datafusion/examples/dataframe_in_memory.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![vec![batch]])?;
+    let provider = MemTable::try_new(schema, vec![vec![batch]])?;
     ctx.register_table("t", Box::new(provider));
     let df = ctx.table("t")?;
 

--- a/rust/datafusion/examples/simple_udaf.rs
+++ b/rust/datafusion/examples/simple_udaf.rs
@@ -47,7 +47,7 @@ fn create_context() -> Result<ExecutionContext> {
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![vec![batch1], vec![batch2]])?;
+    let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
     ctx.register_table("t", Box::new(provider));
     Ok(ctx)
 }

--- a/rust/datafusion/examples/simple_udf.rs
+++ b/rust/datafusion/examples/simple_udf.rs
@@ -49,7 +49,7 @@ fn create_context() -> Result<ExecutionContext> {
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![vec![batch]])?;
+    let provider = MemTable::try_new(schema, vec![vec![batch]])?;
     ctx.register_table("t", Box::new(provider));
     Ok(ctx)
 }

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -39,7 +39,7 @@ pub struct MemTable {
 
 impl MemTable {
     /// Create a new in-memory table from the provided schema and record batches
-    pub fn new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
+    pub fn try_new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
         if partitions.iter().all(|partition| {
             partition
                 .iter()
@@ -81,7 +81,7 @@ impl MemTable {
             data.push(result);
         }
 
-        MemTable::new(schema.clone(), data)
+        MemTable::try_new(schema.clone(), data)
     }
 }
 
@@ -158,7 +158,7 @@ mod tests {
             ],
         )?;
 
-        let provider = MemTable::new(schema, vec![vec![batch]])?;
+        let provider = MemTable::try_new(schema, vec![vec![batch]])?;
 
         // scan with projection
         let exec = provider.scan(&Some(vec![2, 1]), 1024)?;
@@ -189,7 +189,7 @@ mod tests {
             ],
         )?;
 
-        let provider = MemTable::new(schema, vec![vec![batch]])?;
+        let provider = MemTable::try_new(schema, vec![vec![batch]])?;
 
         let exec = provider.scan(&None, 1024)?;
         let mut it = exec.execute(0).await?;
@@ -217,7 +217,7 @@ mod tests {
             ],
         )?;
 
-        let provider = MemTable::new(schema, vec![vec![batch]])?;
+        let provider = MemTable::try_new(schema, vec![vec![batch]])?;
 
         let projection: Vec<usize> = vec![0, 4];
 
@@ -254,7 +254,7 @@ mod tests {
             ],
         )?;
 
-        match MemTable::new(schema2, vec![vec![batch]]) {
+        match MemTable::try_new(schema2, vec![vec![batch]]) {
             Err(DataFusionError::Plan(e)) => assert_eq!(
                 "\"Mismatch between schema and batches\"",
                 format!("{:?}", e)

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -206,20 +206,9 @@ impl ExecutionContext {
         filename: &str,
         options: CsvReadOptions,
     ) -> Result<Arc<dyn DataFrame>> {
-        let csv = CsvFile::try_new(filename, options)?;
-
-        let table_scan = LogicalPlan::CsvScan {
-            path: filename.to_string(),
-            schema: csv.schema(),
-            has_header: options.has_header,
-            delimiter: Some(options.delimiter),
-            projection: None,
-            projected_schema: Arc::new(DFSchema::from(&csv.schema())?),
-        };
-
         Ok(Arc::new(DataFrameImpl::new(
             self.state.clone(),
-            &LogicalPlanBuilder::from(&table_scan).build()?,
+            &LogicalPlanBuilder::scan_csv(&filename, options, None)?.build()?,
         )))
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -214,18 +214,9 @@ impl ExecutionContext {
 
     /// Creates a DataFrame for reading a Parquet data source.
     pub fn read_parquet(&mut self, filename: &str) -> Result<Arc<dyn DataFrame>> {
-        let parquet = ParquetTable::try_new(filename)?;
-
-        let table_scan = LogicalPlan::ParquetScan {
-            path: filename.to_string(),
-            schema: parquet.schema(),
-            projection: None,
-            projected_schema: Arc::new(DFSchema::from(&parquet.schema())?),
-        };
-
         Ok(Arc::new(DataFrameImpl::new(
             self.state.clone(),
-            &LogicalPlanBuilder::from(&table_scan).build()?,
+            &LogicalPlanBuilder::scan_parquet(&filename, None)?.build()?,
         )))
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -727,33 +727,31 @@ mod tests {
             Field::new("c", DataType::Int32, false),
         ]);
         let schema = SchemaRef::new(schema);
-        let plan = LogicalPlanBuilder::from(&LogicalPlan::InMemoryScan {
-            data: vec![vec![RecordBatch::try_new(
-                schema.clone(),
-                vec![
-                    Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
-                    Arc::new(Int32Array::from(vec![2, 12, 12, 120])),
-                    Arc::new(Int32Array::from(vec![3, 12, 12, 120])),
-                ],
-            )?]],
-            schema: schema.clone(),
-            projection: None,
-            projected_schema: DFSchemaRef::new(DFSchema::from(&schema)?),
-        })
-        .project(vec![col("b")])?
-        .build()?;
+
+        let partitions = vec![vec![RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
+                Arc::new(Int32Array::from(vec![2, 12, 12, 120])),
+                Arc::new(Int32Array::from(vec![3, 12, 12, 120])),
+            ],
+        )?]];
+
+        let plan = LogicalPlanBuilder::scan_memory(partitions, schema, None)?
+            .project(vec![col("b")])?
+            .build()?;
         assert_fields_eq(&plan, vec!["b"]);
 
         let ctx = ExecutionContext::new();
         let optimized_plan = ctx.optimize(&plan)?;
         match &optimized_plan {
             LogicalPlan::Projection { input, .. } => match &**input {
-                LogicalPlan::InMemoryScan {
-                    schema,
+                LogicalPlan::TableScan {
+                    table_schema,
                     projected_schema,
                     ..
                 } => {
-                    assert_eq!(schema.fields().len(), 3);
+                    assert_eq!(table_schema.fields().len(), 3);
                     assert_eq!(projected_schema.fields().len(), 1);
                 }
                 _ => assert!(false, "input to projection should be InMemoryScan"),
@@ -762,7 +760,7 @@ mod tests {
         }
 
         let expected = "Projection: #b\
-        \n  InMemoryScan: projection=Some([1])";
+        \n  TableScan: projection=Some([1])";
         assert_eq!(format!("{:?}", optimized_plan), expected);
 
         let physical_plan = ctx.create_physical_plan(&optimized_plan)?;
@@ -1314,7 +1312,7 @@ mod tests {
 
         let mut ctx = ExecutionContext::new();
 
-        let provider = MemTable::new(Arc::new(schema), vec![vec![batch]])?;
+        let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
         ctx.register_table("t", Box::new(provider));
 
         let myfunc: ScalarFunctionImplementation = Arc::new(|args: &[ArrayRef]| {
@@ -1404,7 +1402,8 @@ mod tests {
 
         let mut ctx = ExecutionContext::new();
 
-        let provider = MemTable::new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
+        let provider =
+            MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
         ctx.register_table("t", Box::new(provider));
 
         let result = collect(&mut ctx, "SELECT AVG(a) FROM t").await?;
@@ -1440,7 +1439,8 @@ mod tests {
 
         let mut ctx = ExecutionContext::new();
 
-        let provider = MemTable::new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
+        let provider =
+            MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
         ctx.register_table("t", Box::new(provider));
 
         // define a udaf, using a DataFusion's accumulator

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -68,7 +68,6 @@ impl LogicalPlanBuilder {
         let provider = Arc::new(MemTable::try_new(schema.clone(), partitions)?);
 
         let projected_schema = projection
-            .clone()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()));
         let projected_schema = projected_schema.map_or(schema.clone(), SchemaRef::new);
         let projected_schema = DFSchemaRef::new(DFSchema::from(&projected_schema)?);
@@ -76,7 +75,7 @@ impl LogicalPlanBuilder {
         let table_scan = LogicalPlan::TableScan {
             schema_name: "".to_string(),
             source: TableSource::FromProvider(provider),
-            table_schema: schema.clone(),
+            table_schema: schema,
             projected_schema,
             projection: None,
         };
@@ -99,9 +98,8 @@ impl LogicalPlanBuilder {
         };
 
         let projected_schema = projection
-            .clone()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()))
-            .or(Some(schema.clone()))
+            .or(Some(schema))
             .unwrap();
         let projected_schema = DFSchemaRef::new(DFSchema::from(&projected_schema)?);
 
@@ -111,7 +109,7 @@ impl LogicalPlanBuilder {
         let table_scan = LogicalPlan::TableScan {
             schema_name: "".to_string(),
             source: TableSource::FromProvider(provider),
-            table_schema: schema.clone(),
+            table_schema: schema,
             projected_schema,
             projection: None,
         };
@@ -125,7 +123,6 @@ impl LogicalPlanBuilder {
         let schema = provider.schema();
 
         let projected_schema = projection
-            .clone()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()));
         let projected_schema = projected_schema.map_or(schema.clone(), SchemaRef::new);
         let projected_schema = DFSchemaRef::new(DFSchema::from(&projected_schema)?);
@@ -133,7 +130,7 @@ impl LogicalPlanBuilder {
         let table_scan = LogicalPlan::TableScan {
             schema_name: "".to_string(),
             source: TableSource::FromProvider(provider),
-            table_schema: schema.clone(),
+            table_schema: schema,
             projected_schema,
             projection: None,
         };

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -143,17 +143,6 @@ pub enum LogicalPlan {
         /// The schema description of the output
         projected_schema: DFSchemaRef,
     },
-    /// Produces rows by scanning Parquet file(s)
-    ParquetScan {
-        /// The path to the files
-        path: String,
-        /// The schema of the Parquet file(s)
-        schema: SchemaRef,
-        /// Optional column indices to use as a projection
-        projection: Option<Vec<usize>>,
-        /// The schema description of the output
-        projected_schema: DFSchemaRef,
-    },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {
         /// Whether to produce a placeholder row
@@ -206,9 +195,6 @@ impl LogicalPlan {
         match self {
             LogicalPlan::EmptyRelation { schema, .. } => &schema,
             LogicalPlan::InMemoryScan {
-                projected_schema, ..
-            } => &projected_schema,
-            LogicalPlan::ParquetScan {
                 projected_schema, ..
             } => &projected_schema,
             LogicalPlan::TableScan {
@@ -315,7 +301,6 @@ impl LogicalPlan {
             // plans without inputs
             LogicalPlan::TableScan { .. }
             | LogicalPlan::InMemoryScan { .. }
-            | LogicalPlan::ParquetScan { .. }
             | LogicalPlan::EmptyRelation { .. }
             | LogicalPlan::CreateExternalTable { .. }
             | LogicalPlan::Explain { .. } => true,
@@ -522,11 +507,6 @@ impl LogicalPlan {
                     LogicalPlan::InMemoryScan { ref projection, .. } => {
                         write!(f, "InMemoryScan: projection={:?}", projection)
                     }
-                    LogicalPlan::ParquetScan {
-                        ref path,
-                        ref projection,
-                        ..
-                    } => write!(f, "ParquetScan: {} projection={:?}", path, projection),
                     LogicalPlan::Projection { ref expr, .. } => {
                         write!(f, "Projection: ")?;
                         for i in 0..expr.len() {

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -154,21 +154,6 @@ pub enum LogicalPlan {
         /// The schema description of the output
         projected_schema: DFSchemaRef,
     },
-    /// Produces rows by scanning a CSV file(s)
-    CsvScan {
-        /// The path to the files
-        path: String,
-        /// The underlying table schema
-        schema: SchemaRef,
-        /// Whether the CSV file(s) have a header containing column names
-        has_header: bool,
-        /// An optional column delimiter. Defaults to `b','`
-        delimiter: Option<u8>,
-        /// Optional column indices to use as a projection
-        projection: Option<Vec<usize>>,
-        /// The schema description of the output
-        projected_schema: DFSchemaRef,
-    },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {
         /// Whether to produce a placeholder row
@@ -221,9 +206,6 @@ impl LogicalPlan {
         match self {
             LogicalPlan::EmptyRelation { schema, .. } => &schema,
             LogicalPlan::InMemoryScan {
-                projected_schema, ..
-            } => &projected_schema,
-            LogicalPlan::CsvScan {
                 projected_schema, ..
             } => &projected_schema,
             LogicalPlan::ParquetScan {
@@ -334,7 +316,6 @@ impl LogicalPlan {
             LogicalPlan::TableScan { .. }
             | LogicalPlan::InMemoryScan { .. }
             | LogicalPlan::ParquetScan { .. }
-            | LogicalPlan::CsvScan { .. }
             | LogicalPlan::EmptyRelation { .. }
             | LogicalPlan::CreateExternalTable { .. }
             | LogicalPlan::Explain { .. } => true,
@@ -541,11 +522,6 @@ impl LogicalPlan {
                     LogicalPlan::InMemoryScan { ref projection, .. } => {
                         write!(f, "InMemoryScan: projection={:?}", projection)
                     }
-                    LogicalPlan::CsvScan {
-                        ref path,
-                        ref projection,
-                        ..
-                    } => write!(f, "CsvScan: {} projection={:?}", path, projection),
                     LogicalPlan::ParquetScan {
                         ref path,
                         ref projection,

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -269,25 +269,6 @@ fn optimize_plan(
                 projected_schema,
             })
         }
-        LogicalPlan::InMemoryScan {
-            data,
-            schema,
-            projection,
-            ..
-        } => {
-            let (projection, projected_schema) = get_projected_schema(
-                &schema,
-                projection,
-                required_columns,
-                has_projection,
-            )?;
-            Ok(LogicalPlan::InMemoryScan {
-                data: data.clone(),
-                schema: schema.clone(),
-                projection: Some(projection),
-                projected_schema,
-            })
-        }
         LogicalPlan::Explain {
             verbose,
             plan,

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -288,30 +288,6 @@ fn optimize_plan(
                 projected_schema,
             })
         }
-        LogicalPlan::CsvScan {
-            path,
-            has_header,
-            delimiter,
-            schema,
-            projection,
-            ..
-        } => {
-            let (projection, projected_schema) = get_projected_schema(
-                &schema,
-                projection,
-                required_columns,
-                has_projection,
-            )?;
-
-            Ok(LogicalPlan::CsvScan {
-                path: path.to_owned(),
-                has_header: *has_header,
-                schema: schema.clone(),
-                delimiter: *delimiter,
-                projection: Some(projection),
-                projected_schema,
-            })
-        }
         LogicalPlan::ParquetScan {
             path,
             schema,

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -288,26 +288,6 @@ fn optimize_plan(
                 projected_schema,
             })
         }
-        LogicalPlan::ParquetScan {
-            path,
-            schema,
-            projection,
-            ..
-        } => {
-            let (projection, projected_schema) = get_projected_schema(
-                &schema,
-                projection,
-                required_columns,
-                has_projection,
-            )?;
-
-            Ok(LogicalPlan::ParquetScan {
-                path: path.to_owned(),
-                schema: schema.clone(),
-                projection: Some(projection),
-                projected_schema,
-            })
-        }
         LogicalPlan::Explain {
             verbose,
             plan,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -148,7 +148,6 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
         LogicalPlan::Extension { node } => node.expressions(),
         // plans without expressions
         LogicalPlan::TableScan { .. }
-        | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Limit { .. }
         | LogicalPlan::CreateExternalTable { .. }
@@ -168,7 +167,6 @@ pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
         LogicalPlan::Extension { node } => node.inputs(),
         // plans without inputs
         LogicalPlan::TableScan { .. }
-        | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => vec![],
@@ -224,7 +222,6 @@ pub fn from_plan(
         }),
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }
-        | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => Ok(plan.clone()),
     }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -150,7 +150,6 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
         LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
-        | LogicalPlan::CsvScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Limit { .. }
         | LogicalPlan::CreateExternalTable { .. }
@@ -172,7 +171,6 @@ pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
         LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
-        | LogicalPlan::CsvScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => vec![],
@@ -230,7 +228,6 @@ pub fn from_plan(
         | LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
-        | LogicalPlan::CsvScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => Ok(plan.clone()),
     }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -149,7 +149,6 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
         // plans without expressions
         LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
-        | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Limit { .. }
         | LogicalPlan::CreateExternalTable { .. }
@@ -170,7 +169,6 @@ pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
         // plans without inputs
         LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
-        | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => vec![],
@@ -227,7 +225,6 @@ pub fn from_plan(
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }
         | LogicalPlan::InMemoryScan { .. }
-        | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => Ok(plan.clone()),
     }

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -35,7 +35,6 @@ use crate::physical_plan::hash_utils;
 use crate::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::merge::MergeExec;
-use crate::physical_plan::parquet::ParquetExec;
 use crate::physical_plan::projection::ProjectionExec;
 use crate::physical_plan::sort::SortExec;
 use crate::physical_plan::udf;
@@ -224,13 +223,6 @@ impl DefaultPhysicalPlanner {
                     initial_aggr,
                 )?))
             }
-            LogicalPlan::ParquetScan {
-                path, projection, ..
-            } => Ok(Arc::new(ParquetExec::try_new(
-                path,
-                projection.to_owned(),
-                batch_size,
-            )?)),
             LogicalPlan::Projection { input, expr, .. } => {
                 let input_exec = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema();

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -33,7 +33,6 @@ use crate::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
 use crate::physical_plan::hash_join::HashJoinExec;
 use crate::physical_plan::hash_utils;
 use crate::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
-use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::merge::MergeExec;
 use crate::physical_plan::projection::ProjectionExec;
 use crate::physical_plan::sort::SortExec;
@@ -154,16 +153,6 @@ impl DefaultPhysicalPlanner {
                     provider.scan(projection, batch_size)
                 }
             },
-            LogicalPlan::InMemoryScan {
-                data,
-                projection,
-                projected_schema,
-                ..
-            } => Ok(Arc::new(MemoryExec::try_new(
-                data,
-                projected_schema.as_ref().to_owned().into(),
-                projection.to_owned(),
-            )?)),
             LogicalPlan::Aggregate {
                 input,
                 group_expr,

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -26,7 +26,6 @@ use crate::logical_plan::{
     DFSchema, Expr, LogicalPlan, PlanType, StringifiedPlan, TableSource,
     UserDefinedLogicalNode,
 };
-use crate::physical_plan::csv::{CsvExec, CsvReadOptions};
 use crate::physical_plan::explain::ExplainExec;
 use crate::physical_plan::expressions::{CaseExpr, Column, Literal, PhysicalSortExpr};
 use crate::physical_plan::filter::FilterExec;
@@ -165,22 +164,6 @@ impl DefaultPhysicalPlanner {
                 data,
                 projected_schema.as_ref().to_owned().into(),
                 projection.to_owned(),
-            )?)),
-            LogicalPlan::CsvScan {
-                path,
-                schema,
-                has_header,
-                delimiter,
-                projection,
-                ..
-            } => Ok(Arc::new(CsvExec::try_new(
-                path,
-                CsvReadOptions::new()
-                    .schema(schema.as_ref())
-                    .delimiter_option(*delimiter)
-                    .has_header(*has_header),
-                projection.to_owned(),
-                batch_size,
             )?)),
             LogicalPlan::Aggregate {
                 input,

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -45,7 +45,7 @@ pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
         ],
     )
     .unwrap();
-    let provider = MemTable::new(dual_schema, vec![vec![batch]]).unwrap();
+    let provider = MemTable::try_new(dual_schema, vec![vec![batch]]).unwrap();
     Box::new(provider)
 }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1040,7 +1040,7 @@ fn create_case_context() -> Result<ExecutionContext> {
             None,
         ]))],
     )?;
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
     ctx.register_table("t1", Box::new(table));
     Ok(ctx)
 }
@@ -1190,7 +1190,7 @@ fn create_join_context(
             ])),
         ],
     )?;
-    let t1_table = MemTable::new(t1_schema, vec![vec![t1_data]])?;
+    let t1_table = MemTable::try_new(t1_schema, vec![vec![t1_data]])?;
     ctx.register_table("t1", Box::new(t1_table));
 
     let t2_schema = Arc::new(Schema::new(vec![
@@ -1209,7 +1209,7 @@ fn create_join_context(
             ])),
         ],
     )?;
-    let t2_table = MemTable::new(t2_schema, vec![vec![t2_data]])?;
+    let t2_table = MemTable::try_new(t2_schema, vec![vec![t2_data]])?;
     ctx.register_table("t2", Box::new(t2_table));
 
     Ok(ctx)
@@ -1411,7 +1411,7 @@ async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
         vec![Arc::new(T::from(vec!["", "a", "aa", "aaa"]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1445,7 +1445,7 @@ async fn query_not() -> Result<()> {
         ]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1471,7 +1471,7 @@ async fn query_concat() -> Result<()> {
         ],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1502,7 +1502,7 @@ async fn query_array() -> Result<()> {
         ],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1591,7 +1591,7 @@ fn make_timestamp_nano_table() -> Result<Box<MemTable>> {
             Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)])),
         ],
     )?;
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
     Ok(Box::new(table))
 }
 
@@ -1621,7 +1621,7 @@ async fn query_is_null() -> Result<()> {
         ]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1645,7 +1645,7 @@ async fn query_is_not_null() -> Result<()> {
         ]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1672,7 +1672,7 @@ async fn query_count_distinct() -> Result<()> {
         ]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
@@ -1702,7 +1702,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     let data = RecordBatch::try_new(schema.clone(), vec![array])?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));
 
@@ -1772,7 +1772,7 @@ async fn query_scalar_minus_array() -> Result<()> {
         ]))],
     )?;
 
-    let table = MemTable::new(schema, vec![vec![data]])?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
     ctx.register_table("test", Box::new(table));


### PR DESCRIPTION
This PR simplifies the logical plan by removing `CsvScan`, `ParquetScan` and `InMemoryScan` and encapsulating all of them into `TableScan`.

The underlying aspect here is that all these nodes perform the same operation (through the `dyn TableProvider`), they are just described in the plan differently. This PR makes all scans be encapsulated via `TableScan`, thereby removing the other ones.

This has no execution differences - it only simplifies code at the logical level.

This also renames the function `MemTable::new -> Result<Self>` to `MemTable::try_new`, as that is the standard in rust for falible constructors.