### PR TITLE
[Rust] [DataFusion] [Experiment] Blocking threads filter

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -59,7 +59,7 @@ chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
-tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded", "sync"] }
+tokio = { version = "0.2", features = ["macros", "blocking", "rt-core", "rt-threaded", "sync"] }
 log = "^0.4"
 
 [dev-dependencies]

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -290,6 +290,7 @@ pub mod parquet;
 pub mod planner;
 pub mod projection;
 pub mod repartition;
+pub mod sized_stream;
 pub mod sort;
 pub mod string_expressions;
 pub mod type_coercion;

--- a/rust/datafusion/src/physical_plan/sized_stream.rs
+++ b/rust/datafusion/src/physical_plan/sized_stream.rs
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! SizedRecordBatchStream is a stream of [arrow::record_batch::RecordBatch] that knows its schema.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use arrow::record_batch::RecordBatch;
+use arrow::{datatypes::SchemaRef, error::Result as ArrowResult};
+use futures::stream::{Stream, StreamExt};
+
+use super::RecordBatchStream;
+
+/// A schema-aware [Stream] of [`RecordBatch`]es.
+pub struct SizedRecordBatchStream<S: Stream<Item = ArrowResult<RecordBatch>>> {
+    stream: Pin<Box<S>>,
+    schema: SchemaRef,
+}
+
+impl<S> SizedRecordBatchStream<S>
+where
+    S: Stream<Item = ArrowResult<RecordBatch>>,
+{
+    /// Create a new [SizedRecordBatchStream]
+    pub fn new(stream: S, schema: SchemaRef) -> Self {
+        Self {
+            stream: Box::pin(stream),
+            schema,
+        }
+    }
+}
+
+impl<S> Stream for SizedRecordBatchStream<S>
+where
+    S: Stream<Item = ArrowResult<RecordBatch>>,
+{
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+impl<S> RecordBatchStream for SizedRecordBatchStream<S>
+where
+    S: Stream<Item = ArrowResult<RecordBatch>>,
+{
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}


### PR DESCRIPTION
The motivation behind this PR is that Tokio does not really like blocking (e.g. cpu-intensive) operations, because (by definition) it forbids the scheduler from switching to other tasks. Because of this, tokio recommends (throughout its documentation, but most notably [here](https://docs.rs/tokio/1.0.1/tokio/index.html#cpu-bound-tasks-and-blocking-code)) to use `spawn_blocking` or `rayon` to handle blocking tasks.

This PR is just an experiment / proposal / idea of how we could handle this within tokio. Specifically, it is using `spawn_blocking` to spawn a thread on tokio's "blocking-dedicated" thread pool to handle a blocking operation, thereby avoiding starving the "async-dedicated" thread pool.

I do not expect this code to have much difference in performance, as `filter` is not such a blocking operation compared to e.g. a group by. However, I think that this idea could address performance issues when we have multiple stages (as one stage currently blocks the whole thread pool due to how we perform blocking ops inside `async` code).

@andygrove @alamb @Dandandan , I have been looking at DataFusion's code and tokio's documentation, and I hypothesize that this is would be one way to follow tokio's recommendations for our use-case, but I would really like to get your opinions.