### PR TITLE
ARROW-10929: [Rust] Change CI to use Stable Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -114,11 +114,17 @@ jobs:
           cd datafusion
           cargo run --example csv_sql
           cargo run --example parquet_sql
+          cd ..
+          cd arrow
+          cargo test
+          cargo run --example builders
+          cargo run --example dynamic_types
+          cargo run --example read_csv
+          cargo run --example read_csv_infer_schema
 
-  # test the --features "simd" of the arrow crate
+  # test the --features "simd" of the arrow crate. This requires nightly.
   linux-test-simd:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }} test arrow simd
-    needs: [linux-build-lib]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -156,57 +162,13 @@ jobs:
           cd rust/arrow
           cargo test --features "simd"
 
-  # test the arrow crate with stable rust
-  linux-test-stable:
-    name: AMD64 Debian 10 Rust ${{ matrix.rust }} test arrow
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64]
-        rust: [stable]
-    container:
-      image: ${{ matrix.arch }}/rust
-      env:
-        ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: /github/home/.cargo
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v2
-        with:
-          path: /github/home/target
-          # this key equals the ones on `linux-build-lib` for re-use
-          key: ${{ runner.os }}-${{ matrix.arch }}-target-cache-${{ matrix.rust }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          default: true
-          components: rustfmt
-      - name: Run tests
-        run: |
-          export CARGO_HOME="/github/home/.cargo"
-          export CARGO_TARGET_DIR="/github/home/target"
-          cd rust/arrow
-          cargo test
-          cargo run --example builders
-          cargo run --example dynamic_types
-          cargo run --example read_csv
-          cargo run --example read_csv_infer_schema
-
   windows-and-macos:
     name: ${{ matrix.os }} Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -234,7 +196,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
     steps:
@@ -271,7 +233,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -311,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [nightly-2020-11-24]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/rust/arrow/src/array/array_struct.rs
+++ b/rust/arrow/src/array/array_struct.rs
@@ -361,7 +361,7 @@ mod tests {
             .null_count(2)
             .null_bit_buffer(Buffer::from(&[9_u8]))
             .add_buffer(Buffer::from(&[0, 3, 3, 3, 7].to_byte_slice()))
-            .add_buffer(Buffer::from("joemark".as_bytes()))
+            .add_buffer(Buffer::from(b"joemark"))
             .build();
 
         let expected_int_data = ArrayData::builder(DataType::Int32)

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -17,7 +17,6 @@
 #![warn(missing_docs)]
 // Clippy lints, some should be disabled incrementally
 #![allow(
-    clippy::field_reassign_with_default,
     clippy::float_cmp,
     clippy::module_inception,
     clippy::needless_lifetimes,

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -689,6 +689,7 @@ pub fn create_udf(
 
 /// Creates a new UDAF with a specific signature, state type and return type.
 /// The signature and state type must match the `Acumulator's implementation`.
+#[allow(clippy::rc_buffer)]
 pub fn create_udaf(
     name: &str,
     input_type: DataType,

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -561,6 +561,7 @@ impl From<&PlanType> for String {
 
 /// Represents some sort of execution plan, in String form
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::rc_buffer)]
 pub struct StringifiedPlan {
     /// An identifier of what type of plan this string represents
     pub plan_type: PlanType,

--- a/rust/parquet/src/util/cursor.rs
+++ b/rust/parquet/src/util/cursor.rs
@@ -26,6 +26,7 @@ use crate::file::writer::TryClone;
 /// To achieve this, it uses Arc instead of shared references. Indeed reference fields are painfull
 /// because the lack of Generic Associated Type implies that you would require complex lifetime propagation when
 /// returning such a cursor.
+#[allow(clippy::rc_buffer)]
 pub struct SliceableCursor {
     inner: Arc<Vec<u8>>,
     start: u64,

--- a/rust/parquet/src/util/memory.rs
+++ b/rust/parquet/src/util/memory.rs
@@ -269,6 +269,7 @@ impl<T: Clone> Drop for Buffer<T> {
 /// An representation of a slice on a reference-counting and read-only byte array.
 /// Sub-slices can be further created from this. The byte array will be released
 /// when all slices are dropped.
+#[allow(clippy::rc_buffer)]
 #[derive(Clone, Debug)]
 pub struct BufferPtr<T> {
     data: Arc<Vec<T>>,


### PR DESCRIPTION
This is a cherry-pick of https://github.com/jorgecarleitao/arrow/commit/ca66d6d945e265dd2c83464bd80ff1dd7d231f7c by @jorgecarleitao 

It runs all tests except the simd using `stable` -- The SIMD feature still require nightly rust, but the default features do not (after https://github.com/apache/arrow/pull/8698)

Update: It also silences a few clippy lints which start complaining on stable -- I'll comment inline