### PR TITLE
ARROW-11131: [Rust] Improve performance of boolean_equal

### DIFF
--- a/rust/arrow/benches/equal.rs
+++ b/rust/arrow/benches/equal.rs
@@ -50,6 +50,18 @@ fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
     Arc::new(builder.finish())
 }
 
+fn create_bool_array(size: usize) -> ArrayRef {
+    // use random numbers to avoid spurious compiler optimizations wrt to branching
+    let mut rng = seedable_rng();
+    let mut builder = BooleanBuilder::new(size);
+
+    for _ in 0..size {
+        let val = rng.gen::<i32>();
+        builder.append_value(val % 2 == 0).unwrap();
+    }
+    Arc::new(builder.finish())
+}
+
 fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
     // use random numbers to avoid spurious compiler optimizations wrt to branching
     let mut rng = seedable_rng();
@@ -83,6 +95,12 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("equal_string_nulls_512", |b| {
         b.iter(|| bench_equal(&arr_a_nulls))
     });
+
+    let arr_a = create_bool_array(512);
+    c.bench_function("equal_bool_512", |b| b.iter(|| bench_equal(&arr_a)));
+
+    let arr_a = create_bool_array(513);
+    c.bench_function("equal_bool_513", |b| b.iter(|| bench_equal(&arr_a)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -360,6 +360,20 @@ mod tests {
         let b_slice = b.slice(3, 4);
         assert_eq!(equal(&a_slice, &b_slice), false);
         assert_eq!(equal(&b_slice, &a_slice), false);
+
+        // Test the optimization cases where null_count == 0 and starts at 0 and len >= size_of(u8)
+
+        // Elements fill in `u8`'s exactly.
+        let mut vector = vec![false, false, true, true, true, true, true, true];
+        let a = BooleanArray::from(vector.clone()).data();
+        let b = BooleanArray::from(vector.clone()).data();
+        test_equal(a.as_ref(), b.as_ref(), true);
+
+        // Elements fill in `u8`s + suffix bits.
+        vector.push(true);
+        let a = BooleanArray::from(vector.clone()).data();
+        let b = BooleanArray::from(vector).data();
+        test_equal(a.as_ref(), b.as_ref(), true);
     }
 
     #[test]


### PR DESCRIPTION
This PR optimized performance of `boolean_equal` and added benches for this.
The average change is about -95% for both `equal_bool_512` and `equal_bool_513`.