### PR TITLE
ARROW-11021: [Rust] Update dependencies

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 [dependencies]
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT" }
 tonic = "0.3"
-bytes = "0.5"
+bytes = "1"
 prost = "0.6"
 prost-derive = "0.6"
 tokio = { version = "0.2", features = ["macros"] }

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -51,7 +51,7 @@ arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", features = ["prettyprin
 parquet = { path = "../parquet", version = "3.0.0-SNAPSHOT", features = ["arrow"] }
 sqlparser = "0.6.1"
 clap = "2.33"
-rustyline = {version = "6.0", optional = true}
+rustyline = {version = "7.0", optional = true}
 crossbeam = "0.8"
 paste = "^1.0"
 num_cpus = "1.13.0"
@@ -63,7 +63,7 @@ tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded", "sync
 log = "^0.4"
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 criterion = "0.3"
 tempfile = "3"
 prost = "0.6"

--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -36,19 +36,19 @@ snap = { version = "1.0", optional = true }
 brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
-zstd = { version = "0.5", optional = true }
+zstd = { version = "0.6", optional = true }
 chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", optional = true }
 base64 = { version = "*", optional = true }
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 snap = "1.0"
 brotli = "3.3"
 flate2 = "1.0"
 lz4 = "1.23"
-zstd = "0.5"
+zstd = "0.6"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -2152,10 +2152,10 @@ mod tests {
             let mut values = Vec::with_capacity(values_per_page);
 
             for _ in 0..values_per_page {
-                let def_level = rng.gen_range(0, max_def_level + 1);
-                let rep_level = rng.gen_range(0, max_rep_level + 1);
+                let def_level = rng.gen_range(0..max_def_level + 1);
+                let rep_level = rng.gen_range(0..max_rep_level + 1);
                 if def_level == max_def_level {
-                    let len = rng.gen_range(1, str_base.len());
+                    let len = rng.gen_range(1..str_base.len());
                     let slice = &str_base[..len];
                     values.push(ByteArray::from(slice));
                     all_values.push(Some(slice.to_string()));

--- a/rust/parquet/src/encodings/rle.rs
+++ b/rust/parquet/src/encodings/rle.rs
@@ -814,7 +814,7 @@ mod tests {
 
             let mut parity = false;
             for _ in 0..ngroups {
-                let mut group_size = gen.gen_range(1, 20);
+                let mut group_size = gen.gen_range(1..20);
                 if group_size > max_group_size {
                     group_size = 1;
                 }

--- a/rust/parquet/src/util/test_common/rand_gen.rs
+++ b/rust/parquet/src/util/test_common/rand_gen.rs
@@ -80,9 +80,9 @@ impl RandGen<ByteArrayType> for ByteArrayType {
         let mut rng = thread_rng();
         let mut result = ByteArray::new();
         let mut value = vec![];
-        let len = rng.gen_range(0, 128);
+        let len = rng.gen_range(0..128);
         for _ in 0..len {
-            value.push(rng.gen_range(0, 255));
+            value.push(rng.gen_range(0..255));
         }
         result.set_data(ByteBufferPtr::new(value));
         result
@@ -93,7 +93,7 @@ impl RandGen<FixedLenByteArrayType> for FixedLenByteArrayType {
     fn gen(len: i32) -> FixedLenByteArray {
         let mut rng = thread_rng();
         let value_len = if len < 0 {
-            rng.gen_range(0, 128)
+            rng.gen_range(0..128)
         } else {
             len as usize
         };
@@ -106,7 +106,7 @@ pub fn random_bytes(n: usize) -> Vec<u8> {
     let mut result = vec![];
     let mut rng = thread_rng();
     for _ in 0..n {
-        result.push(rng.gen_range(0, 255));
+        result.push(rng.gen_range(0..255));
     }
     result
 }
@@ -134,6 +134,6 @@ where
 {
     let mut rng = thread_rng();
     for _ in 0..n {
-        result.push(rng.gen_range(low, high));
+        result.push(rng.gen_range(low..high));
     }
 }


### PR DESCRIPTION
Updates dependencies bytes,. rustyline, rand and zstd.
Notably, the zstd upgrade includes some nice perf. improvements https://github.com/facebook/zstd/releases/tag/v1.4.7 .

I skipped updating `rand` in `arrow` for now, as it requires quite some changes in the benchmark code.