### PR TITLE
ARROW-11190: [C++] Clean up compiler warnings

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -434,7 +434,7 @@ class PrimitiveConverter : public ConcreteConverter {
       if (decoder_.IsNull(data, size, quoted /* quoted */)) {
         return builder.AppendNull();
       }
-      value_type value;
+      value_type value{};
       RETURN_NOT_OK(decoder_.Decode(data, size, quoted, &value));
       builder.UnsafeAppend(value);
       return Status::OK();
@@ -480,7 +480,7 @@ class TypedDictionaryConverter : public ConcreteDictionaryConverter {
       if (ARROW_PREDICT_FALSE(builder.dictionary_length() > max_cardinality_)) {
         return Status::IndexError("Dictionary length exceeded max cardinality");
       }
-      value_type value;
+      value_type value{};
       RETURN_NOT_OK(decoder_.Decode(data, size, quoted, &value));
       return builder.Append(value);
     };


### PR DESCRIPTION
Some unused variables:
- https://github.com/apache/arrow/runs/1669466544#step:8:1434

Some maybe uninitialized:
- https://github.com/apache/arrow/runs/1669466544#step:8:1498