### PR TITLE
ARROW-11029: [Rust] [DataFusion] Add documentation for code that determines number of rows per operator

### DIFF
--- a/rust/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/rust/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -53,7 +53,18 @@ fn get_num_rows(logical_plan: &LogicalPlan) -> Option<usize> {
             let num_rows_input = get_num_rows(input);
             num_rows_input.map(|rows| std::cmp::min(*limit, rows))
         }
+        LogicalPlan::Aggregate { .. } => {
+            // we cannot yet predict how many rows will be produced by an aggregate because
+            // we do not know the cardinality of the grouping keys
+            None
+        }
+        LogicalPlan::Filter { .. } => {
+            // we cannot yet predict how many rows will be produced by a filter because
+            // we don't know how selective it is (how many rows it will filter out)
+            None
+        }
         _ => {
+            // by default, recurse down the plan
             let inputs = utils::inputs(logical_plan);
             if inputs.len() == 1 {
                 get_num_rows(inputs[0])


### PR DESCRIPTION
Recurse down the plan when looking for number of rows when optimizing join order, so that we get the optimization even when the table scan is wrapped in a filter.

Without this change, TPC-H q12 has the larger lineitem table on the left.