### PR TITLE
ARROW-10463: [R] Better messaging for currently unsupported CSV options in open_dataset

### DIFF
--- a/r/R/dataset-factory.R
+++ b/r/R/dataset-factory.R
@@ -107,7 +107,9 @@ DatasetFactory$create <- function(x,
 #' @param ... Additional format-specific options, passed to
 #' `FileFormat$create()`. For CSV options, note that you can specify them either
 #' with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
-#' `readr`-style naming used in [read_csv_arrow()] ("delim", "quote", etc.)
+#' `readr`-style naming used in [read_csv_arrow()] ("delim", "quote", etc.).
+#' Not all `readr` options are currently supported; please file an issue if you
+#' encounter one that `arrow` should support.
 #' @return A `DatasetFactory` object. Pass this to [open_dataset()],
 #' in a list potentially with other `DatasetFactory` objects, to create
 #' a `Dataset`.

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -105,7 +105,7 @@ CsvFileFormat$create <- function(..., opts = csv_file_format_parse_options(...))
 
 csv_file_format_parse_options <- function(...) {
   # Support both the readr spelling of options and the arrow spelling
-  readr_opts <- c("delim", "quote", "escape_double", "escape_backslash", "skip_empty_rows")
+  readr_opts <- names(formals(readr_to_csv_parse_options))
   if (any(readr_opts %in% names(list(...)))) {
     readr_to_csv_parse_options(...)
   } else {

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -42,7 +42,9 @@
 #'
 #'   `format = "text"`: see [CsvReadOptions]. Note that you can specify them either
 #'   with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
-#'   `readr`-style naming used in [read_csv_arrow()] ("delim", "quote", etc.)
+#'   `readr`-style naming used in [read_csv_arrow()] ("delim", "quote", etc.).
+#'   Not all `readr` options are currently supported; please file an issue if
+#'   you encounter one that `arrow` should support.
 #'
 #' It returns the appropriate subclass of `FileFormat` (e.g. `ParquetFileFormat`)
 #' @rdname FileFormat

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -104,9 +104,31 @@ CsvFileFormat$create <- function(..., opts = csv_file_format_parse_options(...))
 }
 
 csv_file_format_parse_options <- function(...) {
+  opt_names <- names(list(...))
   # Support both the readr spelling of options and the arrow spelling
+  arrow_opts <- names(formals(CsvParseOptions$create))
   readr_opts <- names(formals(readr_to_csv_parse_options))
-  if (any(readr_opts %in% names(list(...)))) {
+  is_arrow_opt <- !is.na(pmatch(opt_names, arrow_opts))
+  is_readr_opt <- !is.na(pmatch(opt_names, readr_opts))
+  bad_opts <- opt_names[!is_arrow_opt & !is_readr_opt]
+  if (length(bad_opts)) {
+    stop("Unsupported options: ",
+         paste(bad_opts, collapse = ", "),
+         call. = FALSE)
+  }
+  is_ambig_opt <- is.na(pmatch(opt_names, c(arrow_opts, readr_opts)))
+  ambig_opts <- opt_names[is_ambig_opt]
+  if (length(ambig_opts)) {
+    stop("Ambiguous arguments: ",
+         paste(ambig_opts, collapse = ", "),
+         ". Use full argument names",
+         call. = FALSE)
+  }
+  if (any(is_readr_opt)) {
+    if (!all(is_readr_opt)) {
+      stop("Use either Arrow parse options or readr parse options, not both",
+           call. = FALSE)
+    }
     readr_to_csv_parse_options(...)
   } else {
     CsvParseOptions$create(...)

--- a/r/man/FileFormat.Rd
+++ b/r/man/FileFormat.Rd
@@ -37,7 +37,9 @@ to reduce memory overhead. Disabled by default.
 
 \code{format = "text"}: see \link{CsvReadOptions}. Note that you can specify them either
 with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
-\code{readr}-style naming used in \code{\link[=read_csv_arrow]{read_csv_arrow()}} ("delim", "quote", etc.)
+\code{readr}-style naming used in \code{\link[=read_csv_arrow]{read_csv_arrow()}} ("delim", "quote", etc.).
+Not all \code{readr} options are currently supported; please file an issue if
+you encounter one that \code{arrow} should support.
 }
 
 It returns the appropriate subclass of \code{FileFormat} (e.g. \code{ParquetFileFormat})

--- a/r/man/dataset_factory.Rd
+++ b/r/man/dataset_factory.Rd
@@ -53,7 +53,9 @@ Hive-style path segments
 \item{...}{Additional format-specific options, passed to
 \code{FileFormat$create()}. For CSV options, note that you can specify them either
 with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
-\code{readr}-style naming used in \code{\link[=read_csv_arrow]{read_csv_arrow()}} ("delim", "quote", etc.)}
+\code{readr}-style naming used in \code{\link[=read_csv_arrow]{read_csv_arrow()}} ("delim", "quote", etc.).
+Not all \code{readr} options are currently supported; please file an issue if you
+encounter one that \code{arrow} should support.}
 }
 \value{
 A \code{DatasetFactory} object. Pass this to \code{\link[=open_dataset]{open_dataset()}},

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -315,14 +315,25 @@ test_that("readr parse options", {
     character(0)
   )
 
-  # With unsupported readr parse options
+  # With not yet supported readr parse options
   # (remove this after ARROW-8631)
   if (!"na" %in% readr_opts) {
     expect_error(
       open_dataset(tsv_dir, partitioning = "part", delim = "\t", na = "\\N"),
-      "Unsupported"
+      "supported"
     )
   }
+
+  # With unrecognized (garbage) parse options
+  expect_error(
+    open_dataset(
+      tsv_dir,
+      partitioning = "part",
+      format = "text",
+      asdfg = "\\"
+    ),
+    "Unrecognized"
+  )
 
   # With both Arrow and readr parse options (disallowed)
   expect_error(

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -318,14 +318,11 @@ test_that("readr parse options", {
     character(0)
   )
 
-  # With not yet supported readr parse options
-  # (remove this after ARROW-8631)
-  if (!"na" %in% readr_opts) {
-    expect_error(
-      open_dataset(tsv_dir, partitioning = "part", delim = "\t", na = "\\N"),
-      "supported"
-    )
-  }
+  # With not yet supported readr parse options (ARROW-8631)
+  expect_error(
+    open_dataset(tsv_dir, partitioning = "part", delim = "\t", na = "\\N"),
+    "supported"
+  )
 
   # With unrecognized (garbage) parse options
   expect_error(

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -309,7 +309,10 @@ test_that("readr parse options", {
   arrow_opts <- names(formals(CsvParseOptions$create))
   readr_opts <- names(formals(readr_to_csv_parse_options))
 
-  # Arrow and readr options are mutually exclusive
+  # Arrow and readr parse options must be mutually exclusive, or else the code
+  # in `csv_file_format_parse_options()` will error or behave incorrectly. A
+  # failure of this test indicates that these two sets of option names are not
+  # mutually exclusive.
   expect_equal(
     intersect(arrow_opts, readr_opts),
     character(0)


### PR DESCRIPTION
Improves messaging for currently unsupported readr parse options and improves handling in related cases such as ambiguous partial argument names and invalid combinations of Arrow and readr options