### PR TITLE
ARROW-11169: [Rust] Add a comment explaining where float total_order algorithm came from

### DIFF
--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -41,7 +41,7 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
     take(values.as_ref(), &indices, None)
 }
 
-// sorts f32 in IEEE 754 total ordering
+// implements comparison using IEEE 754 total ordering for f32
 // Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
 // TODO to change to use std when it becomes stable
 fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
@@ -54,7 +54,7 @@ fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
     left.cmp(&right)
 }
 
-// sorts f64 in IEEE 754 total ordering
+// implements comparison using IEEE 754 total ordering for f64
 // Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
 // TODO to change to use std when it becomes stable
 fn total_cmp_64(l: f64, r: f64) -> std::cmp::Ordering {

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -42,6 +42,8 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
 }
 
 // sorts f32 in IEEE 754 total ordering
+// Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
+// TODO to change to use std when it becomes stable
 fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
     let mut left = l.to_bits() as i32;
     let mut right = r.to_bits() as i32;
@@ -53,6 +55,8 @@ fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
 }
 
 // sorts f64 in IEEE 754 total ordering
+// Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
+// TODO to change to use std when it becomes stable
 fn total_cmp_64(l: f64, r: f64) -> std::cmp::Ordering {
     let mut left = l.to_bits() as i64;
     let mut right = r.to_bits() as i64;


### PR DESCRIPTION
Follow up from https://github.com/apache/arrow/pull/8882