### PR TITLE
ARROW-11030: [Rust][DataFusion] Concatenate left side batches to single batch in HashJoinExec

### DIFF
--- a/rust/datafusion/src/physical_plan/coalesce_batches.rs
+++ b/rust/datafusion/src/physical_plan/coalesce_batches.rs
@@ -194,7 +194,7 @@ impl RecordBatchStream for CoalesceBatchesStream {
     }
 }
 
-fn concat_batches(
+pub fn concat_batches(
     schema: &SchemaRef,
     batches: &[RecordBatch],
     row_count: usize,

--- a/rust/datafusion/src/physical_plan/coalesce_batches.rs
+++ b/rust/datafusion/src/physical_plan/coalesce_batches.rs
@@ -194,6 +194,7 @@ impl RecordBatchStream for CoalesceBatchesStream {
     }
 }
 
+/// Concatenates an array of `RecordBatch` into one batch
 pub fn concat_batches(
     schema: &SchemaRef,
     batches: &[RecordBatch],

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -515,7 +515,6 @@ fn build_join_indexes(
                     left_indices.append_slice(&indices)?;
 
                     for _ in 0..indices.len() {
-                        // on an inner join, left and right indices are present
                         right_indices.append_value(row as u32)?;
                     }
                 }
@@ -525,6 +524,9 @@ fn build_join_indexes(
         JoinType::Left => {
             // Keep track of which item is visited in the build input
             // TODO: this can be stored more efficiently with a marker
+            //       https://issues.apache.org/jira/browse/ARROW-11116
+            // TODO: Fix LEFT join with multiple right batches
+            //       https://issues.apache.org/jira/browse/ARROW-10971
             let mut is_visited = HashSet::new();
 
             // First visit all of the rows
@@ -535,7 +537,6 @@ fn build_join_indexes(
                     is_visited.insert(key.clone());
                     left_indices.append_slice(&indices)?;
                     for _ in 0..indices.len() {
-                        // on an inner join, left and right indices are present
                         right_indices.append_value(row as u32)?;
                     }
                 };

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -215,8 +215,8 @@ impl ExecutionPlan for HashJoinExec {
                         .try_fold(initial, |mut acc, batch| async {
                             let hash = &mut acc.0;
                             let values = &mut acc.1;
-                            let index = acc.2;
-                            update_hash(&on_left, &batch, hash, index).unwrap();
+                            let offset = acc.2;
+                            update_hash(&on_left, &batch, hash, offset).unwrap();
                             acc.2 += batch.num_rows();
                             values.push(batch);
                             Ok(acc)
@@ -274,7 +274,7 @@ fn update_hash(
     on: &HashSet<String>,
     batch: &RecordBatch,
     hash: &mut JoinHashMap,
-    index: usize,
+    offset: usize,
 ) -> Result<()> {
     // evaluate the keys
     let keys_values = on
@@ -290,8 +290,8 @@ fn update_hash(
 
         hash.raw_entry_mut()
             .from_key(&key)
-            .and_modify(|_, v| v.push(row + index))
-            .or_insert_with(|| (key.clone(), vec![row + index]));
+            .and_modify(|_, v| v.push(row + offset))
+            .or_insert_with(|| (key.clone(), vec![row + offset]));
     }
     Ok(())
 }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -380,7 +380,7 @@ pub(crate) fn create_key(
                 // store the size
                 vec.extend(value.len().to_le_bytes().iter());
                 // store the string value
-                vec.extend(array.value(row).as_bytes().iter());
+                vec.extend(value.as_bytes().iter());
             }
             _ => {
                 // This is internal because we should have caught this before.

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -222,8 +222,6 @@ impl ExecutionPlan for HashJoinExec {
                             Ok(acc)
                         })
                         .await?;
-                    let num_rows: usize =
-                        batches.iter().map(|batch| batch.num_rows()).sum();
 
                     let single_batch =
                         concat_batches(&batches[0].schema(), &batches, num_rows)?;

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -509,10 +509,9 @@ fn build_join_indexes(
             for row in 0..right.num_rows() {
                 // Get the key and find it in the build index
                 create_key(&keys_values, row, &mut key)?;
-                let left_indexes = left.get(&key);
-                // for every item on the left and right with this key, add the respective pair
 
-                if let Some(indices) = left_indexes {
+                // for every item on the left and right with this key, add the respective pair
+                if let Some(indices) = left.get(&key) {
                     left_indices.append_slice(&indices)?;
 
                     for _ in 0..indices.len() {
@@ -531,9 +530,8 @@ fn build_join_indexes(
             // First visit all of the rows
             for row in 0..right.num_rows() {
                 create_key(&keys_values, row, &mut key)?;
-                let left_indexes = left.get(&key);
 
-                if let Some(indices) = left_indexes {
+                if let Some(indices) = left.get(&key) {
                     is_visited.insert(key.clone());
                     left_indices.append_slice(&indices)?;
                     for _ in 0..indices.len() {
@@ -558,9 +556,7 @@ fn build_join_indexes(
             for row in 0..right.num_rows() {
                 create_key(&keys_values, row, &mut key)?;
 
-                let left_indexes = left.get(&key);
-
-                match left_indexes {
+                match left.get(&key) {
                     Some(indices) => {
                         left_indices.append_slice(&indices)?;
 

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -295,8 +295,8 @@ fn update_hash(
 
         hash.raw_entry_mut()
             .from_key(&key)
-            .and_modify(|_, v| v.push(row as u64 + offset as u64))
-            .or_insert_with(|| (key.clone(), vec![row as u64 + offset as u64]));
+            .and_modify(|_, v| v.push((row + offset) as u64))
+            .or_insert_with(|| (key.clone(), vec![(row + offset) as u64]));
     }
     Ok(())
 }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -81,8 +81,11 @@ pub struct HashJoinExec {
     build_side: Arc<Mutex<Option<JoinLeftData>>>,
 }
 
+/// Information about the index and placement (left or right) of the columns
 struct ColumnIndex {
+    /// Index of the column 
     index: usize,
+    /// Whether the column is at the left or right side
     is_left: bool,
 }
 

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -217,9 +217,9 @@ impl ExecutionPlan for HashJoinExec {
                             let hash = &mut acc.0;
                             let values = &mut acc.1;
                             let index = acc.2;
-                            update_hash(&on_left, &batch, hash, 0).unwrap();
+                            update_hash(&on_left, &batch, hash, index).unwrap();
+                            acc.2 += batch.num_rows();
                             values.push(batch);
-                            acc.2 += 1;
                             Ok(acc)
                         })
                         .await?;
@@ -276,8 +276,8 @@ fn update_hash(
 
         hash.raw_entry_mut()
             .from_key(&key)
-            .and_modify(|_, v| v.push((index, row)))
-            .or_insert_with(|| (key.clone(), vec![(index, row)]));
+            .and_modify(|_, v| v.push((0, row + index)))
+            .or_insert_with(|| (key.clone(), vec![(0, row + index)]));
     }
     Ok(())
 }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -18,8 +18,11 @@
 //! Defines the join plan for executing partitions in parallel and then joining the results
 //! into a set of partitions.
 
-use arrow::{array::{TimestampMicrosecondArray, TimestampNanosecondArray, UInt32Builder}, datatypes::TimeUnit};
 use arrow::{array::ArrayRef, compute};
+use arrow::{
+    array::{TimestampMicrosecondArray, TimestampNanosecondArray, UInt32Builder},
+    datatypes::TimeUnit,
+};
 use std::sync::Arc;
 use std::{any::Any, collections::HashSet};
 
@@ -342,23 +345,23 @@ pub(crate) fn create_key(
         match col.data_type() {
             DataType::UInt8 => {
                 let array = col.as_any().downcast_ref::<UInt8Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::UInt16 => {
                 let array = col.as_any().downcast_ref::<UInt16Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::UInt32 => {
                 let array = col.as_any().downcast_ref::<UInt32Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::UInt64 => {
                 let array = col.as_any().downcast_ref::<UInt64Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Int8 => {
                 let array = col.as_any().downcast_ref::<Int8Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Int16 => {
                 let array = col.as_any().downcast_ref::<Int16Array>().unwrap();
@@ -366,33 +369,33 @@ pub(crate) fn create_key(
             }
             DataType::Int32 => {
                 let array = col.as_any().downcast_ref::<Int32Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Int64 => {
                 let array = col.as_any().downcast_ref::<Int64Array>().unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Timestamp(TimeUnit::Microsecond, None) => {
                 let array = col
                     .as_any()
                     .downcast_ref::<TimestampMicrosecondArray>()
                     .unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                 let array = col
                     .as_any()
                     .downcast_ref::<TimestampNanosecondArray>()
                     .unwrap();
-                vec.extend(array.value(row).to_le_bytes().iter());
+                vec.extend_from_slice(&array.value(row).to_le_bytes());
             }
             DataType::Utf8 => {
                 let array = col.as_any().downcast_ref::<StringArray>().unwrap();
                 let value = array.value(row);
                 // store the size
-                vec.extend(value.len().to_le_bytes().iter());
+                vec.extend_from_slice(&value.len().to_le_bytes());
                 // store the string value
-                vec.extend(value.as_bytes().iter());
+                vec.extend_from_slice(value.as_bytes());
             }
             _ => {
                 // This is internal because we should have caught this before.

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -212,7 +212,7 @@ impl ExecutionPlan for HashJoinExec {
                     // 1. creates a [JoinHashMap] of all batches from the stream
                     // 2. stores the batches in a vector.
                     let initial = (JoinHashMap::default(), Vec::new(), 0);
-                    let (hashmap, batches, _len) = stream
+                    let (hashmap, batches, num_rows) = stream
                         .try_fold(initial, |mut acc, batch| async {
                             let hash = &mut acc.0;
                             let values = &mut acc.1;
@@ -223,7 +223,9 @@ impl ExecutionPlan for HashJoinExec {
                             Ok(acc)
                         })
                         .await?;
-                    let single_batch = vec![concat_batches(&batches[0].schema(), &batches, 32768)?];
+
+                    let single_batch =
+                        vec![concat_batches(&batches[0].schema(), &batches, num_rows)?];
 
                     let left_side = Arc::new((hashmap, single_batch));
                     *build_side = Some(left_side.clone());


### PR DESCRIPTION
This PR removes the exponential slowdown based on the number of left/right batches in the hash join by concatenating all left batches to a single batch, so we can directly index into the array (with `take`) instead of building a structure / iterating all the left arrays. This also simplifies the code, which can help with further speed improvements and reducing memory usage.

The benchmark results look very promising, mostly removing the overhead of small batches and big datasets with many left-side batches. For a very small batch size of 64, on tcph q 12:

```
Query 12 iteration 0 took 1596.1 ms
Query 12 iteration 1 took 1602.6 ms
Query 12 iteration 2 took 1594.3 ms
Query 12 iteration 3 took 1610.6 ms
Query 12 iteration 4 took 1615.9 ms
Query 12 iteration 5 took 1619.8 ms
Query 12 iteration 6 took 1645.5 ms
Query 12 iteration 7 took 1653.7 ms
Query 12 iteration 8 took 1644.0 ms
Query 12 iteration 9 took 1641.9 ms
Query 12 avg time: 1622.43 ms
```

Master

```
Query 12 iteration 0 took 10701.6 ms
Query 12 iteration 1 took 10949.0 ms
Query 12 iteration 2 took 11556.2 ms
Query 12 iteration 3 took 11929.1 ms
Query 12 iteration 4 took 11850.4 ms
Query 12 iteration 5 took 11993.6 ms
Query 12 iteration 6 took 12132.9 ms
Query 12 iteration 7 took 12637.8 ms
Query 12 iteration 8 took 12561.6 ms
Query 12 iteration 9 took 12887.9 ms
Query 12 avg time: 11920.01 ms
```


The PR also includes improvements on query 1 / 5 (batch size 64k):

This PR:
```
Query 1 iteration 0 took 571.0 ms
Query 1 iteration 1 took 566.0 ms
Query 1 iteration 2 took 569.0 ms
Query 1 iteration 3 took 565.1 ms
Query 1 iteration 4 took 569.6 ms
Query 1 iteration 5 took 567.7 ms
Query 1 iteration 6 took 567.7 ms
Query 1 iteration 7 took 564.9 ms
Query 1 iteration 8 took 566.2 ms
Query 1 iteration 9 took 567.1 ms
Query 1 avg time: 567.44 ms
```

Master

```
Query 1 iteration 0 took 647.8 ms
Query 1 iteration 1 took 632.8 ms
Query 1 iteration 2 took 634.1 ms
Query 1 iteration 3 took 629.0 ms
Query 1 iteration 4 took 631.8 ms
Query 1 iteration 5 took 639.6 ms
Query 1 iteration 6 took 640.1 ms
Query 1 iteration 7 took 628.1 ms
Query 1 iteration 8 took 635.3 ms
Query 1 iteration 9 took 642.9 ms
Query 1 avg time: 636.16 ms
```

PR
```
Query 5 iteration 0 took 628.6 ms
Query 5 iteration 1 took 604.9 ms
Query 5 iteration 2 took 619.2 ms
Query 5 iteration 3 took 614.4 ms
Query 5 iteration 4 took 629.2 ms
Query 5 iteration 5 took 617.0 ms
Query 5 iteration 6 took 618.9 ms
Query 5 iteration 7 took 636.1 ms
Query 5 iteration 8 took 639.5 ms
Query 5 iteration 9 took 636.1 ms
Query 5 avg time: 624.39 ms
```

Master:
```
Query 5 iteration 0 took 662.2 ms
Query 5 iteration 1 took 715.7 ms
Query 5 iteration 2 took 671.4 ms
Query 5 iteration 3 took 664.9 ms
Query 5 iteration 4 took 645.6 ms
Query 5 iteration 5 took 655.9 ms
Query 5 iteration 6 took 657.7 ms
Query 5 iteration 7 took 634.3 ms
Query 5 iteration 8 took 658.3 ms
Query 5 iteration 9 took 665.6 ms
Query 5 avg time: 663.15 ms
```