### PR TITLE
ARROW-11195: [Rust] [DataFusion] Add accessor methods for Parquet and CSV TableProviders

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -81,6 +81,26 @@ impl CsvFile {
             statistics: Statistics::default(),
         })
     }
+
+    /// Get the path for the CSV file(s) represented by this CsvFile instance
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Determine whether the CSV file(s) represented by this CsvFile instance have a header row
+    pub fn has_header(&self) -> bool {
+        self.has_header
+    }
+
+    /// Get the delimiter for the CSV file(s) represented by this CsvFile instance
+    pub fn delimiter(&self) -> u8 {
+        self.delimiter
+    }
+
+    /// Get the file extension for the CSV file(s) represented by this CsvFile instance
+    pub fn file_extension(&self) -> &str {
+        &self.file_extension
+    }
 }
 
 impl TableProvider for CsvFile {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -50,6 +50,11 @@ impl ParquetTable {
             max_concurrency,
         })
     }
+
+    /// Get the path for the Parquet file(s) represented by this ParquetTable instance
+    pub fn path(&self) -> &str {
+        &self.path
+    }
 }
 
 impl TableProvider for ParquetTable {


### PR DESCRIPTION
For projects that depend on the DataFusion logical plan, there is a breaking change currently compared to 2.0.0 where it is not possible to introspect the TableScan node for CSV and Parquet files to get the file path and other meta-data (such as delimiter for CSV).

I propose adding public methods to the specific providers so that other crates can downcast to specific implementations in order to access this data.

My specific use case is the ability to serialize a DataFusion logical plan.
