### PR TITLE
ARROW-10770: [Rust] JSON nested list reader

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -123,6 +123,10 @@ name = "csv_writer"
 harness = false
 
 [[bench]]
+name = "json_reader"
+harness = false
+
+[[bench]]
 name = "equal"
 harness = false
 

--- a/rust/arrow/benches/json_reader.rs
+++ b/rust/arrow/benches/json_reader.rs
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate arrow;
+extern crate criterion;
+
+use criterion::*;
+
+use arrow::datatypes::*;
+use arrow::json::ReaderBuilder;
+use std::io::Cursor;
+use std::sync::Arc;
+
+fn json_primitive_to_record_batch() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("c1", DataType::Utf8, true),
+        Field::new("c2", DataType::Float64, true),
+        Field::new("c3", DataType::UInt32, true),
+        Field::new("c4", DataType::Boolean, true),
+    ]));
+    let builder = ReaderBuilder::new().with_schema(schema).with_batch_size(64);
+    let json_content = r#"
+        {"c1": "eleven", "c2": 6.2222222225, "c3": 5.0, "c4": false}
+        {"c1": "twelve", "c2": -55555555555555.2, "c3": 3}
+        {"c1": null, "c2": 3, "c3": 125, "c4": null}
+        {"c2": -35, "c3": 100.0, "c4": true}
+        {"c1": "fifteen", "c2": null, "c4": true}
+        {"c1": "eleven", "c2": 6.2222222225, "c3": 5.0, "c4": false}
+        {"c1": "twelve", "c2": -55555555555555.2, "c3": 3}
+        {"c1": null, "c2": 3, "c3": 125, "c4": null}
+        {"c2": -35, "c3": 100.0, "c4": true}
+        {"c1": "fifteen", "c2": null, "c4": true}
+        "#;
+    let cursor = Cursor::new(json_content);
+    let mut reader = builder.build(cursor).unwrap();
+    #[allow(clippy::unit_arg)]
+    criterion::black_box({
+        reader.next().unwrap();
+    });
+}
+
+fn json_list_primitive_to_record_batch() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "c1",
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new(
+            "c2",
+            DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
+            true,
+        ),
+        Field::new(
+            "c3",
+            DataType::List(Box::new(Field::new("item", DataType::UInt32, true))),
+            true,
+        ),
+        Field::new(
+            "c4",
+            DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
+            true,
+        ),
+    ]));
+    let builder = ReaderBuilder::new().with_schema(schema).with_batch_size(64);
+    let json_content = r#"
+        {"c1": ["eleven"], "c2": [6.2222222225, -3.2, null], "c3": [5.0, 6], "c4": [false, true]}
+        {"c1": ["twelve"], "c2": [-55555555555555.2, 12500000.0], "c3": [3, 4, 5]}
+        {"c1": null, "c2": [3], "c3": [125, 127, 129], "c4": [null, false, true]}
+        {"c2": [-35], "c3": [100.0, 200.0], "c4": null}
+        {"c1": ["fifteen"], "c2": [null, 2.1, 1.5, -3], "c4": [true, false, null]}
+        {"c1": ["fifteen"], "c2": [], "c4": [true, false, null]}
+        {"c1": ["eleven"], "c2": [6.2222222225, -3.2, null], "c3": [5.0, 6], "c4": [false, true]}
+        {"c1": ["twelve"], "c2": [-55555555555555.2, 12500000.0], "c3": [3, 4, 5]}
+        {"c1": null, "c2": [3], "c3": [125, 127, 129], "c4": [null, false, true]}
+        {"c2": [-35], "c3": [100.0, 200.0], "c4": null}
+        {"c1": ["fifteen"], "c2": [null, 2.1, 1.5, -3], "c4": [true, false, null]}
+        {"c1": ["fifteen"], "c2": [], "c4": [true, false, null]}
+        "#;
+    let cursor = Cursor::new(json_content);
+    let mut reader = builder.build(cursor).unwrap();
+    #[allow(clippy::unit_arg)]
+    criterion::black_box({
+        reader.next().unwrap();
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench(
+        "json_primitive_to_record_batch",
+        Benchmark::new("json_primitive_to_record_batch", move |b| {
+            b.iter(json_primitive_to_record_batch)
+        }),
+    );
+    c.bench(
+        "json_list_primitive_to_record_batch",
+        Benchmark::new("json_list_primitive_to_record_batch", move |b| {
+            b.iter(json_list_primitive_to_record_batch)
+        }),
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -1296,15 +1296,6 @@ impl Decoder {
                                 DataType::Boolean => {
                                     self.build_boolean_list_array(rows, field.name())
                                 }
-                                ref dtype @ DataType::Utf8 => {
-                                    // UInt64Type passed down below is a fake type for dictionary builder.
-                                    // It is there to make compiler happy.
-                                    self.list_array_string_array_builder::<UInt64Type>(
-                                        &dtype,
-                                        field.name(),
-                                        rows,
-                                    )
-                                }
                                 DataType::Dictionary(ref key_ty, _) => self
                                     .build_wrapped_list_array(rows, field.name(), key_ty),
                                 _ => {


### PR DESCRIPTION
Big one!

This implements a JSON nested list reader, which means that we can now read `<struct<list<struct<_>>>` and other variants.
While working on this, I noticed some bugs in the reader, which I fixed. They were:

* `<list<string>>` was not read correctly by the dictionary hack
* `<list<primitive>>` was not creating the correct list offsets, sometimes `null` was placed in the incorrect logical location

I've also added a few benchmarks, where the nested list benchmark now performs about ~20% slower . I'm fine with this, as we weren't always reading values correctly anyways.

I suspect the main perf loss is from having to peek into JSON values in order to make the nesting work.
By this, I mean that if we have `{"a": [_, _, _]}`, we extract `a` values into a `Vec<Value>`, i.e. `[_, _, _]`.
By extracting values, we are able to then use the reader to read `&[Value]` without caring about its key (`a`).
The downside of this approach is that we have to clone values to get `Vec<Value>`, as I couldn't find an alternative.

I could probably defer the extraction of `[_, _, _]` for later, but I was concerned that it was just going to make things messy.
I got lost a lot in the slough of complexity in this code.