### PR TITLE
ARROW-11039: [Rust] Performance improvement for utf-8 to float cast

### DIFF
--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -191,7 +191,7 @@ fn add_benchmark(c: &mut Criterion) {
         })
     });
     c.bench_function("cast utf8 to f32", |b| {
-        b.iter(|| cast_array(&f32_string_array, DataType::Float32))
+        b.iter(|| cast_array(&f32_utf8_array, DataType::Float32))
     });
 
     c.bench_function("cast timestamp_ms to i64 512", |b| {

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -120,6 +120,8 @@ fn add_benchmark(c: &mut Criterion) {
     let i32_array = build_array::<Int32Type>(512);
     let i64_array = build_array::<Int64Type>(512);
     let f32_array = build_array::<Float32Type>(512);
+    let f32_utf8_array = cast(&build_array::<Float32Type>(512), &DataType::Utf8).unwrap();
+
     let f64_array = build_array::<Float64Type>(512);
     let date64_array = build_array::<Date64Type>(512);
     let date32_array = build_array::<Date32Type>(512);
@@ -188,6 +190,10 @@ fn add_benchmark(c: &mut Criterion) {
             )
         })
     });
+    c.bench_function("cast utf8 to f32", |b| {
+        b.iter(|| cast_array(&f32_string_array, DataType::Float32))
+    });
+
     c.bench_function("cast timestamp_ms to i64 512", |b| {
         b.iter(|| cast_array(&time_ms_array, DataType::Int64))
     });

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -926,7 +926,7 @@ where
 fn cast_string_to_numeric<T>(from: &ArrayRef) -> Result<ArrayRef>
 where
     T: ArrowNumericType,
-    <T as ArrowPrimitiveType>::Native: lexical_core::FromLexical
+    <T as ArrowPrimitiveType>::Native: lexical_core::FromLexical,
 {
     Ok(Arc::new(string_to_numeric_cast::<T>(
         from.as_any().downcast_ref::<StringArray>().unwrap(),
@@ -936,7 +936,7 @@ where
 fn string_to_numeric_cast<T>(from: &StringArray) -> PrimitiveArray<T>
 where
     T: ArrowNumericType,
-    <T as ArrowPrimitiveType>::Native: lexical_core::FromLexical
+    <T as ArrowPrimitiveType>::Native: lexical_core::FromLexical,
 {
     (0..from.len())
         .map(|i| {

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -43,7 +43,7 @@ use crate::compute::kernels::arithmetic::{divide, multiply};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::{array::*, compute::take};
-use lexical_core;
+
 /// Return true if a value of type `from_type` can be cast into a
 /// value of `to_type`. Note that such as cast may be lossy.
 ///


### PR DESCRIPTION
Utilize `lexical_core::parse` for faster parsing.

```
cast utf8 to f32        time:   [25.840 us 25.878 us 25.921 us]                                
                        change: [-45.735% -45.590% -45.408%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
```