### PR TITLE
ARROW-11129: [Rust][DataFusion] Use tokio thread pool for loading parquet

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -59,7 +59,7 @@ chrono = "0.4"
 async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
-tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded", "sync"] }
+tokio = { version = "0.2", features = ["macros", "blocking", "rt-core", "rt-threaded", "sync"] }
 log = "^0.4"
 
 [dev-dependencies]

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -258,12 +258,7 @@ impl ExecutionPlan for ParquetExec {
         let batch_size = self.batch_size;
 
         task::spawn_blocking(move || {
-            read_files(
-                &filenames,
-                &projection,
-                batch_size,
-                response_tx,
-            )
+            read_files(&filenames, &projection, batch_size, response_tx)
         });
 
         Ok(Box::pin(ParquetStream {
@@ -293,8 +288,8 @@ fn read_files(
         let file = File::open(&filename)?;
         let file_reader = Arc::new(SerializedFileReader::new(file)?);
         let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
-        let mut batch_reader =
-            arrow_reader.get_record_reader_by_columns(projection.to_owned(), batch_size)?;
+        let mut batch_reader = arrow_reader
+            .get_record_reader_by_columns(projection.to_owned(), batch_size)?;
         loop {
             match batch_reader.next() {
                 Some(Ok(batch)) => {

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -258,7 +258,9 @@ impl ExecutionPlan for ParquetExec {
         let batch_size = self.batch_size;
 
         task::spawn_blocking(move || {
-            read_files(&filenames, &projection, batch_size, response_tx)
+            if let Err(e) = read_files(&filenames, &projection, batch_size, response_tx) {
+                println!("Parquet reader thread terminated due to error: {:?}", e);
+            }
         });
 
         Ok(Box::pin(ParquetStream {


### PR DESCRIPTION
Inspired by PR https://github.com/apache/arrow/pull/9086 from @jorgecarleitao 

Seems better to use  `task::spawn_blocking` to set an upper limit on the nr. of threads (512 by default) using tokio and get better error handling as well.