### PR TITLE
ARROW-10905: [Python] Add support for Python 3.9 Windows wheels

### DIFF
--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -28,7 +28,7 @@ SET VS_VERSION=
 if %PYTHON_VERSION% == 3.6 (
     @rem When using this variable do not quote it because in batch files
     @rem quotes are included when rendered.
-    SET VS_VERSION="<14.16"
+    SET VS_VERSION=">=14.0,<14.16"
 ) else if %PYTHON_VERSION% == 3.9 (
     SET NUMPY_VERSION=1.19.5
 )

--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -22,11 +22,21 @@
 
 @rem --file=arrow\ci\conda_env_gandiva.yml ^
 
-@rem create conda environment for compiling
 @rem FIXME: Update to numpy 1.16.6
+SET NUMPY_VERSION=1.16.5
+SET VS_VERSION=
+if %PYTHON_VERSION% == 3.6 (
+    @rem When using this variable do not quote it because in batch files
+    @rem quotes are included when rendered.
+    SET VS_VERSION="<14.16"
+) else if %PYTHON_VERSION% == 3.9 (
+    SET NUMPY_VERSION=1.19.5
+)
+
+@rem create conda environment for compiling
 call conda.bat create -n wheel-build -q -y -c conda-forge ^
-    cmake ninja pkg-config numpy=1.16.5 ^
-    "vs2015_runtime<14.16" ^
+    cmake ninja pkg-config numpy=%NUMPY_VERSION% ^
+    vs2015_runtime%VS_VERSION% ^
     python=%PYTHON_VERSION% || exit /B
 
 call conda.bat activate wheel-build
@@ -111,6 +121,6 @@ python -c "import pyarrow.flight" || exit /B
 python -c "import pyarrow.dataset" || exit /B
 
 @rem run the python tests, but disable the cython because there is a linking
-@rem issue on python 3.8
+@rem issue on python 3.9
 set PYARROW_TEST_CYTHON=OFF
 python -m pytest -rs --pyargs pyarrow || exit /B

--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -35,7 +35,7 @@ if %PYTHON_VERSION% == 3.6 (
 
 @rem create conda environment for compiling
 call conda.bat create -n wheel-build -q -y -c conda-forge ^
-    cmake ninja pkg-config numpy=%NUMPY_VERSION% ^
+    cmake ninja pkg-config numpy=%NUMPY_VERSION% libopenssl-static ^
     vs2015_runtime%VS_VERSION% ^
     python=%PYTHON_VERSION% || exit /B
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -330,6 +330,15 @@ tasks:
       - arrow-cpp-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
 
+  conda-win-vs2017-py39:
+    ci: azure
+    template: conda-recipes/azure.win.yml
+    params:
+      config: win_python3.9.____cpython
+    artifacts:
+      - arrow-cpp-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
+      - pyarrow-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
+
   ############################## Wheel Linux ##################################
 
   wheel-manylinux1-cp36m:
@@ -609,6 +618,14 @@ tasks:
       python_version: 3.8
     artifacts:
       - pyarrow-{no_rc_version}-cp38-cp38-win_amd64.whl
+
+  wheel-win-cp39:
+    ci: github
+    template: python-wheels/github.win.yml
+    params:
+      python_version: 3.9
+    artifacts:
+      - pyarrow-{no_rc_version}-cp39-cp39-win_amd64.whl
 
   ############################## Linux PKGS ####################################
 


### PR DESCRIPTION
Picking back up from #8386 in case I can handle this or someone else wants to work off of it. Likely will need to be updated based on #8881 / #8778.