### PR TITLE
ARROW-10943: [Rust][Parquet] Always init new RleDecoder

### DIFF
--- a/rust/parquet/src/encodings/decoding.rs
+++ b/rust/parquet/src/encodings/decoding.rs
@@ -301,6 +301,7 @@ impl<T: DataType> Decoder<T> for RleValueDecoder<T> {
         // We still need to remove prefix of i32 from the stream.
         const I32_SIZE: usize = mem::size_of::<i32>();
         let data_size = read_num_bytes!(i32, I32_SIZE, data.as_ref()) as usize;
+        self.decoder = RleDecoder::new(1);
         self.decoder.set_data(data.range(I32_SIZE, data_size));
         self.values_left = num_values;
         Ok(())


### PR DESCRIPTION
Part of the removal of specialisation makes the RleDecoder remain
instanticated. This is done to lose some allocations but right now
appears to leave a decoder in a semi configured state that can mis-read
RLE packed data.

As such we just init a new one each time the parent decoder has data set
on it in a fashion to the pre refactored code.