### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,33 +104,12 @@ jobs:
         # We should use LLVM provided by Ubuntu.
         LLVM: "10"
         UBUNTU: "20.04"
-
-    - name: "Go on s390x"
-      os: linux
-      arch: s390x
-      env:
-        <<: *global_env
-        ARCH: s390x
-        ARROW_CI_MODULES: "GO"
-        DOCKER_IMAGE_ID: debian-go
-
-    - name: "Java on s390x"
-      os: linux
-      arch: s390x
-      env:
-        <<: *global_env
-        ARCH: s390x
-        ARROW_CI_MODULES: "JAVA"
-        DOCKER_IMAGE_ID: debian-java
-        JDK: 11
-        
-    
     - name: "C++ on ppc64le"
       os: linux
       arch: ppc64le
       env:
         <<: *global_env
-        ARCH: s390x
+        ARCH: ppc64le
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
         # Can't enable ARROW_MIMALLOC because of failures in memory pool tests.
@@ -156,25 +135,43 @@ jobs:
         # We should use LLVM provided by Ubuntu.
         LLVM: "10"
         UBUNTU: "20.04"
+ 
 
-    - name: "Go on ppc64le"
+    - name: "Go on s390x"
       os: linux
-      arch: ppc64le
+      arch: s390x
       env:
         <<: *global_env
         ARCH: s390x
         ARROW_CI_MODULES: "GO"
         DOCKER_IMAGE_ID: debian-go
-
-    - name: "Java on ppc64le"
+    - name: "Go on ppc64le"
       os: linux
       arch: ppc64le
+      env:
+        <<: *global_env
+        ARCH: ppc64le
+        ARROW_CI_MODULES: "GO"
+        DOCKER_IMAGE_ID: debian-go
+
+    - name: "Java on s390x"
+      os: linux
+      arch: s390x
       env:
         <<: *global_env
         ARCH: s390x
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
-        JDK: 11    
+        JDK: 11
+    - name: "Java on ppc64le"
+      os: linux
+      arch: ppc64le
+      env:
+        <<: *global_env
+        ARCH: ppc64le
+        ARROW_CI_MODULES: "JAVA"
+        DOCKER_IMAGE_ID: debian-java
+        JDK: 11 
 
   allow_failures:
     - arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@
 dist: bionic
 
 language: minimal
+arch:
+ - amd64
+ - ppc64le
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# Package             : pyarrow
-# Source Repo         : https://github.com/apache/arrow
-# Travis Job Link     : https://travis-ci.com/github/santosh653/arrow
-# Created travis.yml  : No
-# Maintainer          : Santosh Kulkarni <santoshkulkarni70@gmail.com>
-#
-# Script License      : Apache License, Version 2 or later
+
 dist: bionic
 
 language: minimal
-arch:
- - amd64
- - ppc64le
 
 cache:
   directories:
@@ -40,12 +31,21 @@ addons:
 services:
   - docker
 
+# Note that the global "env" setting isn't inherited automatically by
+# matrix entries with their own "env", so we have to insert it explicitly.
+env: &global_env
+  ARROW_ENABLE_TIMING_TESTS: "OFF"
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  DOCKER_BUILDKIT: 0
+  DOCKER_VOLUME_PREFIX: $TRAVIS_BUILD_DIR/.docker/
+
 jobs:
   include:
     - name: "C++ on ARM"
       os: linux
       arch: arm64
       env:
+        <<: *global_env
         ARCH: arm64v8
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
@@ -56,6 +56,9 @@ jobs:
         # been received in the last 10m0s, this potentially indicates
         # a stalled build or something wrong with the build itself."
         # on Travis CI.
+        #
+        # Limiting CPP_MAKE_PARALLELISM is required to avoid random compiler
+        # crashes.
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
@@ -63,16 +66,7 @@ jobs:
           -e ARROW_S3=OFF
           -e ARROW_USE_GLOG=OFF
           -e CMAKE_UNITY_BUILD=ON
-          "
-        # We need to use smaller build when cache doesn't exist
-        # because Travis CI has "No output has been received in the
-        # last 10m0s" limitation. If we build many modules, we reach
-        # the limitation.
-        DOCKER_RUN_ARGS_NO_CACHE: >-
-          "
-          -e ARROW_BUILD_TESTS=OFF
-          -e ARROW_GANDIVA=OFF
-          -e ARROW_PARQUET=OFF
+          -e CPP_MAKE_PARALLELISM=4
           "
         # The LLVM's APT repository provides only arm64 binaries.
         # We should use LLVM provided by Ubuntu.
@@ -83,19 +77,23 @@ jobs:
       os: linux
       arch: s390x
       env:
+        <<: *global_env
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
-        # Can't use CMAKE_UNITIFY_BUILD=ON because of compiler crash.
+        # Can't enable ARROW_MIMALLOC because of failures in memory pool tests.
         # Can't enable ARROW_S3 because compiler is killed while compiling
         # aws-sdk-cpp.
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_S3=OFF
+          -e CMAKE_UNITY_BUILD=ON
+          -e CPP_MAKE_PARALLELISM=4
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF
           -e Protobuf_SOURCE=BUNDLED
@@ -111,6 +109,7 @@ jobs:
       os: linux
       arch: s390x
       env:
+        <<: *global_env
         ARCH: s390x
         ARROW_CI_MODULES: "GO"
         DOCKER_IMAGE_ID: debian-go
@@ -119,28 +118,34 @@ jobs:
       os: linux
       arch: s390x
       env:
+        <<: *global_env
         ARCH: s390x
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
         JDK: 11
+        
     
     - name: "C++ on ppc64le"
       os: linux
       arch: ppc64le
       env:
-        ARCH: ppc64le
+        <<: *global_env
+        ARCH: s390x
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
-        # Can't use CMAKE_UNITIFY_BUILD=ON because of compiler crash.
+        # Can't enable ARROW_MIMALLOC because of failures in memory pool tests.
         # Can't enable ARROW_S3 because compiler is killed while compiling
         # aws-sdk-cpp.
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_S3=OFF
+          -e CMAKE_UNITY_BUILD=ON
+          -e CPP_MAKE_PARALLELISM=4
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF
           -e Protobuf_SOURCE=BUNDLED
@@ -156,7 +161,8 @@ jobs:
       os: linux
       arch: ppc64le
       env:
-        ARCH: ppc64le
+        <<: *global_env
+        ARCH: s390x
         ARROW_CI_MODULES: "GO"
         DOCKER_IMAGE_ID: debian-go
 
@@ -164,18 +170,14 @@ jobs:
       os: linux
       arch: ppc64le
       env:
-        ARCH: ppc64le
+        <<: *global_env
+        ARCH: s390x
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
-        JDK: 11
+        JDK: 11    
 
   allow_failures:
     - arch: s390x
-
-env:
-  DOCKER_BUILDKIT: 0
-  COMPOSE_DOCKER_CLI_BUILD: 1
-  ARROW_ENABLE_TIMING_TESTS: "OFF"
 
 before_install:
   - eval "$(python ci/detect-changes.py)"
@@ -190,7 +192,6 @@ before_install:
     if [ "${arrow_ci_affected}" = "no" ]; then
       travis_terminate 0
     fi
-
 install:
   - pip3 install -e dev/archery[docker]
 
@@ -201,15 +202,10 @@ script:
   - |
     ulimit -c unlimited || :
   - |
-    if [ $(ls $TRAVIS_BUILD_DIR/.docker | wc -l) -eq 0 ]; then
-      DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} ${DOCKER_RUN_ARGS_NO_CACHE}"
-    fi
-  - |
     archery docker run \
       ${DOCKER_RUN_ARGS} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
-
 after_success:
   - |
     if [ "${TRAVIS_EVENT_TYPE}" = "push" -a \

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+# Package             : pyarrow
+# Source Repo         : https://github.com/apache/arrow
+# Travis Job Link     : https://travis-ci.com/github/santosh653/arrow
+# Created travis.yml  : No
+# Maintainer          : Santosh Kulkarni <santoshkulkarni70@gmail.com>
+#
+# Script License      : Apache License, Version 2 or later
 dist: bionic
 
 language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,51 @@ jobs:
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
         JDK: 11
+    
+    - name: "C++ on ppc64le"
+      os: linux
+      arch: ppc64le
+      env:
+        ARCH: ppc64le
+        ARROW_CI_MODULES: "CPP"
+        DOCKER_IMAGE_ID: ubuntu-cpp
+        # Can't use CMAKE_UNITIFY_BUILD=ON because of compiler crash.
+        # Can't enable ARROW_S3 because compiler is killed while compiling
+        # aws-sdk-cpp.
+        DOCKER_RUN_ARGS: >-
+          "
+          -e ARROW_BUILD_STATIC=OFF
+          -e ARROW_FLIGHT=ON
+          -e ARROW_ORC=OFF
+          -e ARROW_PARQUET=OFF
+          -e ARROW_S3=OFF
+          -e PARQUET_BUILD_EXAMPLES=OFF
+          -e PARQUET_BUILD_EXECUTABLES=OFF
+          -e Protobuf_SOURCE=BUNDLED
+          -e cares_SOURCE=BUNDLED
+          -e gRPC_SOURCE=BUNDLED
+          "
+        # The LLVM's APT repository provides only arm64 binaries.
+        # We should use LLVM provided by Ubuntu.
+        LLVM: "10"
+        UBUNTU: "20.04"
+
+    - name: "Go on ppc64le"
+      os: linux
+      arch: ppc64le
+      env:
+        ARCH: ppc64le
+        ARROW_CI_MODULES: "GO"
+        DOCKER_IMAGE_ID: debian-go
+
+    - name: "Java on ppc64le"
+      os: linux
+      arch: ppc64le
+      env:
+        ARCH: ppc64le
+        ARROW_CI_MODULES: "JAVA"
+        DOCKER_IMAGE_ID: debian-java
+        JDK: 11
 
   allow_failures:
     - arch: s390x


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/arrow