### PR TITLE
ARROW-11076: [Rust][DataFusion] Refactor usage of right indices in hash join

### DIFF
--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -321,12 +321,13 @@ fn build_batch_from_indices(
             }
             make_array(Arc::new(mutable.freeze()))
         } else {
+            // use the right indices
             let array = right.column(column_index);
-            let ind = indices
+            let right_indices = indices
                 .iter()
                 .map(|(_, join_index)| join_index)
                 .collect::<UInt32Array>();
-            compute::take(array.as_ref(), &ind, None)?
+            compute::take(array.as_ref(), &right_indices, None)?
         };
         columns.push(array);
     }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -287,6 +287,9 @@ fn build_batch_from_indices(
     // 1. pick whether the column is from the left or right
     // 2. based on the pick, `take` items from the different recordBatches
     let mut columns: Vec<Arc<dyn Array>> = Vec::with_capacity(schema.fields().len());
+
+    let right_indices = indices.iter().map(|(_, join_index)| join_index).collect();
+
     for field in schema.fields() {
         // pick the column (left or right) based on the field name.
         let (is_primary, column_index) = match primary[0].schema().index_of(field.name()) {
@@ -323,10 +326,6 @@ fn build_batch_from_indices(
         } else {
             // use the right indices
             let array = right.column(column_index);
-            let right_indices = indices
-                .iter()
-                .map(|(_, join_index)| join_index)
-                .collect::<UInt32Array>();
             compute::take(array.as_ref(), &right_indices, None)?
         };
         columns.push(array);

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -276,11 +276,11 @@ fn build_batch_from_indices(
         todo!("Create empty record batch");
     }
     // this is just for symmetry of the code below.
-    let right = vec![right.clone()];
+    let right_batches = vec![right.clone()];
 
     let (primary_is_left, primary, secondary) = match join_type {
-        JoinType::Inner | JoinType::Left => (true, left, &right),
-        JoinType::Right => (false, &right, left),
+        JoinType::Inner | JoinType::Left => (true, left, &right_batches),
+        JoinType::Right => (false, &right_batches, left),
     };
 
     // build the columns of the new [RecordBatch]:
@@ -321,7 +321,7 @@ fn build_batch_from_indices(
             }
             make_array(Arc::new(mutable.freeze()))
         } else {
-            let array = right[0].column(column_index);
+            let array = right.column(column_index);
             let ind = indices
                 .iter()
                 .map(|(_, join_index)| join_index)

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -275,7 +275,6 @@ fn build_batch_from_indices(
     if left.is_empty() {
         todo!("Create empty record batch");
     }
-    // this is just for symmetry of the code below.
 
     let (primary_is_left, primary_schema, secondary_schema) = match join_type {
         JoinType::Inner | JoinType::Left => (true, left[0].schema(), right.schema()),

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -311,8 +311,7 @@ fn build_batch_from_indices(
                 .map(|batch| batch.column(column_index).data_ref().as_ref())
                 .collect::<Vec<_>>();
 
-            let capacity = arrays.iter().map(|array| array.len()).sum();
-            let mut mutable = MutableArrayData::new(arrays, true, capacity);
+            let mut mutable = MutableArrayData::new(arrays, true, indices.len());
             // use the left indices
             for (join_index, _) in indices {
                 match join_index {


### PR DESCRIPTION
This applies some refactoring to `build_batch_from_indices` which is supposed to make further changes easier, e.g. solving https://issues.apache.org/jira/browse/ARROW-11030

* This starts handling right (1) batch and left (many) batches differently as for the right batches we can directly use `take` on it. This should be more efficient anyway, and also allows in the future to build the index array directly instead of doing extra copying.
* Use `indices.len()` for the capacity parameter, rather than the number of rows at the left. This is of impact at larger sizes (e.g. SF 100), see: https://github.com/apache/arrow/pull/9036 Rather than estimating it based on previous batches, this does it based on the (known) number of resulting rows.
* Reuse "computed" right indices across multiple columns.
* The refactoring makes it easier to apply changes needed for https://issues.apache.org/jira/browse/ARROW-11030 where we need to remove the n*n work that is done for the build side 
* The changes don't have a big impact locally on performance on TPC-H with small scale factor, but I believe it should have a similar effect as https://github.com/apache/arrow/pull/9036 on SF=100 by using `indices.len()` rather than the number of rows in the build side.

FYI @jorgecarleitao @andygrove 