### PR TITLE
ARROW-11123: [Rust] Use cast kernel to simplify csv parser

### DIFF
--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -416,7 +416,7 @@ fn parse(
             let field = &fields[i];
             match field.data_type() {
                 &DataType::Boolean => build_boolean_array(line_number, rows, i),
-                | &DataType::Int8
+                &DataType::Int8
                 | &DataType::Int16
                 | &DataType::Int32
                 | &DataType::Int64
@@ -453,7 +453,6 @@ fn parse(
 
     arrays.and_then(|arr| RecordBatch::try_new(projected_schema, arr))
 }
-
 
 fn parse_bool(string: &str) -> Option<bool> {
     if string.eq_ignore_ascii_case("false") {


### PR DESCRIPTION
This came up in https://github.com/apache/arrow/pull/9084 when discussing the PR with @jorgecarleitao 

One of the ideas here is that we could take advantage of the `cast` kernel in Arrow to parse the csv column, deduplicating code and making more use of Arrow. We can get rid of the custom parsers and parsing / building primitive arrays.

On loading the CSV in the TCPH benchmark looks like this has a small negative effect on performance.