### PR TITLE
[C++] Add replace and isnan scalar kernels

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -381,6 +381,7 @@ if(ARROW_COMPUTE)
               compute/kernels/scalar_string.cc
               compute/kernels/scalar_validity.cc
               compute/kernels/scalar_fill_null.cc
+              compute/kernels/scalar_replace.cc
               compute/kernels/util_internal.cc
               compute/kernels/vector_hash.cc
               compute/kernels/vector_nested.cc

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -128,9 +128,14 @@ Result<Datum> Compare(const Datum& left, const Datum& right, CompareOptions opti
 
 SCALAR_EAGER_UNARY(IsValid, "is_valid")
 SCALAR_EAGER_UNARY(IsNull, "is_null")
+SCALAR_EAGER_UNARY(IsNan, "is_nan")
 
 Result<Datum> FillNull(const Datum& values, const Datum& fill_value, ExecContext* ctx) {
   return CallFunction("fill_null", {values, fill_value}, ctx);
+}
+
+Result<Datum> Replace(const Datum& values, const Datum& mask, const Datum& replacement, ExecContext* ctx) {
+    return CallFunction("replace", {values, mask, replacement}, ctx);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -345,6 +345,18 @@ Result<Datum> IsValid(const Datum& values, ExecContext* ctx = NULLPTR);
 ARROW_EXPORT
 Result<Datum> IsNull(const Datum& values, ExecContext* ctx = NULLPTR);
 
+/// \brief IsNan returns true for each element of `values` that is NaN,
+/// false otherwise
+///
+/// \param[in] values input to look for NaN
+/// \param[in] ctx the function execution context, optional
+/// \return the resulting datum
+///
+/// \since X.X.X
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> IsNan(const Datum& values, ExecContext* ctx = NULLPTR);
+
 /// \brief FillNull replaces each null element in `values`
 /// with `fill_value`
 ///
@@ -359,6 +371,22 @@ Result<Datum> IsNull(const Datum& values, ExecContext* ctx = NULLPTR);
 ARROW_EXPORT
 Result<Datum> FillNull(const Datum& values, const Datum& fill_value,
                        ExecContext* ctx = NULLPTR);
+
+/// \brief Replace replaces each element in `values` for which mask bit is true
+/// with `fill_value`
+///
+/// \param[in] values input to replace based on mask
+/// \param[in] mask bits
+/// \param[in] replacement scalar
+/// \param[in] ctx the function execution context, optional
+///
+/// \return the resulting datum
+///
+/// \since X.X.X
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> Replace(const Datum& values, const Datum& mask, const Datum& replacement,
+                      ExecContext* ctx = NULLPTR);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -29,6 +29,7 @@ add_arrow_compute_test(scalar_test
                        scalar_string_test.cc
                        scalar_validity_test.cc
                        scalar_fill_null_test.cc
+                       scalar_replace_test.cc
                        test_util.cc)
 
 add_arrow_benchmark(scalar_arithmetic_benchmark PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/kernels/common.h
+++ b/cpp/src/arrow/compute/kernels/common.h
@@ -19,6 +19,7 @@
 
 // IWYU pragma: begin_exports
 
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/compute/kernels/scalar_replace.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_replace.cc
@@ -1,0 +1,241 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/kernels/common.h"
+#include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_ops.h"
+
+namespace arrow {
+
+using internal::BitBlockCount;
+using internal::BitBlockCounter;
+
+namespace compute {
+namespace internal {
+
+namespace {
+
+template <typename Type, typename Enable = void>
+struct ReplaceFunctor {};
+
+// Numeric inputs
+
+template <typename Type>
+struct ReplaceFunctor<Type, enable_if_t<is_number_type<Type>::value>> {
+    using T = typename TypeTraits<Type>::CType;
+
+    static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+        const ArrayData& data = *batch[0].array();
+        const ArrayData& mask = *batch[1].array();
+        const Scalar& replacement = *batch[2].scalar();
+        ArrayData* output = out->mutable_array();
+
+        if (replacement.is_valid) {
+            KERNEL_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> out_buf, ctx,
+                                   ctx->Allocate(data.length * sizeof(T)));
+            T value = UnboxScalar<Type>::Unbox(replacement);
+            const uint8_t* to_replace = mask.buffers[1]->data();
+            const T* in_values = data.GetValues<T>(1);
+            T* out_values = reinterpret_cast<T*>(out_buf->mutable_data());
+            int64_t offset = data.offset;
+            BitBlockCounter bit_counter(to_replace, data.offset, data.length);
+            while (offset < data.offset + data.length) {
+                BitBlockCount block = bit_counter.NextWord();
+                if (block.NoneSet()) {
+                    std::memcpy(out_values, in_values, block.length * sizeof(T));
+                } else if (block.AllSet()) {
+                    std::fill(out_values, out_values + block.length, value);
+                } else {
+                    for (int64_t i = 0; i < block.length; ++i) {
+                        out_values[i] = BitUtil::GetBit(to_replace, offset + i) ? value : in_values[i];
+                    }
+                }
+                offset += block.length;
+                out_values += block.length;
+                in_values += block.length;
+            }
+            output->buffers[1] = out_buf;
+        } else {
+            *output = data;
+        }
+    }
+};
+
+// Boolean input
+
+template <typename Type>
+struct ReplaceFunctor<Type, enable_if_t<is_boolean_type<Type>::value>> {
+    static void Exec(KernelContext* ctx, const ExecBatch batch, Datum* out) {
+        const ArrayData& data = *batch[0].array();
+        const ArrayData& mask = *batch[1].array();
+        const Scalar& replacement = *batch[2].scalar();
+        ArrayData* output = out->mutable_array();
+
+        bool value = UnboxScalar<BooleanType>::Unbox(replacement);
+        if (replacement.is_valid) {
+            KERNEL_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> out_buf, ctx,
+                                   ctx->AllocateBitmap(data.length));
+
+            const uint8_t* to_replace = mask.buffers[1]->data();
+            const uint8_t* data_bitmap = data.buffers[1]->data();
+            uint8_t* out_bitmap = out_buf->mutable_data();
+
+            int64_t data_offset = data.offset;
+            BitBlockCounter bit_counter(to_replace, data.offset, data.length);
+
+            int64_t out_offset = 0;
+            while (out_offset < data.length) {
+                BitBlockCount block = bit_counter.NextWord();
+                if (block.NoneSet()) {
+                    ::arrow::internal::CopyBitmap(data_bitmap, data_offset, block.length,
+                                                  out_bitmap, out_offset);
+                } else if (block.AllSet()) {
+                    BitUtil::SetBitsTo(out_bitmap, out_offset, block.length, value);
+                } else {
+                    for (int64_t i = 0 ; i < block.length ; ++i) {
+                        BitUtil::SetBitTo(out_bitmap,
+                                          out_offset + i,
+                                          BitUtil::GetBit(to_replace, data_offset + i) ? value : BitUtil::GetBit(data_bitmap, data_offset + i));
+                    }
+                }
+                data_offset += block.length;
+                out_offset += block.length;
+            }
+            output->buffers[1] = out_buf;
+        } else {
+            *output = data;
+        }
+    }
+};
+
+// Null input
+
+template <typename Type>
+struct ReplaceFunctor<Type, enable_if_t<is_null_type<Type>::value>> {
+    static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+        // Nothing preallocated, so we assign into the output
+        *out->mutable_array() = *batch[0].array();
+    }
+};
+
+// Binary-like
+
+template <typename Type>
+struct ReplaceFunctor<Type, enable_if_t<is_base_binary_type<Type>::value>> {
+    using BuilderType = typename TypeTraits<Type>::BuilderType;
+    using OffsetType = typename Type::offset_type;
+
+    static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+        const ArrayData& input = *batch[0].array();
+        const ArrayData& mask = *batch[1].array();
+        const auto& replacement_scalar = checked_cast<const BaseBinaryScalar&>(*batch[2].scalar());
+        util::string_view replacement(*replacement_scalar.value);
+        ArrayData* output = out->mutable_array();
+
+        const uint8_t* to_replace = mask.buffers[1]->data();
+        uint64_t replace_count = 0;
+        {
+            BitBlockCounter bit_counter(to_replace, input.offset, input.length);
+            int64_t out_offset = 0;
+            while (out_offset < input.length) {
+                BitBlockCount block = bit_counter.NextWord();
+                replace_count += block.popcount;
+                out_offset += block.length;
+            }
+        }
+
+        if (replace_count > 0 && replacement_scalar.is_valid) {
+            auto input_offsets = input.GetValues<OffsetType>(1);
+            auto input_values = input.GetValues<char>(2, input.offset);
+            BuilderType builder(input.type, ctx->memory_pool());
+            KERNEL_RETURN_IF_ERROR(ctx, builder.ReserveData(input.buffers[2]->size()
+                                        + replacement.length() * replace_count));
+            KERNEL_RETURN_IF_ERROR(ctx, builder.Resize(input.length));
+
+            BitBlockCounter bit_counter(to_replace, input.offset, input.length);
+            int64_t input_offset = 0;
+            while (input_offset < input.length) {
+                BitBlockCount block = bit_counter.NextWord();
+                for (int64_t i = 0 ; i < block.length ; ++i) {
+                    if (BitUtil::GetBit(to_replace, input_offset + i)) {
+                        builder.UnsafeAppend(replacement);
+                    } else {
+                        auto current_offset = input_offsets[input_offset+i];
+                        auto next_offset = input_offsets[input_offset+i+1];
+                        auto string_value = util::string_view(input_values + current_offset,
+                                                              next_offset - current_offset);
+                        builder.UnsafeAppend(string_value);
+                    }
+                }
+                input_offset += block.length;
+            }
+            std::shared_ptr<Array> string_array;
+            KERNEL_RETURN_IF_ERROR(ctx, builder.Finish(&string_array));
+            *output = *string_array->data();
+            // The builder does not match the logical type, due to
+            // GenerateTypeAgnosticVarBinaryBase
+            output->type = input.type;
+        } else {
+            *output = input;
+        }
+    }
+};
+
+void AddBasicReplaceKernels(ScalarKernel kernel, ScalarFunction* func) {
+    auto AddKernels = [&](const std::vector<std::shared_ptr<DataType>>& types) {
+        for (const std::shared_ptr<DataType>& ty : types) {
+            kernel.signature = KernelSignature::Make({InputType::Array(ty), InputType::Array(boolean()), InputType::Scalar(ty)}, ty);
+            kernel.exec = GenerateTypeAgnosticPrimitive<ReplaceFunctor>(*ty);
+            DCHECK_OK(func->AddKernel(kernel));
+        }
+    };
+    AddKernels(NumericTypes());
+    AddKernels(TemporalTypes());
+    AddKernels({boolean(), null()});
+}
+
+void AddBinaryReplaceKernels(ScalarKernel kernel, ScalarFunction* func) {
+    for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
+        kernel.signature = KernelSignature::Make({InputType::Array(ty), InputType::Array(boolean()), InputType::Scalar(ty)}, ty);
+        kernel.exec = GenerateTypeAgnosticVarBinaryBase<ReplaceFunctor>(*ty);
+        DCHECK_OK(func->AddKernel(kernel));
+    }
+}
+
+const FunctionDoc replace_doc{
+        "Replace selected elements",
+        ("`replacement` must be a scalar of the same type as `values`.\n"
+         "Each unmasked value in `values` is emitted as-is.\n"
+         "Each masked value in `values` is replaced with `replacement`."),
+        {"values", "mask", "replacement"}};
+
+}  // namespace
+
+void RegisterScalarReplace(FunctionRegistry* registry) {
+    ScalarKernel replace_base;
+    replace_base.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
+    replace_base.mem_allocation = MemAllocation::NO_PREALLOCATE;
+    auto replace = std::make_shared<ScalarFunction>("replace", Arity::Ternary(), &replace_doc);
+    AddBasicReplaceKernels(replace_base, replace.get());
+    AddBinaryReplaceKernels(replace_base, replace.get());
+    DCHECK_OK(registry->AddFunction(replace));
+}
+
+}  // namespace internal
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_replace_test.cc
@@ -1,0 +1,225 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/compute/api.h"
+#include "arrow/scalar.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/type.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/bitmap_ops.h"
+
+namespace arrow {
+
+using internal::InvertBitmap;
+
+namespace compute {
+
+void CheckReplace(const Array& input,
+                  const Array& mask,
+                  const Datum& replacement,
+                  const Array& expected) {
+    auto Check = [&](const Array& input, const Array& mask, const Array& expected) {
+        ASSERT_OK_AND_ASSIGN(Datum datum_out, Replace(input, mask, replacement));
+        std::shared_ptr<Array> result = datum_out.make_array();
+        ASSERT_OK(result->ValidateFull());
+        AssertArraysEqual(expected, *result, /*verbose=*/true);
+    };
+
+    Check(input, mask, expected);
+    if (input.length() > 0) {
+        Check(*input.Slice(1),
+              *mask.Slice(1),
+              *expected.Slice(1));
+    }
+}
+
+void CheckReplace(const std::shared_ptr<DataType>& type,
+                  const std::string& in_values,
+                  const std::string& in_mask,
+                  const Datum& replacement,
+                  const std::string& out_values) {
+    std::shared_ptr<Array> input = ArrayFromJSON(type, in_values);
+    std::shared_ptr<Array> mask = ArrayFromJSON(boolean(), in_mask);
+    std::shared_ptr<Array> expected = ArrayFromJSON(type, out_values);
+    CheckReplace(*input, *mask, replacement, *expected);
+}
+
+class TestReplaceKernel : public ::testing::Test {};
+
+template <typename Type>
+class TestReplacePrimitive : public ::testing::Test {};
+
+typedef ::testing::Types<Int8Type, UInt8Type, Int16Type, UInt16Type, Int32Type,
+                         UInt32Type, Int64Type, UInt64Type, FloatType, DoubleType,
+                         Date32Type, Date64Type>
+    PrimitiveTypes;
+
+TEST_F(TestReplaceKernel, ReplaceInvalidScalar) {
+    auto scalar = std::make_shared<Int8Scalar>(3);
+    scalar->is_valid = false;
+    CheckReplace(int8(),
+                 "[2, 4, 7, 9]",
+                 "[true, false, false, false]",
+                 Datum(scalar),
+                 "[2, 4, 7, 9]");
+}
+
+TYPED_TEST_SUITE(TestReplacePrimitive, PrimitiveTypes);
+
+TYPED_TEST(TestReplacePrimitive, Replace) {
+    using T = typename TypeParam::c_type;
+    using ArrayType = typename TypeTraits<TypeParam>::ArrayType;
+    using ScalarType = typename TypeTraits<TypeParam>::ScalarType;
+    auto type = TypeTraits<TypeParam>::type_singleton();
+    auto scalar = std::make_shared<ScalarType>(static_cast<T>(42));
+
+    // No replacement
+    CheckReplace(type, "[2, 4, 7, 9]", "[false, false, false, false]", Datum(scalar), "[2, 4, 7, 9]");
+    // Some replacements
+    CheckReplace(type, "[2, 4, 7, 9]", "[true, false, true, false]", Datum(scalar), "[42, 4, 42, 9]");
+    // Empty Array
+    CheckReplace(type, "[]", "[]", Datum(scalar), "[]");
+
+    random::RandomArrayGenerator rand(/*seed=*/0);
+    auto arr = std::static_pointer_cast<ArrayType>(rand.ArrayOf(type, 1000, /*null_probability=*/0.01));
+    // use arr inverted null bits as mask, so expect to replace all null values...
+    auto mask_data = std::make_shared<ArrayData>(boolean(), arr->length(), 0);
+    mask_data->null_count = 0;
+    mask_data->buffers.resize(2);
+    mask_data->buffers[0] = nullptr;
+    mask_data->buffers[1] = *AllocateEmptyBitmap(arr->length());
+    InvertBitmap(arr->data()->buffers[0]->data(), arr->offset(), arr->length(),
+                 mask_data->buffers[1]->mutable_data(), mask_data->offset);
+    std::shared_ptr<ArrayData> expected_data = arr->data()->Copy();
+    expected_data->null_count = 0;
+    expected_data->buffers[0] = nullptr;
+    expected_data->buffers[1] = *AllocateBuffer(arr->length() * sizeof(T));
+    T* out_data = expected_data->GetMutableValues<T>(1);
+    for (int64_t i = 0 ; i < arr->length() ; ++i) {
+        if (arr->IsValid(i)) {
+            out_data[i] = arr->Value(i);
+        } else {
+            out_data[i] = scalar->value;
+        }
+    }
+    CheckReplace(*arr, BooleanArray(mask_data), Datum(scalar), ArrayType(expected_data));
+}
+
+TEST_F(TestReplaceKernel, ReplaceNull) {
+    auto datum = Datum(std::make_shared<NullScalar>());
+    CheckReplace(null(),
+                 "[null, null, null, null]",
+                 "[true, true, true, true]",
+                 /*replacement=*/datum,
+                 "[null, null, null, null]");
+}
+
+TEST_F(TestReplaceKernel, ReplaceBoolean) {
+    auto scalar1 = std::make_shared<BooleanScalar>(false);
+    auto scalar2 = std::make_shared<BooleanScalar>(true);
+
+    // No replacement
+    CheckReplace(boolean(),
+                 "[true, false, true, false]",
+                 "[false, false, false, false]",
+                 Datum(scalar1),
+                 "[true, false, true, false]");
+    // Some replacements
+    CheckReplace(boolean(),
+                 "[true, false, true, false]",
+                 "[true, false, true, false]",
+                 Datum(scalar1),
+                 "[false, false, false, false]");
+
+    random::RandomArrayGenerator rand(/*seed=*/0);
+    auto arr = std::static_pointer_cast<BooleanArray>(rand.Boolean(1000,
+                                                      /*true_probability=*/0.5,
+                                                      /*null_probability=*/0.01));
+    // use arr inverted null bits as mask, so expect to replace all null values...
+    auto mask_data = std::make_shared<ArrayData>(boolean(), arr->length(), 0);
+    mask_data->null_count = 0;
+    mask_data->buffers.resize(2);
+    mask_data->buffers[0] = nullptr;
+    mask_data->buffers[1] = *AllocateEmptyBitmap(arr->length());
+    InvertBitmap(arr->data()->buffers[0]->data(), arr->offset(), arr->length(),
+                 mask_data->buffers[1]->mutable_data(), mask_data->offset);
+    auto expected_data = arr->data()->Copy();
+    expected_data->null_count = 0;
+    expected_data->buffers[0] = nullptr;
+    expected_data->buffers[1] = *AllocateEmptyBitmap(arr->length());
+    uint8_t* out_data = expected_data->buffers[1]->mutable_data();
+    for (int64_t i = 0 ; i < arr->length() ; ++i) {
+        if (arr->IsValid(i)) {
+            BitUtil::SetBitTo(out_data, i, arr->Value(i));
+        } else {
+            BitUtil::SetBitTo(out_data, i, scalar1->value);
+        }
+    }
+    CheckReplace(*arr, BooleanArray(mask_data), Datum(scalar1), BooleanArray(expected_data));
+}
+
+TEST_F(TestReplaceKernel, ReplaceTimestamp) {
+    auto time32_type = time32(TimeUnit::SECOND);
+    auto time64_type = time64(TimeUnit::NANO);
+    auto scalar1 = std::make_shared<Time32Scalar>(5, time32_type);
+    auto scalar2 = std::make_shared<Time64Scalar>(6, time64_type);
+    // No replacement
+    CheckReplace(time32_type,
+                 "[2, 1, 6, 9]",
+                 "[false, false, false, false]",
+                 Datum(scalar1),
+                 "[2, 1, 6, 9]");
+    CheckReplace(time64_type,
+                 "[2, 1, 6, 9]",
+                 "[false, false, false, false]",
+                 Datum(scalar2),
+                 "[2, 1, 6, 9]");
+    // Some replacements
+    CheckReplace(time32_type,
+                 "[2, 1, 6, 9]",
+                 "[true, false, true, false]",
+                 Datum(scalar1),
+                 "[5, 1, 5, 9]");
+    CheckReplace(time64_type,
+                 "[2, 1, 6, 9]",
+                 "[false, true, false, true]",
+                 Datum(scalar2),
+                 "[2, 6, 6, 6]");
+}
+
+TEST_F(TestReplaceKernel, ReplaceString) {
+    auto type = large_utf8();
+    auto scalar = std::make_shared<LargeStringScalar>("arrow");
+    // No replacement
+    CheckReplace(type,
+                 R"(["foo", "bar"])",
+                 "[false, false]",
+                 Datum(scalar),
+                 R"(["foo", "bar"])");
+    // Some replacements
+    CheckReplace(type,
+                 R"(["foo", "bar"])",
+                 "[true, false]",
+                 Datum(scalar),
+                 R"(["arrow", "bar"])");
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -31,18 +31,19 @@
 namespace arrow {
 namespace compute {
 
+template <typename ArrowType>
 class TestValidityKernels : public ::testing::Test {
  protected:
-  // XXX Since IsValid and IsNull don't touch any buffers but the null bitmap
-  // testing multiple types seems redundant.
-  using ArrowType = BooleanType;
-
   static std::shared_ptr<DataType> type_singleton() {
     return TypeTraits<ArrowType>::type_singleton();
   }
 };
 
-TEST_F(TestValidityKernels, ArrayIsValid) {
+typedef TestValidityKernels<BooleanType> TestBooleanValidityKernels;
+typedef TestValidityKernels<FloatType> TestFloatValidityKernels;
+typedef TestValidityKernels<DoubleType> TestDoubleValidityKernels;
+
+TEST_F(TestBooleanValidityKernels, ArrayIsValid) {
   CheckScalarUnary("is_valid", type_singleton(), "[]", type_singleton(), "[]");
   CheckScalarUnary("is_valid", type_singleton(), "[null]", type_singleton(), "[false]");
   CheckScalarUnary("is_valid", type_singleton(), "[1]", type_singleton(), "[true]");
@@ -50,25 +51,25 @@ TEST_F(TestValidityKernels, ArrayIsValid) {
                    "[false, true, true, false]");
 }
 
-TEST_F(TestValidityKernels, IsValidIsNullNullType) {
+TEST_F(TestBooleanValidityKernels, IsValidIsNullNullType) {
   CheckScalarUnary("is_null", std::make_shared<NullArray>(5),
                    ArrayFromJSON(boolean(), "[true, true, true, true, true]"));
   CheckScalarUnary("is_valid", std::make_shared<NullArray>(5),
                    ArrayFromJSON(boolean(), "[false, false, false, false, false]"));
 }
 
-TEST_F(TestValidityKernels, ArrayIsValidBufferPassthruOptimization) {
+TEST_F(TestBooleanValidityKernels, ArrayIsValidBufferPassthruOptimization) {
   Datum arg = ArrayFromJSON(boolean(), "[null, 1, 0, null]");
   ASSERT_OK_AND_ASSIGN(auto validity, arrow::compute::IsValid(arg));
   ASSERT_EQ(validity.array()->buffers[1], arg.array()->buffers[0]);
 }
 
-TEST_F(TestValidityKernels, ScalarIsValid) {
+TEST_F(TestBooleanValidityKernels, ScalarIsValid) {
   CheckScalarUnary("is_valid", MakeScalar(19.7), MakeScalar(true));
   CheckScalarUnary("is_valid", MakeNullScalar(float64()), MakeScalar(false));
 }
 
-TEST_F(TestValidityKernels, ArrayIsNull) {
+TEST_F(TestBooleanValidityKernels, ArrayIsNull) {
   CheckScalarUnary("is_null", type_singleton(), "[]", type_singleton(), "[]");
   CheckScalarUnary("is_null", type_singleton(), "[null]", type_singleton(), "[true]");
   CheckScalarUnary("is_null", type_singleton(), "[1]", type_singleton(), "[false]");
@@ -76,16 +77,55 @@ TEST_F(TestValidityKernels, ArrayIsNull) {
                    "[true, false, false, true]");
 }
 
-TEST_F(TestValidityKernels, IsNullSetsZeroNullCount) {
+TEST_F(TestBooleanValidityKernels, IsNullSetsZeroNullCount) {
   auto arr = ArrayFromJSON(int32(), "[1, 2, 3, 4]");
   std::shared_ptr<ArrayData> result = (*IsNull(arr)).array();
   ASSERT_EQ(result->null_count, 0);
 }
 
-TEST_F(TestValidityKernels, ScalarIsNull) {
+TEST_F(TestBooleanValidityKernels, ScalarIsNull) {
   CheckScalarUnary("is_null", MakeScalar(19.7), MakeScalar(false));
   CheckScalarUnary("is_null", MakeNullScalar(float64()), MakeScalar(true));
 }
+
+TEST_F(TestFloatValidityKernels, FloatArrayIsNan) {
+    CheckScalarUnary("is_nan",
+                     ArrayFromJSON(float32(), "[NaN, NaN, NaN, NaN, NaN]"),
+                     ArrayFromJSON(boolean(), "[true, true, true, true, true]"));
+
+    CheckScalarUnary("is_nan",
+    ArrayFromJSON(float32(), "[0.0, 1.0, 2.0, 3.0, 4.0]"),
+    ArrayFromJSON(boolean(), "[false, false, false, false, false]"));
+
+    CheckScalarUnary("is_nan",
+    ArrayFromJSON(float32(), "[0.0, NaN, 2.0, NaN, 4.0]"),
+    ArrayFromJSON(boolean(), "[false, true, false, true, false]"));
+}
+
+TEST_F(TestDoubleValidityKernels, DoubleArrayIsNan) {
+    CheckScalarUnary("is_nan",
+    ArrayFromJSON(float64(), "[NaN, NaN, NaN, NaN, NaN]"),
+    ArrayFromJSON(boolean(), "[true, true, true, true, true]"));
+
+    CheckScalarUnary("is_nan",
+    ArrayFromJSON(float64(), "[0.0, 1.0, 2.0, 3.0, 4.0]"),
+    ArrayFromJSON(boolean(), "[false, false, false, false, false]"));
+
+    CheckScalarUnary("is_nan",
+    ArrayFromJSON(float64(), "[0.0, NaN, 2.0, NaN, 4.0]"),
+    ArrayFromJSON(boolean(), "[false, true, false, true, false]"));
+}
+
+TEST_F(TestFloatValidityKernels, FloatScalarIsNan) {
+    CheckScalarUnary("is_nan", MakeScalar(42.0), MakeScalar(false));
+    CheckScalarUnary("is_nan", MakeScalar(std::nanf("")), MakeScalar(true));
+}
+
+TEST_F(TestDoubleValidityKernels, DoubleScalarIsNan) {
+    CheckScalarUnary("is_nan", MakeScalar(42.0), MakeScalar(false));
+    CheckScalarUnary("is_nan", MakeScalar(std::nan("")), MakeScalar(true));
+}
+
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -125,6 +125,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterScalarStringAscii(registry.get());
   RegisterScalarValidity(registry.get());
   RegisterScalarFillNull(registry.get());
+  RegisterScalarReplace(registry.get());
 
   // Aggregate functions
   RegisterScalarAggregateBasic(registry.get());

--- a/cpp/src/arrow/compute/registry_internal.h
+++ b/cpp/src/arrow/compute/registry_internal.h
@@ -34,6 +34,7 @@ void RegisterScalarSetLookup(FunctionRegistry* registry);
 void RegisterScalarStringAscii(FunctionRegistry* registry);
 void RegisterScalarValidity(FunctionRegistry* registry);
 void RegisterScalarFillNull(FunctionRegistry* registry);
+void RegisterScalarReplace(FunctionRegistry* registry);
 
 // Vector functions
 void RegisterVectorHash(FunctionRegistry* registry);


### PR DESCRIPTION
Purpose a "replace" compute kernel which could fulfil ARROW-10641 - [C++] A "replace" or "map" kernel to replace values in array based on mapping (@jorisvandenbossche). The implementation is inspired by "fill_null" kernel except it takes an additional BooleanArray parameter which is used as a mask to trigger value replacement. 
**WARNING:** the current implementation expects all null values to be replaced in the output (corresponding bit set to 1 in input mask) because it will not carry nulls into the output (feel free to share your thoughts on the current implementation and to give me hints on the easiest way to deal with nulls that should make it in the output).

Add a "is_nan" kernel to check for NaN "equality" for FloatArray and DoubleArray (based on std::isnan()). The kernel signature is based on "is_null" kernel so I put my code in arrow/compute/kernels/scalar_validity.cc... but the implementation take some inspiration from "compare" kernel.

Both kernels are used to mimic pandas.DataFrame.fillna(value=X) in C++. See below an example of usage:

`
    template <typename value_type>
    std::shared_ptr<DataFrame> DataFrame::fillna(value_type value) {
        auto outdf = std::make_shared<DataFrame>();

        if (outdf->table_->num_rows() == 0)
            outdf->table_ = arrow::Table::Make(
                    std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>()),
                    std::vector<std::shared_ptr<arrow::ChunkedArray>>(),
                    this->table_->num_rows());

        for (int i = 0 ; i < this->table_->num_columns() ; ++i) {

            if (this->table_->ColumnNames()[i] == INDEX_COLUMN) {
                auto field = this->table_->schema()->field(i);
                auto chunked_array = this->table_->column(i);
                outdf->table_ = outdf->table_->AddColumn(i, field, chunked_array).ValueOrDie();
            } else {
                auto field = this->table_->schema()->field(i);
                auto chunked_array = this->table_->column(i);
                auto value_datum = arrow::compute::Cast(arrow::Datum(value), chunked_array->type()).ValueOrDie();
                auto nulls = arrow::compute::IsNull(chunked_array).ValueOrDie();
                auto nans = arrow::compute::IsNan(chunked_array).ValueOrDie().chunked_array();
                auto to_replace = arrow::compute::Or(nulls, nans).ValueOrDie();
                auto clean_chunked_array = arrow::compute::Replace(chunked_array, nans, value_datum).ValueOrDie().chunked_array();
                outdf->table_ = outdf->table_->AddColumn(i, field, clean_chunked_array).ValueOrDie();
            }
        }

        return outdf;
    }
`
