### PR TITLE
ARROW-11034: [Rust] remove rustfmt ignore list, fix format

### DIFF
--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -163,20 +163,23 @@ impl ScalarValue {
 
     /// whether this value is null or not.
     pub fn is_null(&self) -> bool {
-        matches!(*self, ScalarValue::Boolean(None)
-            | ScalarValue::UInt8(None)
-            | ScalarValue::UInt16(None)
-            | ScalarValue::UInt32(None)
-            | ScalarValue::UInt64(None)
-            | ScalarValue::Int8(None)
-            | ScalarValue::Int16(None)
-            | ScalarValue::Int32(None)
-            | ScalarValue::Int64(None)
-            | ScalarValue::Float32(None)
-            | ScalarValue::Float64(None)
-            | ScalarValue::Utf8(None)
-            | ScalarValue::LargeUtf8(None)
-            | ScalarValue::List(None, _))
+        matches!(
+            *self,
+            ScalarValue::Boolean(None)
+                | ScalarValue::UInt8(None)
+                | ScalarValue::UInt16(None)
+                | ScalarValue::UInt32(None)
+                | ScalarValue::UInt64(None)
+                | ScalarValue::Int8(None)
+                | ScalarValue::Int16(None)
+                | ScalarValue::Int32(None)
+                | ScalarValue::Int64(None)
+                | ScalarValue::Float32(None)
+                | ScalarValue::Float64(None)
+                | ScalarValue::Utf8(None)
+                | ScalarValue::LargeUtf8(None)
+                | ScalarValue::List(None, _)
+        )
     }
 
     /// Converts a scalar value into an 1-row array.

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -537,7 +537,10 @@ impl Field {
 
     /// Determines if this Row represents a primitive value.
     pub fn is_primitive(&self) -> bool {
-        !matches!(*self, Field::Group(_) | Field::ListInternal(_) | Field::MapInternal(_))
+        !matches!(
+            *self,
+            Field::Group(_) | Field::ListInternal(_) | Field::MapInternal(_)
+        )
     }
 
     /// Converts Parquet BOOLEAN type with logical type into `bool` value.

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -18,6 +18,6 @@
 max_width = 90
 
 # ignore generated files
-ignore = [
-    "arrow/src/ipc/gen",
-]
+# ignore = [
+#    "arrow/src/ipc/gen",
+#]


### PR DESCRIPTION
In this PR:

- Ignore list is commented out from rustfmt.toml, thus `carrgo +stable fmt` would not show warnings
- Two files are re-formatted by nightly, stable: this may avoid formatting problem we had seen in CI (hope so).

Shell commands that I had run:
```
cargo +nightly-2020-11-24-x86_64 fmt
cargo +1.48.0-x86_64 fmt
```