### PR TITLE
ARROW-10259: [Rust] Add custom metadata to Field

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1568,8 +1568,7 @@ def get_generated_json_files(tempdir=None):
 
         generate_custom_metadata_case()
         .skip_category('Go')
-        .skip_category('JS')
-        .skip_category('Rust'),  # TODO(ARROW-10259)
+        .skip_category('JS'),
 
         generate_duplicate_fieldnames_case()
         .skip_category('Go')

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -2974,7 +2974,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Data type List(Field { name: \"item\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false }) is not currently supported"
+        expected = "Data type List(Field { name: \"item\", data_type: Int64, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }) is not currently supported"
     )]
     fn test_struct_array_builder_from_schema_unsupported_type() {
         let mut fields = Vec::new();

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1307,9 +1307,8 @@ impl Field {
 
     /// Sets the `Field`'s optional custom metadata.
     /// The metadata is set as `None` for empty map.
-    /// Return cloned `Self`.
     #[inline]
-    pub fn with_metadata(&mut self, metadata: Option<BTreeMap<String, String>>) -> Self {
+    pub fn set_metadata(&mut self, metadata: Option<BTreeMap<String, String>>) {
         // To make serde happy, convert Some(empty_map) to None.
         self.metadata = None;
         if let Some(v) = metadata {
@@ -1317,7 +1316,6 @@ impl Field {
                 self.metadata = Some(v);
             }
         }
-        self.clone()
     }
 
     /// Returns the immutable reference to the `Field`'s optional custom metadata.
@@ -1617,10 +1615,10 @@ impl Field {
                         merged.insert(key.clone(), from_value.clone());
                     }
                 }
-                self.with_metadata(Some(merged));
+                self.set_metadata(Some(merged));
             }
             (None, Some(from_metadata)) => {
-                self.with_metadata(Some(from_metadata.clone()));
+                self.set_metadata(Some(from_metadata.clone()));
             }
             _ => {}
         }
@@ -2091,12 +2089,12 @@ mod tests {
         let field_metadata: BTreeMap<String, String> = kv_array.iter().cloned().collect();
 
         // Non-empty map: should be converted as JSON obj { ... }
-        let first_name = Field::new("first_name", DataType::Utf8, false)
-            .with_metadata(Some(field_metadata));
+        let mut first_name = Field::new("first_name", DataType::Utf8, false);
+        first_name.set_metadata(Some(field_metadata));
 
         // Empty map: should be omitted.
-        let last_name = Field::new("last_name", DataType::Utf8, false)
-            .with_metadata(Some(BTreeMap::default()));
+        let mut last_name = Field::new("last_name", DataType::Utf8, false);
+        last_name.set_metadata(Some(BTreeMap::default()));
 
         let person = DataType::Struct(vec![
             first_name,
@@ -2927,7 +2925,8 @@ mod tests {
         assert!(schema2 != schema4);
         assert!(schema3 != schema4);
 
-        let f = Field::new("c1", DataType::Utf8, false).with_metadata(Some(
+        let mut f = Field::new("c1", DataType::Utf8, false);
+        f.set_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()
@@ -2966,8 +2965,8 @@ mod tests {
     fn person_schema() -> Schema {
         let kv_array = [("k".to_string(), "v".to_string())];
         let field_metadata: BTreeMap<String, String> = kv_array.iter().cloned().collect();
-        let first_name = Field::new("first_name", DataType::Utf8, false)
-            .with_metadata(Some(field_metadata));
+        let mut first_name = Field::new("first_name", DataType::Utf8, false);
+        first_name.set_metadata(Some(field_metadata));
 
         Schema::new(vec![
             first_name,
@@ -2998,16 +2997,16 @@ mod tests {
                 .iter()
                 .cloned()
                 .collect();
-        let f1 = Field::new("first_name", DataType::Utf8, false)
-            .with_metadata(Some(metadata1));
+        let mut f1 = Field::new("first_name", DataType::Utf8, false);
+        f1.set_metadata(Some(metadata1));
 
         let metadata2: BTreeMap<String, String> =
             [("foo".to_string(), "baz".to_string())]
                 .iter()
                 .cloned()
                 .collect();
-        let f2 = Field::new("first_name", DataType::Utf8, false)
-            .with_metadata(Some(metadata2));
+        let mut f2 = Field::new("first_name", DataType::Utf8, false);
+        f2.set_metadata(Some(metadata2));
 
         assert!(
             Schema::try_merge(&[Schema::new(vec![f1]), Schema::new(vec![f2])]).is_err()
@@ -3020,21 +3019,23 @@ mod tests {
                 .iter()
                 .cloned()
                 .collect();
-        let f2 = Field::new("first_name", DataType::Utf8, false)
-            .with_metadata(Some(metadata2));
+        let mut f2 = Field::new("first_name", DataType::Utf8, false);
+        f2.set_metadata(Some(metadata2));
 
         assert!(f1.try_merge(&f2).is_ok());
         assert!(f1.metadata.is_some());
         assert_eq!(f1.metadata.unwrap(), f2.metadata.unwrap());
 
         // 3. Some + Some
-        let mut f1 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
+        let mut f1 = Field::new("first_name", DataType::Utf8, false);
+        f1.set_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()
                 .collect(),
         ));
-        let f2 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
+        let mut f2 = Field::new("first_name", DataType::Utf8, false);
+        f2.set_metadata(Some(
             [("foo2".to_string(), "bar2".to_string())]
                 .iter()
                 .cloned()
@@ -3055,7 +3056,8 @@ mod tests {
         );
 
         // 4. Some + None.
-        let mut f1 = Field::new("first_name", DataType::Utf8, false).with_metadata(Some(
+        let mut f1 = Field::new("first_name", DataType::Utf8, false);
+        f1.set_metadata(Some(
             [("foo".to_string(), "bar".to_string())]
                 .iter()
                 .cloned()

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1312,7 +1312,7 @@ impl Field {
         if let Some(v) = metadata {
             if !v.is_empty() {
                 self.metadata = Some(v);
-                return
+                return;
             }
         }
         self.metadata = None;
@@ -2754,7 +2754,7 @@ mod tests {
         let md = metadata.as_ref().unwrap();
         assert_eq!(md.len(), 1);
         let key = md.get("k");
-        assert!(md.get("k").is_some());
+        assert!(key.is_some());
         assert_eq!(key.unwrap(), "v");
 
         let interests = &schema.fields()[3];

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1388,6 +1388,7 @@ impl Field {
                         ));
                     }
                 };
+                // Referenced example file: testing/data/arrow-ipc-stream/integration/1.0.0-littleendian/generated_custom_metadata.json.gz
                 let metadata = match map.get("metadata") {
                     Some(&Value::Array(ref values)) => {
                         let mut res: BTreeMap<String, String> = BTreeMap::new();
@@ -1417,6 +1418,21 @@ impl Field {
                                         "Field 'metadata' contains non-object key-value pair".to_string(),
                                     ));
                                 }
+                            }
+                        }
+                        Some(res)
+                    }
+                    // We also support map format, because Schema's metadata supports this.
+                    // See https://github.com/apache/arrow/pull/5907
+                    Some(&Value::Object(ref values)) => {
+                        let mut res: BTreeMap<String, String> = BTreeMap::new();
+                        for (k, v) in values {
+                            if let Some(str_value) = v.as_str() {
+                                res.insert(k.clone(), str_value.to_string().clone());
+                            } else {
+                                return Err(ArrowError::ParseError(
+                                    format!("Field 'metadata' contains non-string value for key {}", k),
+                                ));
                             }
                         }
                         Some(res)

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1307,6 +1307,7 @@ impl Field {
 
     /// Sets the `Field`'s optional custom metadata.
     /// The metadata is set as `None` for empty map.
+    /// Return cloned `Self`.
     #[inline]
     pub fn with_metadata(&mut self, metadata: Option<BTreeMap<String, String>>) -> Self {
         // To make serde happy, convert Some(empty_map) to None.
@@ -2961,7 +2962,7 @@ mod tests {
     fn person_schema() -> Schema {
         let kv_array = [("k".to_string(), "v".to_string())];
         let field_metadata: BTreeMap<String, String> = kv_array.iter().cloned().collect();
-        let mut first_name = Field::new("first_name", DataType::Utf8, false)
+        let first_name = Field::new("first_name", DataType::Utf8, false)
             .with_metadata(Some(field_metadata));
 
         Schema::new(vec![

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -2918,6 +2918,20 @@ mod tests {
         assert!(schema2 != schema3);
         assert!(schema2 != schema4);
         assert!(schema3 != schema4);
+
+        let mut f = Field::new("c1", DataType::Utf8, false);
+        f.set_metadata(Some(
+            [("foo".to_string(), "bar".to_string())]
+                .iter()
+                .cloned()
+                .collect(),
+        ));
+        let schema5 = Schema::new(vec![
+            f,
+            Field::new("c2", DataType::Float64, true),
+            Field::new("c3", DataType::LargeBinary, true),
+        ]);
+        assert!(schema1 != schema5);
     }
 
     #[test]

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -690,9 +690,13 @@ mod tests {
             .iter()
             .cloned()
             .collect();
+        let field_md: BTreeMap<String, String> = [("k".to_string(), "v".to_string())]
+            .iter()
+            .cloned()
+            .collect();
         let schema = Schema::new_with_metadata(
             vec![
-                Field::new("uint8", DataType::UInt8, false),
+                Field::new("uint8", DataType::UInt8, false).with_metadata(Some(field_md)),
                 Field::new("uint16", DataType::UInt16, true),
                 Field::new("uint32", DataType::UInt32, false),
                 Field::new("uint64", DataType::UInt64, true),

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -96,13 +96,10 @@ impl<'a> From<ipc::Field<'a>> for Field {
                     metadata_map.insert(k.to_string(), v.to_string());
                 }
             }
-            if !metadata_map.is_empty() {
-                metadata = Some(metadata_map);
-            }
+            metadata = Some(metadata_map);
         }
 
-        arrow_field.set_metadata(metadata);
-        arrow_field
+        arrow_field.with_metadata(metadata)
     }
 }
 

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -99,7 +99,8 @@ impl<'a> From<ipc::Field<'a>> for Field {
             metadata = Some(metadata_map);
         }
 
-        arrow_field.with_metadata(metadata)
+        arrow_field.set_metadata(metadata);
+        arrow_field
     }
 }
 
@@ -696,7 +697,11 @@ mod tests {
             .collect();
         let schema = Schema::new_with_metadata(
             vec![
-                Field::new("uint8", DataType::UInt8, false).with_metadata(Some(field_md)),
+                {
+                    let mut f = Field::new("uint8", DataType::UInt8, false);
+                    f.set_metadata(Some(field_md));
+                    f
+                },
                 Field::new("uint16", DataType::UInt16, true),
                 Field::new("uint32", DataType::UInt32, false),
                 Field::new("uint64", DataType::UInt64, true),

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -727,11 +727,15 @@ mod tests {
         let micros_tz = Some("UTC".to_string());
         let nanos_tz = Some("Africa/Johannesburg".to_string());
 
-        let mut field_bools_with_metadata =
-            Field::new("bools-with-metadata", DataType::Boolean, true);
-        let mut field_metadata = std::collections::BTreeMap::new();
-        field_metadata.insert("k".to_string(), "v".to_string());
-        field_bools_with_metadata.set_metadata(Some(field_metadata));
+        let field_bools_with_metadata =
+            Field::new("bools-with-metadata", DataType::Boolean, true).with_metadata(
+                Some(
+                    [("k".to_string(), "v".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
+            );
 
         let schema = Schema::new(vec![
             field_bools_with_metadata,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -727,88 +727,95 @@ mod tests {
         let micros_tz = Some("UTC".to_string());
         let nanos_tz = Some("Africa/Johannesburg".to_string());
 
-        let field_bools_with_metadata =
-            Field::new("bools-with-metadata", DataType::Boolean, true).with_metadata(
-                Some(
-                    [("k".to_string(), "v".to_string())]
-                        .iter()
-                        .cloned()
-                        .collect(),
+        let schema =
+            Schema::new(vec![
+                Field::new("bools-with-metadata-map", DataType::Boolean, true)
+                    .with_metadata(Some(
+                        [("k".to_string(), "v".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect(),
+                    )),
+                Field::new("bools-with-metadata-vec", DataType::Boolean, true)
+                    .with_metadata(Some(
+                        [("k2".to_string(), "v2".to_string())]
+                            .iter()
+                            .cloned()
+                            .collect(),
+                    )),
+                Field::new("bools", DataType::Boolean, true),
+                Field::new("int8s", DataType::Int8, true),
+                Field::new("int16s", DataType::Int16, true),
+                Field::new("int32s", DataType::Int32, true),
+                Field::new("int64s", DataType::Int64, true),
+                Field::new("uint8s", DataType::UInt8, true),
+                Field::new("uint16s", DataType::UInt16, true),
+                Field::new("uint32s", DataType::UInt32, true),
+                Field::new("uint64s", DataType::UInt64, true),
+                Field::new("float32s", DataType::Float32, true),
+                Field::new("float64s", DataType::Float64, true),
+                Field::new("date_days", DataType::Date32(DateUnit::Day), true),
+                Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
+                Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
+                Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
+                Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
+                Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
+                Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
+                Field::new(
+                    "ts_millis",
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    true,
                 ),
-            );
+                Field::new(
+                    "ts_micros",
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    true,
+                ),
+                Field::new(
+                    "ts_nanos",
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    true,
+                ),
+                Field::new(
+                    "ts_secs_tz",
+                    DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_millis_tz",
+                    DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_micros_tz",
+                    DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
+                    true,
+                ),
+                Field::new(
+                    "ts_nanos_tz",
+                    DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
+                    true,
+                ),
+                Field::new("utf8s", DataType::Utf8, true),
+                Field::new(
+                    "lists",
+                    DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                    true,
+                ),
+                Field::new(
+                    "structs",
+                    DataType::Struct(vec![
+                        Field::new("int32s", DataType::Int32, true),
+                        Field::new("utf8s", DataType::Utf8, true),
+                    ]),
+                    true,
+                ),
+            ]);
 
-        let schema = Schema::new(vec![
-            field_bools_with_metadata,
-            Field::new("bools", DataType::Boolean, true),
-            Field::new("int8s", DataType::Int8, true),
-            Field::new("int16s", DataType::Int16, true),
-            Field::new("int32s", DataType::Int32, true),
-            Field::new("int64s", DataType::Int64, true),
-            Field::new("uint8s", DataType::UInt8, true),
-            Field::new("uint16s", DataType::UInt16, true),
-            Field::new("uint32s", DataType::UInt32, true),
-            Field::new("uint64s", DataType::UInt64, true),
-            Field::new("float32s", DataType::Float32, true),
-            Field::new("float64s", DataType::Float64, true),
-            Field::new("date_days", DataType::Date32(DateUnit::Day), true),
-            Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
-            Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
-            Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
-            Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
-            Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
-            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
-            Field::new(
-                "ts_millis",
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_micros",
-                DataType::Timestamp(TimeUnit::Microsecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_nanos",
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-                true,
-            ),
-            Field::new(
-                "ts_secs_tz",
-                DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_millis_tz",
-                DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_micros_tz",
-                DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
-                true,
-            ),
-            Field::new(
-                "ts_nanos_tz",
-                DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
-                true,
-            ),
-            Field::new("utf8s", DataType::Utf8, true),
-            Field::new(
-                "lists",
-                DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
-                true,
-            ),
-            Field::new(
-                "structs",
-                DataType::Struct(vec![
-                    Field::new("int32s", DataType::Int32, true),
-                    Field::new("utf8s", DataType::Utf8, true),
-                ]),
-                true,
-            ),
-        ]);
-
-        let bools_with_metadata = BooleanArray::from(vec![Some(true), None, Some(false)]);
+        let bools_with_metadata_map =
+            BooleanArray::from(vec![Some(true), None, Some(false)]);
+        let bools_with_metadata_vec =
+            BooleanArray::from(vec![Some(true), None, Some(false)]);
         let bools = BooleanArray::from(vec![Some(true), None, Some(false)]);
         let int8s = Int8Array::from(vec![Some(1), None, Some(3)]);
         let int16s = Int16Array::from(vec![Some(1), None, Some(3)]);
@@ -897,7 +904,8 @@ mod tests {
         let record_batch = RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
-                Arc::new(bools_with_metadata),
+                Arc::new(bools_with_metadata_map),
+                Arc::new(bools_with_metadata_vec),
                 Arc::new(bools),
                 Arc::new(int8s),
                 Arc::new(int16s),

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -20,7 +20,7 @@
 //! These utilities define structs that read the integration JSON format for integration testing purposes.
 
 use serde_derive::{Deserialize, Serialize};
-use serde_json::{Number as VNumber, Value};
+use serde_json::{Map as VMap, Number as VNumber, Value};
 
 use crate::array::*;
 use crate::datatypes::*;
@@ -60,13 +60,22 @@ pub struct ArrowJsonField {
 
 impl From<&Field> for ArrowJsonField {
     fn from(field: &Field) -> Self {
+        let mut metadata_value = None;
+        if let Some(kv_list) = field.metadata() {
+            let mut json_map = VMap::new();
+            for (k, v) in kv_list {
+                json_map.insert(k.clone(), Value::String(v.clone()));
+            }
+            metadata_value = Some(Value::Object(json_map));
+        }
+
         Self {
             name: field.name().to_string(),
             field_type: field.data_type().to_json(),
             nullable: field.is_nullable(),
             children: vec![],
-            dictionary: None, // TODO: not enough info
-            metadata: None,   // TODO(ARROW-10259)
+            dictionary: None,         // TODO: not enough info
+            metadata: metadata_value, // TODO(ARROW-10259): metadata is not used.
         }
     }
 }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -727,90 +727,97 @@ mod tests {
         let micros_tz = Some("UTC".to_string());
         let nanos_tz = Some("Africa/Johannesburg".to_string());
 
-        let schema =
-            Schema::new(vec![
-                Field::new("bools-with-metadata-map", DataType::Boolean, true)
-                    .with_metadata(Some(
-                        [("k".to_string(), "v".to_string())]
-                            .iter()
-                            .cloned()
-                            .collect(),
-                    )),
-                Field::new("bools-with-metadata-vec", DataType::Boolean, true)
-                    .with_metadata(Some(
-                        [("k2".to_string(), "v2".to_string())]
-                            .iter()
-                            .cloned()
-                            .collect(),
-                    )),
-                Field::new("bools", DataType::Boolean, true),
-                Field::new("int8s", DataType::Int8, true),
-                Field::new("int16s", DataType::Int16, true),
-                Field::new("int32s", DataType::Int32, true),
-                Field::new("int64s", DataType::Int64, true),
-                Field::new("uint8s", DataType::UInt8, true),
-                Field::new("uint16s", DataType::UInt16, true),
-                Field::new("uint32s", DataType::UInt32, true),
-                Field::new("uint64s", DataType::UInt64, true),
-                Field::new("float32s", DataType::Float32, true),
-                Field::new("float64s", DataType::Float64, true),
-                Field::new("date_days", DataType::Date32(DateUnit::Day), true),
-                Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
-                Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
-                Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
-                Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
-                Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
-                Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
-                Field::new(
-                    "ts_millis",
-                    DataType::Timestamp(TimeUnit::Millisecond, None),
-                    true,
-                ),
-                Field::new(
-                    "ts_micros",
-                    DataType::Timestamp(TimeUnit::Microsecond, None),
-                    true,
-                ),
-                Field::new(
-                    "ts_nanos",
-                    DataType::Timestamp(TimeUnit::Nanosecond, None),
-                    true,
-                ),
-                Field::new(
-                    "ts_secs_tz",
-                    DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
-                    true,
-                ),
-                Field::new(
-                    "ts_millis_tz",
-                    DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
-                    true,
-                ),
-                Field::new(
-                    "ts_micros_tz",
-                    DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
-                    true,
-                ),
-                Field::new(
-                    "ts_nanos_tz",
-                    DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
-                    true,
-                ),
-                Field::new("utf8s", DataType::Utf8, true),
-                Field::new(
-                    "lists",
-                    DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
-                    true,
-                ),
-                Field::new(
-                    "structs",
-                    DataType::Struct(vec![
-                        Field::new("int32s", DataType::Int32, true),
-                        Field::new("utf8s", DataType::Utf8, true),
-                    ]),
-                    true,
-                ),
-            ]);
+        let schema = Schema::new(vec![
+            {
+                let mut f =
+                    Field::new("bools-with-metadata-map", DataType::Boolean, true);
+                f.set_metadata(Some(
+                    [("k".to_string(), "v".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ));
+                f
+            },
+            {
+                let mut f =
+                    Field::new("bools-with-metadata-vec", DataType::Boolean, true);
+                f.set_metadata(Some(
+                    [("k2".to_string(), "v2".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ));
+                f
+            },
+            Field::new("bools", DataType::Boolean, true),
+            Field::new("int8s", DataType::Int8, true),
+            Field::new("int16s", DataType::Int16, true),
+            Field::new("int32s", DataType::Int32, true),
+            Field::new("int64s", DataType::Int64, true),
+            Field::new("uint8s", DataType::UInt8, true),
+            Field::new("uint16s", DataType::UInt16, true),
+            Field::new("uint32s", DataType::UInt32, true),
+            Field::new("uint64s", DataType::UInt64, true),
+            Field::new("float32s", DataType::Float32, true),
+            Field::new("float64s", DataType::Float64, true),
+            Field::new("date_days", DataType::Date32(DateUnit::Day), true),
+            Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
+            Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
+            Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
+            Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
+            Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
+            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
+            Field::new(
+                "ts_millis",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            ),
+            Field::new(
+                "ts_micros",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+            Field::new(
+                "ts_nanos",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            Field::new(
+                "ts_secs_tz",
+                DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_millis_tz",
+                DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_micros_tz",
+                DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_nanos_tz",
+                DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
+                true,
+            ),
+            Field::new("utf8s", DataType::Utf8, true),
+            Field::new(
+                "lists",
+                DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                true,
+            ),
+            Field::new(
+                "structs",
+                DataType::Struct(vec![
+                    Field::new("int32s", DataType::Int32, true),
+                    Field::new("utf8s", DataType::Utf8, true),
+                ]),
+                true,
+            ),
+        ]);
 
         let bools_with_metadata_map =
             BooleanArray::from(vec![Some(true), None, Some(false)]);

--- a/rust/arrow/test/data/integration.json
+++ b/rust/arrow/test/data/integration.json
@@ -2,13 +2,27 @@
   "schema": {
     "fields": [
       {
-        "name": "bools-with-metadata",
+        "name": "bools-with-metadata-map",
+        "type": {
+          "name": "bool"
+        },
+        "nullable": true,
+        "metadata": {
+          "k": "v"
+        },
+        "children": []
+      },
+      {
+        "name": "bools-with-metadata-vec",
         "type": {
           "name": "bool"
         },
         "nullable": true,
         "metadata": [
-          {"k": "v"}
+          {
+            "key": "k2",
+            "value": "v2"
+          }
         ],
         "children": []
       },
@@ -313,7 +327,21 @@
       "count": 3,
       "columns": [
         {
-          "name": "bools-with-metadata",
+          "name": "bools-with-metadata-map",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            true,
+            true,
+            false
+          ]
+        },
+        {
+          "name": "bools-with-metadata-vec",
           "count": 3,
           "VALIDITY": [
             1,

--- a/rust/arrow/test/data/integration.json
+++ b/rust/arrow/test/data/integration.json
@@ -2,6 +2,17 @@
   "schema": {
     "fields": [
       {
+        "name": "bools-with-metadata",
+        "type": {
+          "name": "bool"
+        },
+        "nullable": true,
+        "metadata": [
+          {"k": "v"}
+        ],
+        "children": []
+      },
+      {
         "name": "bools",
         "type": {
           "name": "bool"
@@ -301,6 +312,20 @@
     {
       "count": 3,
       "columns": [
+        {
+          "name": "bools-with-metadata",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            true,
+            true,
+            false
+          ]
+        },
         {
           "name": "bools",
           "count": 3,

--- a/rust/datafusion/src/logical_plan/dfschema.rs
+++ b/rust/datafusion/src/logical_plan/dfschema.rs
@@ -390,7 +390,9 @@ mod tests {
     fn from_qualified_schema_into_arrow_schema() -> Result<()> {
         let schema = DFSchema::try_from_qualified("t1", &test_schema_1())?;
         let arrow_schema: Schema = schema.into();
-        assert_eq!("t1.c0: Boolean, t1.c1: Boolean", arrow_schema.to_string());
+        let expected = "Field { name: \"t1.c0\", data_type: Boolean, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, \
+        Field { name: \"t1.c1\", data_type: Boolean, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }";
+        assert_eq!(expected, arrow_schema.to_string());
         Ok(())
     }
 

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -860,7 +860,8 @@ mod tests {
                 data_type: Int32, \
                 nullable: false, \
                 dict_id: 0, \
-                dict_is_ordered: false } }\
+                dict_is_ordered: false, \
+                metadata: None } }\
         ] }, \
         ExecutionPlan schema: Schema { fields: [\
             Field { \
@@ -868,7 +869,8 @@ mod tests {
                 data_type: Int32, \
                 nullable: false, \
                 dict_id: 0, \
-                dict_is_ordered: false }\
+                dict_is_ordered: false, \
+                metadata: None }\
         ], metadata: {} }";
         match plan {
             Ok(_) => panic!("Expected planning failure"),


### PR DESCRIPTION
This PR adds the missing custom metadata to data type `Field` -- the requirement is specified by ARROW-10259.

To adapt existing tests for custom metadata, I updated Field's display: print the struct with debug, this will be improved in later PRs.