### PR TITLE
ARROW-11045: [Rust] Fix performance issues of allocator

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -141,3 +141,7 @@ harness = false
 [[bench]]
 name = "mutable_array"
 harness = false
+
+[[bench]]
+name = "buffer_create"
+harness = false

--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -28,7 +28,7 @@ fn create_buffer(size: usize) -> Buffer {
     let mut result = MutableBuffer::new(size).with_bitset(size, false);
 
     for i in 0..size {
-        result.data_mut()[i] = 0b01010101 << i << (i % 4);
+        result.as_slice_mut()[i] = 0b01010101 << i << (i % 4);
     }
 
     result.freeze()

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+extern crate arrow;
+
+use arrow::{
+    buffer::{Buffer, MutableBuffer},
+    datatypes::ToByteSlice,
+};
+
+fn mutable_buffer(bytes: &[u32], size: usize, capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut result = MutableBuffer::new(capacity);
+
+        for _ in 0..size {
+            result.extend_from_slice(bytes.to_byte_slice())
+        }
+
+        result.freeze()
+    })
+}
+
+fn from_slice(bytes: &[u32], size: usize, capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut a = Vec::<u32>::with_capacity(capacity);
+        
+        for _ in 0..size {
+            a.extend_from_slice(bytes)
+        }
+
+        Buffer::from(a.to_byte_slice())
+    })
+}
+
+fn benchmark(c: &mut Criterion) {
+    let bytes = &[128u32; 1025];
+    let size = 2usize.pow(10);
+
+    c.bench_function("mutable", |b| b.iter(|| mutable_buffer(bytes, size, 0)));
+
+    c.bench_function("mutable prepared", |b| {
+        b.iter(|| mutable_buffer(bytes, size, size * bytes.len() * std::mem::size_of::<u32>()))
+    });
+
+    c.bench_function("from_slice", |b| b.iter(|| from_slice(bytes, size, 0)));
+
+    c.bench_function("from_slice prepared", |b| {
+        b.iter(|| from_slice(bytes, size, size * bytes.len()))
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/alloc.rs
+++ b/rust/arrow/src/alloc.rs
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// This module is largely copied (with minor simplifications) from the implementation of Rust's std alloc.
+/// Rust's current allocator's API is `unstable`, but it solves our main use-case: a container with a custom alignment.
+/// The problem that this module solves is to offer an API to allocate, reallocate and deallocate
+/// Memory blocks. Main responsibilities:
+/// * safeguards against null pointers
+/// * panic on Out of memory (OOM)
+/// * global thread-safe tracking of allocations
+/// * only allocate initialized regions (zero).
+/// This module makes no assumptions about type alignments or buffer sizes. Consumers use [std::alloc::Layout] to
+/// share this information with this module.
+use std::alloc::handle_alloc_error;
+use std::ptr::NonNull;
+use std::{alloc::Layout, sync::atomic::AtomicIsize};
+
+// If this number is not zero after all objects have been `drop`, there is a memory leak
+pub static mut ALLOCATIONS: AtomicIsize = AtomicIsize::new(0);
+
+/// A memory region
+#[derive(Debug, Copy, Clone)]
+pub struct MemoryBlock {
+    pub ptr: NonNull<u8>,
+    pub size: usize,
+}
+
+/// Returns a dangling pointer aligned with `layout.align()`.
+#[inline]
+pub fn dangling(layout: Layout) -> NonNull<u8> {
+    // SAFETY: align is guaranteed to be non-zero
+    unsafe { NonNull::new_unchecked(layout.align() as *mut u8) }
+}
+
+/// Allocates a new memory region. Returns a dangling pointer iff `layout.size() == 0`.
+/// # Panic
+/// This function panics whenever it is impossible to allocate a new region (e.g. OOM)
+#[inline]
+pub fn alloc(layout: Layout) -> MemoryBlock {
+    debug_assert!(layout.align() > 0);
+    unsafe {
+        let size = layout.size();
+        if size == 0 {
+            MemoryBlock {
+                ptr: dangling(layout),
+                size: 0,
+            }
+        } else {
+            let raw_ptr = std::alloc::alloc_zeroed(layout);
+            let ptr = NonNull::new(raw_ptr).unwrap_or_else(|| handle_alloc_error(layout));
+            ALLOCATIONS
+                .fetch_add(layout.size() as isize, std::sync::atomic::Ordering::SeqCst);
+            MemoryBlock { ptr, size }
+        }
+    }
+}
+
+/// Deallocates a previously allocated region. This can be safely called with a dangling pointer iff `layout.size() == 0`.
+/// # Safety
+/// This function requires the region to be allocated according to the `layout`.
+#[inline]
+pub unsafe fn dealloc(ptr: NonNull<u8>, layout: Layout) {
+    if layout.size() != 0 {
+        std::alloc::dealloc(ptr.as_ptr(), layout);
+        ALLOCATIONS
+            .fetch_sub(layout.size() as isize, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// Initializes a [MemoryBlock] with zeros starting at `offset`.
+#[inline]
+unsafe fn init_zero(memory: &mut MemoryBlock, offset: usize) {
+    memory
+        .ptr
+        .as_ptr()
+        .add(offset)
+        .write_bytes(0, memory.size - offset);
+}
+
+/// Grows a memory region, potentially reallocating it.
+// This is similar to AllocRef::grow, but without placement, since it is a no-op, and init, since we always
+// allocate initialized to 0.
+#[inline]
+pub unsafe fn grow(ptr: NonNull<u8>, layout: Layout, new_size: usize) -> MemoryBlock {
+    let size = layout.size();
+    debug_assert!(
+        new_size >= size,
+        "`new_size` must be greater than or equal to `memory.size()`"
+    );
+
+    if size == new_size {
+        return MemoryBlock { ptr, size };
+    }
+
+    if layout.size() == 0 {
+        let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
+        alloc(new_layout)
+    } else {
+        let ptr = std::alloc::realloc(ptr.as_ptr(), layout, new_size);
+        let mut memory = MemoryBlock {
+            ptr: NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout)),
+            size: new_size,
+        };
+        ALLOCATIONS.fetch_add(
+            (new_size - size) as isize,
+            std::sync::atomic::Ordering::SeqCst,
+        );
+        init_zero(&mut memory, size);
+        memory
+    }
+}
+
+// similar to AllocRef::shrink, but without placement, since it is a no-op
+#[inline]
+pub unsafe fn shrink(ptr: NonNull<u8>, layout: Layout, new_size: usize) -> MemoryBlock {
+    let size = layout.size();
+    debug_assert!(
+        new_size <= size,
+        "`new_size` must be smaller than or equal to `memory.size()`"
+    );
+
+    if size == new_size {
+        return MemoryBlock { ptr, size };
+    }
+
+    if new_size == 0 {
+        dealloc(ptr, layout);
+        MemoryBlock {
+            ptr: dangling(layout),
+            size: 0,
+        }
+    } else {
+        // `realloc` probably checks for `new_size < size` or something similar.
+        let ptr = std::alloc::realloc(ptr.as_ptr(), layout, new_size);
+        let ptr = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout));
+        ALLOCATIONS.fetch_sub(
+            (size - new_size) as isize,
+            std::sync::atomic::Ordering::SeqCst,
+        );
+        MemoryBlock {
+            ptr,
+            size: new_size,
+        }
+    }
+}

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -205,8 +205,8 @@ impl<OffsetSize: BinaryOffsetSizeTrait> From<ArrayDataRef>
             2,
             "BinaryArray data should contain 2 buffers only (offsets and values)"
         );
-        let raw_value_offsets = data.buffers()[0].raw_data();
-        let value_data = data.buffers()[1].raw_data();
+        let raw_value_offsets = data.buffers()[0].ptr();
+        let value_data = data.buffers()[1].ptr();
         Self {
             data,
             value_offsets: RawPtrBox::new(as_aligned_pointer::<OffsetSize>(
@@ -421,7 +421,7 @@ impl From<ArrayDataRef> for FixedSizeBinaryArray {
             1,
             "FixedSizeBinaryArray data should contain 1 buffer only (values)"
         );
-        let value_data = data.buffers()[0].raw_data();
+        let value_data = data.buffers()[0].ptr();
         let length = match data.data_type() {
             DataType::FixedSizeBinary(len) => *len,
             _ => panic!("Expected data type to be FixedSizeBinary"),
@@ -589,7 +589,7 @@ impl From<ArrayDataRef> for DecimalArray {
             1,
             "DecimalArray data should contain 1 buffer only (values)"
         );
-        let value_data = data.buffers()[0].raw_data();
+        let value_data = data.buffers()[0].ptr();
         let (precision, scale) = match data.data_type() {
             DataType::Decimal(precision, scale) => (*precision, *scale),
             _ => panic!("Expected data type to be Decimal"),

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -24,9 +24,9 @@ use std::{
 };
 
 use super::{
-    array::print_long_array, raw_pointer::as_aligned_pointer, raw_pointer::RawPtrBox,
-    Array, ArrayData, ArrayDataRef, FixedSizeListArray, GenericBinaryIter,
-    GenericListArray, LargeListArray, ListArray, OffsetSizeTrait,
+    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
+    FixedSizeListArray, GenericBinaryIter, GenericListArray, LargeListArray, ListArray,
+    OffsetSizeTrait,
 };
 use crate::util::bit_util;
 use crate::{buffer::Buffer, datatypes::ToByteSlice};
@@ -82,7 +82,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
 
     #[inline]
     fn value_offset_at(&self, i: usize) -> OffsetSize {
-        unsafe { *self.value_offsets.get().add(i) }
+        unsafe { *self.value_offsets.as_ptr().add(i) }
     }
 
     /// Returns the element at index `i` as a byte slice.
@@ -92,7 +92,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         unsafe {
             let pos = self.value_offset_at(offset);
             std::slice::from_raw_parts(
-                self.value_data.get().offset(pos.to_isize()),
+                self.value_data.as_ptr().offset(pos.to_isize()),
                 (self.value_offset_at(offset + 1) - pos).to_usize().unwrap(),
             )
         }
@@ -205,14 +205,12 @@ impl<OffsetSize: BinaryOffsetSizeTrait> From<ArrayDataRef>
             2,
             "BinaryArray data should contain 2 buffers only (offsets and values)"
         );
-        let raw_value_offsets = data.buffers()[0].ptr();
-        let value_data = data.buffers()[1].ptr();
+        let offsets = data.buffers()[0].as_ptr();
+        let values = data.buffers()[1].as_ptr();
         Self {
             data,
-            value_offsets: RawPtrBox::new(as_aligned_pointer::<OffsetSize>(
-                raw_value_offsets,
-            )),
-            value_data: RawPtrBox::new(value_data),
+            value_offsets: unsafe { RawPtrBox::new(offsets) },
+            value_data: unsafe { RawPtrBox::new(values) },
         }
     }
 }
@@ -234,7 +232,7 @@ where
         offsets.push(length_so_far);
 
         {
-            let null_slice = null_buf.data_mut();
+            let null_slice = null_buf.as_slice_mut();
 
             for (i, s) in iter.enumerate() {
                 if let Some(s) = s {
@@ -328,7 +326,7 @@ impl FixedSizeBinaryArray {
         unsafe {
             let pos = self.value_offset_at(offset);
             std::slice::from_raw_parts(
-                self.value_data.get().offset(pos as isize),
+                self.value_data.as_ptr().offset(pos as isize),
                 (self.value_offset_at(offset + 1) - pos) as usize,
             )
         }
@@ -389,7 +387,7 @@ impl From<Vec<Option<Vec<u8>>>> for FixedSizeBinaryArray {
 
         let num_bytes = bit_util::ceil(len, 8);
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
 
         data.iter().enumerate().for_each(|(i, entry)| {
             if entry.is_some() {
@@ -421,14 +419,14 @@ impl From<ArrayDataRef> for FixedSizeBinaryArray {
             1,
             "FixedSizeBinaryArray data should contain 1 buffer only (values)"
         );
-        let value_data = data.buffers()[0].ptr();
+        let value_data = data.buffers()[0].as_ptr();
         let length = match data.data_type() {
             DataType::FixedSizeBinary(len) => *len,
             _ => panic!("Expected data type to be FixedSizeBinary"),
         };
         Self {
             data,
-            value_data: RawPtrBox::new(value_data),
+            value_data: unsafe { RawPtrBox::new(value_data) },
             length,
         }
     }
@@ -514,7 +512,7 @@ impl DecimalArray {
         let raw_val = unsafe {
             let pos = self.value_offset_at(offset);
             std::slice::from_raw_parts(
-                self.value_data.get().offset(pos as isize),
+                self.value_data.as_ptr().offset(pos as isize),
                 (self.value_offset_at(offset + 1) - pos) as usize,
             )
         };
@@ -589,7 +587,7 @@ impl From<ArrayDataRef> for DecimalArray {
             1,
             "DecimalArray data should contain 1 buffer only (values)"
         );
-        let value_data = data.buffers()[0].ptr();
+        let values = data.buffers()[0].as_ptr();
         let (precision, scale) = match data.data_type() {
             DataType::Decimal(precision, scale) => (*precision, *scale),
             _ => panic!("Expected data type to be Decimal"),
@@ -597,7 +595,7 @@ impl From<ArrayDataRef> for DecimalArray {
         let length = 16;
         Self {
             data,
-            value_data: RawPtrBox::new(value_data),
+            value_data: unsafe { RawPtrBox::new(values) },
             precision,
             scale,
             length,

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -24,7 +24,6 @@ use std::{convert::From, sync::Arc};
 use super::*;
 use super::{array::print_long_array, raw_pointer::RawPtrBox};
 use crate::buffer::{Buffer, MutableBuffer};
-use crate::memory;
 use crate::util::bit_util;
 
 /// Array of bools
@@ -58,7 +57,7 @@ impl BooleanArray {
 
     /// Returns a raw pointer to the values of this array.
     pub fn raw_values(&self) -> *const u8 {
-        unsafe { self.raw_values.get().add(self.data.offset()) }
+        unsafe { self.raw_values.as_ptr().add(self.data.offset()) }
     }
 
     /// Returns a slice for the given offset and length
@@ -87,7 +86,7 @@ impl BooleanArray {
     /// Note this doesn't do any bound checking, for performance reason.
     pub fn value(&self, i: usize) -> bool {
         let offset = i + self.offset();
-        unsafe { bit_util::get_bit_raw(self.raw_values.get() as *const u8, offset) }
+        unsafe { bit_util::get_bit_raw(self.raw_values.as_ptr(), offset) }
     }
 }
 
@@ -119,7 +118,7 @@ impl From<Vec<bool>> for BooleanArray {
     fn from(data: Vec<bool>) -> Self {
         let mut mut_buf = MutableBuffer::new_null(data.len());
         {
-            let mut_slice = mut_buf.data_mut();
+            let mut_slice = mut_buf.as_slice_mut();
             for (i, b) in data.iter().enumerate() {
                 if *b {
                     bit_util::set_bit(mut_slice, i);
@@ -147,14 +146,10 @@ impl From<ArrayDataRef> for BooleanArray {
             1,
             "BooleanArray data should contain a single buffer only (values buffer)"
         );
-        let raw_values = data.buffers()[0].ptr();
-        assert!(
-            memory::is_aligned::<u8>(raw_values, mem::align_of::<bool>()),
-            "memory is not aligned"
-        );
+        let ptr = data.buffers()[0].as_ptr();
         Self {
             data,
-            raw_values: RawPtrBox::new(raw_values as *const u8),
+            raw_values: unsafe { RawPtrBox::new(ptr) },
         }
     }
 }
@@ -185,11 +180,9 @@ impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
         let mut val_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
 
-        let data = unsafe {
-            std::slice::from_raw_parts_mut(val_buf.raw_data_mut(), val_buf.capacity())
-        };
+        let data = val_buf.as_slice_mut();
 
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
         iter.enumerate().for_each(|(i, item)| {
             if let Some(a) = item.borrow() {
                 bit_util::set_bit(null_slice, i);

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -147,7 +147,7 @@ impl From<ArrayDataRef> for BooleanArray {
             1,
             "BooleanArray data should contain a single buffer only (values buffer)"
         );
-        let raw_values = data.buffers()[0].raw_data();
+        let raw_values = data.buffers()[0].ptr();
         assert!(
             memory::is_aligned::<u8>(raw_values, mem::align_of::<bool>()),
             "memory is not aligned"

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -302,7 +302,6 @@ mod tests {
         array::Int32Array,
         buffer::Buffer,
         datatypes::{Field, ToByteSlice},
-        memory,
         util::bit_util,
     };
 
@@ -778,37 +777,6 @@ mod tests {
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
-            .add_child_data(value_data)
-            .build();
-        ListArray::from(list_data);
-    }
-
-    #[test]
-    #[should_panic(expected = "memory is not aligned")]
-    fn test_primitive_array_alignment() {
-        let ptr = memory::allocate_aligned(8);
-        let buf = unsafe { Buffer::from_raw_parts(ptr, 8, 8) };
-        let buf2 = buf.slice(1);
-        let array_data = ArrayData::builder(DataType::Int32).add_buffer(buf2).build();
-        Int32Array::from(array_data);
-    }
-
-    #[test]
-    #[should_panic(expected = "memory is not aligned")]
-    fn test_list_array_alignment() {
-        let ptr = memory::allocate_aligned(8);
-        let buf = unsafe { Buffer::from_raw_parts(ptr, 8, 8) };
-        let buf2 = buf.slice(1);
-
-        let values: [i32; 8] = [0; 8];
-        let value_data = ArrayData::builder(DataType::Int32)
-            .add_buffer(Buffer::from(values.to_byte_slice()))
-            .build();
-
-        let list_data_type =
-            DataType::List(Box::new(Field::new("item", DataType::Int32, false)));
-        let list_data = ArrayData::builder(list_data_type)
-            .add_buffer(buf2)
             .add_child_data(value_data)
             .build();
         ListArray::from(list_data);

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -117,7 +117,7 @@ impl<OffsetSize: OffsetSizeTrait> From<ArrayDataRef> for GenericListArray<Offset
             "ListArray should contain a single child array (values array)"
         );
         let values = make_array(data.child_data()[0].clone());
-        let raw_value_offsets = data.buffers()[0].raw_data();
+        let raw_value_offsets = data.buffers()[0].ptr();
         let value_offsets: *const OffsetSize = as_aligned_pointer(raw_value_offsets);
         unsafe {
             assert!(

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -23,8 +23,8 @@ use std::mem;
 use num::Num;
 
 use super::{
-    array::print_long_array, make_array, raw_pointer::as_aligned_pointer,
-    raw_pointer::RawPtrBox, Array, ArrayDataRef, ArrayRef,
+    array::print_long_array, make_array, raw_pointer::RawPtrBox, Array, ArrayDataRef,
+    ArrayRef,
 };
 use crate::datatypes::ArrowNativeType;
 use crate::datatypes::DataType;
@@ -100,7 +100,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
 
     #[inline]
     fn value_offset_at(&self, i: usize) -> OffsetSize {
-        unsafe { *self.value_offsets.get().add(i) }
+        unsafe { *self.value_offsets.as_ptr().add(i) }
     }
 }
 
@@ -117,18 +117,19 @@ impl<OffsetSize: OffsetSizeTrait> From<ArrayDataRef> for GenericListArray<Offset
             "ListArray should contain a single child array (values array)"
         );
         let values = make_array(data.child_data()[0].clone());
-        let raw_value_offsets = data.buffers()[0].ptr();
-        let value_offsets: *const OffsetSize = as_aligned_pointer(raw_value_offsets);
+        let value_offsets = data.buffers()[0].as_ptr();
+
+        let value_offsets = unsafe { RawPtrBox::<OffsetSize>::new(value_offsets) };
         unsafe {
             assert!(
-                (*value_offsets.offset(0)).is_zero(),
+                (*value_offsets.as_ptr().offset(0)).is_zero(),
                 "offsets do not start at zero"
             );
         }
         Self {
             data,
             values,
-            value_offsets: RawPtrBox::new(value_offsets),
+            value_offsets,
         }
     }
 }

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -442,7 +442,7 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for PrimitiveArray<T> {
             1,
             "PrimitiveArray data should contain a single buffer only (values buffer)"
         );
-        let raw_values = data.buffers()[0].raw_data();
+        let raw_values = data.buffers()[0].ptr();
         assert!(
             memory::is_aligned::<u8>(raw_values, mem::align_of::<T::Native>()),
             "memory is not aligned"

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -313,15 +313,13 @@ impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native
             data_len * mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
         );
 
-        let null = vec![0; mem::size_of::<<T as ArrowPrimitiveType>::Native>()];
-
         let null_slice = null_buf.as_slice_mut();
         iter.enumerate().for_each(|(i, item)| {
             if let Some(a) = item.borrow() {
                 bit_util::set_bit(null_slice, i);
                 val_buf.extend_from_slice(a.to_byte_slice());
             } else {
-                val_buf.extend_from_slice(&null);
+                val_buf.extend(mem::size_of::<<T as ArrowPrimitiveType>::Native>());
             }
         });
 
@@ -411,14 +409,13 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
         let mut val_buf = MutableBuffer::new(data_len * mem::size_of::<i64>());
 
         {
-            let null = vec![0; mem::size_of::<i64>()];
             let null_slice = null_buf.as_slice_mut();
             for (i, v) in data.iter().enumerate() {
                 if let Some(n) = v {
                     bit_util::set_bit(null_slice, i);
                     val_buf.extend_from_slice(&n.to_byte_slice());
                 } else {
-                    val_buf.extend_from_slice(&null);
+                    val_buf.extend(mem::size_of::<i64>());
                 }
             }
         }

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -29,7 +29,6 @@ use super::array::print_long_array;
 use super::raw_pointer::RawPtrBox;
 use super::*;
 use crate::buffer::{Buffer, MutableBuffer};
-use crate::memory;
 use crate::util::bit_util;
 
 /// Number of seconds in a day
@@ -75,7 +74,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     #[deprecated(note = "Please use values() instead")]
     pub unsafe fn value_slice(&self, offset: usize, len: usize) -> &[T::Native] {
         std::slice::from_raw_parts(
-            self.raw_values.get().add(self.data.offset()).add(offset),
+            self.raw_values.as_ptr().add(self.data.offset()).add(offset),
             len,
         )
     }
@@ -88,7 +87,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         //     buffer bounds/offset is ensured by the ArrayData instance.
         unsafe {
             std::slice::from_raw_parts(
-                self.raw_values.get().add(self.data.offset()),
+                self.raw_values.as_ptr().add(self.data.offset()),
                 self.len(),
             )
         }
@@ -106,7 +105,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     /// caller must ensure that the passed in offset is less than the array len()
     pub fn value(&self, i: usize) -> T::Native {
         let offset = i + self.offset();
-        unsafe { *self.raw_values.get().add(offset) }
+        unsafe { *self.raw_values.as_ptr().add(offset) }
     }
 }
 
@@ -316,7 +315,7 @@ impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native
 
         let null = vec![0; mem::size_of::<<T as ArrowPrimitiveType>::Native>()];
 
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
         iter.enumerate().for_each(|(i, item)| {
             if let Some(a) = item.borrow() {
                 bit_util::set_bit(null_slice, i);
@@ -413,7 +412,7 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
 
         {
             let null = vec![0; mem::size_of::<i64>()];
-            let null_slice = null_buf.data_mut();
+            let null_slice = null_buf.as_slice_mut();
             for (i, v) in data.iter().enumerate() {
                 if let Some(n) = v {
                     bit_util::set_bit(null_slice, i);
@@ -442,14 +441,11 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for PrimitiveArray<T> {
             1,
             "PrimitiveArray data should contain a single buffer only (values buffer)"
         );
-        let raw_values = data.buffers()[0].ptr();
-        assert!(
-            memory::is_aligned::<u8>(raw_values, mem::align_of::<T::Native>()),
-            "memory is not aligned"
-        );
+
+        let ptr = data.buffers()[0].as_ptr();
         Self {
             data,
-            raw_values: RawPtrBox::new(raw_values as *const T::Native),
+            raw_values: unsafe { RawPtrBox::new(ptr) },
         }
     }
 }

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -21,9 +21,8 @@ use std::mem;
 use std::{any::Any, iter::FromIterator};
 
 use super::{
-    array::print_long_array, raw_pointer::as_aligned_pointer, raw_pointer::RawPtrBox,
-    Array, ArrayData, ArrayDataRef, GenericListArray, GenericStringIter, LargeListArray,
-    ListArray, OffsetSizeTrait,
+    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
+    GenericListArray, GenericStringIter, LargeListArray, ListArray, OffsetSizeTrait,
 };
 use crate::util::bit_util;
 use crate::{buffer::Buffer, datatypes::ToByteSlice};
@@ -80,7 +79,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
 
     #[inline]
     fn value_offset_at(&self, i: usize) -> OffsetSize {
-        unsafe { *self.value_offsets.get().add(i) }
+        unsafe { *self.value_offsets.as_ptr().add(i) }
     }
 
     /// Returns the element at index `i` as &str
@@ -90,7 +89,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         unsafe {
             let pos = self.value_offset_at(offset);
             let slice = std::slice::from_raw_parts(
-                self.value_data.get().offset(pos.to_isize()),
+                self.value_data.as_ptr().offset(pos.to_isize()),
                 (self.value_offset_at(offset + 1) - pos).to_usize().unwrap(),
             );
 
@@ -168,7 +167,7 @@ where
             if let Some(s) = s {
                 let s = s.as_ref();
                 // set null bit
-                let null_slice = null_buf.data_mut();
+                let null_slice = null_buf.as_slice_mut();
                 bit_util::set_bit(null_slice, i);
 
                 length_so_far = length_so_far + OffsetSize::from_usize(s.len()).unwrap();
@@ -254,14 +253,12 @@ impl<OffsetSize: StringOffsetSizeTrait> From<ArrayDataRef>
             2,
             "StringArray data should contain 2 buffers only (offsets and values)"
         );
-        let raw_value_offsets = data.buffers()[0].ptr();
-        let value_data = data.buffers()[1].ptr();
+        let offsets = data.buffers()[0].as_ptr();
+        let values = data.buffers()[1].as_ptr();
         Self {
             data,
-            value_offsets: RawPtrBox::new(as_aligned_pointer::<OffsetSize>(
-                raw_value_offsets,
-            )),
-            value_data: RawPtrBox::new(value_data),
+            value_offsets: unsafe { RawPtrBox::new(offsets) },
+            value_data: unsafe { RawPtrBox::new(values) },
         }
     }
 }

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -254,8 +254,8 @@ impl<OffsetSize: StringOffsetSizeTrait> From<ArrayDataRef>
             2,
             "StringArray data should contain 2 buffers only (offsets and values)"
         );
-        let raw_value_offsets = data.buffers()[0].raw_data();
-        let value_data = data.buffers()[1].raw_data();
+        let raw_value_offsets = data.buffers()[0].ptr();
+        let value_data = data.buffers()[1].ptr();
         Self {
             data,
             value_offsets: RawPtrBox::new(as_aligned_pointer::<OffsetSize>(

--- a/rust/arrow/src/array/array_struct.rs
+++ b/rust/arrow/src/array/array_struct.rs
@@ -388,8 +388,8 @@ mod tests {
         for i in 0..expected_int_data.len() {
             if !expected_int_data.is_null(i) {
                 assert_eq!(
-                    expected_value_buf.data()[i * 4..(i + 1) * 4],
-                    actual_value_buf.data()[i * 4..(i + 1) * 4]
+                    expected_value_buf.as_slice()[i * 4..(i + 1) * 4],
+                    actual_value_buf.as_slice()[i * 4..(i + 1) * 4]
                 );
             }
         }

--- a/rust/arrow/src/array/array_union.rs
+++ b/rust/arrow/src/array/array_union.rs
@@ -219,7 +219,7 @@ impl UnionArray {
     /// Panics if `index` is greater than the length of the array.
     pub fn type_id(&self, index: usize) -> i8 {
         assert!(index - self.offset() < self.len());
-        self.data().buffers()[0].data()[index] as i8
+        self.data().buffers()[0].as_slice()[index] as i8
     }
 
     /// Returns the offset into the underlying values array for the array slot at `index`.
@@ -236,7 +236,7 @@ impl UnionArray {
                 Some(b) => b.count_set_bits_offset(0, index),
                 None => index,
             };
-            self.data().buffers()[1].data()[valid_slots * size_of::<i32>()] as i32
+            self.data().buffers()[1].as_slice()[valid_slots * size_of::<i32>()] as i32
         } else {
             index as i32
         }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -2504,7 +2504,7 @@ mod tests {
         let buf2 = builder.finish();
 
         assert_eq!(buf.len(), buf2.len());
-        assert_eq!(buf.data(), buf2.data());
+        assert_eq!(buf.as_slice(), buf2.as_slice());
     }
 
     #[test]
@@ -3166,8 +3166,8 @@ mod tests {
         for i in 0..expected_int_data.len() {
             if !expected_int_data.is_null(i) {
                 assert_eq!(
-                    expected_value_buf.data()[i * 4..(i + 1) * 4],
-                    actual_value_buf.data()[i * 4..(i + 1) * 4]
+                    expected_value_buf.as_slice()[i * 4..(i + 1) * 4],
+                    actual_value_buf.as_slice()[i * 4..(i + 1) * 4]
                 );
             }
         }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -344,7 +344,7 @@ impl BooleanBufferBuilder {
         if v {
             let data = unsafe {
                 std::slice::from_raw_parts_mut(
-                    self.buffer.raw_data_mut(),
+                    self.buffer.as_mut_ptr(),
                     self.buffer.capacity(),
                 )
             };
@@ -359,7 +359,7 @@ impl BooleanBufferBuilder {
         if n != 0 && v {
             let data = unsafe {
                 std::slice::from_raw_parts_mut(
-                    self.buffer.raw_data_mut(),
+                    self.buffer.as_mut_ptr(),
                     self.buffer.capacity(),
                 )
             };
@@ -379,7 +379,7 @@ impl BooleanBufferBuilder {
                 // updated on each append but is updated in the
                 // `freeze` method instead.
                 unsafe {
-                    bit_util::set_bit_raw(self.buffer.raw_data_mut(), self.len);
+                    bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len);
                 }
             }
             self.len += 1;

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -239,7 +239,7 @@ impl ArrayData {
     /// * the datatype is `Boolean` (it corresponds to a bit-packed buffer where the offset is not applicable)
     #[inline]
     pub(super) fn buffer<T: ArrowNativeType>(&self, buffer: usize) -> &[T] {
-        let values = unsafe { self.buffers[buffer].data().align_to::<T>() };
+        let values = unsafe { self.buffers[buffer].as_slice().align_to::<T>() };
         if !values.0.is_empty() || !values.2.is_empty() {
             panic!("The buffer is not byte-aligned with its interpretation")
         };
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(10, arr_data.null_count());
         assert_eq!(5, arr_data.offset());
         assert_eq!(1, arr_data.buffers().len());
-        assert_eq!(&[0, 1, 2, 3], arr_data.buffers()[0].data());
+        assert_eq!(&[0, 1, 2, 3], arr_data.buffers()[0].as_slice());
         assert_eq!(1, arr_data.child_data().len());
         assert_eq!(child_arr_data, arr_data.child_data()[0]);
     }
@@ -424,7 +424,7 @@ mod tests {
             .null_bit_buffer(Buffer::from(bit_v))
             .build();
         assert!(arr_data.null_buffer().is_some());
-        assert_eq!(&bit_v, arr_data.null_buffer().unwrap().data());
+        assert_eq!(&bit_v, arr_data.null_buffer().unwrap().as_slice());
     }
 
     #[test]

--- a/rust/arrow/src/array/equal/boolean.rs
+++ b/rust/arrow/src/array/equal/boolean.rs
@@ -26,8 +26,8 @@ pub(super) fn boolean_equal(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    let lhs_values = lhs.buffers()[0].data();
-    let rhs_values = rhs.buffers()[0].data();
+    let lhs_values = lhs.buffers()[0].as_slice();
+    let rhs_values = rhs.buffers()[0].as_slice();
 
     // TODO: we can do this more efficiently if all values are not-null
     (0..len).all(|i| {

--- a/rust/arrow/src/array/equal/decimal.rs
+++ b/rust/arrow/src/array/equal/decimal.rs
@@ -31,8 +31,8 @@ pub(super) fn decimal_equal(
         _ => unreachable!(),
     };
 
-    let lhs_values = &lhs.buffers()[0].data()[lhs.offset() * size..];
-    let rhs_values = &rhs.buffers()[0].data()[rhs.offset() * size..];
+    let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
+    let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
     if lhs.null_count() == 0 && rhs.null_count() == 0 {
         equal_len(

--- a/rust/arrow/src/array/equal/fixed_binary.rs
+++ b/rust/arrow/src/array/equal/fixed_binary.rs
@@ -31,8 +31,8 @@ pub(super) fn fixed_binary_equal(
         _ => unreachable!(),
     };
 
-    let lhs_values = &lhs.buffers()[0].data()[lhs.offset() * size..];
-    let rhs_values = &rhs.buffers()[0].data()[rhs.offset() * size..];
+    let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * size..];
+    let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * size..];
 
     if lhs.null_count() == 0 && rhs.null_count() == 0 {
         equal_len(

--- a/rust/arrow/src/array/equal/primitive.rs
+++ b/rust/arrow/src/array/equal/primitive.rs
@@ -29,8 +29,8 @@ pub(super) fn primitive_equal<T>(
     len: usize,
 ) -> bool {
     let byte_width = size_of::<T>();
-    let lhs_values = &lhs.buffers()[0].data()[lhs.offset() * byte_width..];
-    let rhs_values = &rhs.buffers()[0].data()[rhs.offset() * byte_width..];
+    let lhs_values = &lhs.buffers()[0].as_slice()[lhs.offset() * byte_width..];
+    let rhs_values = &rhs.buffers()[0].as_slice()[rhs.offset() * byte_width..];
 
     if lhs.null_count() == 0 && rhs.null_count() == 0 {
         // without nulls, we just need to compare slices

--- a/rust/arrow/src/array/equal/structure.rs
+++ b/rust/arrow/src/array/equal/structure.rs
@@ -93,8 +93,8 @@ pub(super) fn struct_equal(
         equal_values(lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len)
     } else {
         // get a ref of the null buffer bytes, to use in testing for nullness
-        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().data();
-        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().data();
+        let lhs_null_bytes = lhs_nulls.as_ref().unwrap().as_slice();
+        let rhs_null_bytes = rhs_nulls.as_ref().unwrap().as_slice();
         // with nulls, we need to compare item by item whenever it is not null
         (0..len).all(|i| {
             let lhs_pos = lhs_start + i;

--- a/rust/arrow/src/array/equal/utils.rs
+++ b/rust/arrow/src/array/equal/utils.rs
@@ -46,8 +46,8 @@ pub(super) fn equal_nulls(
     let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
     let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
     if lhs_null_count > 0 || rhs_null_count > 0 {
-        let lhs_values = lhs_nulls.unwrap().data();
-        let rhs_values = rhs_nulls.unwrap().data();
+        let lhs_values = lhs_nulls.unwrap().as_slice();
+        let rhs_values = rhs_nulls.unwrap().as_slice();
         equal_bits(
             lhs_values,
             rhs_values,

--- a/rust/arrow/src/array/equal/variable_size.rs
+++ b/rust/arrow/src/array/equal/variable_size.rs
@@ -61,8 +61,8 @@ pub(super) fn variable_sized_equal<T: OffsetSizeTrait>(
     let rhs_offsets = rhs.buffer::<T>(0);
 
     // these are bytes, and thus the offset does not need to be multiplied
-    let lhs_values = &lhs.buffers()[1].data()[lhs.offset()..];
-    let rhs_values = &rhs.buffers()[1].data()[rhs.offset()..];
+    let lhs_values = &lhs.buffers()[1].as_slice()[lhs.offset()..];
+    let rhs_values = &rhs.buffers()[1].as_slice()[rhs.offset()..];
 
     let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
     let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);
@@ -88,10 +88,10 @@ pub(super) fn variable_sized_equal<T: OffsetSizeTrait>(
 
             // the null bits can still be `None`, so we don't unwrap
             let lhs_is_null = !lhs_nulls
-                .map(|v| get_bit(v.data(), lhs_pos))
+                .map(|v| get_bit(v.as_slice(), lhs_pos))
                 .unwrap_or(false);
             let rhs_is_null = !rhs_nulls
-                .map(|v| get_bit(v.data(), rhs_pos))
+                .map(|v| get_bit(v.as_slice(), rhs_pos))
                 .unwrap_or(false);
 
             lhs_is_null

--- a/rust/arrow/src/array/raw_pointer.rs
+++ b/rust/arrow/src/array/raw_pointer.rs
@@ -16,28 +16,37 @@
 // under the License.
 
 use crate::memory;
+use std::ptr::NonNull;
 
+/// This struct is highly `unsafe` and offers the possibility to self-reference a [arrow::Buffer] from [arrow::array::ArrayData].
+/// as a pointer to the beginning of its contents.
 pub(super) struct RawPtrBox<T> {
-    inner: *const T,
+    ptr: NonNull<T>,
 }
 
 impl<T> RawPtrBox<T> {
-    pub(super) fn new(inner: *const T) -> Self {
-        Self { inner }
+    /// # Safety
+    /// The user must guarantee that:
+    /// * the contents where `ptr` points to are never `moved`. This is guaranteed when they are Pinned.
+    /// * the lifetime of this struct does not outlive the lifetime of `ptr`.
+    /// Failure to fulfill any the above conditions results in undefined behavior.
+    /// # Panic
+    /// This function panics if:
+    /// * `ptr` is null
+    /// * `ptr` is not aligned to a slice of type `T`. This is guaranteed if it was built from a slice of type `T`.
+    pub(super) unsafe fn new(ptr: *const u8) -> Self {
+        let ptr = NonNull::new(ptr as *mut u8).expect("Pointer cannot be null");
+        assert!(
+            memory::is_aligned(ptr, std::mem::align_of::<T>()),
+            "memory is not aligned"
+        );
+        Self { ptr: ptr.cast() }
     }
 
-    pub(super) fn get(&self) -> *const T {
-        self.inner
+    pub(super) fn as_ptr(&self) -> *const T {
+        self.ptr.as_ptr()
     }
 }
 
 unsafe impl<T> Send for RawPtrBox<T> {}
 unsafe impl<T> Sync for RawPtrBox<T> {}
-
-pub(super) fn as_aligned_pointer<T>(p: *const u8) -> *const T {
-    assert!(
-        memory::is_aligned(p, std::mem::align_of::<T>()),
-        "memory is not aligned"
-    );
-    p as *const T
-}

--- a/rust/arrow/src/array/raw_pointer.rs
+++ b/rust/arrow/src/array/raw_pointer.rs
@@ -36,10 +36,7 @@ impl<T> RawPtrBox<T> {
     /// * `ptr` is not aligned to a slice of type `T`. This is guaranteed if it was built from a slice of type `T`.
     pub(super) unsafe fn new(ptr: *const u8) -> Self {
         let ptr = NonNull::new(ptr as *mut u8).expect("Pointer cannot be null");
-        assert!(
-            memory::is_aligned(ptr, std::mem::align_of::<T>()),
-            "memory is not aligned"
-        );
+        assert!(memory::is_ptr_aligned::<T>(ptr), "memory is not aligned");
         Self { ptr: ptr.cast() }
     }
 
@@ -50,3 +47,15 @@ impl<T> RawPtrBox<T> {
 
 unsafe impl<T> Send for RawPtrBox<T> {}
 unsafe impl<T> Sync for RawPtrBox<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "memory is not aligned")]
+    fn test_primitive_array_alignment() {
+        let bytes = vec![0u8, 1u8];
+        unsafe { RawPtrBox::<u64>::new(bytes.as_ptr().offset(1)) };
+    }
+}

--- a/rust/arrow/src/array/transform/boolean.rs
+++ b/rust/arrow/src/array/transform/boolean.rs
@@ -23,7 +23,7 @@ use super::{
 };
 
 pub(super) fn build_extend(array: &ArrayData) -> Extend {
-    let values = array.buffers()[0].data();
+    let values = array.buffers()[0].as_slice();
     Box::new(
         move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
             let buffer = &mut mutable.buffer1;

--- a/rust/arrow/src/array/transform/boolean.rs
+++ b/rust/arrow/src/array/transform/boolean.rs
@@ -29,7 +29,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
             let buffer = &mut mutable.buffer1;
             reserve_for_bits(buffer, mutable.len + len);
             set_bits(
-                &mut buffer.data_mut(),
+                &mut buffer.as_slice_mut(),
                 values,
                 mutable.len,
                 array.offset() + start,

--- a/rust/arrow/src/array/transform/fixed_binary.rs
+++ b/rust/arrow/src/array/transform/fixed_binary.rs
@@ -25,7 +25,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
         _ => unreachable!(),
     };
 
-    let values = &array.buffers()[0].data()[array.offset() * size..];
+    let values = &array.buffers()[0].as_slice()[array.offset() * size..];
     if array.null_count() == 0 {
         // fast case where we can copy regions without null issues
         Box::new(

--- a/rust/arrow/src/array/transform/list.rs
+++ b/rust/arrow/src/array/transform/list.rs
@@ -66,8 +66,7 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                 let mut last_offset: T = unsafe { get_last_offset(offset_buffer) };
 
                 let delta_len = array.len() - array.null_count();
-                offset_buffer
-                    .reserve(offset_buffer.len() + delta_len * std::mem::size_of::<T>());
+                offset_buffer.reserve(delta_len * std::mem::size_of::<T>());
 
                 let child = &mut mutable.child_data[0];
                 (start..start + len).for_each(|i| {

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -92,7 +92,7 @@ impl<'a> _MutableArrayData<'a> {
 
 fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits {
     if let Some(bitmap) = array.null_bitmap() {
-        let bytes = bitmap.bits.data();
+        let bytes = bitmap.bits.as_slice();
         Box::new(move |mutable, start, len| {
             utils::reserve_for_bits(&mut mutable.null_buffer, mutable.len + len);
             mutable.null_count += utils::set_bits(

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -96,7 +96,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
         Box::new(move |mutable, start, len| {
             utils::reserve_for_bits(&mut mutable.null_buffer, mutable.len + len);
             mutable.null_count += utils::set_bits(
-                mutable.null_buffer.data_mut(),
+                mutable.null_buffer.as_slice_mut(),
                 bytes,
                 mutable.len,
                 array.offset() + start,
@@ -106,7 +106,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
     } else if use_nulls {
         Box::new(|mutable, _, len| {
             utils::reserve_for_bits(&mut mutable.null_buffer, mutable.len + len);
-            let write_data = mutable.null_buffer.data_mut();
+            let write_data = mutable.null_buffer.as_slice_mut();
             let offset = mutable.len;
             (0..len).for_each(|i| {
                 bit_util::set_bit(write_data, offset + i);

--- a/rust/arrow/src/array/transform/primitive.rs
+++ b/rust/arrow/src/array/transform/primitive.rs
@@ -22,7 +22,7 @@ use crate::{array::ArrayData, datatypes::ArrowNativeType};
 use super::{Extend, _MutableArrayData};
 
 pub(super) fn build_extend<T: ArrowNativeType>(array: &ArrayData) -> Extend {
-    let values = &array.buffers()[0].data()[array.offset() * size_of::<T>()..];
+    let values = &array.buffers()[0].as_slice()[array.offset() * size_of::<T>()..];
     Box::new(
         move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
             let start = start * size_of::<T>();

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -72,7 +72,7 @@ pub(super) unsafe fn get_last_offset<T: OffsetSizeTrait>(
     //  Soundness
     //      * offset buffer is always extended in slices of T and aligned accordingly.
     //      * Buffer[0] is initialized with one element, 0, and thus `mutable_offsets.len() - 1` is always valid.
-    let (prefix, offsets, suffix) = offset_buffer.data().align_to::<T>();
+    let (prefix, offsets, suffix) = offset_buffer.as_slice().align_to::<T>();
     debug_assert!(prefix.is_empty() && suffix.is_empty());
     *offsets.get_unchecked(offsets.len() - 1)
 }

--- a/rust/arrow/src/array/transform/utils.rs
+++ b/rust/arrow/src/array/transform/utils.rs
@@ -53,7 +53,7 @@ pub(super) fn extend_offsets<T: OffsetSizeTrait>(
     mut last_offset: T,
     offsets: &[T],
 ) {
-    buffer.reserve(buffer.len() + offsets.len() * std::mem::size_of::<T>());
+    buffer.reserve(offsets.len() * std::mem::size_of::<T>());
     offsets.windows(2).for_each(|offsets| {
         // compute the new offset
         let length = offsets[1] - offsets[0];

--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -42,7 +42,7 @@ fn extend_offset_values<T: OffsetSizeTrait>(
 
 pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
     let offsets = array.buffer::<T>(0);
-    let values = &array.buffers()[1].data()[array.offset()..];
+    let values = &array.buffers()[1].as_slice()[array.offset()..];
     if array.null_count() == 0 {
         // fast case where we can copy regions without null issues
         Box::new(

--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -72,8 +72,7 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                 let mut last_offset: T = unsafe { get_last_offset(offset_buffer) };
 
                 // nulls present: append item by item, ignoring null entries
-                offset_buffer
-                    .reserve(offset_buffer.len() + len * std::mem::size_of::<T>());
+                offset_buffer.reserve(len * std::mem::size_of::<T>());
 
                 (start..start + len).for_each(|i| {
                     if array.is_valid(i) {

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -54,7 +54,7 @@ impl Bitmap {
 
     pub fn is_set(&self, i: usize) -> bool {
         assert!(i < (self.bits.len() << 3));
-        unsafe { bit_util::get_bit_raw(self.bits.raw_data(), i) }
+        unsafe { bit_util::get_bit_raw(self.bits.ptr(), i) }
     }
 
     pub fn buffer_ref(&self) -> &Buffer {

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -107,7 +107,7 @@ impl PartialEq for Bitmap {
         if self_len != other_len {
             return false;
         }
-        self.bits.data()[..self_len] == other.bits.data()[..self_len]
+        self.bits.as_slice()[..self_len] == other.bits.as_slice()[..self_len]
     }
 }
 

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -54,7 +54,7 @@ impl Bitmap {
 
     pub fn is_set(&self, i: usize) -> bool {
         assert!(i < (self.bits.len() << 3));
-        unsafe { bit_util::get_bit_raw(self.bits.ptr(), i) }
+        unsafe { bit_util::get_bit_raw(self.bits.as_ptr(), i) }
     }
 
     pub fn buffer_ref(&self) -> &Buffer {

--- a/rust/arrow/src/bytes.rs
+++ b/rust/arrow/src/bytes.rs
@@ -125,7 +125,7 @@ impl Drop for Bytes {
     fn drop(&mut self) {
         match &self.deallocation {
             Deallocation::Native(capacity) => {
-                unsafe { memory::free_aligned(self.ptr, *capacity) };
+                unsafe { memory::dealloc(self.ptr, *capacity) };
             }
             // foreign interface knows how to deallocate itself.
             Deallocation::Foreign(_) => (),
@@ -154,18 +154,5 @@ impl Debug for Bytes {
         f.debug_list().entries(self.iter()).finish()?;
 
         write!(f, " }}")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_dealloc_native() {
-        let capacity = 5;
-        let a = memory::allocate_aligned(capacity);
-        // create Bytes and release it. This will make `a` be an invalid pointer, but it is defined behavior
-        unsafe { Bytes::new(a, 3, Deallocation::Native(capacity)) };
     }
 }

--- a/rust/arrow/src/bytes.rs
+++ b/rust/arrow/src/bytes.rs
@@ -86,9 +86,8 @@ impl Bytes {
         }
     }
 
-    #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    fn as_slice(&self) -> &[u8] {
+        self
     }
 
     #[inline]
@@ -102,13 +101,8 @@ impl Bytes {
     }
 
     #[inline]
-    pub fn raw_data(&self) -> *const u8 {
+    pub fn ptr(&self) -> *const u8 {
         self.ptr
-    }
-
-    #[inline]
-    pub fn raw_data_mut(&mut self) -> *mut u8 {
-        self.ptr as *mut u8
     }
 
     pub fn capacity(&self) -> usize {
@@ -136,6 +130,14 @@ impl Drop for Bytes {
     }
 }
 
+impl std::ops::Deref for Bytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
 impl PartialEq for Bytes {
     fn eq(&self, other: &Bytes) -> bool {
         self.as_slice() == other.as_slice()
@@ -146,7 +148,7 @@ impl Debug for Bytes {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "Bytes {{ ptr: {:?}, len: {}, data: ", self.ptr, self.len,)?;
 
-        f.debug_list().entries(self.as_slice().iter()).finish()?;
+        f.debug_list().entries(self.iter()).finish()?;
 
         write!(f, " }}")
     }

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -190,7 +190,7 @@ where
     if let Some(b) = &null_bit_buffer {
         // some value is null
         for i in 0..left.len() {
-            let is_valid = unsafe { bit_util::get_bit_raw(b.raw_data(), i) };
+            let is_valid = unsafe { bit_util::get_bit_raw(b.ptr(), i) };
             values.push(if is_valid {
                 let right_value = right.value(i);
                 if right_value.is_zero() {

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -190,7 +190,7 @@ where
     if let Some(b) = &null_bit_buffer {
         // some value is null
         for i in 0..left.len() {
-            let is_valid = unsafe { bit_util::get_bit_raw(b.ptr(), i) };
+            let is_valid = unsafe { bit_util::get_bit_raw(b.as_ptr(), i) };
             values.push(if is_valid {
                 let right_value = right.value(i);
                 if right_value.is_zero() {

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -51,7 +51,7 @@ macro_rules! compare_op {
         let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
         let mut buffer = MutableBuffer::new(actual_capacity);
         buffer.resize(byte_capacity);
-        let data = buffer.raw_data_mut();
+        let data = buffer.as_mut_ptr();
 
         for i in 0..$left.len() {
             if $op($left.value(i), $right.value(i)) {
@@ -84,7 +84,7 @@ macro_rules! compare_op_scalar {
         let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
         let mut buffer = MutableBuffer::new(actual_capacity);
         buffer.resize(byte_capacity);
-        let data = buffer.raw_data_mut();
+        let data = buffer.as_mut_ptr();
 
         for i in 0..$left.len() {
             if $op($left.value(i), $right) {
@@ -656,7 +656,7 @@ where
     let not_both_null_bitmap = not_both_null_bit_buffer.data();
 
     let mut bool_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
-    let bool_slice = bool_buf.data_mut();
+    let bool_slice = bool_buf.as_slice_mut();
 
     // if both array slots are valid, check if list contains primitive
     for i in 0..left_len {
@@ -711,7 +711,7 @@ where
     let not_both_null_bitmap = not_both_null_bit_buffer.data();
 
     let mut bool_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
-    let bool_slice = bool_buf.data_mut();
+    let bool_slice = &mut bool_buf;
 
     for i in 0..left_len {
         // contains(null, null) = false

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -48,9 +48,8 @@ macro_rules! compare_op {
             combine_option_bitmap($left.data_ref(), $right.data_ref(), $left.len())?;
 
         let byte_capacity = bit_util::ceil($left.len(), 8);
-        let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
-        let mut buffer = MutableBuffer::new(actual_capacity);
-        buffer.resize(byte_capacity);
+        let mut buffer = MutableBuffer::new(byte_capacity);
+        buffer.resize(byte_capacity, 0);
         let data = buffer.as_mut_ptr();
 
         for i in 0..$left.len() {
@@ -81,9 +80,8 @@ macro_rules! compare_op_scalar {
         let null_bit_buffer = $left.data().null_buffer().cloned();
 
         let byte_capacity = bit_util::ceil($left.len(), 8);
-        let actual_capacity = bit_util::round_upto_multiple_of_64(byte_capacity);
-        let mut buffer = MutableBuffer::new(actual_capacity);
-        buffer.resize(byte_capacity);
+        let mut buffer = MutableBuffer::new(byte_capacity);
+        buffer.resize(byte_capacity, 0);
         let data = buffer.as_mut_ptr();
 
         for i in 0..$left.len() {

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -653,7 +653,7 @@ where
             Some(buff) => buff,
             None => new_all_set_buffer(num_bytes),
         };
-    let not_both_null_bitmap = not_both_null_bit_buffer.data();
+    let not_both_null_bitmap = not_both_null_bit_buffer.as_slice();
 
     let mut bool_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
     let bool_slice = bool_buf.as_slice_mut();
@@ -708,7 +708,7 @@ where
             Some(buff) => buff,
             None => new_all_set_buffer(num_bytes),
         };
-    let not_both_null_bitmap = not_both_null_bit_buffer.data();
+    let not_both_null_bitmap = not_both_null_bit_buffer.as_slice();
 
     let mut bool_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
     let bool_slice = &mut bool_buf;

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -297,7 +297,7 @@ fn sort_boolean(
     // collect results directly into a buffer instead of a vec to avoid another aligned allocation
     let mut result = MutableBuffer::new(values.len() * std::mem::size_of::<u32>());
     // sets len to capacity so we can access the whole buffer as a typed slice
-    result.resize(values.len() * std::mem::size_of::<u32>());
+    result.resize(values.len() * std::mem::size_of::<u32>(), 0);
     let result_slice: &mut [u32] = result.typed_data_mut();
 
     debug_assert_eq!(result_slice.len(), nulls_len + valids_len);
@@ -364,7 +364,7 @@ where
     // collect results directly into a buffer instead of a vec to avoid another aligned allocation
     let mut result = MutableBuffer::new(values.len() * std::mem::size_of::<u32>());
     // sets len to capacity so we can access the whole buffer as a typed slice
-    result.resize(values.len() * std::mem::size_of::<u32>());
+    result.resize(values.len() * std::mem::size_of::<u32>(), 0);
     let result_slice: &mut [u32] = result.typed_data_mut();
 
     debug_assert_eq!(result_slice.len(), nulls_len + nans_len + valids_len);

--- a/rust/arrow/src/compute/kernels/substring.rs
+++ b/rust/arrow/src/compute/kernels/substring.rs
@@ -38,7 +38,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
 
     // compute values
     let values = &array.data_ref().buffers()[1];
-    let data = values.data();
+    let data = values.as_slice();
 
     let mut new_values = Vec::new(); // we have no way to estimate how much this will be.
     let mut new_offsets: Vec<OffsetSize> = Vec::with_capacity(array.len() + 1);

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -291,7 +291,7 @@ where
         let num_bytes = bit_util::ceil(data_len, 8);
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
 
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
 
         for (i, elem) in data.iter_mut().enumerate() {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
@@ -342,7 +342,7 @@ where
     let num_byte = bit_util::ceil(data_len, 8);
     let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
 
-    let val_slice = val_buf.data_mut();
+    let val_slice = val_buf.as_slice_mut();
 
     let null_count = values.null_count();
 
@@ -363,7 +363,7 @@ where
         nulls = indices.data_ref().null_buffer().cloned();
     } else {
         let mut null_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, true);
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
 
         (0..data_len).try_for_each::<_, Result<()>>(|i| {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
@@ -442,7 +442,7 @@ where
         let num_bytes = bit_util::ceil(data_len, 8);
 
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
 
         for (i, offset) in offsets.iter_mut().skip(1).enumerate() {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
@@ -480,7 +480,7 @@ where
         let num_bytes = bit_util::ceil(data_len, 8);
 
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
 
         for (i, offset) in offsets.iter_mut().skip(1).enumerate() {
             let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {
@@ -544,7 +544,7 @@ where
     let num_bytes = bit_util::ceil(indices.len(), 8);
     let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
     {
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
         offsets[..].windows(2).enumerate().for_each(
             |(i, window): (usize, &[OffsetType::Native])| {
                 if window[0] == window[1] {
@@ -589,7 +589,7 @@ where
     let mut null_count = 0;
     let num_bytes = bit_util::ceil(indices.len(), 8);
     let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, true);
-    let null_slice = null_buf.data_mut();
+    let null_slice = null_buf.as_slice_mut();
 
     for i in 0..indices.len() {
         let index = ToPrimitive::to_usize(&indices.value(i)).ok_or_else(|| {

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -272,7 +272,7 @@ where
     let data_len = indices.len();
 
     let mut buffer = MutableBuffer::new(data_len * std::mem::size_of::<T::Native>());
-    buffer.resize(data_len * std::mem::size_of::<T::Native>());
+    buffer.resize(data_len * std::mem::size_of::<T::Native>(), 0);
     let data = buffer.typed_data_mut();
 
     let nulls;
@@ -417,7 +417,7 @@ where
 
     let bytes_offset = (data_len + 1) * std::mem::size_of::<OffsetSize>();
     let mut offsets_buffer = MutableBuffer::new(bytes_offset);
-    offsets_buffer.resize(bytes_offset);
+    offsets_buffer.resize(bytes_offset, 0);
 
     let offsets = offsets_buffer.typed_data_mut();
     let mut values = Vec::with_capacity(bytes_offset);

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -297,7 +297,7 @@ pub(super) mod tests {
                 values.append(&mut array);
             } else {
                 list_null_count += 1;
-                bit_util::unset_bit(&mut list_bitmap.data_mut(), idx);
+                bit_util::unset_bit(&mut list_bitmap.as_slice_mut(), idx);
             }
             offset.push(values.len() as i64);
         }
@@ -387,7 +387,7 @@ pub(super) mod tests {
                 values.extend(items.into_iter());
             } else {
                 list_null_count += 1;
-                bit_util::unset_bit(&mut list_bitmap.data_mut(), idx);
+                bit_util::unset_bit(&mut list_bitmap.as_slice_mut(), idx);
                 values.extend(vec![None; length as usize].into_iter());
             }
         }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -942,6 +942,7 @@ pub trait ToByteSlice {
 }
 
 impl<T: ArrowNativeType> ToByteSlice for [T] {
+    #[inline]
     fn to_byte_slice(&self) -> &[u8] {
         let raw_ptr = self.as_ptr() as *const T as *const u8;
         unsafe { from_raw_parts(raw_ptr, self.len() * size_of::<T>()) }
@@ -949,6 +950,7 @@ impl<T: ArrowNativeType> ToByteSlice for [T] {
 }
 
 impl<T: ArrowNativeType> ToByteSlice for T {
+    #[inline]
     fn to_byte_slice(&self) -> &[u8] {
         let raw_ptr = self as *const T as *const u8;
         unsafe { from_raw_parts(raw_ptr, size_of::<T>()) }

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -329,7 +329,7 @@ impl FFI_ArrowArray {
             .iter()
             .map(|maybe_buffer| match maybe_buffer {
                 // note that `raw_data` takes into account the buffer's offset
-                Some(b) => b.raw_data() as *const std::os::raw::c_void,
+                Some(b) => b.ptr() as *const std::os::raw::c_void,
                 None => std::ptr::null(),
             })
             .collect::<Box<[_]>>();

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -76,7 +76,14 @@ To import an array, unsafely create an `ArrowArray` from two pointers using [Arr
 To export an array, create an `ArrowArray` using [ArrowArray::try_new].
 */
 
-use std::{ffi::CStr, ffi::CString, iter, mem::size_of, ptr, sync::Arc};
+use std::{
+    ffi::CStr,
+    ffi::CString,
+    iter,
+    mem::size_of,
+    ptr::{self, NonNull},
+    sync::Arc,
+};
 
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
@@ -329,7 +336,7 @@ impl FFI_ArrowArray {
             .iter()
             .map(|maybe_buffer| match maybe_buffer {
                 // note that `raw_data` takes into account the buffer's offset
-                Some(b) => b.ptr() as *const std::os::raw::c_void,
+                Some(b) => b.as_ptr() as *const std::os::raw::c_void,
                 None => std::ptr::null(),
             })
             .collect::<Box<[_]>>();
@@ -393,11 +400,7 @@ unsafe fn create_buffer(
     assert!(index < array.n_buffers as usize);
     let ptr = *buffers.add(index);
 
-    if ptr.is_null() {
-        None
-    } else {
-        Some(Buffer::from_unowned(ptr, len, array))
-    }
+    NonNull::new(ptr as *mut u8).map(|ptr| Buffer::from_unowned(ptr, len, array))
 }
 
 impl Drop for FFI_ArrowArray {

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -718,7 +718,7 @@ fn write_buffer(
     let total_len: i64 = (len + pad_len) as i64;
     // assert_eq!(len % 8, 0, "Buffer width not a multiple of 8 bytes");
     buffers.push(ipc::Buffer::new(offset, total_len));
-    arrow_data.extend_from_slice(buffer.data());
+    arrow_data.extend_from_slice(buffer.as_slice());
     arrow_data.extend_from_slice(&vec![0u8; pad_len][..]);
     offset + total_len
 }

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -872,7 +872,7 @@ impl Decoder {
         rows.iter().enumerate().for_each(|(i, v)| {
             if let Value::Array(a) = v {
                 cur_offset = cur_offset + OffsetSize::from_usize(a.len()).unwrap();
-                bit_util::set_bit(list_nulls.data_mut(), i);
+                bit_util::set_bit(list_nulls.as_slice_mut(), i);
             } else if let Value::Null = v {
                 // value is null, not incremented
             } else {
@@ -896,11 +896,17 @@ impl Decoder {
                             if let Value::Bool(child) = value {
                                 // if valid boolean, append value
                                 if *child {
-                                    bit_util::set_bit(bool_values.data_mut(), curr_index);
+                                    bit_util::set_bit(
+                                        bool_values.as_slice_mut(),
+                                        curr_index,
+                                    );
                                 }
                             } else {
                                 // null slot
-                                bit_util::unset_bit(bool_nulls.data_mut(), curr_index);
+                                bit_util::unset_bit(
+                                    bool_nulls.as_slice_mut(),
+                                    curr_index,
+                                );
                             }
                             curr_index += 1;
                         });
@@ -964,7 +970,10 @@ impl Decoder {
                     .flat_map(|row| {
                         if let Value::Array(values) = row {
                             values.iter().for_each(|_| {
-                                bit_util::set_bit(null_buffer.data_mut(), struct_index);
+                                bit_util::set_bit(
+                                    null_buffer.as_slice_mut(),
+                                    struct_index,
+                                );
                                 struct_index += 1;
                             });
                             values.clone()
@@ -1178,7 +1187,7 @@ impl Decoder {
                             .map(|(i, v)| match v {
                                 // we want the field as an object, if it's not, we treat as null
                                 Some(Value::Object(value)) => {
-                                    bit_util::set_bit(null_buffer.data_mut(), i);
+                                    bit_util::set_bit(null_buffer.as_slice_mut(), i);
                                     Value::Object(value.clone())
                                 }
                                 _ => Value::Object(Default::default()),

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -135,11 +135,12 @@
 // introduced to ignore lint errors when upgrading from 2020-04-22 to 2020-11-14
 #![allow(clippy::float_equality_without_abs, clippy::type_complexity)]
 
+pub(crate) mod alloc;
 mod arch;
 pub mod array;
 pub mod bitmap;
 pub mod buffer;
-pub mod bytes;
+mod bytes;
 pub mod compute;
 pub mod csv;
 pub mod datatypes;
@@ -147,7 +148,7 @@ pub mod error;
 pub mod ffi;
 pub mod ipc;
 pub mod json;
-pub mod memory;
+mod memory;
 pub mod record_batch;
 pub mod tensor;
 pub mod util;

--- a/rust/arrow/src/zz_memory_check.rs
+++ b/rust/arrow/src/zz_memory_check.rs
@@ -21,7 +21,7 @@
 
 #[cfg(feature = "memory-check")]
 mod tests {
-    use crate::memory::ALLOCATIONS;
+    use crate::alloc::ALLOCATIONS;
 
     // verify that there is no data un-allocated
     #[test]

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -599,7 +599,7 @@ fn create_null_buf(json_col: &ArrowJsonColumn) -> Buffer {
         .iter()
         .enumerate()
         .for_each(|(i, v)| {
-            let null_slice = null_buf.data_mut();
+            let null_slice = null_buf.as_slice_mut();
             if *v != 0 {
                 bit_util::set_bit(null_slice, i);
             }

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -291,7 +291,7 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
         if T::get_physical_type() == PhysicalType::BOOLEAN {
             let mut boolean_buffer = BooleanBufferBuilder::new(record_data.len());
 
-            for e in record_data.data() {
+            for e in record_data.as_slice() {
                 boolean_buffer.append(*e > 0);
             }
             record_data = boolean_buffer.finish();

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -920,7 +920,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
 
         let num_bytes = bit_util::ceil(offsets.len(), 8);
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
-        let null_slice = null_buf.data_mut();
+        let null_slice = null_buf.as_slice_mut();
         let mut list_index = 0;
         for i in 0..rep_levels.len() {
             if rep_levels[i] == 0 && def_levels[i] != 0 {

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -163,8 +163,8 @@ impl<T: DataType> RecordReader<T> {
 
             new_buffer.resize(num_bytes);
 
-            let new_def_levels = new_buffer.data_mut();
-            let left_def_levels = &def_levels_buf.data_mut()[new_len..];
+            let new_def_levels = new_buffer.as_slice_mut();
+            let left_def_levels = &def_levels_buf.as_slice_mut()[new_len..];
 
             new_def_levels[0..num_bytes].copy_from_slice(&left_def_levels[0..num_bytes]);
 
@@ -190,8 +190,8 @@ impl<T: DataType> RecordReader<T> {
 
             new_buffer.resize(num_bytes);
 
-            let new_rep_levels = new_buffer.data_mut();
-            let left_rep_levels = &rep_levels_buf.data_mut()[new_len..];
+            let new_rep_levels = new_buffer.as_slice_mut();
+            let left_rep_levels = &rep_levels_buf.as_slice_mut()[new_len..];
 
             new_rep_levels[0..num_bytes].copy_from_slice(&left_rep_levels[0..num_bytes]);
 
@@ -217,8 +217,8 @@ impl<T: DataType> RecordReader<T> {
 
         new_buffer.resize(num_bytes);
 
-        let new_records = new_buffer.data_mut();
-        let left_records = &mut self.records.data_mut()[new_len..];
+        let new_records = new_buffer.as_slice_mut();
+        let left_records = &mut self.records.as_slice_mut()[new_len..];
 
         new_records[0..num_bytes].copy_from_slice(&left_records[0..num_bytes]);
 
@@ -291,20 +291,20 @@ impl<T: DataType> RecordReader<T> {
 
         // Convert mutable buffer spaces to mutable slices
         let (prefix, values, suffix) =
-            unsafe { self.records.data_mut().align_to_mut::<T::T>() };
+            unsafe { self.records.as_slice_mut().align_to_mut::<T::T>() };
         assert!(prefix.is_empty() && suffix.is_empty());
         let values = &mut values[values_written..];
 
         let def_levels = self.def_levels.as_mut().map(|buf| {
             let (prefix, def_levels, suffix) =
-                unsafe { buf.data_mut().align_to_mut::<i16>() };
+                unsafe { buf.as_slice_mut().align_to_mut::<i16>() };
             assert!(prefix.is_empty() && suffix.is_empty());
             &mut def_levels[values_written..]
         });
 
         let rep_levels = self.rep_levels.as_mut().map(|buf| {
             let (prefix, rep_levels, suffix) =
-                unsafe { buf.data_mut().align_to_mut::<i16>() };
+                unsafe { buf.as_slice_mut().align_to_mut::<i16>() };
             assert!(prefix.is_empty() && suffix.is_empty());
             &mut rep_levels[values_written..]
         });
@@ -317,7 +317,8 @@ impl<T: DataType> RecordReader<T> {
 
         // get new references for the def levels.
         let def_levels = self.def_levels.as_ref().map(|buf| {
-            let (prefix, def_levels, suffix) = unsafe { buf.data().align_to::<i16>() };
+            let (prefix, def_levels, suffix) =
+                unsafe { buf.as_slice().align_to::<i16>() };
             assert!(prefix.is_empty() && suffix.is_empty());
             &def_levels[values_written..]
         });
@@ -370,7 +371,8 @@ impl<T: DataType> RecordReader<T> {
     /// records read.
     fn split_records(&mut self, records_to_read: usize) -> Result<usize> {
         let rep_levels = self.rep_levels.as_ref().map(|buf| {
-            let (prefix, rep_levels, suffix) = unsafe { buf.data().align_to::<i16>() };
+            let (prefix, rep_levels, suffix) =
+                unsafe { buf.as_slice().align_to::<i16>() };
             assert!(prefix.is_empty() && suffix.is_empty());
             rep_levels
         });


### PR DESCRIPTION
This PR addresses a performance issue in how we allocate and reallocate the `MutableBuffer` by migrating the relevant parts of rust's std `alloc` lib into this crate.

# Problem

The following is the result of 4 runs:

```
mutable                 time:   [929.26 us 931.88 us 935.42 us]                    
mutable prepared        time:   [1.0682 ms 1.0693 ms 1.0709 ms]                              
from_slice              time:   [4.4857 ms 4.5043 ms 4.5247 ms]                        
from_slice prepared     time:   [1.4358 ms 1.4406 ms 1.4467 ms]                                 
```

1. start with an empty `MutableBuffer` and grow it (`realloc + memcopy`)
2. start with a mutable with the correct capacity and grow (i.e. ` memcopy`)
3. do the same as 1. with a `Vec<u8>` (`realloc + memcopy`) and at the end of all use `Buffer::from` (a `memcopy`)
4. same as 2 and at the end of all use `Buffer::from` (`memcopy to vec + memcopy to Buffer`)

The fact that there is no difference between 1 and 2 but a 3.5x difference between 3 and 4 shows that we are doing something wrong. The fact that 1 is as fast as 2 shows that we are doing something wrong.

# This PR

This PR rewrites our current allocator code to a code very close to the code used by `std` allocator. The core reason we do this is that we benefit from cache-line aligned allocated buffers [ref](https://github.com/apache/arrow/pull/8796#issuecomment-748470192), but Rust's custom allocator's API is `unstable` (and thus only available in nightly).

The code in this PR is not very complex and I assume that it was already well though through from rust's std team. I did the necessary modifications for our use-case:
* always allocate aligned
* always allocate in chunks of 64 bytes
* always allocate initialized to zero (`std::alloc::alloc_zeroed`)

The main benefit of this is that we can use `MutableBuffer`, `BooleanBufferBuilder` and `BufferBuilder` in the same way as we would use `Vec<u8>`, `Vec<bool>` and `Vec<T: Primitive>` respectively without having to rely on unsafe code to efficiently build buffers.

The performance difference is mostly present in variable-sized buffers, such as strings.

Benchmarks for `take`:

```bash
git checkout master
cargo bench --bench take_kernels --features simd
git checkout alloc
cargo bench --bench take_kernels --features simd
```

|  benchmark | variation (%) |
|-------------- | -------------- | 
| take i32 nulls 1024 | 5.9 | 
| take i32 1024 | 4.4 | 
| take i32 512 | 2.1 | 
| take str 512 | 2.1 | 
| take i32 nulls 512 | 1.6 | 
| take str 1024 | 1.0 | 
| take bool nulls 1024 | -1.5 | 
| take bool nulls 512 | -2.4 | 
| take bool 512 | -6.8 | 
| take bool 1024 | -8.3 | 
| take str null values 1024 | -10.6 | 
| take str null values null indices 1024 | -18.9 | 

Builder benches:

```
bench_primitive         time:   [967.71 us 969.06 us 970.62 us]                            
                        thrpt:  [4.0245 GiB/s 4.0310 GiB/s 4.0366 GiB/s]
                 change:
                        time:   [-4.3022% -3.2064% -2.2317%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2826% +3.3126% +4.4956%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

bench_bool              time:   [2.0547 ms 2.0823 ms 2.1163 ms]                        
                        thrpt:  [236.27 MiB/s 240.11 MiB/s 243.35 MiB/s]
                 change:
                        time:   [-25.302% -24.178% -22.857%] (p = 0.00 < 0.05)
                        thrpt:  [+29.629% +31.887% +33.873%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
```
