### PR TITLE
ARROW-10889: [Rust] [Proposal] Add guidelines about usage of `unsafe`

### DIFF
--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -165,7 +165,7 @@ Usage of `unsafe` for performance reasons is justified only when the performance
 Usage of `unsafe` in this crate *must*:
 
 * not expose a public API as `safe` when there are necessary invariants for that API to be defined behavior.
-* have code documentation for why a `safe` is not used / possible (e.g. `// 30% performance degradation if the safe counterpart is used, see bench X`)
+* have code documentation for why `safe` is not used / possible (e.g. `// 30% performance degradation if the safe counterpart is used, see bench X`)
 * have code documentation about which invariant the user needs to enforce to ensure no undefined behavior (e.g. `// this buffer must be constructed according to the arrow specification`)
 * if applicable, have the necessary `assert`s (not `debug_assert`!) of invariants.
 

--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -104,7 +104,7 @@ This crate only accepts the usage of `unsafe` code upon careful consideration, a
 
 ### When can `unsafe` be used?
 
-Generally, `unsafe` can only be used when a `safe` counterpart is not available or has performance implications. The following is a summary of the current components of the crate that require `unsafe`:
+Generally, `unsafe` should only be used when a `safe` counterpart is not available and there is no `safe` way to achieve additional performance in that area. The following is a summary of the current components of the crate that require `unsafe`:
 
 * alloc, dealloc and realloc of buffers along cache lines
 * Interpreting bytes as certain rust types, for access, representation and compute

--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -99,7 +99,7 @@ compile Arrow to the `wasm32-unknown-unknown` WASM target.
 ## Guidelines in usage of `unsafe`
 
 [`unsafe`](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html) has a high maintenance cost because debugging and testing it is difficult, time consuming, often requires external tools (e.g. `valgrind`), and requires a higher-than-usual attention to details. Undefined behavior is particularly difficult to identify and test, and usage of `unsafe` is the primary cause of undefined behavior in a program written in Rust `[citation needed]`.
-
+For two real world examples of where `unsafe` has consumed time in the past in this project see [#8545](https://github.com/apache/arrow/pull/8645) and [8829](https://github.com/apache/arrow/pull/8829)
 This crate only accepts the usage of `unsafe` code upon careful consideration, and strives to avoid it to the largest possible extent.
 
 ### When can `unsafe` be used?


### PR DESCRIPTION
I would like to propose that we outline and enforce guidelines on the arrow crate implementation with respect to the usage of `unsafe`.

The background of this proposal are PRs #8645 and #8829. In both cases, while addressing an unrelated issue, they hit undefined behavior (UB) due to an incorrect usage of `unsafe` in the code base. This UB was very time-consuming to identify and debug: combined, they accounted for more than 12hs of my time.

Safety against undefined behavior is the core premise of the Rust language. In many cases, the maintenance burden (time to find and fix bugs) does not justify the performance improvements and the decrease in motivation in handling them (they are just painful due to how difficult they are to debug). In particular, IMO those 12 hours would have been better spent in other parts of the code if `unsafe` would have not been used in the first place, which would have been likely translated in faster code or more features.

There are situations where `unsafe` is necessary, and the guidelines outline these cases. However, I also see many uses of `unsafe` that are not necessary nor properly documented.

The goal of these guidelines is to motivate contributors of the Rust implementation to be conscious about the maintenance cost of `unsafe`, and outline specific necessary conditions for any new `unsafe` to be introduced in the code base.