### PR TITLE
ARROW-11706: [JS] Better BigInt compatibility check

### DIFF
--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -18,7 +18,7 @@
 import { ArrayBufferViewInput, toArrayBufferView } from './buffer';
 import { TypedArray, TypedArrayConstructor } from '../interfaces';
 import { BigIntArray, BigIntArrayConstructor } from '../interfaces';
-import { BigIntAvailable, BigInt64Array, BigUint64Array } from './compat';
+import { BigIntAvailable, BigInt64Array, BigInt64ArrayAvailable, BigUint64Array, BigUint64ArrayAvailable } from './compat';
 
 /** @ignore */
 export const isArrowBigNumSymbol = Symbol.for('isArrowBigNum');
@@ -88,7 +88,7 @@ export let bignumToString: { <T extends BN<BigNumArray>>(a: T): string; };
 /** @ignore */
 export let bignumToBigInt: { <T extends BN<BigNumArray>>(a: T): bigint; };
 
-if (!BigIntAvailable) {
+if (!BigIntAvailable || !BigInt64ArrayAvailable || !BigUint64ArrayAvailable) {
     bignumToString = decimalToString;
     bignumToBigInt = <any> bignumToString;
 } else {


### PR DESCRIPTION
Check for whether `BigInt64ArrayAvailable` and `BigUint64ArrayAvailable` are available, rather than just `BigIntAvailable`. Recent versions of JavaScriptCore/WebKit in Safari support `BigInt` but do not support `BigInt64Array`, and so anything that relies on `BigInt64Array` will fail despite `BigIntAvailable` being `true`.