### PR TITLE
ARROW-11013: [Rust][DataFusion] Add trim to CsvReader

### DIFF
--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -35,7 +35,8 @@ fn main() -> Result<()> {
 
     let file = File::open("test/data/uk_cities.csv").unwrap();
 
-    let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None);
+    let mut csv =
+        csv::Reader::new(file, Arc::new(schema), false, None, false, 1024, None, None);
     let _batch = csv.next().unwrap().unwrap();
     #[cfg(feature = "prettyprint")]
     {

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -53,6 +53,7 @@ pub struct CsvFile {
     schema: SchemaRef,
     has_header: bool,
     delimiter: u8,
+    trim: bool,
     file_extension: String,
     statistics: Statistics,
 }
@@ -77,6 +78,7 @@ impl CsvFile {
             schema,
             has_header: options.has_header,
             delimiter: options.delimiter,
+            trim: options.trim,
             file_extension: String::from(options.file_extension),
             statistics: Statistics::default(),
         })
@@ -104,6 +106,7 @@ impl TableProvider for CsvFile {
                 .schema(&self.schema)
                 .has_header(self.has_header)
                 .delimiter(self.delimiter)
+                .trim(self.trim)
                 .file_extension(self.file_extension.as_str()),
             projection.clone(),
             batch_size,


### PR DESCRIPTION
The current CSV reader cannot parse strings to types with leading/trailing white spaces as the parsers are very strict. This means being able to read and parse the [tpch-dbgen included answers](https://github.com/databricks/tpch-dbgen/tree/master/answers) files is not possible.

The underlying csv crate supports a four different [behaviors for trimming strings](https://docs.rs/csv/1.1.5/csv/enum.Trim.html): 
- `None` (default): does no trimming.
- `Headers`: trim only header fields.
- `Fields`: trim only field values.
- `All`: trim both headers and field values.

Rather than exposing all these options and forcing users to understand the underlying csv crate this PR simplifies this decision to boolean: `None` (false) or `All` (true) while retaining the default false behavior.