### PR TITLE
ARROW-10356: [Rust][DataFusion] Add support for is_in

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -656,7 +656,7 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
             on
                 l_orderkey = o_orderkey
             where
-                (l_shipmode = 'MAIL' or l_shipmode = 'SHIP')
+                l_shipmode in ('MAIL', 'SHIP')
                 and l_commitdate < l_receiptdate
                 and l_shipdate < l_commitdate
                 and l_receiptdate >= date '1994-01-01'

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -158,6 +158,15 @@ pub enum Expr {
         /// List of expressions to feed to the functions as arguments
         args: Vec<Expr>,
     },
+    /// Returns whether the list contains the expr value.
+    InList {
+        /// The expression to compare
+        expr: Box<Expr>,
+        /// A list of values to compare against
+        list: Vec<Expr>,
+        /// Whether the expression is negated
+        negated: bool,
+    },
     /// Represents a reference to all fields in a schema.
     Wildcard,
 }
@@ -224,6 +233,7 @@ impl Expr {
             ),
             Expr::Sort { ref expr, .. } => expr.get_type(schema),
             Expr::Between { .. } => Ok(DataType::Boolean),
+            Expr::InList { .. } => Ok(DataType::Boolean),
             Expr::Wildcard => Err(DataFusionError::Internal(
                 "Wildcard expressions are not valid in a logical query plan".to_owned(),
             )),
@@ -278,6 +288,7 @@ impl Expr {
             } => Ok(left.nullable(input_schema)? || right.nullable(input_schema)?),
             Expr::Sort { ref expr, .. } => expr.nullable(input_schema),
             Expr::Between { ref expr, .. } => expr.nullable(input_schema),
+            Expr::InList { ref expr, .. } => expr.nullable(input_schema),
             Expr::Wildcard => Err(DataFusionError::Internal(
                 "Wildcard expressions are not valid in a logical query plan".to_owned(),
             )),
@@ -387,6 +398,15 @@ impl Expr {
     /// Alias
     pub fn alias(&self, name: &str) -> Expr {
         Expr::Alias(Box::new(self.clone()), name.to_owned())
+    }
+
+    /// InList
+    pub fn in_list(&self, list: Vec<Expr>, negated: bool) -> Expr {
+        Expr::InList {
+            expr: Box::new(self.clone()),
+            list,
+            negated,
+        }
     }
 
     /// Create a sort expression from an existing expression.
@@ -576,6 +596,15 @@ pub fn count_distinct(expr: Expr) -> Expr {
         fun: aggregates::AggregateFunction::Count,
         distinct: true,
         args: vec![expr],
+    }
+}
+
+/// Create an in_list expression
+pub fn in_list(expr: Expr, list: Vec<Expr>, negated: bool) -> Expr {
+    Expr::InList {
+        expr: Box::new(expr),
+        list,
+        negated,
     }
 }
 
@@ -814,6 +843,17 @@ impl fmt::Debug for Expr {
                     write!(f, "{:?} BETWEEN {:?} AND {:?}", expr, low, high)
                 }
             }
+            Expr::InList {
+                expr,
+                list,
+                negated,
+            } => {
+                if *negated {
+                    write!(f, "{:?} NOT IN ({:?})", expr, list)
+                } else {
+                    write!(f, "{:?} IN ({:?})", expr, list)
+                }
+            }
             Expr::Wildcard => write!(f, "*"),
         }
     }
@@ -905,6 +945,19 @@ fn create_name(e: &Expr, input_schema: &DFSchema) -> Result<String> {
                 names.push(create_name(e, input_schema)?);
             }
             Ok(format!("{}({})", fun.name, names.join(",")))
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            let expr = create_name(expr, input_schema)?;
+            let list = list.iter().map(|expr| create_name(expr, input_schema));
+            if *negated {
+                Ok(format!("{:?} NOT IN ({:?})", expr, list))
+            } else {
+                Ok(format!("{:?} IN ({:?})", expr, list))
+            }
         }
         other => Err(DataFusionError::NotImplemented(format!(
             "Physical plan does not support logical expression {:?}",

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -36,8 +36,8 @@ pub use display::display_schema;
 pub use expr::{
     abs, acos, and, array, asin, atan, avg, binary_expr, case, ceil, col, concat, cos,
     count, count_distinct, create_udaf, create_udf, exp, exprlist_to_fields, floor,
-    length, lit, ln, log10, log2, lower, ltrim, max, min, or, round, rtrim, signum, sin,
-    sqrt, sum, tan, trim, trunc, upper, when, Expr, Literal,
+    in_list, length, lit, ln, log10, log2, lower, ltrim, max, min, or, round, rtrim,
+    signum, sin, sqrt, sum, tan, trim, trunc, upper, when, Expr, Literal,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -26,7 +26,10 @@ use crate::error::{DataFusionError, Result};
 use crate::logical_plan::Operator;
 use crate::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::scalar::ScalarValue;
-use arrow::array::{self, Array, BooleanBuilder, LargeStringArray};
+use arrow::array::{
+    self, Array, BooleanBuilder, GenericStringArray, LargeStringArray,
+    StringOffsetSizeTrait,
+};
 use arrow::compute;
 use arrow::compute::kernels;
 use arrow::compute::kernels::arithmetic::{add, divide, multiply, negate, subtract};
@@ -2414,6 +2417,236 @@ impl PhysicalSortExpr {
     }
 }
 
+/// InList
+#[derive(Debug)]
+pub struct InListExpr {
+    expr: Arc<dyn PhysicalExpr>,
+    list: Vec<Arc<dyn PhysicalExpr>>,
+    negated: bool,
+}
+
+macro_rules! make_contains {
+    ($ARRAY:expr, $LIST_VALUES:expr, $NEGATED:expr, $SCALAR_VALUE:ident, $ARRAY_TYPE:ident) => {{
+        let array = $ARRAY.as_any().downcast_ref::<$ARRAY_TYPE>().unwrap();
+
+        let mut contains_null = false;
+        let values = $LIST_VALUES
+            .iter()
+            .flat_map(|expr| match expr {
+                ColumnarValue::Scalar(s) => match s {
+                    ScalarValue::$SCALAR_VALUE(Some(v)) => Some(*v),
+                    ScalarValue::$SCALAR_VALUE(None) => {
+                        contains_null = true;
+                        None
+                    }
+                    ScalarValue::Utf8(None) => {
+                        contains_null = true;
+                        None
+                    }
+                    datatype => unimplemented!("Unexpected type {} for InList", datatype),
+                },
+                ColumnarValue::Array(_) => {
+                    unimplemented!("InList does not yet support nested columns.")
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Ok(ColumnarValue::Array(Arc::new(
+            array
+                .iter()
+                .map(|x| {
+                    let contains = x.map(|x| values.contains(&x));
+                    match contains {
+                        Some(true) => {
+                            if $NEGATED {
+                                Some(false)
+                            } else {
+                                Some(true)
+                            }
+                        }
+                        Some(false) => {
+                            if contains_null {
+                                None
+                            } else if $NEGATED {
+                                Some(true)
+                            } else {
+                                Some(false)
+                            }
+                        }
+                        None => None,
+                    }
+                })
+                .collect::<BooleanArray>(),
+        )))
+    }};
+}
+
+impl InListExpr {
+    /// Create a new InList expression
+    pub fn new(
+        expr: Arc<dyn PhysicalExpr>,
+        list: Vec<Arc<dyn PhysicalExpr>>,
+        negated: bool,
+    ) -> Self {
+        Self {
+            expr,
+            list,
+            negated,
+        }
+    }
+
+    /// Compare for specific utf8 types
+    fn compare_utf8<T: StringOffsetSizeTrait>(
+        &self,
+        array: ArrayRef,
+        list_values: Vec<ColumnarValue>,
+        negated: bool,
+    ) -> Result<ColumnarValue> {
+        let array = array
+            .as_any()
+            .downcast_ref::<GenericStringArray<T>>()
+            .unwrap();
+
+        let mut contains_null = false;
+        let values = list_values
+            .iter()
+            .flat_map(|expr| match expr {
+                ColumnarValue::Scalar(s) => match s {
+                    ScalarValue::Utf8(Some(v)) => Some(v.as_str()),
+                    ScalarValue::Utf8(None) => {
+                        contains_null = true;
+                        None
+                    }
+                    ScalarValue::LargeUtf8(Some(v)) => Some(v.as_str()),
+                    ScalarValue::LargeUtf8(None) => {
+                        contains_null = true;
+                        None
+                    }
+                    datatype => unimplemented!("Unexpected type {} for InList", datatype),
+                },
+                ColumnarValue::Array(_) => {
+                    unimplemented!("InList does not yet support nested columns.")
+                }
+            })
+            .collect::<Vec<&str>>();
+
+        Ok(ColumnarValue::Array(Arc::new(
+            array
+                .iter()
+                .map(|x| {
+                    let contains = x.map(|x| values.contains(&x));
+                    match contains {
+                        Some(true) => {
+                            if negated {
+                                Some(false)
+                            } else {
+                                Some(true)
+                            }
+                        }
+                        Some(false) => {
+                            if contains_null {
+                                None
+                            } else if negated {
+                                Some(true)
+                            } else {
+                                Some(false)
+                            }
+                        }
+                        None => None,
+                    }
+                })
+                .collect::<BooleanArray>(),
+        )))
+    }
+}
+
+impl fmt::Display for InListExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.negated {
+            write!(f, "{} NOT IN ({:?})", self.expr, self.list)
+        } else {
+            write!(f, "{} IN ({:?})", self.expr, self.list)
+        }
+    }
+}
+
+impl PhysicalExpr for InListExpr {
+    fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        self.expr.nullable(input_schema)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let value = self.expr.evaluate(batch)?;
+        let value_data_type = value.data_type();
+        let list_values = self
+            .list
+            .iter()
+            .map(|expr| expr.evaluate(batch))
+            .collect::<Result<Vec<_>>>()?;
+
+        let array = match value {
+            ColumnarValue::Array(array) => array,
+            ColumnarValue::Scalar(scalar) => scalar.to_array(),
+        };
+
+        match value_data_type {
+            DataType::Float32 => {
+                make_contains!(array, list_values, self.negated, Float32, Float32Array)
+            }
+            DataType::Float64 => {
+                make_contains!(array, list_values, self.negated, Float64, Float64Array)
+            }
+            DataType::Int16 => {
+                make_contains!(array, list_values, self.negated, Int16, Int16Array)
+            }
+            DataType::Int32 => {
+                make_contains!(array, list_values, self.negated, Int32, Int32Array)
+            }
+            DataType::Int64 => {
+                make_contains!(array, list_values, self.negated, Int64, Int64Array)
+            }
+            DataType::Int8 => {
+                make_contains!(array, list_values, self.negated, Int8, Int8Array)
+            }
+            DataType::UInt16 => {
+                make_contains!(array, list_values, self.negated, UInt16, UInt16Array)
+            }
+            DataType::UInt32 => {
+                make_contains!(array, list_values, self.negated, UInt32, UInt32Array)
+            }
+            DataType::UInt64 => {
+                make_contains!(array, list_values, self.negated, UInt64, UInt64Array)
+            }
+            DataType::UInt8 => {
+                make_contains!(array, list_values, self.negated, UInt8, UInt8Array)
+            }
+            DataType::Boolean => {
+                make_contains!(array, list_values, self.negated, Boolean, BooleanArray)
+            }
+            DataType::Utf8 => self.compare_utf8::<i32>(array, list_values, self.negated),
+            DataType::LargeUtf8 => {
+                self.compare_utf8::<i64>(array, list_values, self.negated)
+            }
+            datatype => {
+                unimplemented!("InList does not support datatype {:?}.", datatype)
+            }
+        }
+    }
+}
+
+/// Creates a unary expression InList
+pub fn in_list(
+    expr: Arc<dyn PhysicalExpr>,
+    list: Vec<Arc<dyn PhysicalExpr>>,
+    negated: &bool,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    Ok(Arc::new(InListExpr::new(expr, list, *negated)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3768,5 +4001,167 @@ mod tests {
         let a = StringArray::from(vec![Some("foo"), Some("baz"), None, Some("bar")]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
         Ok(batch)
+    }
+
+    // applies the in_list expr to an input batch and list
+    macro_rules! in_list {
+        ($BATCH:expr, $LIST:expr, $NEGATED:expr, $EXPECTED:expr) => {{
+            let expr = in_list(col("a"), $LIST, $NEGATED).unwrap();
+            let result = expr.evaluate(&$BATCH)?.into_array($BATCH.num_rows());
+            let result = result
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("failed to downcast to BooleanArray");
+            let expected = &BooleanArray::from($EXPECTED);
+            assert_eq!(expected, result);
+        }};
+    }
+
+    #[test]
+    fn in_list_utf8() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
+        let a = StringArray::from(vec![Some("a"), Some("d"), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
+
+        // expression: "a in ("a", "b")"
+        let list = vec![
+            lit(ScalarValue::Utf8(Some("a".to_string()))),
+            lit(ScalarValue::Utf8(Some("b".to_string()))),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), Some(false), None]);
+
+        // expression: "a not in ("a", "b")"
+        let list = vec![
+            lit(ScalarValue::Utf8(Some("a".to_string()))),
+            lit(ScalarValue::Utf8(Some("b".to_string()))),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), Some(true), None]);
+
+        // expression: "a not in ("a", "b")"
+        let list = vec![
+            lit(ScalarValue::Utf8(Some("a".to_string()))),
+            lit(ScalarValue::Utf8(Some("b".to_string()))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None, None]);
+
+        // expression: "a not in ("a", "b")"
+        let list = vec![
+            lit(ScalarValue::Utf8(Some("a".to_string()))),
+            lit(ScalarValue::Utf8(Some("b".to_string()))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None, None]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_list_int64() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+        let a = Int64Array::from(vec![Some(0), Some(2), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
+
+        // expression: "a in (0, 1)"
+        let list = vec![
+            lit(ScalarValue::Int64(Some(0))),
+            lit(ScalarValue::Int64(Some(1))),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), Some(false), None]);
+
+        // expression: "a not in (0, 1)"
+        let list = vec![
+            lit(ScalarValue::Int64(Some(0))),
+            lit(ScalarValue::Int64(Some(1))),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), Some(true), None]);
+
+        // expression: "a in (0, 1, NULL)"
+        let list = vec![
+            lit(ScalarValue::Int64(Some(0))),
+            lit(ScalarValue::Int64(Some(1))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None, None]);
+
+        // expression: "a not in (0, 1, NULL)"
+        let list = vec![
+            lit(ScalarValue::Int64(Some(0))),
+            lit(ScalarValue::Int64(Some(1))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None, None]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_list_float64() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Float64, true)]);
+        let a = Float64Array::from(vec![Some(0.0), Some(0.2), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
+
+        // expression: "a in (0.0, 0.2)"
+        let list = vec![
+            lit(ScalarValue::Float64(Some(0.0))),
+            lit(ScalarValue::Float64(Some(0.1))),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), Some(false), None]);
+
+        // expression: "a not in (0.0, 0.2)"
+        let list = vec![
+            lit(ScalarValue::Float64(Some(0.0))),
+            lit(ScalarValue::Float64(Some(0.1))),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), Some(true), None]);
+
+        // expression: "a in (0.0, 0.2, NULL)"
+        let list = vec![
+            lit(ScalarValue::Float64(Some(0.0))),
+            lit(ScalarValue::Float64(Some(0.1))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None, None]);
+
+        // expression: "a not in (0.0, 0.2, NULL)"
+        let list = vec![
+            lit(ScalarValue::Float64(Some(0.0))),
+            lit(ScalarValue::Float64(Some(0.1))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None, None]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_list_bool() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Boolean, true)]);
+        let a = BooleanArray::from(vec![Some(true), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)])?;
+
+        // expression: "a in (true)"
+        let list = vec![lit(ScalarValue::Boolean(Some(true)))];
+        in_list!(batch, list, &false, vec![Some(true), None]);
+
+        // expression: "a not in (true)"
+        let list = vec![lit(ScalarValue::Boolean(Some(true)))];
+        in_list!(batch, list, &true, vec![Some(false), None]);
+
+        // expression: "a in (true, NULL)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &false, vec![Some(true), None]);
+
+        // expression: "a not in (true, NULL)"
+        let list = vec![
+            lit(ScalarValue::Boolean(Some(true))),
+            lit(ScalarValue::Utf8(None)),
+        ];
+        in_list!(batch, list, &true, vec![Some(false), None]);
+
+        Ok(())
     }
 }

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -28,7 +28,7 @@
 pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::logical_plan::{
-    array, avg, col, concat, count, create_udf, length, lit, lower, ltrim, max, min,
-    rtrim, sum, trim, upper, JoinType, Partitioning,
+    array, avg, col, concat, count, create_udf, in_list, length, lit, lower, ltrim, max,
+    min, rtrim, sum, trim, upper, JoinType, Partitioning,
 };
 pub use crate::physical_plan::csv::CsvReadOptions;

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -759,6 +759,23 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 high: Box::new(self.sql_expr_to_logical_expr(&high)?),
             }),
 
+            SQLExpr::InList {
+                ref expr,
+                ref list,
+                ref negated,
+            } => {
+                let list_expr = list
+                    .iter()
+                    .map(|e| self.sql_expr_to_logical_expr(e))
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(Expr::InList {
+                    expr: Box::new(self.sql_expr_to_logical_expr(&expr)?),
+                    list: list_expr,
+                    negated: *negated,
+                })
+            }
+
             SQLExpr::BinaryOp {
                 ref left,
                 ref op,


### PR DESCRIPTION
This PR is a work-in-progress simple implementation of `InList` (`'ABC' IN ('ABC', 'DEF')`) which currently only operates on strings.

It uses the `kernels::comparison::contains` implementation but there are a few issues I am struggling with:

1. `kernels::comparison::contains` allows each value in the input array to match against potentially different value arrays. My implementation is very inefficiently creating the same array n times to prevent the error of mismatched input lengths (https://github.com/apache/arrow/blob/master/rust/arrow/src/compute/kernels/comparison.rs#L696). Is there a more efficient way to create these `ListArray`s?

2. `kernels::comparison::contains` returns `false` if either of the comparison values is `null`. Is this the desired behavior? If not I can modify the kernel to return null instead.

3. If the basic implementation looks correct I can add the rest of the data types (via macros).