### PR TITLE
ARROW-10867: [C++] Workaround gcc internal compiler error

### DIFF
--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -100,11 +100,13 @@ ValueDescr::Shape GetBroadcastShape(const std::vector<ValueDescr>& args);
 struct ARROW_EXPORT Datum {
   enum Kind { NONE, SCALAR, ARRAY, CHUNKED_ARRAY, RECORD_BATCH, TABLE, COLLECTION };
 
+  struct Empty {};
+
   // Datums variants may have a length. This special value indicate that the
   // current variant does not have a length.
   static constexpr int64_t kUnknownLength = -1;
 
-  util::Variant<decltype(NULLPTR), std::shared_ptr<Scalar>, std::shared_ptr<ArrayData>,
+  util::Variant<Empty, std::shared_ptr<Scalar>, std::shared_ptr<ArrayData>,
                 std::shared_ptr<ChunkedArray>, std::shared_ptr<RecordBatch>,
                 std::shared_ptr<Table>, std::vector<Datum>>
       value;


### PR DESCRIPTION
Several gcc versions (from at least 7.x to 10.x) crash on the current development version of Arrow.

Upstream bug report is at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98282