### PR TITLE
ARROW-11033 [Rust] Csv writing performance improvements 

### DIFF
--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -73,18 +73,32 @@ use crate::array::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
-
+use lexical_core;
 const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
+
+unsafe fn vector_as_slice<'a, T>(buf: &'a mut Vec<T>) -> &'a mut [T] {
+    let first = buf.as_mut_ptr();
+    std::slice::from_raw_parts_mut(first, buf.capacity())
+}
+pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
+    let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
+    unsafe {
+        let len = lexical_core::write(n, vector_as_slice(&mut buf)).len();
+        buf.set_len(len);
+        String::from_utf8_unchecked(buf)
+    }
+}
 
 fn write_primitive_value<T>(array: &ArrayRef, i: usize) -> String
 where
     T: ArrowNumericType,
     T::Native: std::string::ToString,
+    T::Native: lexical_core::ToLexical,
 {
     let c = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
-    c.value(i).to_string()
+    to_string::<T::Native>(c.value(i))
 }
 
 /// A CSV writer

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -272,7 +272,7 @@ impl<W: Write> Writer<W> {
 
         for row_index in 0..batch.num_rows() {
             self.convert(batch, row_index, &mut buffer)?;
-            self.writer.write_record(&buffer[..])?;
+            self.writer.write_record(&buffer)?;
         }
         self.writer.flush()?;
 

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -80,7 +80,7 @@ const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
 pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
     let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
     unsafe {
-        let mut slice = std::slice::from_raw_parts_mut(first.as_mut_ptr(), buf.capacity());
+        let mut slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
         let len = lexical_core::write(n, slice).len();
         buf.set_len(len);
         String::from_utf8_unchecked(buf)

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -80,6 +80,12 @@ const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
 pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
     let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
     unsafe {
+        // JUSTIFICATION
+        //  Benefit
+        //      Allows using the faster serializer lexical core and convert to string
+        //  Soundness
+        //      Length of buf is set as written length afterwards. lexical_core
+        //      creates a valid string, so doesn't need to be checked.
         let mut slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
         let len = lexical_core::write(n, slice).len();
         buf.set_len(len);

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -73,7 +73,6 @@ use crate::array::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
-use lexical_core;
 const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -86,7 +86,7 @@ pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
         //  Soundness
         //      Length of buf is set as written length afterwards. lexical_core
         //      creates a valid string, so doesn't need to be checked.
-        let mut slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
+        let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
         let len = lexical_core::write(n, slice).len();
         buf.set_len(len);
         String::from_utf8_unchecked(buf)

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -136,7 +136,7 @@ impl<W: Write> Writer<W> {
             if col.is_null(row_index) {
                 // write an empty value
                 *item = "".to_string();
-                continue;   
+                continue;
             }
             let string = match col.data_type() {
                 DataType::Float64 => write_primitive_value::<Float64Type>(col, row_index),

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -96,11 +96,10 @@ pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
 fn write_primitive_value<T>(array: &ArrayRef, i: usize) -> String
 where
     T: ArrowNumericType,
-    T::Native: std::string::ToString,
     T::Native: lexical_core::ToLexical,
 {
     let c = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
-    to_string::<T::Native>(c.value(i))
+    to_string(c.value(i))
 }
 
 /// A CSV writer

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -77,14 +77,11 @@ const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
 
-unsafe fn vector_as_slice<'a, T>(buf: &'a mut Vec<T>) -> &'a mut [T] {
-    let first = buf.as_mut_ptr();
-    std::slice::from_raw_parts_mut(first, buf.capacity())
-}
 pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
     let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
     unsafe {
-        let len = lexical_core::write(n, vector_as_slice(&mut buf)).len();
+        let mut slice = std::slice::from_raw_parts_mut(first.as_mut_ptr(), buf.capacity());
+        let len = lexical_core::write(n, slice).len();
         buf.set_len(len);
         String::from_utf8_unchecked(buf)
     }

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -89,6 +89,10 @@ struct ConvertOpt {
     /// Number of partitions to produce
     #[structopt(short = "p", long = "partitions", default_value = "1")]
     partitions: usize,
+
+    /// Batch size when reading CSV or Parquet files
+    #[structopt(short = "s", long = "batch-size", default_value = "4096")]
+    batch_size: usize,
 }
 
 #[derive(Debug, StructOpt)]
@@ -1019,7 +1023,8 @@ async fn convert_tbl(opt: ConvertOpt) -> Result<()> {
             .delimiter(b'|')
             .file_extension(".tbl");
 
-        let mut ctx = ExecutionContext::new();
+        let config = ExecutionConfig::new().with_batch_size(opt.batch_size);
+        let mut ctx = ExecutionContext::with_config(config);
 
         // build plan to read the TBL file
         let mut csv = ctx.read_csv(&input_path, options)?;


### PR DESCRIPTION
Some performance improvements for the csv writer

* Use lexical core for numeric types
* Allow setting batch size in convert (slightly faster reading when using higher batch size, could also be helpful in writing)
* Avoid allocation of vec


PR: `cargo run --release --bin tpch -- convert --input path --output ./output --format csv -s 20000`
Orders / lineitems:

```
Conversion completed in 2050 ms
Conversion completed in 16955 ms
```
Master `cargo run --release --bin tpch -- convert --input path --output ./output --format csv`

```
Conversion completed in 2336 ms
Conversion completed in 19070 ms
```