### PR TITLE
ARROW-11188: [Rust] Support crypto functions from PostgreSQL dialect

### DIFF
--- a/rust/arrow/src/util/display.rs
+++ b/rust/arrow/src/util/display.rs
@@ -55,7 +55,7 @@ macro_rules! make_string_hex {
             let mut tmp = "".to_string();
 
             for character in array.value($row) {
-                tmp += &format!("{:X?}", character);
+                tmp += &format!("{:02x}", character);
             }
 
             tmp

--- a/rust/arrow/src/util/display.rs
+++ b/rust/arrow/src/util/display.rs
@@ -44,6 +44,27 @@ macro_rules! make_string {
     }};
 }
 
+// It's not possible to do array.value($row).to_string() for &[u8], let's format it as hex
+macro_rules! make_string_hex {
+    ($array_type:ty, $column: ident, $row: ident) => {{
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+
+        let s = if array.is_null($row) {
+            "".to_string()
+        } else {
+            let mut tmp = "".to_string();
+
+            for character in array.value($row) {
+                tmp += &format!("{:X?}", character);
+            }
+
+            tmp
+        };
+
+        Ok(s)
+    }};
+}
+
 macro_rules! make_string_from_list {
     ($column: ident, $row: ident) => {{
         let list = $column
@@ -67,6 +88,9 @@ macro_rules! make_string_from_list {
 pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<String> {
     match column.data_type() {
         DataType::Utf8 => make_string!(array::StringArray, column, row),
+        DataType::LargeUtf8 => make_string!(array::LargeStringArray, column, row),
+        DataType::Binary => make_string_hex!(array::BinaryArray, column, row),
+        DataType::LargeBinary => make_string_hex!(array::LargeBinaryArray, column, row),
         DataType::Boolean => make_string!(array::BooleanArray, column, row),
         DataType::Int8 => make_string!(array::Int8Array, column, row),
         DataType::Int16 => make_string!(array::Int16Array, column, row),

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -61,6 +61,8 @@ futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "0.2", features = ["macros", "blocking", "rt-core", "rt-threaded", "sync"] }
 log = "^0.4"
+md-5 = "^0.9.1"
+sha2 = "^0.9.1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -690,6 +690,11 @@ unary_scalar_expr!(Trim, trim);
 unary_scalar_expr!(Ltrim, ltrim);
 unary_scalar_expr!(Rtrim, rtrim);
 unary_scalar_expr!(Upper, upper);
+unary_scalar_expr!(MD5, md5);
+unary_scalar_expr!(SHA224, sha224);
+unary_scalar_expr!(SHA256, sha256);
+unary_scalar_expr!(SHA384, sha384);
+unary_scalar_expr!(SHA512, sha512);
 
 /// returns the length of a string in bytes
 pub fn length(e: Expr) -> Expr {

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -36,8 +36,9 @@ pub use display::display_schema;
 pub use expr::{
     abs, acos, and, array, asin, atan, avg, binary_expr, case, ceil, col, concat, cos,
     count, count_distinct, create_udaf, create_udf, exp, exprlist_to_fields, floor,
-    in_list, length, lit, ln, log10, log2, lower, ltrim, max, min, or, round, rtrim,
-    signum, sin, sqrt, sum, tan, trim, trunc, upper, when, Expr, Literal,
+    in_list, length, lit, ln, log10, log2, lower, ltrim, max, md5, min, or, round, rtrim,
+    sha224, sha256, sha384, sha512, signum, sin, sqrt, sum, tan, trim, trunc, upper,
+    when, Expr, Literal,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -25,8 +25,7 @@ use sha2::{
 
 use crate::error::{DataFusionError, Result};
 use arrow::array::{
-    ArrayRef, BinaryBuilder, GenericBinaryArray, GenericStringArray,
-    StringOffsetSizeTrait,
+    ArrayRef, GenericBinaryArray, GenericStringArray, StringOffsetSizeTrait,
 };
 
 fn md5_process(input: &str) -> String {
@@ -94,15 +93,8 @@ macro_rules! crypto_unary_binary_function {
                 .downcast_ref::<GenericStringArray<T>>()
                 .unwrap();
 
-            let mut builder = BinaryBuilder::new(args.len());
-
-            for value in array.iter() {
-                builder
-                    .append_value($FUNC(value.unwrap()).as_slice())
-                    .unwrap();
-            }
-
-            Ok(builder.finish())
+            // first map is the iterator, second is for the `Option<_>`
+            Ok(array.iter().map(|x| x.map(|x| $FUNC(x))).collect())
         }
     };
 }

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Crypto expressions
+
+use md5::Md5;
+use sha2::{
+    digest::Output as SHA2DigestOutput, Digest as SHA2Digest, Sha224, Sha256, Sha384,
+    Sha512,
+};
+
+use crate::error::{DataFusionError, Result};
+use arrow::array::{
+    ArrayRef, BinaryBuilder, GenericBinaryArray, GenericStringArray,
+    StringOffsetSizeTrait,
+};
+
+fn md5_process(input: &str) -> String {
+    let mut digest = Md5::default();
+    digest.update(&input);
+
+    let mut result = String::new();
+
+    for byte in &digest.finalize() {
+        result.push_str(&format!("{:02x}", byte));
+    }
+
+    result
+}
+
+// It's not possible to return &[u8], because trait in trait without short lifetime
+fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
+    let mut digest = D::default();
+    digest.update(&input);
+
+    digest.finalize()
+}
+
+macro_rules! crypto_unary_string_function {
+    ($NAME:ident, $FUNC:expr) => {
+        /// crypto function that accepts Utf8 or LargeUtf8 and returns Utf8 string
+        pub fn $NAME<T: StringOffsetSizeTrait>(
+            args: &[ArrayRef],
+        ) -> Result<GenericStringArray<i32>> {
+            if args.len() != 1 {
+                return Err(DataFusionError::Internal(format!(
+                    "{:?} args were supplied but {} takes exactly one argument",
+                    args.len(),
+                    String::from(stringify!($NAME)),
+                )));
+            }
+
+            let array = args[0]
+                .as_any()
+                .downcast_ref::<GenericStringArray<T>>()
+                .unwrap();
+
+            // first map is the iterator, second is for the `Option<_>`
+            Ok(array.iter().map(|x| x.map(|x| $FUNC(x))).collect())
+        }
+    };
+}
+
+macro_rules! crypto_unary_binary_function {
+    ($NAME:ident, $FUNC:expr) => {
+        /// crypto function that accepts Utf8 or LargeUtf8 and returns Binary
+        pub fn $NAME<T: StringOffsetSizeTrait>(
+            args: &[ArrayRef],
+        ) -> Result<GenericBinaryArray<i32>> {
+            if args.len() != 1 {
+                return Err(DataFusionError::Internal(format!(
+                    "{:?} args were supplied but {} takes exactly one argument",
+                    args.len(),
+                    String::from(stringify!($NAME)),
+                )));
+            }
+
+            let array = args[0]
+                .as_any()
+                .downcast_ref::<GenericStringArray<T>>()
+                .unwrap();
+
+            let mut builder = BinaryBuilder::new(args.len());
+
+            for value in array.iter() {
+                builder
+                    .append_value($FUNC(value.unwrap()).as_slice())
+                    .unwrap();
+            }
+
+            Ok(builder.finish())
+        }
+    };
+}
+
+crypto_unary_string_function!(md5, md5_process);
+crypto_unary_binary_function!(sha224, sha_process::<Sha224>);
+crypto_unary_binary_function!(sha256, sha_process::<Sha256>);
+crypto_unary_binary_function!(sha384, sha_process::<Sha384>);
+crypto_unary_binary_function!(sha512, sha_process::<Sha512>);

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -270,6 +270,7 @@ pub mod aggregates;
 pub mod array_expressions;
 pub mod coalesce_batches;
 pub mod common;
+pub mod crypto_expressions;
 pub mod csv;
 pub mod datetime_expressions;
 pub mod distinct_expressions;

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -29,6 +29,7 @@ pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::logical_plan::{
     array, avg, col, concat, count, create_udf, in_list, length, lit, lower, ltrim, max,
-    min, rtrim, sum, trim, upper, JoinType, Partitioning,
+    md5, min, rtrim, sha224, sha256, sha384, sha512, sum, trim, upper, JoinType,
+    Partitioning,
 };
 pub use crate::physical_plan::csv::CsvReadOptions;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1859,19 +1859,33 @@ async fn crypto_expressions() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     let sql = "SELECT
         md5('tom') AS md5_tom,
+        md5('') AS md5_empty_str,
+        md5(null) AS md5_null,
         sha224('tom') AS sha224_tom,
+        sha224('') AS sha224_empty_str,
+        sha224(null) AS sha224_null,
         sha256('tom') AS sha256_tom,
+        sha256('') AS sha256_empty_str,
         sha384('tom') AS sha348_tom,
-        sha512('tom') AS sha512_tom
+        sha384('') AS sha384_empty_str,
+        sha512('tom') AS sha512_tom,
+        sha512('') AS sha512_empty_str
     ";
     let actual = execute(&mut ctx, sql).await;
 
     let expected = vec![vec![
         "34b7da764b21d298ef307d04d8152dc5",
-        "BF6CB62649C42A9AE3876AB6F6D92AD36CB5414E495F8873292BE4D",
-        "E1608F75C5D7813F3D4031CB30BFB786507D98137538FF8E128A6FF74E84E643",
-        "96F5B68AA77848E4FDF5C1CB35DE2DBFAD6FFD7C25D9EA7C6C19B8A4D55A9187EB117C557883F58C16DFAC3E343",
-        "6E1B9B3FE84068E3751F7AD5E959D6F39AD0F8885D855166F55C659469D3C8B78118C44A2A49C72DDB481CD6D8731034E11CC0307BA843A9B3495CB8D3E"
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "NULL",
+        "0bf6cb62649c42a9ae3876ab6f6d92ad36cb5414e495f8873292be4d",
+        "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
+        "NULL",
+        "e1608f75c5d7813f3d4031cb30bfb786507d98137538ff8e128a6ff74e84e643",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "096f5b68aa77848e4fdf5c1c0b350de2dbfad60ffd7c25d9ea07c6c19b8a4d55a9187eb117c557883f58c16dfac3e343",
+        "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+        "6e1b9b3fe840680e37051f7ad5e959d6f39ad0f8885d855166f55c659469d3c8b78118c44a2a49c72ddb481cd6d8731034e11cc030070ba843a90b3495cb8d3e",
+        "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
     ]];
     assert_eq!(expected, actual);
     Ok(())

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1855,6 +1855,29 @@ async fn string_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn crypto_expressions() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    let sql = "SELECT
+        md5('tom') AS md5_tom,
+        sha224('tom') AS sha224_tom,
+        sha256('tom') AS sha256_tom,
+        sha384('tom') AS sha348_tom,
+        sha512('tom') AS sha512_tom
+    ";
+    let actual = execute(&mut ctx, sql).await;
+
+    let expected = vec![vec![
+        "34b7da764b21d298ef307d04d8152dc5",
+        "BF6CB62649C42A9AE3876AB6F6D92AD36CB5414E495F8873292BE4D",
+        "E1608F75C5D7813F3D4031CB30BFB786507D98137538FF8E128A6FF74E84E643",
+        "96F5B68AA77848E4FDF5C1CB35DE2DBFAD6FFD7C25D9EA7C6C19B8A4D55A9187EB117C557883F58C16DFAC3E343",
+        "6E1B9B3FE84068E3751F7AD5E959D6F39AD0F8885D855166F55C659469D3C8B78118C44A2A49C72DDB481CD6D8731034E11CC0307BA843A9B3495CB8D3E"
+    ]];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn in_list_array() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;


### PR DESCRIPTION
Implemented functions:

- [x] MD5 (return type string)
- [x] SHA224 (return type binary)
- [x] SHA256 (return type binary)
- [x] SHA384 (return type binary)
- [x] SHA512 (return type binary)