### PR TITLE
ARROW-11063: [Rust] [Breaking] Validate null counts when building arrays

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -140,9 +140,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
             .add_buffer(v.data_ref().buffers()[0].clone())
             .add_buffer(v.data_ref().child_data()[0].buffers()[0].clone());
         if let Some(bitmap) = v.data_ref().null_bitmap() {
-            builder = builder
-                .null_count(v.data_ref().null_count())
-                .null_bit_buffer(bitmap.bits.clone())
+            builder = builder.null_bit_buffer(bitmap.bits.clone())
         }
 
         let data = builder.build();
@@ -453,9 +451,7 @@ impl From<FixedSizeListArray> for FixedSizeBinaryArray {
             .len(v.len())
             .add_buffer(v.data_ref().child_data()[0].buffers()[0].clone());
         if let Some(bitmap) = v.data_ref().null_bitmap() {
-            builder = builder
-                .null_count(v.data_ref().null_count())
-                .null_bit_buffer(bitmap.bits.clone())
+            builder = builder.null_bit_buffer(bitmap.bits.clone())
         }
 
         let data = builder.build();
@@ -572,9 +568,7 @@ impl DecimalArray {
             .len(v.len())
             .add_buffer(v.data_ref().child_data()[0].buffers()[0].clone());
         if let Some(bitmap) = v.data_ref().null_bitmap() {
-            builder = builder
-                .null_count(v.data_ref().null_count())
-                .null_bit_buffer(bitmap.bits.clone())
+            builder = builder.null_bit_buffer(bitmap.bits.clone())
         }
 
         let data = builder.build();

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -116,9 +116,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
             .add_buffer(v.data_ref().buffers()[0].clone())
             .add_buffer(v.data_ref().child_data()[0].buffers()[0].clone());
         if let Some(bitmap) = v.data().null_bitmap() {
-            builder = builder
-                .null_count(v.data_ref().null_count())
-                .null_bit_buffer(bitmap.bits.clone())
+            builder = builder.null_bit_buffer(bitmap.bits.clone())
         }
 
         let data = builder.build();

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -946,7 +946,6 @@ mod tests {
         ]))
         .null_bit_buffer(Buffer::from(vec![0b00001011]))
         .len(5)
-        .null_count(2)
         .add_child_data(strings.data_ref().clone())
         .add_child_data(ints.data_ref().clone())
         .build();
@@ -958,7 +957,6 @@ mod tests {
         ]))
         .null_bit_buffer(Buffer::from(vec![0b00001011]))
         .len(5)
-        .null_count(2)
         .add_child_data(strings.data_ref().clone())
         .add_child_data(ints_non_null.data_ref().clone())
         .build();
@@ -974,7 +972,6 @@ mod tests {
         ]))
         .null_bit_buffer(Buffer::from(vec![0b00001011]))
         .len(5)
-        .null_count(2)
         .add_child_data(strings.data_ref().clone())
         .add_child_data(c_ints_non_null.data_ref().clone())
         .build();
@@ -990,7 +987,6 @@ mod tests {
         )]))
         .null_bit_buffer(Buffer::from(vec![0b00011110]))
         .len(5)
-        .null_count(1)
         .add_child_data(a.data_ref().clone())
         .build();
         let a = crate::array::make_array(a);
@@ -1009,7 +1005,6 @@ mod tests {
         ]))
         .null_bit_buffer(Buffer::from(vec![0b00001011]))
         .len(5)
-        .null_count(2)
         .add_child_data(strings.data_ref().clone())
         .add_child_data(ints_non_null.data_ref().clone())
         .build();
@@ -1021,7 +1016,6 @@ mod tests {
         )]))
         .null_bit_buffer(Buffer::from(vec![0b00011110]))
         .len(5)
-        .null_count(1)
         .add_child_data(b)
         .build();
         let b = crate::array::make_array(b);
@@ -1054,7 +1048,6 @@ mod tests {
         )]))
         .null_bit_buffer(Buffer::from(vec![0b00001010]))
         .len(5)
-        .null_count(3)
         .add_child_data(strings1.data_ref().clone())
         .build();
         let a = crate::array::make_array(a);
@@ -1066,7 +1059,6 @@ mod tests {
         )]))
         .null_bit_buffer(Buffer::from(vec![0b00001010]))
         .len(5)
-        .null_count(3)
         .add_child_data(strings2.data_ref().clone())
         .build();
         let b = crate::array::make_array(b);
@@ -1088,7 +1080,6 @@ mod tests {
         )]))
         .null_bit_buffer(Buffer::from(vec![0b00001011]))
         .len(5)
-        .null_count(2)
         .add_child_data(strings3.data_ref().clone())
         .build();
         let c = crate::array::make_array(c);

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -1029,7 +1029,6 @@ mod tests {
         let list_data = ArrayData::builder(list_data_type)
             .len(4)
             .add_buffer(value_offsets)
-            .null_count(1)
             .add_child_data(value_data)
             .null_bit_buffer(Buffer::from([0b00001011]))
             .build();

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -335,7 +335,6 @@ pub(super) mod tests {
 
         let list_data = ArrayData::builder(list_data_type)
             .len(list_len)
-            .null_count(list_null_count)
             .null_bit_buffer(list_bitmap.freeze())
             .add_buffer(value_offsets)
             .add_child_data(value_data)
@@ -401,7 +400,6 @@ pub(super) mod tests {
 
         let list_data = ArrayData::builder(list_data_type)
             .len(list_len)
-            .null_count(list_null_count)
             .null_bit_buffer(list_bitmap.freeze())
             .add_child_data(child_data)
             .build();

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -163,7 +163,6 @@ fn create_array(
                 StructArray::from((
                     struct_arrays,
                     null_buffer,
-                    struct_node.null_count() as usize,
                 ))
             } else {
                 StructArray::from(struct_arrays)
@@ -232,9 +231,7 @@ fn create_primitive_array(
                 .buffers(buffers[1..3].to_vec())
                 .offset(0);
             if null_count > 0 {
-                builder = builder
-                    .null_count(null_count)
-                    .null_bit_buffer(buffers[0].clone())
+                builder = builder.null_bit_buffer(buffers[0].clone())
             }
             builder.build()
         }
@@ -245,9 +242,7 @@ fn create_primitive_array(
                 .buffers(buffers[1..2].to_vec())
                 .offset(0);
             if null_count > 0 {
-                builder = builder
-                    .null_count(null_count)
-                    .null_bit_buffer(buffers[0].clone())
+                builder = builder.null_bit_buffer(buffers[0].clone())
             }
             builder.build()
         }
@@ -267,9 +262,7 @@ fn create_primitive_array(
                     .buffers(buffers[1..].to_vec())
                     .offset(0);
                 if null_count > 0 {
-                    builder = builder
-                        .null_count(null_count)
-                        .null_bit_buffer(buffers[0].clone())
+                    builder = builder.null_bit_buffer(buffers[0].clone())
                 }
                 let values = Arc::new(Int64Array::from(builder.build())) as ArrayRef;
                 // this cast is infallible, the unwrap is safe
@@ -281,9 +274,7 @@ fn create_primitive_array(
                     .buffers(buffers[1..].to_vec())
                     .offset(0);
                 if null_count > 0 {
-                    builder = builder
-                        .null_count(null_count)
-                        .null_bit_buffer(buffers[0].clone())
+                    builder = builder.null_bit_buffer(buffers[0].clone())
                 }
                 builder.build()
             }
@@ -296,9 +287,7 @@ fn create_primitive_array(
                     .buffers(buffers[1..].to_vec())
                     .offset(0);
                 if null_count > 0 {
-                    builder = builder
-                        .null_count(null_count)
-                        .null_bit_buffer(buffers[0].clone())
+                    builder = builder.null_bit_buffer(buffers[0].clone())
                 }
                 let values = Arc::new(Float64Array::from(builder.build())) as ArrayRef;
                 // this cast is infallible, the unwrap is safe
@@ -310,9 +299,7 @@ fn create_primitive_array(
                     .buffers(buffers[1..].to_vec())
                     .offset(0);
                 if null_count > 0 {
-                    builder = builder
-                        .null_count(null_count)
-                        .null_bit_buffer(buffers[0].clone())
+                    builder = builder.null_bit_buffer(buffers[0].clone())
                 }
                 builder.build()
             }
@@ -331,9 +318,7 @@ fn create_primitive_array(
                 .buffers(buffers[1..].to_vec())
                 .offset(0);
             if null_count > 0 {
-                builder = builder
-                    .null_count(null_count)
-                    .null_bit_buffer(buffers[0].clone())
+                builder = builder.null_bit_buffer(buffers[0].clone())
             }
             builder.build()
         }
@@ -344,9 +329,7 @@ fn create_primitive_array(
                 .buffers(buffers[1..2].to_vec())
                 .offset(0);
             if null_count > 0 {
-                builder = builder
-                    .null_count(null_count)
-                    .null_bit_buffer(buffers[0].clone())
+                builder = builder.null_bit_buffer(buffers[0].clone())
             }
             builder.build()
         }
@@ -372,9 +355,7 @@ fn create_list_array(
             .offset(0)
             .child_data(vec![child_array.data()]);
         if null_count > 0 {
-            builder = builder
-                .null_count(null_count)
-                .null_bit_buffer(buffers[0].clone())
+            builder = builder.null_bit_buffer(buffers[0].clone())
         }
         make_array(builder.build())
     } else if let DataType::LargeList(_) = *data_type {
@@ -385,9 +366,7 @@ fn create_list_array(
             .offset(0)
             .child_data(vec![child_array.data()]);
         if null_count > 0 {
-            builder = builder
-                .null_count(null_count)
-                .null_bit_buffer(buffers[0].clone())
+            builder = builder.null_bit_buffer(buffers[0].clone())
         }
         make_array(builder.build())
     } else if let DataType::FixedSizeList(_, _) = *data_type {
@@ -398,9 +377,7 @@ fn create_list_array(
             .offset(0)
             .child_data(vec![child_array.data()]);
         if null_count > 0 {
-            builder = builder
-                .null_count(null_count)
-                .null_bit_buffer(buffers[0].clone())
+            builder = builder.null_bit_buffer(buffers[0].clone())
         }
         make_array(builder.build())
     } else {
@@ -424,9 +401,7 @@ fn create_dictionary_array(
             .offset(0)
             .child_data(vec![value_array.data()]);
         if null_count > 0 {
-            builder = builder
-                .null_count(null_count)
-                .null_bit_buffer(buffers[0].clone())
+            builder = builder.null_bit_buffer(buffers[0].clone())
         }
         make_array(builder.build())
     } else {

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -1947,14 +1947,12 @@ mod tests {
         // build expected output
         let d = StringArray::from(vec![Some("text"), None, Some("text"), None]);
         let c = ArrayDataBuilder::new(c_field.data_type().clone())
-            .null_count(2)
             .len(4)
             .add_child_data(d.data())
             .null_bit_buffer(Buffer::from(vec![0b00000101]))
             .build();
         let b = BooleanArray::from(vec![Some(true), Some(false), Some(true), None]);
         let a = ArrayDataBuilder::new(a_field.data_type().clone())
-            .null_count(1)
             .len(4)
             .add_child_data(b.data())
             .add_child_data(c)
@@ -2010,7 +2008,6 @@ mod tests {
             None,
         ]);
         let c = ArrayDataBuilder::new(c_field.data_type().clone())
-            .null_count(2)
             .len(7)
             .add_child_data(d.data())
             .null_bit_buffer(Buffer::from(vec![0b00111011]))
@@ -2031,7 +2028,6 @@ mod tests {
             .null_bit_buffer(Buffer::from(vec![0b00111111]))
             .build();
         let a_list = ArrayDataBuilder::new(a_field.data_type().clone())
-            .null_count(1)
             .len(5)
             .add_buffer(Buffer::from(vec![0i32, 2, 3, 6, 6, 6].to_byte_slice()))
             .add_child_data(a)


### PR DESCRIPTION
Removes the null_count() function, forcing the builder to always validate the null count.

This breaks existing code that provides null counts, with the required action being to remove that code.