### PR TITLE
ARROW-10915: [Rust] README.md: set the Env vars as absolute dirs; several minor fixes.

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -92,22 +92,14 @@ This populates data in two git submodules:
 - `../cpp/submodules/parquet_testing/data` (sourced from https://github.com/apache/parquet-testing.git)
 - `../testing` (sourced from https://github.com/apache/arrow-testing)
 
-To run the tests of the whole crate, create two new environment variables to point to these directories as follows:
+The following Env vars are required to run `cargo test`, examples, etc.
 
 ```bash
-export PARQUET_TEST_DATA=../cpp/submodules/parquet-testing/data
-export ARROW_TEST_DATA=../testing/data
+export PARQUET_TEST_DATA=$(cd ../cpp/submodules/parquet-testing/data; pwd)
+export ARROW_TEST_DATA=$(cd ../testing/data; pwd)
 ```
 
-To run the tests of an individual crate within the project (e.g. in `datafusion/`), adjust the path
-accordingly:
-
-```bash
-export PARQUET_TEST_DATA=../../cpp/submodules/parquet-testing/data
-export ARROW_TEST_DATA=../../testing/data
-```
-
-from here on, this is a pure Rust project and `cargo` can be used to run tests, benchmarks, docs and examples as usual.
+From here on, this is a pure Rust project and `cargo` can be used to run tests, benchmarks, docs and examples as usual.
 
 ## Code Formatting
 

--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -33,8 +33,8 @@ The tests of this crate depend on two environment variables to be defined.
 Assuming that you are in this crates' current directory:
 
 ```bash
-export PARQUET_TEST_DATA=../../cpp/submodules/parquet-testing/data
-export ARROW_TEST_DATA=../../testing/data
+export PARQUET_TEST_DATA=$(cd ../../cpp/submodules/parquet-testing/data; pwd)
+export ARROW_TEST_DATA=$(cd ../../testing/data; pwd)
 cargo test
 ```
 

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -128,7 +128,7 @@ impl PartialEq for StructArray {
 /// If an array is a child of a struct or list, the array's nulls have to be merged with the parent.
 /// This then affects the null count of the array, thus the merged nulls are passed separately
 /// as `lhs_nulls` and `rhs_nulls` variables to functions.
-/// The nulls are merged with a bitwise AND, and null counts are recomputed wheer necessary.
+/// The nulls are merged with a bitwise AND, and null counts are recomputed where necessary.
 #[inline]
 fn equal_values(
     lhs: &ArrayData,
@@ -274,7 +274,7 @@ fn equal_range(
 /// Logically compares two [ArrayData].
 /// Two arrays are logically equal if and only if:
 /// * their data types are equal
-/// * their lenghts are equal
+/// * their lengths are equal
 /// * their null counts are equal
 /// * their null bitmaps are equal
 /// * each of their items are equal
@@ -444,7 +444,7 @@ mod tests {
     }
 
     fn test_equal(lhs: &ArrayData, rhs: &ArrayData, expected: bool) {
-        // equality is symetric
+        // equality is symmetric
         assert_eq!(equal(lhs, lhs), true, "\n{:?}\n{:?}", lhs, lhs);
         assert_eq!(equal(rhs, rhs), true, "\n{:?}\n{:?}", rhs, rhs);
 

--- a/rust/arrow/src/compute/kernels/substring.rs
+++ b/rust/arrow/src/compute/kernels/substring.rs
@@ -47,19 +47,19 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
     new_offsets.push(length_so_far);
     (0..array.len()).for_each(|i| {
         // the length of this entry
-        let lenght_i: OffsetSize = offsets[i + 1] - offsets[i];
+        let length_i: OffsetSize = offsets[i + 1] - offsets[i];
         // compute where we should start slicing this entry
         let start = offsets[i]
             + if start >= OffsetSize::zero() {
                 start
             } else {
-                lenght_i + start
+                length_i + start
             };
 
         let start = start.max(offsets[i]).min(offsets[i + 1]);
-        // compute the lenght of the slice
+        // compute the length of the slice
         let length: OffsetSize = length
-            .unwrap_or(lenght_i)
+            .unwrap_or(length_i)
             // .max(0) is not needed as it is guaranteed
             .min(offsets[i + 1] - start); // so we do not go beyond this entry
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1690,7 +1690,7 @@ impl Schema {
                     }
                 }
             }
-            // merge fileds
+            // merge fields
             for field in &schema.fields {
                 let mut new_field = true;
                 for merged_field in &mut merged.fields {

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -60,7 +60,7 @@ impl From<csv_crate::Error> for ArrowError {
         match error.kind() {
             csv_crate::ErrorKind::Io(error) => ArrowError::CsvError(error.to_string()),
             csv_crate::ErrorKind::Utf8 { pos: _, err } => ArrowError::CsvError(format!(
-                "Encountered UTF-8 error while reading CSV file: {:?}",
+                "Encountered UTF-8 error while reading CSV file: {}",
                 err.to_string()
             )),
             csv_crate::ErrorKind::UnequalLengths {

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -209,10 +209,9 @@ fn from_datatype(datatype: &DataType) -> Result<String> {
         DataType::LargeBinary => "Z",
         DataType::Utf8 => "u",
         DataType::LargeUtf8 => "U",
-        _ => {
+        z => {
             return Err(ArrowError::CDataInterface(
-                "The datatype \"{:?}\" is still not supported in Rust implementation"
-                    .to_string(),
+                format!("The datatype \"{:?}\" is still not supported in Rust implementation", z),
             ))
         }
     }

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -210,9 +210,10 @@ fn from_datatype(datatype: &DataType) -> Result<String> {
         DataType::Utf8 => "u",
         DataType::LargeUtf8 => "U",
         z => {
-            return Err(ArrowError::CDataInterface(
-                format!("The datatype \"{:?}\" is still not supported in Rust implementation", z),
-            ))
+            return Err(ArrowError::CDataInterface(format!(
+                "The datatype \"{:?}\" is still not supported in Rust implementation",
+                z
+            )))
         }
     }
     .to_string())


### PR DESCRIPTION
In rust/README.md,  both ARROW_TEST_DATA and PARQUET_TEST_DATA are set as relative path. The problem is: we MAY have to reset them back-and-forth across top and subdirectories – that's annoying. So, the obvious solution is: set the Env vars as absolute dirs.

This PR also contains several minor fixes to spelling and format!