### PR TITLE
ARROW-11187: [Rust] [Parquet] Fix Build error by Pin specific parquet-format-rs version

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -29,7 +29,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-parquet-format = "2.6.1"
+parquet-format = "~2.6.1"
 byteorder = "1"
 thrift = "0.13"
 snap = { version = "1.0", optional = true }
@@ -40,7 +40,7 @@ zstd = { version = "0.6", optional = true }
 chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", optional = true }
-base64 = { version = "*", optional = true }
+base64 = { version = "0.12", optional = true }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
parquet-format 2.7.0 was released yesterday, and our cargo.toml file specifies 2.6.1, which means cargo will update this on new builds or of you run `cargo update`

```
alamb@ip-192-168-0-182:~/Software/arrow2/rust$ cargo update
cargo update
    Updating crates.io index
    Updating parquet-format v2.6.1 -> v2.7.0
```

Sadly this version of new parquet format causes a build error:


```
157 Compiling arrow-flight v3.0.0-SNAPSHOT (/__w/arrow/arrow/rust/arrow-flight) 
 158error[E0063]: missing fields `file_offset`, `ordinal`, `total_compressed_size` in initializer of `RowGroup` 
 159 --> parquet/src/file/metadata.rs:262:9 
 160 | 
 161262 | RowGroup { 
 162 | ^^^^^^^^ missing `file_offset`, `ordinal`, `total_compressed_size` 
 163
 164error[E0063]: missing field `bloom_filter_offset` in initializer of `ColumnMetaData` 
 165 --> parquet/src/file/metadata.rs:501:31 
 166 | 
 167501 | let column_metadata = ColumnMetaData { 
 168 | ^^^^^^^^^^^^^^ missing `bloom_filter_offset` 
 169
 170error[E0063]: missing fields `crypto_metadata`, `encrypted_column_metadata` in initializer of `ColumnChunk` 
 171 --> parquet/src/file/metadata.rs:517:9 
 172 | 
 173517 | ColumnChunk { 
 174 | ^^^^^^^^^^^ missing `crypto_metadata`, `encrypted_column_metadata` 
 175
```

This PR pins the version so that it will not pick up 2.7

