### PR TITLE
ARROW-11111: [GLib] Add GArrowFixedSizeBinaryArrayBuilder

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -798,6 +798,54 @@ gboolean garrow_large_string_array_builder_append_strings(GArrowLargeStringArray
                                                           GError **error);
 
 
+#define GARROW_TYPE_FIXED_SIZE_BINARY_ARRAY_BUILDER      \
+  (garrow_fixed_size_binary_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeBinaryArrayBuilder,
+                         garrow_fixed_size_binary_array_builder,
+                         GARROW,
+                         FIXED_SIZE_BINARY_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowFixedSizeBinaryArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_3_0
+GArrowFixedSizeBinaryArrayBuilder *
+garrow_fixed_size_binary_array_builder_new(
+  GArrowFixedSizeBinaryDataType *data_type);
+
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_fixed_size_binary_array_builder_append_value(
+  GArrowFixedSizeBinaryArrayBuilder *builder,
+  const guint8 *value,
+  gint32 length,
+  GError **error);
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_fixed_size_binary_array_builder_append_value_bytes(
+  GArrowFixedSizeBinaryArrayBuilder *builder,
+  GBytes *value,
+  GError **error);
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_fixed_size_binary_array_builder_append_values(
+  GArrowFixedSizeBinaryArrayBuilder *builder,
+  GBytes **values,
+  gint64 values_length,
+  const gboolean *is_valids,
+  gint64 is_valids_length,
+  GError **error);
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_fixed_size_binary_array_builder_append_values_packed(
+  GArrowFixedSizeBinaryArrayBuilder *builder,
+  GBytes *values,
+  const gboolean *is_valids,
+  gint64 is_valids_length,
+  GError **error);
+
 #define GARROW_TYPE_DATE32_ARRAY_BUILDER        \
   (garrow_date32_array_builder_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowDate32ArrayBuilder,
@@ -1274,10 +1322,10 @@ G_DECLARE_DERIVABLE_TYPE(GArrowDecimal128ArrayBuilder,
                          garrow_decimal128_array_builder,
                          GARROW,
                          DECIMAL128_ARRAY_BUILDER,
-                         GArrowArrayBuilder)
+                         GArrowFixedSizeBinaryArrayBuilder)
 struct _GArrowDecimal128ArrayBuilderClass
 {
-  GArrowArrayBuilderClass parent_class;
+  GArrowFixedSizeBinaryArrayBuilderClass parent_class;
 };
 
 GArrowDecimal128ArrayBuilder *garrow_decimal128_array_builder_new(GArrowDecimal128DataType *data_type);
@@ -1292,6 +1340,15 @@ GARROW_AVAILABLE_IN_0_12
 gboolean garrow_decimal128_array_builder_append_value(GArrowDecimal128ArrayBuilder *builder,
                                                       GArrowDecimal128 *value,
                                                       GError **error);
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_decimal128_array_builder_append_values(
+  GArrowDecimal128ArrayBuilder *builder,
+  GArrowDecimal128 **values,
+  gint64 values_length,
+  const gboolean *is_valids,
+  gint64 is_valids_length,
+  GError **error);
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_DEPRECATED_IN_3_0_FOR(garrow_array_builder_append_null)
 GARROW_AVAILABLE_IN_0_12
@@ -1305,10 +1362,10 @@ G_DECLARE_DERIVABLE_TYPE(GArrowDecimal256ArrayBuilder,
                          garrow_decimal256_array_builder,
                          GARROW,
                          DECIMAL256_ARRAY_BUILDER,
-                         GArrowArrayBuilder)
+                         GArrowFixedSizeBinaryArrayBuilder)
 struct _GArrowDecimal256ArrayBuilderClass
 {
-  GArrowArrayBuilderClass parent_class;
+  GArrowFixedSizeBinaryArrayBuilderClass parent_class;
 };
 
 GArrowDecimal256ArrayBuilder *garrow_decimal256_array_builder_new(GArrowDecimal256DataType *data_type);
@@ -1317,5 +1374,14 @@ GARROW_AVAILABLE_IN_3_0
 gboolean garrow_decimal256_array_builder_append_value(GArrowDecimal256ArrayBuilder *builder,
                                                       GArrowDecimal256 *value,
                                                       GError **error);
+GARROW_AVAILABLE_IN_3_0
+gboolean
+garrow_decimal256_array_builder_append_values(
+  GArrowDecimal256ArrayBuilder *builder,
+  GArrowDecimal256 **values,
+  gint64 values_length,
+  const gboolean *is_valids,
+  gint64 is_valids_length,
+  GError **error);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -587,6 +587,24 @@ struct _GArrowFixedSizeBinaryArrayClass
   GArrowPrimitiveArrayClass parent_class;
 };
 
+GARROW_AVAILABLE_IN_3_0
+GArrowFixedSizeBinaryArray *
+garrow_fixed_size_binary_array_new(GArrowFixedSizeBinaryDataType *data_type,
+                                   gint64 length,
+                                   GArrowBuffer *data,
+                                   GArrowBuffer *null_bitmap,
+                                   gint64 n_nulls);
+GARROW_AVAILABLE_IN_3_0
+gint32
+garrow_fixed_size_binary_array_get_byte_width(GArrowFixedSizeBinaryArray *array);
+GARROW_AVAILABLE_IN_3_0
+GBytes *
+garrow_fixed_size_binary_array_get_value(GArrowFixedSizeBinaryArray *array,
+                                         gint64 i);
+GARROW_AVAILABLE_IN_3_0
+GBytes *
+garrow_fixed_size_binary_array_get_values_bytes(GArrowFixedSizeBinaryArray *array);
+
 
 #define GARROW_TYPE_DECIMAL128_ARRAY (garrow_decimal128_array_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowDecimal128Array,

--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -176,6 +176,17 @@ garrow_decimal_to_string(typename DecimalConverter<Decimal>::GArrowType *decimal
 }
 
 template <typename Decimal>
+GBytes *
+garrow_decimal_to_bytes(typename DecimalConverter<Decimal>::GArrowType *decimal)
+{
+  DecimalConverter<Decimal> converter;
+  const auto arrow_decimal = converter.get_raw(decimal);
+  uint8_t data[DecimalConverter<Decimal>::ArrowType::bit_width / 8];
+  arrow_decimal->ToBytes(data);
+  return g_bytes_new(data, sizeof(data));
+}
+
+template <typename Decimal>
 void
 garrow_decimal_abs(typename DecimalConverter<Decimal>::GArrowType *decimal)
 {
@@ -540,6 +551,20 @@ gchar *
 garrow_decimal128_to_string(GArrowDecimal128 *decimal)
 {
   return garrow_decimal_to_string<arrow::Decimal128>(decimal);
+}
+
+/**
+ * garrow_decimal128_to_bytes:
+ * @decimal: A #GArrowDecimal128.
+ *
+ * Returns: (transfer full): The binary representation of the decimal.
+ *
+ * Since: 3.0.0
+ */
+GBytes *
+garrow_decimal128_to_bytes(GArrowDecimal128 *decimal)
+{
+  return garrow_decimal_to_bytes<arrow::Decimal128>(decimal);
 }
 
 /**
@@ -931,6 +956,20 @@ gchar *
 garrow_decimal256_to_string(GArrowDecimal256 *decimal)
 {
   return garrow_decimal_to_string<arrow::Decimal256>(decimal);
+}
+
+/**
+ * garrow_decimal256_to_bytes:
+ * @decimal: A #GArrowDecimal256.
+ *
+ * Returns: (transfer full): The binary representation of the decimal.
+ *
+ * Since: 3.0.0
+ */
+GBytes *
+garrow_decimal256_to_bytes(GArrowDecimal256 *decimal)
+{
+  return garrow_decimal_to_bytes<arrow::Decimal256>(decimal);
 }
 
 /**

--- a/c_glib/arrow-glib/decimal.h
+++ b/c_glib/arrow-glib/decimal.h
@@ -62,6 +62,8 @@ gboolean garrow_decimal128_greater_than_or_equal(GArrowDecimal128 *decimal,
 gchar *garrow_decimal128_to_string_scale(GArrowDecimal128 *decimal,
                                          gint32 scale);
 gchar *garrow_decimal128_to_string(GArrowDecimal128 *decimal);
+GARROW_AVAILABLE_IN_3_0
+GBytes *garrow_decimal128_to_bytes(GArrowDecimal128 *decimal);
 void garrow_decimal128_abs(GArrowDecimal128 *decimal);
 void garrow_decimal128_negate(GArrowDecimal128 *decimal);
 gint64 garrow_decimal128_to_integer(GArrowDecimal128 *decimal);
@@ -125,6 +127,8 @@ gchar *garrow_decimal256_to_string_scale(GArrowDecimal256 *decimal,
                                          gint32 scale);
 GARROW_AVAILABLE_IN_3_0
 gchar *garrow_decimal256_to_string(GArrowDecimal256 *decimal);
+GARROW_AVAILABLE_IN_3_0
+GBytes *garrow_decimal256_to_bytes(GArrowDecimal256 *decimal);
 GARROW_AVAILABLE_IN_3_0
 void garrow_decimal256_abs(GArrowDecimal256 *decimal);
 GARROW_AVAILABLE_IN_3_0

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -105,6 +105,11 @@ module Helper
       build_array(Arrow::LargeBinaryArrayBuilder.new, values)
     end
 
+    def build_fixed_size_binary_array(data_type, values)
+      build_array(Arrow::FixedSizeBinaryArrayBuilder.new(data_type),
+                  values)
+    end
+
     def build_string_array(values)
       build_array(Arrow::StringArrayBuilder.new, values)
     end

--- a/c_glib/test/test-decimal128.rb
+++ b/c_glib/test/test-decimal128.rb
@@ -36,6 +36,12 @@ class TestDecimal128 < Test::Unit::TestCase
     assert_equal(string_data, decimal.to_s)
   end
 
+  def test_to_bytes
+    decimal = Arrow::Decimal128.new("12.3")
+    assert_equal([123, 0].pack("q*"),
+                 decimal.to_bytes.to_s)
+  end
+
   def test_abs
     absolute_value = "23049223942343532412"
     negative_value = "-23049223942343532412"

--- a/c_glib/test/test-decimal256.rb
+++ b/c_glib/test/test-decimal256.rb
@@ -36,6 +36,12 @@ class TestDecimal256 < Test::Unit::TestCase
     assert_equal(string_data, decimal.to_s)
   end
 
+  def test_to_bytes
+    decimal = Arrow::Decimal256.new("12.3")
+    assert_equal([123, 0, 0, 0].pack("q*"),
+                 decimal.to_bytes.to_s)
+  end
+
   def test_abs
     absolute_value = "23049223942343532412"
     negative_value = "-23049223942343532412"

--- a/c_glib/test/test-fixed-size-binary-array.rb
+++ b/c_glib/test/test-fixed-size-binary-array.rb
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeBinaryrray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @data_type = Arrow::FixedSizeBinaryDataType.new(4)
+  end
+
+  def test_new
+    args = [
+      @data_type,
+      3,
+      Arrow::Buffer.new("0123abcd0000"),
+      Arrow::Buffer.new([0b011].pack("C*")),
+      -1,
+    ]
+    assert_equal(build_fixed_size_binary_array(@data_type,
+                                               ["0123", "abcd", nil]),
+                 Arrow::FixedSizeBinaryArray.new(*args))
+  end
+
+  def test_buffer
+    array = build_fixed_size_binary_array(@data_type,
+                                          ["0123", "abcd", "0000"])
+    assert_equal("0123abcd0000", array.buffer.data.to_s)
+  end
+
+  def test_byte_width
+    array = build_fixed_size_binary_array(@data_type, ["0123"])
+    assert_equal(@data_type.byte_width, array.byte_width)
+  end
+
+  def test_value
+    array = build_fixed_size_binary_array(@data_type, ["0123"])
+    assert_equal("0123", array.get_value(0).to_s)
+  end
+
+  def test_values_bytes
+    array = build_fixed_size_binary_array(@data_type,
+                                          ["0123", "abcd", "0000"])
+    assert_equal("0123abcd0000", array.values_bytes.to_s)
+  end
+end

--- a/ruby/red-arrow/lib/arrow/decimal256-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/decimal256-array-builder.rb
@@ -28,37 +28,33 @@ module Arrow
     alias_method :append_value_raw, :append_value
     # @since 3.0.0
     def append_value(value)
-      case value
-      when nil
-        return append_null
-      when String
-        value = Decimal256.new(value)
-      when Float
-        value = Decimal256.new(value.to_s)
-      when BigDecimal
-        value = Decimal256.new(value.to_s)
-      end
-      append_value_raw(value)
+      append_value_raw(normalize_value(value))
     end
 
+    alias_method :append_values_raw, :append_values
     # @since 3.0.0
     def append_values(values, is_valids=nil)
-      if is_valids
-        is_valids.each_with_index do |is_valid, i|
-          if is_valid
-            append_value(values[i])
-          else
-            append_null
-          end
+      if values.is_a?(::Array)
+        values = values.collect do |value|
+          normalize_value(value)
         end
+        append_values_raw(values, is_valids)
       else
-        values.each do |value|
-          if value.nil?
-            append_null
-          else
-            append_value(value)
-          end
-        end
+        append_values_packed(values, is_valids)
+      end
+    end
+
+    private
+    def normalize_value(value)
+      case value
+      when String
+        Decimal256.new(value)
+      when Float
+        Decimal256.new(value.to_s)
+      when BigDecimal
+        Decimal256.new(value.to_s)
+      else
+        value
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/fixed-size-binary-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/fixed-size-binary-array-builder.rb
@@ -16,42 +16,22 @@
 # under the License.
 
 module Arrow
-  class Decimal128ArrayBuilder
+  class FixedSizeBinaryArrayBuilder
     class << self
+      # @since 3.0.0
       def build(data_type, values)
         builder = new(data_type)
         builder.build(values)
       end
     end
 
-    alias_method :append_value_raw, :append_value
-    def append_value(value)
-      append_value_raw(normalize_value(value))
-    end
-
     alias_method :append_values_raw, :append_values
+    # @since 3.0.0
     def append_values(values, is_valids=nil)
       if values.is_a?(::Array)
-        values = values.collect do |value|
-          normalize_value(value)
-        end
         append_values_raw(values, is_valids)
       else
         append_values_packed(values, is_valids)
-      end
-    end
-
-    private
-    def normalize_value(value)
-      case value
-      when String
-        Decimal128.new(value)
-      when Float
-        Decimal128.new(value.to_s)
-      when BigDecimal
-        Decimal128.new(value.to_s)
-      else
-        value
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/fixed-size-binary-array.rb
+++ b/ruby/red-arrow/lib/arrow/fixed-size-binary-array.rb
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class FixedSizeBinaryArray
+    alias_method :get_value_raw, :get_value
+    # @since 3.0.0
+    def get_value(i)
+      get_value_raw(i).to_s
+    end
+  end
+end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -65,6 +65,8 @@ module Arrow
       require "arrow/dictionary-data-type"
       require "arrow/field"
       require "arrow/file-output-stream"
+      require "arrow/fixed-size-binary-array"
+      require "arrow/fixed-size-binary-array-builder"
       require "arrow/group"
       require "arrow/list-array-builder"
       require "arrow/list-data-type"

--- a/ruby/red-arrow/test/test-decimal256-array-builder.rb
+++ b/ruby/red-arrow/test/test-decimal256-array-builder.rb
@@ -80,9 +80,26 @@ class Decimal256ArrayBuilderTest < Test::Unit::TestCase
     test("is_valids") do
       @builder.append_values([
                                Arrow::Decimal256.new("10.1"),
-                               nil,
                                Arrow::Decimal256.new("10.1"),
+                               Arrow::Decimal256.new("10.1"),
+                             ],
+                             [
+                               true,
+                               false,
+                               true,
                              ])
+      array = @builder.finish
+      assert_equal([
+                     BigDecimal("10.1"),
+                     nil,
+                     BigDecimal("10.1"),
+                   ],
+                   array.to_a)
+    end
+
+    test("packed") do
+      @builder.append_values(Arrow::Decimal256.new("10.1").to_bytes.to_s * 3,
+                             [true, false, true])
       array = @builder.finish
       assert_equal([
                      BigDecimal("10.1"),

--- a/ruby/red-arrow/test/test-fixed-size-binary-array-builder.rb
+++ b/ruby/red-arrow/test/test-fixed-size-binary-array-builder.rb
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Decimal128ArrayBuilderTest < Test::Unit::TestCase
+class FixedSizeBinaryArrayBuilderTest < Test::Unit::TestCase
   def setup
-    @data_type = Arrow::Decimal128DataType.new(3, 1)
-    @builder = Arrow::Decimal128ArrayBuilder.new(@data_type)
+    @data_type = Arrow::FixedSizeBinaryDataType.new(4)
+    @builder = Arrow::FixedSizeBinaryArrayBuilder.new(@data_type)
   end
 
   sub_test_case("#append_value") do
@@ -28,60 +28,40 @@ class Decimal128ArrayBuilderTest < Test::Unit::TestCase
       assert_equal(nil, array[0])
     end
 
-    test("Arrow::Decimal128") do
-      @builder.append_value(Arrow::Decimal128.new("10.1"))
-      array = @builder.finish
-      assert_equal(BigDecimal("10.1"),
-                   array[0])
-    end
-
     test("String") do
-      @builder.append_value("10.1")
+      @builder.append_value("0123")
       array = @builder.finish
-      assert_equal(BigDecimal("10.1"),
-                   array[0])
+      assert_equal("0123", array[0])
     end
 
-    test("Float") do
-      @builder.append_value(10.1)
+    test("GLib::Bytes") do
+      @builder.append_value(GLib::Bytes.new("0123"))
       array = @builder.finish
-      assert_equal(BigDecimal("10.1"),
-                   array[0])
-    end
-
-    test("BigDecimal") do
-      @builder.append_value(BigDecimal("10.1"))
-      array = @builder.finish
-      assert_equal(BigDecimal("10.1"),
-                   array[0])
+      assert_equal("0123", array[0])
     end
   end
 
   sub_test_case("#append_values") do
     test("mixed") do
       @builder.append_values([
-                               Arrow::Decimal128.new("10.1"),
+                               "0123",
                                nil,
-                               "10.1",
-                               10.1,
-                               BigDecimal("10.1"),
+                               GLib::Bytes.new("abcd"),
                              ])
       array = @builder.finish
       assert_equal([
-                     BigDecimal("10.1"),
+                     "0123",
                      nil,
-                     BigDecimal("10.1"),
-                     BigDecimal("10.1"),
-                     BigDecimal("10.1"),
+                     "abcd",
                    ],
                    array.to_a)
     end
 
     test("is_valids") do
       @builder.append_values([
-                               Arrow::Decimal128.new("10.1"),
-                               Arrow::Decimal128.new("10.1"),
-                               Arrow::Decimal128.new("10.1"),
+                               "0123",
+                               "0123",
+                               "0123",
                              ],
                              [
                                true,
@@ -90,21 +70,21 @@ class Decimal128ArrayBuilderTest < Test::Unit::TestCase
                              ])
       array = @builder.finish
       assert_equal([
-                     BigDecimal("10.1"),
+                     "0123",
                      nil,
-                     BigDecimal("10.1"),
+                     "0123",
                    ],
                    array.to_a)
     end
 
     test("packed") do
-      @builder.append_values(Arrow::Decimal128.new("10.1").to_bytes.to_s * 3,
+      @builder.append_values("0123" * 3,
                              [true, false, true])
       array = @builder.finish
       assert_equal([
-                     BigDecimal("10.1"),
+                     "0123",
                      nil,
-                     BigDecimal("10.1"),
+                     "0123",
                    ],
                    array.to_a)
     end

--- a/ruby/red-arrow/test/test-fixed-size-binary-array.rb
+++ b/ruby/red-arrow/test/test-fixed-size-binary-array.rb
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class FixedSizeBinaryArrayTest < Test::Unit::TestCase
+  sub_test_case(".new") do
+    test("build") do
+      data_type = Arrow::FixedSizeBinaryDataType.new(4)
+      values = [
+        "0123",
+        nil,
+        GLib::Bytes.new("abcd"),
+      ]
+      array = Arrow::FixedSizeBinaryArray.new(data_type, values)
+      assert_equal([
+                     "0123",
+                     nil,
+                     "abcd",
+                   ],
+                   array.to_a)
+    end
+  end
+end


### PR DESCRIPTION
The following functions are also added:

  * garrow_fixed_size_binary_array_new()
  * garrow_fixed_size_binary_array_get_byte_width()
  * garrow_fixed_size_binary_array_get_value()
  * garrow_fixed_size_binary_array_get_values_bytes()
  * garrow_decimal128_array_builder_append_values()
  * garrow_decimal256_array_builder_append_values()
  * garrow_decimal128_to_bytes()
  * garrow_decimal256_to_bytes()