### PR TITLE
ARROW-10470: [R] Fix missing file error causing NYC taxi example to fail

### DIFF
--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -52,25 +52,20 @@ with some additional code:
 
 ```{r, eval = FALSE}
 bucket <- "https://ursa-labs-taxi-data.s3.us-east-2.amazonaws.com"
-dir.create("nyc-taxi")
 for (year in 2009:2019) {
-  dir.create(file.path("nyc-taxi", year))
   if (year == 2019) {
     # We only have through June 2019 there
     months <- 1:6
   } else {
     months <- 1:12
   }
-  for (month in months) {
-    if (month < 10) {
-      month <- paste0("0", month)
-    }
-    dir.create(file.path("nyc-taxi", year, month))
-    download.file(
+  for (month in sprintf("%02d", months)) {
+    dir.create(file.path("nyc-taxi", year, month), recursive = TRUE)
+    try(download.file(
       paste(bucket, year, month, "data.parquet", sep = "/"),
       file.path("nyc-taxi", year, month, "data.parquet"),
-      mode = 'wb'
-    )
+      mode = "wb"
+    ), silent = TRUE)
   }
 }
 ```


### PR DESCRIPTION
Simplifies the S3 download code in the **Working with Arrow Datasets and dplyr** vignette and allows it to finish despite the missing file `s3://ursa-labs-taxi-data/2010/03/data.parquet`. The missing file now causes a warning instead of an error.