### PR TITLE
ARROW-10350: [Rust] Fixes to publication metadata in Cargo.toml

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -363,8 +363,8 @@ class PrepareTest < Test::Unit::TestCase
                      path: "rust/parquet_derive_test/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
-                        "+version = \"#{@release_version}\"",
-                        "-parquet = { path = \"../parquet\", version = \"#{@snapshot_version}\" }",
+                        "+version = \"#{@release_version}\""],
+                       ["-parquet = { path = \"../parquet\", version = \"#{@snapshot_version}\" }",
                         "-parquet_derive = { path = \"../parquet_derive\", version = \"#{@snapshot_version}\" }",
                         "+parquet = { path = \"../parquet\", version = \"#{@release_version}\" }",
                         "+parquet_derive = { path = \"../parquet_derive\", version = \"#{@release_version}\" }"],
@@ -610,8 +610,8 @@ class PrepareTest < Test::Unit::TestCase
                      path: "rust/parquet_derive_test/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",
-                        "+version = \"#{@next_snapshot_version}\"",
-                        "-parquet = { path = \"../parquet\", version = \"#{@release_version}\" }",
+                        "+version = \"#{@next_snapshot_version}\""],
+                       ["-parquet = { path = \"../parquet\", version = \"#{@release_version}\" }",
                         "-parquet_derive = { path = \"../parquet_derive\", version = \"#{@release_version}\" }",
                         "+parquet = { path = \"../parquet\", version = \"#{@next_snapshot_version}\" }",
                         "+parquet_derive = { path = \"../parquet_derive\", version = \"#{@next_snapshot_version}\" }"],

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -24,6 +24,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow"
 repository = "https://github.com/apache/arrow"
 license = "Apache-2.0"
+publish = false
 
 [dependencies]
 arrow = { path = "../arrow" }

--- a/rust/integration-testing/Cargo.toml
+++ b/rust/integration-testing/Cargo.toml
@@ -24,6 +24,7 @@ repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 edition = "2018"
+publish = false
 
 [features]
 logging = ["tracing-subscriber"]

--- a/rust/parquet_derive/Cargo.toml
+++ b/rust/parquet_derive/Cargo.toml
@@ -18,8 +18,13 @@
 [package]
 name = "parquet_derive"
 version = "3.0.0-SNAPSHOT"
+license = "Apache-2.0"
+description = "Derive macros for the Rust implementation of Apache Parquet"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
+readme = "README.md"
 edition = "2018"
 
 [lib]

--- a/rust/parquet_derive_test/Cargo.toml
+++ b/rust/parquet_derive_test/Cargo.toml
@@ -25,6 +25,7 @@ repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"
+publish = false
 
 [dependencies]
 parquet = { path = "../parquet", version = "3.0.0-SNAPSHOT" }

--- a/rust/parquet_derive_test/Cargo.toml
+++ b/rust/parquet_derive_test/Cargo.toml
@@ -18,6 +18,10 @@
 [package]
 name = "parquet_derive_test"
 version = "3.0.0-SNAPSHOT"
+license = "Apache-2.0"
+description = "Integration test package for parquet-derive"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"


### PR DESCRIPTION
Cleans some TOML fields and marks some testing crates not-for-publication.