### PR TITLE
ARROW-10900: [Rust] [DataFusion] Resolve TableScan provider eagerly

### DIFF
--- a/rust/datafusion/src/datasource/empty.rs
+++ b/rust/datafusion/src/datasource/empty.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! An empty plan that is usefull for testing and generating plans without mapping them to actual data.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::*;
+
+use crate::datasource::datasource::Statistics;
+use crate::datasource::TableProvider;
+use crate::error::Result;
+use crate::physical_plan::{empty::EmptyExec, ExecutionPlan};
+
+/// A table with a schema but no data.
+pub struct EmptyTable {
+    schema: SchemaRef,
+}
+
+impl EmptyTable {
+    /// Initialize a new `EmptyTable` from a schema.
+    pub fn new(schema: SchemaRef) -> Self {
+        Self { schema }
+    }
+}
+
+impl TableProvider for EmptyTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        _batch_size: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // even though there is no data, projections apply
+        let projection = match projection.clone() {
+            Some(p) => p,
+            None => (0..self.schema.fields().len()).collect(),
+        };
+        let projected_schema = Schema::new(
+            projection
+                .iter()
+                .map(|i| self.schema.field(*i).clone())
+                .collect(),
+        );
+        Ok(Arc::new(EmptyExec::new(false, Arc::new(projected_schema))))
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics {
+            num_rows: Some(0),
+            total_byte_size: Some(0),
+        }
+    }
+}

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod csv;
 pub mod datasource;
+pub mod empty;
 pub mod memory;
 pub mod parquet;
 

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -27,14 +27,13 @@ use arrow::{
 use crate::datasource::TableProvider;
 use crate::error::{DataFusionError, Result};
 use crate::{
-    datasource::{parquet::ParquetTable, CsvFile, MemTable},
+    datasource::{empty::EmptyTable, parquet::ParquetTable, CsvFile, MemTable},
     prelude::CsvReadOptions,
 };
 
 use super::dfschema::ToDFSchema;
 use super::{
     col, exprlist_to_fields, Expr, JoinType, LogicalPlan, PlanType, StringifiedPlan,
-    TableSource,
 };
 use crate::logical_plan::{DFField, DFSchema, DFSchemaRef};
 use std::collections::HashSet;
@@ -67,21 +66,7 @@ impl LogicalPlanBuilder {
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         let provider = Arc::new(MemTable::try_new(schema.clone(), partitions)?);
-
-        let projected_schema = projection
-            .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()))
-            .map_or(schema.clone(), SchemaRef::new)
-            .to_dfschema_ref()?;
-
-        let table_scan = LogicalPlan::TableScan {
-            schema_name: "".to_string(),
-            source: TableSource::FromProvider(provider),
-            table_schema: schema,
-            projected_schema,
-            projection: None,
-        };
-
-        Ok(Self::from(&table_scan))
+        Self::scan("", provider, projection)
     }
 
     /// Scan a CSV data source
@@ -90,75 +75,49 @@ impl LogicalPlanBuilder {
         options: CsvReadOptions,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
-        let schema: Schema = match options.schema {
-            Some(s) => s.to_owned(),
-            None => CsvFile::try_new(path, options)?
-                .schema()
-                .as_ref()
-                .to_owned(),
-        };
-
-        let projected_schema = projection
-            .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()))
-            .map_or(SchemaRef::new(schema), SchemaRef::new)
-            .to_dfschema_ref()?;
-
         let provider = Arc::new(CsvFile::try_new(path, options)?);
-        let schema = provider.schema();
-
-        let table_scan = LogicalPlan::TableScan {
-            schema_name: "".to_string(),
-            source: TableSource::FromProvider(provider),
-            table_schema: schema,
-            projected_schema,
-            projection: None,
-        };
-
-        Ok(Self::from(&table_scan))
+        Self::scan("", provider, projection)
     }
 
     /// Scan a Parquet data source
     pub fn scan_parquet(path: &str, projection: Option<Vec<usize>>) -> Result<Self> {
         let provider = Arc::new(ParquetTable::try_new(path)?);
+        Self::scan("", provider, projection)
+    }
+
+    /// Scan an empty data source, mainly used in tests
+    pub fn scan_empty(
+        name: &str,
+        table_schema: &Schema,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
+        let table_schema = Arc::new(table_schema.clone());
+        let provider = Arc::new(EmptyTable::new(table_schema));
+        Self::scan(name, provider, projection)
+    }
+
+    /// Convert a table provider into a builder with a TableScan
+    pub fn scan(
+        name: &str,
+        provider: Arc<dyn TableProvider + Send + Sync>,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
         let schema = provider.schema();
 
         let projected_schema = projection
+            .as_ref()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()))
             .map_or(schema.clone(), SchemaRef::new)
             .to_dfschema_ref()?;
 
         let table_scan = LogicalPlan::TableScan {
-            schema_name: "".to_string(),
-            source: TableSource::FromProvider(provider),
-            table_schema: schema,
+            table_name: name.to_string(),
+            source: provider,
             projected_schema,
-            projection: None,
+            projection,
         };
 
         Ok(Self::from(&table_scan))
-    }
-
-    /// Scan a data source
-    pub fn scan(
-        schema_name: &str,
-        table_name: &str,
-        table_schema: &Schema,
-        projection: Option<Vec<usize>>,
-    ) -> Result<Self> {
-        let table_schema = SchemaRef::new(table_schema.clone());
-        let projected_schema = projection.clone().map(|p| {
-            Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
-        });
-        let projected_schema =
-            projected_schema.map_or(table_schema.clone(), SchemaRef::new);
-
-        Ok(Self::from(&LogicalPlan::TableScan {
-            schema_name: schema_name.to_owned(),
-            source: TableSource::FromContext(table_name.to_owned()),
-            table_schema,
-            projected_schema: projected_schema.to_dfschema_ref()?,
-            projection,
-        }))
     }
 
     /// Apply a projection.
@@ -373,8 +332,7 @@ mod tests {
 
     #[test]
     fn plan_builder_simple() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan(
-            "default",
+        let plan = LogicalPlanBuilder::scan_empty(
             "employee.csv",
             &employee_schema(),
             Some(vec![0, 3]),
@@ -394,8 +352,7 @@ mod tests {
 
     #[test]
     fn plan_builder_aggregate() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan(
-            "default",
+        let plan = LogicalPlanBuilder::scan_empty(
             "employee.csv",
             &employee_schema(),
             Some(vec![3, 4]),
@@ -418,8 +375,7 @@ mod tests {
 
     #[test]
     fn plan_builder_sort() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan(
-            "default",
+        let plan = LogicalPlanBuilder::scan_empty(
             "employee.csv",
             &employee_schema(),
             Some(vec![3, 4]),
@@ -448,8 +404,7 @@ mod tests {
 
     #[test]
     fn projection_non_unique_names() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan(
-            "default",
+        let plan = LogicalPlanBuilder::scan_empty(
             "employee.csv",
             &employee_schema(),
             Some(vec![0, 3]),
@@ -472,8 +427,7 @@ mod tests {
 
     #[test]
     fn aggregate_non_unique_names() -> Result<()> {
-        let plan = LogicalPlanBuilder::scan(
-            "default",
+        let plan = LogicalPlanBuilder::scan_empty(
             "employee.csv",
             &employee_schema(),
             Some(vec![0, 3]),

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -65,7 +65,7 @@ impl LogicalPlanBuilder {
         schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
-        let provider = Arc::new(MemTable::try_new(schema.clone(), partitions)?);
+        let provider = Arc::new(MemTable::try_new(schema, partitions)?);
         Self::scan("", provider, projection)
     }
 
@@ -107,7 +107,7 @@ impl LogicalPlanBuilder {
         let projected_schema = projection
             .as_ref()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()))
-            .map_or(schema.clone(), SchemaRef::new)
+            .map_or(schema, SchemaRef::new)
             .to_dfschema_ref()?;
 
         let table_scan = LogicalPlan::TableScan {

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -41,7 +41,5 @@ pub use expr::{
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;
-pub use plan::{
-    JoinType, LogicalPlan, PlanType, PlanVisitor, StringifiedPlan, TableSource,
-};
+pub use plan::{JoinType, LogicalPlan, PlanType, PlanVisitor, StringifiedPlan};
 pub use registry::FunctionRegistry;

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -240,14 +240,13 @@ fn optimize_plan(
         // scans:
         // * remove un-used columns from the scan projection
         LogicalPlan::TableScan {
-            schema_name,
+            table_name,
             source,
-            table_schema,
             projection,
             ..
         } => {
             let (projection, projected_schema) = get_projected_schema(
-                &table_schema,
+                &source.schema(),
                 projection,
                 required_columns,
                 has_projection,
@@ -255,9 +254,8 @@ fn optimize_plan(
 
             // return the table scan with projection
             Ok(LogicalPlan::TableScan {
-                schema_name: schema_name.to_string(),
+                table_name: table_name.to_string(),
                 source: source.clone(),
-                table_schema: table_schema.clone(),
                 projection: Some(projection),
                 projected_schema,
             })

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -23,7 +23,7 @@ use super::{aggregates, empty::EmptyExec, expressions::binary, functions, udaf};
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::ExecutionContextState;
 use crate::logical_plan::{
-    DFSchema, Expr, LogicalPlan, Operator, PlanType, StringifiedPlan, TableSource,
+    DFSchema, Expr, LogicalPlan, Operator, PlanType, StringifiedPlan,
     UserDefinedLogicalNode,
 };
 use crate::physical_plan::explain::ExplainExec;
@@ -138,21 +138,7 @@ impl DefaultPhysicalPlanner {
         match logical_plan {
             LogicalPlan::TableScan {
                 source, projection, ..
-            } => match source {
-                TableSource::FromContext(table_name) => {
-                    match ctx_state.datasources.get(table_name) {
-                        Some(provider) => provider.scan(projection, batch_size),
-                        _ => Err(DataFusionError::Plan(format!(
-                            "No table named {}. Existing tables: {:?}",
-                            table_name,
-                            ctx_state.datasources.keys().collect::<Vec<_>>(),
-                        ))),
-                    }
-                }
-                TableSource::FromProvider(ref provider) => {
-                    provider.scan(projection, batch_size)
-                }
-            },
+            } => source.scan(projection, batch_size),
             LogicalPlan::Aggregate {
                 input,
                 group_expr,

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -231,7 +231,7 @@ pub fn test_table_scan() -> Result<LogicalPlan> {
         Field::new("b", DataType::UInt32, false),
         Field::new("c", DataType::UInt32, false),
     ]);
-    LogicalPlanBuilder::scan("default", "test", &schema, None)?.build()
+    LogicalPlanBuilder::scan_empty("test", &schema, None)?.build()
 }
 
 pub fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -165,11 +165,11 @@ async fn custom_source_dataframe() -> Result<()> {
     match &optimized_plan {
         LogicalPlan::Projection { input, .. } => match &**input {
             LogicalPlan::TableScan {
-                table_schema,
+                source,
                 projected_schema,
                 ..
             } => {
-                assert_eq!(table_schema.fields().len(), 2);
+                assert_eq!(source.schema().fields().len(), 2);
                 assert_eq!(projected_schema.fields().len(), 1);
             }
             _ => panic!("input to projection should be TableScan"),


### PR DESCRIPTION
> Currently, the TableScan logical plan is quite complex. It can either reference a provider or a table name that is registered to the context.
> 
> This issue is about linking the logical plan to the TableProvider directly upon parsing of the SQL. This allows to simplify greatly the code and also makes the TableScan plan easier to use by external query plan manipulations.

https://issues.apache.org/jira/browse/ARROW-10900
