### PR TITLE
ARROW-11189: [Developer] support benchmark diff between JSONs

### DIFF
--- a/ci/conda_env_archery.yml
+++ b/ci/conda_env_archery.yml
@@ -15,8 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# cli
 click
-gitpython
+
+# bot, crossbow
+github3.py
+jinja2
+jira
+pygit2
 pygithub
 ruamel.yaml
+setuptools_scm
+toolz
+
+# benchmark
+pandas
+
+# docker
+python-dotenv
+#ruamel.yaml
+
+# release
+gitpython
+#jinja2
+#jira
 semver

--- a/dev/archery/archery/benchmark/core.py
+++ b/dev/archery/archery/benchmark/core.py
@@ -27,12 +27,13 @@ def median(values):
 
 
 class Benchmark:
-    def __init__(self, name, unit, less_is_better, values, stats=None):
+    def __init__(self, name, unit, less_is_better, values, counters={}):
         self.name = name
         self.unit = unit
         self.less_is_better = less_is_better
         self.values = sorted(values)
         self.median = median(self.values)
+        self.counters = counters
 
     @property
     def value(self):

--- a/dev/archery/archery/benchmark/core.py
+++ b/dev/archery/archery/benchmark/core.py
@@ -27,13 +27,13 @@ def median(values):
 
 
 class Benchmark:
-    def __init__(self, name, unit, less_is_better, values, counters={}):
+    def __init__(self, name, unit, less_is_better, values, counters=None):
         self.name = name
         self.unit = unit
         self.less_is_better = less_is_better
         self.values = sorted(values)
         self.median = median(self.values)
-        self.counters = counters
+        self.counters = counters or {}
 
     @property
     def value(self):

--- a/dev/archery/archery/benchmark/runner.py
+++ b/dev/archery/archery/benchmark/runner.py
@@ -144,7 +144,9 @@ class CppBenchmarkRunner(BenchmarkRunner):
         return CppConfiguration(
             build_type="release", with_tests=False, with_benchmarks=True,
             with_compute=True,
+            with_csv=True,
             with_dataset=True,
+            with_json=True,
             with_parquet=True,
             with_python=False,
             with_brotli=True,

--- a/dev/archery/archery/lang/cpp.py
+++ b/dev/archery/archery/lang/cpp.py
@@ -42,6 +42,7 @@ class CppConfiguration:
                  cc=None, cxx=None, cxx_flags=None,
                  build_type=None, warn_level=None,
                  cpp_package_prefix=None, install_prefix=None, use_conda=None,
+                 build_static=False, build_shared=True,
                  # tests & examples
                  with_tests=None, with_benchmarks=None, with_examples=None,
                  with_integration=None,
@@ -73,6 +74,8 @@ class CppConfiguration:
         self._install_prefix = install_prefix
         self._package_prefix = cpp_package_prefix
         self._use_conda = use_conda
+        self.build_static = build_static
+        self.build_shared = build_shared
 
         self.with_tests = with_tests
         self.with_benchmarks = with_benchmarks
@@ -173,6 +176,7 @@ class CppConfiguration:
 
         yield ("CMAKE_EXPORT_COMPILE_COMMANDS", truthifier(True))
         yield ("CMAKE_BUILD_TYPE", self.build_type)
+        yield ("CMAKE_UNITY_BUILD", True)
 
         if not self.with_lint_only:
             yield ("BUILD_WARNING_LEVEL",
@@ -188,6 +192,9 @@ class CppConfiguration:
         if self._package_prefix is not None:
             yield ("ARROW_DEPENDENCY_SOURCE", "SYSTEM")
             yield ("ARROW_PACKAGE_PREFIX", self._package_prefix)
+
+        yield ("ARROW_BUILD_STATIC", truthifier(self.build_static))
+        yield ("ARROW_BUILD_SHARED", truthifier(self.build_shared))
 
         # Tests and benchmarks
         yield ("ARROW_BUILD_TESTS", truthifier(self.with_tests))


### PR DESCRIPTION
Enables diffing two cached JSON benchmark results. Also groups regressions and non-regressions for easier inspection:

```shell-session
$ export FILTERS="--benchmark-filter=value-parsing --suite-filter=IntegerFormatting"
$ archery benchmark run $FILTERS --output=baseline.json
$ git checkout $BRANCH
$ archery benchmark run $FILTERS --output=contender.json
$ archery benchmark diff contender.json baseline.json
---------------------------------------------------------------------------------------
Non-regressions: (1)
---------------------------------------------------------------------------------------
                   benchmark            baseline           contender  change % counters
 IntegerFormatting<Int8Type>  106.163m items/sec  108.091m items/sec     1.816       {}

-----------------------------------------------------------------------------------------
Regressions: (9)
-----------------------------------------------------------------------------------------
                     benchmark            baseline           contender  change % counters
  IntegerFormatting<UInt8Type>  112.739m items/sec  102.576m items/sec    -9.015       {}
 IntegerFormatting<UInt32Type>   61.029m items/sec   54.603m items/sec   -10.530       {}
  IntegerFormatting<Int16Type>   86.396m items/sec   74.601m items/sec   -13.653       {}
  IntegerFormatting<Int32Type>   61.305m items/sec   51.841m items/sec   -15.437       {}
 IntegerFormatting<UInt16Type>   88.665m items/sec   74.442m items/sec   -16.041       {}
 IntegerFormatting<UInt64Type>   34.248m items/sec   27.239m items/sec   -20.464       {}
  IntegerFormatting<Int64Type>   38.401m items/sec   27.475m items/sec   -28.451       {}
   FloatFormatting<DoubleType>    5.642m items/sec    3.614m items/sec   -35.939       {}
    FloatFormatting<FloatType>    5.823m items/sec    3.608m items/sec   -38.038       {}
```