### PR TITLE
ARROW-10927: [Rust][Parquet] Add Decimal to ArrayBuilderReader

### DIFF
--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -381,6 +381,33 @@ mod tests {
         >(2, message_type, &converter);
     }
 
+    #[test]
+    fn test_read_decimal_file() {
+        use arrow::array::DecimalArray;
+        let testdata =
+            env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+        let path = format!("{}/fixed_length_decimal.parquet", testdata);
+        let parquet_reader =
+            SerializedFileReader::try_from(File::open(&path).unwrap()).unwrap();
+        let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(parquet_reader));
+
+        let mut record_reader = arrow_reader.get_record_reader(32).unwrap();
+
+        let batch = record_reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 24);
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<DecimalArray>()
+            .unwrap();
+
+        let expected = 1..25;
+
+        for (i, v) in expected.enumerate() {
+            assert_eq!(col.value(i), v * 100 as i128);
+        }
+    }
+
     /// Parameters for single_column_reader_test
     #[derive(Debug)]
     struct TestOptions {

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -404,7 +404,7 @@ mod tests {
         let expected = 1..25;
 
         for (i, v) in expected.enumerate() {
-            assert_eq!(col.value(i), v * 100 as i128);
+            assert_eq!(col.value(i), v * 100_i128);
         }
     }
 

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -328,8 +328,11 @@ pub type FixedLenBinaryConverter = ArrayRefConverter<
     FixedSizeArrayConverter,
 >;
 
-pub type DecimalConverter =
-    ArrayRefConverter<Vec<Option<FixedLenByteArray>>, DecimalArray, DecimalArrayConverter>;
+pub type DecimalConverter = ArrayRefConverter<
+    Vec<Option<FixedLenByteArray>>,
+    DecimalArray,
+    DecimalArrayConverter,
+>;
 
 pub struct FromConverter<S, T> {
     _source: PhantomData<S>,

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -97,8 +97,8 @@ impl DecimalArrayConverter {
     }
 }
 
-impl Converter<Vec<Option<ByteArray>>, DecimalArray> for DecimalArrayConverter {
-    fn convert(&self, source: Vec<Option<ByteArray>>) -> Result<DecimalArray> {
+impl Converter<Vec<Option<FixedLenByteArray>>, DecimalArray> for DecimalArrayConverter {
+    fn convert(&self, source: Vec<Option<FixedLenByteArray>>) -> Result<DecimalArray> {
         let mut builder = DecimalBuilder::new(
             source.len(),
             self.precision as usize,
@@ -329,7 +329,7 @@ pub type FixedLenBinaryConverter = ArrayRefConverter<
 >;
 
 pub type DecimalConverter =
-    ArrayRefConverter<Vec<Option<ByteArray>>, DecimalArray, DecimalArrayConverter>;
+    ArrayRefConverter<Vec<Option<FixedLenByteArray>>, DecimalArray, DecimalArrayConverter>;
 
 pub struct FromConverter<S, T> {
     _source: PhantomData<S>,

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -606,6 +606,21 @@ impl ParquetTypeConverter<'_> {
     }
 
     fn from_fixed_len_byte_array(&self) -> Result<DataType> {
+        if self.schema.get_basic_info().logical_type() == LogicalType::DECIMAL {
+            let (precision, scale) = match self.schema {
+                Type::PrimitiveType {
+                    ref precision,
+                    ref scale,
+                    ..
+                } => (*precision, *scale),
+                _ => {
+                    return Err(ArrowError(
+                        "Expected a physical type, not a group type".to_string(),
+                    ))
+                }
+            };
+            return Ok(DataType::Decimal(precision as usize, scale as usize));
+        }
         let byte_width = match self.schema {
             Type::PrimitiveType {
                 ref type_length, ..


### PR DESCRIPTION
This PR introduces capabilities to construct a `DecimalArray` from Parquet files.

This is done by adding a new `Converter<Vec<Option<ByteArray>>, DecimalArray>` in `parquet::arrow::converter`:

```
pub struct DecimalArrayConverter {
    precision: i32,
    scale: i32,
}
```

It is then used in `ArrayBuilderReader` using a match guard to differentiate it from regular fixed size binaries:

```
  PhysicalType::FIXED_LEN_BYTE_ARRAY if cur_type.get_basic_info().logical_type() == LogicalType::DECIMAL =>
```

A test was added that uses a parquet file from `PARQUET_TEST_DATA` to check whether loading and casting to `DecimalArray` works. I did not find a corresponding json file with the correct values, but I used `pyarrow` to extract the correct values and hard coded them in the test.

I thought that this PR would require #8784 to be merged, but they are independent. I used the same JIRA issue here - I hope that this is okay.