### PR TITLE
ARROW-11194: [Rust] Enable packed_simd for aarch64

### DIFF
--- a/rust/arrow/build.rs
+++ b/rust/arrow/build.rs
@@ -21,5 +21,6 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
         simd_x86: { all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd") },
+        simd_aarch64: { all(target_arch = "aarch64", feature = "simd") },
     }
 }

--- a/rust/arrow/build.rs
+++ b/rust/arrow/build.rs
@@ -20,7 +20,6 @@ use cfg_aliases::cfg_aliases;
 fn main() {
     // Setup cfg aliases
     cfg_aliases! {
-        simd_x86: { all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd") },
-        simd_aarch64: { all(target_arch = "aarch64", feature = "simd") },
+        simd: { all(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"), feature = "simd") },
     }
 }

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -254,7 +254,7 @@ impl std::ops::Deref for Buffer {
 /// and the `scalar_op` gets applied to remaining bytes.
 /// Contrary to the non-simd version `bitwise_bin_op_helper`, the offset and length is specified in bytes
 /// and this version does not support operations starting at arbitrary bit offsets.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn bitwise_bin_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
     left_offset: usize,
@@ -303,7 +303,7 @@ where
 /// and the `scalar_op` gets applied to remaining bytes.
 /// Contrary to the non-simd version `bitwise_unary_op_helper`, the offset and length is specified in bytes
 /// and this version does not support operations starting at arbitrary bit offsets.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn bitwise_unary_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
     left_offset: usize,
@@ -468,7 +468,7 @@ pub(super) fn buffer_bin_and(
     }
 }
 
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub(super) fn buffer_bin_and(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -579,7 +579,7 @@ pub(super) fn buffer_bin_or(
     }
 }
 
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub(super) fn buffer_bin_or(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -636,7 +636,7 @@ pub(super) fn buffer_unary_not(
     len_in_bits: usize,
 ) -> Buffer {
     // SIMD implementation if available and byte-aligned
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     if offset_in_bits % 8 == 0 && len_in_bits % 8 == 0 {
         return bitwise_unary_op_simd_helper(
             &left,

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -254,7 +254,7 @@ impl std::ops::Deref for Buffer {
 /// and the `scalar_op` gets applied to remaining bytes.
 /// Contrary to the non-simd version `bitwise_bin_op_helper`, the offset and length is specified in bytes
 /// and this version does not support operations starting at arbitrary bit offsets.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn bitwise_bin_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
     left_offset: usize,
@@ -303,7 +303,7 @@ where
 /// and the `scalar_op` gets applied to remaining bytes.
 /// Contrary to the non-simd version `bitwise_unary_op_helper`, the offset and length is specified in bytes
 /// and this version does not support operations starting at arbitrary bit offsets.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn bitwise_unary_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
     left_offset: usize,
@@ -468,7 +468,7 @@ pub(super) fn buffer_bin_and(
     }
 }
 
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub(super) fn buffer_bin_and(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -579,7 +579,7 @@ pub(super) fn buffer_bin_or(
     }
 }
 
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub(super) fn buffer_bin_or(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -636,7 +636,7 @@ pub(super) fn buffer_unary_not(
     len_in_bits: usize,
 ) -> Buffer {
     // SIMD implementation if available and byte-aligned
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     if offset_in_bits % 8 == 0 && len_in_bits % 8 == 0 {
         return bitwise_unary_op_simd_helper(
             &left,

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -68,7 +68,7 @@ fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
 
 /// Returns the minimum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[cfg(not(simd_x86))]
+#[cfg(not(any(simd_x86, simd_aarch64)))]
 pub fn min<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -79,7 +79,7 @@ where
 
 /// Returns the maximum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[cfg(not(simd_x86))]
+#[cfg(not(any(simd_x86, simd_aarch64)))]
 pub fn max<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -190,7 +190,7 @@ pub fn max_boolean(array: &BooleanArray) -> Option<bool> {
 /// Returns the sum of values in the array.
 ///
 /// Returns `None` if the array is empty or only contains null values.
-#[cfg(not(simd_x86))]
+#[cfg(not(any(simd_x86, simd_aarch64)))]
 pub fn sum<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -244,7 +244,7 @@ where
     }
 }
 
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 mod simd {
     use super::is_nan;
     use crate::array::{Array, PrimitiveArray};
@@ -589,7 +589,7 @@ mod simd {
 /// Returns the sum of values in the array.
 ///
 /// Returns `None` if the array is empty or only contains null values.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub fn sum<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T::Native: Add<Output = T::Native>,
@@ -599,7 +599,7 @@ where
     simd::simd_aggregation::<T, SumAggregate<T>>(&array)
 }
 
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 /// Returns the minimum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn min<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>
@@ -611,7 +611,7 @@ where
     simd::simd_aggregation::<T, MinAggregate<T>>(&array)
 }
 
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 /// Returns the maximum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn max<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -68,7 +68,7 @@ fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
 
 /// Returns the minimum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[cfg(not(any(simd_x86, simd_aarch64)))]
+#[cfg(not(simd))]
 pub fn min<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -79,7 +79,7 @@ where
 
 /// Returns the maximum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[cfg(not(any(simd_x86, simd_aarch64)))]
+#[cfg(not(simd))]
 pub fn max<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -190,7 +190,7 @@ pub fn max_boolean(array: &BooleanArray) -> Option<bool> {
 /// Returns the sum of values in the array.
 ///
 /// Returns `None` if the array is empty or only contains null values.
-#[cfg(not(any(simd_x86, simd_aarch64)))]
+#[cfg(not(simd))]
 pub fn sum<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
@@ -244,7 +244,7 @@ where
     }
 }
 
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 mod simd {
     use super::is_nan;
     use crate::array::{Array, PrimitiveArray};
@@ -589,7 +589,7 @@ mod simd {
 /// Returns the sum of values in the array.
 ///
 /// Returns `None` if the array is empty or only contains null values.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub fn sum<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T::Native: Add<Output = T::Native>,
@@ -599,7 +599,7 @@ where
     simd::simd_aggregation::<T, SumAggregate<T>>(&array)
 }
 
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 /// Returns the minimum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn min<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>
@@ -611,7 +611,7 @@ where
     simd::simd_aggregation::<T, MinAggregate<T>>(&array)
 }
 
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 /// Returns the maximum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn max<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<T::Native>

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -35,9 +35,9 @@ use crate::datatypes;
 use crate::datatypes::{ArrowNumericType, ToByteSlice};
 use crate::error::{ArrowError, Result};
 use crate::{array::*, util::bit_util};
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 use std::borrow::BorrowMut;
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 use std::slice::{ChunksExact, ChunksExactMut};
 
 /// Helper function to perform math lambda function on values from single array of signed numeric
@@ -70,7 +70,7 @@ where
 }
 
 /// SIMD vectorized version of `signed_unary_math_op` above.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn simd_signed_unary_math_op<T, SIMD_OP, SCALAR_OP>(
     array: &PrimitiveArray<T>,
     simd_op: SIMD_OP,
@@ -227,7 +227,7 @@ where
 }
 
 /// SIMD vectorized version of `math_op` above.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn simd_math_op<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -292,7 +292,7 @@ where
 /// SIMD vectorized implementation of `left / right`.
 /// If any of the lanes marked as valid in `valid_mask` are `0` then an `ArrowError::DivideByZero`
 /// is returned. The contents of no-valid lanes are undefined.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 #[inline]
 fn simd_checked_divide<T: ArrowNumericType>(
     valid_mask: Option<u64>,
@@ -325,7 +325,7 @@ where
 
 /// Scalar implementation of `left / right` for the remainder elements after complete chunks have been processed using SIMD.
 /// If any of the values marked as valid in `valid_mask` are `0` then an `ArrowError::DivideByZero` is returned.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 #[inline]
 fn simd_checked_divide_remainder<T: ArrowNumericType>(
     valid_mask: Option<u64>,
@@ -360,7 +360,7 @@ where
 /// SIMD vectorized version of `divide`, the divide kernel needs it's own implementation as there
 /// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULL`
 /// slots and padding.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn simd_divide<T>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -490,9 +490,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_math_op(&left, &right, |a, b| a + b, |a, b| a + b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return math_op(left, right, |a, b| a + b);
 }
 
@@ -510,9 +510,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_math_op(&left, &right, |a, b| a - b, |a, b| a - b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return math_op(left, right, |a, b| a - b);
 }
 
@@ -522,9 +522,9 @@ where
     T: datatypes::ArrowSignedNumericType,
     T::Native: Neg<Output = T::Native>,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_signed_unary_math_op(array, |x| -x, |x| -x);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return signed_unary_math_op(array, |x| -x);
 }
 
@@ -542,9 +542,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_math_op(&left, &right, |a, b| a * b, |a, b| a * b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return math_op(left, right, |a, b| a * b);
 }
 
@@ -564,9 +564,9 @@ where
         + Zero
         + One,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_divide(&left, &right);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return math_divide(&left, &right);
 }
 

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -35,9 +35,9 @@ use crate::datatypes;
 use crate::datatypes::{ArrowNumericType, ToByteSlice};
 use crate::error::{ArrowError, Result};
 use crate::{array::*, util::bit_util};
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 use std::borrow::BorrowMut;
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 use std::slice::{ChunksExact, ChunksExactMut};
 
 /// Helper function to perform math lambda function on values from single array of signed numeric
@@ -70,7 +70,7 @@ where
 }
 
 /// SIMD vectorized version of `signed_unary_math_op` above.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn simd_signed_unary_math_op<T, SIMD_OP, SCALAR_OP>(
     array: &PrimitiveArray<T>,
     simd_op: SIMD_OP,
@@ -227,7 +227,7 @@ where
 }
 
 /// SIMD vectorized version of `math_op` above.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn simd_math_op<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -292,7 +292,7 @@ where
 /// SIMD vectorized implementation of `left / right`.
 /// If any of the lanes marked as valid in `valid_mask` are `0` then an `ArrowError::DivideByZero`
 /// is returned. The contents of no-valid lanes are undefined.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 #[inline]
 fn simd_checked_divide<T: ArrowNumericType>(
     valid_mask: Option<u64>,
@@ -325,7 +325,7 @@ where
 
 /// Scalar implementation of `left / right` for the remainder elements after complete chunks have been processed using SIMD.
 /// If any of the values marked as valid in `valid_mask` are `0` then an `ArrowError::DivideByZero` is returned.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 #[inline]
 fn simd_checked_divide_remainder<T: ArrowNumericType>(
     valid_mask: Option<u64>,
@@ -360,7 +360,7 @@ where
 /// SIMD vectorized version of `divide`, the divide kernel needs it's own implementation as there
 /// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULL`
 /// slots and padding.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn simd_divide<T>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -490,9 +490,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_math_op(&left, &right, |a, b| a + b, |a, b| a + b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return math_op(left, right, |a, b| a + b);
 }
 
@@ -510,9 +510,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_math_op(&left, &right, |a, b| a - b, |a, b| a - b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return math_op(left, right, |a, b| a - b);
 }
 
@@ -522,9 +522,9 @@ where
     T: datatypes::ArrowSignedNumericType,
     T::Native: Neg<Output = T::Native>,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_signed_unary_math_op(array, |x| -x, |x| -x);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return signed_unary_math_op(array, |x| -x);
 }
 
@@ -542,9 +542,9 @@ where
         + Div<Output = T::Native>
         + Zero,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_math_op(&left, &right, |a, b| a * b, |a, b| a * b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return math_op(left, right, |a, b| a * b);
 }
 
@@ -564,9 +564,9 @@ where
         + Zero
         + One,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_divide(&left, &right);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return math_divide(&left, &right);
 }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -370,7 +370,7 @@ pub fn gt_eq_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray
 
 /// Helper function to perform boolean lambda function on values from two arrays using
 /// SIMD.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn simd_compare_op<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -460,7 +460,7 @@ where
 
 /// Helper function to perform boolean lambda function on values from an array and a scalar value using
 /// SIMD.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 fn simd_compare_op_scalar<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: T::Native,
@@ -546,9 +546,9 @@ pub fn eq<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::eq, |a, b| a == b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a == b);
 }
 
@@ -557,9 +557,9 @@ pub fn eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::eq, |a, b| a == b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a == b);
 }
 
@@ -568,9 +568,9 @@ pub fn neq<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::ne, |a, b| a != b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a != b);
 }
 
@@ -579,9 +579,9 @@ pub fn neq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boole
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::ne, |a, b| a != b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a != b);
 }
 
@@ -591,9 +591,9 @@ pub fn lt<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::lt, |a, b| a < b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a < b);
 }
 
@@ -603,9 +603,9 @@ pub fn lt_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::lt, |a, b| a < b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a < b);
 }
 
@@ -618,9 +618,9 @@ pub fn lt_eq<T>(
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::le, |a, b| a <= b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a <= b);
 }
 
@@ -630,9 +630,9 @@ pub fn lt_eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::le, |a, b| a <= b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a <= b);
 }
 
@@ -642,9 +642,9 @@ pub fn gt<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::gt, |a, b| a > b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a > b);
 }
 
@@ -654,9 +654,9 @@ pub fn gt_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::gt, |a, b| a > b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a > b);
 }
 
@@ -669,9 +669,9 @@ pub fn gt_eq<T>(
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op(left, right, T::ge, |a, b| a >= b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op!(left, right, |a, b| a >= b);
 }
 
@@ -681,9 +681,9 @@ pub fn gt_eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     return simd_compare_op_scalar(left, right, T::ge, |a, b| a >= b);
-    #[cfg(not(simd_x86))]
+    #[cfg(not(any(simd_x86, simd_aarch64)))]
     return compare_op_scalar!(left, right, |a, b| a >= b);
 }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -370,7 +370,7 @@ pub fn gt_eq_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray
 
 /// Helper function to perform boolean lambda function on values from two arrays using
 /// SIMD.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn simd_compare_op<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -460,7 +460,7 @@ where
 
 /// Helper function to perform boolean lambda function on values from an array and a scalar value using
 /// SIMD.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 fn simd_compare_op_scalar<T, SIMD_OP, SCALAR_OP>(
     left: &PrimitiveArray<T>,
     right: T::Native,
@@ -546,9 +546,9 @@ pub fn eq<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::eq, |a, b| a == b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a == b);
 }
 
@@ -557,9 +557,9 @@ pub fn eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::eq, |a, b| a == b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a == b);
 }
 
@@ -568,9 +568,9 @@ pub fn neq<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::ne, |a, b| a != b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a != b);
 }
 
@@ -579,9 +579,9 @@ pub fn neq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boole
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::ne, |a, b| a != b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a != b);
 }
 
@@ -591,9 +591,9 @@ pub fn lt<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::lt, |a, b| a < b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a < b);
 }
 
@@ -603,9 +603,9 @@ pub fn lt_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::lt, |a, b| a < b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a < b);
 }
 
@@ -618,9 +618,9 @@ pub fn lt_eq<T>(
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::le, |a, b| a <= b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a <= b);
 }
 
@@ -630,9 +630,9 @@ pub fn lt_eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::le, |a, b| a <= b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a <= b);
 }
 
@@ -642,9 +642,9 @@ pub fn gt<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<Bool
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::gt, |a, b| a > b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a > b);
 }
 
@@ -654,9 +654,9 @@ pub fn gt_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boolea
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::gt, |a, b| a > b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a > b);
 }
 
@@ -669,9 +669,9 @@ pub fn gt_eq<T>(
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op(left, right, T::ge, |a, b| a >= b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op!(left, right, |a, b| a >= b);
 }
 
@@ -681,9 +681,9 @@ pub fn gt_eq_scalar<T>(left: &PrimitiveArray<T>, right: T::Native) -> Result<Boo
 where
     T: ArrowNumericType,
 {
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     return simd_compare_op_scalar(left, right, T::ge, |a, b| a >= b);
-    #[cfg(not(any(simd_x86, simd_aarch64)))]
+    #[cfg(not(simd))]
     return compare_op_scalar!(left, right, |a, b| a >= b);
 }
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -509,7 +509,7 @@ impl ArrowDictionaryKeyType for UInt64Type {}
 /// A subtype of primitive type that represents numeric values.
 ///
 /// SIMD operations are defined in this trait if available on the target system.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub trait ArrowNumericType: ArrowPrimitiveType
 where
     Self::Simd: Add<Output = Self::Simd>
@@ -591,12 +591,12 @@ where
     fn write(simd_result: Self::Simd, slice: &mut [Self::Native]);
 }
 
-#[cfg(not(any(simd_x86, simd_aarch64)))]
+#[cfg(not(simd))]
 pub trait ArrowNumericType: ArrowPrimitiveType {}
 
 macro_rules! make_numeric_type {
     ($impl_ty:ty, $native_ty:ty, $simd_ty:ident, $simd_mask_ty:ident) => {
-        #[cfg(any(simd_x86, simd_aarch64))]
+        #[cfg(simd)]
         impl ArrowNumericType for $impl_ty {
             type Simd = $simd_ty;
 
@@ -792,7 +792,7 @@ macro_rules! make_numeric_type {
             }
         }
 
-        #[cfg(not(any(simd_x86, simd_aarch64)))]
+        #[cfg(not(simd))]
         impl ArrowNumericType for $impl_ty {}
     };
 }
@@ -828,7 +828,7 @@ make_numeric_type!(DurationNanosecondType, i64, i64x8, m64x8);
 /// A subtype of primitive type that represents signed numeric values.
 ///
 /// SIMD operations are defined in this trait if available on the target system.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub trait ArrowSignedNumericType: ArrowNumericType
 where
     Self::SignedSimd: Neg<Output = Self::SignedSimd>,
@@ -849,7 +849,7 @@ where
     fn write_signed(simd_result: Self::SignedSimd, slice: &mut [Self::Native]);
 }
 
-#[cfg(not(any(simd_x86, simd_aarch64)))]
+#[cfg(not(simd))]
 pub trait ArrowSignedNumericType: ArrowNumericType
 where
     Self::Native: Neg<Output = Self::Native>,
@@ -858,7 +858,7 @@ where
 
 macro_rules! make_signed_numeric_type {
     ($impl_ty:ty, $simd_ty:ident) => {
-        #[cfg(any(simd_x86, simd_aarch64))]
+        #[cfg(simd)]
         impl ArrowSignedNumericType for $impl_ty {
             type SignedSimd = $simd_ty;
 
@@ -881,7 +881,7 @@ macro_rules! make_signed_numeric_type {
             }
         }
 
-        #[cfg(not(any(simd_x86, simd_aarch64)))]
+        #[cfg(not(simd))]
         impl ArrowSignedNumericType for $impl_ty {}
     };
 }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -509,7 +509,7 @@ impl ArrowDictionaryKeyType for UInt64Type {}
 /// A subtype of primitive type that represents numeric values.
 ///
 /// SIMD operations are defined in this trait if available on the target system.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub trait ArrowNumericType: ArrowPrimitiveType
 where
     Self::Simd: Add<Output = Self::Simd>
@@ -591,12 +591,12 @@ where
     fn write(simd_result: Self::Simd, slice: &mut [Self::Native]);
 }
 
-#[cfg(not(simd_x86))]
+#[cfg(not(any(simd_x86, simd_aarch64)))]
 pub trait ArrowNumericType: ArrowPrimitiveType {}
 
 macro_rules! make_numeric_type {
     ($impl_ty:ty, $native_ty:ty, $simd_ty:ident, $simd_mask_ty:ident) => {
-        #[cfg(simd_x86)]
+        #[cfg(any(simd_x86, simd_aarch64))]
         impl ArrowNumericType for $impl_ty {
             type Simd = $simd_ty;
 
@@ -792,7 +792,7 @@ macro_rules! make_numeric_type {
             }
         }
 
-        #[cfg(not(simd_x86))]
+        #[cfg(not(any(simd_x86, simd_aarch64)))]
         impl ArrowNumericType for $impl_ty {}
     };
 }
@@ -828,7 +828,7 @@ make_numeric_type!(DurationNanosecondType, i64, i64x8, m64x8);
 /// A subtype of primitive type that represents signed numeric values.
 ///
 /// SIMD operations are defined in this trait if available on the target system.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub trait ArrowSignedNumericType: ArrowNumericType
 where
     Self::SignedSimd: Neg<Output = Self::SignedSimd>,
@@ -849,7 +849,7 @@ where
     fn write_signed(simd_result: Self::SignedSimd, slice: &mut [Self::Native]);
 }
 
-#[cfg(not(simd_x86))]
+#[cfg(not(any(simd_x86, simd_aarch64)))]
 pub trait ArrowSignedNumericType: ArrowNumericType
 where
     Self::Native: Neg<Output = Self::Native>,
@@ -858,7 +858,7 @@ where
 
 macro_rules! make_signed_numeric_type {
     ($impl_ty:ty, $simd_ty:ident) => {
-        #[cfg(simd_x86)]
+        #[cfg(any(simd_x86, simd_aarch64))]
         impl ArrowSignedNumericType for $impl_ty {
             type SignedSimd = $simd_ty;
 
@@ -881,7 +881,7 @@ macro_rules! make_signed_numeric_type {
             }
         }
 
-        #[cfg(not(simd_x86))]
+        #[cfg(not(any(simd_x86, simd_aarch64)))]
         impl ArrowSignedNumericType for $impl_ty {}
     };
 }

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -104,7 +104,7 @@ pub fn ceil(value: usize, divisor: usize) -> usize {
 /// Note that each slice should be 64 bytes and it is the callers responsibility to ensure
 /// that this is the case.  If passed slices larger than 64 bytes the operation will only
 /// be performed on the first 64 bytes.  Slices less than 64 bytes will panic.
-#[cfg(simd_x86)]
+#[cfg(any(simd_x86, simd_aarch64))]
 pub unsafe fn bitwise_bin_op_simd<F>(left: &[u8], right: &[u8], result: &mut [u8], op: F)
 where
     F: Fn(u8x64, u8x64) -> u8x64,
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     fn test_bitwise_and_simd() {
         let buf1 = [0b00110011u8; 64];
         let buf2 = [0b11110000u8; 64];
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(simd_x86)]
+    #[cfg(any(simd_x86, simd_aarch64))]
     fn test_bitwise_or_simd() {
         let buf1 = [0b00110011u8; 64];
         let buf2 = [0b11110000u8; 64];

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -104,7 +104,7 @@ pub fn ceil(value: usize, divisor: usize) -> usize {
 /// Note that each slice should be 64 bytes and it is the callers responsibility to ensure
 /// that this is the case.  If passed slices larger than 64 bytes the operation will only
 /// be performed on the first 64 bytes.  Slices less than 64 bytes will panic.
-#[cfg(any(simd_x86, simd_aarch64))]
+#[cfg(simd)]
 pub unsafe fn bitwise_bin_op_simd<F>(left: &[u8], right: &[u8], result: &mut [u8], op: F)
 where
     F: Fn(u8x64, u8x64) -> u8x64,
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     fn test_bitwise_and_simd() {
         let buf1 = [0b00110011u8; 64];
         let buf2 = [0b11110000u8; 64];
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(simd_x86, simd_aarch64))]
+    #[cfg(simd)]
     fn test_bitwise_or_simd() {
         let buf1 = [0b00110011u8; 64];
         let buf2 = [0b11110000u8; 64];


### PR DESCRIPTION
packed_simd has support for aarch64 for the functions that we are using.

We can't test this feature yet, as we don't have aarch64 targets on our Rust CI yet. I however tested this on an ARM Mac device.
I perceive the build risk to be low, as I'm only enabling `aarch64` in addition to the already used `x86_64` target in `packed_simd`.