### PR TITLE
ARROW-11166: [Python] Add binding for ProjectOptions

### DIFF
--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -461,6 +461,8 @@ Structural transforms
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
 | list_value_length        | Unary      | List-like                                      | Int32 or Int64      | \(5)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
+| project                  | Varargs    | Any                                            | Struct              | \(6)    |
++--------------------------+------------+------------------------------------------------+---------------------+---------+
 
 * \(1) First input must be an array, second input a scalar of the same type.
   Output is an array of the same type as the inputs, and with the same values
@@ -474,6 +476,11 @@ Structural transforms
 
 * \(5) Each output element is the length of the corresponding input element
   (null if input is null).  Output type is Int32 for List, Int64 for LargeList.
+
+* \(6) The output struct's field types are the types of its arguments. The
+  field names are specified using an instance of :struct:`ProjectOptions`.
+  The output shape will be scalar if all inputs are scalar, otherwise any
+  scalars will be broadcast to arrays.
 
 Conversions
 ~~~~~~~~~~~

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -665,6 +665,26 @@ class PartitionNthOptions(_PartitionNthOptions):
         self._set_options(pivot)
 
 
+cdef class _ProjectOptions(FunctionOptions):
+    cdef:
+        unique_ptr[CProjectOptions] project_options
+
+    cdef const CFunctionOptions* get_options(self) except NULL:
+        return self.project_options.get()
+
+    def _set_options(self, field_names):
+        cdef:
+            vector[c_string] c_field_names
+        for n in field_names:
+            c_field_names.push_back(tobytes(n))
+        self.project_options.reset(new CProjectOptions(field_names))
+
+
+class ProjectOptions(_ProjectOptions):
+    def __init__(self, field_names):
+        self._set_options(field_names)
+
+
 cdef class _MinMaxOptions(FunctionOptions):
     cdef:
         CMinMaxOptions min_max_options

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -36,6 +36,7 @@ from pyarrow._compute import (  # noqa
     MinMaxOptions,
     ModeOptions,
     PartitionNthOptions,
+    ProjectOptions,
     SetLookupOptions,
     StrptimeOptions,
     TakeOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1813,6 +1813,11 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CPartitionNthOptions(int64_t pivot)
         int64_t pivot
 
+    cdef cppclass CProjectOptions \
+            "arrow::compute::ProjectOptions"(CFunctionOptions):
+        CProjectOptions(vector[c_string] field_names)
+        vector[c_string] field_names
+
     ctypedef enum CSortOrder" arrow::compute::SortOrder":
         CSortOrder_Ascending \
             "arrow::compute::SortOrder::Ascending"


### PR DESCRIPTION
See also: https://github.com/apache/arrow/pull/8894/#issuecomment-756222590

The "project" compute function is not really intended for direct use; it's primarily a convenience for exposing expressions to projection: https://issues.apache.org/jira/browse/ARROW-11174

As such, maybe it should be hidden instead of exposed to python?