### PR TITLE
ARROW-10719: [C#] ArrowStreamWriter doesn't write schema metadata

### DIFF
--- a/csharp/src/Apache.Arrow/Field.Builder.cs
+++ b/csharp/src/Apache.Arrow/Field.Builder.cs
@@ -23,14 +23,13 @@ namespace Apache.Arrow
     {
         public class Builder
         {
-            private readonly Dictionary<string, string> _metadata;
+            private Dictionary<string, string> _metadata;
             private string _name;
             private IArrowType _type;
             private bool _nullable;
 
             public Builder()
             {
-                _metadata = new Dictionary<string, string>();
                 _name = string.Empty;
                 _type = NullType.Default;
                 _nullable = true;
@@ -65,6 +64,8 @@ namespace Apache.Arrow
                 {
                     throw new ArgumentNullException(nameof(key));
                 }
+
+                _metadata ??= new Dictionary<string, string>();
 
                 _metadata[key] = value;
                 return this;

--- a/csharp/src/Apache.Arrow/Field.cs
+++ b/csharp/src/Apache.Arrow/Field.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Apache.Arrow.Types;
 
@@ -34,6 +35,22 @@ namespace Apache.Arrow
 
         public Field(string name, IArrowType dataType, bool nullable,
             IEnumerable<KeyValuePair<string, string>> metadata = default)
+            : this(name, dataType, nullable)
+        {
+            Metadata = metadata?.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        }
+
+        internal Field(string name, IArrowType dataType, bool nullable,
+            IReadOnlyDictionary<string, string> metadata, bool copyCollections)
+            : this(name, dataType, nullable)
+        {
+            Debug.Assert(copyCollections == false, "This internal constructor is to not copy the collections.");
+
+            Metadata = metadata;
+        }
+
+        private Field(string name, IArrowType dataType, bool nullable)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -43,7 +60,6 @@ namespace Apache.Arrow
             Name = name;
             DataType = dataType ?? NullType.Default;
             IsNullable = nullable;
-            Metadata = metadata?.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Schema.Builder.cs
+++ b/csharp/src/Apache.Arrow/Schema.Builder.cs
@@ -20,22 +20,20 @@ namespace Apache.Arrow
 {
     public partial class Schema
     {
-
         public class Builder
         {
             private readonly List<Field> _fields;
-            private readonly Dictionary<string, string> _metadata;
+            private Dictionary<string, string> _metadata;
 
             public Builder()
             {
                 _fields = new List<Field>();
-                _metadata = new Dictionary<string, string>();
             }
 
             public Builder Clear()
             {
                 _fields.Clear();
-                _metadata.Clear();
+                _metadata?.Clear();
                 return this;
             }
 
@@ -65,6 +63,8 @@ namespace Apache.Arrow
                 {
                     throw new ArgumentNullException(nameof(key));
                 }
+
+                _metadata ??= new Dictionary<string, string>();
 
                 _metadata[key] = value;
                 return this;

--- a/csharp/src/Apache.Arrow/Schema.cs
+++ b/csharp/src/Apache.Arrow/Schema.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Apache.Arrow
@@ -51,6 +52,20 @@ namespace Apache.Arrow
                 StringComparer.OrdinalIgnoreCase);
 
             Metadata = metadata?.ToDictionary(kv => kv.Key, kv => kv.Value);
+        }
+
+        internal Schema(List<Field> fields, IReadOnlyDictionary<string, string> metadata, bool copyCollections)
+        {
+            Debug.Assert(fields != null);
+            Debug.Assert(copyCollections == false, "This internal constructor is to not copy the collections.");
+
+            _fields = fields;
+
+            _fieldsDictionary = fields.ToDictionary(
+                field => field.Name, field => field,
+                StringComparer.OrdinalIgnoreCase);
+
+            Metadata = metadata;
         }
 
         public Field GetFieldByIndex(int i)

--- a/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Apache.Arrow.Tests
 {
-    public class FieldComparer
+    public static class FieldComparer
     {
         public static void Compare(Field expected, Field actual)
         {

--- a/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Apache.Arrow.Tests
 {
-    public class SchemaComparer
+    public static class SchemaComparer
     {
         public static void Compare(Schema expected, Schema actual)
         {


### PR DESCRIPTION
Add support for reading and writing Schema and Field metadata

Also, reducing some allocations in a few spots.

Tagging people who have contributed to the C# library in the past year for review. (Feel free to ignore if you don't have time.)

@pgovind @suhsteve @chutchinson @Ulimo @mr-smidge @zgramana @HashidaTKS @nhustler 

cc @olgacarpenter