### PR TITLE
Fix walk

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -412,7 +412,7 @@ class S3FSWrapper(DaskFileSystem):
         directories = set()
         files = set()
 
-        for key in list(self.fs._ls(path, refresh=refresh)):
+        for key in list(self.fs.ls(path, refresh=refresh)):
             path = key['Key']
             if key['StorageClass'] == 'DIRECTORY':
                 directories.add(path)


### PR DESCRIPTION
```
/usr/local/lib/python3.7/site-packages/pyarrow/filesystem.py:412: RuntimeWarning: coroutine 'S3FileSystem._ls' was never awaited
  for key in list(self.fs._ls(path, refresh=refresh)):
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

see 
https://github.com/dask/s3fs/blob/master/s3fs/core.py#L657
for reference