### PR TITLE
ARROW-10944: [Rust] Implement min/max aggregate kernels for BooleanArray

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -145,7 +145,11 @@ fn min_boolean(array: &BooleanArray) -> Option<bool> {
     }
 
     // Note the min bool is false (0), so short circuit as soon as we see it
-    array.iter().find(|&b| b == Some(false)).flatten()
+    array
+        .iter()
+        .find(|&b| b == Some(false))
+        .flatten()
+        .or(Some(true))
 }
 
 /// Returns the maximum value in the boolean array
@@ -156,7 +160,11 @@ fn max_boolean(array: &BooleanArray) -> Option<bool> {
     }
 
     // Note the max bool is true (1), so short circuit as soon as we see it
-    array.iter().find(|&b| b == Some(true)).flatten()
+    array
+        .iter()
+        .find(|&b| b == Some(true))
+        .flatten()
+        .or(Some(false))
 }
 
 /// Returns the sum of values in the array.
@@ -928,6 +936,25 @@ mod tests {
         let a =
             BooleanArray::from(vec![Some(false), Some(true), None, Some(false), None]);
         assert_eq!(Some(false), min_boolean(&a));
+        assert_eq!(Some(true), max_boolean(&a));
+    }
+
+    #[test]
+    fn test_boolean_min_max_smaller() {
+        let a = BooleanArray::from(vec![Some(false)]);
+        assert_eq!(Some(false), min_boolean(&a));
+        assert_eq!(Some(false), max_boolean(&a));
+
+        let a = BooleanArray::from(vec![None, Some(false)]);
+        assert_eq!(Some(false), min_boolean(&a));
+        assert_eq!(Some(false), max_boolean(&a));
+
+        let a = BooleanArray::from(vec![None, Some(true)]);
+        assert_eq!(Some(true), min_boolean(&a));
+        assert_eq!(Some(true), max_boolean(&a));
+
+        let a = BooleanArray::from(vec![Some(true)]);
+        assert_eq!(Some(true), min_boolean(&a));
         assert_eq!(Some(true), max_boolean(&a));
     }
 }

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -137,38 +137,26 @@ where
     Some(n)
 }
 
-/// Helper function to perform min/max lambda function on values from a `BooleanArray`
-fn min_max_boolean<F>(array: &BooleanArray, cmp: F) -> Option<bool>
-where
-    F: Fn(bool, bool) -> bool,
-{
-    let null_count = array.null_count();
-
-    // Includes case array.len() == 0
-    if null_count == array.len() {
+/// Returns the minimum value in the boolean array
+fn min_boolean(array: &BooleanArray) -> Option<bool> {
+    // short circuit if all nulls / zero length array
+    if array.null_count() == array.len() {
         return None;
     }
 
-    let m0: Option<bool> = array.iter().next().unwrap();
-
-    array.iter().fold(m0, |max, item| match (max, item) {
-        (Some(max), Some(item)) => Some(if cmp(max, item) { item } else { max }),
-        (Some(max), None) => Some(max),
-        (None, Some(item)) => Some(item),
-        (None, None) => None,
-    })
-}
-
-/// Returns the minimum value in the boolean array
-fn min_boolean(array: &BooleanArray) -> Option<bool> {
-    // a > b == a & !b
-    min_max_boolean(array, |a, b| a & !b)
+    // Note the min bool is false (0), so short circuit as soon as we see it
+    array.iter().find(|&b| b == Some(false)).flatten()
 }
 
 /// Returns the maximum value in the boolean array
 fn max_boolean(array: &BooleanArray) -> Option<bool> {
-    // a < b == !a & b
-    min_max_boolean(array, |a, b| !a & b)
+    // short circuit if all nulls / zero length array
+    if array.null_count() == array.len() {
+        return None;
+    }
+
+    // Note the max bool is true (1), so short circuit as soon as we see it
+    array.iter().find(|&b| b == Some(true)).flatten()
 }
 
 /// Returns the sum of values in the array.

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -921,9 +921,6 @@ mod tests {
 
     #[test]
     fn test_boolean_min_max() {
-        // since implementation treats [0] specially, test arrays
-        // starting with each of Some(true), Some(false) and None
-
         let a = BooleanArray::from(vec![Some(true), Some(true), None, Some(false), None]);
         assert_eq!(Some(false), min_boolean(&a));
         assert_eq!(Some(true), max_boolean(&a));
@@ -932,7 +929,6 @@ mod tests {
         assert_eq!(Some(false), min_boolean(&a));
         assert_eq!(Some(true), max_boolean(&a));
 
-        // since implementation treats [0] specially, also test starting with Some(false) and None
         let a =
             BooleanArray::from(vec![Some(false), Some(true), None, Some(false), None]);
         assert_eq!(Some(false), min_boolean(&a));

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -137,8 +137,18 @@ where
     Some(n)
 }
 
-/// Returns the minimum value in the boolean array
-fn min_boolean(array: &BooleanArray) -> Option<bool> {
+/// Returns the minimum value in the boolean array.
+///
+/// ```
+/// use arrow::{
+///   array::BooleanArray,
+///   compute::min_boolean,
+/// };
+///
+/// let a = BooleanArray::from(vec![Some(true), None, Some(false)]);
+/// assert_eq!(min_boolean(&a), Some(false))
+/// ```
+pub fn min_boolean(array: &BooleanArray) -> Option<bool> {
     // short circuit if all nulls / zero length array
     if array.null_count() == array.len() {
         return None;
@@ -153,7 +163,17 @@ fn min_boolean(array: &BooleanArray) -> Option<bool> {
 }
 
 /// Returns the maximum value in the boolean array
-fn max_boolean(array: &BooleanArray) -> Option<bool> {
+///
+/// ```
+/// use arrow::{
+///   array::BooleanArray,
+///   compute::max_boolean,
+/// };
+///
+/// let a = BooleanArray::from(vec![Some(true), None, Some(false)]);
+/// assert_eq!(max_boolean(&a), Some(true))
+/// ```
+pub fn max_boolean(array: &BooleanArray) -> Option<bool> {
     // short circuit if all nulls / zero length array
     if array.null_count() == array.len() {
         return None;


### PR DESCRIPTION
Rationale: While Min/Max is a somewhat silly / meaningless operation,  typically database systems support it for completeness. 

This PR adds a basic implementation and tests. 

More detail on usecase is [here](https://github.com/influxdata/influxdb_iox/issues/568)
