### PR TITLE
ARROW-10582: [Rust] [DataFusion] Implement "repartition" operator

### DIFF
--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -19,7 +19,9 @@
 
 use crate::arrow::record_batch::RecordBatch;
 use crate::error::Result;
-use crate::logical_plan::{DFSchema, Expr, FunctionRegistry, JoinType, LogicalPlan};
+use crate::logical_plan::{
+    DFSchema, Expr, FunctionRegistry, JoinType, LogicalPlan, Partitioning,
+};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -170,6 +172,24 @@ pub trait DataFrame {
         join_type: JoinType,
         left_cols: &[&str],
         right_cols: &[&str],
+    ) -> Result<Arc<dyn DataFrame>>;
+
+    /// Repartition a DataFrame based on a logical partitioning scheme.
+    ///
+    /// ```
+    /// # use datafusion::prelude::*;
+    /// # use datafusion::error::Result;
+    /// # fn main() -> Result<()> {
+    /// let mut ctx = ExecutionContext::new();
+    /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
+    /// let df1 = df.repartition(Partitioning::RoundRobinBatch(4))?;
+    /// let df2 = df.repartition(Partitioning::Hash(vec![col("a")], 4))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn repartition(
+        &self,
+        partitioning_scheme: Partitioning,
     ) -> Result<Arc<dyn DataFrame>>;
 
     /// Executes this DataFrame and collects all results into a vector of RecordBatch.

--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -183,7 +183,6 @@ pub trait DataFrame {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
     /// let df1 = df.repartition(Partitioning::RoundRobinBatch(4))?;
-    /// let df2 = df.repartition(Partitioning::Hash(vec![col("a")], 4))?;
     /// # Ok(())
     /// # }
     /// ```

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -24,6 +24,7 @@ use crate::error::Result;
 use crate::execution::context::{ExecutionContext, ExecutionContextState};
 use crate::logical_plan::{
     col, DFSchema, Expr, FunctionRegistry, JoinType, LogicalPlan, LogicalPlanBuilder,
+    Partitioning,
 };
 use crate::{arrow::record_batch::RecordBatch, physical_plan::collect};
 
@@ -107,6 +108,16 @@ impl DataFrame for DataFrameImpl {
     ) -> Result<Arc<dyn DataFrame>> {
         let plan = LogicalPlanBuilder::from(&self.plan)
             .join(&right.to_logical_plan(), join_type, left_cols, right_cols)?
+            .build()?;
+        Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))
+    }
+
+    fn repartition(
+        &self,
+        partitioning_scheme: Partitioning,
+    ) -> Result<Arc<dyn DataFrame>> {
+        let plan = LogicalPlanBuilder::from(&self.plan)
+            .repartition(partitioning_scheme)?
             .build()?;
         Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))
     }

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -35,7 +35,7 @@ use super::dfschema::ToDFSchema;
 use super::{
     col, exprlist_to_fields, Expr, JoinType, LogicalPlan, PlanType, StringifiedPlan,
 };
-use crate::logical_plan::{DFField, DFSchema, DFSchemaRef};
+use crate::logical_plan::{DFField, DFSchema, DFSchemaRef, Partitioning};
 use std::collections::HashSet;
 
 /// Builder for logical plans
@@ -205,6 +205,14 @@ impl LogicalPlanBuilder {
                 schema: DFSchemaRef::new(join_schema),
             }))
         }
+    }
+
+    /// Repartition
+    pub fn repartition(&self, partitioning_scheme: Partitioning) -> Result<Self> {
+        Ok(Self::from(&LogicalPlan::Repartition {
+            input: Arc::new(self.plan.clone()),
+            partitioning_scheme,
+        }))
     }
 
     /// Apply an aggregate

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -41,5 +41,7 @@ pub use expr::{
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;
-pub use plan::{JoinType, LogicalPlan, PlanType, PlanVisitor, StringifiedPlan};
+pub use plan::{
+    JoinType, LogicalPlan, Partitioning, PlanType, PlanVisitor, StringifiedPlan,
+};
 pub use registry::FunctionRegistry;

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -110,6 +110,13 @@ pub enum LogicalPlan {
         /// The output schema, containing fields from the left and right inputs
         schema: DFSchemaRef,
     },
+    /// Repartition the plan based on a partitioning scheme.
+    Repartition {
+        /// The incoming logical plan
+        input: Arc<LogicalPlan>,
+        /// The partitioning scheme
+        partitioning_scheme: Partitioning,
+    },
     /// Produces rows from a table provider by reference or from the context
     TableScan {
         /// The name of the table
@@ -182,6 +189,7 @@ impl LogicalPlan {
             LogicalPlan::Aggregate { schema, .. } => &schema,
             LogicalPlan::Sort { input, .. } => input.schema(),
             LogicalPlan::Join { schema, .. } => &schema,
+            LogicalPlan::Repartition { input, .. } => input.schema(),
             LogicalPlan::Limit { input, .. } => input.schema(),
             LogicalPlan::CreateExternalTable { schema, .. } => &schema,
             LogicalPlan::Explain { schema, .. } => &schema,
@@ -196,6 +204,15 @@ impl LogicalPlan {
             Field::new("plan", DataType::Utf8, false),
         ]))
     }
+}
+
+/// Logical partitioning schemes supported by the repartition operator.
+#[derive(Debug, Clone)]
+pub enum Partitioning {
+    /// Allocate batches using a round-robin algorithm
+    RoundRobinBatch(usize),
+    /// Allocate rows based on a hash of one of more expressions
+    Hash(Vec<Expr>, usize),
 }
 
 /// Trait that implements the [Visitor
@@ -261,6 +278,7 @@ impl LogicalPlan {
         let recurse = match self {
             LogicalPlan::Projection { input, .. } => input.accept(visitor)?,
             LogicalPlan::Filter { input, .. } => input.accept(visitor)?,
+            LogicalPlan::Repartition { input, .. } => input.accept(visitor)?,
             LogicalPlan::Aggregate { input, .. } => input.accept(visitor)?,
             LogicalPlan::Sort { input, .. } => input.accept(visitor)?,
             LogicalPlan::Join { left, right, .. } => {
@@ -464,7 +482,7 @@ impl LogicalPlan {
         struct Wrapper<'a>(&'a LogicalPlan);
         impl<'a> fmt::Display for Wrapper<'a> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                match *self.0 {
+                match &*self.0 {
                     LogicalPlan::EmptyRelation { .. } => write!(f, "EmptyRelation"),
                     LogicalPlan::TableScan {
                         ref table_name,
@@ -523,6 +541,28 @@ impl LogicalPlan {
                             keys.iter().map(|(l, r)| format!("{} = {}", l, r)).collect();
                         write!(f, "Join: {}", join_expr.join(", "))
                     }
+                    LogicalPlan::Repartition {
+                        partitioning_scheme,
+                        ..
+                    } => match partitioning_scheme {
+                        Partitioning::RoundRobinBatch(n) => {
+                            write!(
+                                f,
+                                "Repartition: RoundRobinBatch partition_count={}",
+                                n
+                            )
+                        }
+                        Partitioning::Hash(expr, n) => {
+                            let hash_expr: Vec<String> =
+                                expr.iter().map(|e| format!("{:?}", e)).collect();
+                            write!(
+                                f,
+                                "Repartition: Hash({}) partition_count={}",
+                                hash_expr.join(", "),
+                                n
+                            )
+                        }
+                    },
                     LogicalPlan::Limit { ref n, .. } => write!(f, "Limit: {}", n),
                     LogicalPlan::CreateExternalTable { ref name, .. } => {
                         write!(f, "CreateExternalTable: {:?}", name)

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -209,9 +209,11 @@ impl LogicalPlan {
 /// Logical partitioning schemes supported by the repartition operator.
 #[derive(Debug, Clone)]
 pub enum Partitioning {
-    /// Allocate batches using a round-robin algorithm
+    /// Allocate batches using a round-robin algorithm and the specified number of partitions
     RoundRobinBatch(usize),
-    /// Allocate rows based on a hash of one of more expressions
+    /// Allocate rows based on a hash of one of more expressions and the specified number
+    /// of partitions.
+    /// This partitioning scheme is not yet fully supported. See https://issues.apache.org/jira/browse/ARROW-11011
     Hash(Vec<Expr>, usize),
 }
 

--- a/rust/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/rust/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -117,6 +117,7 @@ impl OptimizerRule for HashBuildProbeOrder {
             | LogicalPlan::TableScan { .. }
             | LogicalPlan::Limit { .. }
             | LogicalPlan::Filter { .. }
+            | LogicalPlan::Repartition { .. }
             | LogicalPlan::EmptyRelation { .. }
             | LogicalPlan::Sort { .. }
             | LogicalPlan::CreateExternalTable { .. }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -275,6 +275,7 @@ fn optimize_plan(
         // expressions in this node to the list of required columns
         LogicalPlan::Limit { .. }
         | LogicalPlan::Filter { .. }
+        | LogicalPlan::Repartition { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Sort { .. }
         | LogicalPlan::CreateExternalTable { .. }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::Schema;
 use super::optimizer::OptimizerRule;
 use crate::error::{DataFusionError, Result};
 use crate::logical_plan::{
-    Expr, LogicalPlan, Operator, PlanType, StringifiedPlan, ToDFSchema,
+    Expr, LogicalPlan, Operator, Partitioning, PlanType, StringifiedPlan, ToDFSchema,
 };
 use crate::prelude::{col, lit};
 use crate::scalar::ScalarValue;
@@ -140,6 +140,13 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
     match plan {
         LogicalPlan::Projection { expr, .. } => expr.clone(),
         LogicalPlan::Filter { predicate, .. } => vec![predicate.clone()],
+        LogicalPlan::Repartition {
+            partitioning_scheme,
+            ..
+        } => match partitioning_scheme {
+            Partitioning::Hash(expr, _) => expr.clone(),
+            _ => vec![],
+        },
         LogicalPlan::Aggregate {
             group_expr,
             aggr_expr,
@@ -168,6 +175,7 @@ pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
     match plan {
         LogicalPlan::Projection { input, .. } => vec![input],
         LogicalPlan::Filter { input, .. } => vec![input],
+        LogicalPlan::Repartition { input, .. } => vec![input],
         LogicalPlan::Aggregate { input, .. } => vec![input],
         LogicalPlan::Sort { input, .. } => vec![input],
         LogicalPlan::Join { left, right, .. } => vec![left, right],
@@ -197,6 +205,19 @@ pub fn from_plan(
             predicate: expr[0].clone(),
             input: Arc::new(inputs[0].clone()),
         }),
+        LogicalPlan::Repartition {
+            partitioning_scheme,
+            ..
+        } => match partitioning_scheme {
+            Partitioning::RoundRobinBatch(n) => Ok(LogicalPlan::Repartition {
+                partitioning_scheme: Partitioning::RoundRobinBatch(*n),
+                input: Arc::new(inputs[0].clone()),
+            }),
+            Partitioning::Hash(_, n) => Ok(LogicalPlan::Repartition {
+                partitioning_scheme: Partitioning::Hash(expr.to_owned(), *n),
+                input: Arc::new(inputs[0].clone()),
+            }),
+        },
         LogicalPlan::Aggregate {
             group_expr, schema, ..
         } => Ok(LogicalPlan::Aggregate {

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -260,6 +260,7 @@ pub mod merge;
 pub mod parquet;
 pub mod planner;
 pub mod projection;
+pub mod repartition;
 pub mod sort;
 pub mod string_expressions;
 pub mod type_coercion;

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -107,11 +107,13 @@ pub async fn collect(plan: Arc<dyn ExecutionPlan>) -> Result<Vec<RecordBatch>> {
 /// Partitioning schemes supported by operators.
 #[derive(Debug, Clone)]
 pub enum Partitioning {
-    /// Allocate batches using a round-robin algorithm
+    /// Allocate batches using a round-robin algorithm and the specified number of partitions
     RoundRobinBatch(usize),
-    /// Allocate rows based on a hash of one of more expressions
+    /// Allocate rows based on a hash of one of more expressions and the specified
+    /// number of partitions
+    /// This partitioning scheme is not yet fully supported. See https://issues.apache.org/jira/browse/ARROW-11011
     Hash(Vec<Arc<dyn PhysicalExpr>>, usize),
-    /// Unknown partitioning scheme
+    /// Unknown partitioning scheme with a known number of partitions
     UnknownPartitioning(usize),
 }
 

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -109,9 +109,6 @@ pub async fn collect(plan: Arc<dyn ExecutionPlan>) -> Result<Vec<RecordBatch>> {
 pub enum Partitioning {
     /// Allocate batches using a round-robin algorithm
     RoundRobinBatch(usize),
-    /// Allocate rows using a round-robin algorithm. This provides finer-grained partitioning
-    /// than `RoundRobinBatch` but also has much more overhead.
-    RoundRobinRow(usize),
     /// Allocate rows based on a hash of one of more expressions
     Hash(Vec<Arc<dyn PhysicalExpr>>, usize),
     /// Unknown partitioning scheme
@@ -124,7 +121,6 @@ impl Partitioning {
         use Partitioning::*;
         match self {
             RoundRobinBatch(n) => *n,
-            RoundRobinRow(n) => *n,
             Hash(_, n) => *n,
             UnknownPartitioning(n) => *n,
         }

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -178,7 +178,9 @@ impl RepartitionExec {
 }
 
 struct RepartitionStream {
+    /// Number of input partitions that will be sending batches to this output channel
     num_input_partitions: usize,
+    /// Number of input partitions that have finished sending batches to this output channel
     num_input_partitions_processed: usize,
     /// Schema
     schema: SchemaRef,
@@ -202,6 +204,7 @@ impl Stream for RepartitionStream {
                     // all input partitions have finished sending batches
                     Poll::Ready(None)
                 } else {
+                    // other partitions still have data to send
                     Poll::Pending
                 }
             }

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+///! The repartition operator maps N input partitions to M output partitions based on a
+///! partitioning scheme.
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use crate::error::{DataFusionError, Result};
+use crate::physical_plan::{ExecutionPlan, Partitioning, PhysicalExpr};
+use arrow::datatypes::SchemaRef;
+use arrow::error::Result as ArrowResult;
+use arrow::record_batch::RecordBatch;
+
+use super::{RecordBatchStream, SendableRecordBatchStream};
+use async_trait::async_trait;
+
+use futures::stream::Stream;
+
+/// Partitioning schemes
+#[derive(Debug, Clone)]
+pub enum PartitioningScheme {
+    /// Allocate batches using a round-robin algorithm
+    RoundRobinBatch,
+    /// Allocate rows using a round-robin algorithm. This provides finer-grained partitioning
+    /// than `RoundRobinBatch` but also has much more overhead.
+    RoundRobinRow,
+    /// Allocate rows based on a hash of one of more expressions
+    Hash(Vec<Arc<dyn PhysicalExpr>>),
+}
+
+/// partition. No guarantees are made about the order of the resulting partition.
+#[derive(Debug)]
+pub struct RepartitionExec {
+    /// Input execution plan
+    input: Arc<dyn ExecutionPlan>,
+    /// Partitioning scheme to use
+    partitioning_scheme: PartitioningScheme,
+    /// Number of output partitions
+    num_partitions: usize,
+}
+
+#[async_trait]
+impl ExecutionPlan for RepartitionExec {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Get the schema for this execution plan
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match children.len() {
+            1 => Ok(Arc::new(RepartitionExec::try_new(
+                children[0].clone(),
+                self.partitioning_scheme.clone(),
+                self.num_partitions,
+            )?)),
+            _ => Err(DataFusionError::Internal(
+                "RepartitionExec wrong number of children".to_string(),
+            )),
+        }
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        //TODO needs more work
+        Partitioning::UnknownPartitioning(self.num_partitions)
+    }
+
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        // lock mutex
+        // if first call to this method {
+        //   create one channel per *output* partition
+        //   launch one async task per *input* partition
+        // }
+
+        // now return stream for the specified *output* partition which will
+        // read from the channel
+
+        Ok(Box::pin(RepartitionStream {
+            schema: self.input.schema(),
+            //input: the *output* channel to read from
+        }))
+    }
+}
+
+impl RepartitionExec {
+    /// Create a new MergeExec
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        partioning_scheme: PartitioningScheme,
+        num_partitions: usize,
+    ) -> Result<Self> {
+        match &partioning_scheme {
+            PartitioningScheme::RoundRobinBatch => Ok(RepartitionExec {
+                input,
+                partitioning_scheme: partioning_scheme,
+                num_partitions,
+            }),
+            other => Err(DataFusionError::NotImplemented(format!(
+                "Partitioning scheme not supported yet: {:?}",
+                other
+            ))),
+        }
+    }
+
+    async fn process_input_partition(&self, partition: usize) -> Result<()> {
+        let input = self.input.execute(partition).await?;
+        // for each input batch {
+        //   compute output partition based on partitioning schema
+        //     send batch to the appropriate output channel, or split batch into
+        //     multiple batches if using row-based partitioning
+        //   }
+        // }
+        Ok(())
+    }
+}
+
+struct RepartitionStream {
+    schema: SchemaRef,
+    //input: Channel to read
+}
+
+impl Stream for RepartitionStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        unimplemented!()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        unimplemented!()
+    }
+}
+
+impl RecordBatchStream for RepartitionStream {
+    /// Get the schema
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -98,9 +98,8 @@ impl ExecutionPlan for RepartitionExec {
         if tx.is_empty() {
             // create one channel per *output* partition
             for _ in 0..num_output_partition {
-                //TODO this operator currently uses unbounded channels to avoid deadlocks and
-                // this is far from ideal
-
+                // note that this operator uses unbounded channels to avoid deadlocks because
+                // the output partitions can be read in any order and block the input partitions
                 let (sender, receiver) = unbounded::<Option<ArrowResult<RecordBatch>>>();
                 tx.push(sender);
                 rx.push(receiver);

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -40,7 +40,8 @@ use tokio::task::JoinHandle;
 
 type MaybeBatch = Option<ArrowResult<RecordBatch>>;
 
-/// partition. No guarantees are made about the order of the resulting partition.
+/// The repartition operator maps N input partitions to M output partitions based on a
+/// partitioning scheme. No guarantees are made about the order of the resulting partitions.
 #[derive(Debug)]
 pub struct RepartitionExec {
     /// Input execution plan
@@ -312,11 +313,11 @@ mod tests {
     async fn repartition(
         schema: &SchemaRef,
         input_partitions: Vec<Vec<RecordBatch>>,
-        partitioning_scheme: Partitioning,
+        partitioning: Partitioning,
     ) -> Result<Vec<Vec<RecordBatch>>> {
         // create physical plan
         let exec = MemoryExec::try_new(&input_partitions, schema.clone(), None)?;
-        let exec = RepartitionExec::try_new(Arc::new(exec), partitioning_scheme)?;
+        let exec = RepartitionExec::try_new(Arc::new(exec), partitioning)?;
 
         // execute and collect results
         let mut output_partitions = vec![];

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -192,3 +192,14 @@ impl RecordBatchStream for RepartitionStream {
         self.schema.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test() -> Result<()> {
+        // TODO write tests for the physical operator
+        Ok(())
+    }
+}

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -48,6 +48,7 @@ pub struct RepartitionExec {
     /// Partitioning scheme to use
     partitioning: Partitioning,
     /// Channels for sending batches from input partitions to output partitions
+    /// there is one entry in this Vec for each output partition
     channels: Arc<Mutex<Vec<(Sender<MaybeBatch>, Receiver<MaybeBatch>)>>>,
 }
 

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -193,7 +193,7 @@ impl Stream for RepartitionStream {
 
     fn poll_next(
         mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         match self.input.recv() {
             Ok(Some(batch)) => Poll::Ready(Some(batch)),
@@ -205,7 +205,7 @@ impl Stream for RepartitionStream {
                     Poll::Ready(None)
                 } else {
                     // other partitions still have data to send
-                    Poll::Pending
+                    self.poll_next(cx)
                 }
             }
             // RecvError means receiver has exited and closed the channel
@@ -278,11 +278,11 @@ mod tests {
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(5)).await?;
 
         assert_eq!(5, output_partitions.len());
-        assert_eq!(150, output_partitions[0].len());
-        assert_eq!(150, output_partitions[1].len());
-        assert_eq!(150, output_partitions[2].len());
-        assert_eq!(150, output_partitions[3].len());
-        assert_eq!(150, output_partitions[4].len());
+        assert_eq!(30, output_partitions[0].len());
+        assert_eq!(30, output_partitions[1].len());
+        assert_eq!(30, output_partitions[2].len());
+        assert_eq!(30, output_partitions[3].len());
+        assert_eq!(30, output_partitions[4].len());
 
         Ok(())
     }

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -29,5 +29,6 @@ pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::logical_plan::{
     array, avg, col, concat, count, create_udf, length, lit, max, min, sum, JoinType,
+    Partitioning,
 };
 pub use crate::physical_plan::csv::CsvReadOptions;


### PR DESCRIPTION
This PR adds support for the `repartition` operator and it is plumbed through from the `DataFrame` API all the way through to execution.

The benchmark crate TPC-H file conversion utility has been updated to take advantage of this new operator.

I can break this down into smaller PRs if that helps.