### PR TITLE
ARROW-11092: [CI] (Temporarily) move offending workflows to separate files

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -301,95 +301,95 @@ jobs:
         shell: bash
         run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
 
-  windows-mingw:
-    name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
-    runs-on: windows-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        mingw-n-bits:
-          - 32
-          - 64
-    env:
-      ARROW_BUILD_SHARED: ON
-      ARROW_BUILD_STATIC: OFF
-      ARROW_BUILD_TESTS: ON
-      ARROW_BUILD_TYPE: release
-      ARROW_DATASET: ON
-      ARROW_FLIGHT: ON
-      ARROW_GANDIVA: ON
-      ARROW_HDFS: OFF
-      ARROW_HOME: /mingw${{ matrix.mingw-n-bits }}
-      ARROW_JEMALLOC: OFF
-      ARROW_PARQUET: ON
-      ARROW_PYTHON: ON
-      ARROW_S3: ON
-      ARROW_USE_GLOG: OFF
-      ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
-      ARROW_WITH_BROTLI: ON
-      ARROW_WITH_BZ2: ON
-      ARROW_WITH_LZ4: ON
-      ARROW_WITH_SNAPPY: ON
-      ARROW_WITH_ZLIB: ON
-      ARROW_WITH_ZSTD: ON
-      # Don't use preinstalled Boost by empty BOOST_ROOT and
-      # -DBoost_NO_BOOST_CMAKE=ON
-      BOOST_ROOT: ""
-      CMAKE_ARGS: >-
-        -DARROW_PACKAGE_PREFIX=/mingw${{ matrix.mingw-n-bits }}
-        -DBoost_NO_BOOST_CMAKE=ON
-      CMAKE_UNITY_BUILD: ON
-    steps:
-      - name: Disable Crash Dialogs
-        run: |
-          reg add `
-            "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
-            /v DontShowUI `
-            /t REG_DWORD `
-            /d 1 `
-            /f
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Fetch Submodules and Tags
-        shell: bash
-        run: ci/scripts/util_checkout.sh
-      - uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW${{ matrix.mingw-n-bits }}
-          update: true
-      - name: Setup MSYS2
-        shell: msys2 {0}
-        run: |
-          ci/scripts/msys2_setup.sh cpp
-      - name: Cache ccache
-        uses: actions/cache@v1
-        with:
-          path: ccache
-          key: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
-          restore-keys: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-
-      - name: Build
-        shell: msys2 {0}
-        run: |
-          export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
-          ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
-      - name: Download MinIO
-        shell: msys2 {0}
-        run: |
-          mkdir -p /usr/local/bin
-          wget \
-            --output-document /usr/local/bin/minio.exe \
-            https://dl.min.io/server/minio/release/windows-amd64/minio.exe
-          chmod +x /usr/local/bin/minio.exe
-      - name: Test
-        shell: msys2 {0}
-        run: |
-          python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
-          export PYTHONHOME="$(cygpath --windows ${MINGW_PREFIX})\lib\python${python_version}"
-          PYTHONPATH="${PYTHONHOME}"
-          PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\lib-dynload"
-          PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\site-packages"
-          export PYTHONPATH
-          ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
+  # windows-mingw:
+  #   name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
+  #   runs-on: windows-latest
+  #   if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       mingw-n-bits:
+  #         - 32
+  #         - 64
+  #   env:
+  #     ARROW_BUILD_SHARED: ON
+  #     ARROW_BUILD_STATIC: OFF
+  #     ARROW_BUILD_TESTS: ON
+  #     ARROW_BUILD_TYPE: release
+  #     ARROW_DATASET: ON
+  #     ARROW_FLIGHT: ON
+  #     ARROW_GANDIVA: ON
+  #     ARROW_HDFS: OFF
+  #     ARROW_HOME: /mingw${{ matrix.mingw-n-bits }}
+  #     ARROW_JEMALLOC: OFF
+  #     ARROW_PARQUET: ON
+  #     ARROW_PYTHON: ON
+  #     ARROW_S3: ON
+  #     ARROW_USE_GLOG: OFF
+  #     ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
+  #     ARROW_WITH_BROTLI: ON
+  #     ARROW_WITH_BZ2: ON
+  #     ARROW_WITH_LZ4: ON
+  #     ARROW_WITH_SNAPPY: ON
+  #     ARROW_WITH_ZLIB: ON
+  #     ARROW_WITH_ZSTD: ON
+  #     # Don't use preinstalled Boost by empty BOOST_ROOT and
+  #     # -DBoost_NO_BOOST_CMAKE=ON
+  #     BOOST_ROOT: ""
+  #     CMAKE_ARGS: >-
+  #       -DARROW_PACKAGE_PREFIX=/mingw${{ matrix.mingw-n-bits }}
+  #       -DBoost_NO_BOOST_CMAKE=ON
+  #     CMAKE_UNITY_BUILD: ON
+  #   steps:
+  #     - name: Disable Crash Dialogs
+  #       run: |
+  #         reg add `
+  #           "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+  #           /v DontShowUI `
+  #           /t REG_DWORD `
+  #           /d 1 `
+  #           /f
+  #     - name: Checkout Arrow
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Fetch Submodules and Tags
+  #       shell: bash
+  #       run: ci/scripts/util_checkout.sh
+  #     - uses: msys2/setup-msys2@v2
+  #       with:
+  #         msystem: MINGW${{ matrix.mingw-n-bits }}
+  #         update: true
+  #     - name: Setup MSYS2
+  #       shell: msys2 {0}
+  #       run: |
+  #         ci/scripts/msys2_setup.sh cpp
+  #     - name: Cache ccache
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: ccache
+  #         key: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
+  #         restore-keys: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-
+  #     - name: Build
+  #       shell: msys2 {0}
+  #       run: |
+  #         export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
+  #         ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
+  #     - name: Download MinIO
+  #       shell: msys2 {0}
+  #       run: |
+  #         mkdir -p /usr/local/bin
+  #         wget \
+  #           --output-document /usr/local/bin/minio.exe \
+  #           https://dl.min.io/server/minio/release/windows-amd64/minio.exe
+  #         chmod +x /usr/local/bin/minio.exe
+  #     - name: Test
+  #       shell: msys2 {0}
+  #       run: |
+  #         python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
+  #         export PYTHONHOME="$(cygpath --windows ${MINGW_PREFIX})\lib\python${python_version}"
+  #         PYTHONPATH="${PYTHONHOME}"
+  #         PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\lib-dynload"
+  #         PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\site-packages"
+  #         export PYTHONPATH
+  #         ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"

--- a/.github/workflows/cpp_blocked_by_infra.yml
+++ b/.github/workflows/cpp_blocked_by_infra.yml
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: C++
+
+on:
+  push:
+    paths:
+      - '.github/workflows/cpp.yml'
+      - 'ci/docker/**'
+      - 'ci/scripts/cpp_*'
+      - 'ci/scripts/msys2_*'
+      - 'ci/scripts/util_*'
+      - 'cpp/**'
+      - 'format/Flight.proto'
+  pull_request:
+    paths:
+      - '.github/workflows/cpp.yml'
+      - 'ci/docker/**'
+      - 'ci/scripts/cpp_*'
+      - 'ci/scripts/msys2_*'
+      - 'ci/scripts/util_*'
+      - 'cpp/**'
+      - 'format/Flight.proto'
+
+env:
+  DOCKER_BUILDKIT: 0
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  ARROW_ENABLE_TIMING_TESTS: OFF
+  ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
+  ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  windows-mingw:
+    name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
+    runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        mingw-n-bits:
+          - 32
+          - 64
+    env:
+      ARROW_BUILD_SHARED: ON
+      ARROW_BUILD_STATIC: OFF
+      ARROW_BUILD_TESTS: ON
+      ARROW_BUILD_TYPE: release
+      ARROW_DATASET: ON
+      ARROW_FLIGHT: ON
+      ARROW_GANDIVA: ON
+      ARROW_HDFS: OFF
+      ARROW_HOME: /mingw${{ matrix.mingw-n-bits }}
+      ARROW_JEMALLOC: OFF
+      ARROW_PARQUET: ON
+      ARROW_PYTHON: ON
+      ARROW_S3: ON
+      ARROW_USE_GLOG: OFF
+      ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
+      ARROW_WITH_BROTLI: ON
+      ARROW_WITH_BZ2: ON
+      ARROW_WITH_LZ4: ON
+      ARROW_WITH_SNAPPY: ON
+      ARROW_WITH_ZLIB: ON
+      ARROW_WITH_ZSTD: ON
+      # Don't use preinstalled Boost by empty BOOST_ROOT and
+      # -DBoost_NO_BOOST_CMAKE=ON
+      BOOST_ROOT: ""
+      CMAKE_ARGS: >-
+        -DARROW_PACKAGE_PREFIX=/mingw${{ matrix.mingw-n-bits }}
+        -DBoost_NO_BOOST_CMAKE=ON
+      CMAKE_UNITY_BUILD: ON
+    steps:
+      - name: Disable Crash Dialogs
+        run: |
+          reg add `
+            "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+            /v DontShowUI `
+            /t REG_DWORD `
+            /d 1 `
+            /f
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: ci/scripts/util_checkout.sh
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW${{ matrix.mingw-n-bits }}
+          update: true
+      - name: Setup MSYS2
+        shell: msys2 {0}
+        run: |
+          ci/scripts/msys2_setup.sh cpp
+      - name: Cache ccache
+        uses: actions/cache@v1
+        with:
+          path: ccache
+          key: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
+          restore-keys: cpp-ccache-mingw${{ matrix.mingw-n-bits }}-
+      - name: Build
+        shell: msys2 {0}
+        run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
+          ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
+      - name: Download MinIO
+        shell: msys2 {0}
+        run: |
+          mkdir -p /usr/local/bin
+          wget \
+            --output-document /usr/local/bin/minio.exe \
+            https://dl.min.io/server/minio/release/windows-amd64/minio.exe
+          chmod +x /usr/local/bin/minio.exe
+      - name: Test
+        shell: msys2 {0}
+        run: |
+          python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
+          export PYTHONHOME="$(cygpath --windows ${MINGW_PREFIX})\lib\python${python_version}"
+          PYTHONPATH="${PYTHONHOME}"
+          PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\lib-dynload"
+          PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\site-packages"
+          export PYTHONPATH
+          ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -139,76 +139,76 @@ jobs:
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
         run: archery docker push r
-
-  windows:
-    name: AMD64 Windows RTools ${{ matrix.rtools }}
-    runs-on: windows-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rtools: [35, 40]
-    env:
-      TEST_R_WITH_ARROW: "TRUE"
-      ARROW_R_CXXFLAGS: '-Werror'
-      _R_CHECK_TESTS_NLINES_: 0
-    steps:
-      - run: git config --global core.autocrlf false
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Make R tests verbose
-        # If you get a segfault/mysterious test Execution halted,
-        # make this `true` to see where it dies.
-        if: false
-        shell: cmd
-        run: |
-          cd r/tests
-          sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
-          rm -f testthat.R.bak
-      # We use the makepkg-mingw setup that is included in rtools40 even when
-      # we use the rtools35 compilers, so we always install R 4.0/Rtools40
-      - uses: r-lib/actions/setup-r@master
-        with:
-          rtools-version: 40
-          r-version: '4.0'
-          Ncpus: 2
-      - uses: r-lib/actions/setup-r@master
-        if: ${{ matrix.rtools == 35 }}
-        with:
-          rtools-version: 35
-          r-version: '3.6'
-          Ncpus: 2
-      - name: Build Arrow C++
-        shell: bash
-        env:
-          RTOOLS_VERSION: ${{ matrix.rtools }}
-        run: ci/scripts/r_windows_build.sh
-      - uses: actions/upload-artifact@v1
-        with:
-          name: Rtools ${{ matrix.rtools }} Arrow C++
-          path: libarrow.zip
-      - name: Install R package dependencies
-        shell: Rscript {0}
-        run: |
-          options(pkgType="win.binary")
-          install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps("r", dependencies = TRUE)
-      - name: Check
-        shell: Rscript {0}
-        run: |
-          Sys.setenv(
-            RWINLIB_LOCAL = file.path(Sys.getenv("GITHUB_WORKSPACE"), "libarrow.zip"),
-            MAKEFLAGS = paste0("-j", parallel::detectCores())
-          )
-          rcmdcheck::rcmdcheck("r",
-            build_args = '--no-build-vignettes',
-            args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'),
-            error_on = 'warning',
-            check_dir = 'check'
-          )
-      - name: Dump install logs
-        shell: cmd
-        run: cat check/arrow.Rcheck/00install.out
-        if: always()
+  # 
+  # windows:
+  #   name: AMD64 Windows RTools ${{ matrix.rtools }}
+  #   runs-on: windows-latest
+  #   if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       rtools: [35, 40]
+  #   env:
+  #     TEST_R_WITH_ARROW: "TRUE"
+  #     ARROW_R_CXXFLAGS: '-Werror'
+  #     _R_CHECK_TESTS_NLINES_: 0
+  #   steps:
+  #     - run: git config --global core.autocrlf false
+  #     - name: Checkout Arrow
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Make R tests verbose
+  #       # If you get a segfault/mysterious test Execution halted,
+  #       # make this `true` to see where it dies.
+  #       if: false
+  #       shell: cmd
+  #       run: |
+  #         cd r/tests
+  #         sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
+  #         rm -f testthat.R.bak
+  #     # We use the makepkg-mingw setup that is included in rtools40 even when
+  #     # we use the rtools35 compilers, so we always install R 4.0/Rtools40
+  #     - uses: r-lib/actions/setup-r@master
+  #       with:
+  #         rtools-version: 40
+  #         r-version: '4.0'
+  #         Ncpus: 2
+  #     - uses: r-lib/actions/setup-r@master
+  #       if: ${{ matrix.rtools == 35 }}
+  #       with:
+  #         rtools-version: 35
+  #         r-version: '3.6'
+  #         Ncpus: 2
+  #     - name: Build Arrow C++
+  #       shell: bash
+  #       env:
+  #         RTOOLS_VERSION: ${{ matrix.rtools }}
+  #       run: ci/scripts/r_windows_build.sh
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: Rtools ${{ matrix.rtools }} Arrow C++
+  #         path: libarrow.zip
+  #     - name: Install R package dependencies
+  #       shell: Rscript {0}
+  #       run: |
+  #         options(pkgType="win.binary")
+  #         install.packages(c("remotes", "rcmdcheck"))
+  #         remotes::install_deps("r", dependencies = TRUE)
+  #     - name: Check
+  #       shell: Rscript {0}
+  #       run: |
+  #         Sys.setenv(
+  #           RWINLIB_LOCAL = file.path(Sys.getenv("GITHUB_WORKSPACE"), "libarrow.zip"),
+  #           MAKEFLAGS = paste0("-j", parallel::detectCores())
+  #         )
+  #         rcmdcheck::rcmdcheck("r",
+  #           build_args = '--no-build-vignettes',
+  #           args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'),
+  #           error_on = 'warning',
+  #           check_dir = 'check'
+  #         )
+  #     - name: Dump install logs
+  #       shell: cmd
+  #       run: cat check/arrow.Rcheck/00install.out
+  #       if: always()

--- a/.github/workflows/r_blocked_by_infra.yml
+++ b/.github/workflows/r_blocked_by_infra.yml
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: R
+
+on:
+  push:
+    paths:
+      - '.github/workflows/r.yml'
+      - 'ci/scripts/r_*.sh'
+      - 'ci/scripts/cpp_*.sh'
+      - 'ci/scripts/PKGBUILD'
+      - 'ci/etc/rprofile'
+      - 'ci/docker/**'
+      - 'cpp/**'
+      - 'r/**'
+  pull_request:
+    paths:
+      - '.github/workflows/r.yml'
+      - 'ci/scripts/r_*.sh'
+      - 'ci/scripts/cpp_*.sh'
+      - 'ci/scripts/PKGBUILD'
+      - 'ci/etc/rprofile'
+      - 'ci/docker/**'
+      - 'cpp/**'
+      - 'r/**'
+
+env:
+  DOCKER_BUILDKIT: 0
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
+  ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  windows:
+    name: AMD64 Windows RTools ${{ matrix.rtools }}
+    runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rtools: [35, 40]
+    env:
+      TEST_R_WITH_ARROW: "TRUE"
+      ARROW_R_CXXFLAGS: '-Werror'
+      _R_CHECK_TESTS_NLINES_: 0
+    steps:
+      - run: git config --global core.autocrlf false
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Make R tests verbose
+        # If you get a segfault/mysterious test Execution halted,
+        # make this `true` to see where it dies.
+        if: false
+        shell: cmd
+        run: |
+          cd r/tests
+          sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
+          rm -f testthat.R.bak
+      # We use the makepkg-mingw setup that is included in rtools40 even when
+      # we use the rtools35 compilers, so we always install R 4.0/Rtools40
+      - uses: r-lib/actions/setup-r@master
+        with:
+          rtools-version: 40
+          r-version: '4.0'
+          Ncpus: 2
+      - uses: r-lib/actions/setup-r@master
+        if: ${{ matrix.rtools == 35 }}
+        with:
+          rtools-version: 35
+          r-version: '3.6'
+          Ncpus: 2
+      - name: Build Arrow C++
+        shell: bash
+        env:
+          RTOOLS_VERSION: ${{ matrix.rtools }}
+        run: ci/scripts/r_windows_build.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Rtools ${{ matrix.rtools }} Arrow C++
+          path: libarrow.zip
+      - name: Install R package dependencies
+        shell: Rscript {0}
+        run: |
+          options(pkgType="win.binary")
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps("r", dependencies = TRUE)
+      - name: Check
+        shell: Rscript {0}
+        run: |
+          Sys.setenv(
+            RWINLIB_LOCAL = file.path(Sys.getenv("GITHUB_WORKSPACE"), "libarrow.zip"),
+            MAKEFLAGS = paste0("-j", parallel::detectCores())
+          )
+          rcmdcheck::rcmdcheck("r",
+            build_args = '--no-build-vignettes',
+            args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'),
+            error_on = 'warning',
+            check_dir = 'check'
+          )
+      - name: Dump install logs
+        shell: cmd
+        run: cat check/arrow.Rcheck/00install.out
+        if: always()


### PR DESCRIPTION
Without warning, INFRA broke several of our GitHub Actions workflows, and have been unresponsive all week. See https://issues.apache.org/jira/browse/INFRA-21239. Since then, the Rust developers have removed their offending actions, so those are no longer blocked. This PR does harm reduction for C++ and R workflows, moving the workflows that INFRA doesn't like to their own files (temporarily, I hope, while this business gets sorted out). This enables the other workflows in each file to run, so we at least get some C++ and R tests running, and we can still verify on our personal forks the workflows that have been blocked on apache/arrow.