### PR TITLE
ARROW-11173: [Java] Add map type in complex reader / writer

### DIFF
--- a/java/vector/src/main/codegen/includes/vv_imports.ftl
+++ b/java/vector/src/main/codegen/includes/vv_imports.ftl
@@ -36,6 +36,7 @@ import org.apache.arrow.vector.complex.impl.*;
 import org.apache.arrow.vector.complex.writer.*;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 
 import java.util.Arrays;

--- a/java/vector/src/main/codegen/templates/AbstractFieldReader.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldReader.java
@@ -77,6 +77,10 @@ abstract class AbstractFieldReader extends AbstractBaseReader implements FieldRe
     fail("CopyAsFieldList");
   }
 
+  public void copyAsField(String name, MapWriter writer) {
+    fail("CopyAsFieldMap");
+  }
+
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign boxedType = (minor.boxedType!type.boxedType) />
   public void read(${name}Holder holder) {

--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -56,12 +56,42 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
 
   @Override
   public void startList() {
-    throw new IllegalStateException(String.format("You tried to start when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+    throw new IllegalStateException(String.format("You tried to start a list when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
   }
 
   @Override
   public void endList() {
-    throw new IllegalStateException(String.format("You tried to end when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+    throw new IllegalStateException(String.format("You tried to end a list when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public void startMap() {
+    throw new IllegalStateException(String.format("You tried to start a map when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public void endMap() {
+    throw new IllegalStateException(String.format("You tried to end a map when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public void startEntry() {
+    throw new IllegalStateException(String.format("You tried to start a map entry when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public MapWriter key() {
+    throw new IllegalStateException(String.format("You tried to start a map key when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public MapWriter value() {
+    throw new IllegalStateException(String.format("You tried to start a map value when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public void endEntry() {
+    throw new IllegalStateException(String.format("You tried to end a map entry when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
   }
 
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
@@ -124,6 +154,12 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   }
 
   @Override
+  public MapWriter map() {
+    fail("Map");
+    return null;
+  }
+
+  @Override
   public StructWriter struct(String name) {
     fail("Struct");
     return null;
@@ -135,6 +171,23 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
     return null;
   }
 
+  @Override
+  public MapWriter map(String name) {
+    fail("Map");
+    return null;
+  }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    fail("Map");
+    return null;
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    fail("Map");
+    return null;
+  }
   <#list vv.types as type><#list type.minor as minor>
   <#assign lowerName = minor.class?uncap_first />
   <#if lowerName == "int" ><#assign lowerName = "integer" /></#if>

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -15,11 +15,6 @@
  * limitations under the License.
  */
 
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.drill.common.types.TypeProtos.MinorType;
-
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/AbstractPromotableFieldWriter.java" />
 
@@ -186,7 +181,7 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
 
   @Override
   public MapWriter map(boolean keysSorted) {
-    return getWriter(MinorType.MAP, new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted));
+    return getWriter(MinorType.MAP, new ArrowType.Map(keysSorted));
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -44,7 +44,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
    * @param type the type of the values we want to write
    * @return the corresponding field writer
    */
-  abstract protected FieldWriter getWriter(MinorType type);
+  protected FieldWriter getWriter(MinorType type) {
+    return getWriter(type, null);
+  }
+
+  abstract protected FieldWriter getWriter(MinorType type, ArrowType arrowType);
 
   /**
    * @return the current FieldWriter
@@ -71,6 +75,37 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   public void endList() {
     getWriter(MinorType.LIST).endList();
     setPosition(idx() + 1);
+  }
+
+  @Override
+  public void startMap() {
+    getWriter(MinorType.MAP).startMap();
+  }
+
+  @Override
+  public void endMap() {
+    getWriter(MinorType.MAP).endMap();
+    setPosition(idx() + 1);
+  }
+
+  @Override
+  public void startEntry() {
+    getWriter(MinorType.MAP).startEntry();
+  }
+
+  @Override
+  public MapWriter key() {
+    return getWriter(MinorType.MAP).key();
+  }
+
+  @Override
+  public MapWriter value() {
+    return getWriter(MinorType.MAP).value();
+  }
+
+  @Override
+  public void endEntry() {
+    getWriter(MinorType.MAP).endEntry();
   }
 
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
@@ -145,6 +180,16 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public MapWriter map() {
+    return getWriter(MinorType.LIST).map();
+  }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    return getWriter(MinorType.MAP, new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted));
+  }
+
+  @Override
   public StructWriter struct(String name) {
     return getWriter(MinorType.STRUCT).struct(name);
   }
@@ -154,6 +199,15 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
     return getWriter(MinorType.STRUCT).list(name);
   }
 
+  @Override
+  public MapWriter map(String name) {
+    return getWriter(MinorType.STRUCT).map(name);
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    return getWriter(MinorType.STRUCT).map(name, keysSorted);
+  }
   <#list vv.types as type><#list type.minor as minor>
   <#assign lowerName = minor.class?uncap_first />
   <#if lowerName == "int" ><#assign lowerName = "integer" /></#if>

--- a/java/vector/src/main/codegen/templates/BaseReader.java
+++ b/java/vector/src/main/codegen/templates/BaseReader.java
@@ -60,6 +60,16 @@ public interface BaseReader extends Positionable{
     int size();
     void copyAsValue(ListWriter writer);
   }
+
+  public interface MapReader extends BaseReader{
+    FieldReader reader();
+  }
+
+  public interface RepeatedMapReader extends MapReader{
+    boolean next();
+    int size();
+    void copyAsValue(MapWriter writer);
+  }
   
   public interface ScalarReader extends  
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first /> ${name}Reader, </#list></#list> 

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -62,6 +62,8 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void copyReaderToField(String name, FieldReader reader);
     StructWriter struct(String name);
     ListWriter list(String name);
+    MapWriter map(String name);
+    MapWriter map(String name, boolean keysSorted);
     void start();
     void end();
   }
@@ -71,6 +73,8 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void endList();
     StructWriter struct();
     ListWriter list();
+    MapWriter map();
+    MapWriter map(boolean keysSorted);
     void copyReader(FieldReader reader);
 
     <#list vv.types as type><#list type.minor as minor>
@@ -80,6 +84,17 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     <#assign capName = minor.class?cap_first />
     ${capName}Writer ${lowerName}();
     </#list></#list>
+  }
+
+  public interface MapWriter extends ListWriter {
+    void startMap();
+    void endMap();
+
+    void startEntry();
+    void endEntry();
+
+    MapWriter key();
+    MapWriter value();
   }
 
   public interface ScalarWriter extends

--- a/java/vector/src/main/codegen/templates/DenseUnionReader.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionReader.java
@@ -129,6 +129,18 @@ public class DenseUnionReader extends AbstractFieldReader {
     return listReader;
   }
 
+  private UnionMapReader mapReader;
+
+  private FieldReader getMap(byte typeId) {
+    UnionMapReader mapReader = (UnionMapReader) readers[typeId];
+    if (mapReader == null) {
+      mapReader = new UnionMapReader((MapVector) data.getVectorByType(typeId));
+      mapReader.setPosition(idx());
+      readers[typeId] = mapReader;
+    }
+    return mapReader;
+  }
+
   @Override
   public java.util.Iterator<String> iterator() {
     throw new UnsupportedOperationException();

--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -342,6 +342,22 @@ public class DenseUnionVector implements FieldVector {
     return listVector;
   }
 
+  public MapVector getMap(byte typeId) {
+    MapVector mapVector = typeId < 0 ? null : (MapVector) childVectors[typeId];
+    if (mapVector == null) {
+      int vectorCount = internalStruct.size();
+      mapVector = addOrGet(typeId, MinorType.MAP, MapVector.class);
+      if (internalStruct.size() > vectorCount) {
+        mapVector.allocateNew();
+        childVectors[typeId] = mapVector;
+        if (callBack != null) {
+          callBack.doWork();
+        }
+      }
+    }
+    return mapVector;
+  }
+
   public byte getTypeId(int index) {
     return typeBuffer.getByte(index * TYPE_WIDTH);
   }

--- a/java/vector/src/main/codegen/templates/DenseUnionWriter.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionWriter.java
@@ -111,6 +111,20 @@ public class DenseUnionWriter extends AbstractFieldWriter implements FieldWriter
     return getListWriter(typeId);
   }
 
+  private MapWriter getMapWriter(byte typeId) {
+    MapWriter mapWriter = (MapWriter) writers[typeId];
+    if (mapWriter == null) {
+      mapWriter = new UnionMapWriter((MapVector) data.getVectorByType(typeId));
+      writers[typeId] = mapWriter;
+    }
+    return mapWriter;
+  }
+
+  public MapWriter asMap(byte typeId) {
+    data.setTypeId(idx(), typeId);
+    return getMapWriter(typeId);
+  }
+
   BaseWriter getWriter(byte typeId) {
     MinorType minorType = data.getVectorByType(typeId).getMinorType();
     switch (minorType) {
@@ -118,6 +132,8 @@ public class DenseUnionWriter extends AbstractFieldWriter implements FieldWriter
         return getStructWriter(typeId);
       case LIST:
         return getListWriter(typeId);
+      case MAP:
+        return getMapWriter(typeId);
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -193,6 +209,30 @@ public class DenseUnionWriter extends AbstractFieldWriter implements FieldWriter
     data.setTypeId(idx(), typeId);
     getStructWriter(typeId).setPosition(data.getOffset(idx()));
     return getStructWriter(typeId).list(name);
+  }
+
+  @Override
+  public MapWriter map() {
+    byte typeId = data.getTypeId(idx());
+    data.setTypeId(idx(), typeId);
+    getListWriter(typeId).setPosition(data.getOffset(idx()));
+    return getMapWriter(typeId).map();
+  }
+
+  @Override
+  public MapWriter map(String name) {
+    byte typeId = data.getTypeId(idx());
+    data.setTypeId(idx(), typeId);
+    getStructWriter(typeId).setPosition(data.getOffset(idx()));
+    return getStructWriter(typeId).map(name);
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    byte typeId = data.getTypeId(idx());
+    data.setTypeId(idx(), typeId);
+    getStructWriter(typeId).setPosition(data.getOffset(idx()));
+    return getStructWriter(typeId).map(name, keysSorted);
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/StructWriters.java
+++ b/java/vector/src/main/codegen/templates/StructWriters.java
@@ -64,6 +64,11 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
       case LIST:
         list(child.getName());
         break;
+      case MAP:{
+        org.apache.arrow.vector.types.pojo.ArrowType.Map arrowType = (org.apache.arrow.vector.types.pojo.ArrowType.Map) child.getType();
+        map(child.getName(), arrowType.getKeysSorted());
+        break;
+      }
       case UNION:
         FieldType fieldType = new FieldType(addVectorAsNullable, MinorType.UNION.getType(), null, null);
         UnionWriter writer = new UnionWriter(container.addOrGet(child.getName(), fieldType, UnionVector.class), getNullableStructWriterFactory());
@@ -179,6 +184,44 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
       if (writer instanceof PromotableWriter) {
         // ensure writers are initialized
         ((PromotableWriter)writer).getWriter(MinorType.LIST);
+      }
+    }
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name) {
+    // returns existing writer
+    final FieldWriter writer = fields.get(handleCase(name));
+    Preconditions.checkNotNull(writer);
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    FieldWriter writer = fields.get(handleCase(name));
+    if(writer == null) {
+      ValueVector vector;
+      ValueVector currentVector = container.getChild(name);
+      MapVector v = container.addOrGet(name,
+          new FieldType(addVectorAsNullable,
+            new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted)
+          ,null, null),
+          MapVector.class);
+      writer = new PromotableWriter(v, container, getNullableStructWriterFactory());
+      vector = v;
+      if (currentVector == null || currentVector != vector) {
+        if(this.initialCapacity > 0) {
+          vector.setInitialCapacity(this.initialCapacity);
+        }
+        vector.allocateNewSafe();
+      }
+      writer.setPosition(idx());
+      fields.put(handleCase(name), writer);
+    } else {
+      if (writer instanceof PromotableWriter) {
+        // ensure writers are initialized
+        ((PromotableWriter)writer).getWriter(MinorType.MAP, new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted));
       }
     }
     return writer;

--- a/java/vector/src/main/codegen/templates/StructWriters.java
+++ b/java/vector/src/main/codegen/templates/StructWriters.java
@@ -64,8 +64,8 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
       case LIST:
         list(child.getName());
         break;
-      case MAP:{
-        org.apache.arrow.vector.types.pojo.ArrowType.Map arrowType = (org.apache.arrow.vector.types.pojo.ArrowType.Map) child.getType();
+      case MAP: {
+        ArrowType.Map arrowType = (ArrowType.Map) child.getType();
         map(child.getName(), arrowType.getKeysSorted());
         break;
       }
@@ -205,7 +205,7 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
       ValueVector currentVector = container.getChild(name);
       MapVector v = container.addOrGet(name,
           new FieldType(addVectorAsNullable,
-            new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted)
+            new ArrowType.Map(keysSorted)
           ,null, null),
           MapVector.class);
       writer = new PromotableWriter(v, container, getNullableStructWriterFactory());

--- a/java/vector/src/main/codegen/templates/StructWriters.java
+++ b/java/vector/src/main/codegen/templates/StructWriters.java
@@ -191,10 +191,7 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
 
   @Override
   public MapWriter map(String name) {
-    // returns existing writer
-    final FieldWriter writer = fields.get(handleCase(name));
-    Preconditions.checkNotNull(writer);
-    return writer;
+    return map(name, false);
   }
 
   @Override
@@ -221,7 +218,7 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
     } else {
       if (writer instanceof PromotableWriter) {
         // ensure writers are initialized
-        ((PromotableWriter)writer).getWriter(MinorType.MAP, new org.apache.arrow.vector.types.pojo.ArrowType.Map(keysSorted));
+        ((PromotableWriter)writer).getWriter(MinorType.MAP, new ArrowType.Map(keysSorted));
       }
     }
     return writer;

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -170,6 +170,29 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public MapWriter map() {
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name) {
+    MapWriter mapWriter = writer.map(name);
+    return mapWriter;
+  }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    writer.map(keysSorted);
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    MapWriter mapWriter = writer.map(name, keysSorted);
+    return mapWriter;
+  }
+
+  @Override
   public void startList() {
     int start = vector.startNewValue(idx());
     writer.setPosition(start);

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -176,6 +176,29 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     return structWriter;
   }
 
+  @Override
+  public MapWriter map() {
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name) {
+    MapWriter mapWriter = writer.map(name);
+    return mapWriter;
+  }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    writer.map(keysSorted);
+    return writer;
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    MapWriter mapWriter = writer.map(name, keysSorted);
+    return mapWriter;
+  }
+
   <#if listName == "LargeList">
   @Override
   public void startList() {

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -207,4 +207,16 @@ public class UnionMapWriter extends UnionListWriter {
         return super.list();
     }
   }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    switch (mode) {
+      case KEY:
+        return entryWriter.map(MapVector.KEY_NAME, keysSorted);
+      case VALUE:
+        return entryWriter.map(MapVector.VALUE_NAME, keysSorted);
+      default:
+        return super.map();
+    }
+  }
 }

--- a/java/vector/src/main/codegen/templates/UnionReader.java
+++ b/java/vector/src/main/codegen/templates/UnionReader.java
@@ -84,6 +84,8 @@ public class UnionReader extends AbstractFieldReader {
       return (FieldReader) getStruct();
     case LIST:
       return (FieldReader) getList();
+    case MAP:
+      return (FieldReader) getMap();
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -119,6 +121,17 @@ public class UnionReader extends AbstractFieldReader {
       readers[MinorType.LIST.ordinal()] = listReader;
     }
     return listReader;
+  }
+
+  private UnionMapReader mapReader;
+
+  private FieldReader getMap() {
+    if (mapReader == null) {
+      mapReader = new UnionMapReader(data.getMap());
+      mapReader.setPosition(idx());
+      readers[MinorType.MAP.ordinal()] = mapReader;
+    }
+    return mapReader;
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -95,6 +95,7 @@ public class UnionVector implements FieldVector {
 
   private StructVector structVector;
   private ListVector listVector;
+  private MapVector mapVector;
 
   private FieldReader reader;
 
@@ -317,6 +318,31 @@ public class UnionVector implements FieldVector {
       }
     }
     return listVector;
+  }
+
+  public MapVector getMap() {
+    if (mapVector == null) {
+      throw new IllegalArgumentException("No map present. Provide ArrowType argument to create a new vector");
+    }
+    return mapVector;
+  }
+
+  public MapVector getMap(ArrowType arrowType) {
+    return getMap(null, arrowType);
+  }
+
+  public MapVector getMap(String name, ArrowType arrowType) {
+    if (mapVector == null) {
+      int vectorCount = internalStruct.size();
+      mapVector = addOrGet(name, MinorType.MAP, arrowType, MapVector.class);
+      if (internalStruct.size() > vectorCount) {
+        mapVector.allocateNew();
+        if (callBack != null) {
+          callBack.doWork();
+        }
+      }
+    }
+    return mapVector;
   }
 
   public int getTypeValue(int index) {
@@ -647,6 +673,8 @@ public class UnionVector implements FieldVector {
           return getStruct();
         case LIST:
           return getList();
+        case MAP:
+          return getMap();
         default:
           throw new UnsupportedOperationException("Cannot support type: " + MinorType.values()[typeId]);
       }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -674,7 +674,7 @@ public class UnionVector implements FieldVector {
         case LIST:
           return getList();
         case MAP:
-          return getMap();
+          return getMap(name, arrowType);
         default:
           throw new UnsupportedOperationException("Cannot support type: " + MinorType.values()[typeId]);
       }

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.NullableStructWriterFactory;
 import org.apache.arrow.vector.types.Types;
 
@@ -39,6 +40,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
   UnionVector data;
   private StructWriter structWriter;
   private UnionListWriter listWriter;
+  private UnionMapWriter mapWriter;
   private List<BaseWriter> writers = new java.util.ArrayList<>();
   private final NullableStructWriterFactory nullableStructWriterFactory;
 
@@ -82,6 +84,37 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     getListWriter().endList();
   }
 
+  @Override
+  public void startMap() {
+    getMapWriter().startMap();
+    data.setType(idx(), MinorType.MAP);
+  }
+
+  @Override
+  public void endMap() {
+    getMapWriter().endMap();
+  }
+
+  @Override
+  public void startEntry() {
+    getMapWriter().startEntry();
+  }
+
+  @Override
+  public MapWriter key() {
+    return getMapWriter().key();
+  }
+
+  @Override
+  public MapWriter value() {
+    return getMapWriter().value();
+  }
+
+  @Override
+  public void endEntry() {
+    getMapWriter().endEntry();
+  }
+
   private StructWriter getStructWriter() {
     if (structWriter == null) {
       structWriter = nullableStructWriterFactory.build(data.getStruct());
@@ -110,6 +143,26 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     return getListWriter();
   }
 
+  private MapWriter getMapWriter() {
+    // returns existing writer
+    Preconditions.checkNotNull(mapWriter);
+    return mapWriter;
+  }
+
+  private MapWriter getMapWriter(ArrowType arrowType) {
+    if (mapWriter == null) {
+      mapWriter = new UnionMapWriter(data.getMap(arrowType));
+      mapWriter.setPosition(idx());
+      writers.add(mapWriter);
+    }
+    return mapWriter;
+  }
+
+  public MapWriter asMap(ArrowType arrowType) {
+    data.setType(idx(), MinorType.MAP);
+    return getMapWriter(arrowType);
+  }
+
   BaseWriter getWriter(MinorType minorType) {
     return getWriter(minorType, null);
   }
@@ -120,6 +173,8 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       return getStructWriter();
     case LIST:
       return getListWriter();
+    case MAP:
+      return getMapWriter(arrowType);
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -219,6 +274,34 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     data.setType(idx(), MinorType.STRUCT);
     getStructWriter().setPosition(idx());
     return getStructWriter().struct(name);
+  }
+
+  @Override
+  public MapWriter map() {
+    data.setType(idx(), MinorType.MAP);
+    getListWriter().setPosition(idx());
+    return getListWriter().map();
+  }
+
+  @Override
+  public MapWriter map(boolean keysSorted) {
+    data.setType(idx(), MinorType.MAP);
+    getListWriter().setPosition(idx());
+    return getListWriter().map(keysSorted);
+  }
+
+  @Override
+  public MapWriter map(String name) {
+    data.setType(idx(), MinorType.MAP);
+    getStructWriter().setPosition(idx());
+    return getStructWriter().map(name);
+  }
+
+  @Override
+  public MapWriter map(String name, boolean keysSorted) {
+    data.setType(idx(), MinorType.MAP);
+    getStructWriter().setPosition(idx());
+    return getStructWriter().map(name, keysSorted);
   }
 
   <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -144,8 +144,11 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
   }
 
   private MapWriter getMapWriter() {
-    // returns existing writer
-    Preconditions.checkNotNull(mapWriter);
+    if (mapWriter == null) {
+      mapWriter = new UnionMapWriter(data.getMap(new ArrowType.Map(false)));
+      mapWriter.setPosition(idx());
+      writers.add(mapWriter);
+    }
     return mapWriter;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.holders.DenseUnionHolder;
 import org.apache.arrow.vector.holders.UnionHolder;
@@ -107,6 +108,11 @@ abstract class AbstractBaseReader implements FieldReader {
 
   @Override
   public void copyAsValue(ListWriter writer) {
+    ComplexCopier.copy(this, (FieldWriter) writer);
+  }
+
+  @Override
+  public void copyAsValue(MapWriter writer) {
     ComplexCopier.copy(this, (FieldWriter) writer);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -27,6 +27,7 @@ import org.apache.arrow.vector.complex.AbstractStructVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
@@ -214,6 +215,9 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       case LIST:
         writer = new UnionListWriter((ListVector) vector, nullableStructWriterFactory);
         break;
+      case MAP:
+        writer = new UnionMapWriter((MapVector) vector);
+        break;
       case UNION:
         writer = new UnionWriter((UnionVector) vector, nullableStructWriterFactory);
         break;
@@ -243,13 +247,10 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
     }
   }
 
-  protected FieldWriter getWriter(MinorType type) {
-    return getWriter(type, null);
-  }
-
+  @Override
   protected FieldWriter getWriter(MinorType type, ArrowType arrowType) {
     if (state == State.UNION) {
-      if (type == MinorType.DECIMAL) {
+      if (type == MinorType.DECIMAL || type == MinorType.MAP) {
         ((UnionWriter) writer).getWriter(type, arrowType);
       } else {
         ((UnionWriter) writer).getWriter(type);
@@ -276,7 +277,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       writer.setPosition(position);
     } else if (type != this.type) {
       promoteToUnion();
-      if (type == MinorType.DECIMAL) {
+      if (type == MinorType.DECIMAL || type == MinorType.MAP) {
         ((UnionWriter) writer).getWriter(type, arrowType);
       } else {
         ((UnionWriter) writer).getWriter(type);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/reader/FieldReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/reader/FieldReader.java
@@ -18,7 +18,9 @@
 package org.apache.arrow.vector.complex.reader;
 
 import org.apache.arrow.vector.complex.reader.BaseReader.ListReader;
+import org.apache.arrow.vector.complex.reader.BaseReader.MapReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.RepeatedListReader;
+import org.apache.arrow.vector.complex.reader.BaseReader.RepeatedMapReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.RepeatedStructReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.ScalarReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.StructReader;
@@ -28,5 +30,6 @@ import org.apache.arrow.vector.complex.reader.BaseReader.StructReader;
  * Composite of all Reader types (e.g. {@link StructReader}, {@link ScalarReader}, etc).  Each reader type
  * is in essence a way of iterating over a {@link org.apache.arrow.vector.ValueVector}.
  */
-public interface FieldReader extends StructReader, ListReader, ScalarReader, RepeatedStructReader, RepeatedListReader {
+public interface FieldReader extends StructReader, ListReader, MapReader, ScalarReader,
+    RepeatedStructReader, RepeatedListReader, RepeatedMapReader {
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex.writer;
 
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 
@@ -25,7 +26,7 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
  * Composite of all writer types.  Writers are convenience classes for incrementally
  * adding values to {@linkplain org.apache.arrow.vector.ValueVector}s.
  */
-public interface FieldWriter extends StructWriter, ListWriter, ScalarWriter {
+public interface FieldWriter extends StructWriter, ListWriter, MapWriter, ScalarWriter {
   void allocate();
 
   void clear();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -29,7 +29,9 @@ import java.util.Map;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.complex.impl.UnionWriter;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
@@ -88,6 +90,67 @@ public class TestUnionVector {
       assertEquals(100, unionVector.getObject(2));
 
       assertNull(unionVector.getObject(3));
+    }
+  }
+
+  @Test
+  public void testUnionVectorMapValue() throws Exception {
+    try (UnionVector unionVector = new UnionVector(EMPTY_SCHEMA_PATH, allocator, null)) {
+      unionVector.allocateNew();
+
+      UnionWriter writer = (UnionWriter) unionVector.getWriter();
+
+      // populate map vector with the following two records
+      // [
+      //    null,
+      //    [[1: 2], [3: 4], [5: null]]
+      // ]
+
+      writer.setPosition(0);
+      writer.writeNull();
+
+      writer.setPosition(1);
+      writer.startMap();
+
+      writer.startEntry();
+      writer.key().integer().writeInt(1);
+      writer.value().integer().writeInt(2);
+      writer.endEntry();
+
+      writer.startEntry();
+      writer.key().integer().writeInt(3);
+      writer.value().integer().writeInt(4);
+      writer.endEntry();
+
+      writer.startEntry();
+      writer.key().integer().writeInt(5);
+      writer.endEntry();
+
+      writer.endMap();
+
+      unionVector.setValueCount(2);
+
+      // check that what we wrote is correct
+      assertEquals(2, unionVector.getValueCount());
+
+      // first entry
+      assertNull(unionVector.getObject(0));
+
+      // second entry
+      List<Map<String, Integer>> resultList = (List<Map<String, Integer>>) unionVector.getObject(1);
+      assertEquals(3, resultList.size());
+
+      Map<String, Integer> resultMap = resultList.get(0);
+      assertEquals(1, (int) resultMap.get(MapVector.KEY_NAME));
+      assertEquals(2, (int) resultMap.get(MapVector.VALUE_NAME));
+
+      resultMap = resultList.get(1);
+      assertEquals(3, (int) resultMap.get(MapVector.KEY_NAME));
+      assertEquals(4, (int) resultMap.get(MapVector.VALUE_NAME));
+
+      resultMap = resultList.get(2);
+      assertEquals(5, (int) resultMap.get(MapVector.KEY_NAME));
+      assertNull(resultMap.get(MapVector.VALUE_NAME));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -44,6 +44,7 @@ import org.apache.arrow.vector.complex.impl.SingleStructReaderImpl;
 import org.apache.arrow.vector.complex.impl.SingleStructWriter;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.complex.impl.UnionReader;
 import org.apache.arrow.vector.complex.impl.UnionWriter;
 import org.apache.arrow.vector.complex.reader.BaseReader.StructReader;
@@ -54,6 +55,7 @@ import org.apache.arrow.vector.complex.reader.Float8Reader;
 import org.apache.arrow.vector.complex.reader.IntReader;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ComplexWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.holders.DecimalHolder;
 import org.apache.arrow.vector.holders.IntHolder;
@@ -547,6 +549,54 @@ public class TestComplexWriter {
   }
 
   @Test
+  public void testListMapType() {
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      MapWriter innerMapWriter = listWriter.map(true);
+
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          innerMapWriter.startMap();
+          for (int k = 0; k < i % 13; k++) {
+            innerMapWriter.startEntry();
+            innerMapWriter.key().integer().writeInt(k);
+            if (k % 2 == 0) {
+              innerMapWriter.value().bigInt().writeBigInt(k);
+            }
+            innerMapWriter.endEntry();
+          }
+          innerMapWriter.endMap();
+        }
+        listWriter.endList();
+      }
+      listWriter.setValueCount(COUNT);
+      checkListMap(listVector);
+    }
+  }
+
+  private void checkListMap(ListVector listVector) {
+    UnionListReader listReader = new UnionListReader(listVector);
+    for (int i = 0; i < COUNT; i++) {
+      listReader.setPosition(i);
+      for (int j = 0; j < i % 7; j++) {
+        listReader.next();
+        UnionMapReader mapReader = (UnionMapReader) listReader.reader();
+        for (int k = 0; k < i % 13; k++) {
+          mapReader.next();
+          Assert.assertEquals("record key: " + i, k, mapReader.key().readInteger().intValue());
+          if (k % 2 == 0) {
+            Assert.assertEquals("record value: " + i, k, mapReader.value().readLong().longValue());
+          } else {
+            Assert.assertNull("record value: " + i, mapReader.value().readLong());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   public void simpleUnion() {
     UnionVector vector = new UnionVector("union", allocator, null);
     UnionWriter unionWriter = new UnionWriter(vector);
@@ -1022,6 +1072,7 @@ public class TestComplexWriter {
       Float4Writer float4Writer = singleStructWriter.float4("float4Field");
       Float8Writer float8Writer = singleStructWriter.float8("float8Field");
       ListWriter listWriter = singleStructWriter.list("listField");
+      MapWriter mapWriter = singleStructWriter.map("mapField", false);
 
       int intValue = 100;
       long bigIntValue = 10000;
@@ -1043,6 +1094,18 @@ public class TestComplexWriter {
         listWriter.integer().writeInt(intValue + i + 2);
         listWriter.integer().writeInt(intValue + i + 3);
         listWriter.endList();
+
+        mapWriter.setPosition(i);
+        mapWriter.startMap();
+        mapWriter.startEntry();
+        mapWriter.key().integer().writeInt(intValue + i);
+        mapWriter.value().integer().writeInt(intValue + i + 1);
+        mapWriter.endEntry();
+        mapWriter.startEntry();
+        mapWriter.key().integer().writeInt(intValue + i + 2);
+        mapWriter.value().integer().writeInt(intValue + i + 3);
+        mapWriter.endEntry();
+        mapWriter.endMap();
 
         singleStructWriter.end();
       }
@@ -1070,6 +1133,7 @@ public class TestComplexWriter {
       Float4Reader float4Reader = singleStructReader.reader("float4Field");
       Float8Reader float8Reader = singleStructReader.reader("float8Field");
       UnionListReader listReader = (UnionListReader) singleStructReader.reader("listField");
+      UnionMapReader mapReader = (UnionMapReader) singleStructReader.reader("mapField");
 
       for (int i = 0; i < initialCapacity; i++) {
         intReader.setPosition(i);
@@ -1077,6 +1141,7 @@ public class TestComplexWriter {
         float4Reader.setPosition(i);
         float8Reader.setPosition(i);
         listReader.setPosition(i);
+        mapReader.setPosition(i);
 
         assertEquals(intValue + i, intReader.readInteger().intValue());
         assertEquals(bigIntValue + (long) i, bigIntReader.readLong().longValue());
@@ -1086,6 +1151,12 @@ public class TestComplexWriter {
         for (int j = 0; j < 4; j++) {
           listReader.next();
           assertEquals(intValue + i + j, listReader.reader().readInteger().intValue());
+        }
+
+        for (int k = 0; k < 4; k += 2) {
+          mapReader.next();
+          assertEquals(intValue + k + i, mapReader.key().readInteger().intValue());
+          assertEquals(intValue + k + i + 1, mapReader.value().readInteger().intValue());
         }
       }
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -36,6 +36,7 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SchemaChangeCallBack;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -573,6 +574,11 @@ public class TestComplexWriter {
       }
       listWriter.setValueCount(COUNT);
       checkListMap(listVector);
+
+      // Verify that the map vector has keysSorted = true
+      MapVector mapVector = (MapVector) listVector.getDataVector();
+      ArrowType arrowType = mapVector.getField().getFieldType().getType();
+      assertTrue(((ArrowType.Map) arrowType).getKeysSorted());
     }
   }
 


### PR DESCRIPTION
This pull request adds support for Map types in FieldReader and FieldWriter. 

Initial unit tests show how to add the following nested types:
- A list of maps: `List<Map<Integer, Long>>`
- Nesting a map as the value of another map: `Map<Long, Map<Long, Long>>`
- Nesting maps as both the key and value of another map: `Map<Map<Integer, Integer>, Map<Long, Long>>`

Appreciate any feedback or suggestions for improvement. 