### PR TITLE
ARROW-10950: [Rust] Improved performance of MutableDataArray

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -133,3 +133,7 @@ harness = false
 [[bench]]
 name = "concatenate_kernel"
 harness = false
+
+[[bench]]
+name = "mutable_array"
+harness = false

--- a/rust/arrow/benches/mutable_array.rs
+++ b/rust/arrow/benches/mutable_array.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::util::test_util::seedable_rng;
+
+fn create_strings(size: usize, null_density: f32) -> ArrayRef {
+    let rng = &mut seedable_rng();
+
+    let mut builder = StringBuilder::new(size);
+    for _ in 0..size {
+        let x = rng.gen::<f32>();
+        if x < null_density {
+            let value = rng.sample_iter(&Alphanumeric).take(4).collect::<String>();
+            builder.append_value(&value).unwrap();
+        } else {
+            builder.append_null().unwrap()
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn create_slices(size: usize) -> Vec<(usize, usize)> {
+    let rng = &mut seedable_rng();
+
+    (0..size)
+        .map(|_| {
+            let start = rng.gen_range(0, size / 2);
+            let end = rng.gen_range(start + 1, size);
+            (start, end)
+        })
+        .collect()
+}
+
+fn bench(v1: &ArrayRef, slices: &Vec<(usize, usize)>) {
+    let mut mutable = MutableArrayData::new(vec![v1.data_ref()], false, 5);
+    for (start, end) in slices {
+        mutable.extend(0, *start, *end)
+    }
+    mutable.freeze();
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let v1 = create_strings(1024, 0.0);
+    let v2 = create_slices(1024);
+    c.bench_function("mutable str 1024", |b| b.iter(|| bench(&v1, &v2)));
+
+    let v1 = create_strings(1024, 0.5);
+    let v2 = create_slices(1024);
+    c.bench_function("mutable str nulls 1024", |b| b.iter(|| bench(&v1, &v2)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -46,16 +46,22 @@ struct _MutableArrayData<'a> {
     pub len: usize,
     pub null_buffer: MutableBuffer,
 
-    pub buffers: Vec<MutableBuffer>,
+    // fixed sized array to avoid runtime bound checks.
+    pub buffers: [MutableBuffer; 2],
     pub child_data: Vec<MutableArrayData<'a>>,
 }
 
 impl<'a> _MutableArrayData<'a> {
     fn freeze(self, dictionary: Option<ArrayDataRef>) -> ArrayData {
-        let mut buffers = Vec::with_capacity(self.buffers.len());
-        for buffer in self.buffers {
-            buffers.push(buffer.freeze());
-        }
+        let [buffer1, buffer2] = self.buffers;
+        let buffers = match self.data_type {
+            DataType::Struct(_) => vec![],
+            DataType::Utf8
+            | DataType::Binary
+            | DataType::LargeUtf8
+            | DataType::LargeBinary => vec![buffer1.freeze(), buffer2.freeze()],
+            _ => vec![buffer1.freeze()],
+        };
 
         let child_data = match self.data_type {
             DataType::Dictionary(_, _) => vec![dictionary.unwrap()],
@@ -225,7 +231,6 @@ fn build_extend(array: &ArrayData) -> Extend {
         /*
         DataType::Null => {}
         DataType::FixedSizeList(_, _) => {}
-        DataType::Struct(_) => {}
         DataType::Union(_) => {}
         */
         _ => todo!("Take and filter operations still not supported for this datatype"),
@@ -298,75 +303,132 @@ impl<'a> MutableArrayData<'a> {
             use_nulls = true;
         };
 
-        let buffers = match &data_type {
+        let empty_buffer = MutableBuffer::new(0);
+        let buffers: [MutableBuffer; 2] = match &data_type {
             DataType::Boolean => {
                 let bytes = bit_util::ceil(capacity, 8);
                 let buffer = MutableBuffer::new(bytes).with_bitset(bytes, false);
-                vec![buffer]
+                [buffer, empty_buffer]
             }
-            DataType::UInt8 => vec![MutableBuffer::new(capacity * size_of::<u8>())],
-            DataType::UInt16 => vec![MutableBuffer::new(capacity * size_of::<u16>())],
-            DataType::UInt32 => vec![MutableBuffer::new(capacity * size_of::<u32>())],
-            DataType::UInt64 => vec![MutableBuffer::new(capacity * size_of::<u64>())],
-            DataType::Int8 => vec![MutableBuffer::new(capacity * size_of::<i8>())],
-            DataType::Int16 => vec![MutableBuffer::new(capacity * size_of::<i16>())],
-            DataType::Int32 => vec![MutableBuffer::new(capacity * size_of::<i32>())],
-            DataType::Int64 => vec![MutableBuffer::new(capacity * size_of::<i64>())],
-            DataType::Float32 => vec![MutableBuffer::new(capacity * size_of::<f32>())],
-            DataType::Float64 => vec![MutableBuffer::new(capacity * size_of::<f64>())],
-            DataType::Date32(_) | DataType::Time32(_) => {
-                vec![MutableBuffer::new(capacity * size_of::<i32>())]
+            DataType::UInt8 => {
+                [MutableBuffer::new(capacity * size_of::<u8>()), empty_buffer]
             }
+            DataType::UInt16 => [
+                MutableBuffer::new(capacity * size_of::<u16>()),
+                empty_buffer,
+            ],
+            DataType::UInt32 => [
+                MutableBuffer::new(capacity * size_of::<u32>()),
+                empty_buffer,
+            ],
+            DataType::UInt64 => [
+                MutableBuffer::new(capacity * size_of::<u64>()),
+                empty_buffer,
+            ],
+            DataType::Int8 => {
+                [MutableBuffer::new(capacity * size_of::<i8>()), empty_buffer]
+            }
+            DataType::Int16 => [
+                MutableBuffer::new(capacity * size_of::<i16>()),
+                empty_buffer,
+            ],
+            DataType::Int32 => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
+            DataType::Int64 => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
+            DataType::Float32 => [
+                MutableBuffer::new(capacity * size_of::<f32>()),
+                empty_buffer,
+            ],
+            DataType::Float64 => [
+                MutableBuffer::new(capacity * size_of::<f64>()),
+                empty_buffer,
+            ],
+            DataType::Date32(_) | DataType::Time32(_) => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
             DataType::Date64(_)
             | DataType::Time64(_)
             | DataType::Duration(_)
-            | DataType::Timestamp(_, _) => {
-                vec![MutableBuffer::new(capacity * size_of::<i64>())]
-            }
-            DataType::Interval(IntervalUnit::YearMonth) => {
-                vec![MutableBuffer::new(capacity * size_of::<i32>())]
-            }
-            DataType::Interval(IntervalUnit::DayTime) => {
-                vec![MutableBuffer::new(capacity * size_of::<i64>())]
-            }
+            | DataType::Timestamp(_, _) => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
+            DataType::Interval(IntervalUnit::YearMonth) => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
+            DataType::Interval(IntervalUnit::DayTime) => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
             DataType::Utf8 | DataType::Binary => {
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i32>());
+                // safety: `unsafe` code assumes that this buffer is initialized with one element
                 buffer.extend_from_slice(&[0i32].to_byte_slice());
-                vec![buffer, MutableBuffer::new(capacity * size_of::<u8>())]
+                [buffer, MutableBuffer::new(capacity * size_of::<u8>())]
             }
             DataType::LargeUtf8 | DataType::LargeBinary => {
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i64>());
+                // safety: `unsafe` code assumes that this buffer is initialized with one element
                 buffer.extend_from_slice(&[0i64].to_byte_slice());
-                vec![buffer, MutableBuffer::new(capacity * size_of::<u8>())]
+                [buffer, MutableBuffer::new(capacity * size_of::<u8>())]
             }
             DataType::List(_) => {
                 // offset buffer always starts with a zero
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i32>());
                 buffer.extend_from_slice(0i32.to_byte_slice());
-                vec![buffer]
+                [buffer, empty_buffer]
             }
             DataType::LargeList(_) => {
                 // offset buffer always starts with a zero
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i64>());
                 buffer.extend_from_slice(&[0i64].to_byte_slice());
-                vec![buffer]
+                [buffer, empty_buffer]
             }
             DataType::FixedSizeBinary(size) => {
-                vec![MutableBuffer::new(capacity * *size as usize)]
+                [MutableBuffer::new(capacity * *size as usize), empty_buffer]
             }
             DataType::Dictionary(child_data_type, _) => match child_data_type.as_ref() {
-                DataType::UInt8 => vec![MutableBuffer::new(capacity * size_of::<u8>())],
-                DataType::UInt16 => vec![MutableBuffer::new(capacity * size_of::<u16>())],
-                DataType::UInt32 => vec![MutableBuffer::new(capacity * size_of::<u32>())],
-                DataType::UInt64 => vec![MutableBuffer::new(capacity * size_of::<u64>())],
-                DataType::Int8 => vec![MutableBuffer::new(capacity * size_of::<i8>())],
-                DataType::Int16 => vec![MutableBuffer::new(capacity * size_of::<i16>())],
-                DataType::Int32 => vec![MutableBuffer::new(capacity * size_of::<i32>())],
-                DataType::Int64 => vec![MutableBuffer::new(capacity * size_of::<i64>())],
+                DataType::UInt8 => {
+                    [MutableBuffer::new(capacity * size_of::<u8>()), empty_buffer]
+                }
+                DataType::UInt16 => [
+                    MutableBuffer::new(capacity * size_of::<u16>()),
+                    empty_buffer,
+                ],
+                DataType::UInt32 => [
+                    MutableBuffer::new(capacity * size_of::<u32>()),
+                    empty_buffer,
+                ],
+                DataType::UInt64 => [
+                    MutableBuffer::new(capacity * size_of::<u64>()),
+                    empty_buffer,
+                ],
+                DataType::Int8 => {
+                    [MutableBuffer::new(capacity * size_of::<i8>()), empty_buffer]
+                }
+                DataType::Int16 => [
+                    MutableBuffer::new(capacity * size_of::<i16>()),
+                    empty_buffer,
+                ],
+                DataType::Int32 => [
+                    MutableBuffer::new(capacity * size_of::<i32>()),
+                    empty_buffer,
+                ],
+                DataType::Int64 => [
+                    MutableBuffer::new(capacity * size_of::<i64>()),
+                    empty_buffer,
+                ],
                 _ => unreachable!(),
             },
             DataType::Float16 => unreachable!(),
-            DataType::Struct(_) => vec![],
+            DataType::Struct(_) => [empty_buffer, MutableBuffer::new(0)],
             _ => {
                 todo!("Take and filter operations still not supported for this datatype")
             }

--- a/rust/arrow/src/array/transform/primitive.rs
+++ b/rust/arrow/src/array/transform/primitive.rs
@@ -28,8 +28,7 @@ pub(super) fn build_extend<T: ArrowNativeType>(array: &ArrayData) -> Extend {
             let start = start * size_of::<T>();
             let len = len * size_of::<T>();
             let bytes = &values[start..start + len];
-            let buffer = &mut mutable.buffers[0];
-            buffer.extend_from_slice(bytes);
+            mutable.buffers[0].extend_from_slice(bytes);
         },
     )
 }
@@ -38,7 +37,5 @@ pub(super) fn extend_nulls<T: ArrowNativeType>(
     mutable: &mut _MutableArrayData,
     len: usize,
 ) {
-    let buffer = &mut mutable.buffers[0];
-    let bytes = vec![0u8; len * size_of::<T>()];
-    buffer.extend_from_slice(&bytes);
+    mutable.buffers[0].extend(len * size_of::<T>());
 }


### PR DESCRIPTION
This PR offers a 20% performance improvement to `MutableArrayData` by removing un-needed bound checks.