### PR TITLE
ARROW-11040: [Rust] Simplified builders

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -25,8 +25,7 @@ use std::{
 
 use super::{
     array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
-    FixedSizeListArray, GenericBinaryIter, GenericListArray, LargeListArray, ListArray,
-    OffsetSizeTrait,
+    FixedSizeListArray, GenericBinaryIter, GenericListArray, OffsetSizeTrait,
 };
 use crate::util::bit_util;
 use crate::{buffer::Buffer, datatypes::ToByteSlice};
@@ -294,15 +293,9 @@ impl From<Vec<Option<&[u8]>>> for LargeBinaryArray {
     }
 }
 
-impl From<ListArray> for BinaryArray {
-    fn from(v: ListArray) -> Self {
-        BinaryArray::from_list(v)
-    }
-}
-
-impl From<LargeListArray> for LargeBinaryArray {
-    fn from(v: LargeListArray) -> Self {
-        LargeBinaryArray::from_list(v)
+impl<T: BinaryOffsetSizeTrait> From<GenericListArray<T>> for GenericBinaryArray<T> {
+    fn from(v: GenericListArray<T>) -> Self {
+        GenericBinaryArray::<T>::from_list(v)
     }
 }
 
@@ -633,7 +626,10 @@ impl Array for DecimalArray {
 
 #[cfg(test)]
 mod tests {
-    use crate::datatypes::Field;
+    use crate::{
+        array::{LargeListArray, ListArray},
+        datatypes::Field,
+    };
 
     use super::*;
 

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -104,7 +104,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         let mut length_so_far: OffsetSize = OffsetSize::zero();
         offsets.push(length_so_far);
         for s in &v {
-            length_so_far = length_so_far + OffsetSize::from_usize(s.len()).unwrap();
+            length_so_far += OffsetSize::from_usize(s.len()).unwrap();
             offsets.push(length_so_far);
             values.extend_from_slice(s);
         }
@@ -235,8 +235,7 @@ where
                 if let Some(s) = s {
                     let s = s.as_ref();
                     bit_util::set_bit(null_slice, i);
-                    length_so_far =
-                        length_so_far + OffsetSize::from_usize(s.len()).unwrap();
+                    length_so_far += OffsetSize::from_usize(s.len()).unwrap();
                     values.extend_from_slice(s);
                 }
                 // always add an element in offsets

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -30,7 +30,7 @@ use crate::datatypes::ArrowNativeType;
 use crate::datatypes::DataType;
 
 /// trait declaring an offset size, relevant for i32 vs i64 array types.
-pub trait OffsetSizeTrait: ArrowNativeType + Num + Ord {
+pub trait OffsetSizeTrait: ArrowNativeType + Num + Ord + std::ops::AddAssign {
     fn prefix() -> &'static str;
 
     fn to_isize(&self) -> isize;

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -22,7 +22,7 @@ use std::{any::Any, iter::FromIterator};
 
 use super::{
     array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
-    GenericListArray, GenericStringIter, LargeListArray, ListArray, OffsetSizeTrait,
+    GenericListArray, GenericStringIter, OffsetSizeTrait,
 };
 use crate::util::bit_util;
 use crate::{buffer::Buffer, datatypes::ToByteSlice};
@@ -269,15 +269,9 @@ pub type StringArray = GenericStringArray<i32>;
 /// whose maximum length (in bytes) is represented by a i64.
 pub type LargeStringArray = GenericStringArray<i64>;
 
-impl From<ListArray> for StringArray {
-    fn from(v: ListArray) -> Self {
-        StringArray::from_list(v)
-    }
-}
-
-impl From<LargeListArray> for LargeStringArray {
-    fn from(v: LargeListArray) -> Self {
-        LargeStringArray::from_list(v)
+impl<T: StringOffsetSizeTrait> From<GenericListArray<T>> for GenericStringArray<T> {
+    fn from(v: GenericListArray<T>) -> Self {
+        GenericStringArray::<T>::from_list(v)
     }
 }
 

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -128,7 +128,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         let mut length_so_far = OffsetSize::zero();
         offsets.push(length_so_far);
         for s in &v {
-            length_so_far = length_so_far + OffsetSize::from_usize(s.len()).unwrap();
+            length_so_far += OffsetSize::from_usize(s.len()).unwrap();
             offsets.push(length_so_far);
             values.extend_from_slice(s.as_bytes());
         }
@@ -168,7 +168,7 @@ where
                 let null_slice = null_buf.as_slice_mut();
                 bit_util::set_bit(null_slice, i);
 
-                length_so_far = length_so_far + OffsetSize::from_usize(s.len()).unwrap();
+                length_so_far += OffsetSize::from_usize(s.len()).unwrap();
                 offsets.push(length_so_far);
                 values.extend_from_slice(s.as_bytes());
             } else {

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -780,10 +780,10 @@ where
             values_data.data_type().clone(),
             true, // TODO: find a consistent way of getting this
         ));
-        let data_type = if OffsetSize::prefix() == "" {
-            DataType::List(field)
-        } else {
+        let data_type = if OffsetSize::prefix() == "Large" {
             DataType::LargeList(field)
+        } else {
+            DataType::List(field)
         };
         let data = ArrayData::builder(data_type)
             .len(len)

--- a/rust/arrow/src/array/transform/list.rs
+++ b/rust/arrow/src/array/transform/list.rs
@@ -73,7 +73,7 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                 (start..start + len).for_each(|i| {
                     if array.is_valid(i) {
                         // compute the new offset
-                        last_offset = last_offset + offsets[i + 1] - offsets[i];
+                        last_offset += offsets[i + 1] - offsets[i];
 
                         // append value
                         child.extend(

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -57,7 +57,7 @@ pub(super) fn extend_offsets<T: OffsetSizeTrait>(
     offsets.windows(2).for_each(|offsets| {
         // compute the new offset
         let length = offsets[1] - offsets[0];
-        last_offset = last_offset + length;
+        last_offset += length;
         buffer.extend_from_slice(last_offset.to_byte_slice());
     });
 }

--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -79,7 +79,7 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                     if array.is_valid(i) {
                         // compute the new offset
                         let length = offsets[i + 1] - offsets[i];
-                        last_offset = last_offset + length;
+                        last_offset += length;
                         let length = length.to_usize().unwrap();
 
                         // append value

--- a/rust/arrow/src/compute/kernels/substring.rs
+++ b/rust/arrow/src/compute/kernels/substring.rs
@@ -63,7 +63,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
             // .max(0) is not needed as it is guaranteed
             .min(offsets[i + 1] - start); // so we do not go beyond this entry
 
-        length_so_far = length_so_far + length;
+        length_so_far += length;
 
         new_offsets.push(length_so_far);
 

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -124,7 +124,7 @@ where
             })?;
             let start = offsets[ix];
             let end = offsets[ix + 1];
-            current_offset = current_offset + (end - start);
+            current_offset += end - start;
             new_offsets.push(current_offset);
 
             let mut curr = start;
@@ -132,7 +132,7 @@ where
             // if start == end, this slot is empty
             while curr < end {
                 values.push(Some(curr));
-                curr = curr + OffsetType::Native::one();
+                curr += OffsetType::Native::one();
             }
         } else {
             new_offsets.push(current_offset);

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -871,12 +871,12 @@ impl Decoder {
         offsets.push(cur_offset);
         rows.iter().enumerate().for_each(|(i, v)| {
             if let Value::Array(a) = v {
-                cur_offset = cur_offset + OffsetSize::from_usize(a.len()).unwrap();
+                cur_offset += OffsetSize::from_usize(a.len()).unwrap();
                 bit_util::set_bit(list_nulls.as_slice_mut(), i);
             } else if let Value::Null = v {
                 // value is null, not incremented
             } else {
-                cur_offset = cur_offset + OffsetSize::one();
+                cur_offset += OffsetSize::one();
             }
             offsets.push(cur_offset);
         });

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -913,7 +913,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
                 offsets.push(cur_offset)
             }
             if def_levels[i] > 0 {
-                cur_offset = cur_offset + OffsetSize::one();
+                cur_offset += OffsetSize::one();
             }
         }
         offsets.push(cur_offset);


### PR DESCRIPTION
This PR simplifies the builders code. It has no semantic, execution or API change.

The main idea here is to generalize `[Large]ListBuilder`, `[Large]StringBuilder`, `[Large]BinaryBuilder` as `GenericListBuilder`, `GenericStringBuilder` and `GenericBinaryBuilder` respectively, thereby removing duplicated code.

The relevant changes in this PR are on `src/array/builders.rs` only.