### PR TITLE
ARROW-10996: [Rust] [Parquet] change return value type of get_arrow_schema_from_metadata()

### DIFF
--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -42,19 +42,14 @@ pub fn parquet_to_arrow_schema(
     key_value_metadata: &Option<Vec<KeyValue>>,
 ) -> Result<Schema> {
     let mut metadata = parse_key_value_metadata(key_value_metadata).unwrap_or_default();
-    let arrow_schema_metadata = metadata
+    metadata
         .remove(super::ARROW_SCHEMA_META_KEY)
         .map(|encoded| get_arrow_schema_from_metadata(&encoded))
-        .map_or(Ok(None), |v| v.map(Some))?;
-
-    match arrow_schema_metadata {
-        Some(schema) => Ok(schema),
-        _ => parquet_to_arrow_schema_by_columns(
+        .unwrap_or(parquet_to_arrow_schema_by_columns(
             parquet_schema,
             0..parquet_schema.columns().len(),
             key_value_metadata,
-        ),
-    }
+        ))
 }
 
 /// Convert parquet schema to arrow schema including optional metadata,

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -42,14 +42,10 @@ pub fn parquet_to_arrow_schema(
     key_value_metadata: &Option<Vec<KeyValue>>,
 ) -> Result<Schema> {
     let mut metadata = parse_key_value_metadata(key_value_metadata).unwrap_or_default();
-    let maybe_schema = metadata
+    let arrow_schema_metadata = metadata
         .remove(super::ARROW_SCHEMA_META_KEY)
-        .map(|encoded| get_arrow_schema_from_metadata(&encoded));
-
-    let arrow_schema_metadata = match maybe_schema {
-        Some(v) => Some(v?),
-        _ => None,
-    };
+        .map(|encoded| get_arrow_schema_from_metadata(&encoded))
+        .map_or(Ok(None), |v| v.map(Some))?;
 
     match arrow_schema_metadata {
         Some(schema) => Ok(schema),
@@ -125,14 +121,10 @@ where
     T: IntoIterator<Item = usize>,
 {
     let mut metadata = parse_key_value_metadata(key_value_metadata).unwrap_or_default();
-    let maybe_schema = metadata
+    let arrow_schema_metadata = metadata
         .remove(super::ARROW_SCHEMA_META_KEY)
-        .map(|encoded| get_arrow_schema_from_metadata(&encoded));
-
-    let arrow_schema_metadata = match maybe_schema {
-        Some(v) => Some(v?),
-        _ => None,
-    };
+        .map(|encoded| get_arrow_schema_from_metadata(&encoded))
+        .map_or(Ok(None), |v| v.map(Some))?;
 
     // add the Arrow metadata to the Parquet metadata
     if let Some(arrow_schema) = &arrow_schema_metadata {

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -42,12 +42,17 @@ pub fn parquet_to_arrow_schema(
     key_value_metadata: &Option<Vec<KeyValue>>,
 ) -> Result<Schema> {
     let mut metadata = parse_key_value_metadata(key_value_metadata).unwrap_or_default();
-    let arrow_schema_metadata = metadata
+    let maybe_schema = metadata
         .remove(super::ARROW_SCHEMA_META_KEY)
         .map(|encoded| get_arrow_schema_from_metadata(&encoded));
 
+    let arrow_schema_metadata = match maybe_schema {
+        Some(v) => Some(v?),
+        _ => None,
+    };
+
     match arrow_schema_metadata {
-        Some(Ok(schema)) => Ok(schema),
+        Some(schema) => Ok(schema),
         _ => parquet_to_arrow_schema_by_columns(
             parquet_schema,
             0..parquet_schema.columns().len(),


### PR DESCRIPTION
https://github.com/apache/arrow/pull/8936 updated crate `flatbuffers` to 0.8.0 , but function `get_arrow_schema_from_metadata` still returning `Option` rather than `Result`. This PR fixes this issue.