### PR TITLE
ARROW-10990: [Rust] Refactor simd comparison kernels to avoid out of bounds reads

### DIFF
--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -67,19 +67,6 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         self.data.is_empty()
     }
 
-    /// Returns a slice for the given offset and length
-    ///
-    /// Note this doesn't do any bound checking, for performance reason.
-    /// # Safety
-    /// caller must ensure that the passed in offset + len are less than the array len()
-    #[deprecated(note = "Please use values() instead")]
-    pub unsafe fn value_slice(&self, offset: usize, len: usize) -> &[T::Native] {
-        std::slice::from_raw_parts(
-            self.raw_values.get().add(self.data.offset()).add(offset),
-            len,
-        )
-    }
-
     /// Returns a slice of the values of this array
     #[inline]
     pub fn values(&self) -> &[T::Native] {

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -542,13 +542,12 @@ where
     /// The number of bits used corresponds to the number of lanes of this type
     fn mask_from_u64(mask: u64) -> Self::SimdMask;
 
+    /// Creates a bitmask from the given SIMD mask.
+    /// Each bit corresponds to one vector lane, starting with the least-significant bit.
+    fn mask_to_u64(mask: &Self::SimdMask) -> u64;
+
     /// Gets the value of a single lane in a SIMD mask
     fn mask_get(mask: &Self::SimdMask, idx: usize) -> bool;
-
-    /// Gets the bitmask for a SimdMask as a byte slice and passes it to the closure used as the action parameter
-    fn bitmask<T>(mask: &Self::SimdMask, action: T)
-    where
-        T: FnMut(&[u8]);
 
     /// Sets the value of a single lane of a SIMD mask
     fn mask_set(mask: Self::SimdMask, idx: usize, value: bool) -> Self::SimdMask;
@@ -715,15 +714,13 @@ macro_rules! make_numeric_type {
             }
 
             #[inline]
-            fn mask_get(mask: &Self::SimdMask, idx: usize) -> bool {
-                unsafe { mask.extract_unchecked(idx) }
+            fn mask_to_u64(mask: &Self::SimdMask) -> u64 {
+                mask.bitmask() as u64
             }
 
-            fn bitmask<T>(mask: &Self::SimdMask, mut action: T)
-            where
-                T: FnMut(&[u8]),
-            {
-                action(mask.bitmask().to_byte_slice());
+            #[inline]
+            fn mask_get(mask: &Self::SimdMask, idx: usize) -> bool {
+                unsafe { mask.extract_unchecked(idx) }
             }
 
             #[inline]


### PR DESCRIPTION
- [x] Adjust tests so the input data is bigger than one vector lane
- [x] Remove `value_slice` function when ARROW-10989 gets merged