### PR TITLE
ARROW-11165: [Rust][DataFusion] Document Postgres as standard SQL dialect

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -91,6 +91,13 @@ This library currently supports the following SQL constructs:
 * `GROUP BY` together with one of the following aggregations: `MIN`, `MAX`, `COUNT`, `SUM`, `AVG`
 * `ORDER BY` together with an expression and optional `ASC` or `DESC` and also optional `NULLS FIRST` or `NULLS LAST`
 
+## Supported Functions
+
+DataFusion implements a subset of the [PostgreSQL SQL dialect](https://www.postgresql.org/docs/current/functions.html) where possible. We explicitly choose a single dialect to maximize interoperability with other tools and allow reuse of the PostgreSQL documents and tutorials as much as possible.
+
+Currently, only a subset of the PosgreSQL dialect is implemented, and we will document any deviations.
+
+
 ## Supported Data Types
 
 DataFusion uses Arrow, and thus the Arrow type system, for query

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -93,7 +93,7 @@ This library currently supports the following SQL constructs:
 
 ## Supported Functions
 
-DataFusion implements a subset of the [PostgreSQL SQL dialect](https://www.postgresql.org/docs/current/functions.html) where possible. We explicitly choose a single dialect to maximize interoperability with other tools and allow reuse of the PostgreSQL documents and tutorials as much as possible.
+DataFusion strives to implement a subset of the [PostgreSQL SQL dialect](https://www.postgresql.org/docs/current/functions.html) where possible. We explicitly choose a single dialect to maximize interoperability with other tools and allow reuse of the PostgreSQL documents and tutorials as much as possible.
 
 Currently, only a subset of the PosgreSQL dialect is implemented, and we will document any deviations.
 


### PR DESCRIPTION
PROPOSAL Document postgres as the target SQL / function dialect and rationale for this choice. I will also send an email to the dev mailing list soliciting feedback 

There are several comments and more discussion on https://github.com/apache/arrow/pull/9108