### PR TITLE
ARROW-10893: [Rust] [DataFusion] More clippy lints

### DIFF
--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -241,7 +241,7 @@ mod tests {
             Err(DataFusionError::Internal(e)) => {
                 assert_eq!("\"Projection index out of range\"", format!("{:?}", e))
             }
-            _ => assert!(false, "Scan should failed on invalid projection"),
+            _ => panic!("Scan should failed on invalid projection"),
         };
 
         Ok(())
@@ -275,10 +275,7 @@ mod tests {
                 "\"Mismatch between schema and batches\"",
                 format!("{:?}", e)
             ),
-            _ => assert!(
-                false,
-                "MemTable::new should have failed due to schema mismatch"
-            ),
+            _ => panic!("MemTable::new should have failed due to schema mismatch"),
         }
 
         Ok(())

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -106,7 +106,7 @@ impl ExecutionContext {
 
     /// Create a new execution context using the provided configuration
     pub fn with_config(config: ExecutionConfig) -> Self {
-        let ctx = Self {
+        Self {
             state: ExecutionContextState {
                 datasources: HashMap::new(),
                 scalar_functions: HashMap::new(),
@@ -114,8 +114,7 @@ impl ExecutionContext {
                 aggregate_functions: HashMap::new(),
                 config,
             },
-        };
-        ctx
+        }
     }
 
     /// Get the configuration of this execution context
@@ -514,15 +513,11 @@ impl SchemaProvider for ExecutionContextState {
     }
 
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
-        self.scalar_functions
-            .get(name)
-            .and_then(|func| Some(func.clone()))
+        self.scalar_functions.get(name).cloned()
     }
 
     fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
-        self.aggregate_functions
-            .get(name)
-            .and_then(|func| Some(func.clone()))
+        self.aggregate_functions.get(name).cloned()
     }
 }
 
@@ -676,9 +671,9 @@ mod tests {
                     assert_eq!(table_schema.fields().len(), 2);
                     assert_eq!(projected_schema.fields().len(), 1);
                 }
-                _ => assert!(false, "input to projection should be TableScan"),
+                _ => panic!("input to projection should be TableScan"),
             },
-            _ => assert!(false, "expect optimized_plan to be projection"),
+            _ => panic!("expect optimized_plan to be projection"),
         }
 
         let expected = "Projection: #c2\
@@ -754,9 +749,9 @@ mod tests {
                     assert_eq!(table_schema.fields().len(), 3);
                     assert_eq!(projected_schema.fields().len(), 1);
                 }
-                _ => assert!(false, "input to projection should be InMemoryScan"),
+                _ => panic!("input to projection should be InMemoryScan"),
             },
-            _ => assert!(false, "expect optimized_plan to be projection"),
+            _ => panic!("expect optimized_plan to be projection"),
         }
 
         let expected = "Projection: #b\

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -17,30 +17,14 @@
 #![warn(missing_docs)]
 // Clippy lints, some should be disabled incrementally
 #![allow(
-    clippy::assertions_on_constants,
-    clippy::bind_instead_of_map,
-    clippy::blocks_in_if_conditions,
-    clippy::collapsible_if,
-    clippy::explicit_counter_loop,
     clippy::field_reassign_with_default,
     clippy::float_cmp,
-    clippy::into_iter_on_ref,
-    clippy::len_zero,
-    clippy::let_and_return,
-    clippy::map_collect_result_unit,
-    clippy::match_like_matches_macro,
-    clippy::match_ref_pats,
     clippy::module_inception,
     clippy::needless_lifetimes,
     clippy::needless_range_loop,
-    clippy::needless_return,
     clippy::new_without_default,
     clippy::ptr_arg,
-    clippy::single_match,
-    clippy::stable_sort_primitive,
-    clippy::type_complexity,
-    clippy::unit_arg,
-    clippy::zero_prefixed_literal
+    clippy::type_complexity
 )]
 
 //! DataFusion is an extensible query execution framework that uses

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -344,7 +344,7 @@ fn validate_unique_names(
     input_schema: &DFSchema,
 ) -> Result<()> {
     let mut unique_names = HashMap::new();
-    expressions.iter().enumerate().map(|(position, expr)| {
+    expressions.iter().enumerate().try_for_each(|(position, expr)| {
         let name = expr.name(input_schema)?;
         match unique_names.get(&name) {
             None => {
@@ -361,7 +361,7 @@ fn validate_unique_names(
                 ))
             }
         }
-    }).collect::<Result<()>>()
+    })
 }
 
 #[cfg(test)]

--- a/rust/datafusion/src/logical_plan/dfschema.rs
+++ b/rust/datafusion/src/logical_plan/dfschema.rs
@@ -55,13 +55,11 @@ impl DFSchema {
                         field.qualified_name()
                     )));
                 }
-            } else {
-                if !unqualified_names.insert(field.name()) {
-                    return Err(DataFusionError::Plan(format!(
-                        "Schema contains duplicate unqualified field name '{}'",
-                        field.name()
-                    )));
-                }
+            } else if !unqualified_names.insert(field.name()) {
+                return Err(DataFusionError::Plan(format!(
+                    "Schema contains duplicate unqualified field name '{}'",
+                    field.name()
+                )));
             }
         }
 
@@ -217,7 +215,7 @@ impl TryFrom<Schema> for DFSchema {
         Self::new(
             schema
                 .fields()
-                .into_iter()
+                .iter()
                 .map(|f| DFField {
                     field: f.clone(),
                     qualifier: None,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -438,7 +438,7 @@ mod tests {
         }
 
         fn name(&self) -> &str {
-            return "test_optimizer";
+            "test_optimizer"
         }
     }
 
@@ -476,11 +476,7 @@ mod tests {
                 ];
                 assert_eq!(*stringified_plans, expected_stringified_plans);
             }
-            _ => assert!(
-                false,
-                "Expected explain plan but got {:?}",
-                optimized_explain
-            ),
+            _ => panic!("Expected explain plan but got {:?}", optimized_explain),
         }
 
         Ok(())

--- a/rust/datafusion/src/physical_plan/array_expressions.rs
+++ b/rust/datafusion/src/physical_plan/array_expressions.rs
@@ -61,7 +61,7 @@ macro_rules! array {
 /// put values in an array.
 pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
     // do not accept 0 arguments.
-    if args.len() == 0 {
+    if args.is_empty() {
         return Err(DataFusionError::Internal(
             "array requires at least one argument".to_string(),
         ));

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -101,10 +101,8 @@ pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Res
             if let Some(path_name) = path.to_str() {
                 if path.is_dir() {
                     build_file_list(path_name, filenames, ext)?;
-                } else {
-                    if path_name.ends_with(ext) {
-                        filenames.push(path_name.to_string());
-                    }
+                } else if path_name.ends_with(ext) {
+                    filenames.push(path_name.to_string());
                 }
             } else {
                 return Err(DataFusionError::Plan("Invalid path".to_string()));

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -87,11 +87,8 @@ impl<'a> CsvReadOptions<'a> {
 
     /// Configure delimiter setting with Option, None value will be ignored
     pub fn delimiter_option(mut self, delimiter: Option<u8>) -> Self {
-        match delimiter {
-            Some(d) => {
-                self.delimiter = d;
-            }
-            _ => (),
+        if let Some(d) = delimiter {
+            self.delimiter = d;
         }
         self
     }

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -280,7 +280,7 @@ mod tests {
         // timezone the test machine is running. Thus it is still
         // somewhat suceptable to bugs in the use of chrono
         let naive_datetime = NaiveDateTime::new(
-            NaiveDate::from_ymd(2020, 09, 08),
+            NaiveDate::from_ymd(2020, 9, 8),
             NaiveTime::from_hms_nano(13, 42, 29, 190855),
         );
 
@@ -298,7 +298,7 @@ mod tests {
         // Also ensure that parsing timestamps with no fractional
         // second part works as well
         let naive_datetime_whole_secs = NaiveDateTime::new(
-            NaiveDate::from_ymd(2020, 09, 08),
+            NaiveDate::from_ymd(2020, 9, 8),
             NaiveTime::from_hms(13, 42, 29),
         );
 
@@ -342,8 +342,7 @@ mod tests {
 
     fn expect_timestamp_parse_error(s: &str, expected_err: &str) {
         match string_to_timestamp_nanos(s) {
-            Ok(v) => assert!(
-                false,
+            Ok(v) => panic!(
                 "Expected error '{}' while parsing '{}', but parsed {} instead",
                 expected_err, s, v
             ),

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1638,7 +1638,7 @@ impl fmt::Display for NotExpr {
 
 impl PhysicalExpr for NotExpr {
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
-        return Ok(DataType::Boolean);
+        Ok(DataType::Boolean)
     }
 
     fn nullable(&self, input_schema: &Schema) -> Result<bool> {
@@ -1791,7 +1791,7 @@ impl fmt::Display for IsNullExpr {
 }
 impl PhysicalExpr for IsNullExpr {
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
-        return Ok(DataType::Boolean);
+        Ok(DataType::Boolean)
     }
 
     fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
@@ -1836,7 +1836,7 @@ impl fmt::Display for IsNotNullExpr {
 }
 impl PhysicalExpr for IsNotNullExpr {
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
-        return Ok(DataType::Boolean);
+        Ok(DataType::Boolean)
     }
 
     fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
@@ -1911,7 +1911,7 @@ impl CaseExpr {
         when_then_expr: &[(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)],
         else_expr: Option<Arc<dyn PhysicalExpr>>,
     ) -> Result<Self> {
-        if when_then_expr.len() == 0 {
+        if when_then_expr.is_empty() {
             Err(DataFusionError::Execution(
                 "There must be at least one WHEN clause".to_string(),
             ))
@@ -2280,11 +2280,16 @@ pub struct CastExpr {
 
 /// Determine if a DataType is signed numeric or not
 pub fn is_signed_numeric(dt: &DataType) -> bool {
-    match dt {
-        DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => true,
-        DataType::Float16 | DataType::Float32 | DataType::Float64 => true,
-        _ => false,
-    }
+    matches!(
+        dt,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+    )
 }
 
 /// Determine if a DataType is numeric or not

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -180,7 +180,7 @@ pub fn return_type(
     // verify that this is a valid set of data types for this function
     data_types(&arg_types, &signature(fun))?;
 
-    if arg_types.len() == 0 {
+    if arg_types.is_empty() {
         // functions currently cannot be evaluated without arguments, as they can't
         // know the number of rows to return.
         return Err(DataFusionError::Plan(format!(

--- a/rust/datafusion/src/physical_plan/hash_utils.rs
+++ b/rust/datafusion/src/physical_plan/hash_utils.rs
@@ -52,7 +52,7 @@ fn check_join_set_is_valid(
     right: &HashSet<String>,
     on: &JoinOn,
 ) -> Result<()> {
-    if on.len() == 0 {
+    if on.is_empty() {
         return Err(DataFusionError::Plan(
             "The 'on' clause of a join cannot be empty".to_string(),
         ));
@@ -63,7 +63,7 @@ fn check_join_set_is_valid(
     let on_right = &on.iter().map(|on| on.1.to_string()).collect::<HashSet<_>>();
     let right_missing = on_right.difference(right).collect::<HashSet<_>>();
 
-    if (left_missing.len() > 0) | (right_missing.len() > 0) {
+    if !left_missing.is_empty() | !right_missing.is_empty() {
         return Err(DataFusionError::Plan(format!(
                 "The left or right side of the join does not have all columns on \"on\": \nMissing on the left: {:?}\nMissing on the right: {:?}",
                 left_missing,
@@ -78,7 +78,7 @@ fn check_join_set_is_valid(
 
     let collisions = left.intersection(&remaining).collect::<HashSet<_>>();
 
-    if collisions.len() > 0 {
+    if !collisions.is_empty() {
         return Err(DataFusionError::Plan(format!(
                 "The left schema and the right schema have the following columns with the same name without being on the ON statement: {:?}. Consider aliasing them.",
                 collisions,

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -202,10 +202,10 @@ impl LimitStream {
 
     fn stream_limit(&mut self, batch: RecordBatch) -> Option<RecordBatch> {
         if self.current_len == self.limit {
-            return None;
+            None
         } else if self.current_len + batch.num_rows() <= self.limit {
             self.current_len += batch.num_rows();
-            return Some(batch);
+            Some(batch)
         } else {
             let batch_rows = self.limit - self.current_len;
             self.current_len = self.limit;

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -185,18 +185,16 @@ pub trait Accumulator: Send + Sync + Debug {
 
     /// updates the accumulator's state from a vector of arrays.
     fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
-        if values.len() == 0 {
+        if values.is_empty() {
             return Ok(());
         };
-        (0..values[0].len())
-            .map(|index| {
-                let v = values
-                    .iter()
-                    .map(|array| ScalarValue::try_from_array(array, index))
-                    .collect::<Result<Vec<_>>>()?;
-                self.update(&v)
-            })
-            .collect::<Result<_>>()
+        (0..values[0].len()).try_for_each(|index| {
+            let v = values
+                .iter()
+                .map(|array| ScalarValue::try_from_array(array, index))
+                .collect::<Result<Vec<_>>>()?;
+            self.update(&v)
+        })
     }
 
     /// updates the accumulator's state from a vector of scalars.
@@ -204,18 +202,16 @@ pub trait Accumulator: Send + Sync + Debug {
 
     /// updates the accumulator's state from a vector of states.
     fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
-        if states.len() == 0 {
+        if states.is_empty() {
             return Ok(());
         };
-        (0..states[0].len())
-            .map(|index| {
-                let v = states
-                    .iter()
-                    .map(|array| ScalarValue::try_from_array(array, index))
-                    .collect::<Result<Vec<_>>>()?;
-                self.merge(&v)
-            })
-            .collect::<Result<_>>()
+        (0..states[0].len()).try_for_each(|index| {
+            let v = states
+                .iter()
+                .map(|array| ScalarValue::try_from_array(array, index))
+                .collect::<Result<Vec<_>>>()?;
+            self.merge(&v)
+        })
     }
 
     /// returns its value based on its current state.

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -105,7 +105,7 @@ impl DefaultPhysicalPlanner {
             .map(|child| self.optimize_plan(child.clone(), ctx_state))
             .collect::<Result<Vec<_>>>()?;
 
-        if children.len() == 0 {
+        if children.is_empty() {
             // leaf node, children cannot be replaced
             Ok(plan.clone())
         } else {
@@ -782,7 +782,7 @@ mod tests {
 
         let expected_error = "DefaultPhysicalPlanner does not know how to plan NoOp";
         match plan {
-            Ok(_) => assert!(false, "Expected planning failure"),
+            Ok(_) => panic!("Expected planning failure"),
             Err(e) => assert!(
                 e.to_string().contains(expected_error),
                 "Error '{}' did not contain expected error '{}'",
@@ -826,7 +826,7 @@ mod tests {
                 dict_is_ordered: false }\
         ], metadata: {} }";
         match plan {
-            Ok(_) => assert!(false, "Expected planning failure"),
+            Ok(_) => panic!("Expected planning failure"),
             Err(e) => assert!(
                 e.to_string().contains(expected_error),
                 "Error '{}' did not contain expected error '{}'",

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -36,7 +36,7 @@ pub fn concatenate(args: &[ArrayRef]) -> Result<StringArray> {
     // downcast all arguments to strings
     let args = downcast_vec!(args, StringArray).collect::<Result<Vec<&StringArray>>>()?;
     // do not accept 0 arguments.
-    if args.len() == 0 {
+    if args.is_empty() {
         return Err(DataFusionError::Internal(
             "Concatenate was called with 0 arguments. It requires at least one."
                 .to_string(),

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -149,50 +149,33 @@ fn maybe_data_types(
 pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
     use self::DataType::*;
     match type_into {
-        Int8 => match type_from {
-            Int8 => true,
-            _ => false,
-        },
-        Int16 => match type_from {
-            Int8 | Int16 | UInt8 => true,
-            _ => false,
-        },
-        Int32 => match type_from {
-            Int8 | Int16 | Int32 | UInt8 | UInt16 => true,
-            _ => false,
-        },
-        Int64 => match type_from {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 => true,
-            _ => false,
-        },
-        UInt8 => match type_from {
-            UInt8 => true,
-            _ => false,
-        },
-        UInt16 => match type_from {
-            UInt8 | UInt16 => true,
-            _ => false,
-        },
-        UInt32 => match type_from {
-            UInt8 | UInt16 | UInt32 => true,
-            _ => false,
-        },
-        UInt64 => match type_from {
-            UInt8 | UInt16 | UInt32 | UInt64 => true,
-            _ => false,
-        },
-        Float32 => match type_from {
-            Int8 | Int16 | Int32 | Int64 => true,
-            UInt8 | UInt16 | UInt32 | UInt64 => true,
-            Float32 => true,
-            _ => false,
-        },
-        Float64 => match type_from {
-            Int8 | Int16 | Int32 | Int64 => true,
-            UInt8 | UInt16 | UInt32 | UInt64 => true,
-            Float32 | Float64 => true,
-            _ => false,
-        },
+        Int8 => matches!(type_from, Int8),
+        Int16 => matches!(type_from, Int8 | Int16 | UInt8),
+        Int32 => matches!(type_from, Int8 | Int16 | Int32 | UInt8 | UInt16),
+        Int64 => matches!(
+            type_from,
+            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32
+        ),
+        UInt8 => matches!(type_from, UInt8),
+        UInt16 => matches!(type_from, UInt8 | UInt16),
+        UInt32 => matches!(type_from, UInt8 | UInt16 | UInt32),
+        UInt64 => matches!(type_from, UInt8 | UInt16 | UInt32 | UInt64),
+        Float32 => matches!(
+            type_from,
+            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 | Float32
+        ),
+        Float64 => matches!(
+            type_from,
+            Int8 | Int16
+                | Int32
+                | Int64
+                | UInt8
+                | UInt16
+                | UInt32
+                | UInt64
+                | Float32
+                | Float64
+        ),
         Utf8 => true,
         _ => false,
     }

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -163,8 +163,7 @@ impl ScalarValue {
 
     /// whether this value is null or not.
     pub fn is_null(&self) -> bool {
-        match *self {
-            ScalarValue::Boolean(None)
+        matches!(*self, ScalarValue::Boolean(None)
             | ScalarValue::UInt8(None)
             | ScalarValue::UInt16(None)
             | ScalarValue::UInt32(None)
@@ -177,9 +176,7 @@ impl ScalarValue {
             | ScalarValue::Float64(None)
             | ScalarValue::Utf8(None)
             | ScalarValue::LargeUtf8(None)
-            | ScalarValue::List(None, _) => true,
-            _ => false,
-        }
+            | ScalarValue::List(None, _))
     }
 
     /// Converts a scalar value into an 1-row array.
@@ -391,20 +388,20 @@ impl TryFrom<&DataType> for ScalarValue {
 
     fn try_from(datatype: &DataType) -> Result<Self> {
         Ok(match datatype {
-            &DataType::Boolean => ScalarValue::Boolean(None),
-            &DataType::Float64 => ScalarValue::Float64(None),
-            &DataType::Float32 => ScalarValue::Float32(None),
-            &DataType::Int8 => ScalarValue::Int8(None),
-            &DataType::Int16 => ScalarValue::Int16(None),
-            &DataType::Int32 => ScalarValue::Int32(None),
-            &DataType::Int64 => ScalarValue::Int64(None),
-            &DataType::UInt8 => ScalarValue::UInt8(None),
-            &DataType::UInt16 => ScalarValue::UInt16(None),
-            &DataType::UInt32 => ScalarValue::UInt32(None),
-            &DataType::UInt64 => ScalarValue::UInt64(None),
-            &DataType::Utf8 => ScalarValue::Utf8(None),
-            &DataType::LargeUtf8 => ScalarValue::LargeUtf8(None),
-            &DataType::List(ref nested_type) => {
+            DataType::Boolean => ScalarValue::Boolean(None),
+            DataType::Float64 => ScalarValue::Float64(None),
+            DataType::Float32 => ScalarValue::Float32(None),
+            DataType::Int8 => ScalarValue::Int8(None),
+            DataType::Int16 => ScalarValue::Int16(None),
+            DataType::Int32 => ScalarValue::Int32(None),
+            DataType::Int64 => ScalarValue::Int64(None),
+            DataType::UInt8 => ScalarValue::UInt8(None),
+            DataType::UInt16 => ScalarValue::UInt16(None),
+            DataType::UInt32 => ScalarValue::UInt32(None),
+            DataType::UInt64 => ScalarValue::UInt64(None),
+            DataType::Utf8 => ScalarValue::Utf8(None),
+            DataType::LargeUtf8 => ScalarValue::LargeUtf8(None),
+            DataType::List(ref nested_type) => {
                 ScalarValue::List(None, nested_type.data_type().clone())
             }
             _ => {

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -337,8 +337,7 @@ mod tests {
     fn expect_parse_error(sql: &str, expected_error: &str) -> Result<(), ParserError> {
         match DFParser::parse_sql(sql) {
             Ok(statements) => {
-                assert!(
-                    false,
+                panic!(
                     "Expected parse error for '{}', but was successful: {:?}",
                     sql, statements
                 );

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -369,7 +369,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                             join_keys.push((r.as_str(), l.as_str()));
                         }
                     }
-                    if join_keys.len() == 0 {
+                    if join_keys.is_empty() {
                         return Err(DataFusionError::NotImplemented(
                             "Cartesian joins are not supported".to_string(),
                         ));
@@ -419,7 +419,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
             .collect();
 
         // apply projection or aggregate
-        let plan = if (select.group_by.len() > 0) | (aggr_expr.len() > 0) {
+        let plan = if !select.group_by.is_empty() | !aggr_expr.is_empty() {
             self.aggregate(&plan, projection_expr, &select.group_by, aggr_expr)?
         } else {
             self.project(&plan, projection_expr)?
@@ -505,7 +505,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
         plan: &LogicalPlan,
         order_by: &Vec<OrderByExpr>,
     ) -> Result<LogicalPlan> {
-        if order_by.len() == 0 {
+        if order_by.is_empty() {
             return Ok(plan.clone());
         }
 

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -78,8 +78,7 @@ pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<Strin
 
     let f = File::open(&path)?;
     let f = BufReader::new(f);
-    let mut i = 0;
-    for line in f.lines() {
+    for (i, line) in f.lines().enumerate() {
         let line = line.unwrap();
 
         if i == 0 {
@@ -94,8 +93,6 @@ pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<Strin
             writers[partition].write_all(line.as_bytes()).unwrap();
             writers[partition].write_all(b"\n").unwrap();
         }
-
-        i += 1;
     }
     for w in writers.iter_mut() {
         w.flush().unwrap();


### PR DESCRIPTION
This addresses more clippy lints, especially the ones that `cargo clippy --fix -Z unstable-options --allow-dirty` can address