### PR TITLE
ARROW-8221: [Python][Dataset] Expose schema inference/validation factory options through the validate_schema keyword

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -382,7 +382,7 @@ def _ensure_single_source(path, filesystem=None):
 def _filesystem_dataset(source, schema=None, filesystem=None,
                         partitioning=None, format=None,
                         partition_base_dir=None, exclude_invalid_files=None,
-                        selector_ignore_prefixes=None):
+                        selector_ignore_prefixes=None, validate_schema=None):
     """
     Create a FileSystemDataset which can be used to build a Dataset.
 
@@ -408,7 +408,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     )
     factory = FileSystemDatasetFactory(fs, paths_or_selector, format, options)
 
-    return factory.finish(schema)
+    return factory.finish(schema, validate_schema=validate_schema)
 
 
 def _in_memory_dataset(source, schema=None, **kwargs):
@@ -499,7 +499,8 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
 
 def dataset(source, schema=None, format=None, filesystem=None,
             partitioning=None, partition_base_dir=None,
-            exclude_invalid_files=None, ignore_prefixes=None):
+            exclude_invalid_files=None, ignore_prefixes=None,
+            validate_schema=None):
     """
     Open a dataset.
 
@@ -575,6 +576,17 @@ or tables, iterable of batches, RecordBatchReader, or URI
         discovery process. This is matched to the basename of a path.
         By default this is ['.', '_'].
         Note that discovery happens only if a directory is passed as source.
+    validate_schema : bool or int, optional
+        Whether to validate the specified or inspected schema. By default
+        (``validate_schema=None``), it will not validate a specified schema
+        or will infer the schema from the first fragment if no `schema` is
+        manually specified.
+        When specifying ``validate_schema=True``, all fragments will be
+        checked for inspecting the schema or for validating the specified
+        schema.
+        You can further specify an integer to have greater control on the
+        exact number of fragments that will be inspected to infer or validate
+        the schema.
 
     Returns
     -------
@@ -649,7 +661,8 @@ or tables, iterable of batches, RecordBatchReader, or URI
         format=format,
         partition_base_dir=partition_base_dir,
         exclude_invalid_files=exclude_invalid_files,
-        selector_ignore_prefixes=ignore_prefixes
+        selector_ignore_prefixes=ignore_prefixes,
+        validate_schema=validate_schema,
     )
 
     if _is_path_like(source):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -159,6 +159,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CSchema]] Inspect(CInspectOptions)
         CResult[shared_ptr[CDataset]] FinishWithSchema "Finish"(
             const shared_ptr[CSchema]& schema)
+        CResult[shared_ptr[CDataset]] FinishWithOptions "Finish"(
+            CFinishOptions options)
         CResult[shared_ptr[CDataset]] Finish()
         const CExpression& root_partition()
         CStatus SetRootPartition(CExpression partition)


### PR DESCRIPTION
The C++ `FileSystemDatasetFactory::Finish` method handles the schema inference or validation with two options: `InspectOptions::fragments` to indicate the number of fragments to use when inferring *or* validating the schema (default of 1), and the `FinishOptions::validate_fragments` to indicate whether to validate the specified schema (when not inferred). 

For now, I decided to combine this in a single keyword on the Python side (`validate_schema`). This avoids adding 2 inter-dependent keywords for this, and makes it easier to express some typical use cases (eg validate the specified schema with all fragments is now `validate_schema=True` instead of `validate_schema=True, fragments=-1`). On the other hand, it gives a single keyword that accepts both boolean or int (which is not super clean). So this is certainly up for discussion.

