### PR TITLE
ARROW-11067: [C++] Fix CSV null detection on large values

### DIFF
--- a/cpp/src/arrow/util/trie.h
+++ b/cpp/src/arrow/util/trie.h
@@ -116,6 +116,7 @@ std::ostream& operator<<(std::ostream& os, const SmallString<N>& str) {
 class ARROW_EXPORT Trie {
   using index_type = int16_t;
   using fast_index_type = int_fast16_t;
+  static constexpr auto kMaxIndex = std::numeric_limits<index_type>::max();
 
  public:
   Trie() : size_(0) {}
@@ -125,6 +126,9 @@ class ARROW_EXPORT Trie {
   int32_t Find(util::string_view s) const {
     const Node* node = &nodes_[0];
     fast_index_type pos = 0;
+    if (s.length() > static_cast<size_t>(kMaxIndex)) {
+      return -1;
+    }
     fast_index_type remaining = static_cast<fast_index_type>(s.length());
 
     while (remaining > 0) {

--- a/cpp/src/arrow/util/trie_test.cc
+++ b/cpp/src/arrow/util/trie_test.cc
@@ -176,12 +176,25 @@ TEST(Trie, EmptyString) {
 }
 
 TEST(Trie, LongString) {
-  TrieBuilder builder;
-  ASSERT_OK(builder.Append(""));
-  const Trie trie = builder.Finish();
-  auto maxlen = static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 1;
-  std::string long_string(maxlen, 'x');
-  ASSERT_EQ(-1, trie.Find(long_string));
+  auto maxlen = static_cast<size_t>(std::numeric_limits<int16_t>::max());
+  // Ensure we can insert strings with length up to maxlen
+  for (auto&& length : {maxlen, maxlen - 1, maxlen / 2}) {
+    TrieBuilder builder;
+    std::string long_string(length, 'x');
+    ASSERT_OK(builder.Append(""));
+    ASSERT_OK(builder.Append(long_string));
+    const Trie trie = builder.Finish();
+    ASSERT_EQ(1, trie.Find(long_string));
+  }
+
+  // Ensure that the trie always returns false for strings with length > maxlen
+  for (auto&& length : {maxlen, maxlen - 1, maxlen / 2, maxlen + 1, maxlen * 2}) {
+    TrieBuilder builder;
+    ASSERT_OK(builder.Append(""));
+    const Trie trie = builder.Finish();
+    std::string long_string(length, 'x');
+    ASSERT_EQ(-1, trie.Find(long_string));
+  }
 }
 
 TEST(Trie, Basics1) {

--- a/cpp/src/arrow/util/trie_test.cc
+++ b/cpp/src/arrow/util/trie_test.cc
@@ -175,6 +175,15 @@ TEST(Trie, EmptyString) {
   ASSERT_EQ(-1, trie.Find("x"));
 }
 
+TEST(Trie, LongString) {
+  TrieBuilder builder;
+  ASSERT_OK(builder.Append(""));
+  const Trie trie = builder.Finish();
+  auto maxlen = static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 1;
+  std::string long_string(maxlen, 'x');
+  ASSERT_EQ(-1, trie.Find(long_string));
+}
+
 TEST(Trie, Basics1) {
   TestTrieContents({"abc", "de", "f"});
   TestTrieContents({"abc", "de", "f", ""});


### PR DESCRIPTION
On mac int_fast16_t is 2 bytes (it is 4+ bytes on linux/windows).  The Trie was not checking this bound and could return a false positive if a string has more than 2^15-1 characters.