### PR TITLE
ARROW-11005: [Rust] Remove indirection from `take` kernel

### DIFF
--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -21,8 +21,9 @@
 
 use super::{
     Array, ArrayData, BinaryOffsetSizeTrait, BooleanArray, DecimalArray,
-    FixedSizeBinaryArray, GenericBinaryArray, GenericListArray, GenericStringArray,
-    NullArray, OffsetSizeTrait, PrimitiveArray, StringOffsetSizeTrait, StructArray,
+    FixedSizeBinaryArray, FixedSizeListArray, GenericBinaryArray, GenericListArray,
+    GenericStringArray, NullArray, OffsetSizeTrait, PrimitiveArray,
+    StringOffsetSizeTrait, StructArray,
 };
 
 use crate::{
@@ -111,6 +112,12 @@ impl PartialEq for DecimalArray {
 }
 
 impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericListArray<OffsetSize> {
+    fn eq(&self, other: &Self) -> bool {
+        equal(self.data().as_ref(), other.data().as_ref())
+    }
+}
+
+impl PartialEq for FixedSizeListArray {
     fn eq(&self, other: &Self) -> bool {
         equal(self.data().as_ref(), other.data().as_ref())
     }

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -1123,7 +1123,7 @@ where
                 )
             })?;
 
-    take(&cast_dict_values, u32_indicies, None)
+    take(cast_dict_values.as_ref(), u32_indicies, None)
 }
 
 /// Attempts to encode an array into an `ArrayDictionary` with index

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -38,7 +38,7 @@ use TimeUnit::*;
 ///
 pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef> {
     let indices = sort_to_indices(values, options)?;
-    take(values, &indices, None)
+    take(values.as_ref(), &indices, None)
 }
 
 // partition indices into non-NaN and NaN
@@ -626,7 +626,7 @@ pub fn lexsort(columns: &[SortColumn]) -> Result<Vec<ArrayRef>> {
     let indices = lexsort_to_indices(columns)?;
     columns
         .iter()
-        .map(|c| take(&c.values, &indices, None))
+        .map(|c| take(c.values.as_ref(), &indices, None))
         .collect()
 }
 

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -303,7 +303,7 @@ fn group_aggregate_batch(
                             .map(|array| {
                                 // 2.3
                                 compute::take(
-                                    array,
+                                    array.as_ref(),
                                     &UInt32Array::from(indices.clone()),
                                     None, // None: no index check
                                 )

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -167,7 +167,7 @@ fn sort_batches(
             .iter()
             .map(|column| {
                 take(
-                    column,
+                    column.as_ref(),
                     &indices,
                     // disable bound check overhead since indices are already generated from
                     // the same record batch


### PR DESCRIPTION
This PR is a small cleanup of the `take` kernel.

1. replaces `&Arc<Array>` by `&Array`. This is a small change in the API, but makes it more obvious that the only requirements for `take` is implementing the trait `Array`.
2. internal concrete implementations of `take` are no longer `dyn`, and instead expect the corresponding array types and return the corresponding array types.
3. Clarified in the documentation that not performing bound checks can lead to undefined behavior.
4. Added equality for `FixedSizeListArray`, that was missing.

The rational for this PR is that it makes it more obvious the design of the module: each array type has its own implementation (e.g. `take_primitive<T>(array: &PrimitiveArray<T>, indices: ...) -> PrimitiveArray<T>`), and there is one `dyn` implementation, `take(array: &Array, indices: ...) -> ArrayRef`, that uses each type-specific implementation and wraps it on an `Arc<Array>` for the `dyn` behavior. This is mostly for simplicity and readability, but we could expose these methods publicly.