### PR TITLE
ARROW-10851: [C++] Reduce size of generated code for sort kernels

### DIFF
--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -23,6 +23,7 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/validate.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
@@ -31,7 +32,7 @@ namespace arrow {
 using internal::checked_cast;
 
 BinaryArray::BinaryArray(const std::shared_ptr<ArrayData>& data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::BINARY);
+  ARROW_CHECK(is_binary_like(data->type->id()));
   SetData(data);
 }
 
@@ -44,7 +45,7 @@ BinaryArray::BinaryArray(int64_t length, const std::shared_ptr<Buffer>& value_of
 }
 
 LargeBinaryArray::LargeBinaryArray(const std::shared_ptr<ArrayData>& data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::LARGE_BINARY);
+  ARROW_CHECK(is_large_binary_like(data->type->id()));
   SetData(data);
 }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -181,6 +181,18 @@ class ARROW_EXPORT DataType : public detail::Fingerprintable {
 ARROW_EXPORT
 std::ostream& operator<<(std::ostream& os, const DataType& type);
 
+/// \brief Return the compatible physical data type
+///
+/// Some types may have distinct logical meanings but the exact same physical
+/// representation.  For example, TimestampType has Int64Type as a physical
+/// type (defined as TimestampType::PhysicalType).
+///
+/// The return value is as follows:
+/// - if a `PhysicalType` alias exists in the concrete type class, return
+///   an instance of `PhysicalType`.
+/// - otherwise, return the input type itself.
+std::shared_ptr<DataType> GetPhysicalType(const std::shared_ptr<DataType>& type);
+
 /// \brief Base class for all fixed-width data types
 class ARROW_EXPORT FixedWidthType : public DataType {
  public:


### PR DESCRIPTION
Reduce generated code size and compilation time for `vector_sort.cc` by 35%.

Before:
```
$ ls -la ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
-rw-rw-r-- 1 antoine antoine 29292160 déc.   9 10:12 ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
$ size ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
   text	   data	    bss	    dec	    hex	filename
1191948	   2864	    360	1195172	 123ca4	./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
$ rm ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o && time CCACHE_DISABLE=1 ninja
[65/65] Linking CXX executable release/arrow-flight-benchmark

real	0m40,730s
user	0m44,445s
sys	0m2,286s
```

After:
```
$ ls -la ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
-rw-rw-r-- 1 antoine antoine 19131928 déc.   9 10:15 ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
$ size ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
   text	   data	    bss	    dec	    hex	filename
 763009	   2528	    360	 765897	  bafc9	./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o
$ rm ./src/arrow/CMakeFiles/arrow_objlib.dir/compute/kernels/vector_sort.cc.o && time CCACHE_DISABLE=1 ninja
[65/65] Linking CXX executable release/arrow-flight-benchmark

real	0m25,740s
user	0m29,434s
sys	0m2,209s
```