### PR TITLE
ARROW-10914: [Rust] Refactor simd arithmetic kernels to use chunked iteration

### DIFF
--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -824,7 +824,7 @@ impl MutableBuffer {
     }
 
     /// View buffer as typed slice.
-    pub fn typed_data_mut<T: ArrowNativeType + num::Num>(&mut self) -> &mut [T] {
+    pub fn typed_data_mut<T: ArrowNativeType>(&mut self) -> &mut [T] {
         assert_eq!(self.len() % mem::size_of::<T>(), 0);
         assert!(memory::is_ptr_aligned::<T>(self.raw_data() as *const T));
         unsafe {

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -768,7 +768,7 @@ mod tests {
 
     #[test]
     fn test_primitive_array_negate() {
-        let a: Int64Array = (0..100).into_iter().map(|i| Some(i)).collect();
+        let a: Int64Array = (0..100).into_iter().map(Some).collect();
         let actual = negate(&a).unwrap();
         let expected: Int64Array = (0..100).into_iter().map(|i| Some(-i)).collect();
         assert_eq!(expected, actual);

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -129,7 +129,7 @@ pub fn math_op<T, F>(
     op: F,
 ) -> Result<PrimitiveArray<T>>
 where
-    T: datatypes::ArrowNumericType,
+    T: ArrowNumericType,
     F: Fn(T::Native, T::Native) -> T::Native,
 {
     if left.len() != right.len() {
@@ -169,7 +169,7 @@ fn math_divide<T>(
     right: &PrimitiveArray<T>,
 ) -> Result<PrimitiveArray<T>>
 where
-    T: datatypes::ArrowNumericType,
+    T: ArrowNumericType,
     T::Native: Div<Output = T::Native> + Zero,
 {
     if left.len() != right.len() {
@@ -230,7 +230,7 @@ fn simd_math_op<T, SIMD_OP, SCALAR_OP>(
     scalar_op: SCALAR_OP,
 ) -> Result<PrimitiveArray<T>>
 where
-    T: datatypes::ArrowNumericType,
+    T: ArrowNumericType,
     SIMD_OP: Fn(T::Simd, T::Simd) -> T::Simd,
     SCALAR_OP: Fn(T::Native, T::Native) -> T::Native,
 {
@@ -361,7 +361,7 @@ fn simd_divide<T>(
     right: &PrimitiveArray<T>,
 ) -> Result<PrimitiveArray<T>>
 where
-    T: datatypes::ArrowNumericType,
+    T: ArrowNumericType,
     T::Native: One + Zero + Div<Output = T::Native>,
 {
     if left.len() != right.len() {
@@ -478,7 +478,7 @@ pub fn add<T>(
     right: &PrimitiveArray<T>,
 ) -> Result<PrimitiveArray<T>>
 where
-    T: datatypes::ArrowNumericType,
+    T: ArrowNumericType,
     T::Native: Add<Output = T::Native>
         + Sub<Output = T::Native>
         + Mul<Output = T::Native>


### PR DESCRIPTION
This should avoid out of bounds reads in those kernels and also removes some unsafe blocks. The performance actually seems to increase slightly, I will post the numbers later.

The division kernel looks a bit more complex now, but follows the same pattern as used in the simd aggregation functions, with two separate codepaths for the nullable/non-null cases.

The comparison kernels might also do some out of bounds reads, I will look at those in a separate ticket/PR.