### PR TITLE
ARROW-10796: [C++] Implement optimized RecordBatch sorting

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -23,6 +23,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/benchmark_util.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace compute {
@@ -90,16 +91,15 @@ static void ChunkedArraySortIndicesInt64Wide(benchmark::State& state) {
   ChunkedArraySortIndicesInt64Benchmark(state, min, max);
 }
 
-static void TableSortIndicesBenchmark(benchmark::State& state,
-                                      const std::shared_ptr<Table>& table,
+static void DatumSortIndicesBenchmark(benchmark::State& state, const Datum& datum,
                                       const SortOptions& options) {
   for (auto _ : state) {
-    ABORT_NOT_OK(SortIndices(Datum(*table), options).status());
+    ABORT_NOT_OK(SortIndices(datum, options).status());
   }
 }
 
 // Extract benchmark args from benchmark::State
-struct TableSortIndicesArgs {
+struct RecordBatchSortIndicesArgs {
   // the number of records
   const int64_t num_records;
 
@@ -109,20 +109,18 @@ struct TableSortIndicesArgs {
   // the number of columns
   const int64_t num_columns;
 
-  // the number of chunks in each generated column
-  const int64_t num_chunks;
-
   // Extract args
-  explicit TableSortIndicesArgs(benchmark::State& state)
+  explicit RecordBatchSortIndicesArgs(benchmark::State& state)
       : num_records(state.range(0)),
         null_proportion(ComputeNullProportion(state.range(1))),
         num_columns(state.range(2)),
-        num_chunks(state.range(3)),
         state_(state) {}
 
-  ~TableSortIndicesArgs() { state_.SetItemsProcessed(state_.iterations() * num_records); }
+  ~RecordBatchSortIndicesArgs() {
+    state_.SetItemsProcessed(state_.iterations() * num_records);
+  }
 
- private:
+ protected:
   double ComputeNullProportion(int64_t inverse_null_proportion) {
     if (inverse_null_proportion == 0) {
       return 0.0;
@@ -134,37 +132,86 @@ struct TableSortIndicesArgs {
   benchmark::State& state_;
 };
 
-static void TableSortIndicesInt64(benchmark::State& state, int64_t min, int64_t max) {
-  TableSortIndicesArgs args(state);
+struct TableSortIndicesArgs : public RecordBatchSortIndicesArgs {
+  // the number of chunks in each generated column
+  const int64_t num_chunks;
 
-  auto rand = random::RandomArrayGenerator(kSeed);
-  std::vector<std::shared_ptr<Field>> fields;
+  // Extract args
+  explicit TableSortIndicesArgs(benchmark::State& state)
+      : RecordBatchSortIndicesArgs(state), num_chunks(state.range(3)) {}
+};
+
+struct BatchOrTableBenchmarkData {
+  std::shared_ptr<Schema> schema;
   std::vector<SortKey> sort_keys;
-  std::vector<std::shared_ptr<ChunkedArray>> columns;
+  ChunkedArrayVector columns;
+};
+
+BatchOrTableBenchmarkData MakeBatchOrTableBenchmarkDataInt64(
+    const RecordBatchSortIndicesArgs& args, int64_t num_chunks, int64_t min_value,
+    int64_t max_value) {
+  auto rand = random::RandomArrayGenerator(kSeed);
+  FieldVector fields;
+  BatchOrTableBenchmarkData data;
+
   for (int64_t i = 0; i < args.num_columns; ++i) {
     auto name = std::to_string(i);
     fields.push_back(field(name, int64()));
     auto order = (i % 2) == 0 ? SortOrder::Ascending : SortOrder::Descending;
-    sort_keys.emplace_back(name, order);
-    std::vector<std::shared_ptr<Array>> arrays;
-    if ((args.num_records % args.num_chunks) != 0) {
-      Status::Invalid("The number of chunks (", args.num_chunks,
+    data.sort_keys.emplace_back(name, order);
+    ArrayVector chunks;
+    if ((args.num_records % num_chunks) != 0) {
+      Status::Invalid("The number of chunks (", num_chunks,
                       ") must be "
                       "a multiple of the number of records (",
                       args.num_records, ")")
           .Abort();
     }
-    auto num_records_in_array = args.num_records / args.num_chunks;
-    for (int64_t j = 0; j < args.num_chunks; ++j) {
-      arrays.push_back(rand.Int64(num_records_in_array, min, max, args.null_proportion));
+    auto num_records_in_array = args.num_records / num_chunks;
+    for (int64_t j = 0; j < num_chunks; ++j) {
+      chunks.push_back(
+          rand.Int64(num_records_in_array, min_value, max_value, args.null_proportion));
     }
-    ASSIGN_OR_ABORT(auto chunked_array, ChunkedArray::Make(arrays, int64()));
-    columns.push_back(chunked_array);
+    ASSIGN_OR_ABORT(auto chunked_array, ChunkedArray::Make(chunks, int64()));
+    data.columns.push_back(chunked_array);
   }
 
-  auto table = Table::Make(schema(fields), columns, args.num_records);
-  SortOptions options(sort_keys);
-  TableSortIndicesBenchmark(state, table, options);
+  data.schema = schema(fields);
+  return data;
+}
+
+static void RecordBatchSortIndicesInt64(benchmark::State& state, int64_t min,
+                                        int64_t max) {
+  RecordBatchSortIndicesArgs args(state);
+
+  auto data = MakeBatchOrTableBenchmarkDataInt64(args, /*num_chunks=*/1, min, max);
+  ArrayVector columns;
+  for (const auto& chunked : data.columns) {
+    ARROW_CHECK_EQ(chunked->num_chunks(), 1);
+    columns.push_back(chunked->chunk(0));
+  }
+
+  auto batch = RecordBatch::Make(data.schema, args.num_records, columns);
+  SortOptions options(data.sort_keys);
+  DatumSortIndicesBenchmark(state, Datum(*batch), options);
+}
+
+static void TableSortIndicesInt64(benchmark::State& state, int64_t min, int64_t max) {
+  TableSortIndicesArgs args(state);
+
+  auto data = MakeBatchOrTableBenchmarkDataInt64(args, args.num_chunks, min, max);
+  auto table = Table::Make(data.schema, data.columns, args.num_records);
+  SortOptions options(data.sort_keys);
+  DatumSortIndicesBenchmark(state, Datum(*table), options);
+}
+
+static void RecordBatchSortIndicesInt64Narrow(benchmark::State& state) {
+  RecordBatchSortIndicesInt64(state, -100, 100);
+}
+
+static void RecordBatchSortIndicesInt64Wide(benchmark::State& state) {
+  RecordBatchSortIndicesInt64(state, std::numeric_limits<int64_t>::min(),
+                              std::numeric_limits<int64_t>::max());
 }
 
 static void TableSortIndicesInt64Narrow(benchmark::State& state) {
@@ -180,28 +227,40 @@ BENCHMARK(ArraySortIndicesInt64Narrow)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})
-    ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(ArraySortIndicesInt64Wide)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})
-    ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(ChunkedArraySortIndicesInt64Narrow)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})
-    ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(ChunkedArraySortIndicesInt64Wide)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})
-    ->MinTime(1.0)
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(RecordBatchSortIndicesInt64Narrow)
+    ->ArgsProduct({
+        {1 << 20},      // the number of records
+        {100, 0},       // inverse null proportion
+        {16, 8, 2, 1},  // the number of columns
+    })
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(RecordBatchSortIndicesInt64Wide)
+    ->ArgsProduct({
+        {1 << 20},      // the number of records
+        {100, 0},       // inverse null proportion
+        {16, 8, 2, 1},  // the number of columns
+    })
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(TableSortIndicesInt64Narrow)
@@ -211,7 +270,6 @@ BENCHMARK(TableSortIndicesInt64Narrow)
         {16, 8, 2, 1},  // the number of columns
         {32, 4, 1},     // the number of chunks
     })
-    ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(TableSortIndicesInt64Wide)
@@ -221,7 +279,6 @@ BENCHMARK(TableSortIndicesInt64Wide)
         {16, 8, 2, 1},  // the number of columns
         {32, 4, 1},     // the number of chunks
     })
-    ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -230,6 +230,32 @@ class Random : public RandomImpl {
 };
 
 template <>
+class Random<FloatType> : public RandomImpl {
+  using CType = float;
+
+ public:
+  explicit Random(random::SeedType seed) : RandomImpl(seed) {}
+
+  std::shared_ptr<Array> Generate(uint64_t count, double null_prob, double nan_prob = 0) {
+    return generator.Float32(count, std::numeric_limits<CType>::min(),
+                             std::numeric_limits<CType>::max(), null_prob, nan_prob);
+  }
+};
+
+template <>
+class Random<DoubleType> : public RandomImpl {
+  using CType = double;
+
+ public:
+  explicit Random(random::SeedType seed) : RandomImpl(seed) {}
+
+  std::shared_ptr<Array> Generate(uint64_t count, double null_prob, double nan_prob = 0) {
+    return generator.Float64(count, std::numeric_limits<CType>::min(),
+                             std::numeric_limits<CType>::max(), null_prob, nan_prob);
+  }
+};
+
+template <>
 class Random<StringType> : public RandomImpl {
  public:
   explicit Random(random::SeedType seed) : RandomImpl(seed) {}
@@ -514,19 +540,7 @@ TYPED_TEST(TestArraySortIndicesKernelRandomCompare, SortRandomValuesCompare) {
 }
 
 // Test basic cases for chunked array.
-class TestChunkedArraySortIndices : public ::testing::Test {
- protected:
-  void AssertSortIndices(const std::shared_ptr<ChunkedArray> chunked_array,
-                         SortOrder order, const std::shared_ptr<Array> expected) {
-    ASSERT_OK_AND_ASSIGN(auto actual, SortIndices(*chunked_array, order));
-    AssertArraysEqual(*expected, *actual, /*verbose=*/true);
-  }
-
-  void AssertSortIndices(const std::shared_ptr<ChunkedArray> chunked_array,
-                         SortOrder order, const std::string expected) {
-    AssertSortIndices(chunked_array, order, ArrayFromJSON(uint64(), expected));
-  }
-};
+class TestChunkedArraySortIndices : public ::testing::Test {};
 
 TEST_F(TestChunkedArraySortIndices, Null) {
   auto chunked_array = ChunkedArrayFromJSON(uint8(), {
@@ -534,8 +548,8 @@ TEST_F(TestChunkedArraySortIndices, Null) {
                                                          "[3, null, 2]",
                                                          "[1]",
                                                      });
-  this->AssertSortIndices(chunked_array, SortOrder::Ascending, "[1, 5, 4, 2, 0, 3]");
-  this->AssertSortIndices(chunked_array, SortOrder::Descending, "[2, 4, 1, 5, 0, 3]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, "[1, 5, 4, 2, 0, 3]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, "[2, 4, 1, 5, 0, 3]");
 }
 
 TEST_F(TestChunkedArraySortIndices, NaN) {
@@ -544,8 +558,8 @@ TEST_F(TestChunkedArraySortIndices, NaN) {
                                                            "[3, null, NaN]",
                                                            "[NaN, 1]",
                                                        });
-  this->AssertSortIndices(chunked_array, SortOrder::Ascending, "[1, 6, 2, 4, 5, 0, 3]");
-  this->AssertSortIndices(chunked_array, SortOrder::Descending, "[2, 1, 6, 4, 5, 0, 3]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, "[1, 6, 2, 4, 5, 0, 3]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, "[2, 1, 6, 4, 5, 0, 3]");
 }
 
 // Tests for temporal types
@@ -563,8 +577,8 @@ TYPED_TEST(TestChunkedArraySortIndicesForTemporal, NoNull) {
                                                       "[3, 2, 1]",
                                                       "[5, 0]",
                                                   });
-  this->AssertSortIndices(chunked_array, SortOrder::Ascending, "[0, 6, 1, 4, 3, 2, 5]");
-  this->AssertSortIndices(chunked_array, SortOrder::Descending, "[5, 2, 3, 1, 4, 0, 6]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, "[0, 6, 1, 4, 3, 2, 5]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, "[5, 2, 3, 1, 4, 0, 6]");
 }
 
 // Base class for testing against random chunked array.
@@ -746,19 +760,7 @@ TEST_F(TestRecordBatchSortIndices, MoreTypes) {
 }
 
 // Test basic cases for table.
-class TestTableSortIndices : public ::testing::Test {
- protected:
-  void AssertSortIndices(const std::shared_ptr<Table>& table, const SortOptions& options,
-                         const std::shared_ptr<Array>& expected) {
-    ASSERT_OK_AND_ASSIGN(auto actual, SortIndices(Datum(*table), options));
-    AssertArraysEqual(*expected, *actual);
-  }
-
-  void AssertSortIndices(const std::shared_ptr<Table>& table, const SortOptions& options,
-                         const std::string& expected) {
-    AssertSortIndices(table, options, ArrayFromJSON(uint64(), expected));
-  }
-};
+class TestTableSortIndices : public ::testing::Test {};
 
 TEST_F(TestTableSortIndices, Null) {
   auto schema = ::arrow::schema({
@@ -776,7 +778,7 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 2,    "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  this->AssertSortIndices(table, options, "[5, 1, 4, 2, 0, 3]");
+  AssertSortIndices(table, options, "[5, 1, 4, 2, 0, 3]");
 
   // Same data, several chunks
   table = TableFromJSON(schema, {R"([{"a": null, "b": 5},
@@ -787,10 +789,43 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 2,    "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  this->AssertSortIndices(table, options, "[5, 1, 4, 2, 0, 3]");
+  AssertSortIndices(table, options, "[5, 1, 4, 2, 0, 3]");
 }
 
 TEST_F(TestTableSortIndices, NaN) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+  SortOptions options(
+      {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
+  std::shared_ptr<Table> table;
+  table = TableFromJSON(schema, {R"([{"a": 3,    "b": 5},
+                                     {"a": 1,    "b": NaN},
+                                     {"a": 3,    "b": 4},
+                                     {"a": 0,    "b": 6},
+                                     {"a": NaN,  "b": 5},
+                                     {"a": NaN,  "b": NaN},
+                                     {"a": NaN,  "b": 5},
+                                     {"a": 1,    "b": 5}
+                                    ])"});
+  AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
+
+  // Same data, several chunks
+  table = TableFromJSON(schema, {R"([{"a": 3,    "b": 5},
+                                     {"a": 1,    "b": NaN},
+                                     {"a": 3,    "b": 4},
+                                     {"a": 0,    "b": 6}
+                                    ])",
+                                 R"([{"a": NaN,  "b": 5},
+                                     {"a": NaN,  "b": NaN},
+                                     {"a": NaN,  "b": 5},
+                                     {"a": 1,    "b": 5}
+                                    ])"});
+  AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
+}
+
+TEST_F(TestTableSortIndices, NaNAndNull) {
   auto schema = ::arrow::schema({
       {field("a", float32())},
       {field("b", float64())},
@@ -807,7 +842,7 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  this->AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
+  AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
 
   // Same data, several chunks
   table = TableFromJSON(schema, {R"([{"a": null, "b": 5},
@@ -820,7 +855,7 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  this->AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
+  AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
 }
 
 // Tests for temporal types
@@ -849,7 +884,7 @@ TYPED_TEST(TestTableSortIndicesForTemporal, NoNull) {
                               "]"});
   SortOptions options(
       {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
-  this->AssertSortIndices(table, options, "[0, 6, 1, 4, 7, 3, 2, 5]");
+  AssertSortIndices(table, options, "[0, 6, 1, 4, 7, 3, 2, 5]");
 }
 
 // For random table tests.
@@ -881,7 +916,8 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
         if (lhs_array_->IsNull(lhs_index_)) return false;
         status_ = lhs_array_->type()->Accept(this);
         if (compared_ == 0) continue;
-        if (pair.second == SortOrder::Ascending) {
+        // If either value is NaN, it must sort after the other regardless of order
+        if (pair.second == SortOrder::Ascending || lhs_isnan_ || rhs_isnan_) {
           return compared_ < 0;
         } else {
           return compared_ > 0;
@@ -939,11 +975,14 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
       auto lhs_value = checked_cast<const ArrayType*>(lhs_array_)->GetView(lhs_index_);
       auto rhs_value = checked_cast<const ArrayType*>(rhs_array_)->GetView(rhs_index_);
       if (is_floating_type<Type>::value) {
-        const bool lhs_isnan = lhs_value != lhs_value;
-        const bool rhs_isnan = rhs_value != rhs_value;
-        if (lhs_isnan && rhs_isnan) return 0;
-        if (rhs_isnan) return 1;
-        if (lhs_isnan) return -1;
+        lhs_isnan_ = lhs_value != lhs_value;
+        rhs_isnan_ = rhs_value != rhs_value;
+        if (lhs_isnan_ && rhs_isnan_) return 0;
+        // NaN is considered greater than non-NaN
+        if (rhs_isnan_) return -1;
+        if (lhs_isnan_) return 1;
+      } else {
+        lhs_isnan_ = rhs_isnan_ = false;
       }
       if (lhs_value == rhs_value) {
         return 0;
@@ -962,6 +1001,7 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     int64_t rhs_;
     const Array* rhs_array_;
     int64_t rhs_index_;
+    bool lhs_isnan_, rhs_isnan_;
     int compared_;
     Status status_;
   };
@@ -974,8 +1014,8 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     for (int i = 1; i < table.num_rows(); i++) {
       uint64_t lhs = offsets.Value(i - 1);
       uint64_t rhs = offsets.Value(i);
-      ASSERT_TRUE(comparator(lhs, rhs));
       ASSERT_OK(comparator.status());
+      ASSERT_TRUE(comparator(lhs, rhs)) << "lhs = " << lhs << ", rhs = " << rhs;
     }
   }
 };
@@ -999,15 +1039,15 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
   const auto length = 200;
   std::vector<std::shared_ptr<Array>> columns = {
       Random<UInt8Type>(seed).Generate(length, null_probability),
-      Random<UInt16Type>(seed).Generate(length, null_probability),
+      Random<UInt16Type>(seed).Generate(length, 0.0),
       Random<UInt32Type>(seed).Generate(length, null_probability),
-      Random<UInt64Type>(seed).Generate(length, null_probability),
-      Random<Int8Type>(seed).Generate(length, null_probability),
+      Random<UInt64Type>(seed).Generate(length, 0.0),
+      Random<Int8Type>(seed).Generate(length, 0.0),
       Random<Int16Type>(seed).Generate(length, null_probability),
-      Random<Int32Type>(seed).Generate(length, null_probability),
+      Random<Int32Type>(seed).Generate(length, 0.0),
       Random<Int64Type>(seed).Generate(length, null_probability),
-      Random<FloatType>(seed).Generate(length, null_probability),
-      Random<DoubleType>(seed).Generate(length, null_probability),
+      Random<FloatType>(seed).Generate(length, null_probability, 1 - null_probability),
+      Random<DoubleType>(seed).Generate(length, 0.0, null_probability),
       Random<StringType>(seed).Generate(length, null_probability),
   };
   const auto table = Table::Make(schema(fields), columns, length);
@@ -1032,6 +1072,13 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
     ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*chunked_table), options));
     Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
   }
+  // Also validate RecordBatch sorting
+  TableBatchReader reader(*table);
+  RecordBatchVector batches;
+  ASSERT_OK(reader.ReadAll(&batches));
+  ASSERT_EQ(batches.size(), 1);
+  ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*batches[0]), options));
+  Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
 }
 
 INSTANTIATE_TEST_SUITE_P(NoNull, TestTableSortIndicesRandom,

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -165,10 +165,11 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] min the lower bound of the uniform distribution
   /// \param[in] max the upper bound of the uniform distribution
   /// \param[in] null_probability the probability of a row being null
+  /// \param[in] nan_probability the probability of a row being NaN
   ///
   /// \return a generated Array
   std::shared_ptr<Array> Float32(int64_t size, float min, float max,
-                                 double null_probability = 0);
+                                 double null_probability = 0, double nan_probability = 0);
 
   /// \brief Generate a random DoubleArray
   ///
@@ -176,10 +177,11 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] min the lower bound of the uniform distribution
   /// \param[in] max the upper bound of the uniform distribution
   /// \param[in] null_probability the probability of a row being null
+  /// \param[in] nan_probability the probability of a row being NaN
   ///
   /// \return a generated Array
   std::shared_ptr<Array> Float64(int64_t size, double min, double max,
-                                 double null_probability = 0);
+                                 double null_probability = 0, double nan_probability = 0);
 
   template <typename ArrowType, typename CType = typename ArrowType::c_type>
   std::shared_ptr<Array> Numeric(int64_t size, CType min, CType max,


### PR DESCRIPTION
Add two RecordBatch sorting implementations:
* A single-pass left-to-right radix sort that's fast up to ~8 sort keys
* A single-pass multiple-key-comparing sort that gives decent performance for large numbers of sort keys

Both implementations benefit from direct indexed access into the contiguous RecordBatch columns (as opposed to table sorting, which must index into the chunks).

Add some RecordBatch-sorting benchmarks.

Also, add and improve tests; and fix a bug related to sorting of NaNs and nulls.

Benchmarks (changes less than 10% in absolute value not shown):
```
                                           benchmark            baseline           contender  change %                                                                                                                                                            counters
10   RecordBatchSortIndicesInt64Narrow/1048576/100/8    1.482m items/sec    5.410m items/sec   265.083    {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/100/8', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
20     RecordBatchSortIndicesInt64Narrow/1048576/0/8    1.524m items/sec    5.478m items/sec   259.478      {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/0/8', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
60   RecordBatchSortIndicesInt64Narrow/1048576/100/2    2.276m items/sec    7.803m items/sec   242.839    {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/100/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 2}
21     RecordBatchSortIndicesInt64Narrow/1048576/0/2    2.340m items/sec    7.802m items/sec   233.369      {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/0/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 2}
23     RecordBatchSortIndicesInt64Wide/1048576/100/2    4.673m items/sec    9.867m items/sec   111.164      {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/100/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
61       RecordBatchSortIndicesInt64Wide/1048576/0/2    4.677m items/sec    9.820m items/sec   109.971        {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/0/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
35     RecordBatchSortIndicesInt64Wide/1048576/100/8    4.680m items/sec    9.822m items/sec   109.850      {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/100/8', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
55       RecordBatchSortIndicesInt64Wide/1048576/0/8    4.755m items/sec    9.933m items/sec   108.895        {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/0/8', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
59      RecordBatchSortIndicesInt64Wide/1048576/0/16    4.794m items/sec    8.408m items/sec    75.389       {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/0/16', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
16    RecordBatchSortIndicesInt64Wide/1048576/100/16    4.733m items/sec    8.177m items/sec    72.780     {'run_name': 'RecordBatchSortIndicesInt64Wide/1048576/100/16', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3}
29    RecordBatchSortIndicesInt64Narrow/1048576/0/16    1.640m items/sec    2.627m items/sec    60.146     {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/0/16', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
9   RecordBatchSortIndicesInt64Narrow/1048576/100/16    1.559m items/sec    2.342m items/sec    50.201   {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/100/16', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
4          TableSortIndicesInt64Narrow/1048576/0/2/1    2.415m items/sec    2.699m items/sec    11.723          {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/2/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 2}
51        TableSortIndicesInt64Narrow/1048576/0/2/32    1.814m items/sec    2.023m items/sec    11.513         {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/2/32', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
49        TableSortIndicesInt64Narrow/1048576/0/16/4    1.542m items/sec    1.717m items/sec    11.361         {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/16/4', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
30         TableSortIndicesInt64Narrow/1048576/0/2/4    2.272m items/sec    2.516m items/sec    10.733          {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/2/4', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 2}
25         TableSortIndicesInt64Narrow/1048576/0/8/4    1.542m items/sec    1.706m items/sec    10.628          {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/8/4', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
11        TableSortIndicesInt64Narrow/1048576/0/16/1    1.691m items/sec    1.866m items/sec    10.316         {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/16/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
12         TableSortIndicesInt64Narrow/1048576/0/8/1    1.683m items/sec    1.856m items/sec    10.280          {'run_name': 'TableSortIndicesInt64Narrow/1048576/0/8/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1}
[...]
6      RecordBatchSortIndicesInt64Narrow/1048576/0/1  185.050m items/sec  164.579m items/sec   -11.062    {'run_name': 'RecordBatchSortIndicesInt64Narrow/1048576/0/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 122}
```
