### PR TITLE
ARROW-11048: [Rust] Added bench to MutableBuffer

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -141,3 +141,7 @@ harness = false
 [[bench]]
 name = "mutable_array"
 harness = false
+
+[[bench]]
+name = "buffer_create"
+harness = false

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use arrow::util::test_util::seedable_rng;
+use criterion::Criterion;
+use rand::distributions::Uniform;
+use rand::Rng;
+
+extern crate arrow;
+
+use arrow::{
+    buffer::{Buffer, MutableBuffer},
+    datatypes::ToByteSlice,
+};
+
+fn mutable_buffer(data: &[Vec<u32>], capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut result = MutableBuffer::new(capacity);
+
+        data.iter()
+            .for_each(|vec| result.extend_from_slice(vec.to_byte_slice()));
+
+        result.freeze()
+    })
+}
+
+fn from_slice(data: &[Vec<u32>], capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut a = Vec::<u32>::with_capacity(capacity);
+
+        data.iter().for_each(|vec| a.extend(vec));
+
+        Buffer::from(a.to_byte_slice())
+    })
+}
+
+fn create_data(size: usize) -> Vec<Vec<u32>> {
+    let rng = &mut seedable_rng();
+    let range = Uniform::new(0, 33);
+
+    (0..size)
+        .map(|_| {
+            let size = rng.sample(range);
+            seedable_rng()
+                .sample_iter(&range)
+                .take(size as usize)
+                .collect()
+        })
+        .collect()
+}
+
+fn benchmark(c: &mut Criterion) {
+    let size = 2usize.pow(15);
+    let data = create_data(size);
+    let cap = data.iter().map(|i| i.len()).sum();
+    let byte_cap = cap * std::mem::size_of::<u32>();
+
+    c.bench_function("mutable", |b| b.iter(|| mutable_buffer(&data, 0)));
+
+    c.bench_function("mutable prepared", |b| {
+        b.iter(|| mutable_buffer(&data, byte_cap))
+    });
+
+    c.bench_function("from_slice", |b| b.iter(|| from_slice(&data, 0)));
+
+    c.bench_function("from_slice prepared", |b| b.iter(|| from_slice(&data, cap)));
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This bench compares the behavior of `MutableBuffer` vs allocating `Vec<u8>` and using `extend_from_slice`.

On my computer:
```
mutable                 time:   [579.24 us 580.21 us 581.34 us]                    
mutable prepared        time:   [614.98 us 616.15 us 617.42 us]                             
from_slice              time:   [1.2945 ms 1.3262 ms 1.3607 ms]                        
from_slice prepared     time:   [1.0161 ms 1.0472 ms 1.0881 ms]                                 
```

I.e. growing a `MutableBuffer` seems to be 2x faster than creating a `Vec` and using `Buffer::from` to convert it to a `Buffer`.

It is odd that creating a buffer with the correct capacity takes longer, though. Any ideas @jhorstmann , @Dandandan ?