### PR TITLE
ARROW-10947: [Rust][DataFusion] Optimize UTF8 to Date32 Conversion

### DIFF
--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -509,15 +509,17 @@ impl Parser for Int16Type {}
 
 impl Parser for Int8Type {}
 
+/// Number of days between 0001-01-01 and 1970-01-01
+const EPOCH_DAYS_FROM_CE: i32 = 719_163;
+
 impl Parser for Date32Type {
     fn parse(string: &str) -> Option<i32> {
-        let from_ymd = chrono::NaiveDate::from_ymd;
-        let since = chrono::NaiveDate::signed_duration_since;
+        use chrono::Datelike;
 
         match Self::DATA_TYPE {
             DataType::Date32(DateUnit::Day) => {
-                let days = string.parse::<chrono::NaiveDate>().ok()?;
-                Self::Native::from_i32(since(days, from_ymd(1970, 1, 1)).num_days() as i32)
+                let date = string.parse::<chrono::NaiveDate>().ok()?;
+                Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
             }
             _ => None,
         }


### PR DESCRIPTION
After adding benchmarking capability to the UTF8 to Date32/Date64 CAST functions there was opportunity to improve the performance.

This PR uses inbuilt `chrono` functionality to calculate the number of days since CE then uses a constant to calculate the offset days relative to 1970-01-01. This improves performance around 10% for this operation relative to the `since` function presumably as `chrono` does not have to ensure the `from_ymd` is a valid date.

Before:
```
cast utf8 to date32 512 time:   [41.966 us 42.508 us 43.087 us]
cast utf8 to date32 512 time:   [40.591 us 40.661 us 40.740 us]
cast utf8 to date32 512 time:   [40.825 us 40.878 us 40.916 us]
```

After:
```
cast utf8 to date32 512 time:   [36.557 us 36.839 us 37.200 us]
cast utf8 to date32 512 time:   [35.997 us 36.442 us 36.919 us]
cast utf8 to date32 512 time:   [35.750 us 35.969 us 36.160 us]
```