### PR TITLE
ARROW-11053: [Rust] [DataFusion] Optimize joins with dynamic capacity for output batches

### DIFF
--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -20,8 +20,8 @@
 
 use arrow::array::ArrayRef;
 use std::sync::Arc;
-use std::{any::Any, collections::HashSet};
 use std::time::Instant;
+use std::{any::Any, collections::HashSet};
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -279,7 +279,7 @@ struct HashJoinStream {
     num_output_batches: usize,
     /// number of rows produced
     num_output_rows: usize,
-    /// total time for joining stream-side batches to the build-side batches
+    /// total time for joining probe-side batches to the build-side batches
     join_time: usize,
 }
 
@@ -583,7 +583,7 @@ impl Stream for HashJoinStream {
                 }
                 other => {
                     debug!(
-                        "Processed {} stream-side input batches containing {} rows and \
+                        "Processed {} probe-side input batches containing {} rows and \
                         produced {} output batches containing {} rows in {} ms",
                         self.num_input_batches,
                         self.num_input_rows,


### PR DESCRIPTION
This builds on https://github.com/apache/arrow/pull/9035.

I am investigating why join performance is so bad with smaller batch sizes (see https://issues.apache.org/jira/browse/ARROW-11030)  and this is one optimization that I have found so far that helps a bit.

Prior to this PR, we use the size of left or right batches to guess the capacity of output batches and this results in a lot of over allocation in some cases. For TPC-H q12 at SF=100, I see vectors created with capacity of ~3,000,000 (the size of the build-side of the join) and then we only populate it with ~700 entries.

This PR attempts to learn a good capacity based on previously processed batches.

Here are query times in seconds at different batch sizes:

Batch Size | Master | This PR
-- | -- | --
16384 | 189.6 | 158.0
32768 | 61.9 | 47.2
65536 | 28.2 | 21.4
131072 | 19.0 | 15.6




