### PR TITLE
ARROW-11014: [Rust] [DataFusion] Use correct statistics for ParquetExec

### DIFF
--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -27,7 +27,7 @@ use crate::physical_plan::ExecutionPlan;
 
 /// This table statistics are estimates.
 /// It can not be used directly in the precise compute
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Statistics {
     /// The number of table rows
     pub num_rows: Option<usize>,

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -40,7 +40,7 @@ pub struct ParquetTable {
 impl ParquetTable {
     /// Attempt to initialize a new `ParquetTable` from a file path.
     pub fn try_new(path: &str) -> Result<Self> {
-        let parquet_exec = ParquetExec::try_new(path, None, 0)?;
+        let parquet_exec = ParquetExec::try_from_path(path, None, 0)?;
         let schema = parquet_exec.schema();
         Ok(Self {
             path: path.to_string(),
@@ -68,7 +68,7 @@ impl TableProvider for ParquetTable {
         batch_size: usize,
         _filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ParquetExec::try_new(
+        Ok(Arc::new(ParquetExec::try_from_path(
             &self.path,
             projection.clone(),
             batch_size,

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,7 +22,6 @@ use std::string::String;
 use std::sync::Arc;
 
 use arrow::datatypes::*;
-use parquet::file::metadata::RowGroupMetaData;
 
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
@@ -43,26 +42,10 @@ impl ParquetTable {
     pub fn try_new(path: &str) -> Result<Self> {
         let parquet_exec = ParquetExec::try_new(path, None, 0)?;
         let schema = parquet_exec.schema();
-
-        let metadata = parquet_exec.metadata();
-        let num_rows: i64 = metadata
-            .row_groups()
-            .iter()
-            .map(RowGroupMetaData::num_rows)
-            .sum();
-        let total_byte_size: i64 = metadata
-            .row_groups()
-            .iter()
-            .map(RowGroupMetaData::total_byte_size)
-            .sum();
-
         Ok(Self {
             path: path.to_string(),
             schema,
-            statistics: Statistics {
-                num_rows: Some(num_rows as usize),
-                total_byte_size: Some(total_byte_size as usize),
-            },
+            statistics: parquet_exec.statistics().to_owned(),
         })
     }
 }

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -90,6 +90,10 @@ impl ParquetExec {
                 path
             )))
         } else {
+            let filenames = filenames
+                .iter()
+                .map(|filename| filename.as_str())
+                .collect::<Vec<&str>>();
             Self::try_from_files(&filenames, projection, batch_size)
         }
     }
@@ -97,7 +101,7 @@ impl ParquetExec {
     /// Create a new Parquet reader execution plan based on the specified list of Parquet
     /// files
     pub fn try_from_files(
-        filenames: &[String],
+        filenames: &[&str],
         projection: Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Self> {
@@ -127,7 +131,7 @@ impl ParquetExec {
                 total_byte_size: Some(total_byte_size as usize),
             };
             partitions.push(ParquetPartition {
-                filename: filename.to_owned(),
+                filename: filename.to_owned().to_string(),
                 statistics,
             });
         }

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -104,7 +104,7 @@ impl ParquetExec {
         // build a list of Parquet partitions with statistics and gather all unique schemas
         // used in this data set
         let mut schemas: Vec<Schema> = vec![];
-        let mut partitions = vec![];
+        let mut partitions = Vec::with_capacity(filenames.len());
         for filename in filenames {
             let file = File::open(filename)?;
             let file_reader = Arc::new(SerializedFileReader::new(file)?);

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -167,25 +167,20 @@ impl ParquetExec {
         );
 
         // sum the statistics
-        let mut num_rows = 0;
-        let mut total_byte_size = 0;
+        let mut num_rows: Option<usize> = None;
+        let mut total_byte_size: Option<usize> = None;
         for part in &partitions {
-            num_rows += part.statistics.num_rows.unwrap_or(0);
-            total_byte_size += part.statistics.total_byte_size.unwrap_or(0);
+            if let Some(n) = part.statistics.num_rows {
+                num_rows = Some(num_rows.unwrap_or(0) + n)
+            }
+            if let Some(n) = part.statistics.total_byte_size {
+                total_byte_size = Some(total_byte_size.unwrap_or(0) + n)
+            }
         }
         let statistics = Statistics {
-            num_rows: if num_rows == 0 {
-                None
-            } else {
-                Some(num_rows as usize)
-            },
-            total_byte_size: if total_byte_size == 0 {
-                None
-            } else {
-                Some(total_byte_size as usize)
-            },
+            num_rows,
+            total_byte_size,
         };
-
         Self {
             partitions,
             schema: Arc::new(projected_schema),


### PR DESCRIPTION
ParquetExec represents multiple files but we were calculating statistics based on the first file.

I stumbled across this when working on https://issues.apache.org/jira/browse/ARROW-10995