### PR TITLE
ARROW-11114: [Java] Fix Schema and Field metadata JSON serialization

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -271,9 +271,15 @@ public class Field {
     return children;
   }
 
-  @JsonInclude(Include.NON_EMPTY)
+  @JsonIgnore
   public Map<String, String> getMetadata() {
     return fieldType.getMetadata();
+  }
+
+  @JsonProperty("metadata")
+  @JsonInclude(Include.NON_EMPTY)
+  List<Map<String, String>> getMetadataForJson() {
+    return convertMetadata(getMetadata());
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
@@ -69,6 +69,9 @@ public class Schema {
     throw new IllegalArgumentException(String.format("field %s not found in %s", name, fields));
   }
 
+  static final String METADATA_KEY = "key";
+  static final String METADATA_VALUE = "value";
+
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
   private static final ObjectReader reader = mapper.readerFor(Schema.class);
@@ -134,7 +137,7 @@ public class Schema {
 
   static Map<String, String> convertMetadata(List<Map<String, String>> metadata) {
     return (metadata == null) ? null : metadata.stream()
-        .map(e -> new AbstractMap.SimpleImmutableEntry<>(e.get("key"), e.get("value")))
+        .map(e -> new AbstractMap.SimpleImmutableEntry<>(e.get(METADATA_KEY), e.get(METADATA_VALUE)))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -147,8 +150,8 @@ public class Schema {
 
   private static Map<String, String> convertEntryToKeyValueMap(Map.Entry<String, String> entry) {
     Map<String, String> map = new HashMap<>(2);
-    map.put("key", entry.getKey());
-    map.put("value", entry.getValue());
+    map.put(METADATA_KEY, entry.getKey());
+    map.put(METADATA_VALUE, entry.getValue());
     return Collections.unmodifiableMap(map);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
@@ -37,6 +37,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.ipc.message.FBSerializables;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -137,13 +138,33 @@ public class Schema {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
+  static List<Map<String, String>> convertMetadata(Map<String, String> metadata) {
+    return (metadata == null) ? null : metadata.entrySet()
+        .stream()
+        .map(Schema::convertEntryToKeyValueMap)
+        .collect(Collectors.toList());
+  }
+
+  private static Map<String, String> convertEntryToKeyValueMap(Map.Entry<String, String> entry) {
+    Map<String, String> map = new HashMap<>(2);
+    map.put("key", entry.getKey());
+    map.put("value", entry.getValue());
+    return Collections.unmodifiableMap(map);
+  }
+
   public List<Field> getFields() {
     return fields;
   }
 
-  @JsonInclude(Include.NON_EMPTY)
+  @JsonIgnore
   public Map<String, String> getCustomMetadata() {
     return metadata;
+  }
+
+  @JsonProperty("metadata")
+  @JsonInclude(Include.NON_EMPTY)
+  List<Map<String, String>> getCustomMetadataForJson() {
+    return convertMetadata(getCustomMetadata());
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.types.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.arrow.vector.types.pojo.ArrowType.Int;
+import org.junit.Test;
+
+public class TestField {
+
+  private static Field field(String name, boolean nullable, ArrowType type, Map<String, String> metadata) {
+    return new Field(name, new FieldType(nullable, type, null, metadata), Collections.emptyList());
+  }
+
+  @Test
+  public void testMetadata() throws IOException {
+    Map<String, String> metadata = new HashMap<>(1);
+    metadata.put("testKey", "testValue");
+
+    Schema schema = new Schema(Collections.singletonList(
+        field("a", false, new Int(8, true), metadata)
+    ));
+
+    String json = schema.toJson();
+    Schema actual = Schema.fromJSON(json);
+
+    Map<String, String> actualMetadata = actual.getFields().get(0).getMetadata();
+    assertEquals(1, actualMetadata.size());
+    assertEquals("testValue", actualMetadata.get("testKey"));
+
+    contains(schema, "\"key\" : \"testKey\"", "\"value\" : \"testValue\"");
+  }
+
+  private void contains(Schema schema, String... s) {
+    String json = schema.toJson();
+    for (String string : s) {
+      assertTrue(json + " contains " + string, json.contains(string));
+    }
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.types.pojo;
 
+import static org.apache.arrow.vector.types.pojo.Schema.METADATA_KEY;
+import static org.apache.arrow.vector.types.pojo.Schema.METADATA_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -42,6 +44,7 @@ public class TestField {
     Schema schema = new Schema(Collections.singletonList(
         field("a", false, new Int(8, true), metadata)
     ));
+    contains(schema, "\"" + METADATA_KEY + "\" : \"testKey\"", "\"" + METADATA_VALUE + "\" : \"testValue\"");
 
     String json = schema.toJson();
     Schema actual = Schema.fromJSON(json);
@@ -49,8 +52,6 @@ public class TestField {
     Map<String, String> actualMetadata = actual.getFields().get(0).getMetadata();
     assertEquals(1, actualMetadata.size());
     assertEquals("testValue", actualMetadata.get("testKey"));
-
-    contains(schema, "\"key\" : \"testKey\"", "\"value\" : \"testValue\"");
   }
 
   private void contains(Schema schema, String... s) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestField.java
@@ -44,19 +44,19 @@ public class TestField {
     Schema schema = new Schema(Collections.singletonList(
         field("a", false, new Int(8, true), metadata)
     ));
-    contains(schema, "\"" + METADATA_KEY + "\" : \"testKey\"", "\"" + METADATA_VALUE + "\" : \"testValue\"");
 
     String json = schema.toJson();
     Schema actual = Schema.fromJSON(json);
+
+    jsonContains(json, "\"" + METADATA_KEY + "\" : \"testKey\"", "\"" + METADATA_VALUE + "\" : \"testValue\"");
 
     Map<String, String> actualMetadata = actual.getFields().get(0).getMetadata();
     assertEquals(1, actualMetadata.size());
     assertEquals("testValue", actualMetadata.get("testKey"));
   }
 
-  private void contains(Schema schema, String... s) {
-    String json = schema.toJson();
-    for (String string : s) {
+  private void jsonContains(String json, String... strings) {
+    for (String string : strings) {
       assertTrue(json + " contains " + string, json.contains(string));
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -193,6 +195,23 @@ public class TestSchema {
     ));
     roundTrip(schema);
     contains(schema, "HALF", "SINGLE", "DOUBLE");
+  }
+
+  @Test
+  public void testMetadata() throws IOException {
+    Map<String, String> metadata = new HashMap<>(1);
+    metadata.put("testKey", "testValue");
+
+    java.util.List<Field> fields = asList(
+        field("a", false, new Int(8, true)),
+        field("b", new Struct(),
+            field("c", new Int(16, true)),
+            field("d", new Utf8())),
+        field("e", new List(), field(null, new Date(DateUnit.MILLISECOND)))
+    );
+    Schema schema = new Schema(fields, metadata);
+    roundTrip(schema);
+    contains(schema, "\"key\" : \"testKey\"", "\"value\" : \"testValue\"");
   }
 
   private void roundTrip(Schema schema) throws IOException {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
@@ -18,6 +18,8 @@
 package org.apache.arrow.vector.types.pojo;
 
 import static java.util.Arrays.asList;
+import static org.apache.arrow.vector.types.pojo.Schema.METADATA_KEY;
+import static org.apache.arrow.vector.types.pojo.Schema.METADATA_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -211,7 +213,7 @@ public class TestSchema {
     );
     Schema schema = new Schema(fields, metadata);
     roundTrip(schema);
-    contains(schema, "\"key\" : \"testKey\"", "\"value\" : \"testValue\"");
+    contains(schema, "\"" + METADATA_KEY + "\" : \"testKey\"", "\"" + METADATA_VALUE + "\" : \"testValue\"");
   }
 
   private void roundTrip(Schema schema) throws IOException {


### PR DESCRIPTION
Based on [this commit](https://github.com/apache/arrow/commit/c15a511ea19b7ed58e706ef6c8197fe9ed982a8b), it seems that the correct format for metadata serialization is `List<Map<String, String>>` since it was decided to deserialize it in this format. 

There are several ways to accomplish this, but this PR takes a less-impactful approach of defining the correct getter for Jackson to use. Other approaches could be more aggressive and propagate this change throughout the codebase, modifying the `Schema#getCustomMetadata` and `Field#getMetadata` method to return `List<Map<String, String>>`, but at that point it would probably make more sense to get rid of the notion of "converting" metadata entirely.