### PR TITLE
ARROW-11038: [Rust] Removed unused trait and Result.

### DIFF
--- a/rust/arrow/examples/tensor_builder.rs
+++ b/rust/arrow/examples/tensor_builder.rs
@@ -18,7 +18,7 @@
 ///! Tensor builder example
 extern crate arrow;
 
-use arrow::array::*; //{BufferBuilderTrait, Int32BufferBuilder, Float32BufferBuilder};
+use arrow::array::*; //{Int32BufferBuilder, Float32BufferBuilder};
 use arrow::buffer::Buffer;
 use arrow::datatypes::ToByteSlice;
 use arrow::error::Result;

--- a/rust/arrow/examples/tensor_builder.rs
+++ b/rust/arrow/examples/tensor_builder.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     // to match the required size for each buffer
     let mut builder = Int32BufferBuilder::new(16);
     for i in 0..16 {
-        builder.append(i).unwrap();
+        builder.append(i);
     }
     let buf = builder.finish();
 
@@ -43,10 +43,10 @@ fn main() -> Result<()> {
 
     // Creating a tensor using float type buffer builder
     let mut builder = Float32BufferBuilder::new(4);
-    builder.append(1.0).unwrap();
-    builder.append(2.0).unwrap();
-    builder.append(3.0).unwrap();
-    builder.append(4.0).unwrap();
+    builder.append(1.0);
+    builder.append(2.0);
+    builder.append(3.0);
+    builder.append(4.0);
     let buf = builder.finish();
 
     // When building the tensor the buffer and shape are necessary

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -67,7 +67,7 @@ pub(crate) fn builder_to_mutable_buffer<T: ArrowNativeType>(
 /// # Example:
 ///
 /// ```
-/// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+/// use arrow::array::UInt8BufferBuilder;
 ///
 /// # fn main() -> arrow::error::Result<()> {
 /// let mut builder = UInt8BufferBuilder::new(100);
@@ -91,17 +91,17 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// elements of type `T`.
     ///
     /// The capacity can later be manually adjusted with the
-    /// [`reserve()`](BufferBuilderTrait::reserve) method.
+    /// [`reserve()`](BufferBuilder::reserve) method.
     /// Also the
-    /// [`append()`](BufferBuilderTrait::append),
-    /// [`append_slice()`](BufferBuilderTrait::append_slice) and
-    /// [`advance()`](BufferBuilderTrait::advance)
+    /// [`append()`](BufferBuilder::append),
+    /// [`append_slice()`](BufferBuilder::append_slice) and
+    /// [`advance()`](BufferBuilder::advance)
     /// methods automatically increase the capacity if needed.
     ///
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     ///
@@ -123,7 +123,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append(42);
@@ -139,7 +139,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append(42);
@@ -163,14 +163,14 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// Increases the number of elements in the internal buffer by `n`
     /// and resizes the buffer as needed.
     ///
-    /// The values of the newly added elements are undefined.
+    /// The values of the newly added elements are 0.
     /// This method is usually used when appending `NULL` values to the buffer
     /// as they still require physical memory space.
     ///
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.advance(2);
@@ -189,7 +189,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.reserve(10);
@@ -209,7 +209,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append(42);
@@ -233,7 +233,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append_n(10, 42);
@@ -253,7 +253,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append_slice(&[42, 44, 46]);
@@ -273,7 +273,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     /// # Example:
     ///
     /// ```
-    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    /// use arrow::array::UInt8BufferBuilder;
     ///
     /// let mut builder = UInt8BufferBuilder::new(10);
     /// builder.append_slice(&[42, 44, 46]);

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -320,11 +320,10 @@ impl BooleanBufferBuilder {
     }
 
     #[inline]
-    pub fn advance(&mut self, i: usize) -> Result<()> {
+    pub fn advance(&mut self, i: usize) {
         let new_buffer_len = bit_util::ceil(self.len + i, 8);
         self.buffer.resize(new_buffer_len);
         self.len += i;
-        Ok(())
     }
 
     #[inline]
@@ -340,7 +339,7 @@ impl BooleanBufferBuilder {
     }
 
     #[inline]
-    pub fn append(&mut self, v: bool) -> Result<()> {
+    pub fn append(&mut self, v: bool) {
         self.reserve(1);
         if v {
             let data = unsafe {
@@ -352,11 +351,10 @@ impl BooleanBufferBuilder {
             bit_util::set_bit(data, self.len);
         }
         self.len += 1;
-        Ok(())
     }
 
     #[inline]
-    pub fn append_n(&mut self, n: usize, v: bool) -> Result<()> {
+    pub fn append_n(&mut self, n: usize, v: bool) {
         self.reserve(n);
         if n != 0 && v {
             let data = unsafe {
@@ -368,11 +366,10 @@ impl BooleanBufferBuilder {
             (self.len..self.len + n).for_each(|i| bit_util::set_bit(data, i))
         }
         self.len += n;
-        Ok(())
     }
 
     #[inline]
-    pub fn append_slice(&mut self, slice: &[bool]) -> Result<()> {
+    pub fn append_slice(&mut self, slice: &[bool]) {
         let array_slots = slice.len();
         self.reserve(array_slots);
 
@@ -387,7 +384,6 @@ impl BooleanBufferBuilder {
             }
             self.len += 1;
         }
-        Ok(())
     }
 
     #[inline]
@@ -454,15 +450,15 @@ impl BooleanBuilder {
 
     /// Appends a value of type `T` into the builder
     pub fn append_value(&mut self, v: bool) -> Result<()> {
-        self.bitmap_builder.append(true)?;
-        self.values_builder.append(v)?;
+        self.bitmap_builder.append(true);
+        self.values_builder.append(v);
         Ok(())
     }
 
     /// Appends a null slot into the builder
     pub fn append_null(&mut self) -> Result<()> {
-        self.bitmap_builder.append(false)?;
-        self.values_builder.advance(1)?;
+        self.bitmap_builder.append(false);
+        self.values_builder.advance(1);
         Ok(())
     }
 
@@ -477,8 +473,8 @@ impl BooleanBuilder {
 
     /// Appends a slice of type `T` into the builder
     pub fn append_slice(&mut self, v: &[bool]) -> Result<()> {
-        self.bitmap_builder.append_n(v.len(), true)?;
-        self.values_builder.append_slice(v)?;
+        self.bitmap_builder.append_n(v.len(), true);
+        self.values_builder.append_slice(v);
         Ok(())
     }
 
@@ -489,8 +485,9 @@ impl BooleanBuilder {
                 "Value and validity lengths must be equal".to_string(),
             ));
         }
-        self.bitmap_builder.append_slice(is_valid)?;
-        self.values_builder.append_slice(values)
+        self.bitmap_builder.append_slice(is_valid);
+        self.values_builder.append_slice(values);
+        Ok(())
     }
 
     /// Builds the [BooleanArray] and reset this builder.
@@ -598,14 +595,14 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
 
     /// Appends a value of type `T` into the builder
     pub fn append_value(&mut self, v: T::Native) -> Result<()> {
-        self.bitmap_builder.append(true)?;
+        self.bitmap_builder.append(true);
         self.values_builder.append(v);
         Ok(())
     }
 
     /// Appends a null slot into the builder
     pub fn append_null(&mut self) -> Result<()> {
-        self.bitmap_builder.append(false)?;
+        self.bitmap_builder.append(false);
         self.values_builder.advance(1);
         Ok(())
     }
@@ -621,7 +618,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
 
     /// Appends a slice of type `T` into the builder
     pub fn append_slice(&mut self, v: &[T::Native]) -> Result<()> {
-        self.bitmap_builder.append_n(v.len(), true)?;
+        self.bitmap_builder.append_n(v.len(), true);
         self.values_builder.append_slice(v);
         Ok(())
     }
@@ -637,7 +634,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
                 "Value and validity lengths must be equal".to_string(),
             ));
         }
-        self.bitmap_builder.append_slice(is_valid)?;
+        self.bitmap_builder.append_slice(is_valid);
         self.values_builder.append_slice(values);
         Ok(())
     }
@@ -762,7 +759,7 @@ where
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
         self.offsets_builder
             .append(self.values_builder.len() as i32);
-        self.bitmap_builder.append(is_valid)?;
+        self.bitmap_builder.append(is_valid);
         self.len += 1;
         Ok(())
     }
@@ -880,7 +877,7 @@ where
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
         self.offsets_builder
             .append(self.values_builder.len() as i64);
-        self.bitmap_builder.append(is_valid)?;
+        self.bitmap_builder.append(is_valid);
         self.len += 1;
         Ok(())
     }
@@ -1002,7 +999,7 @@ where
 
     /// Finish the current variable-length list array slot
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
-        self.bitmap_builder.append(is_valid)?;
+        self.bitmap_builder.append(is_valid);
         self.len += 1;
         Ok(())
     }
@@ -1742,7 +1739,7 @@ impl StructBuilder {
     /// Appends an element (either null or non-null) to the struct. The actual elements
     /// should be appended for each child sub-array in a consistent way.
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
-        self.bitmap_builder.append(is_valid)?;
+        self.bitmap_builder.append(is_valid);
         self.len += 1;
         Ok(())
     }
@@ -1836,7 +1833,7 @@ impl FieldData {
 
         self.slots += 1;
         if let Some(b) = &mut self.bitmap_builder {
-            b.append(true)?
+            b.append(true)
         };
         Ok(())
     }
@@ -1855,7 +1852,7 @@ impl FieldData {
             self.values_buffer = Some(mutable_buffer);
             self.slots += 1;
             self.null_count += 1;
-            b.append(false)?;
+            b.append(false);
         };
         Ok(())
     }
@@ -1941,14 +1938,14 @@ impl UnionBuilder {
         if self.bitmap_builder.is_none() {
             let mut builder = BooleanBufferBuilder::new(self.len + 1);
             for _ in 0..self.len {
-                builder.append(true)?;
+                builder.append(true);
             }
             self.bitmap_builder = Some(builder)
         }
         self.bitmap_builder
             .as_mut()
             .expect("Cannot be None")
-            .append(false)?;
+            .append(false);
 
         self.type_id_builder.append(i8::default());
 
@@ -2008,7 +2005,7 @@ impl UnionBuilder {
 
         // Update the bitmap builder if it exists
         if let Some(b) = &mut self.bitmap_builder {
-            b.append(true)?;
+            b.append(true);
         }
         self.len += 1;
         Ok(())
@@ -2439,17 +2436,17 @@ mod tests {
     #[test]
     fn test_write_bytes() {
         let mut b = BooleanBufferBuilder::new(4);
-        b.append(false).unwrap();
-        b.append(true).unwrap();
-        b.append(false).unwrap();
-        b.append(true).unwrap();
+        b.append(false);
+        b.append(true);
+        b.append(false);
+        b.append(true);
         assert_eq!(4, b.len());
         assert_eq!(512, b.capacity());
         let buffer = b.finish();
         assert_eq!(1, buffer.len());
 
         let mut b = BooleanBufferBuilder::new(4);
-        b.append_slice(&[false, true, false, true]).unwrap();
+        b.append_slice(&[false, true, false, true]);
         assert_eq!(4, b.len());
         assert_eq!(512, b.capacity());
         let buffer = b.finish();
@@ -2499,9 +2496,9 @@ mod tests {
 
         for i in 0..10 {
             if i == 3 || i == 6 || i == 9 {
-                builder.append(true).unwrap();
+                builder.append(true);
             } else {
-                builder.append(false).unwrap();
+                builder.append(false);
             }
         }
         let buf2 = builder.finish();

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -179,18 +179,17 @@ pub use self::array_string::StringOffsetSizeTrait;
 
 pub use self::builder::BooleanBufferBuilder;
 pub use self::builder::BufferBuilder;
-pub use self::builder::BufferBuilderTrait;
 
-pub type Int8BufferBuilder = BufferBuilder<Int8Type>;
-pub type Int16BufferBuilder = BufferBuilder<Int16Type>;
-pub type Int32BufferBuilder = BufferBuilder<Int32Type>;
-pub type Int64BufferBuilder = BufferBuilder<Int64Type>;
-pub type UInt8BufferBuilder = BufferBuilder<UInt8Type>;
-pub type UInt16BufferBuilder = BufferBuilder<UInt16Type>;
-pub type UInt32BufferBuilder = BufferBuilder<UInt32Type>;
-pub type UInt64BufferBuilder = BufferBuilder<UInt64Type>;
-pub type Float32BufferBuilder = BufferBuilder<Float32Type>;
-pub type Float64BufferBuilder = BufferBuilder<Float64Type>;
+pub type Int8BufferBuilder = BufferBuilder<i8>;
+pub type Int16BufferBuilder = BufferBuilder<i16>;
+pub type Int32BufferBuilder = BufferBuilder<i32>;
+pub type Int64BufferBuilder = BufferBuilder<i64>;
+pub type UInt8BufferBuilder = BufferBuilder<u8>;
+pub type UInt16BufferBuilder = BufferBuilder<u16>;
+pub type UInt32BufferBuilder = BufferBuilder<u32>;
+pub type UInt64BufferBuilder = BufferBuilder<u64>;
+pub type Float32BufferBuilder = BufferBuilder<f32>;
+pub type Float64BufferBuilder = BufferBuilder<f64>;
 
 pub type TimestampSecondBufferBuilder = BufferBuilder<TimestampSecondType>;
 pub type TimestampMillisecondBufferBuilder = BufferBuilder<TimestampMillisecondType>;

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -163,7 +163,7 @@ pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray
             map.get(pat).unwrap()
         };
 
-        result.append(re.is_match(haystack))?;
+        result.append(re.is_match(haystack));
     }
 
     let data = ArrayData::new(
@@ -189,18 +189,18 @@ pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray>
     if !right.contains(is_like_pattern) {
         // fast path, can use equals
         for i in 0..left.len() {
-            result.append(left.value(i) == right)?;
+            result.append(left.value(i) == right);
         }
     } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use starts_with
         for i in 0..left.len() {
-            result.append(left.value(i).starts_with(&right[..right.len() - 1]))?;
+            result.append(left.value(i).starts_with(&right[..right.len() - 1]));
         }
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use ends_with
         for i in 0..left.len() {
-            result.append(left.value(i).ends_with(&right[1..]))?;
+            result.append(left.value(i).ends_with(&right[1..]));
         }
     } else {
         let re_pattern = right.replace("%", ".*").replace("_", ".");
@@ -213,7 +213,7 @@ pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray>
 
         for i in 0..left.len() {
             let haystack = left.value(i);
-            result.append(re.is_match(haystack))?;
+            result.append(re.is_match(haystack));
         }
     };
 
@@ -259,7 +259,7 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
             map.get(pat).unwrap()
         };
 
-        result.append(!re.is_match(haystack))?;
+        result.append(!re.is_match(haystack));
     }
 
     let data = ArrayData::new(
@@ -281,18 +281,18 @@ pub fn nlike_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray
     if !right.contains(is_like_pattern) {
         // fast path, can use equals
         for i in 0..left.len() {
-            result.append(left.value(i) != right)?;
+            result.append(left.value(i) != right);
         }
     } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
     {
         // fast path, can use ends_with
         for i in 0..left.len() {
-            result.append(!left.value(i).starts_with(&right[..right.len() - 1]))?;
+            result.append(!left.value(i).starts_with(&right[..right.len() - 1]));
         }
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use starts_with
         for i in 0..left.len() {
-            result.append(!left.value(i).ends_with(&right[1..]))?;
+            result.append(!left.value(i).ends_with(&right[1..]));
         }
     } else {
         let re_pattern = right.replace("%", ".*").replace("_", ".");
@@ -304,7 +304,7 @@ pub fn nlike_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray
         })?;
         for i in 0..left.len() {
             let haystack = left.value(i);
-            result.append(!re.is_match(haystack))?;
+            result.append(!re.is_match(haystack));
         }
     }
 

--- a/rust/arrow/src/tensor.rs
+++ b/rust/arrow/src/tensor.rs
@@ -359,7 +359,7 @@ mod tests {
     fn test_tensor() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::try_new(buf, Some(vec![2, 8]), None, None).unwrap();
@@ -374,7 +374,7 @@ mod tests {
     fn test_new_row_major() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::new_row_major(buf, Some(vec![2, 8]), None).unwrap();
@@ -392,7 +392,7 @@ mod tests {
     fn test_new_column_major() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::new_column_major(buf, Some(vec![2, 8]), None).unwrap();
@@ -410,7 +410,7 @@ mod tests {
     fn test_with_names() {
         let mut builder = Int64BufferBuilder::new(8);
         for i in 0..8 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
         let names = vec!["Dim 1", "Dim 2"];
@@ -431,7 +431,7 @@ mod tests {
     fn test_inconsistent_strides() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
 
@@ -447,7 +447,7 @@ mod tests {
     fn test_inconsistent_names() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
 
@@ -467,7 +467,7 @@ mod tests {
     fn test_incorrect_shape() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
 
@@ -482,7 +482,7 @@ mod tests {
     fn test_incorrect_stride() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.append(i).unwrap();
+            builder.append(i);
         }
         let buf = builder.finish();
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -25,10 +25,10 @@ use std::vec::Vec;
 
 use arrow::array::{
     Array, ArrayData, ArrayDataBuilder, ArrayDataRef, ArrayRef, BinaryArray,
-    BinaryBuilder, BooleanArray, BooleanBufferBuilder, BufferBuilderTrait,
-    FixedSizeBinaryArray, FixedSizeBinaryBuilder, GenericListArray, Int16BufferBuilder,
-    ListBuilder, OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray,
-    StringBuilder, StructArray,
+    BinaryBuilder, BooleanArray, BooleanBufferBuilder, FixedSizeBinaryArray,
+    FixedSizeBinaryBuilder, GenericListArray, Int16BufferBuilder, ListBuilder,
+    OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
+    StructArray,
 };
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::datatypes::{
@@ -292,7 +292,7 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
             let mut boolean_buffer = BooleanBufferBuilder::new(record_data.len());
 
             for e in record_data.data() {
-                boolean_buffer.append(*e > 0)?;
+                boolean_buffer.append(*e > 0);
             }
             record_data = boolean_buffer.finish();
         }
@@ -1082,7 +1082,7 @@ impl ArrayReader for StructArrayReader {
             if !not_null {
                 null_count += 1;
             }
-            bitmap_builder.append(not_null)?;
+            bitmap_builder.append(not_null);
         }
 
         // Now we can build array data
@@ -1110,7 +1110,7 @@ impl ArrayReader for StructArrayReader {
             .get_rep_levels()
             .map(|data| -> Result<Buffer> {
                 let mut buffer = Int16BufferBuilder::new(children_array_len);
-                buffer.append_slice(data)?;
+                buffer.append_slice(data);
                 Ok(buffer.finish())
             })
             .transpose()?;

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -249,7 +249,7 @@ impl<T: DataType> RecordReader<T> {
                 self.null_bitmap
                     .as_mut()
                     .unwrap()
-                    .append(old_bitmap.is_set(i))?;
+                    .append(old_bitmap.is_set(i));
             }
 
             Ok(Some(old_bitmap.into_buffer()))
@@ -357,9 +357,8 @@ impl<T: DataType> RecordReader<T> {
                     "Definition levels should exist when data is less than levels!"
                 )
             })?;
-            (0..levels_read).try_for_each(|idx| {
-                null_buffer.append(def_levels[idx] == max_def_level)
-            })?;
+            (0..levels_read)
+                .for_each(|idx| null_buffer.append(def_levels[idx] == max_def_level));
         }
 
         let values_read = max(values_read, levels_read);
@@ -439,9 +438,7 @@ mod tests {
     use crate::schema::parser::parse_message_type;
     use crate::schema::types::SchemaDescriptor;
     use crate::util::test_common::page_util::{DataPageBuilder, DataPageBuilderImpl};
-    use arrow::array::{
-        BooleanBufferBuilder, BufferBuilderTrait, Int16BufferBuilder, Int32BufferBuilder,
-    };
+    use arrow::array::{BooleanBufferBuilder, Int16BufferBuilder, Int32BufferBuilder};
     use arrow::bitmap::Bitmap;
     use std::sync::Arc;
 
@@ -529,7 +526,7 @@ mod tests {
         }
 
         let mut bb = Int32BufferBuilder::new(7);
-        bb.append_slice(&[4, 7, 6, 3, 2, 8, 9]).unwrap();
+        bb.append_slice(&[4, 7, 6, 3, 2, 8, 9]);
         let expected_buffer = bb.finish();
         assert_eq!(
             expected_buffer,
@@ -617,7 +614,7 @@ mod tests {
 
         // Verify result record data
         let mut bb = Int32BufferBuilder::new(7);
-        bb.append_slice(&[0, 7, 0, 6, 3, 0, 8]).unwrap();
+        bb.append_slice(&[0, 7, 0, 6, 3, 0, 8]);
         let expected_buffer = bb.finish();
         assert_eq!(
             expected_buffer,
@@ -626,8 +623,7 @@ mod tests {
 
         // Verify result def levels
         let mut bb = Int16BufferBuilder::new(7);
-        bb.append_slice(&[1i16, 2i16, 0i16, 2i16, 2i16, 0i16, 2i16])
-            .unwrap();
+        bb.append_slice(&[1i16, 2i16, 0i16, 2i16, 2i16, 0i16, 2i16]);
         let expected_def_levels = bb.finish();
         assert_eq!(
             Some(expected_def_levels),
@@ -636,8 +632,7 @@ mod tests {
 
         // Verify bitmap
         let mut bb = BooleanBufferBuilder::new(7);
-        bb.append_slice(&[false, true, false, true, true, false, true])
-            .unwrap();
+        bb.append_slice(&[false, true, false, true, true, false, true]);
         let expected_bitmap = Bitmap::from(bb.finish());
         assert_eq!(
             Some(expected_bitmap),
@@ -727,7 +722,7 @@ mod tests {
 
         // Verify result record data
         let mut bb = Int32BufferBuilder::new(9);
-        bb.append_slice(&[4, 0, 0, 7, 6, 3, 2, 8, 9]).unwrap();
+        bb.append_slice(&[4, 0, 0, 7, 6, 3, 2, 8, 9]);
         let expected_buffer = bb.finish();
         assert_eq!(
             expected_buffer,
@@ -736,8 +731,7 @@ mod tests {
 
         // Verify result def levels
         let mut bb = Int16BufferBuilder::new(9);
-        bb.append_slice(&[2i16, 0i16, 1i16, 2i16, 2i16, 2i16, 2i16, 2i16, 2i16])
-            .unwrap();
+        bb.append_slice(&[2i16, 0i16, 1i16, 2i16, 2i16, 2i16, 2i16, 2i16, 2i16]);
         let expected_def_levels = bb.finish();
         assert_eq!(
             Some(expected_def_levels),
@@ -746,8 +740,7 @@ mod tests {
 
         // Verify bitmap
         let mut bb = BooleanBufferBuilder::new(9);
-        bb.append_slice(&[true, false, false, true, true, true, true, true, true])
-            .unwrap();
+        bb.append_slice(&[true, false, false, true, true, true, true, true, true]);
         let expected_bitmap = Bitmap::from(bb.finish());
         assert_eq!(
             Some(expected_bitmap),


### PR DESCRIPTION
This PR removes an unused trait and associated API that returns `Result<()>` for infalible implementations

Both of these are historical artifacts derived from using `io::write`, which was abandoned because these operations are infalible.