### PR TITLE
ARROW-10928: [C++] Better Parquet error when trying to write empty struct

### DIFF
--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -123,9 +123,9 @@ Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
     // XXX (ARROW-10928) We could add a dummy primitive node but that would
     // require special handling when writing and reading, to avoid column index
     // mismatches.
-    return Status::NotImplemented(
-        "Cannot write struct type with no child fields to Parquet. "
-        "Consider adding a dummy field.");
+    return Status::NotImplemented("Cannot write struct type '", name,
+                                  "' with no child field to Parquet. "
+                                  "Consider adding a dummy child field.");
   }
 
   *out = GroupNode::Make(name, RepetitionFromNullable(nullable), std::move(children));

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -65,7 +65,8 @@ namespace arrow {
 // Parquet to Arrow schema conversion
 
 namespace {
-Repetition::type RepitionFromNullable(bool is_nullable) {
+
+Repetition::type RepetitionFromNullable(bool is_nullable) {
   return is_nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
 }
 
@@ -84,8 +85,8 @@ Status ListToNode(const std::shared_ptr<::arrow::BaseListType>& type,
                             &element));
 
   NodePtr list = GroupNode::Make("list", Repetition::REPEATED, {element});
-  *out =
-      GroupNode::Make(name, RepitionFromNullable(nullable), {list}, LogicalType::List());
+  *out = GroupNode::Make(name, RepetitionFromNullable(nullable), {list},
+                         LogicalType::List());
   return Status::OK();
 }
 
@@ -103,7 +104,7 @@ Status MapToNode(const std::shared_ptr<::arrow::MapType>& type, const std::strin
 
   NodePtr key_value =
       GroupNode::Make("key_value", Repetition::REPEATED, {key_node, value_node});
-  *out = GroupNode::Make(name, RepitionFromNullable(nullable), {key_value},
+  *out = GroupNode::Make(name, RepetitionFromNullable(nullable), {key_value},
                          LogicalType::Map());
   return Status::OK();
 }
@@ -113,12 +114,21 @@ Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
                     const WriterProperties& properties,
                     const ArrowWriterProperties& arrow_properties, NodePtr* out) {
   std::vector<NodePtr> children(type->num_fields());
-  for (int i = 0; i < type->num_fields(); i++) {
-    RETURN_NOT_OK(FieldToNode(type->field(i)->name(), type->field(i), properties,
-                              arrow_properties, &children[i]));
+  if (type->num_fields() != 0) {
+    for (int i = 0; i < type->num_fields(); i++) {
+      RETURN_NOT_OK(FieldToNode(type->field(i)->name(), type->field(i), properties,
+                                arrow_properties, &children[i]));
+    }
+  } else {
+    // XXX (ARROW-10928) We could add a dummy primitive node but that would
+    // require special handling when writing and reading, to avoid column index
+    // mismatches.
+    return Status::NotImplemented(
+        "Cannot write struct type with no child fields to Parquet. "
+        "Consider adding a dummy field.");
   }
 
-  *out = GroupNode::Make(name, RepitionFromNullable(nullable), children);
+  *out = GroupNode::Make(name, RepetitionFromNullable(nullable), std::move(children));
   return Status::OK();
 }
 
@@ -225,7 +235,7 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
                    const ArrowWriterProperties& arrow_properties, NodePtr* out) {
   std::shared_ptr<const LogicalType> logical_type = LogicalType::None();
   ParquetType::type type;
-  Repetition::type repetition = RepitionFromNullable(field->nullable());
+  Repetition::type repetition = RepetitionFromNullable(field->nullable());
 
   int length = -1;
   int precision = -1;

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -80,7 +80,8 @@ int CalculateLeafCount(const DataType* type) {
   if (type->id() == ::arrow::Type::EXTENSION) {
     type = checked_cast<const ExtensionType&>(*type).storage_type().get();
   }
-  if (type->num_fields() == 0) {
+  // Note num_fields() can be 0 for an empty struct type
+  if (!::arrow::is_nested(type->id())) {
     // Primitive type.
     return 1;
   }

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -550,11 +550,11 @@ std::unique_ptr<Node> Unflatten(const format::SchemaElement* elements, int lengt
     int field_id = current_id++;
     const void* opaque_element = static_cast<const void*>(&element);
 
-    if (!element.__isset.num_children) {
-      // Leaf (primitive) node
+    if (element.num_children == 0 && element.__isset.type) {
+      // Leaf (primitive) node: always has a type
       return PrimitiveNode::FromParquet(opaque_element, field_id);
     } else {
-      // Group (may have 0 children)
+      // Group node (may have 0 children, but cannot have a type)
       NodeVector fields;
       for (int i = 0; i < element.num_children; ++i) {
         std::unique_ptr<Node> field = NextNode();

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -550,11 +550,11 @@ std::unique_ptr<Node> Unflatten(const format::SchemaElement* elements, int lengt
     int field_id = current_id++;
     const void* opaque_element = static_cast<const void*>(&element);
 
-    if (element.num_children == 0) {
+    if (!element.__isset.num_children) {
       // Leaf (primitive) node
       return PrimitiveNode::FromParquet(opaque_element, field_id);
     } else {
-      // Group
+      // Group (may have 0 children)
       NodeVector fields;
       for (int i = 0; i < element.num_children; ++i) {
         std::unique_ptr<Node> field = NextNode();


### PR DESCRIPTION
An empty struct type (with no child fields) is not easy to write in Parquet,
since Parquet only represents the data of leaf nodes.
We would need a way to distinguish between null and non-null (empty) struct values.
It would probably require a dummy primitive node.

Until we implement such a solution, simply raise a nice error when an empty
struct is encountered.