### PR TITLE
ARROW-11131: [Rust] Improve performance of bool_equal

### DIFF
--- a/rust/arrow/src/array/equal/boolean.rs
+++ b/rust/arrow/src/array/equal/boolean.rs
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use super::utils::{equal_bits, equal_len};
 use crate::array::ArrayData;
-
-use super::utils::equal_bits;
 
 pub(super) fn boolean_equal(
     lhs: &ArrayData,
@@ -29,21 +28,103 @@ pub(super) fn boolean_equal(
     let lhs_values = lhs.buffers()[0].as_slice();
     let rhs_values = rhs.buffers()[0].as_slice();
 
-    // TODO: we can do this more efficiently if all values are not-null
-    (0..len).all(|i| {
-        let lhs_pos = lhs_start + i;
-        let rhs_pos = rhs_start + i;
-        let lhs_is_null = lhs.is_null(lhs_pos);
-        let rhs_is_null = rhs.is_null(rhs_pos);
+    // Try optimize for zero null counts and same align format.
+    if lhs.null_count() == 0 && rhs.null_count() == 0 {
+        let mut lhs_align_left = 0;
+        let mut lhs_prefix_bits = 0;
+        if lhs_start > 0 {
+            lhs_align_left = lhs_start / 8_usize;
+            if lhs_start % 8_usize > 0 {
+                lhs_align_left += 1_usize;
+            }
+            lhs_prefix_bits = lhs_align_left * 8_usize - lhs_start;
+        }
 
-        lhs_is_null
-            || (lhs_is_null == rhs_is_null)
-                && equal_bits(
+        let mut rhs_prefix_bits = 0;
+        if rhs_start > 0 {
+            let mut align = rhs_start / 8_usize;
+            if rhs_start % 8_usize > 0 {
+                align += 1;
+            }
+            rhs_prefix_bits = align * 8_usize - rhs_start;
+        }
+
+        // `lhs_prefix_len == lhs_prefix_len` means same align format:
+        // prefix_bits | aligned_bytes | suffix_bits
+        if lhs_prefix_bits == rhs_prefix_bits {
+            // Compare prefix bit slices.
+            if lhs_prefix_bits > 0
+                && !equal_bits(
                     lhs_values,
                     rhs_values,
-                    lhs_pos + lhs.offset(),
-                    rhs_pos + rhs.offset(),
-                    1,
+                    lhs.offset() + lhs_start,
+                    rhs.offset() + rhs_start,
+                    lhs_prefix_bits,
                 )
-    })
+            {
+                return false;
+            }
+
+            let lhs_align_right = (lhs_start + len) / 8_usize;
+            let align_bytes_len = lhs_align_right - lhs_align_left;
+            let align_bits_len = align_bytes_len * 8_usize;
+            let suffix_len = len - align_bits_len;
+
+            // Compare suffix bit slices.
+            if suffix_len > 0
+                && !equal_bits(
+                    lhs_values,
+                    rhs_values,
+                    lhs.offset() + lhs_start + align_bits_len,
+                    rhs.offset() + rhs_start + align_bits_len,
+                    suffix_len,
+                )
+            {
+                return false;
+            }
+
+            // Compare byte slices.
+            if align_bytes_len > 0
+                && !equal_len(
+                    lhs_values,
+                    rhs_values,
+                    lhs_align_left,
+                    lhs_align_left,
+                    align_bytes_len,
+                )
+            {
+                return false;
+            }
+
+            true
+        } else {
+            equal_bits(
+                lhs_values,
+                rhs_values,
+                lhs.offset() + lhs_start,
+                rhs.offset() + rhs_start,
+                len,
+            )
+        }
+    } else {
+        (0..len).all(|i| {
+            let lhs_pos = lhs_start + i;
+            let rhs_pos = rhs_start + i;
+            let lhs_is_null = lhs.is_null(lhs_pos);
+            let rhs_is_null = rhs.is_null(rhs_pos);
+            if lhs_is_null != rhs_is_null {
+                return false;
+            }
+            if lhs_is_null && rhs_is_null {
+                return true;
+            }
+            equal_bits(
+                lhs_values,
+                rhs_values,
+                lhs_pos + lhs.offset(),
+                rhs_pos + rhs.offset(),
+                1,
+            )
+        })
+    }
 }


### PR DESCRIPTION
This PR follows @jorgecarleitao 's great PR https://github.com/apache/arrow/pull/8541, with the following changes:

1. Implemented the logic when both `lhs` and `rhs` have zero null count.
2. May fixed a possible condition testing bug in `(0..len).all(|i| {...}` . 
    NOTE: there are other similar cases where `test_struct()` failed when updated in this way.
3. Added benchmarks `equal_bool_512` and `equal_bool_nulls_512`.

Benchmark comparing to arrow master:

```
equal_bool_512          time:   [52.946 ns 53.075 ns 53.188 ns]                           
                        change: [-96.295% -96.285% -96.277%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low severe
  2 (2.00%) high mild
  2 (2.00%) high severe

equal_bool_nulls_512    time:   [2.3502 us 2.3696 us 2.3893 us]                                  
                        change: [-62.285% -62.019% -61.714%] (p = 0.00 < 0.05)
                        Performance has improved.
```