### PR TITLE
ARROW-9828: [Rust] [DataFusion] Support filter pushdown optimisation for TableProvider implementations

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -41,6 +41,7 @@ use std::sync::Arc;
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
 use crate::error::{DataFusionError, Result};
+use crate::logical_plan::Expr;
 use crate::physical_plan::csv::CsvExec;
 pub use crate::physical_plan::csv::CsvReadOptions;
 use crate::physical_plan::{common, ExecutionPlan};
@@ -95,6 +96,7 @@ impl TableProvider for CsvFile {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
+        _filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CsvExec::try_new(
             &self.path,

--- a/rust/datafusion/src/datasource/empty.rs
+++ b/rust/datafusion/src/datasource/empty.rs
@@ -25,6 +25,7 @@ use arrow::datatypes::*;
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
 use crate::error::Result;
+use crate::logical_plan::Expr;
 use crate::physical_plan::{empty::EmptyExec, ExecutionPlan};
 
 /// A table with a schema but no data.
@@ -52,6 +53,7 @@ impl TableProvider for EmptyTable {
         &self,
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
+        _filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // even though there is no data, projections apply
         let projection = match projection.clone() {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -26,6 +26,7 @@ use arrow::datatypes::*;
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
 use crate::error::Result;
+use crate::logical_plan::Expr;
 use crate::physical_plan::parquet::ParquetExec;
 use crate::physical_plan::ExecutionPlan;
 
@@ -65,6 +66,7 @@ impl TableProvider for ParquetTable {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
+        _filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(ParquetExec::try_new(
             &self.path,
@@ -93,7 +95,7 @@ mod tests {
     async fn read_small_batches() -> Result<()> {
         let table = load_table("alltypes_plain.parquet")?;
         let projection = None;
-        let exec = table.scan(&projection, 2)?;
+        let exec = table.scan(&projection, 2, &[])?;
         let stream = exec.execute(0).await?;
 
         let count = stream
@@ -314,7 +316,7 @@ mod tests {
         table: Box<dyn TableProvider>,
         projection: &Option<Vec<usize>>,
     ) -> Result<RecordBatch> {
-        let exec = table.scan(projection, 1024)?;
+        let exec = table.scan(projection, 1024, &[])?;
         let mut it = exec.execute(0).await?;
         it.next()
             .await

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -232,6 +232,7 @@ impl ExecutionContext {
             source: provider,
             projected_schema: schema.to_dfschema_ref()?,
             projection: None,
+            filters: vec![],
         };
         Ok(Arc::new(DataFrameImpl::new(
             self.state.clone(),
@@ -285,6 +286,7 @@ impl ExecutionContext {
                     source: Arc::clone(provider),
                     projected_schema: schema.to_dfschema_ref()?,
                     projection: None,
+                    filters: vec![],
                 };
                 Ok(Arc::new(DataFrameImpl::new(
                     self.state.clone(),

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -115,6 +115,7 @@ impl LogicalPlanBuilder {
             source: provider,
             projected_schema,
             projection,
+            filters: vec![],
         };
 
         Ok(Self::from(&table_scan))

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -120,6 +120,8 @@ pub enum LogicalPlan {
         projection: Option<Vec<usize>>,
         /// The schema description of the output
         projected_schema: DFSchemaRef,
+        /// Optional expressions to be used as filters by the table provider
+        filters: Vec<Expr>,
     },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {
@@ -467,6 +469,7 @@ impl LogicalPlan {
                     LogicalPlan::TableScan {
                         ref table_name,
                         ref projection,
+                        ref filters,
                         ..
                     } => {
                         let sep = " ".repeat(min(1, table_name.len()));
@@ -474,7 +477,13 @@ impl LogicalPlan {
                             f,
                             "TableScan: {}{}projection={:?}",
                             table_name, sep, projection
-                        )
+                        )?;
+
+                        if !filters.is_empty() {
+                            write!(f, ", filters={:?}", filters)?;
+                        }
+
+                        Ok(())
                     }
                     LogicalPlan::Projection { ref expr, .. } => {
                         write!(f, "Projection: ")?;

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -243,6 +243,7 @@ fn optimize_plan(
             table_name,
             source,
             projection,
+            filters,
             ..
         } => {
             let (projection, projected_schema) = get_projected_schema(
@@ -258,6 +259,7 @@ fn optimize_plan(
                 source: source.clone(),
                 projection: Some(projection),
                 projected_schema,
+                filters: filters.clone(),
             })
         }
         LogicalPlan::Explain {

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -137,8 +137,11 @@ impl DefaultPhysicalPlanner {
 
         match logical_plan {
             LogicalPlan::TableScan {
-                source, projection, ..
-            } => source.scan(projection, batch_size),
+                source,
+                projection,
+                filters,
+                ..
+            } => source.scan(projection, batch_size, filters),
             LogicalPlan::Aggregate {
                 input,
                 group_expr,

--- a/rust/datafusion/tests/custom_sources.rs
+++ b/rust/datafusion/tests/custom_sources.rs
@@ -27,7 +27,7 @@ use datafusion::{
 };
 
 use datafusion::execution::context::ExecutionContext;
-use datafusion::logical_plan::{col, LogicalPlan, LogicalPlanBuilder};
+use datafusion::logical_plan::{col, Expr, LogicalPlan, LogicalPlanBuilder};
 use datafusion::physical_plan::{
     ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream,
 };
@@ -143,6 +143,7 @@ impl TableProvider for CustomTableProvider {
         &self,
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
+        _filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CustomExecutionPlan {
             projection: projection.clone(),

--- a/rust/datafusion/tests/provider_filter_pushdown.rs
+++ b/rust/datafusion/tests/provider_filter_pushdown.rs
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{as_primitive_array, Int32Builder, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::datasource::datasource::{
+    Statistics, TableProvider, TableProviderFilterPushDown,
+};
+use datafusion::error::Result;
+use datafusion::execution::context::ExecutionContext;
+use datafusion::logical_plan::Expr;
+use datafusion::physical_plan::common::SizedRecordBatchStream;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream};
+use datafusion::prelude::*;
+use datafusion::scalar::ScalarValue;
+use std::sync::Arc;
+
+fn create_batch(value: i32, num_rows: usize) -> Result<RecordBatch> {
+    let mut builder = Int32Builder::new(num_rows);
+    for _ in 0..num_rows {
+        builder.append_value(value)?;
+    }
+
+    Ok(RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "flag",
+            DataType::Int32,
+            false,
+        )])),
+        vec![Arc::new(builder.finish())],
+    )?)
+}
+
+#[derive(Debug)]
+struct CustomPlan {
+    schema: SchemaRef,
+    batches: Vec<Arc<RecordBatch>>,
+}
+
+#[async_trait]
+impl ExecutionPlan for CustomPlan {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        &self,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        unreachable!()
+    }
+
+    async fn execute(&self, _: usize) -> Result<SendableRecordBatchStream> {
+        Ok(Box::pin(SizedRecordBatchStream::new(
+            self.schema(),
+            self.batches.clone(),
+        )))
+    }
+}
+
+#[derive(Clone)]
+struct CustomProvider {
+    zero_batch: RecordBatch,
+    one_batch: RecordBatch,
+}
+
+impl TableProvider for CustomProvider {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.zero_batch.schema()
+    }
+
+    fn scan(
+        &self,
+        _: &Option<Vec<usize>>,
+        _: usize,
+        filters: &[Expr],
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match &filters[0] {
+            Expr::BinaryExpr { right, .. } => {
+                let int_value = match &**right {
+                    Expr::Literal(ScalarValue::Int64(i)) => i.unwrap(),
+                    _ => unimplemented!(),
+                };
+
+                Ok(Arc::new(CustomPlan {
+                    schema: self.zero_batch.schema(),
+                    batches: match int_value {
+                        0 => vec![Arc::new(self.zero_batch.clone())],
+                        1 => vec![Arc::new(self.one_batch.clone())],
+                        _ => vec![],
+                    },
+                }))
+            }
+            _ => Ok(Arc::new(CustomPlan {
+                schema: self.zero_batch.schema(),
+                batches: vec![],
+            })),
+        }
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+
+    fn supports_filter_pushdown(&self, _: &Expr) -> Result<TableProviderFilterPushDown> {
+        Ok(TableProviderFilterPushDown::Exact)
+    }
+}
+
+async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()> {
+    let provider = CustomProvider {
+        zero_batch: create_batch(0, 10)?,
+        one_batch: create_batch(1, 5)?,
+    };
+
+    let mut ctx = ExecutionContext::new();
+    let df = ctx
+        .read_table(Arc::new(provider.clone()))?
+        .filter(col("flag").eq(lit(value)))?
+        .aggregate(vec![], vec![count(col("flag"))])?;
+
+    let results = df.collect().await?;
+    let result_col: &UInt64Array = as_primitive_array(results[0].column(0));
+    assert_eq!(result_col.value(0), expected_count);
+
+    ctx.register_table("data", Box::new(provider));
+    let sql_results = ctx
+        .sql(&format!("select count(*) from data where flag = {}", value))?
+        .collect()
+        .await?;
+
+    let sql_result_col: &UInt64Array = as_primitive_array(sql_results[0].column(0));
+    assert_eq!(sql_result_col.value(0), expected_count);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_filter_pushdown_results() -> Result<()> {
+    assert_provider_row_count(0, 10).await?;
+    assert_provider_row_count(1, 5).await?;
+    assert_provider_row_count(2, 0).await?;
+    Ok(())
+}


### PR DESCRIPTION
I've got a use case for this with a custom TableProvider implementation, so thought I'd give this a go :)

This PR allows TableProviders to optionally indicate that they support handling filter expressions either:
- Inexactly, to simply optimise data retrieval in an approximate fashion; e.g. pruning in your classic chunked storage system with min/max column metadata stored per chunk
- Exactly, in which case the relevant filter plan nodes can be optimised out entirely

Some preemptive concerns from my side:
- Most of these concepts could probably have better names, open to suggestions here.
- I'm not sure whether expressions are the correct thing to be pushing down to the provider.
- I've had to update quite a few `scan` callsites with empty filter lists. Could this be handled in a better way?
- Currently, only table scans using TableSource::FromProvider are supported, because we need a reference to the provider at optimisation time. #8910 removes the provider/named-based reference distinction entirely so I can rebase this once that's merged and add an extra test using an ordinary sql statement, rather than just a `ctx.read_table(provider)` call.

I'd appreciate any thoughts or feedback!