### PR TITLE
ARROW-10852 [C++] AssertTablesEqual(verbose=true) segfaults if the le…

### DIFF
--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -199,6 +199,20 @@ TEST_F(TestChunkedArray, Validate) {
   ASSERT_RAISES(Invalid, one_->ValidateFull());
 }
 
+TEST_F(TestChunkedArray, PrintDiff) {
+  random::RandomArrayGenerator gen(0);
+  arrays_one_.push_back(gen.Int32(50, 0, 100, 0.1));
+  Construct();
+  
+  auto other = one_->Slice(25);
+  ASSERT_OK_AND_ASSIGN(auto diff, PrintArrayDiff(*one_, *other));
+  ASSERT_EQ(*diff, "Expected length 50 but was actually 25");
+
+  ASSERT_OK_AND_ASSIGN(diff, PrintArrayDiff(*other, *one_));
+  ASSERT_EQ(*diff, "Expected length 25 but was actually 50");
+}
+
+
 TEST_F(TestChunkedArray, View) {
   auto in_ty = int32();
   auto out_ty = fixed_size_binary(4);

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -203,7 +203,7 @@ TEST_F(TestChunkedArray, PrintDiff) {
   random::RandomArrayGenerator gen(0);
   arrays_one_.push_back(gen.Int32(50, 0, 100, 0.1));
   Construct();
-  
+
   auto other = one_->Slice(25);
   ASSERT_OK_AND_ASSIGN(auto diff, PrintArrayDiff(*one_, *other));
   ASSERT_EQ(*diff, "Expected length 50 but was actually 25");
@@ -211,7 +211,6 @@ TEST_F(TestChunkedArray, PrintDiff) {
   ASSERT_OK_AND_ASSIGN(diff, PrintArrayDiff(*other, *one_));
   ASSERT_EQ(*diff, "Expected length 25 but was actually 50");
 }
-
 
 TEST_F(TestChunkedArray, View) {
   auto in_ty = int32();

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -400,6 +400,35 @@ std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>& schema,
   return *Table::FromRecordBatches(schema, std::move(batches));
 }
 
+Result<util::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected, const ChunkedArray& actual) {
+  if (actual.Equals(expected)) {
+    return util::nullopt;
+  }
+
+  std::stringstream ss;
+  if (expected.length() != actual.length()) {
+    ss << "Expected length " << expected.length() << " but was actually " << actual.length();
+    return ss.str();
+  }
+
+  PrettyPrintOptions options(/*indent=*/2);
+  options.window = 50;
+  RETURN_NOT_OK(internal::ApplyBinaryChunked(
+      actual, expected,
+      [&](const Array& left_piece, const Array& right_piece, int64_t position) {
+        std::stringstream diff;
+        if (!left_piece.Equals(right_piece, EqualOptions().diff_sink(&diff))) {
+          ss << "Unequal at absolute position " << position << "\n" << diff.str();
+          ss << "Expected:\n";
+          ARROW_EXPECT_OK(PrettyPrint(right_piece, options, &ss));
+          ss << "\nActual:\n";
+          ARROW_EXPECT_OK(PrettyPrint(left_piece, options, &ss));
+        }
+        return Status::OK();
+      }));
+  return ss.str();
+}
+
 void AssertTablesEqual(const Table& expected, const Table& actual, bool same_chunk_layout,
                        bool combine_chunks) {
   ASSERT_EQ(expected.num_columns(), actual.num_columns());
@@ -423,24 +452,9 @@ void AssertTablesEqual(const Table& expected, const Table& actual, bool same_chu
       auto actual_col = actual.column(i);
       auto expected_col = expected.column(i);
 
-      PrettyPrintOptions options(/*indent=*/2);
-      options.window = 50;
-
-      if (!actual_col->Equals(*expected_col)) {
-        ASSERT_OK(internal::ApplyBinaryChunked(
-            *actual_col, *expected_col,
-            [&](const Array& left_piece, const Array& right_piece, int64_t position) {
-              std::stringstream diff;
-              if (!left_piece.Equals(right_piece, EqualOptions().diff_sink(&diff))) {
-                ss << "Unequal at absolute position " << position << "\n" << diff.str();
-                ss << "Expected:\n";
-                ARROW_EXPECT_OK(PrettyPrint(right_piece, options, &ss));
-                ss << "\nActual:\n";
-                ARROW_EXPECT_OK(PrettyPrint(left_piece, options, &ss));
-              }
-              return Status::OK();
-            }));
-        FAIL() << ss.str();
+      ASSERT_OK_AND_ASSIGN(auto diff, PrintArrayDiff(*expected_col, *actual_col));
+      if (diff.has_value()) {
+        FAIL() << *diff;
       }
     }
   }

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -400,14 +400,16 @@ std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>& schema,
   return *Table::FromRecordBatches(schema, std::move(batches));
 }
 
-Result<util::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected, const ChunkedArray& actual) {
+Result<util::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected,
+                                                   const ChunkedArray& actual) {
   if (actual.Equals(expected)) {
     return util::nullopt;
   }
 
   std::stringstream ss;
   if (expected.length() != actual.length()) {
-    ss << "Expected length " << expected.length() << " but was actually " << actual.length();
+    ss << "Expected length " << expected.length() << " but was actually "
+       << actual.length();
     return ss.str();
   }
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -224,6 +224,9 @@ ARROW_TESTING_EXPORT void AssertSchemaNotEqual(const Schema& lhs, const Schema& 
 ARROW_TESTING_EXPORT void AssertSchemaNotEqual(const std::shared_ptr<Schema>& lhs,
                                                const std::shared_ptr<Schema>& rhs,
                                                bool check_metadata = false);
+                                               
+ARROW_TESTING_EXPORT Result<util::optional<std::string>> PrintArrayDiff(
+                const ChunkedArray& expected, const ChunkedArray& actual);
 
 ARROW_TESTING_EXPORT void AssertTablesEqual(const Table& expected, const Table& actual,
                                             bool same_chunk_layout = true,

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -224,9 +224,9 @@ ARROW_TESTING_EXPORT void AssertSchemaNotEqual(const Schema& lhs, const Schema& 
 ARROW_TESTING_EXPORT void AssertSchemaNotEqual(const std::shared_ptr<Schema>& lhs,
                                                const std::shared_ptr<Schema>& rhs,
                                                bool check_metadata = false);
-                                               
+
 ARROW_TESTING_EXPORT Result<util::optional<std::string>> PrintArrayDiff(
-                const ChunkedArray& expected, const ChunkedArray& actual);
+    const ChunkedArray& expected, const ChunkedArray& actual);
 
 ARROW_TESTING_EXPORT void AssertTablesEqual(const Table& expected, const Table& actual,
                                             bool same_chunk_layout = true,


### PR DESCRIPTION
…ft array has more rows

* Extracted printing logic to its own method (PrintDiff) so a failure case could be tested without triggering assert.

* If the arrays are unequal then the print method returns a message stating as much and MultipleChunkIterator is unused.