### PR TITLE
ARROW-10675: [C++][Python] Support AWS S3 web identity credentials.

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -40,6 +40,7 @@
 #include <aws/core/Region.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
@@ -195,6 +196,14 @@ void S3Options::ConfigureAssumeRoleCredentials(
       load_frequency, stsClient);
 }
 
+void S3Options::ConfigureAssumeRoleWithWebIdentityCredentials() {
+  // The AWS SDK is using environment variables to retrieve the role & token. More
+  // specifically, checking for: AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE and
+  // AWS_ROLE_SESSION_NAME
+  credentials_provider =
+      std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>();
+}
+
 std::string S3Options::GetAccessKey() const {
   auto credentials = credentials_provider->GetAWSCredentials();
   return std::string(FromAwsString(credentials.GetAWSAccessKeyId()));
@@ -241,6 +250,13 @@ S3Options S3Options::FromAssumeRole(
   options.load_frequency = load_frequency;
   options.ConfigureAssumeRoleCredentials(role_arn, session_name, external_id,
                                          load_frequency, stsClient);
+  return options;
+}
+
+S3Options S3Options::FromAssumeRoleWithWebIdentity() {
+  S3Options options;
+  options.use_web_identity = true;
+  options.ConfigureAssumeRoleWithWebIdentityCredentials();
   return options;
 }
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -61,10 +61,12 @@ struct ARROW_EXPORT S3Options {
   std::string role_arn;
   /// Optional identifier for an assumed role session.
   std::string session_name;
-  /// Optional external idenitifer to pass to STS when assuming a role
+  /// Optional external identifier to pass to STS when assuming a role
   std::string external_id;
   /// Frequency (in seconds) to refresh temporary credentials from assumed role
   int load_frequency;
+  /// Optional: use STS web identity, obtained from environment variables.
+  bool use_web_identity = false;
 
   /// AWS credentials provider
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
@@ -87,6 +89,9 @@ struct ARROW_EXPORT S3Options {
       const std::string& role_arn, const std::string& session_name = "",
       const std::string& external_id = "", int load_frequency = 900,
       const std::shared_ptr<Aws::STS::STSClient>& stsClient = NULLPTR);
+
+  /// Configure with credentials from an assumed role with web identity.
+  void ConfigureAssumeRoleWithWebIdentityCredentials();
 
   std::string GetAccessKey() const;
   std::string GetSecretKey() const;
@@ -118,6 +123,9 @@ struct ARROW_EXPORT S3Options {
       const std::string& role_arn, const std::string& session_name = "",
       const std::string& external_id = "", int load_frequency = 900,
       const std::shared_ptr<Aws::STS::STSClient>& stsClient = NULLPTR);
+
+  /// \brief Initialize from an assumed role with web identity.
+  static S3Options FromAssumeRoleWithWebIdentity();
 
   static Result<S3Options> FromUri(const ::arrow::internal::Uri& uri,
                                    std::string* out_path = NULLPTR);

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -133,6 +133,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string role_arn
         c_string session_name
         c_string external_id
+        c_bool use_web_identity
         int load_frequency
         void ConfigureDefaultCredentials()
         void ConfigureAccessKey(const c_string& access_key,
@@ -159,6 +160,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
                                   const c_string& session_name,
                                   const c_string& external_id,
                                   const int load_frequency)
+
+        @staticmethod
+        CS3Options FromAssumeRoleWithWebIdentity()
 
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
         @staticmethod


### PR DESCRIPTION
Add support for AWS STS web identity.

The AWS SDK has made the strange choice to force users to pass web identity arguments through environment variables (see https://github.com/aws/aws-sdk-cpp/blob/2be13177875e944151132d90305dbc46e80bf8e3/aws-cpp-sdk-core/source/auth/STSCredentialsProvider.cpp), and does not provide a way of directly passing these values. 

I am not sure the design choice made in this PR is so great, but I have failed to find a nicer way to integrate, considering the limitations of the AWS sdk.