### PR TITLE
Arrow-10967: [Rust] Make env vars ARROW_TEST_DATA and PARQUET_TEST_DATA optional

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -92,7 +92,14 @@ This populates data in two git submodules:
 - `../cpp/submodules/parquet_testing/data` (sourced from https://github.com/apache/parquet-testing.git)
 - `../testing` (sourced from https://github.com/apache/arrow-testing)
 
-The following Env vars are required to run `cargo test`, examples, etc.
+The following environment variables are **optional** to run `cargo test`, benchmarks, examples, etc.
+
+They are required to be set **only if**:
+
+- either apache arrow is not a git repository,
+- or the data dirs are not default.
+
+Assuming that you are in this crates' current directory, and have to set the environment variables:
 
 ```bash
 export PARQUET_TEST_DATA=$(cd ../cpp/submodules/parquet-testing/data; pwd)

--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -29,8 +29,13 @@ Refer to [lib.rs](src/lib.rs) for an introduction to this crate and current func
 
 ### How to run the tests
 
-The tests of this crate depend on two environment variables to be defined.
-Assuming that you are in this crates' current directory:
+The tests of this crate **optionally** depend on two environment variables to be defined.
+
+They are required to set **only if**:
+- either apache arrow is not a git repository,
+- or the data dirs are not default.
+
+Assuming that you are in this crates' current directory, and have to set the environment variables:
 
 ```bash
 export PARQUET_TEST_DATA=$(cd ../../cpp/submodules/parquet-testing/data; pwd)

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -939,12 +939,13 @@ mod tests {
     use flate2::read::GzDecoder;
 
     use crate::util::integration_util::*;
-    use std::env;
     use std::fs::File;
+
+    use crate::util::test_data_dir::ARROW_TEST_DATA;
 
     #[test]
     fn read_generated_files() {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         // the test is repetitive, thus we can read all supported files at once
         let paths = vec![
             "generated_interval",
@@ -974,7 +975,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Big Endian is not supported for Decimal!")]
     fn read_decimal_be_file_should_panic() {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         let file = File::open(format!(
                 "{}/arrow-ipc-stream/integration/1.0.0-bigendian/generated_decimal.arrow_file",
                 testdata
@@ -986,7 +987,7 @@ mod tests {
     #[test]
     fn read_generated_be_files_should_work() {
         // complementary to the previous test
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         let paths = vec![
             "generated_interval",
             "generated_datetime",
@@ -1009,7 +1010,7 @@ mod tests {
 
     #[test]
     fn read_generated_streams() {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         // the test is repetitive, thus we can read all supported files at once
         let paths = vec![
             "generated_interval",
@@ -1091,7 +1092,7 @@ mod tests {
 
     /// Read gzipped JSON file
     fn read_gzip_json(path: &str) -> ArrowJson {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         let file = File::open(format!(
             "{}/arrow-ipc-stream/integration/0.14.1/{}.json.gz",
             testdata, path

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -739,7 +739,7 @@ mod tests {
     use crate::datatypes::Field;
     use crate::ipc::reader::*;
     use crate::util::integration_util::*;
-    use std::env;
+    use crate::util::test_data_dir::ARROW_TEST_DATA;
     use std::fs::File;
     use std::io::Read;
     use std::sync::Arc;
@@ -841,7 +841,7 @@ mod tests {
 
     #[test]
     fn read_and_rewrite_generated_files() {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         // the test is repetitive, thus we can read all supported files at once
         let paths = vec![
             "generated_interval",
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn read_and_rewrite_generated_streams() {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         // the test is repetitive, thus we can read all supported files at once
         let paths = vec![
             "generated_interval",
@@ -930,7 +930,7 @@ mod tests {
 
     /// Read gzipped JSON file
     fn read_gzip_json(path: &str) -> ArrowJson {
-        let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+        let testdata = ARROW_TEST_DATA().unwrap();
         let file = File::open(format!(
             "{}/arrow-ipc-stream/integration/0.14.1/{}.json.gz",
             testdata, path

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -22,4 +22,5 @@ pub mod integration_util;
 #[cfg(feature = "prettyprint")]
 pub mod pretty;
 pub mod string_writer;
+pub mod test_data_dir;
 pub mod test_util;

--- a/rust/arrow/src/util/test_data_dir.rs
+++ b/rust/arrow/src/util/test_data_dir.rs
@@ -29,7 +29,7 @@ pub fn ARROW_TEST_DATA() -> Result<String, Box<dyn Error>> {
 }
 
 /// Gets parquet test data dir.
-/// The env `ARROW_TEST_DATA` has higher prior to the default git submodule dir.
+/// The env `PARQUET_TEST_DATA` has higher prior to the default git submodule dir.
 #[inline]
 #[allow(non_snake_case)]
 pub fn PARQUET_TEST_DATA() -> Result<String, Box<dyn Error>> {

--- a/rust/arrow/src/util/test_data_dir.rs
+++ b/rust/arrow/src/util/test_data_dir.rs
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Utils for getting "external" test data dirs for arrow and parquet, to make testing,
+//! benchmark and example easier.
+
+use std::{env, error::Error, fs, path::PathBuf};
+
+/// Gets arrow test data dir.
+/// The env `ARROW_TEST_DATA` has higher prior to the default git submodule dir.
+#[inline]
+#[allow(non_snake_case)]
+pub fn ARROW_TEST_DATA() -> Result<String, Box<dyn Error>> {
+    find_dir("ARROW_TEST_DATA", PathBuf::from("."), "testing/data")
+}
+
+/// Gets parquet test data dir.
+/// The env `ARROW_TEST_DATA` has higher prior to the default git submodule dir.
+#[inline]
+#[allow(non_snake_case)]
+pub fn PARQUET_TEST_DATA() -> Result<String, Box<dyn Error>> {
+    find_dir(
+        "PARQUET_TEST_DATA",
+        PathBuf::from("."),
+        "cpp/submodules/parquet-testing/data",
+    )
+}
+
+/// Gets full path dir defined by `env_key` or `relative_dir` relative to git workspace.
+/// The `from_dir` is start point to search ".git" from it's ancestors, the default value
+/// "" means "current dir" of current process, that should be in the git workspace.
+fn find_dir(
+    env_key: &'static str,
+    from_dir: PathBuf,
+    relative_dir: &'static str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    const TIP: &str = "run: `git submodule update --init`";
+
+    if let Ok(v) = env::var(env_key) {
+        if !v.is_empty() {
+            let pb = PathBuf::from(&v);
+            if pb.exists() {
+                return Ok(pb.display().to_string());
+            }
+            return Err(format!(
+                "dir {} defined by env {} not exists, {}",
+                v, env_key, TIP
+            )
+            .into());
+        }
+    }
+
+    let dir = fs::canonicalize(from_dir)?;
+
+    // ancestors() includes self.
+    for ancestor in dir.ancestors() {
+        if ancestor.join(".git").exists() {
+            let sub_dir = ancestor.join(relative_dir);
+            if sub_dir.exists() {
+                return Ok(sub_dir.display().to_string());
+            } else {
+                return Err(format!(
+                    "data dir {:?} => {:?} not exists, {}",
+                    relative_dir, sub_dir, TIP
+                )
+                .into());
+            }
+        }
+    }
+
+    Err(format!("dir {:?} is not in git workspace", dir.to_str()).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_all() {
+        const KEY: &str = "ARROW-MOCK-KEY-1";
+        const NON_EXISTING: &str = "arrow:this-dir-should-not-exist";
+
+        // Unset env value for current process if not empty.
+        if env::var_os(KEY).is_some() {
+            env::set_var(KEY, "");
+        }
+
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_dir_path = tmp_dir.path();
+        let sub_dir = tmp_dir_path.join("sub");
+        fs::create_dir(&sub_dir).unwrap();
+
+        let res = super::find_dir(KEY, sub_dir.to_owned(), NON_EXISTING);
+        debug_assert!(res.is_err());
+
+        env::set_var(KEY, NON_EXISTING);
+        let res = super::find_dir(KEY, sub_dir.to_owned(), NON_EXISTING);
+        debug_assert!(res.is_err());
+
+        // Create .git file in sub dir.
+        let dot_git = sub_dir.join(".git");
+        fs::File::create(&dot_git).unwrap();
+
+        // Set env var as sub dir.
+        env::set_var(KEY, sub_dir.clone());
+
+        let res = super::find_dir(KEY, sub_dir.to_owned(), "");
+        debug_assert!(res.is_ok());
+
+        // Clear env var.
+        env::set_var(KEY, "");
+
+        let res = super::find_dir(KEY, sub_dir.to_owned(), NON_EXISTING);
+        debug_assert!(res.is_err());
+
+        // Remove env var.
+        env::remove_var(KEY);
+
+        let res = super::find_dir(KEY, sub_dir.to_owned(), NON_EXISTING);
+        debug_assert!(res.is_err());
+
+        // Remove file ".git" from sub dir.
+        fs::remove_file(&dot_git).unwrap();
+
+        // Create ".git" dir in tmp dir.
+        let dot_git = tmp_dir_path.join(".git");
+        fs::create_dir(&dot_git).unwrap();
+
+        let res = super::find_dir(KEY, sub_dir, "");
+        debug_assert!(res.is_ok());
+
+        let res = super::ARROW_TEST_DATA();
+        debug_assert!(res.is_ok());
+
+        let res = super::PARQUET_TEST_DATA();
+        debug_assert!(res.is_ok());
+
+        // Finally, remove the tmp dir.
+        fs::remove_dir_all(tmp_dir).unwrap();
+    }
+}

--- a/rust/datafusion/benches/sort_limit_query_sql.rs
+++ b/rust/datafusion/benches/sort_limit_query_sql.rs
@@ -19,13 +19,13 @@
 extern crate criterion;
 use criterion::Criterion;
 
-use std::env;
 use std::sync::{Arc, Mutex};
 
 extern crate arrow;
 extern crate datafusion;
 
 use arrow::datatypes::{DataType, Field, Schema};
+use arrow::util::test_data_dir::ARROW_TEST_DATA;
 
 use datafusion::datasource::{CsvFile, CsvReadOptions, MemTable};
 use datafusion::execution::context::ExecutionContext;
@@ -58,7 +58,7 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
         Field::new("c13", DataType::Utf8, false),
     ]));
 
-    let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+    let testdata = ARROW_TEST_DATA().unwrap();
 
     // create CSV data source
     let csv = CsvFile::try_new(

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow::util::pretty;
+use arrow::util::test_data_dir::ARROW_TEST_DATA;
 
 use datafusion::error::Result;
 use datafusion::prelude::*;
@@ -27,7 +28,7 @@ async fn main() -> Result<()> {
     // create local execution context
     let mut ctx = ExecutionContext::new();
 
-    let testdata = std::env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+    let testdata = ARROW_TEST_DATA().unwrap();
 
     // register csv file with the execution context
     ctx.register_csv(

--- a/rust/datafusion/examples/dataframe.rs
+++ b/rust/datafusion/examples/dataframe.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow::util::pretty;
+use arrow::util::test_data_dir::PARQUET_TEST_DATA;
 
 use datafusion::error::Result;
 use datafusion::prelude::*;
@@ -27,8 +28,7 @@ async fn main() -> Result<()> {
     // create local execution context
     let mut ctx = ExecutionContext::new();
 
-    let testdata =
-        std::env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
 
     let filename = &format!("{}/alltypes_plain.parquet", testdata);
 

--- a/rust/datafusion/examples/flight_client.rs
+++ b/rust/datafusion/examples/flight_client.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::util::pretty;
+use arrow::util::test_data_dir::PARQUET_TEST_DATA;
 
 use arrow_flight::flight_descriptor;
 use arrow_flight::flight_service_client::FlightServiceClient;
@@ -31,8 +32,7 @@ use arrow_flight::{FlightDescriptor, Ticket};
 /// This example is run along-side the example `flight_server`.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let testdata =
-        std::env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
 
     // Create Flight client
     let mut client = FlightServiceClient::connect("http://localhost:50051").await?;

--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -25,6 +25,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::prelude::*;
 use datafusion::{datasource::parquet::ParquetTable, physical_plan::collect};
 
+use arrow::util::test_data_dir::PARQUET_TEST_DATA;
 use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer,
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -87,8 +88,7 @@ impl FlightService for FlightServiceImpl {
                 // create local execution context
                 let mut ctx = ExecutionContext::new();
 
-                let testdata = std::env::var("PARQUET_TEST_DATA")
-                    .expect("PARQUET_TEST_DATA not defined");
+                let testdata = PARQUET_TEST_DATA().unwrap();
 
                 // register parquet file with the execution context
                 ctx.register_parquet(

--- a/rust/datafusion/examples/parquet_sql.rs
+++ b/rust/datafusion/examples/parquet_sql.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow::util::pretty;
+use arrow::util::test_data_dir::PARQUET_TEST_DATA;
 
 use datafusion::error::Result;
 use datafusion::prelude::*;
@@ -27,8 +28,7 @@ async fn main() -> Result<()> {
     // create local execution context
     let mut ctx = ExecutionContext::new();
 
-    let testdata =
-        std::env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
 
     // register parquet file with the execution context
     ctx.register_parquet(

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -24,8 +24,9 @@
 //! ```
 //! use datafusion::datasource::TableProvider;
 //! use datafusion::datasource::csv::{CsvFile, CsvReadOptions};
+//! use arrow::util::test_data_dir::ARROW_TEST_DATA;
 //!
-//! let testdata = std::env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+//! let testdata = ARROW_TEST_DATA().unwrap();
 //! let csvdata = CsvFile::try_new(
 //!     &format!("{}/csv/aggregate_test_100.csv", testdata),
 //!     CsvReadOptions::new().delimiter(b'|'),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -103,8 +103,8 @@ mod tests {
         TimestampNanosecondArray,
     };
     use arrow::record_batch::RecordBatch;
+    use arrow::util::test_data_dir::PARQUET_TEST_DATA;
     use futures::StreamExt;
-    use std::env;
 
     #[tokio::test]
     async fn read_small_batches() -> Result<()> {
@@ -324,8 +324,7 @@ mod tests {
     }
 
     fn load_table(name: &str) -> Result<Box<dyn TableProvider>> {
-        let testdata =
-            env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+        let testdata = PARQUET_TEST_DATA().unwrap();
         let filename = format!("{}/{}", testdata, name);
         let table = ParquetTable::try_new(&filename)?;
         Ok(Box::new(table))

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -151,6 +151,7 @@ mod tests {
     use crate::execution::context::ExecutionContext;
     use crate::logical_plan::*;
     use crate::{physical_plan::functions::ScalarFunctionImplementation, test};
+    use arrow::util::test_data_dir::ARROW_TEST_DATA;
     use arrow::{array::ArrayRef, datatypes::DataType};
 
     #[test]
@@ -323,7 +324,7 @@ mod tests {
 
     fn register_aggregate_csv(ctx: &mut ExecutionContext) -> Result<()> {
         let schema = test::aggr_test_schema();
-        let testdata = test::arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         ctx.register_csv(
             "aggregate_test_100",
             &format!("{}/csv/aggregate_test_100.csv", testdata),

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -282,13 +282,15 @@ impl RecordBatchStream for CsvStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::{aggr_test_schema, arrow_testdata_path};
+    use crate::test::aggr_test_schema;
     use futures::StreamExt;
+
+    use arrow::util::test_data_dir::ARROW_TEST_DATA;
 
     #[tokio::test]
     async fn csv_exec_with_projection() -> Result<()> {
         let schema = aggr_test_schema();
-        let testdata = arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         let filename = "aggregate_test_100.csv";
         let path = format!("{}/csv/{}", testdata, filename);
         let csv = CsvExec::try_new(
@@ -314,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn csv_exec_without_projection() -> Result<()> {
         let schema = aggr_test_schema();
-        let testdata = arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         let filename = "aggregate_test_100.csv";
         let path = format!("{}/csv/{}", testdata, filename);
         let csv =

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -248,13 +248,12 @@ impl RecordBatchStream for ParquetStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::util::test_data_dir::PARQUET_TEST_DATA;
     use futures::StreamExt;
-    use std::env;
 
     #[tokio::test]
     async fn test() -> Result<()> {
-        let testdata =
-            env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+        let testdata = PARQUET_TEST_DATA().unwrap();
         let filename = format!("{}/alltypes_plain.parquet", testdata);
         let parquet_exec = ParquetExec::try_new(&filename, Some(vec![0, 1, 2]), 1024)?;
         assert_eq!(parquet_exec.output_partitioning().partition_count(), 1);

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -639,12 +639,14 @@ mod tests {
     use super::*;
     use crate::logical_plan::{DFField, DFSchema, DFSchemaRef};
     use crate::physical_plan::{csv::CsvReadOptions, expressions, Partitioning};
+    use crate::prelude::ExecutionConfig;
     use crate::{
         logical_plan::{col, lit, sum, LogicalPlanBuilder},
         physical_plan::SendableRecordBatchStream,
     };
-    use crate::{prelude::ExecutionConfig, test::arrow_testdata_path};
     use arrow::datatypes::{DataType, Field, SchemaRef};
+    use arrow::util::test_data_dir::ARROW_TEST_DATA;
+
     use async_trait::async_trait;
     use fmt::Debug;
     use std::{any::Any, collections::HashMap, fmt};
@@ -667,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_all_operators() -> Result<()> {
-        let testdata = arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         let path = format!("{}/csv/aggregate_test_100.csv", testdata);
 
         let options = CsvReadOptions::new().schema_infer_max_records(100);
@@ -706,7 +708,7 @@ mod tests {
 
     #[test]
     fn test_with_csv_plan() -> Result<()> {
-        let testdata = arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         let path = format!("{}/csv/aggregate_test_100.csv", testdata);
 
         let options = CsvReadOptions::new().schema_infer_max_records(100);
@@ -724,7 +726,7 @@ mod tests {
 
     #[test]
     fn errors() -> Result<()> {
-        let testdata = arrow_testdata_path();
+        let testdata = ARROW_TEST_DATA().unwrap();
         let path = format!("{}/csv/aggregate_test_100.csv", testdata);
         let options = CsvReadOptions::new().schema_infer_max_records(100);
 

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -23,7 +23,7 @@ use crate::logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use arrow::array::{self, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
-use std::env;
+use arrow::util::test_data_dir::ARROW_TEST_DATA;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter};
@@ -47,14 +47,9 @@ pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
     Box::new(provider)
 }
 
-/// Get the value of the ARROW_TEST_DATA environment variable
-pub fn arrow_testdata_path() -> String {
-    env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined")
-}
-
 /// Generated partitioned copy of a CSV file
 pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<String> {
-    let testdata = arrow_testdata_path();
+    let testdata = ARROW_TEST_DATA().unwrap();
     let path = format!("{}/csv/{}", testdata, filename);
 
     let tmp_dir = TempDir::new()?;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::convert::TryFrom;
-use std::env;
 use std::sync::Arc;
 
 extern crate arrow;
@@ -27,6 +26,7 @@ use arrow::{datatypes::Int32Type, datatypes::Int64Type, record_batch::RecordBatc
 use arrow::{
     datatypes::{DataType, Field, Schema, SchemaRef},
     util::display::array_value_to_string,
+    util::test_data_dir::{ARROW_TEST_DATA, PARQUET_TEST_DATA},
 };
 
 use datafusion::error::Result;
@@ -118,7 +118,7 @@ async fn parquet_query() {
 #[tokio::test]
 async fn parquet_single_nan_schema() {
     let mut ctx = ExecutionContext::new();
-    let testdata = env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
     ctx.register_parquet("single_nan", &format!("{}/single_nan.parquet", testdata))
         .unwrap();
     let sql = "SELECT mycol FROM single_nan";
@@ -135,7 +135,7 @@ async fn parquet_single_nan_schema() {
 #[tokio::test]
 async fn parquet_list_columns() {
     let mut ctx = ExecutionContext::new();
-    let testdata = env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
     ctx.register_parquet(
         "list_columns",
         &format!("{}/list_columns.parquet", testdata),
@@ -1275,7 +1275,7 @@ fn aggr_test_schema() -> SchemaRef {
 }
 
 async fn register_aggregate_csv_by_sql(ctx: &mut ExecutionContext) {
-    let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+    let testdata = ARROW_TEST_DATA().unwrap();
 
     // TODO: The following c9 should be migrated to UInt32 and c10 should be UInt64 once
     // unsigned is supported.
@@ -1315,7 +1315,7 @@ async fn register_aggregate_csv_by_sql(ctx: &mut ExecutionContext) {
 }
 
 fn register_aggregate_csv(ctx: &mut ExecutionContext) -> Result<()> {
-    let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
+    let testdata = ARROW_TEST_DATA().unwrap();
     let schema = aggr_test_schema();
     ctx.register_csv(
         "aggregate_test_100",
@@ -1326,7 +1326,7 @@ fn register_aggregate_csv(ctx: &mut ExecutionContext) -> Result<()> {
 }
 
 fn register_alltypes_parquet(ctx: &mut ExecutionContext) {
-    let testdata = env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+    let testdata = PARQUET_TEST_DATA().unwrap();
     ctx.register_parquet(
         "alltypes_plain",
         &format!("{}/alltypes_plain.parquet", testdata),

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -258,7 +258,6 @@ mod tests {
     use serde_json::Value::{Array as JArray, Null as JNull, Object as JObject};
     use std::cmp::min;
     use std::convert::TryFrom;
-    use std::env;
     use std::fs::File;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
@@ -563,8 +562,10 @@ mod tests {
     }
 
     fn get_test_file(file_name: &str) -> File {
+        use arrow::util::test_data_dir::ARROW_TEST_DATA;
+
         let mut path = PathBuf::new();
-        path.push(env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined!"));
+        path.push(ARROW_TEST_DATA().unwrap());
         path.push(file_name);
 
         File::open(path.as_path()).expect("File not found!")

--- a/rust/parquet/src/util/test_common/file_util.rs
+++ b/rust/parquet/src/util/test_common/file_util.rs
@@ -15,23 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{env, fs, io::Write, path::PathBuf, str::FromStr};
+use arrow::util::test_data_dir::PARQUET_TEST_DATA;
+use std::{env, fs, io::Write, path::PathBuf};
 
 /// Returns path to the test parquet file in 'data' directory
 pub fn get_test_path(file_name: &str) -> PathBuf {
-    let mut pathbuf = match env::var("PARQUET_TEST_DATA") {
-        Ok(path) => PathBuf::from_str(path.as_str()).unwrap(),
-        Err(_) => {
-            let mut pathbuf = env::current_dir().unwrap();
-            pathbuf.pop();
-            pathbuf.pop();
-            pathbuf
-                .push(PathBuf::from_str("cpp/submodules/parquet-testing/data").unwrap());
-            pathbuf
-        }
-    };
-    pathbuf.push(file_name);
-    pathbuf
+    let testdata = PARQUET_TEST_DATA().unwrap();
+    let mut path = PathBuf::from(testdata);
+    path.push(file_name);
+    path
 }
 
 /// Returns file handle for a test parquet file from 'data' directory


### PR DESCRIPTION
Current state:

Two env vars ARROW_TEST_DATA and PARQUET_TEST_DATA are required to be set, for running tests,  benchmark.
The major usage likes this: let testdata = std::env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined"); 
These already exist some codes that tried to assembly the test data directories by appending relative dir to current dir of current running process. 
So it would be better if add several public utility functions for getting test data dir. Basic design is:

If env is defined  and the value points to existing dir, then we get it;

Else try getting the data dir based on: current dir, default relative dir, etc.

 