### PR TITLE
ARROW-11100: [Rust] Speed up numeric to string cast using lexical_core

### DIFF
--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -196,6 +196,9 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast i64 to string 512", |b| {
         b.iter(|| cast_array(&i64_array, DataType::Utf8))
     });
+    c.bench_function("cast f32 to string 512", |b| {
+        b.iter(|| cast_array(&f32_array, DataType::Utf8))
+    });
 
     c.bench_function("cast timestamp_ms to i64 512", |b| {
         b.iter(|| cast_array(&time_ms_array, DataType::Int64))

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -897,7 +897,7 @@ where
     T::Native: lexical_core::ToLexical,
 {
     from.iter()
-        .map(|maybe_value| maybe_value.map(|value| lexical_to_string(value)))
+        .map(|maybe_value| maybe_value.map(lexical_to_string))
         .collect()
 }
 

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -38,11 +38,11 @@
 use std::str;
 use std::sync::Arc;
 
-use crate::buffer::Buffer;
 use crate::compute::kernels::arithmetic::{divide, multiply};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::{array::*, compute::take};
+use crate::{buffer::Buffer, util::serialization::lexical_to_string};
 
 /// Return true if a value of type `from_type` can be cast into a
 /// value of `to_type`. Note that such as cast may be lossy.
@@ -881,7 +881,7 @@ where
 fn cast_numeric_to_string<FROM>(array: &ArrayRef) -> Result<ArrayRef>
 where
     FROM: ArrowNumericType,
-    FROM::Native: std::string::ToString,
+    FROM::Native: lexical_core::ToLexical,
 {
     Ok(Arc::new(numeric_to_string_cast::<FROM>(
         array
@@ -894,10 +894,10 @@ where
 fn numeric_to_string_cast<T>(from: &PrimitiveArray<T>) -> StringArray
 where
     T: ArrowPrimitiveType + ArrowNumericType,
-    T::Native: std::string::ToString,
+    T::Native: lexical_core::ToLexical,
 {
     from.iter()
-        .map(|maybe_value| maybe_value.map(|value| value.to_string()))
+        .map(|maybe_value| maybe_value.map(|value| lexical_to_string(value)))
         .collect()
 }
 

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -69,7 +69,7 @@ use csv as csv_crate;
 
 use std::io::Write;
 
-use crate::array::*;
+use crate::{array::*, util::serialization::lexical_to_string};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
@@ -77,29 +77,13 @@ const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";
 
-pub fn to_string<N: lexical_core::ToLexical>(n: N) -> String {
-    let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
-    unsafe {
-        // JUSTIFICATION
-        //  Benefit
-        //      Allows using the faster serializer lexical core and convert to string
-        //  Soundness
-        //      Length of buf is set as written length afterwards. lexical_core
-        //      creates a valid string, so doesn't need to be checked.
-        let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
-        let len = lexical_core::write(n, slice).len();
-        buf.set_len(len);
-        String::from_utf8_unchecked(buf)
-    }
-}
-
 fn write_primitive_value<T>(array: &ArrayRef, i: usize) -> String
 where
     T: ArrowNumericType,
     T::Native: lexical_core::ToLexical,
 {
     let c = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
-    to_string(c.value(i))
+    lexical_to_string(c.value(i))
 }
 
 /// A CSV writer

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -69,10 +69,10 @@ use csv as csv_crate;
 
 use std::io::Write;
 
-use crate::{array::*, util::serialization::lexical_to_string};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
+use crate::{array::*, util::serialization::lexical_to_string};
 const DEFAULT_DATE_FORMAT: &str = "%F";
 const DEFAULT_TIME_FORMAT: &str = "%T";
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%FT%H:%M:%S.%9f";

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -21,6 +21,6 @@ pub mod display;
 pub mod integration_util;
 #[cfg(feature = "prettyprint")]
 pub mod pretty;
+pub mod serialization;
 pub mod string_writer;
 pub mod test_util;
-pub mod serialization;

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -21,6 +21,6 @@ pub mod display;
 pub mod integration_util;
 #[cfg(feature = "prettyprint")]
 pub mod pretty;
-pub mod serialization;
+pub(crate) mod serialization;
 pub mod string_writer;
 pub mod test_util;

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -23,3 +23,4 @@ pub mod integration_util;
 pub mod pretty;
 pub mod string_writer;
 pub mod test_util;
+pub mod serialization;

--- a/rust/arrow/src/util/serialization.rs
+++ b/rust/arrow/src/util/serialization.rs
@@ -1,0 +1,16 @@
+/// Converts numeric type to a `String`
+pub fn lexical_to_string<N: lexical_core::ToLexical>(n: N) -> String {
+    let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);
+    unsafe {
+        // JUSTIFICATION
+        //  Benefit
+        //      Allows using the faster serializer lexical core and convert to string
+        //  Soundness
+        //      Length of buf is set as written length afterwards. lexical_core
+        //      creates a valid string, so doesn't need to be checked.
+        let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
+        let len = lexical_core::write(n, slice).len();
+        buf.set_len(len);
+        String::from_utf8_unchecked(buf)
+    }
+}

--- a/rust/arrow/src/util/serialization.rs
+++ b/rust/arrow/src/util/serialization.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 /// Converts numeric type to a `String`
 pub fn lexical_to_string<N: lexical_core::ToLexical>(n: N) -> String {
     let mut buf = Vec::<u8>::with_capacity(N::FORMATTED_SIZE_DECIMAL);


### PR DESCRIPTION
Uses lexical_core to speed up num to string casts.

This gets a nice speed up, especially for floats:
```
cast i64 to string 512  time:   [22.209 us 22.462 us 22.885 us]
                        change: [-38.438% -37.979% -37.154%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  11 (11.00%) low mild
  3 (3.00%) high severe

Benchmarking cast f32 to string 512: Collecting 100 samples in estimated 5.0698                                                                                 cast f32 to string 512  time:   [25.587 us 25.692 us 25.786 us]
                        change: [-62.364% -62.215% -62.076%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
```