### PR TITLE
ARROW-11091: [Rust][DataFusion] Fix new clippy linting errors

### DIFF
--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -498,8 +498,9 @@ pub mod flight_service_server {
     #[async_trait]
     pub trait FlightService: Send + Sync + 'static {
         #[doc = "Server streaming response type for the Handshake method."]
-        type HandshakeStream: Stream<Item = Result<super::HandshakeResponse, tonic::Status>>
-            + Send
+        type HandshakeStream: Stream<
+            Item = Result<super::HandshakeResponse, tonic::Status>,
+        > + Send
             + Sync
             + 'static;
         #[doc = ""]

--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -498,9 +498,8 @@ pub mod flight_service_server {
     #[async_trait]
     pub trait FlightService: Send + Sync + 'static {
         #[doc = "Server streaming response type for the Handshake method."]
-        type HandshakeStream: Stream<
-            Item = Result<super::HandshakeResponse, tonic::Status>,
-        > + Send
+        type HandshakeStream: Stream<Item = Result<super::HandshakeResponse, tonic::Status>>
+            + Send
             + Sync
             + 'static;
         #[doc = ""]

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -838,8 +838,10 @@ mod tests {
     /// test earliy stopping in pre-visit
     #[test]
     fn early_stoping_pre_visit() {
-        let mut visitor = StoppingVisitor::default();
-        visitor.return_false_from_pre_in = OptionalCounter::new(2);
+        let mut visitor = StoppingVisitor {
+            return_false_from_post_in: OptionalCounter::new(1),
+            ..Default::default()
+        };
         let plan = test_plan();
         let res = plan.accept(&mut visitor);
         assert!(res.is_ok());
@@ -852,8 +854,10 @@ mod tests {
 
     #[test]
     fn early_stoping_post_visit() {
-        let mut visitor = StoppingVisitor::default();
-        visitor.return_false_from_post_in = OptionalCounter::new(1);
+        let mut visitor = StoppingVisitor {
+            return_false_from_post_in: OptionalCounter::new(1),
+            ..Default::default()
+        };
         let plan = test_plan();
         let res = plan.accept(&mut visitor);
         assert!(res.is_ok());
@@ -907,8 +911,10 @@ mod tests {
 
     #[test]
     fn error_pre_visit() {
-        let mut visitor = ErrorVisitor::default();
-        visitor.return_error_from_pre_in = OptionalCounter::new(2);
+        let mut visitor = ErrorVisitor {
+            return_error_from_post_in: OptionalCounter::new(1),
+            ..Default::default()
+        };
         let plan = test_plan();
         let res = plan.accept(&mut visitor);
 
@@ -926,8 +932,10 @@ mod tests {
 
     #[test]
     fn error_post_visit() {
-        let mut visitor = ErrorVisitor::default();
-        visitor.return_error_from_post_in = OptionalCounter::new(1);
+        let mut visitor = ErrorVisitor {
+            return_error_from_post_in: OptionalCounter::new(1),
+            ..Default::default()
+        };
         let plan = test_plan();
         let res = plan.accept(&mut visitor);
         if let Err(e) = res {

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -839,7 +839,7 @@ mod tests {
     #[test]
     fn early_stoping_pre_visit() {
         let mut visitor = StoppingVisitor {
-            return_false_from_post_in: OptionalCounter::new(2),
+            return_false_from_pre_in: OptionalCounter::new(2),
             ..Default::default()
         };
         let plan = test_plan();
@@ -912,7 +912,7 @@ mod tests {
     #[test]
     fn error_pre_visit() {
         let mut visitor = ErrorVisitor {
-            return_error_from_post_in: OptionalCounter::new(2),
+            return_error_from_pre_in: OptionalCounter::new(2),
             ..Default::default()
         };
         let plan = test_plan();

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -839,7 +839,7 @@ mod tests {
     #[test]
     fn early_stoping_pre_visit() {
         let mut visitor = StoppingVisitor {
-            return_false_from_post_in: OptionalCounter::new(1),
+            return_false_from_post_in: OptionalCounter::new(2),
             ..Default::default()
         };
         let plan = test_plan();
@@ -912,7 +912,7 @@ mod tests {
     #[test]
     fn error_pre_visit() {
         let mut visitor = ErrorVisitor {
-            return_error_from_post_in: OptionalCounter::new(1),
+            return_error_from_post_in: OptionalCounter::new(2),
             ..Default::default()
         };
         let plan = test_plan();


### PR DESCRIPTION
Rust 1.49 introduced some new clippy lints, failing the build.