### PR TITLE
ARROW-11119: [Rust] Expose functions to parse a single CSV column / StringRecord into an array / recordBatch

### DIFF
--- a/rust/arrow/src/csv/mod.rs
+++ b/rust/arrow/src/csv/mod.rs
@@ -20,8 +20,8 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::infer_schema_from_files;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
+pub use self::reader::{build_array, build_batch, infer_schema_from_files};
 pub use self::writer::Writer;
 pub use self::writer::WriterBuilder;


### PR DESCRIPTION
This PR exposes two new functions:

* to parse a single array out of a CSV column of a `[StringRecord]`) and
* to parse a RecordBatch out of a `StringRecord`.

The motivation for the first function is that parsing arrays is trivially parallelizable. Thus, people may want to use e.g `rayon` to iterate in parallel over fields to build each array. IMO `arrow` crate should not make any assumption about how people want to parallelize this, and only offer the functionality to do it, in the same way we do it with kernels.

The motivation for the second function stems from the fact that parsing (not the IO reading) is the slowest operation in reading a CSV and people may want to iterate over the CSV differently. The main use-case here is to split the read of a single CSV file in multiple parts (using `seek`), and returning record batches (DataFusion is the example here) in parallel. Again, IMO the arrow crate should not make assumptions about how to perform this work, and instead offer the necessary CPU-blocking core functionality for users to build on top of.

The latter function is just a utility of the former function on which no parallelism is used (arrays are built in sequence).