### PR TITLE
ARROW-10783: [Rust][DataFusion] Implement Statistics for Parquet TableProvider

### DIFF
--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -43,8 +43,16 @@ impl ParquetTable {
         let schema = parquet_exec.schema();
 
         let metadata = parquet_exec.metadata();
-        let num_rows = metadata.row_groups().iter().map(|rg| rg.num_rows() as usize).sum();
-        let total_byte_size = metadata.row_groups().iter().map(|rg| rg.total_byte_size() as usize).sum();
+        let num_rows = metadata
+            .row_groups()
+            .iter()
+            .map(|rg| rg.num_rows() as usize)
+            .sum();
+        let total_byte_size = metadata
+            .row_groups()
+            .iter()
+            .map(|rg| rg.total_byte_size() as usize)
+            .sum();
 
         Ok(Self {
             path: path.to_string(),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,6 +22,7 @@ use std::string::String;
 use std::sync::Arc;
 
 use arrow::datatypes::*;
+use parquet::file::metadata::RowGroupMetaData;
 
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
@@ -43,23 +44,23 @@ impl ParquetTable {
         let schema = parquet_exec.schema();
 
         let metadata = parquet_exec.metadata();
-        let num_rows = metadata
+        let num_rows: i64 = metadata
             .row_groups()
             .iter()
-            .map(|rg| rg.num_rows() as usize)
+            .map(RowGroupMetaData::num_rows)
             .sum();
-        let total_byte_size = metadata
+        let total_byte_size: i64 = metadata
             .row_groups()
             .iter()
-            .map(|rg| rg.total_byte_size() as usize)
+            .map(RowGroupMetaData::total_byte_size)
             .sum();
 
         Ok(Self {
             path: path.to_string(),
             schema,
             statistics: Statistics {
-                num_rows: Some(num_rows),
-                total_byte_size: Some(total_byte_size),
+                num_rows: Some(num_rows as usize),
+                total_byte_size: Some(total_byte_size as usize),
             },
         })
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -43,15 +43,8 @@ impl ParquetTable {
         let schema = parquet_exec.schema();
 
         let metadata = parquet_exec.metadata();
-        let (num_rows, total_byte_size) = metadata.row_groups().iter().fold(
-            (0, 0),
-            |(num_rows, total_byte_size), rg| {
-                (
-                    num_rows + rg.num_rows() as usize,
-                    total_byte_size + rg.total_byte_size() as usize,
-                )
-            },
-        );
+        let num_rows = metadata.row_groups().iter().map(|rg| rg.num_rows() as usize).sum();
+        let total_byte_size = metadata.row_groups().iter().map(|rg| rg.total_byte_size() as usize).sum();
 
         Ok(Self {
             path: path.to_string(),

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -23,6 +23,7 @@ use crate::arrow::schema::{
     parquet_to_arrow_schema_by_columns, parquet_to_arrow_schema_by_root_columns,
 };
 use crate::errors::{ParquetError, Result};
+use crate::file::metadata::ParquetMetaData;
 use crate::file::reader::FileReader;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
@@ -153,6 +154,11 @@ impl ArrowReader for ParquetFileArrowReader {
 impl ParquetFileArrowReader {
     pub fn new(file_reader: Arc<dyn FileReader>) -> Self {
         Self { file_reader }
+    }
+
+    // Expose the reader metadata
+    pub fn get_metadata(&mut self) -> ParquetMetaData {
+        self.file_reader.metadata().clone()
     }
 }
 

--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -46,7 +46,7 @@ use crate::schema::types::{
 };
 
 /// Global Parquet metadata.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParquetMetaData {
     file_metadata: FileMetaData,
     row_groups: Vec<RowGroupMetaData>,
@@ -90,7 +90,7 @@ pub type KeyValue = parquet_format::KeyValue;
 pub type FileMetaDataPtr = Arc<FileMetaData>;
 
 /// Metadata for a Parquet file.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileMetaData {
     version: i32,
     num_rows: i64,
@@ -187,7 +187,7 @@ impl FileMetaData {
 pub type RowGroupMetaDataPtr = Arc<RowGroupMetaData>;
 
 /// Metadata for a row group.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RowGroupMetaData {
     columns: Vec<ColumnChunkMetaData>,
     num_rows: i64,
@@ -325,7 +325,7 @@ impl RowGroupMetaDataBuilder {
 }
 
 /// Metadata for a column chunk.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ColumnChunkMetaData {
     column_type: Type,
     column_path: ColumnPath,

--- a/rust/parquet/src/file/statistics.rs
+++ b/rust/parquet/src/file/statistics.rs
@@ -232,7 +232,7 @@ pub fn to_thrift(stats: Option<&Statistics>) -> Option<TStatistics> {
 }
 
 /// Statistics for a column chunk and data page.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Statistics {
     Boolean(TypedStatistics<BoolType>),
     Int32(TypedStatistics<Int32Type>),
@@ -341,6 +341,7 @@ impl fmt::Display for Statistics {
 }
 
 /// Typed implementation for [`Statistics`].
+#[derive(Clone)]
 pub struct TypedStatistics<T: DataType> {
     min: Option<T::T>,
     max: Option<T::T>,


### PR DESCRIPTION
This is an implementation of Statistics for the Parquet datasource as this PR seems to have gone quiet: https://github.com/apache/arrow/pull/8860

This PR exposes the ParquetMetaData produced by the file reader as even though initially we only consume `row_count` and `total_byte_size` there is column level metadata that may be very useful in future for potentially large performance gains.