### PR TITLE
ARROW-11177: [Java] ArrowMessage failed to parse compressed grpc stream

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -334,12 +334,15 @@ class ArrowMessage implements AutoCloseable {
   }
 
   /**
-   * Get first byte with EOF check, it is especially needed when using grpc compression.
-   * InflaterInputStream need another read to change reachEOF after all bytes has been read.
+   * Read a varint32 from the stream, checking for EOF.
+   *
+   * <p>When using gRPC compression, EOF may not be reported by the InflaterInputStream until another read has
+   * been performed. This method checks {@link InputStream#available()} after reading the first byte in order
+   * to handle this case.
    *
    * @param is InputStream
-   * @return -1 if stream is not available, otherwise it will return the actual value.
-   * @throws IOException Read first byte failed.
+   * @return -1 if EOF reached, else the varint32 value.
+   * @throws IOException if an error occurred while reading the stream.
    */
   private static int readRawVarint32WithEOFCheck(InputStream is) throws IOException {
     int firstByte = is.read();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -339,11 +339,7 @@ class ArrowMessage implements AutoCloseable {
 
   private static int readRawVarint32(InputStream is) throws IOException {
     int firstByte = is.read();
-    if (firstByte >= 0) {
-      return CodedInputStream.readRawVarint32(firstByte, is);
-    } else {
-      throw new IOException("It should not reach EOF here.");
-    }
+    return CodedInputStream.readRawVarint32(firstByte, is);
   }
 
   /**


### PR DESCRIPTION
InvalidProtocolBufferException will be thrown in ArrowMessage.frame if we use gzip compress in Grpc.

The reason is, stream.available is still a 1 after we read compressed data. It need another read to change InflaterInputStream.reachEOF to be true, and make stream.available to be 0.
Thus we need check stream.available agian after read first byte from stream.