### PR TITLE
ARROW-11127: [C++] ifdef unused cpu_info on non-x86 platforms

### DIFF
--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -81,7 +81,9 @@ Result<const KernelType*> DispatchExactImpl(const Function& func,
   }
 
   // Dispatch as the CPU feature
+#if defined(ARROW_HAVE_RUNTIME_AVX512) || defined(ARROW_HAVE_RUNTIME_AVX2)
   auto cpu_info = arrow::internal::CpuInfo::GetInstance();
+#endif
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
   if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX512)) {
     if (kernel_matches[SimdLevel::AVX512]) {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -308,7 +308,9 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   aggregate::AddBasicAggKernels(aggregate::SumInit, FloatingPointTypes(), float64(),
                                 func.get());
   // Add the SIMD variants for sum
+#if defined(ARROW_HAVE_RUNTIME_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX512)
   auto cpu_info = arrow::internal::CpuInfo::GetInstance();
+#endif
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
   if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX2)) {
     aggregate::AddSumAvx2AggKernels(func.get());


### PR DESCRIPTION
Otherwise we get an error in debug builds because of `-Werror,Wunused`