### PR TITLE
ARROW-11095 [Python] access pyarrow.RecordBatch field() and column() by string name

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -721,11 +721,13 @@ cdef class RecordBatch(_PandasConvertible):
             field_indices = self.schema.get_all_field_indices(i)
 
             if len(field_indices) == 0:
-                raise KeyError("Field \"{}\" does not exist in record batch schema"
-                               .format(i))
+                raise KeyError(
+                    "Field \"{}\" does not exist in record batch schema"
+                    .format(i))
             elif len(field_indices) > 1:
-                raise KeyError("Field \"{}\" exists {} times in record batch schema"
-                               .format(i, len(field_indices)))
+                raise KeyError(
+                    "Field \"{}\" exists {} times in record batch schema"
+                    .format(i, len(field_indices)))
             else:
                 return field_indices[0]
         elif isinstance(i, int):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -783,17 +783,17 @@ cdef class RecordBatch(_PandasConvertible):
 
     def __getitem__(self, key):
         """
-        Slice or return column at given index
+        Slice or return column at given index or column name
 
         Parameters
         ----------
-        key : integer or slice
+        key : integer, str, or slice
             Slices with step not equal to 1 (or None) will produce a copy
             rather than a zero-copy view
 
         Returns
         -------
-        value : ChunkedArray (index) or RecordBatch (slice)
+        value : Array (index/column) or RecordBatch (slice)
         """
         if isinstance(key, slice):
             return _normalize_slice(self, key)
@@ -1187,6 +1187,19 @@ cdef class Table(_PandasConvertible):
         return _reconstruct_table, (columns, self.schema)
 
     def __getitem__(self, key):
+        """
+        Slice or return column at given index or column name
+
+        Parameters
+        ----------
+        key : integer, str, or slice
+            Slices with step not equal to 1 (or None) will produce a copy
+            rather than a zero-copy view
+
+        Returns
+        -------
+        value : ChunkedArray (index/column) or Table (slice)
+        """
         if isinstance(key, slice):
             return _normalize_slice(self, key)
         else:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -687,6 +687,21 @@ cdef class RecordBatch(_PandasConvertible):
 
         return self._schema
 
+    def field(self, i):
+        """
+        Select a schema field by its column name or numeric index
+
+        Parameters
+        ----------
+        i : int or string
+            The index or name of the field to retrieve
+
+        Returns
+        -------
+        pyarrow.Field
+        """
+        return self.schema.field(i)
+
     @property
     def columns(self):
         """
@@ -698,9 +713,49 @@ cdef class RecordBatch(_PandasConvertible):
         """
         return [self.column(i) for i in range(self.num_columns)]
 
+    def _ensure_integer_index(self, i):
+        """
+        Ensure integer index (convert string column name to integer if needed).
+        """
+        if isinstance(i, (bytes, str)):
+            field_indices = self.schema.get_all_field_indices(i)
+
+            if len(field_indices) == 0:
+                raise KeyError("Field \"{}\" does not exist in record batch schema"
+                               .format(i))
+            elif len(field_indices) > 1:
+                raise KeyError("Field \"{}\" exists {} times in record batch schema"
+                               .format(i, len(field_indices)))
+            else:
+                return field_indices[0]
+        elif isinstance(i, int):
+            return i
+        else:
+            raise TypeError("Index must either be string or integer")
+
     def column(self, i):
         """
         Select single column from record batch
+
+        Parameters
+        ----------
+        i : int or string
+            The index or name of the column to retrieve.
+
+        Returns
+        -------
+        column : pyarrow.Array
+        """
+        return self._column(self._ensure_integer_index(i))
+
+    def _column(self, int i):
+        """
+        Select single column from record batch by its numeric index.
+
+        Parameters
+        ----------
+        i : int
+            The index of the column to retrieve.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -595,8 +595,8 @@ def test_recordbatch_select_column():
 
     assert batch.column('a').equals(batch.column(0))
 
-    with pytest.raises(KeyError,
-                       match='Field "d" does not exist in record batch schema'):
+    with pytest.raises(
+            KeyError, match='Field "d" does not exist in record batch schema'):
         batch.column('d')
 
     with pytest.raises(TypeError):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -564,6 +564,48 @@ def test_recordbatch_pickle():
     assert result.schema == schema
 
 
+def test_recordbatch_get_field():
+    data = [
+        pa.array(range(5)),
+        pa.array([-10, -5, 0, 5, 10]),
+        pa.array(range(5, 10))
+    ]
+    batch = pa.RecordBatch.from_arrays(data, names=('a', 'b', 'c'))
+
+    assert batch.field('a').equals(batch.schema.field('a'))
+    assert batch.field(0).equals(batch.schema.field('a'))
+
+    with pytest.raises(KeyError):
+        batch.field('d')
+
+    with pytest.raises(TypeError):
+        batch.field(None)
+
+    with pytest.raises(IndexError):
+        batch.field(4)
+
+
+def test_recordbatch_select_column():
+    data = [
+        pa.array(range(5)),
+        pa.array([-10, -5, 0, 5, 10]),
+        pa.array(range(5, 10))
+    ]
+    batch = pa.RecordBatch.from_arrays(data, names=('a', 'b', 'c'))
+
+    assert batch.column('a').equals(batch.column(0))
+
+    with pytest.raises(KeyError,
+                       match='Field "d" does not exist in record batch schema'):
+        batch.column('d')
+
+    with pytest.raises(TypeError):
+        batch.column(None)
+
+    with pytest.raises(IndexError):
+        batch.column(4)
+
+
 def test_recordbatch_from_struct_array_invalid():
     with pytest.raises(TypeError):
         pa.RecordBatch.from_struct_array(pa.array(range(5)))


### PR DESCRIPTION
These changes make it easier to get an Array / Field from a `pyarrow.RecordBatch` by name, mimicking the existing functionality of the `pyarrow.Table` API.

```python
# Existing pyarrow.Table API:
table.field('my_column') # returns pyarrow.Field
table.column('my_column') # returns pyarrow.ChunkedArray
table['my_column'] # returns pyarrow.ChunkedArray

# New pyarrow.RecordBatch API:
batch.field('my_column') # returns pyarrow.Field
batch.column('my_column') # returns pyarrow.Array
batch['my_column'] # returns pyarrow.Array
```