### PR TITLE
ARROW-10986: [Rust][DataFusion] Add average stats to TPC-H benchmarks

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -138,12 +138,7 @@ async fn benchmark(opt: BenchmarkOpt) -> Result<()> {
         execute_query(&mut ctx, &plan, opt.debug).await?;
         let elapsed = start.elapsed().as_secs_f64() * 1000.0;
         millis.push(elapsed as f64);
-        println!(
-            "Query {} iteration {} took {:.1} ms",
-            opt.query,
-            i,
-            elapsed
-        );
+        println!("Query {} iteration {} took {:.1} ms", opt.query, i, elapsed);
     }
 
     let avg = millis.iter().sum::<f64>() / millis.len() as f64;

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -130,18 +130,24 @@ async fn benchmark(opt: BenchmarkOpt) -> Result<()> {
         }
     }
 
+    let mut millis = vec![];
     // run benchmark
     for i in 0..opt.iterations {
         let start = Instant::now();
         let plan = create_logical_plan(&mut ctx, opt.query)?;
         execute_query(&mut ctx, &plan, opt.debug).await?;
+        let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+        millis.push(elapsed as f64);
         println!(
-            "Query {} iteration {} took {} ms",
+            "Query {} iteration {} took {:.1} ms",
             opt.query,
             i,
-            start.elapsed().as_millis()
+            elapsed
         );
     }
+
+    let avg = millis.iter().sum::<f64>() / millis.len() as f64;
+    println!("Query {} avg time: {:.2} ms", opt.query, avg);
 
     Ok(())
 }


### PR DESCRIPTION
Tool now outputs average statistic based on all iterations.
Also data is collected with more precision.

Output:

```
Query 12 iteration 0 took 1076.5 ms
Query 12 iteration 1 took 1064.9 ms
Query 12 iteration 2 took 1056.3 ms
Query 12 iteration 3 took 1095.2 ms
Query 12 iteration 4 took 1069.5 ms
Query 12 iteration 5 took 1082.0 ms
Query 12 iteration 6 took 1076.2 ms
Query 12 iteration 7 took 1053.5 ms
Query 12 iteration 8 took 1139.2 ms
Query 12 iteration 9 took 1051.1 ms
Query 12 avg time: 1076.45 ms
```
 