### PR TITLE
ARROW-11105: [Rust] Migrated MutableBuffer::freeze to From<MutableBuffer> for Buffer

### DIFF
--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -31,7 +31,7 @@ fn create_buffer(size: usize) -> Buffer {
         result.as_slice_mut()[i] = 0b01010101 << i << (i % 4);
     }
 
-    result.freeze()
+    result.into()
 }
 
 fn bench_buffer_and(left: &Buffer, right: &Buffer) {

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -36,7 +36,7 @@ fn mutable_buffer(data: &[Vec<u32>], capacity: usize) -> Buffer {
         data.iter()
             .for_each(|vec| result.extend_from_slice(vec.to_byte_slice()));
 
-        result.freeze()
+        result.into()
     })
 }
 

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -249,7 +249,7 @@ where
             .len(data_len)
             .add_buffer(Buffer::from(offsets.to_byte_slice()))
             .add_buffer(Buffer::from(&values[..]))
-            .null_bit_buffer(null_buf.freeze())
+            .null_bit_buffer(null_buf.into())
             .build();
         Self::from(array_data)
     }
@@ -401,7 +401,7 @@ impl From<Vec<Option<Vec<u8>>>> for FixedSizeBinaryArray {
             DataType::FixedSizeBinary(size as i32),
             len,
             None,
-            Some(null_buf.freeze()),
+            Some(null_buf.into()),
             0,
             vec![Buffer::from(&data)],
             vec![],

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -127,7 +127,7 @@ impl From<Vec<bool>> for BooleanArray {
         }
         let array_data = ArrayData::builder(DataType::Boolean)
             .len(data.len())
-            .add_buffer(mut_buf.freeze())
+            .add_buffer(mut_buf.into())
             .build();
         BooleanArray::from(array_data)
     }
@@ -196,9 +196,9 @@ impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
             DataType::Boolean,
             data_len,
             None,
-            Some(null_buf.freeze()),
+            Some(null_buf.into()),
             0,
-            vec![val_buf.freeze()],
+            vec![val_buf.into()],
             vec![],
         );
         BooleanArray::from(Arc::new(data))

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -329,9 +329,9 @@ impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native
             T::DATA_TYPE,
             data_len,
             None,
-            Some(null_buf.freeze()),
+            Some(null_buf.into()),
             0,
-            vec![val_buf.freeze()],
+            vec![val_buf.into()],
             vec![],
         );
         PrimitiveArray::from(Arc::new(data))
@@ -426,8 +426,8 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
         let array_data =
             ArrayData::builder(DataType::Timestamp(T::get_time_unit(), timezone))
                 .len(data_len)
-                .add_buffer(val_buf.freeze())
-                .null_bit_buffer(null_buf.freeze())
+                .add_buffer(val_buf.into())
+                .null_bit_buffer(null_buf.into())
                 .build();
         PrimitiveArray::from(array_data)
     }

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -181,7 +181,7 @@ where
             .len(data_len)
             .add_buffer(Buffer::from(offsets.to_byte_slice()))
             .add_buffer(Buffer::from(&values[..]))
-            .null_bit_buffer(null_buf.freeze())
+            .null_bit_buffer(null_buf.into())
             .build();
         Self::from(array_data)
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -286,7 +286,7 @@ impl<T: ArrowNativeType> BufferBuilder<T> {
     pub fn finish(&mut self) -> Buffer {
         let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
         self.len = 0;
-        buf.freeze()
+        buf.into()
     }
 }
 
@@ -377,7 +377,7 @@ impl BooleanBufferBuilder {
             if *v {
                 // For performance the `len` of the buffer is not
                 // updated on each append but is updated in the
-                // `freeze` method instead.
+                // `into` method instead.
                 unsafe {
                     bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len);
                 }
@@ -388,13 +388,13 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn finish(&mut self) -> Buffer {
-        // `append` does not update the buffer's `len` so do it before `freeze` is called.
+        // `append` does not update the buffer's `len` so do it before `into` is called.
         let new_buffer_len = bit_util::ceil(self.len, 8);
         debug_assert!(new_buffer_len >= self.buffer.len());
         let mut buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
         self.len = 0;
         buf.resize(new_buffer_len);
-        buf.freeze()
+        buf.into()
     }
 }
 
@@ -2011,7 +2011,7 @@ impl UnionBuilder {
         {
             let buffer = values_buffer
                 .expect("The `values_buffer` should only ever be None inside the `append` method.")
-                .freeze();
+                .into();
             let arr_data_builder = ArrayDataBuilder::new(data_type.clone())
                 .add_buffer(buffer)
                 .len(slots);

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -61,8 +61,8 @@ impl<'a> _MutableArrayData<'a> {
             DataType::Utf8
             | DataType::Binary
             | DataType::LargeUtf8
-            | DataType::LargeBinary => vec![self.buffer1.freeze(), self.buffer2.freeze()],
-            _ => vec![self.buffer1.freeze()],
+            | DataType::LargeBinary => vec![self.buffer1.into(), self.buffer2.into()],
+            _ => vec![self.buffer1.into()],
         };
 
         let child_data = match self.data_type {
@@ -80,7 +80,7 @@ impl<'a> _MutableArrayData<'a> {
             self.len,
             Some(self.null_count),
             if self.null_count > 0 {
-                Some(self.null_buffer.freeze())
+                Some(self.null_buffer.into())
             } else {
                 None
             },

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -112,7 +112,7 @@ where
         None,
         array.data_ref().null_buffer().cloned(),
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
@@ -283,7 +283,7 @@ where
         None,
         null_bit_buffer,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
@@ -470,7 +470,7 @@ where
         None,
         null_bit_buffer,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -179,7 +179,7 @@ pub fn is_null(input: &Array) -> Result<BooleanArray> {
             let len_bytes = ceil(len, 8);
             MutableBuffer::new(len_bytes)
                 .with_bitset(len_bytes, false)
-                .freeze()
+                .into()
         }
         Some(buffer) => buffer_unary_not(buffer, input.offset(), len),
     };
@@ -213,7 +213,7 @@ pub fn is_not_null(input: &Array) -> Result<BooleanArray> {
             let len_bytes = ceil(len, 8);
             MutableBuffer::new(len_bytes)
                 .with_bitset(len_bytes, true)
-                .freeze()
+                .into()
         }
         Some(buffer) => buffer.bit_slice(input.offset(), len),
     };

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -69,7 +69,7 @@ macro_rules! compare_op {
             None,
             null_bit_buffer,
             0,
-            vec![buffer.freeze()],
+            vec![buffer.into()],
             vec![],
         );
         Ok(BooleanArray::from(Arc::new(data)))
@@ -102,7 +102,7 @@ macro_rules! compare_op_scalar {
             None,
             null_bit_buffer,
             0,
-            vec![buffer.freeze()],
+            vec![buffer.into()],
             vec![],
         );
         Ok(BooleanArray::from(Arc::new(data)))
@@ -452,7 +452,7 @@ where
         None,
         null_bit_buffer,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     );
     Ok(BooleanArray::from(Arc::new(data)))
@@ -535,7 +535,7 @@ where
         Some(null_count),
         null_bit_buffer,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     );
     Ok(BooleanArray::from(Arc::new(data)))
@@ -737,7 +737,7 @@ where
         None,
         None,
         0,
-        vec![bool_buf.freeze()],
+        vec![bool_buf.into()],
         vec![],
     );
     Ok(BooleanArray::from(Arc::new(data)))
@@ -795,7 +795,7 @@ where
         None,
         None,
         0,
-        vec![bool_buf.freeze()],
+        vec![bool_buf.into()],
         vec![],
     );
     Ok(BooleanArray::from(Arc::new(data)))
@@ -807,7 +807,7 @@ fn new_all_set_buffer(len: usize) -> Buffer {
     let buffer = MutableBuffer::new(len);
     let buffer = buffer.with_bitset(len, true);
 
-    buffer.freeze()
+    buffer.into()
 }
 
 // disable wrapping inside literal vectors used for test data and assertions

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -317,7 +317,7 @@ fn sort_boolean(
         Some(0),
         None,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     ));
 
@@ -384,7 +384,7 @@ where
         Some(0),
         None,
         0,
-        vec![result.freeze()],
+        vec![result.into()],
         vec![],
     ));
 

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -308,11 +308,11 @@ where
             Some(buffer) => Some(buffer_bin_and(
                 buffer,
                 0,
-                &null_buf.freeze(),
+                &null_buf.into(),
                 0,
                 indices.len(),
             )),
-            None => Some(null_buf.freeze()),
+            None => Some(null_buf.into()),
         };
     }
 
@@ -322,7 +322,7 @@ where
         None,
         nulls,
         0,
-        vec![buffer.freeze()],
+        vec![buffer.into()],
         vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
@@ -383,11 +383,11 @@ where
             Some(buffer) => Some(buffer_bin_and(
                 buffer,
                 0,
-                &null_buf.freeze(),
+                &null_buf.into(),
                 0,
                 indices.len(),
             )),
-            None => Some(null_buf.freeze()),
+            None => Some(null_buf.into()),
         };
     }
 
@@ -397,7 +397,7 @@ where
         None,
         nulls,
         0,
-        vec![val_buf.freeze()],
+        vec![val_buf.into()],
         vec![],
     );
     Ok(BooleanArray::from(Arc::new(data)))
@@ -459,7 +459,7 @@ where
             }
             *offset = length_so_far;
         }
-        nulls = Some(null_buf.freeze());
+        nulls = Some(null_buf.into());
     } else if array.null_count() == 0 {
         for (i, offset) in offsets.iter_mut().skip(1).enumerate() {
             if indices.is_valid(i) {
@@ -501,15 +501,15 @@ where
 
         nulls = match indices.data_ref().null_buffer() {
             Some(buffer) => {
-                Some(buffer_bin_and(buffer, 0, &null_buf.freeze(), 0, data_len))
+                Some(buffer_bin_and(buffer, 0, &null_buf.into(), 0, data_len))
             }
-            None => Some(null_buf.freeze()),
+            None => Some(null_buf.into()),
         };
     }
 
     let mut data = ArrayData::builder(<OffsetSize as StringOffsetSizeTrait>::DATA_TYPE)
         .len(data_len)
-        .add_buffer(offsets_buffer.freeze())
+        .add_buffer(offsets_buffer.into())
         .add_buffer(Buffer::from(values));
     if let Some(null_buffer) = nulls {
         data = data.null_bit_buffer(null_buffer);
@@ -559,7 +559,7 @@ where
     // create a new list with taken data and computed null information
     let list_data = ArrayDataBuilder::new(values.data_type().clone())
         .len(indices.len())
-        .null_bit_buffer(null_buf.freeze())
+        .null_bit_buffer(null_buf.into())
         .offset(0)
         .add_child_data(taken.data())
         .add_buffer(value_offsets)
@@ -600,7 +600,7 @@ where
 
     let list_data = ArrayDataBuilder::new(values.data_type().clone())
         .len(indices.len())
-        .null_bit_buffer(null_buf.freeze())
+        .null_bit_buffer(null_buf.into())
         .offset(0)
         .add_child_data(taken.data())
         .build();

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -335,7 +335,7 @@ pub(super) mod tests {
 
         let list_data = ArrayData::builder(list_data_type)
             .len(list_len)
-            .null_bit_buffer(list_bitmap.freeze())
+            .null_bit_buffer(list_bitmap.into())
             .add_buffer(value_offsets)
             .add_child_data(value_data)
             .build();
@@ -400,7 +400,7 @@ pub(super) mod tests {
 
         let list_data = ArrayData::builder(list_data_type)
             .len(list_len)
-            .null_bit_buffer(list_bitmap.freeze())
+            .null_bit_buffer(list_bitmap.into())
             .add_child_data(child_data)
             .build();
 

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -675,7 +675,7 @@ fn write_array_data(
                 let num_bytes = bit_util::ceil(num_rows, 8);
                 let buffer = MutableBuffer::new(num_bytes);
                 let buffer = buffer.with_bitset(num_bytes, true);
-                buffer.freeze()
+                buffer.into()
             }
             Some(buffer) => buffer.clone(),
         };

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -914,8 +914,8 @@ impl Decoder {
                 });
                 ArrayData::builder(list_field.data_type().clone())
                     .len(valid_len)
-                    .add_buffer(bool_values.freeze())
-                    .null_bit_buffer(bool_nulls.freeze())
+                    .add_buffer(bool_values.into())
+                    .null_bit_buffer(bool_nulls.into())
                     .build()
             }
             DataType::Int8 => self.read_primitive_list_values::<Int8Type>(rows),
@@ -986,7 +986,7 @@ impl Decoder {
                 let arrays =
                     self.build_struct_array(rows.as_slice(), fields.as_slice(), &[])?;
                 let data_type = DataType::Struct(fields.clone());
-                let buf = null_buffer.freeze();
+                let buf = null_buffer.into();
                 ArrayDataBuilder::new(data_type)
                     .len(rows.len())
                     .null_bit_buffer(buf)
@@ -1005,7 +1005,7 @@ impl Decoder {
             .len(list_len)
             .add_buffer(Buffer::from(offsets.to_byte_slice()))
             .add_child_data(array_data)
-            .null_bit_buffer(list_nulls.freeze())
+            .null_bit_buffer(list_nulls.into())
             .build();
         Ok(Arc::new(GenericListArray::<OffsetSize>::from(list_data)))
     }
@@ -1192,7 +1192,7 @@ impl Decoder {
                         let data_type = DataType::Struct(fields.clone());
                         let data = ArrayDataBuilder::new(data_type)
                             .len(len)
-                            .null_bit_buffer(null_buffer.freeze())
+                            .null_bit_buffer(null_buffer.into())
                             .child_data(arrays.into_iter().map(|a| a.data()).collect())
                             .build();
                         Ok(make_array(data))

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -604,7 +604,7 @@ fn create_null_buf(json_col: &ArrowJsonColumn) -> Buffer {
                 bit_util::set_bit(null_slice, i);
             }
         });
-    null_buf.freeze()
+    null_buf.into()
 }
 
 fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -936,7 +936,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
             .len(offsets.len() - 1)
             .add_buffer(value_offsets)
             .add_child_data(batch_values.data())
-            .null_bit_buffer(null_buf.freeze())
+            .null_bit_buffer(null_buf.into())
             .offset(next_batch_array.offset())
             .build();
 
@@ -1106,7 +1106,7 @@ impl ArrayReader for StructArrayReader {
             })
             .transpose()?;
 
-        self.def_level_buffer = Some(def_level_data_buffer.freeze());
+        self.def_level_buffer = Some(def_level_data_buffer.into());
         self.rep_level_buffer = rep_level_data;
         Ok(Arc::new(StructArray::from(array_data)))
     }

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -174,7 +174,7 @@ impl<T: DataType> RecordReader<T> {
             None
         };
 
-        Ok(replace(&mut self.def_levels, new_buffer).map(|x| x.freeze()))
+        Ok(replace(&mut self.def_levels, new_buffer).map(|x| x.into()))
     }
 
     /// Return repetition level data.
@@ -202,7 +202,7 @@ impl<T: DataType> RecordReader<T> {
             None
         };
 
-        Ok(replace(&mut self.rep_levels, new_buffer).map(|x| x.freeze()))
+        Ok(replace(&mut self.rep_levels, new_buffer).map(|x| x.into()))
     }
 
     /// Returns currently stored buffer data.
@@ -224,7 +224,7 @@ impl<T: DataType> RecordReader<T> {
 
         self.records.resize(new_len);
 
-        Ok(replace(&mut self.records, new_buffer).freeze())
+        Ok(replace(&mut self.records, new_buffer).into())
     }
 
     /// Returns currently stored null bitmap data.


### PR DESCRIPTION
A backward incompatible modification of the `MutableBuffer`'s API to use `std`'s trait for convertion to `Buffer`.

`std` offers a trait exactly for this. This PR just uses it.
