### PR TITLE
ARROW-10952: [Rust] Add pre-commit hook

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -110,6 +110,9 @@ PR be sure to run the following and check for lint issues:
 cargo +stable fmt --all -- --check
 ```
 
+We can use "git pre-commit hook" to automate this process: copy or soft link [pre-commit.sh](pre-commit.sh)
+as file `.git/hooks/pre-commit`.
+
 ## Clippy Lints
 
 We recommend using `clippy` for checking lints during development. While we do not yet enforce `clippy` checks, we recommend not introducing new `clippy` errors or warnings.

--- a/rust/README.md
+++ b/rust/README.md
@@ -110,9 +110,6 @@ PR be sure to run the following and check for lint issues:
 cargo +stable fmt --all -- --check
 ```
 
-We can use "git pre-commit hook" to automate this process: copy or soft link [pre-commit.sh](pre-commit.sh)
-as file `.git/hooks/pre-commit`.
-
 ## Clippy Lints
 
 We recommend using `clippy` for checking lints during development. While we do not yet enforce `clippy` checks, we recommend not introducing new `clippy` errors or warnings.
@@ -131,3 +128,28 @@ Search for `allow(clippy::` in the codebase to identify lints that are ignored/a
 * If you are introducing a line that returns a lint warning or error, you may disable the lint on that line.
 * If you have several lints on a function or module, you may disable the lint on the function or module.
 * If a lint is pervasive across multiple modules, you may disable it at the crate level.
+
+## Git Pre-Commit Hook
+
+We can use [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to automate various kinds of git pre-commit checking/formatting.
+
+Suppose you are in the root directory of the project.
+
+First check if the file already exists:
+
+```bash
+ls -l .git/hooks/pre-commit
+```
+
+If the file already exists, to avoid mistakenly **overriding**, you MAY have to check
+the link source or file content. Else if not exist, let's safely soft link [pre-commit.sh](pre-commit.sh) as file `.git/hooks/pre-commit`:
+
+```
+ln -s  ../../rust/pre-commit.sh .git/hooks/pre-commit
+```
+
+If sometimes you want to commit without checking, just run `git commit` with `--no-verify`:
+
+```bash
+git commit --no-verify -m "... commit message ..."
+```

--- a/rust/pre-commit.sh
+++ b/rust/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -18,39 +18,69 @@
 # under the License.
 
 # This file is git pre-commit hook.
-# Copy or soft link it as file .git/hooks/pre-commit.
+#
+# Soft link it as git hook under top dir of apache arrow git repository:
+# $ ln -s  ../../rust/pre-commit.sh .git/hooks/pre-commit
 
-function GREEN() {
-	echo "\033[0;32m$@\033[0m"
-}
+# NOTE: colorized output may not work as expected.
+#       I've seen the difference between /bin/sh and GUN bash 5 on macOS.
 
 function RED() {
 	echo "\033[0;31m$@\033[0m"
 }
 
+function GREEN() {
+	echo "\033[0;32m$@\033[0m"
+}
+
+function BYELLOW() {
+	echo "\033[1;33m$@\033[0m"
+}
+
 MSG="git pre-commit hook"
 RUST_DIR="rust"
 CARGO_FMT="cargo +stable fmt --all"
+CARGO_CLIPPY="cargo clippy"
 
 NUM_CHANGES=$(git diff --cached --name-only "${RUST_DIR}" |
-	grep -e ".*/*.rs$" -o -e ".*/rustfmt.toml$" |
+	grep -e ".*/*.rs$" -o -e "^rustfmt.toml$" -o -e "^rust-toolchain$" |
 	awk '{print $1}' |
 	wc -l)
 
 if [ ${NUM_CHANGES} -eq 0 ]; then
-	exit 0
+	echo -e "$(GREEN INFO) ${MSG}: no changes in: *rs, rustfmt.toml, rust-toolchain, skip fmt/clippy"
+	#exit 0
 fi
 
 cd ${RUST_DIR}
-echo "$(GREEN INFO) ${MSG}: check format of *.rs files ..."
+
+# 1. Abort on cargo fmt error.
+
+echo -e "$(GREEN INFO) ${MSG}: cargo fmt checking ..."
 
 $CARGO_FMT -q -- --check 2>/dev/null
-
 if [ $? -eq 0 ]; then
-	echo "$(GREEN INFO) ${MSG}: $(GREEN check passed)"
-	exit 0
+	echo -e "$(GREEN INFO) ${MSG}: $(GREEN cargo fmt check passed)"
 else
-	echo "$(RED FAIL) ${MSG}: check $(RED failed), git commit $(RED aborted)"
-	echo "$(GREEN INFO) ${MSG}: please run: $(GREEN ${CARGO_FMT})"
-	exit 1
+	echo -e "$(GREEN INFO) ${MSG}: cargo fmt formatting ..."
+	$CARGO_FMT
+	echo
+	echo -e "$(BYELLOW WARN) ${MSG}: cargo fmt $(BYELLOW fixed some files)"
 fi
+
+# 2. Warn on cargo clippy errors/warnings.
+
+echo
+echo "===================================================="
+echo
+echo -e "$(GREEN INFO) ${MSG}: cargo clippy ..."
+echo
+
+# Cargo clippy always return exit code 0, and tee doesnt work.
+# So let's just run cargo clippy.
+$CARGO_CLIPPY
+echo
+echo -e "$(BYELLOW WARN) ${MSG}: please try fix $(BYELLOW clippy issues) if any"
+echo
+
+exit 0

--- a/rust/pre-commit.sh
+++ b/rust/pre-commit.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# This file is git pre-commit hook.
+# Copy or soft link it as file .git/hooks/pre-commit.
+
+function GREEN() {
+	echo "\033[0;32m$@\033[0m"
+}
+
+function RED() {
+	echo "\033[0;31m$@\033[0m"
+}
+
+MSG="git pre-commit hook"
+RUST_DIR="rust"
+CARGO_FMT="cargo +stable fmt --all"
+
+NUM_CHANGES=$(git diff --cached --name-only "${RUST_DIR}" |
+	grep -e ".*/*.rs$" -o -e ".*/rustfmt.toml$" |
+	awk '{print $1}' |
+	wc -l)
+
+if [ ${NUM_CHANGES} -eq 0 ]; then
+	exit 0
+fi
+
+cd ${RUST_DIR}
+echo "$(GREEN INFO) ${MSG}: check format of *.rs files ..."
+
+$CARGO_FMT -q -- --check 2>/dev/null
+
+if [ $? -eq 0 ]; then
+	echo "$(GREEN INFO) ${MSG}: $(GREEN check passed)"
+	exit 0
+else
+	echo "$(RED FAIL) ${MSG}: check $(RED failed), git commit $(RED aborted)"
+	echo "$(GREEN INFO) ${MSG}: please run: $(GREEN ${CARGO_FMT})"
+	exit 1
+fi

--- a/rust/pre-commit.sh
+++ b/rust/pre-commit.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,8 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-#!/bin/sh
 
 # This file is git pre-commit hook.
 # Copy or soft link it as file .git/hooks/pre-commit.

--- a/rust/pre-commit.sh
+++ b/rust/pre-commit.sh
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #!/bin/sh
 
 # This file is git pre-commit hook.


### PR DESCRIPTION
If a commit contains only fixes for rust format, it would be very sad to wait for the slow CI checking done, and it may block the CI checking for other PRs.

So, this PR adds  a git pre-commit hook file, which performs the "cargo fmt --check"
