### PR TITLE
ARROW-10954: [C++][Doc] PlasmaClient is threadSafe now

### DIFF
--- a/cpp/apidoc/tutorials/plasma.md
+++ b/cpp/apidoc/tutorials/plasma.md
@@ -94,8 +94,6 @@ g++ test.cc `pkg-config --cflags --libs plasma` --std=c++11
 
 Note that multiple clients can be created within the same process.
 
-Note that a `PlasmaClient` object is **not thread safe**.
-
 If the Plasma store is still running, you can now execute the `a.out` executable
 and the store will print something like
 


### PR DESCRIPTION
There's a pr https://github.com/apache/arrow/pull/4503 make PlasmaClient thread safe now, but in the doc there's "Note that a PlasmaClient object is not thread safe.", which causes misunderstanding.