### PR TITLE
ARROW-10993: [CI][macOS] Fix Python 3.9 installation by Homebrew

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -218,6 +218,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
+          rm -f /usr/local/bin/2to3
           brew update --preinstall
           brew bundle --file=cpp/Brewfile
       - name: Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -129,7 +129,7 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
-      CMAKE_ARGS: "-DPYTHON_EXECUTABLE=/usr/local/bin/python3"
+      CMAKE_ARGS: "-DPython3_EXECUTABLE=/usr/local/bin/python3"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -141,9 +141,10 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
+          rm -f /usr/local/bin/2to3
           brew update --preinstall
           brew bundle --file=cpp/Brewfile
-          brew install coreutils python
+          brew install coreutils
           python3 -mpip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
+          rm -f /usr/local/bin/2to3
           brew update --preinstall
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile


### PR DESCRIPTION
https://github.com/apache/arrow/runs/1579780011#step:4:520

    ==> Pouring python@3.9-3.9.1_1.catalina.bottle.tar.gz
    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/2to3
    Target /usr/local/bin/2to3
    already exists. You may want to remove it:
      rm '/usr/local/bin/2to3'

    To force the link and overwrite all conflicting files:
      brew link --overwrite python@3.9

    To list all files that would be deleted:
      brew link --overwrite --dry-run python@3.9

    Possible conflicting files are:
    /usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/2.7/bin/2to3
