### PR TITLE
ARROW-9777: [Rust] [IPC] write custom metadata [WIP]

### DIFF
--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -57,7 +57,7 @@ pub fn flight_schema_from_arrow_schema(
     options: &IpcWriteOptions,
 ) -> SchemaResult {
     let data_gen = writer::IpcDataGenerator::default();
-    let schema_bytes = data_gen.schema_to_bytes(schema, &options);
+    let schema_bytes = data_gen.schema_to_bytes(schema, &options, &None);
 
     SchemaResult {
         schema: schema_bytes.ipc_message,
@@ -70,7 +70,7 @@ pub fn flight_data_from_arrow_schema(
     options: &IpcWriteOptions,
 ) -> FlightData {
     let data_gen = writer::IpcDataGenerator::default();
-    let schema = data_gen.schema_to_bytes(schema, &options);
+    let schema = data_gen.schema_to_bytes(schema, &options, &None);
     FlightData {
         flight_descriptor: None,
         app_metadata: vec![],

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -185,8 +185,8 @@ pub enum IntervalUnit {
 }
 
 /// The `CustomMetaData` is an alias to `BTreeMap` which implements traits: Hash, PartialOrd, Ord.
-/// It contains custom meta data (key-value pairs), defined by flatbuffers structs:
-/// `Field`, `Message`, or file `Footer`.
+/// It contains custom meta data (key-value pairs) defined by Arrow format for: field, file
+/// footer, message and schema.
 pub type CustomMetaData = BTreeMap<String, String>;
 
 /// Contains the meta-data for a single relative type.

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -22,6 +22,7 @@
 //!  * [`Field`](crate::datatypes::Field) to describe one field within a schema.
 //!  * [`DataType`](crate::datatypes::DataType) to describe the type of a field.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::default::Default;
 use std::fmt;
@@ -182,6 +183,11 @@ pub enum IntervalUnit {
     /// stored as 2 contiguous 32-bit integers (8-bytes in total).
     DayTime,
 }
+
+/// The `CustomMetaData` is an alias to `BTreeMap` which implements traits: Hash, PartialOrd, Ord.
+/// It contains custom meta data (key-value pairs), defined by flatbuffers structs:
+/// `Field`, `Message`, or file `Footer`.
+pub type CustomMetaData = BTreeMap<String, String>;
 
 /// Contains the meta-data for a single relative type.
 ///

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -1068,9 +1068,9 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), arrays).unwrap();
         // create stream writer
         let file = File::create("target/debug/testdata/float.stream").unwrap();
-        let mut stream_writer =
-            crate::ipc::writer::StreamWriter::try_new(file, &schema).unwrap();
-        stream_writer.write(&batch).unwrap();
+        let mut stream_writer = crate::ipc::writer::StreamWriter::new(file, &schema);
+        stream_writer.write_schema().unwrap();
+        stream_writer.write_record_batch(&batch).unwrap();
         stream_writer.finish().unwrap();
 
         // read stream back

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -383,7 +383,7 @@ impl<W: Write> FileWriter<W> {
     /// Try create a new writer, with the schema written as part of the header
     #[deprecated(
         since = "2.0.0",
-        note = "This method is deprecated in favour of `new(...)[.with_write_options(...).with_custom_schema()].build()`"
+        note = "This method is deprecated in favour of `let writer = FileWriter::new(writer, schema); writer.write_header_schema().unwrap();`"
     )]
     pub fn try_new(writer: W, schema: &Schema) -> Result<Self> {
         let mut me = FileWriter::new(writer, schema);
@@ -394,7 +394,7 @@ impl<W: Write> FileWriter<W> {
     /// Try create a new writer with IpcWriteOptions
     #[deprecated(
         since = "2.0.0",
-        note = "This method is deprecated in favour of `new(...).with_write_options(...)`"
+        note = "This method is deprecated in favour of `let writer = FileWriter::new(writer, schema).with_write_options(opt); w.write_header_schema().unwrap();`"
     )]
     pub fn try_new_with_options(
         writer: W,
@@ -549,7 +549,7 @@ impl<W: Write> StreamWriter<W> {
     /// Try create a new writer, with the schema written as part of the header
     #[deprecated(
         since = "2.0.0",
-        note = "This method is deprecated in favour of `new(...)[.with_options(...).with_schema()].build()`"
+        note = "This method is deprecated in favour of `let writer = StreamWriter::new(writer, schema); writer.write_schema().unwrap();`"
     )]
     pub fn try_new(writer: W, schema: &Schema) -> Result<Self> {
         let mut me = StreamWriter::new(writer, schema);
@@ -559,7 +559,7 @@ impl<W: Write> StreamWriter<W> {
 
     #[deprecated(
         since = "2.0.0",
-        note = "This method is deprecated in favour of `new(...)[.with_options(...).with_schema()].build()`"
+        note = "This method is deprecated in favour of `let writer = StreamWriter::new(writer, schema).with_write_options(opt); w.write_schema().unwrap();`"
     )]
     pub fn try_new_with_options(
         writer: W,

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -31,11 +31,11 @@ fn main() -> Result<()> {
     let mut reader = FileReader::try_new(reader)?;
     let schema = reader.schema();
 
-    let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;
-
+    let mut writer = StreamWriter::new(io::stdout(), &schema);
+    writer.write_schema()?;
     reader.try_for_each(|batch| {
         let batch = batch?;
-        writer.write(&batch)
+        writer.write_record_batch(&batch)
     })?;
     writer.finish()?;
 

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -84,10 +84,11 @@ fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()>
     let json_file = read_json_file(json_name)?;
 
     let arrow_file = File::create(arrow_name)?;
-    let mut writer = FileWriter::try_new(arrow_file, &json_file.schema)?;
+    let mut writer = FileWriter::new(arrow_file, &json_file.schema);
+    writer.write_header_schema()?;
 
     for b in json_file.batches {
-        writer.write(&b)?;
+        writer.write_record_batch(&b)?;
     }
 
     Ok(())

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -25,9 +25,10 @@ fn main() -> Result<()> {
     let mut arrow_stream_reader = StreamReader::try_new(io::stdin())?;
     let schema = arrow_stream_reader.schema();
 
-    let mut writer = FileWriter::try_new(io::stdout(), &schema)?;
+    let mut writer = FileWriter::new(io::stdout(), &schema);
+    writer.write_header_schema()?;
 
-    arrow_stream_reader.try_for_each(|batch| writer.write(&batch?))?;
+    arrow_stream_reader.try_for_each(|batch| writer.write_record_batch(&batch?))?;
     writer.finish()?;
 
     Ok(())

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -217,7 +217,7 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Option<Schema> {
 fn encode_arrow_schema(schema: &Schema) -> String {
     let options = writer::IpcWriteOptions::default();
     let data_gen = arrow::ipc::writer::IpcDataGenerator::default();
-    let mut serialized_schema = data_gen.schema_to_bytes(&schema, &options);
+    let mut serialized_schema = data_gen.schema_to_bytes(&schema, &options, &None);
 
     // manually prepending the length to the schema as arrow uses the legacy IPC format
     // TODO: change after addressing ARROW-9777


### PR DESCRIPTION
I think this PR is a sub task of issue [ARROW-9777](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-9777).
Sorry had not seen this issue before I finished this PR.

This PR is extracted from one of my dev branch, which has more changes for custom metadata. You may have a look at the [diff to arrow master]( https://github.com/apache/arrow/compare/master...mqy:custom-metadata).

Two design choices:

**Added a new type `CustomMetaData`** (alias to `BTreeMap`), in datatypes.rs. 

Why `BTreeMap` instead of `HashMap`? Because `Field` implements traits `Hash`, `PartialOrd`, and `Ord`,
but `HashMap` breaks the behavior.

**Additional refactoring**

It tends to be tedious when add more args, for example: 
try_new, try_new_with_options, try_new_with_options_and_custom_metadata.

Finally, I refactored several functions according to [builder pattern](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html). Sorry that, this refactoring may introduce some inconveniences.
