### PR TITLE
ARROW-11088: [Rust][DataFusion] Calculate column indices upfront in hash join

### DIFF
--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -81,8 +81,11 @@ pub struct HashJoinExec {
     build_side: Arc<Mutex<Option<JoinLeftData>>>,
 }
 
+/// Information about the index and placement (left or right) of the columns
 struct ColumnIndex {
+    /// Index of the column 
     index: usize,
+    /// Whether the column is at the left or right side
     is_left: bool,
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/apache/arrow/pull/9048 it is wasteful to calculate the column indexes for every batch. In this PR we instead do it only once.

This doesn't seem to have a large impact on performance, as expected, but seems to give a small improvement when using smaller batch sizes. 