### PR TITLE
ARROW-10540: [Rust] Extended filter kernel to all types and improved performance

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -133,3 +133,7 @@ harness = false
 [[bench]]
 name = "concatenate_kernel"
 harness = false
+
+[[bench]]
+name = "mutable_array"
+harness = false

--- a/rust/arrow/benches/filter_kernels.rs
+++ b/rust/arrow/benches/filter_kernels.rs
@@ -14,128 +14,147 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+extern crate arrow;
+
+use arrow::util::test_util::seedable_rng;
+use rand::{
+    distributions::{Alphanumeric, Standard},
+    prelude::Distribution,
+    Rng,
+};
 
 use arrow::array::*;
 use arrow::compute::{filter, FilterContext};
 use arrow::datatypes::ArrowNumericType;
+use arrow::datatypes::{Float32Type, UInt8Type};
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn create_primitive_array<T, F>(size: usize, value_fn: F) -> PrimitiveArray<T>
+fn create_primitive_array<T>(size: usize, null_density: f32) -> PrimitiveArray<T>
 where
     T: ArrowNumericType,
-    F: Fn(usize) -> T::Native,
+    Standard: Distribution<T::Native>,
 {
+    // use random numbers to avoid spurious compiler optimizations wrt to branching
+    let mut rng = seedable_rng();
     let mut builder = PrimitiveArray::<T>::builder(size);
-    for i in 0..size {
-        builder.append_value(value_fn(i)).unwrap();
-    }
-    builder.finish()
-}
 
-fn create_u8_array_with_nulls(size: usize) -> UInt8Array {
-    let mut builder = UInt8Builder::new(size);
-    for i in 0..size {
-        if i % 2 == 0 {
-            builder.append_value(1).unwrap();
-        } else {
+    for _ in 0..size {
+        if rng.gen::<f32>() < null_density {
             builder.append_null().unwrap();
+        } else {
+            builder.append_value(rng.gen()).unwrap();
         }
     }
     builder.finish()
 }
 
-fn create_bool_array<F>(size: usize, value_fn: F) -> BooleanArray
-where
-    F: Fn(usize) -> bool,
-{
+fn create_string_array(size: usize, null_density: f32) -> StringArray {
+    // use random numbers to avoid spurious compiler optimizations wrt to branching
+    let mut rng = seedable_rng();
+    let mut builder = StringBuilder::new(size);
+
+    for _ in 0..size {
+        if rng.gen::<f32>() < null_density {
+            builder.append_null().unwrap();
+        } else {
+            let value = (&mut rng)
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
+            builder.append_value(&value).unwrap();
+        }
+    }
+    builder.finish()
+}
+
+fn create_bool_array(size: usize, trues_density: f32) -> BooleanArray {
+    let mut rng = seedable_rng();
     let mut builder = BooleanBuilder::new(size);
-    for i in 0..size {
-        builder.append_value(value_fn(i)).unwrap();
+    for _ in 0..size {
+        let value = rng.gen::<f32>() < trues_density;
+        builder.append_value(value).unwrap();
     }
     builder.finish()
 }
 
 fn bench_filter_u8(data_array: &UInt8Array, filter_array: &BooleanArray) {
-    filter(
-        criterion::black_box(data_array),
-        criterion::black_box(filter_array),
-    )
-    .unwrap();
+    criterion::black_box(filter(data_array, filter_array).unwrap());
 }
 
-// fn bench_filter_f32(data_array: &Float32Array, filter_array: &BooleanArray) {
-//     filter(criterion::black_box(data_array), criterion::black_box(filter_array)).unwrap();
-// }
-
-fn bench_filter_context_u8(data_array: &UInt8Array, filter_context: &FilterContext) {
-    filter_context
-        .filter(criterion::black_box(data_array))
-        .unwrap();
+fn bench_filter_f32(data_array: &Float32Array, filter_array: &BooleanArray) {
+    criterion::black_box(filter(data_array, filter_array).unwrap());
 }
 
-fn bench_filter_context_f32(data_array: &Float32Array, filter_context: &FilterContext) {
-    filter_context
-        .filter(criterion::black_box(data_array))
-        .unwrap();
+fn bench_filter_context<T: Array>(data_array: &T, filter_context: &FilterContext) {
+    criterion::black_box(filter_context.filter(data_array).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
-    let filter_array = create_bool_array(size, |i| matches!(i % 2, 0));
-    let sparse_filter_array = create_bool_array(size, |i| matches!(i % 8000, 0));
-    let dense_filter_array = create_bool_array(size, |i| !matches!(i % 8000, 0));
+    let filter_array = create_bool_array(size, 0.5);
+    let dense_filter_array = create_bool_array(size, 1.0 - 1.0 / 1024.0);
+    let sparse_filter_array = create_bool_array(size, 1.0 / 1024.0);
 
     let filter_context = FilterContext::new(&filter_array).unwrap();
-    let sparse_filter_context = FilterContext::new(&sparse_filter_array).unwrap();
     let dense_filter_context = FilterContext::new(&dense_filter_array).unwrap();
+    let sparse_filter_context = FilterContext::new(&sparse_filter_array).unwrap();
 
-    let data_array = create_primitive_array(size, |i| match i % 2 {
-        0 => 1,
-        _ => 0,
-    });
-    c.bench_function("filter u8 low selectivity", |b| {
+    let data_array = create_primitive_array(size, 0.0);
+    c.bench_function("filter u8", |b| {
         b.iter(|| bench_filter_u8(&data_array, &filter_array))
     });
     c.bench_function("filter u8 high selectivity", |b| {
-        b.iter(|| bench_filter_u8(&data_array, &sparse_filter_array))
-    });
-    c.bench_function("filter u8 very low selectivity", |b| {
         b.iter(|| bench_filter_u8(&data_array, &dense_filter_array))
     });
+    c.bench_function("filter u8 low selectivity", |b| {
+        b.iter(|| bench_filter_u8(&data_array, &sparse_filter_array))
+    });
 
-    c.bench_function("filter context u8 low selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &filter_context))
+    c.bench_function("filter context u8", |b| {
+        b.iter(|| bench_filter_context(&data_array, &filter_context))
     });
     c.bench_function("filter context u8 high selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &sparse_filter_context))
+        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
     });
-    c.bench_function("filter context u8 very low selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &dense_filter_context))
+    c.bench_function("filter context u8 low selectivity", |b| {
+        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
     });
 
-    let data_array = create_u8_array_with_nulls(size);
-    c.bench_function("filter context u8 w NULLs low selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &filter_context))
+    let data_array = create_primitive_array::<UInt8Type>(size, 0.5);
+    c.bench_function("filter context u8 w NULLs", |b| {
+        b.iter(|| bench_filter_context(&data_array, &filter_context))
     });
     c.bench_function("filter context u8 w NULLs high selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &sparse_filter_context))
+        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
     });
-    c.bench_function("filter context u8 w NULLs very low selectivity", |b| {
-        b.iter(|| bench_filter_context_u8(&data_array, &dense_filter_context))
+    c.bench_function("filter context u8 w NULLs low selectivity", |b| {
+        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
     });
 
-    let data_array = create_primitive_array(size, |i| match i % 2 {
-        0 => 1.0,
-        _ => 0.0,
+    let data_array = create_primitive_array::<Float32Type>(size, 0.5);
+    c.bench_function("filter f32", |b| {
+        b.iter(|| bench_filter_f32(&data_array, &filter_array))
     });
-    c.bench_function("filter context f32 low selectivity", |b| {
-        b.iter(|| bench_filter_context_f32(&data_array, &filter_context))
+    c.bench_function("filter context f32", |b| {
+        b.iter(|| bench_filter_context(&data_array, &filter_context))
     });
     c.bench_function("filter context f32 high selectivity", |b| {
-        b.iter(|| bench_filter_context_f32(&data_array, &sparse_filter_context))
+        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
     });
-    c.bench_function("filter context f32 very low selectivity", |b| {
-        b.iter(|| bench_filter_context_f32(&data_array, &dense_filter_context))
+    c.bench_function("filter context f32 low selectivity", |b| {
+        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
+    });
+
+    let data_array = create_string_array(size, 0.5);
+    c.bench_function("filter context string", |b| {
+        b.iter(|| bench_filter_context(&data_array, &filter_context))
+    });
+    c.bench_function("filter context string high selectivity", |b| {
+        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
+    });
+    c.bench_function("filter context string low selectivity", |b| {
+        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
     });
 }
 

--- a/rust/arrow/benches/filter_kernels.rs
+++ b/rust/arrow/benches/filter_kernels.rs
@@ -16,7 +16,7 @@
 // under the License.
 extern crate arrow;
 
-use arrow::util::test_util::seedable_rng;
+use arrow::{compute::Filter, util::test_util::seedable_rng};
 use rand::{
     distributions::{Alphanumeric, Standard},
     prelude::Distribution,
@@ -24,7 +24,7 @@ use rand::{
 };
 
 use arrow::array::*;
-use arrow::compute::{filter, FilterContext};
+use arrow::compute::{build_filter, filter};
 use arrow::datatypes::ArrowNumericType;
 use arrow::datatypes::{Float32Type, UInt8Type};
 
@@ -78,16 +78,12 @@ fn create_bool_array(size: usize, trues_density: f32) -> BooleanArray {
     builder.finish()
 }
 
-fn bench_filter_u8(data_array: &UInt8Array, filter_array: &BooleanArray) {
+fn bench_filter(data_array: &dyn Array, filter_array: &BooleanArray) {
     criterion::black_box(filter(data_array, filter_array).unwrap());
 }
 
-fn bench_filter_f32(data_array: &Float32Array, filter_array: &BooleanArray) {
-    criterion::black_box(filter(data_array, filter_array).unwrap());
-}
-
-fn bench_filter_context<T: Array>(data_array: &T, filter_context: &FilterContext) {
-    criterion::black_box(filter_context.filter(data_array).unwrap());
+fn bench_built_filter<'a>(filter: &Filter<'a>, data: &impl Array) {
+    criterion::black_box(filter(&data.data()));
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -96,65 +92,66 @@ fn add_benchmark(c: &mut Criterion) {
     let dense_filter_array = create_bool_array(size, 1.0 - 1.0 / 1024.0);
     let sparse_filter_array = create_bool_array(size, 1.0 / 1024.0);
 
-    let filter_context = FilterContext::new(&filter_array).unwrap();
-    let dense_filter_context = FilterContext::new(&dense_filter_array).unwrap();
-    let sparse_filter_context = FilterContext::new(&sparse_filter_array).unwrap();
+    let filter = build_filter(&filter_array).unwrap();
+    let dense_filter = build_filter(&dense_filter_array).unwrap();
+    let sparse_filter = build_filter(&sparse_filter_array).unwrap();
 
-    let data_array = create_primitive_array(size, 0.0);
+    let data_array = create_primitive_array::<UInt8Type>(size, 0.0);
+
     c.bench_function("filter u8", |b| {
-        b.iter(|| bench_filter_u8(&data_array, &filter_array))
+        b.iter(|| bench_filter(&data_array, &filter_array))
     });
     c.bench_function("filter u8 high selectivity", |b| {
-        b.iter(|| bench_filter_u8(&data_array, &dense_filter_array))
+        b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
     c.bench_function("filter u8 low selectivity", |b| {
-        b.iter(|| bench_filter_u8(&data_array, &sparse_filter_array))
+        b.iter(|| bench_filter(&data_array, &sparse_filter_array))
     });
 
     c.bench_function("filter context u8", |b| {
-        b.iter(|| bench_filter_context(&data_array, &filter_context))
+        b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function("filter context u8 high selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
     c.bench_function("filter context u8 low selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<UInt8Type>(size, 0.5);
     c.bench_function("filter context u8 w NULLs", |b| {
-        b.iter(|| bench_filter_context(&data_array, &filter_context))
+        b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function("filter context u8 w NULLs high selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
     c.bench_function("filter context u8 w NULLs low selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_primitive_array::<Float32Type>(size, 0.5);
     c.bench_function("filter f32", |b| {
-        b.iter(|| bench_filter_f32(&data_array, &filter_array))
+        b.iter(|| bench_filter(&data_array, &filter_array))
     });
     c.bench_function("filter context f32", |b| {
-        b.iter(|| bench_filter_context(&data_array, &filter_context))
+        b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function("filter context f32 high selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
     c.bench_function("filter context f32 low selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
     let data_array = create_string_array(size, 0.5);
     c.bench_function("filter context string", |b| {
-        b.iter(|| bench_filter_context(&data_array, &filter_context))
+        b.iter(|| bench_built_filter(&filter, &data_array))
     });
     c.bench_function("filter context string high selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &dense_filter_context))
+        b.iter(|| bench_built_filter(&dense_filter, &data_array))
     });
     c.bench_function("filter context string low selectivity", |b| {
-        b.iter(|| bench_filter_context(&data_array, &sparse_filter_context))
+        b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 }
 

--- a/rust/arrow/benches/mutable_array.rs
+++ b/rust/arrow/benches/mutable_array.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::util::test_util::seedable_rng;
+
+fn create_strings(size: usize, null_density: f32) -> ArrayRef {
+    let rng = &mut seedable_rng();
+
+    let mut builder = StringBuilder::new(size);
+    for _ in 0..size {
+        let x = rng.gen::<f32>();
+        if x < null_density {
+            let value = rng.sample_iter(&Alphanumeric).take(4).collect::<String>();
+            builder.append_value(&value).unwrap();
+        } else {
+            builder.append_null().unwrap()
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn create_slices(size: usize) -> Vec<(usize, usize)> {
+    let rng = &mut seedable_rng();
+
+    (0..size)
+        .map(|_| {
+            let start = rng.gen_range(0, size / 2);
+            let end = rng.gen_range(start + 1, size);
+            (start, end)
+        })
+        .collect()
+}
+
+fn bench(v1: &ArrayRef, slices: &[(usize, usize)]) {
+    let mut mutable = MutableArrayData::new(vec![v1.data_ref()], false, 5);
+    for (start, end) in slices {
+        mutable.extend(0, *start, *end)
+    }
+    mutable.freeze();
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let v1 = create_strings(1024, 0.0);
+    let v2 = create_slices(1024);
+    c.bench_function("mutable str 1024", |b| b.iter(|| bench(&v1, &v2)));
+
+    let v1 = create_strings(1024, 0.5);
+    let v2 = create_slices(1024);
+    c.bench_function("mutable str nulls 1024", |b| b.iter(|| bench(&v1, &v2)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/array/transform/boolean.rs
+++ b/rust/arrow/src/array/transform/boolean.rs
@@ -26,7 +26,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
     let values = array.buffers()[0].data();
     Box::new(
         move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
-            let buffer = &mut mutable.buffers[0];
+            let buffer = &mut mutable.buffer1;
             reserve_for_bits(buffer, mutable.len + len);
             set_bits(
                 &mut buffer.data_mut(),
@@ -40,6 +40,6 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
 }
 
 pub(super) fn extend_nulls(mutable: &mut _MutableArrayData, len: usize) {
-    let buffer = &mut mutable.buffers[0];
+    let buffer = &mut mutable.buffer1;
     reserve_for_bits(buffer, mutable.len + len);
 }

--- a/rust/arrow/src/array/transform/fixed_binary.rs
+++ b/rust/arrow/src/array/transform/fixed_binary.rs
@@ -30,7 +30,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
         // fast case where we can copy regions without null issues
         Box::new(
             move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
-                let buffer = &mut mutable.buffers[0];
+                let buffer = &mut mutable.buffer1;
                 buffer.extend_from_slice(&values[start * size..(start + len) * size]);
             },
         )
@@ -38,7 +38,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
         Box::new(
             move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
                 // nulls present: append item by item, ignoring null entries
-                let values_buffer = &mut mutable.buffers[0];
+                let values_buffer = &mut mutable.buffer1;
 
                 (start..start + len).for_each(|i| {
                     if array.is_valid(i) {
@@ -60,6 +60,6 @@ pub(super) fn extend_nulls(mutable: &mut _MutableArrayData, len: usize) {
         _ => unreachable!(),
     };
 
-    let values_buffer = &mut mutable.buffers[0];
+    let values_buffer = &mut mutable.buffer1;
     values_buffer.extend(len * size);
 }

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -46,16 +46,21 @@ struct _MutableArrayData<'a> {
     pub len: usize,
     pub null_buffer: MutableBuffer,
 
-    pub buffers: Vec<MutableBuffer>,
+    pub buffer1: MutableBuffer,
+    pub buffer2: MutableBuffer,
     pub child_data: Vec<MutableArrayData<'a>>,
 }
 
 impl<'a> _MutableArrayData<'a> {
     fn freeze(self, dictionary: Option<ArrayDataRef>) -> ArrayData {
-        let mut buffers = Vec::with_capacity(self.buffers.len());
-        for buffer in self.buffers {
-            buffers.push(buffer.freeze());
-        }
+        let buffers = match self.data_type {
+            DataType::Struct(_) => vec![],
+            DataType::Utf8
+            | DataType::Binary
+            | DataType::LargeUtf8
+            | DataType::LargeBinary => vec![self.buffer1.freeze(), self.buffer2.freeze()],
+            _ => vec![self.buffer1.freeze()],
+        };
 
         let child_data = match self.data_type {
             DataType::Dictionary(_, _) => vec![dictionary.unwrap()],
@@ -80,18 +85,6 @@ impl<'a> _MutableArrayData<'a> {
             buffers,
             child_data,
         )
-    }
-
-    /// Returns the buffer `buffer` as a slice of type `T`. When the expected buffer is bit-packed,
-    /// the slice is not offset.
-    #[inline]
-    pub(super) fn buffer<T>(&self, buffer: usize) -> &[T] {
-        let values = unsafe { self.buffers[buffer].data().align_to::<T>() };
-        if !values.0.is_empty() || !values.2.is_empty() {
-            // this is unreachable because
-            unreachable!("The buffer is not byte-aligned with its interpretation")
-        };
-        &values.1
     }
 }
 
@@ -225,7 +218,6 @@ fn build_extend(array: &ArrayData) -> Extend {
         /*
         DataType::Null => {}
         DataType::FixedSizeList(_, _) => {}
-        DataType::Struct(_) => {}
         DataType::Union(_) => {}
         */
         _ => todo!("Take and filter operations still not supported for this datatype"),
@@ -298,79 +290,137 @@ impl<'a> MutableArrayData<'a> {
             use_nulls = true;
         };
 
-        let buffers = match &data_type {
+        let empty_buffer = MutableBuffer::new(0);
+        let buffers: [MutableBuffer; 2] = match &data_type {
             DataType::Boolean => {
                 let bytes = bit_util::ceil(capacity, 8);
                 let buffer = MutableBuffer::new(bytes).with_bitset(bytes, false);
-                vec![buffer]
+                [buffer, empty_buffer]
             }
-            DataType::UInt8 => vec![MutableBuffer::new(capacity * size_of::<u8>())],
-            DataType::UInt16 => vec![MutableBuffer::new(capacity * size_of::<u16>())],
-            DataType::UInt32 => vec![MutableBuffer::new(capacity * size_of::<u32>())],
-            DataType::UInt64 => vec![MutableBuffer::new(capacity * size_of::<u64>())],
-            DataType::Int8 => vec![MutableBuffer::new(capacity * size_of::<i8>())],
-            DataType::Int16 => vec![MutableBuffer::new(capacity * size_of::<i16>())],
-            DataType::Int32 => vec![MutableBuffer::new(capacity * size_of::<i32>())],
-            DataType::Int64 => vec![MutableBuffer::new(capacity * size_of::<i64>())],
-            DataType::Float32 => vec![MutableBuffer::new(capacity * size_of::<f32>())],
-            DataType::Float64 => vec![MutableBuffer::new(capacity * size_of::<f64>())],
-            DataType::Date32(_) | DataType::Time32(_) => {
-                vec![MutableBuffer::new(capacity * size_of::<i32>())]
+            DataType::UInt8 => {
+                [MutableBuffer::new(capacity * size_of::<u8>()), empty_buffer]
             }
+            DataType::UInt16 => [
+                MutableBuffer::new(capacity * size_of::<u16>()),
+                empty_buffer,
+            ],
+            DataType::UInt32 => [
+                MutableBuffer::new(capacity * size_of::<u32>()),
+                empty_buffer,
+            ],
+            DataType::UInt64 => [
+                MutableBuffer::new(capacity * size_of::<u64>()),
+                empty_buffer,
+            ],
+            DataType::Int8 => {
+                [MutableBuffer::new(capacity * size_of::<i8>()), empty_buffer]
+            }
+            DataType::Int16 => [
+                MutableBuffer::new(capacity * size_of::<i16>()),
+                empty_buffer,
+            ],
+            DataType::Int32 => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
+            DataType::Int64 => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
+            DataType::Float32 => [
+                MutableBuffer::new(capacity * size_of::<f32>()),
+                empty_buffer,
+            ],
+            DataType::Float64 => [
+                MutableBuffer::new(capacity * size_of::<f64>()),
+                empty_buffer,
+            ],
+            DataType::Date32(_) | DataType::Time32(_) => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
             DataType::Date64(_)
             | DataType::Time64(_)
             | DataType::Duration(_)
-            | DataType::Timestamp(_, _) => {
-                vec![MutableBuffer::new(capacity * size_of::<i64>())]
-            }
-            DataType::Interval(IntervalUnit::YearMonth) => {
-                vec![MutableBuffer::new(capacity * size_of::<i32>())]
-            }
-            DataType::Interval(IntervalUnit::DayTime) => {
-                vec![MutableBuffer::new(capacity * size_of::<i64>())]
-            }
+            | DataType::Timestamp(_, _) => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
+            DataType::Interval(IntervalUnit::YearMonth) => [
+                MutableBuffer::new(capacity * size_of::<i32>()),
+                empty_buffer,
+            ],
+            DataType::Interval(IntervalUnit::DayTime) => [
+                MutableBuffer::new(capacity * size_of::<i64>()),
+                empty_buffer,
+            ],
             DataType::Utf8 | DataType::Binary => {
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i32>());
+                // safety: `unsafe` code assumes that this buffer is initialized with one element
                 buffer.extend_from_slice(&[0i32].to_byte_slice());
-                vec![buffer, MutableBuffer::new(capacity * size_of::<u8>())]
+                [buffer, MutableBuffer::new(capacity * size_of::<u8>())]
             }
             DataType::LargeUtf8 | DataType::LargeBinary => {
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i64>());
+                // safety: `unsafe` code assumes that this buffer is initialized with one element
                 buffer.extend_from_slice(&[0i64].to_byte_slice());
-                vec![buffer, MutableBuffer::new(capacity * size_of::<u8>())]
+                [buffer, MutableBuffer::new(capacity * size_of::<u8>())]
             }
             DataType::List(_) => {
                 // offset buffer always starts with a zero
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i32>());
                 buffer.extend_from_slice(0i32.to_byte_slice());
-                vec![buffer]
+                [buffer, empty_buffer]
             }
             DataType::LargeList(_) => {
                 // offset buffer always starts with a zero
                 let mut buffer = MutableBuffer::new((1 + capacity) * size_of::<i64>());
                 buffer.extend_from_slice(&[0i64].to_byte_slice());
-                vec![buffer]
+                [buffer, empty_buffer]
             }
             DataType::FixedSizeBinary(size) => {
-                vec![MutableBuffer::new(capacity * *size as usize)]
+                [MutableBuffer::new(capacity * *size as usize), empty_buffer]
             }
             DataType::Dictionary(child_data_type, _) => match child_data_type.as_ref() {
-                DataType::UInt8 => vec![MutableBuffer::new(capacity * size_of::<u8>())],
-                DataType::UInt16 => vec![MutableBuffer::new(capacity * size_of::<u16>())],
-                DataType::UInt32 => vec![MutableBuffer::new(capacity * size_of::<u32>())],
-                DataType::UInt64 => vec![MutableBuffer::new(capacity * size_of::<u64>())],
-                DataType::Int8 => vec![MutableBuffer::new(capacity * size_of::<i8>())],
-                DataType::Int16 => vec![MutableBuffer::new(capacity * size_of::<i16>())],
-                DataType::Int32 => vec![MutableBuffer::new(capacity * size_of::<i32>())],
-                DataType::Int64 => vec![MutableBuffer::new(capacity * size_of::<i64>())],
+                DataType::UInt8 => {
+                    [MutableBuffer::new(capacity * size_of::<u8>()), empty_buffer]
+                }
+                DataType::UInt16 => [
+                    MutableBuffer::new(capacity * size_of::<u16>()),
+                    empty_buffer,
+                ],
+                DataType::UInt32 => [
+                    MutableBuffer::new(capacity * size_of::<u32>()),
+                    empty_buffer,
+                ],
+                DataType::UInt64 => [
+                    MutableBuffer::new(capacity * size_of::<u64>()),
+                    empty_buffer,
+                ],
+                DataType::Int8 => {
+                    [MutableBuffer::new(capacity * size_of::<i8>()), empty_buffer]
+                }
+                DataType::Int16 => [
+                    MutableBuffer::new(capacity * size_of::<i16>()),
+                    empty_buffer,
+                ],
+                DataType::Int32 => [
+                    MutableBuffer::new(capacity * size_of::<i32>()),
+                    empty_buffer,
+                ],
+                DataType::Int64 => [
+                    MutableBuffer::new(capacity * size_of::<i64>()),
+                    empty_buffer,
+                ],
                 _ => unreachable!(),
             },
             DataType::Float16 => unreachable!(),
-            DataType::Struct(_) => vec![],
+            DataType::Struct(_) => [empty_buffer, MutableBuffer::new(0)],
             _ => {
                 todo!("Take and filter operations still not supported for this datatype")
             }
         };
+        let [buffer1, buffer2] = buffers;
 
         let child_data = match &data_type {
             DataType::Null
@@ -443,7 +493,8 @@ impl<'a> MutableArrayData<'a> {
             len: 0,
             null_count: 0,
             null_buffer,
-            buffers,
+            buffer1,
+            buffer2,
             child_data,
         };
         Self {

--- a/rust/arrow/src/array/transform/primitive.rs
+++ b/rust/arrow/src/array/transform/primitive.rs
@@ -28,8 +28,7 @@ pub(super) fn build_extend<T: ArrowNativeType>(array: &ArrayData) -> Extend {
             let start = start * size_of::<T>();
             let len = len * size_of::<T>();
             let bytes = &values[start..start + len];
-            let buffer = &mut mutable.buffers[0];
-            buffer.extend_from_slice(bytes);
+            mutable.buffer1.extend_from_slice(bytes);
         },
     )
 }
@@ -38,7 +37,5 @@ pub(super) fn extend_nulls<T: ArrowNativeType>(
     mutable: &mut _MutableArrayData,
     len: usize,
 ) {
-    let buffer = &mut mutable.buffers[0];
-    let bytes = vec![0u8; len * size_of::<T>()];
-    buffer.extend_from_slice(&bytes);
+    mutable.buffer1.extend(len * size_of::<T>());
 }

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -73,6 +73,6 @@ pub(super) unsafe fn get_last_offset<T: OffsetSizeTrait>(
     //      * offset buffer is always extended in slices of T and aligned accordingly.
     //      * Buffer[0] is initialized with one element, 0, and thus `mutable_offsets.len() - 1` is always valid.
     let (prefix, offsets, suffix) = offset_buffer.data().align_to::<T>();
-    debug_assert!(prefix.len() == 0 && suffix.len() == 0);
+    debug_assert!(prefix.is_empty() && suffix.is_empty());
     *offsets.get_unchecked(offsets.len() - 1)
 }

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -61,3 +61,17 @@ pub(super) fn extend_offsets<T: OffsetSizeTrait>(
         buffer.extend_from_slice(last_offset.to_byte_slice());
     });
 }
+
+#[inline]
+pub(super) unsafe fn get_last_offset<T: OffsetSizeTrait>(
+    offset_buffer: &MutableBuffer,
+) -> T {
+    // JUSTIFICATION
+    //  Benefit
+    //      20% performance improvement extend of variable sized arrays (see bench `mutable_array`)
+    //  Soundness
+    //      * offset buffer is always extended in slices of T and aligned accordingly.
+    //      * Buffer[0] is initialized with one element, 0, and thus `mutable_offsets.len() - 1` is always valid.
+    let offsets = offset_buffer.data().align_to::<T>().1;
+    *offsets.get_unchecked(offsets.len() - 1)
+}

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -72,6 +72,7 @@ pub(super) unsafe fn get_last_offset<T: OffsetSizeTrait>(
     //  Soundness
     //      * offset buffer is always extended in slices of T and aligned accordingly.
     //      * Buffer[0] is initialized with one element, 0, and thus `mutable_offsets.len() - 1` is always valid.
-    let offsets = offset_buffer.data().align_to::<T>().1;
+    let (prefix, offsets, suffix) = offset_buffer.data().align_to::<T>();
+    debug_assert!(prefix.len() == 0 && suffix.len() == 0);
     *offsets.get_unchecked(offsets.len() - 1)
 }

--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -72,9 +72,8 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                 let mut last_offset: T = unsafe { get_last_offset(offset_buffer) };
 
                 // nulls present: append item by item, ignoring null entries
-                offset_buffer.reserve(
-                    offset_buffer.len() + len * std::mem::size_of::<T>(),
-                );
+                offset_buffer
+                    .reserve(offset_buffer.len() + len * std::mem::size_of::<T>());
 
                 (start..start + len).for_each(|i| {
                     if array.is_valid(i) {

--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -21,8 +21,12 @@ use crate::{
     datatypes::ToByteSlice,
 };
 
-use super::{Extend, _MutableArrayData, utils::extend_offsets};
+use super::{
+    Extend, _MutableArrayData,
+    utils::{extend_offsets, get_last_offset},
+};
 
+#[inline]
 fn extend_offset_values<T: OffsetSizeTrait>(
     buffer: &mut MutableBuffer,
     offsets: &[T],
@@ -43,32 +47,33 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
         // fast case where we can copy regions without null issues
         Box::new(
             move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
-                let mutable_offsets = mutable.buffer::<T>(0);
-                let last_offset = mutable_offsets[mutable_offsets.len() - 1];
-                // offsets
-                let buffer = &mut mutable.buffers[0];
+                let offset_buffer = &mut mutable.buffer1;
+                let values_buffer = &mut mutable.buffer2;
+
+                // this is safe due to how offset is built. See details on `get_last_offset`
+                let last_offset = unsafe { get_last_offset(offset_buffer) };
+
                 extend_offsets::<T>(
-                    buffer,
+                    offset_buffer,
                     last_offset,
                     &offsets[start..start + len + 1],
                 );
                 // values
-                let buffer = &mut mutable.buffers[1];
-                extend_offset_values::<T>(buffer, offsets, values, start, len);
+                extend_offset_values::<T>(values_buffer, offsets, values, start, len);
             },
         )
     } else {
         Box::new(
             move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
-                let mutable_offsets = mutable.buffer::<T>(0);
-                let mut last_offset = mutable_offsets[mutable_offsets.len() - 1];
+                let offset_buffer = &mut mutable.buffer1;
+                let values_buffer = &mut mutable.buffer2;
+
+                // this is safe due to how offset is built. See details on `get_last_offset`
+                let mut last_offset: T = unsafe { get_last_offset(offset_buffer) };
 
                 // nulls present: append item by item, ignoring null entries
-                let (offset_buffer, values_buffer) = mutable.buffers.split_at_mut(1);
-                let offset_buffer = &mut offset_buffer[0];
-                let values_buffer = &mut values_buffer[0];
                 offset_buffer.reserve(
-                    offset_buffer.len() + array.len() * std::mem::size_of::<T>(),
+                    offset_buffer.len() + len * std::mem::size_of::<T>(),
                 );
 
                 (start..start + len).for_each(|i| {
@@ -96,10 +101,10 @@ pub(super) fn extend_nulls<T: OffsetSizeTrait>(
     mutable: &mut _MutableArrayData,
     len: usize,
 ) {
-    let mutable_offsets = mutable.buffer::<T>(0);
-    let last_offset = mutable_offsets[mutable_offsets.len() - 1];
+    let offset_buffer = &mut mutable.buffer1;
 
-    let offset_buffer = &mut mutable.buffers[0];
+    // this is safe due to how offset is built. See details on `get_last_offset`
+    let last_offset: T = unsafe { get_last_offset(offset_buffer) };
 
     let offsets = vec![last_offset; len];
     offset_buffer.extend_from_slice(offsets.to_byte_slice());

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -183,7 +183,7 @@ impl Buffer {
     /// in larger chunks and starting at arbitrary bit offsets.
     /// Note that both `offset` and `length` are measured in bits.
     pub fn bit_chunks(&self, offset: usize, len: usize) -> BitChunks {
-        BitChunks::new(&self, offset, len)
+        BitChunks::new(&self.data.as_slice()[self.offset..], offset, len)
     }
 
     /// Returns the number of 1-bits in this buffer.

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -204,6 +204,20 @@ pub fn build_filter(filter: &BooleanArray) -> Result<Filter> {
 /// Filters an [Array], returning elements matching the filter (i.e. where the values are true).
 /// WARNING: the nulls of `filter` are ignored and the value on its slot is considered.
 /// Therefore, it is considered undefined behavior to pass `filter` with null values.
+/// # Example
+/// ```rust
+/// # use arrow::array::{Int32Array, BooleanArray};
+/// # use arrow::error::Result;
+/// # use arrow::compute::kernels::filter::filter;
+/// # fn main() -> Result<()> {
+/// let array = Int32Array::from(vec![5, 6, 7, 8, 9]);
+/// let filter_array = BooleanArray::from(vec![true, false, false, true, false]);
+/// let c = filter(&array, &filter_array)?;
+/// let c = c.as_any().downcast_ref::<Int32Array>().unwrap();
+/// assert_eq!(c, &Int32Array::from(vec![5, 8]));
+/// # Ok(())
+/// # }
+/// ```
 pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
     let iter = SlicesIterator::new(filter);
 
@@ -324,17 +338,6 @@ mod tests {
         TimestampNanosecondArray,
         TimestampNanosecondArray::from_vec(vec![1, 2, 3, 4], None)
     );
-
-    #[test]
-    fn test_filter_array() {
-        let a = Int32Array::from(vec![5, 6, 7, 8, 9]);
-        let b = BooleanArray::from(vec![true, false, false, true, false]);
-        let c = filter(&a, &b).unwrap();
-        let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
-        assert_eq!(2, d.len());
-        assert_eq!(5, d.value(0));
-        assert_eq!(8, d.value(1));
-    }
 
     #[test]
     fn test_filter_array_slice() {

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -572,14 +572,14 @@ mod tests {
 
     #[test]
     fn test_slice_iterator_chunk_and_bits() {
-        let filter_values = (0..127).map(|i| i % 62 != 0).collect::<Vec<bool>>();
+        let filter_values = (0..130).map(|i| i % 62 != 0).collect::<Vec<bool>>();
         let filter = BooleanArray::from(filter_values);
 
         let iter = SlicesIterator::new(&filter);
         let filter_count = iter.filter_count;
         let chunks = iter.collect::<Vec<_>>();
 
-        assert_eq!(chunks, vec![(1, 62), (63, 124), (125, 127)]);
-        assert_eq!(filter_count, 61 + 61 + 2);
+        assert_eq!(chunks, vec![(1, 62), (63, 124), (125, 130)]);
+        assert_eq!(filter_count, 61 + 61 + 5);
     }
 }

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -18,840 +18,131 @@
 //! Defines miscellaneous array kernels.
 
 use crate::array::*;
-use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::Result;
 use crate::record_batch::RecordBatch;
-use crate::{
-    bitmap::Bitmap,
-    buffer::{Buffer, MutableBuffer},
-    util::bit_util,
-};
-use std::{mem, sync::Arc};
+use std::sync::Arc;
 
-/// trait for copying filtered null bitmap bits
-trait CopyNullBit {
-    fn copy_null_bit(&mut self, source_index: usize);
-    fn copy_null_bits(&mut self, source_index: usize, count: usize);
-    fn null_count(&self) -> usize;
-    fn null_buffer(&mut self) -> Buffer;
-}
+/// Function that can filter arbitrary arrays
+pub type Filter<'a> = Box<Fn(&ArrayData) -> ArrayData + 'a>;
 
-/// no-op null bitmap copy implementation,
-/// used when the filtered data array doesn't have a null bitmap
-struct NullBitNoop {}
+/// Returns a vector of slices `(start, end)` denoting the slices to be taken
+/// from an array when `filter` is applied.
+/// Note that this disregards the nullability of `filter`.
+fn compute_slices(filter: &BooleanArray) -> (Vec<(usize, usize)>, usize) {
+    let mut slices = Vec::with_capacity(filter.len());
+    let mut filter_count = 0; // the number of selected slots.
+    let mut len = 0; // the len of the current region of selection
+    let mut start = 0; // the start of the current region of selection
+    let mut on_region = false; // whether it currently is in a region of selection
+    let mut chunks = 0; // current number of chunks
+    let all_ones = !0u64;
 
-impl NullBitNoop {
-    fn new() -> Self {
-        NullBitNoop {}
-    }
-}
-
-impl CopyNullBit for NullBitNoop {
-    #[inline]
-    fn copy_null_bit(&mut self, _source_index: usize) {
-        // do nothing
-    }
-
-    #[inline]
-    fn copy_null_bits(&mut self, _source_index: usize, _count: usize) {
-        // do nothing
-    }
-
-    fn null_count(&self) -> usize {
-        0
-    }
-
-    fn null_buffer(&mut self) -> Buffer {
-        Buffer::from([0u8; 0])
-    }
-}
-
-/// null bitmap copy implementation,
-/// used when the filtered data array has a null bitmap
-struct NullBitSetter<'a> {
-    target_buffer: MutableBuffer,
-    source_bytes: &'a [u8],
-    target_index: usize,
-    null_count: usize,
-}
-
-impl<'a> NullBitSetter<'a> {
-    fn new(null_bitmap: &'a Bitmap) -> Self {
-        let null_bytes = null_bitmap.buffer_ref().data();
-        // create null bitmap buffer with same length and initialize null bitmap buffer to 1s
-        let null_buffer =
-            MutableBuffer::new(null_bytes.len()).with_bitset(null_bytes.len(), true);
-        NullBitSetter {
-            source_bytes: null_bytes,
-            target_buffer: null_buffer,
-            target_index: 0,
-            null_count: 0,
-        }
-    }
-}
-
-impl<'a> CopyNullBit for NullBitSetter<'a> {
-    #[inline]
-    fn copy_null_bit(&mut self, source_index: usize) {
-        if !bit_util::get_bit(self.source_bytes, source_index) {
-            bit_util::unset_bit(self.target_buffer.data_mut(), self.target_index);
-            self.null_count += 1;
-        }
-        self.target_index += 1;
-    }
-
-    #[inline]
-    fn copy_null_bits(&mut self, source_index: usize, count: usize) {
-        for i in 0..count {
-            self.copy_null_bit(source_index + i);
-        }
-    }
-
-    fn null_count(&self) -> usize {
-        self.null_count
-    }
-
-    fn null_buffer(&mut self) -> Buffer {
-        self.target_buffer.resize(self.target_index);
-        // use mem::replace to detach self.target_buffer from self so that it can be returned
-        let target_buffer = mem::replace(&mut self.target_buffer, MutableBuffer::new(0));
-        target_buffer.freeze()
-    }
-}
-
-fn get_null_bit_setter<'a>(data_array: &'a impl Array) -> Box<CopyNullBit + 'a> {
-    if let Some(null_bitmap) = data_array.data_ref().null_bitmap() {
-        // only return an actual null bit copy implementation if null_bitmap is set
-        Box::new(NullBitSetter::new(null_bitmap))
-    } else {
-        // otherwise return a no-op copy null bit implementation
-        // for improved performance when the filtered array doesn't contain NULLs
-        Box::new(NullBitNoop::new())
-    }
-}
-
-// transmute filter array to u64
-// - optimize filtering with highly selective filters by skipping entire batches of 64 filter bits
-// - if the data array being filtered doesn't have a null bitmap, no time is wasted to copy a null bitmap
-fn filter_array_impl(
-    filter_context: &FilterContext,
-    data_array: &impl Array,
-    array_type: DataType,
-    value_size: usize,
-) -> Result<ArrayDataBuilder> {
-    if filter_context.filter_len > data_array.len() {
-        return Err(ArrowError::ComputeError(
-            "Filter array cannot be larger than data array".to_string(),
-        ));
-    }
-    let filtered_count = filter_context.filtered_count;
-    let filter_mask = &filter_context.filter_mask;
-    let filter_u64 = &filter_context.filter_u64;
-    let data_bytes = data_array.data_ref().buffers()[0].data();
-    let mut target_buffer = MutableBuffer::new(filtered_count * value_size);
-    target_buffer.resize(filtered_count * value_size);
-    let target_bytes = target_buffer.data_mut();
-    let mut target_byte_index: usize = 0;
-    let mut null_bit_setter = get_null_bit_setter(data_array);
-    let null_bit_setter = null_bit_setter.as_mut();
-    let all_ones_batch = !0u64;
-    let data_array_offset = data_array.offset();
-
-    for (i, filter_batch) in filter_u64.iter().enumerate() {
-        // foreach u64 batch
-        let filter_batch = *filter_batch;
-        if filter_batch == 0 {
-            // if batch == 0, all items are filtered out, so skip entire batch
-            continue;
-        } else if filter_batch == all_ones_batch {
-            // if batch == all 1s: copy all 64 values in one go
-            let data_index = (i * 64) + data_array_offset;
-            null_bit_setter.copy_null_bits(data_index, 64);
-            let data_byte_index = data_index * value_size;
-            let data_len = value_size * 64;
-            target_bytes[target_byte_index..(target_byte_index + data_len)]
-                .copy_from_slice(
-                    &data_bytes[data_byte_index..(data_byte_index + data_len)],
-                );
-            target_byte_index += data_len;
-            continue;
-        }
-        for (j, filter_mask) in filter_mask.iter().enumerate() {
-            // foreach bit in batch:
-            if (filter_batch & *filter_mask) != 0 {
-                let data_index = (i * 64) + j + data_array_offset;
-                null_bit_setter.copy_null_bit(data_index);
-                // if filter bit == 1: copy data value bytes
-                let data_byte_index = data_index * value_size;
-                target_bytes[target_byte_index..(target_byte_index + value_size)]
-                    .copy_from_slice(
-                        &data_bytes[data_byte_index..(data_byte_index + value_size)],
-                    );
-                target_byte_index += value_size;
+    let buffer = filter.values();
+    // iterate in chunks of 64 bits
+    let bit_chunks = buffer.bit_chunks(filter.offset(), filter.len());
+    bit_chunks.iter().enumerate().for_each(|(i, mask)| {
+        chunks += 1;
+        if mask == 0 {
+            if on_region {
+                slices.push((start, start + len));
+                filter_count += len;
+                len = 0;
+                on_region = false;
             }
-        }
-    }
-
-    let mut array_data_builder = ArrayDataBuilder::new(array_type)
-        .len(filtered_count)
-        .add_buffer(target_buffer.freeze());
-    if null_bit_setter.null_count() > 0 {
-        array_data_builder = array_data_builder
-            .null_count(null_bit_setter.null_count())
-            .null_bit_buffer(null_bit_setter.null_buffer());
-    }
-
-    Ok(array_data_builder)
-}
-
-/// FilterContext can be used to improve performance when
-/// filtering multiple data arrays with the same filter array.
-#[derive(Debug)]
-pub struct FilterContext {
-    filter_u64: Vec<u64>,
-    filter_len: usize,
-    filtered_count: usize,
-    filter_mask: Vec<u64>,
-}
-
-macro_rules! filter_primitive_array {
-    ($context:expr, $array:expr, $array_type:ident) => {{
-        let input_array = $array.as_any().downcast_ref::<$array_type>().unwrap();
-        let output_array = $context.filter_primitive_array(input_array)?;
-        Ok(Arc::new(output_array))
-    }};
-}
-
-macro_rules! filter_dictionary_array {
-    ($context:expr, $array:expr, $array_type:ident) => {{
-        let input_array = $array.as_any().downcast_ref::<$array_type>().unwrap();
-        let output_array = $context.filter_dictionary_array(input_array)?;
-        Ok(Arc::new(output_array))
-    }};
-}
-
-macro_rules! filter_boolean_item_list_array {
-    ($context:expr, $array:expr, $list_type:ident, $list_builder_type:ident) => {{
-        let input_array = $array.as_any().downcast_ref::<$list_type>().unwrap();
-        let values_builder = BooleanBuilder::new($context.filtered_count);
-        let mut builder = $list_builder_type::new(values_builder);
-        for i in 0..$context.filter_u64.len() {
-            // foreach u64 batch
-            let filter_batch = $context.filter_u64[i];
-            if filter_batch == 0 {
-                // if batch == 0, all items are filtered out, so skip entire batch
-                continue;
+        } else if mask == all_ones {
+            if !on_region {
+                start = i * 64;
+                on_region = true;
             }
-            for j in 0..64 {
-                // foreach bit in batch:
-                if (filter_batch & $context.filter_mask[j]) != 0 {
-                    let data_index = (i * 64) + j;
-                    if input_array.is_null(data_index) {
-                        builder.append(false)?;
-                    } else {
-                        let this_inner_list = input_array.value(data_index);
-                        let inner_list = this_inner_list
-                            .as_any()
-                            .downcast_ref::<BooleanArray>()
-                            .unwrap();
-                        for k in 0..inner_list.len() {
-                            if inner_list.is_null(k) {
-                                builder.values().append_null()?;
-                            } else {
-                                builder.values().append_value(inner_list.value(k))?;
-                            }
-                        }
-                        builder.append(true)?;
+            len += 64;
+        } else {
+            (0..64).for_each(|j| {
+                if (mask & (1 << j)) != 0 {
+                    if !on_region {
+                        start = i * 64 + j;
+                        on_region = true;
                     }
+                    len += 1;
+                } else if on_region {
+                    slices.push((start, start + len));
+                    filter_count += len;
+                    len = 0;
+                    on_region = false;
                 }
-            }
+            })
         }
-        Ok(Arc::new(builder.finish()))
-    }};
+    });
+    let mask = bit_chunks.remainder_bits();
+
+    (0..bit_chunks.remainder_len()).for_each(|j| {
+        if (mask & (1 << j)) != 0 {
+            if !on_region {
+                start = chunks * 64 + j;
+                on_region = true;
+            }
+            len += 1;
+        } else if on_region {
+            slices.push((start, start + len));
+            filter_count += len;
+            len = 0;
+            on_region = false;
+        }
+    });
+    if on_region {
+        slices.push((start, start + len));
+        filter_count += len;
+    };
+    // invariant: filter_count is the sum of the lens of all slices
+    (slices, filter_count)
 }
 
-macro_rules! filter_primitive_item_list_array {
-    ($context:expr, $array:expr, $item_type:ident, $list_type:ident, $list_builder_type:ident) => {{
-        let input_array = $array.as_any().downcast_ref::<$list_type>().unwrap();
-        let values_builder = PrimitiveBuilder::<$item_type>::new($context.filtered_count);
-        let mut builder = $list_builder_type::new(values_builder);
-        for i in 0..$context.filter_u64.len() {
-            // foreach u64 batch
-            let filter_batch = $context.filter_u64[i];
-            if filter_batch == 0 {
-                // if batch == 0, all items are filtered out, so skip entire batch
-                continue;
-            }
-            for j in 0..64 {
-                // foreach bit in batch:
-                if (filter_batch & $context.filter_mask[j]) != 0 {
-                    let data_index = (i * 64) + j;
-                    if input_array.is_null(data_index) {
-                        builder.append(false)?;
-                    } else {
-                        let this_inner_list = input_array.value(data_index);
-                        let inner_list = this_inner_list
-                            .as_any()
-                            .downcast_ref::<PrimitiveArray<$item_type>>()
-                            .unwrap();
-                        for k in 0..inner_list.len() {
-                            if inner_list.is_null(k) {
-                                builder.values().append_null()?;
-                            } else {
-                                builder.values().append_value(inner_list.value(k))?;
-                            }
-                        }
-                        builder.append(true)?;
-                    }
-                }
-            }
-        }
-        Ok(Arc::new(builder.finish()))
-    }};
-}
-
-macro_rules! filter_non_primitive_item_list_array {
-    ($context:expr, $array:expr, $item_array_type:ident, $item_builder:ident, $list_type:ident, $list_builder_type:ident) => {{
-        let input_array = $array.as_any().downcast_ref::<$list_type>().unwrap();
-        let values_builder = $item_builder::new($context.filtered_count);
-        let mut builder = $list_builder_type::new(values_builder);
-        for i in 0..$context.filter_u64.len() {
-            // foreach u64 batch
-            let filter_batch = $context.filter_u64[i];
-            if filter_batch == 0 {
-                // if batch == 0, all items are filtered out, so skip entire batch
-                continue;
-            }
-            for j in 0..64 {
-                // foreach bit in batch:
-                if (filter_batch & $context.filter_mask[j]) != 0 {
-                    let data_index = (i * 64) + j;
-                    if input_array.is_null(data_index) {
-                        builder.append(false)?;
-                    } else {
-                        let this_inner_list = input_array.value(data_index);
-                        let inner_list = this_inner_list
-                            .as_any()
-                            .downcast_ref::<$item_array_type>()
-                            .unwrap();
-                        for k in 0..inner_list.len() {
-                            if inner_list.is_null(k) {
-                                builder.values().append_null()?;
-                            } else {
-                                builder.values().append_value(inner_list.value(k))?;
-                            }
-                        }
-                        builder.append(true)?;
-                    }
-                }
-            }
-        }
-        Ok(Arc::new(builder.finish()))
-    }};
-}
-
-impl FilterContext {
-    /// Returns a new instance of FilterContext
-    pub fn new(filter_array: &BooleanArray) -> Result<Self> {
-        if filter_array.offset() > 0 {
-            return Err(ArrowError::ComputeError(
-                "Filter array cannot have offset > 0".to_string(),
-            ));
-        }
-        let filter_mask: Vec<u64> = (0..64).map(|x| 1u64 << x).collect();
-        let filter_buffer = &filter_array.data_ref().buffers()[0];
-        let filtered_count = filter_buffer.count_set_bits_offset(0, filter_array.len());
-
-        let filter_bytes = filter_buffer.data();
-
-        // add to the resulting len so is is a multiple of the size of u64
-        let pad_addional_len = 8 - filter_bytes.len() % 8;
-
-        // transmute filter_bytes to &[u64]
-        let mut u64_buffer = MutableBuffer::new(filter_bytes.len() + pad_addional_len);
-
-        u64_buffer.extend_from_slice(filter_bytes);
-        u64_buffer.extend_from_slice(&vec![0; pad_addional_len]);
-        let mut filter_u64 = u64_buffer.typed_data_mut::<u64>().to_owned();
-
-        // mask of any bits outside of the given len
-        if filter_array.len() % 64 != 0 {
-            let last_idx = filter_u64.len() - 1;
-            let mask = u64::MAX >> (64 - filter_array.len() % 64);
-            filter_u64[last_idx] &= mask;
-        }
-
-        Ok(FilterContext {
-            filter_u64,
-            filter_len: filter_array.len(),
-            filtered_count,
-            filter_mask,
-        })
-    }
-
-    /// Returns a new array, containing only the elements matching the filter
-    pub fn filter(&self, array: &Array) -> Result<ArrayRef> {
-        match array.data_type() {
-            DataType::UInt8 => filter_primitive_array!(self, array, UInt8Array),
-            DataType::UInt16 => filter_primitive_array!(self, array, UInt16Array),
-            DataType::UInt32 => filter_primitive_array!(self, array, UInt32Array),
-            DataType::UInt64 => filter_primitive_array!(self, array, UInt64Array),
-            DataType::Int8 => filter_primitive_array!(self, array, Int8Array),
-            DataType::Int16 => filter_primitive_array!(self, array, Int16Array),
-            DataType::Int32 => filter_primitive_array!(self, array, Int32Array),
-            DataType::Int64 => filter_primitive_array!(self, array, Int64Array),
-            DataType::Float32 => filter_primitive_array!(self, array, Float32Array),
-            DataType::Float64 => filter_primitive_array!(self, array, Float64Array),
-            DataType::Boolean => {
-                let input_array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-                let mut builder = BooleanArray::builder(self.filtered_count);
-                for i in 0..self.filter_u64.len() {
-                    // foreach u64 batch
-                    let filter_batch = self.filter_u64[i];
-                    if filter_batch == 0 {
-                        // if batch == 0, all items are filtered out, so skip entire batch
-                        continue;
-                    }
-                    for j in 0..64 {
-                        // foreach bit in batch:
-                        if (filter_batch & self.filter_mask[j]) != 0 {
-                            let data_index = (i * 64) + j;
-                            if input_array.is_null(data_index) {
-                                builder.append_null()?;
-                            } else {
-                                builder.append_value(input_array.value(data_index))?;
-                            }
-                        }
-                    }
-                }
-                Ok(Arc::new(builder.finish()))
-            },
-            DataType::Date32(_) => filter_primitive_array!(self, array, Date32Array),
-            DataType::Date64(_) => filter_primitive_array!(self, array, Date64Array),
-            DataType::Time32(TimeUnit::Second) => {
-                filter_primitive_array!(self, array, Time32SecondArray)
-            }
-            DataType::Time32(TimeUnit::Millisecond) => {
-                filter_primitive_array!(self, array, Time32MillisecondArray)
-            }
-            DataType::Time64(TimeUnit::Microsecond) => {
-                filter_primitive_array!(self, array, Time64MicrosecondArray)
-            }
-            DataType::Time64(TimeUnit::Nanosecond) => {
-                filter_primitive_array!(self, array, Time64NanosecondArray)
-            }
-            DataType::Duration(TimeUnit::Second) => {
-                filter_primitive_array!(self, array, DurationSecondArray)
-            }
-            DataType::Duration(TimeUnit::Millisecond) => {
-                filter_primitive_array!(self, array, DurationMillisecondArray)
-            }
-            DataType::Duration(TimeUnit::Microsecond) => {
-                filter_primitive_array!(self, array, DurationMicrosecondArray)
-            }
-            DataType::Duration(TimeUnit::Nanosecond) => {
-                filter_primitive_array!(self, array, DurationNanosecondArray)
-            }
-            DataType::Timestamp(TimeUnit::Second, _) => {
-                filter_primitive_array!(self, array, TimestampSecondArray)
-            }
-            DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                filter_primitive_array!(self, array, TimestampMillisecondArray)
-            }
-            DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                filter_primitive_array!(self, array, TimestampMicrosecondArray)
-            }
-            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                filter_primitive_array!(self, array, TimestampNanosecondArray)
-            }
-            DataType::Binary => {
-                let input_array = array.as_any().downcast_ref::<BinaryArray>().unwrap();
-                let mut values: Vec<Option<&[u8]>> = Vec::with_capacity(self.filtered_count);
-                for i in 0..self.filter_u64.len() {
-                    // foreach u64 batch
-                    let filter_batch = self.filter_u64[i];
-                    if filter_batch == 0 {
-                        // if batch == 0, all items are filtered out, so skip entire batch
-                        continue;
-                    }
-                    for j in 0..64 {
-                        // foreach bit in batch:
-                        if (filter_batch & self.filter_mask[j]) != 0 {
-                            let data_index = (i * 64) + j;
-                            if input_array.is_null(data_index) {
-                                values.push(None)
-                            } else {
-                                values.push(Some(input_array.value(data_index)))
-                            }
-                        }
-                    }
-                }
-                Ok(Arc::new(BinaryArray::from(values)))
-            }
-            DataType::Utf8 => {
-                let input_array = array.as_any().downcast_ref::<StringArray>().unwrap();
-                let mut values: Vec<Option<&str>> = Vec::with_capacity(self.filtered_count);
-                for i in 0..self.filter_u64.len() {
-                    // foreach u64 batch
-                    let filter_batch = self.filter_u64[i];
-                    if filter_batch == 0 {
-                        // if batch == 0, all items are filtered out, so skip entire batch
-                        continue;
-                    }
-                    for j in 0..64 {
-                        // foreach bit in batch:
-                        if (filter_batch & self.filter_mask[j]) != 0 {
-                            let data_index = (i * 64) + j;
-                            if input_array.is_null(data_index) {
-                                values.push(None)
-                            } else {
-                                values.push(Some(input_array.value(data_index)))
-                            }
-                        }
-                    }
-                }
-                Ok(Arc::new(StringArray::from(values)))
-            }
-            DataType::Dictionary(ref key_type, ref value_type) => match (key_type.as_ref(), value_type.as_ref()) {
-                (key_type, DataType::Utf8) => match key_type {
-                    DataType::UInt8 => filter_dictionary_array!(self, array, UInt8DictionaryArray),
-                    DataType::UInt16 => filter_dictionary_array!(self, array, UInt16DictionaryArray),
-                    DataType::UInt32 => filter_dictionary_array!(self, array, UInt32DictionaryArray),
-                    DataType::UInt64 => filter_dictionary_array!(self, array, UInt64DictionaryArray),
-                    DataType::Int8 => filter_dictionary_array!(self, array, Int8DictionaryArray),
-                    DataType::Int16 => filter_dictionary_array!(self, array, Int16DictionaryArray),
-                    DataType::Int32 => filter_dictionary_array!(self, array, Int32DictionaryArray),
-                    DataType::Int64 => filter_dictionary_array!(self, array, Int64DictionaryArray),
-                    other => Err(ArrowError::ComputeError(format!(
-                        "filter not supported for string dictionary with key of type {:?}",
-                        other
-                    )))
-                }
-                (key_type, value_type) => Err(ArrowError::ComputeError(format!(
-                    "filter not supported for Dictionary({:?}, {:?})",
-                    key_type, value_type
-                )))
-            }
-            DataType::List(dt) => match dt.data_type() {
-                DataType::UInt8 => {
-                    filter_primitive_item_list_array!(self, array, UInt8Type, ListArray, ListBuilder)
-                }
-                DataType::UInt16 => {
-                    filter_primitive_item_list_array!(self, array, UInt16Type, ListArray, ListBuilder)
-                }
-                DataType::UInt32 => {
-                    filter_primitive_item_list_array!(self, array, UInt32Type, ListArray, ListBuilder)
-                }
-                DataType::UInt64 => {
-                    filter_primitive_item_list_array!(self, array, UInt64Type, ListArray, ListBuilder)
-                }
-                DataType::Int8 => filter_primitive_item_list_array!(self, array, Int8Type, ListArray, ListBuilder),
-                DataType::Int16 => {
-                    filter_primitive_item_list_array!(self, array, Int16Type, ListArray, ListBuilder)
-                }
-                DataType::Int32 => {
-                    filter_primitive_item_list_array!(self, array, Int32Type, ListArray, ListBuilder)
-                }
-                DataType::Int64 => {
-                    filter_primitive_item_list_array!(self, array, Int64Type, ListArray, ListBuilder)
-                }
-                DataType::Float32 => {
-                    filter_primitive_item_list_array!(self, array, Float32Type, ListArray, ListBuilder)
-                }
-                DataType::Float64 => {
-                    filter_primitive_item_list_array!(self, array, Float64Type, ListArray, ListBuilder)
-                }
-                DataType::Boolean => {
-                    filter_boolean_item_list_array!(self, array, ListArray, ListBuilder)
-                }
-                DataType::Date32(_) => {
-                    filter_primitive_item_list_array!(self, array, Date32Type, ListArray, ListBuilder)
-                }
-                DataType::Date64(_) => {
-                    filter_primitive_item_list_array!(self, array, Date64Type, ListArray, ListBuilder)
-                }
-                DataType::Time32(TimeUnit::Second) => {
-                    filter_primitive_item_list_array!(self, array, Time32SecondType, ListArray, ListBuilder)
-                }
-                DataType::Time32(TimeUnit::Millisecond) => {
-                    filter_primitive_item_list_array!(self, array, Time32MillisecondType, ListArray, ListBuilder)
-                }
-                DataType::Time64(TimeUnit::Microsecond) => {
-                    filter_primitive_item_list_array!(self, array, Time64MicrosecondType, ListArray, ListBuilder)
-                }
-                DataType::Time64(TimeUnit::Nanosecond) => {
-                    filter_primitive_item_list_array!(self, array, Time64NanosecondType, ListArray, ListBuilder)
-                }
-                DataType::Duration(TimeUnit::Second) => {
-                    filter_primitive_item_list_array!(self, array, DurationSecondType, ListArray, ListBuilder)
-                }
-                DataType::Duration(TimeUnit::Millisecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationMillisecondType, ListArray, ListBuilder)
-                }
-                DataType::Duration(TimeUnit::Microsecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationMicrosecondType, ListArray, ListBuilder)
-                }
-                DataType::Duration(TimeUnit::Nanosecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationNanosecondType, ListArray, ListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Second, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampSecondType, ListArray, ListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampMillisecondType, ListArray, ListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampMicrosecondType, ListArray, ListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampNanosecondType, ListArray, ListBuilder)
-                }
-                DataType::Binary => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    BinaryArray,
-                    BinaryBuilder,
-                    ListArray,
-                    ListBuilder
-                ),
-                DataType::LargeBinary => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    LargeBinaryArray,
-                    LargeBinaryBuilder,
-                    ListArray,
-                    ListBuilder
-                ),
-                DataType::Utf8 => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    StringArray,
-                    StringBuilder,
-                    ListArray
-                    ,ListBuilder
-                ),
-                DataType::LargeUtf8 => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    LargeStringArray,
-                    LargeStringBuilder,
-                    ListArray,
-                    ListBuilder
-                ),
-                other => {
-                    Err(ArrowError::ComputeError(format!(
-                        "filter not supported for List({:?})",
-                        other
-                    )))
-                }
-            }
-            DataType::LargeList(dt) => match dt.data_type() {
-                DataType::UInt8 => {
-                    filter_primitive_item_list_array!(self, array, UInt8Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::UInt16 => {
-                    filter_primitive_item_list_array!(self, array, UInt16Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::UInt32 => {
-                    filter_primitive_item_list_array!(self, array, UInt32Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::UInt64 => {
-                    filter_primitive_item_list_array!(self, array, UInt64Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Int8 => filter_primitive_item_list_array!(self, array, Int8Type, LargeListArray, LargeListBuilder),
-                DataType::Int16 => {
-                    filter_primitive_item_list_array!(self, array, Int16Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Int32 => {
-                    filter_primitive_item_list_array!(self, array, Int32Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Int64 => {
-                    filter_primitive_item_list_array!(self, array, Int64Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Float32 => {
-                    filter_primitive_item_list_array!(self, array, Float32Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Float64 => {
-                    filter_primitive_item_list_array!(self, array, Float64Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Boolean => {
-                    filter_boolean_item_list_array!(self, array, LargeListArray, LargeListBuilder)
-                }
-                DataType::Date32(_) => {
-                    filter_primitive_item_list_array!(self, array, Date32Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Date64(_) => {
-                    filter_primitive_item_list_array!(self, array, Date64Type, LargeListArray, LargeListBuilder)
-                }
-                DataType::Time32(TimeUnit::Second) => {
-                    filter_primitive_item_list_array!(self, array, Time32SecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Time32(TimeUnit::Millisecond) => {
-                    filter_primitive_item_list_array!(self, array, Time32MillisecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Time64(TimeUnit::Microsecond) => {
-                    filter_primitive_item_list_array!(self, array, Time64MicrosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Time64(TimeUnit::Nanosecond) => {
-                    filter_primitive_item_list_array!(self, array, Time64NanosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Duration(TimeUnit::Second) => {
-                    filter_primitive_item_list_array!(self, array, DurationSecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Duration(TimeUnit::Millisecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationMillisecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Duration(TimeUnit::Microsecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationMicrosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Duration(TimeUnit::Nanosecond) => {
-                    filter_primitive_item_list_array!(self, array, DurationNanosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Second, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampSecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampMillisecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampMicrosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                    filter_primitive_item_list_array!(self, array, TimestampNanosecondType, LargeListArray, LargeListBuilder)
-                }
-                DataType::Binary => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    BinaryArray,
-                    BinaryBuilder,
-                    LargeListArray,
-                    LargeListBuilder
-                ),
-                DataType::LargeBinary => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    LargeBinaryArray,
-                    LargeBinaryBuilder,
-                    LargeListArray,
-                    LargeListBuilder
-                ),
-                DataType::Utf8 => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    StringArray,
-                    StringBuilder,
-                    LargeListArray,
-                    LargeListBuilder
-                ),
-                DataType::LargeUtf8 => filter_non_primitive_item_list_array!(
-                    self,
-                    array,
-                    LargeStringArray,
-                    LargeStringBuilder,
-                    LargeListArray,
-                    LargeListBuilder
-                ),
-                other => {
-                    Err(ArrowError::ComputeError(format!(
-                        "filter not supported for LargeList({:?})",
-                        other
-                    )))
-                }
-            }
-            other => Err(ArrowError::ComputeError(format!(
-                "filter not supported for {:?}",
-                other
-            ))),
-        }
-    }
-
-    /// Returns a new PrimitiveArray<T> containing only those values from the array passed as the data_array parameter,
-    /// selected by the BooleanArray passed as the filter_array parameter
-    pub fn filter_primitive_array<T>(
-        &self,
-        data_array: &PrimitiveArray<T>,
-    ) -> Result<PrimitiveArray<T>>
-    where
-        T: ArrowNumericType,
-    {
-        let array_type = T::DATA_TYPE;
-        let value_size = mem::size_of::<T::Native>();
-        let array_data_builder =
-            filter_array_impl(self, data_array, array_type, value_size)?;
-        let data = array_data_builder.build();
-        Ok(PrimitiveArray::<T>::from(data))
-    }
-
-    /// Returns a new DictionaryArray<T> containing only those keys from the array passed as the data_array parameter,
-    /// selected by the BooleanArray passed as the filter_array parameter. The values are cloned from the data_array.
-    pub fn filter_dictionary_array<T>(
-        &self,
-        data_array: &DictionaryArray<T>,
-    ) -> Result<DictionaryArray<T>>
-    where
-        T: ArrowNumericType,
-    {
-        let array_type = data_array.data_type().clone();
-        let value_size = mem::size_of::<T::Native>();
-        let mut array_data_builder =
-            filter_array_impl(self, data_array, array_type, value_size)?;
-        // copy dictionary values from input array
-        array_data_builder =
-            array_data_builder.add_child_data(data_array.values().data());
-        let data = array_data_builder.build();
-        Ok(DictionaryArray::<T>::from(data))
-    }
+/// Returns a function with pre-computed values that can be used to filter arbitrary arrays,
+/// thereby improving performance when filtering multiple arrays
+pub fn build_filter<'a>(filter: &'a BooleanArray) -> Result<Filter<'a>> {
+    let (chunks, filter_count) = compute_slices(filter);
+    Ok(Box::new(move |array: &ArrayData| {
+        let mut mutable = MutableArrayData::new(vec![array], false, filter_count);
+        chunks
+            .iter()
+            .for_each(|(start, end)| mutable.extend(0, *start, *end));
+        mutable.freeze()
+    }))
 }
 
 /// Returns a new array, containing only the elements matching the filter.
 pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
-    FilterContext::new(filter)?.filter(array)
-}
+    let (chunks, filter_count) = compute_slices(filter);
 
-/// Returns a new PrimitiveArray<T> containing only those values from the array passed as the data_array parameter,
-/// selected by the BooleanArray passed as the filter_array parameter
-pub fn filter_primitive_array<T>(
-    data_array: &PrimitiveArray<T>,
-    filter_array: &BooleanArray,
-) -> Result<PrimitiveArray<T>>
-where
-    T: ArrowNumericType,
-{
-    FilterContext::new(filter_array)?.filter_primitive_array(data_array)
-}
-
-/// Returns a new DictionaryArray<T> containing only those keys from the array passed as the data_array parameter,
-/// selected by the BooleanArray passed as the filter_array parameter. The values are cloned from the data_array.
-pub fn filter_dictionary_array<T>(
-    data_array: &DictionaryArray<T>,
-    filter_array: &BooleanArray,
-) -> Result<DictionaryArray<T>>
-where
-    T: ArrowNumericType,
-{
-    FilterContext::new(filter_array)?.filter_dictionary_array(data_array)
+    let mut mutable = MutableArrayData::new(vec![array.data_ref()], false, filter_count);
+    chunks
+        .iter()
+        .for_each(|(start, end)| mutable.extend(0, *start, *end));
+    let data = mutable.freeze();
+    Ok(make_array(Arc::new(data)))
 }
 
 /// Returns a new RecordBatch with arrays containing only values matching the filter.
-/// The same FilterContext is re-used when filtering arrays in the RecordBatch for better performance.
 pub fn filter_record_batch(
     record_batch: &RecordBatch,
     filter_array: &BooleanArray,
 ) -> Result<RecordBatch> {
-    let filter_context = FilterContext::new(filter_array)?;
+    let filter = build_filter(filter_array)?;
     let filtered_arrays = record_batch
         .columns()
         .iter()
-        .map(|a| filter_context.filter(a.as_ref()))
-        .collect::<Result<Vec<ArrayRef>>>()?;
+        .map(|a| make_array(Arc::new(filter(&a.data()))))
+        .collect();
     RecordBatch::try_new(record_batch.schema(), filtered_arrays)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::buffer::Buffer;
     use crate::datatypes::ToByteSlice;
+    use crate::{
+        buffer::Buffer,
+        datatypes::{DataType, Field},
+    };
 
     macro_rules! def_temporal_test {
         ($test:ident, $array_type: ident, $data: expr) => {
@@ -1009,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_string_array() {
+    fn test_filter_string_array_simple() {
         let a = StringArray::from(vec!["hello", " ", "world", "!"]);
         let b = BooleanArray::from(vec![true, false, true, false]);
         let c = filter(&a, &b).unwrap();
@@ -1131,36 +422,25 @@ mod tests {
         //  a = [[0, 1, 2], [3, 4, 5], [6, 7], null]
         let a = LargeListArray::from(list_data);
         let b = BooleanArray::from(vec![false, true, false, true]);
-        let c = filter(&a, &b).unwrap();
-        let d = c
-            .as_ref()
-            .as_any()
-            .downcast_ref::<LargeListArray>()
-            .unwrap();
+        let result = filter(&a, &b).unwrap();
 
-        assert_eq!(DataType::Int32, d.value_type());
+        // expected: [[3, 4, 5], null]
+        let value_data = ArrayData::builder(DataType::Int32)
+            .len(3)
+            .add_buffer(Buffer::from(&[3, 4, 5].to_byte_slice()))
+            .build();
 
-        // result should be [[3, 4, 5], null]
-        assert_eq!(2, d.len());
-        assert_eq!(1, d.null_count());
-        assert_eq!(true, d.is_null(1));
+        let value_offsets = Buffer::from(&[0i64, 3, 3].to_byte_slice());
 
-        assert_eq!(0, d.value_offset(0));
-        assert_eq!(3, d.value_length(0));
-        assert_eq!(3, d.value_offset(1));
-        assert_eq!(0, d.value_length(1));
-        assert_eq!(
-            Buffer::from(&[3, 4, 5].to_byte_slice()),
-            d.values().data().buffers()[0].clone()
-        );
-        assert_eq!(
-            Buffer::from(&[0i64, 3, 3].to_byte_slice()),
-            d.data().buffers()[0].clone()
-        );
-        let inner_list = d.value(0);
-        let inner_list = inner_list.as_any().downcast_ref::<Int32Array>().unwrap();
-        assert_eq!(3, inner_list.len());
-        assert_eq!(0, inner_list.null_count());
-        assert_eq!(inner_list, &Int32Array::from(vec![3, 4, 5]));
+        let list_data_type =
+            DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
+        let expected = ArrayData::builder(list_data_type)
+            .len(2)
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
+            .null_bit_buffer(Buffer::from([0b00000001]))
+            .build();
+
+        assert_eq!(&make_array(expected), &result);
     }
 }

--- a/rust/arrow/src/util/bit_chunk_iterator.rs
+++ b/rust/arrow/src/util/bit_chunk_iterator.rs
@@ -14,14 +14,12 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-use crate::buffer::Buffer;
 use crate::util::bit_util::ceil;
 use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct BitChunks<'a> {
-    buffer: &'a Buffer,
-    raw_data: *const u8,
+    buffer: &'a [u8],
     /// offset inside a byte, guaranteed to be between 0 and 7 (inclusive)
     bit_offset: usize,
     /// number of complete u64 chunks
@@ -31,13 +29,11 @@ pub struct BitChunks<'a> {
 }
 
 impl<'a> BitChunks<'a> {
-    pub fn new(buffer: &'a Buffer, offset: usize, len: usize) -> Self {
+    pub fn new(buffer: &'a [u8], offset: usize, len: usize) -> Self {
         assert!(ceil(offset + len, 8) <= buffer.len() * 8);
 
         let byte_offset = offset / 8;
         let bit_offset = offset % 8;
-
-        let raw_data = unsafe { buffer.raw_data().add(byte_offset) };
 
         let chunk_bits = 8 * std::mem::size_of::<u64>();
 
@@ -45,8 +41,7 @@ impl<'a> BitChunks<'a> {
         let remainder_len = len & (chunk_bits - 1);
 
         BitChunks::<'a> {
-            buffer: &buffer,
-            raw_data,
+            buffer: &buffer[byte_offset..],
             bit_offset,
             chunk_len,
             remainder_len,
@@ -56,8 +51,7 @@ impl<'a> BitChunks<'a> {
 
 #[derive(Debug)]
 pub struct BitChunkIterator<'a> {
-    buffer: &'a Buffer,
-    raw_data: *const u8,
+    buffer: &'a [u8],
     bit_offset: usize,
     chunk_len: usize,
     index: usize,
@@ -83,7 +77,8 @@ impl<'a> BitChunks<'a> {
             let byte_len = ceil(bit_len + bit_offset, 8);
             // pointer to remainder bytes after all complete chunks
             let base = unsafe {
-                self.raw_data
+                self.buffer
+                    .as_ptr()
                     .add(self.chunk_len * std::mem::size_of::<u64>())
             };
 
@@ -102,7 +97,6 @@ impl<'a> BitChunks<'a> {
     pub const fn iter(&self) -> BitChunkIterator<'a> {
         BitChunkIterator::<'a> {
             buffer: self.buffer,
-            raw_data: self.raw_data,
             bit_offset: self.bit_offset,
             chunk_len: self.chunk_len,
             index: 0,
@@ -131,7 +125,7 @@ impl Iterator for BitChunkIterator<'_> {
 
         // cast to *const u64 should be fine since we are using read_unaligned below
         #[allow(clippy::cast_ptr_alignment)]
-        let raw_data = self.raw_data as *const u64;
+        let raw_data = self.buffer.as_ptr() as *const u64;
 
         // bit-packed buffers are stored starting with the least-significant byte first
         // so when reading as u64 on a big-endian machine, the bytes need to be swapped

--- a/rust/arrow/src/util/bit_chunk_iterator.rs
+++ b/rust/arrow/src/util/bit_chunk_iterator.rs
@@ -64,6 +64,12 @@ impl<'a> BitChunks<'a> {
         self.remainder_len
     }
 
+    /// Returns the number of chunks
+    #[inline]
+    pub const fn chunk_len(&self) -> usize {
+        self.chunk_len
+    }
+
     /// Returns the bitmask of remaining bits
     #[inline]
     pub fn remainder_bits(&self) -> u64 {


### PR DESCRIPTION
This PR improves the filter kernel:

* made the filter benchmarks more realistic
* performance improved by 1.2-4x for all multi-filter operations
* performance decreased by 30% for a single-filter operation with 50% taken (and 2x faster for dense)
* filter now supports all types supported by `MutableArrayData` (in particular nested lists, `struct`, etc.)
* removed 400 LOC

There are two novel ideas here:

1. it minimizes the number of memcopies when building the filtered array, both for single filter and multi-filter operations.

2. for single filter operations, it leverages an iterator to create the new array on the fly. For multi filter operations, it persists the iterator's result in a vector and iterates over it per array.

This PR also improves the performance of `MutableArrayData` by avoiding some bound checks via `unsafe` (properly documented).

Summary of the benchmarks:

|  benchmark | variation (%) |
|-------------- | -------------- | 
| filter u8 | 29.5 | 
| filter u8 low selectivity | 7.3 | 
| filter context u8 w NULLs | -17.5 | 
| filter context u8 w NULLs high selectivity | -21.9 | 
| filter context f32 high selectivity | -22.0 | 
| filter context f32 | -26.8 | 
| filter context string high selectivity | -27.5 | 
| filter context string | -31.4 | 
| filter context u8 | -40.3 | 
| filter u8 high selectivity | -47.3 | 
| filter context string low selectivity | -55.3 | 
| filter context u8 w NULLs low selectivity | -57.7 | 
| filter context f32 low selectivity | -64.8 | 
| filter context u8 low selectivity | -66.0 | 
| filter context u8 high selectivity | -77.2 |

Code used to benchmark:
```bash
git checkout 54da4378d138df12bd4e09a68b0f4c80218834c7
cargo bench --bench filter_kernels
git checkout mutable_filter2
cargo bench --bench filter_kernels
```

Benchmark result:
```
   Compiling arrow v3.0.0-SNAPSHOT (/Users/jorgecarleitao/projects/arrow/rust/arrow)
    Finished bench [optimized] target(s) in 1m 01s
     Running /Users/jorgecarleitao/projects/arrow/rust/target/release/deps/filter_kernels-5208f9a404de52c9
Gnuplot not found, using plotters backend
filter u8               time:   [512.54 us 513.43 us 514.37 us]                      
                        change: [+29.070% +29.548% +30.003%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

filter u8 high selectivity                                                                             
                        time:   [11.494 us 11.513 us 11.532 us]
                        change: [-47.846% -47.337% -46.755%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

filter u8 low selectivity                                                                             
                        time:   [7.0342 us 7.0520 us 7.0693 us]
                        change: [+6.5543% +7.3409% +8.1080%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

filter context u8       time:   [233.81 us 234.31 us 234.93 us]                              
                        change: [-40.715% -40.329% -39.886%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

filter context u8 high selectivity                                                                             
                        time:   [4.5943 us 4.6100 us 4.6276 us]
                        change: [-77.449% -77.231% -77.022%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  10 (10.00%) high mild
  8 (8.00%) high severe

filter context u8 low selectivity                                                                             
                        time:   [1.7582 us 1.7664 us 1.7742 us]
                        change: [-66.250% -65.989% -65.669%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

filter context u8 w NULLs                                                                            
                        time:   [476.99 us 477.71 us 478.44 us]
                        change: [-17.852% -17.457% -17.000%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

filter context u8 w NULLs high selectivity                                                                            
                        time:   [296.46 us 297.03 us 297.67 us]
                        change: [-22.297% -21.871% -21.393%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

filter context u8 w NULLs low selectivity                                                                             
                        time:   [2.5988 us 2.6124 us 2.6268 us]
                        change: [-58.065% -57.668% -57.237%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

filter context f32      time:   [470.69 us 472.39 us 474.73 us]                               
                        change: [-29.574% -26.769% -24.242%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe

filter context f32 high selectivity                                                                            
                        time:   [307.16 us 307.58 us 308.03 us]
                        change: [-22.472% -22.039% -21.532%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

filter context f32 low selectivity                                                                             
                        time:   [2.4266 us 2.4323 us 2.4384 us]
                        change: [-65.024% -64.764% -64.517%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

filter context string   time:   [645.82 us 647.32 us 649.04 us]                                  
                        change: [-31.810% -31.427% -31.046%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

Benchmarking filter context string high selectivity: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 60.
filter context string high selectivity                                                                             
                        time:   [999.11 us 1.0008 ms 1.0027 ms]
                        change: [-28.133% -27.524% -26.930%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

filter context string low selectivity                                                                             
                        time:   [3.6441 us 3.6623 us 3.6799 us]
                        change: [-55.650% -55.329% -55.013%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) low mild
  2 (2.00%) high severe
```
