### PR TITLE
ARROW-11200: [Rust] [DataFusion] Physical operators and expressions should have public accessor methods

### DIFF
--- a/rust/datafusion/src/physical_plan/coalesce_batches.rs
+++ b/rust/datafusion/src/physical_plan/coalesce_batches.rs
@@ -54,6 +54,16 @@ impl CoalesceBatchesExec {
             target_batch_size,
         }
     }
+
+    /// The input plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Minimum number of rows for coalesces batches
+    pub fn target_batch_size(&self) -> usize {
+        self.target_batch_size
+    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -168,6 +168,51 @@ impl CsvExec {
         })
     }
 
+    /// Path to directory containing partitioned CSV files with the same schema
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The individual files under path
+    pub fn filenames(&self) -> &[String] {
+        &self.filenames
+    }
+
+    /// Schema representing the CSV file
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    /// Does the CSV file have a header?
+    pub fn has_header(&self) -> bool {
+        self.has_header
+    }
+
+    /// An optional column delimiter. Defaults to `b','`
+    pub fn delimiter(&self) -> Option<&u8> {
+        self.delimiter.as_ref()
+    }
+
+    /// File extension
+    pub fn file_extension(&self) -> &str {
+        &self.file_extension
+    }
+
+    /// Optional projection for which columns to load
+    pub fn projection(&self) -> Option<&Vec<usize>> {
+        self.projection.as_ref()
+    }
+
+    /// Schema after the projection has been applied
+    pub fn projected_schema(&self) -> SchemaRef {
+        self.projected_schema.clone()
+    }
+
+    /// Batch size
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
     /// Infer schema for given CSV dataset
     pub fn try_infer_schema(
         filenames: &[String],

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -178,11 +178,6 @@ impl CsvExec {
         &self.filenames
     }
 
-    /// Schema representing the CSV file
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
     /// Does the CSV file have a header?
     pub fn has_header(&self) -> bool {
         self.has_header
@@ -201,11 +196,6 @@ impl CsvExec {
     /// Optional projection for which columns to load
     pub fn projection(&self) -> Option<&Vec<usize>> {
         self.projection.as_ref()
-    }
-
-    /// Schema after the projection has been applied
-    pub fn projected_schema(&self) -> SchemaRef {
-        self.projected_schema.clone()
     }
 
     /// Batch size

--- a/rust/datafusion/src/physical_plan/empty.rs
+++ b/rust/datafusion/src/physical_plan/empty.rs
@@ -34,7 +34,9 @@ use async_trait::async_trait;
 /// Execution plan for empty relation (produces no rows)
 #[derive(Debug)]
 pub struct EmptyExec {
+    /// Specifies whether this exec produces a row or not
     produce_one_row: bool,
+    /// The schema for the produced row
     schema: SchemaRef,
 }
 
@@ -45,6 +47,11 @@ impl EmptyExec {
             produce_one_row,
             schema,
         }
+    }
+
+    /// Specifies whether this exec produces a row or not
+    pub fn produce_one_row(&self) -> bool {
+        self.produce_one_row
     }
 }
 

--- a/rust/datafusion/src/physical_plan/explain.rs
+++ b/rust/datafusion/src/physical_plan/explain.rs
@@ -39,7 +39,6 @@ use async_trait::async_trait;
 pub struct ExplainExec {
     /// The schema that this exec plan node outputs
     schema: SchemaRef,
-
     /// The strings to be printed
     stringified_plans: Vec<StringifiedPlan>,
 }
@@ -51,6 +50,11 @@ impl ExplainExec {
             schema,
             stringified_plans,
         }
+    }
+
+    /// The strings to be printed
+    pub fn stringified_plans(&self) -> &[StringifiedPlan] {
+        &self.stringified_plans
     }
 }
 

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -77,6 +77,11 @@ impl Column {
             name: name.to_owned(),
         }
     }
+
+    /// Get the column name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl fmt::Display for Column {
@@ -1154,6 +1159,21 @@ impl BinaryExpr {
     ) -> Self {
         Self { left, op, right }
     }
+
+    /// Get the left side of the binary expression
+    pub fn left(&self) -> &dyn PhysicalExpr {
+        self.left.as_ref()
+    }
+
+    /// Get the right side of the binary expression
+    pub fn right(&self) -> &dyn PhysicalExpr {
+        self.right.as_ref()
+    }
+
+    /// Get the operator for this binary expression
+    pub fn op(&self) -> &Operator {
+        &self.op
+    }
 }
 
 impl fmt::Display for BinaryExpr {
@@ -1615,6 +1635,7 @@ pub static SUPPORTED_NULLIF_TYPES: &[DataType] = &[
 /// Not expression
 #[derive(Debug)]
 pub struct NotExpr {
+    /// Input expression
     arg: Arc<dyn PhysicalExpr>,
 }
 
@@ -1622,6 +1643,11 @@ impl NotExpr {
     /// Create new not expression
     pub fn new(arg: Arc<dyn PhysicalExpr>) -> Self {
         Self { arg }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &dyn PhysicalExpr {
+        self.arg.as_ref()
     }
 }
 
@@ -1691,6 +1717,7 @@ pub fn not(
 /// Negative expression
 #[derive(Debug)]
 pub struct NegativeExpr {
+    /// Input expression
     arg: Arc<dyn PhysicalExpr>,
 }
 
@@ -1698,6 +1725,11 @@ impl NegativeExpr {
     /// Create new not expression
     pub fn new(arg: Arc<dyn PhysicalExpr>) -> Self {
         Self { arg }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &dyn PhysicalExpr {
+        self.arg.as_ref()
     }
 }
 
@@ -1767,6 +1799,7 @@ pub fn negative(
 /// IS NULL expression
 #[derive(Debug)]
 pub struct IsNullExpr {
+    /// Input expression
     arg: Arc<dyn PhysicalExpr>,
 }
 
@@ -1774,6 +1807,11 @@ impl IsNullExpr {
     /// Create new not expression
     pub fn new(arg: Arc<dyn PhysicalExpr>) -> Self {
         Self { arg }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &dyn PhysicalExpr {
+        self.arg.as_ref()
     }
 }
 
@@ -1812,6 +1850,7 @@ pub fn is_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
 /// IS NULL expression
 #[derive(Debug)]
 pub struct IsNotNullExpr {
+    /// The input expression
     arg: Arc<dyn PhysicalExpr>,
 }
 
@@ -1819,6 +1858,11 @@ impl IsNotNullExpr {
     /// Create new not expression
     pub fn new(arg: Arc<dyn PhysicalExpr>) -> Self {
         Self { arg }
+    }
+
+    /// Get the input expression
+    pub fn arg(&self) -> &dyn PhysicalExpr {
+        self.arg.as_ref()
     }
 }
 
@@ -1915,6 +1959,21 @@ impl CaseExpr {
                 else_expr,
             })
         }
+    }
+
+    /// Optional base expression that can be compared to literal values in the "when" expressions
+    pub fn expr(&self) -> &Option<Arc<dyn PhysicalExpr>> {
+        &self.expr
+    }
+
+    /// One or more when/then expressions
+    pub fn when_then_expr(&self) -> &[(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)] {
+        &self.when_then_expr
+    }
+
+    /// Optional "else" expression
+    pub fn else_expr(&self) -> &Option<Arc<dyn PhysicalExpr>> {
+        &self.else_expr
     }
 }
 
@@ -2271,6 +2330,23 @@ pub struct CastExpr {
     cast_type: DataType,
 }
 
+impl CastExpr {
+    /// Create a new CastExpr
+    pub fn new(expr: Arc<dyn PhysicalExpr>, cast_type: DataType) -> Self {
+        Self { expr, cast_type }
+    }
+
+    /// The expression to cast
+    pub fn expr(&self) -> &dyn PhysicalExpr {
+        self.expr.as_ref()
+    }
+
+    /// The data type to cast to
+    pub fn cast_type(&self) -> &DataType {
+        &self.cast_type
+    }
+}
+
 /// Determine if a DataType is signed numeric or not
 pub fn is_signed_numeric(dt: &DataType) -> bool {
     matches!(
@@ -2341,7 +2417,7 @@ pub fn cast(
     if expr_type == cast_type {
         Ok(expr.clone())
     } else if can_cast_types(&expr_type, &cast_type) {
-        Ok(Arc::new(CastExpr { expr, cast_type }))
+        Ok(Arc::new(CastExpr::new(expr, cast_type)))
     } else {
         Err(DataFusionError::Internal(format!(
             "Unsupported CAST from {:?} to {:?}",
@@ -2360,6 +2436,11 @@ impl Literal {
     /// Create a literal value expression
     pub fn new(value: ScalarValue) -> Self {
         Self { value }
+    }
+
+    /// Get the scalar value
+    pub fn value(&self) -> &ScalarValue {
+        &self.value
     }
 }
 
@@ -2493,6 +2574,18 @@ impl InListExpr {
             list,
             negated,
         }
+    }
+
+    pub fn expr(&self) -> &dyn PhysicalExpr {
+        self.expr.as_ref()
+    }
+
+    pub fn list(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.list
+    }
+
+    pub fn negated(&self) -> bool {
+        self.negated
     }
 
     /// Compare for specific utf8 types

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -2576,14 +2576,17 @@ impl InListExpr {
         }
     }
 
+    /// Input expression
     pub fn expr(&self) -> &Arc<dyn PhysicalExpr> {
         &self.expr
     }
 
+    /// List to search in
     pub fn list(&self) -> &[Arc<dyn PhysicalExpr>] {
         &self.list
     }
 
+    /// Is this negated e.g. NOT IN LIST
     pub fn negated(&self) -> bool {
         self.negated
     }

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1161,13 +1161,13 @@ impl BinaryExpr {
     }
 
     /// Get the left side of the binary expression
-    pub fn left(&self) -> &dyn PhysicalExpr {
-        self.left.as_ref()
+    pub fn left(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.left
     }
 
     /// Get the right side of the binary expression
-    pub fn right(&self) -> &dyn PhysicalExpr {
-        self.right.as_ref()
+    pub fn right(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.right
     }
 
     /// Get the operator for this binary expression
@@ -1646,8 +1646,8 @@ impl NotExpr {
     }
 
     /// Get the input expression
-    pub fn arg(&self) -> &dyn PhysicalExpr {
-        self.arg.as_ref()
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
     }
 }
 
@@ -1728,8 +1728,8 @@ impl NegativeExpr {
     }
 
     /// Get the input expression
-    pub fn arg(&self) -> &dyn PhysicalExpr {
-        self.arg.as_ref()
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
     }
 }
 
@@ -1810,8 +1810,8 @@ impl IsNullExpr {
     }
 
     /// Get the input expression
-    pub fn arg(&self) -> &dyn PhysicalExpr {
-        self.arg.as_ref()
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
     }
 }
 
@@ -1861,8 +1861,8 @@ impl IsNotNullExpr {
     }
 
     /// Get the input expression
-    pub fn arg(&self) -> &dyn PhysicalExpr {
-        self.arg.as_ref()
+    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.arg
     }
 }
 
@@ -2337,8 +2337,8 @@ impl CastExpr {
     }
 
     /// The expression to cast
-    pub fn expr(&self) -> &dyn PhysicalExpr {
-        self.expr.as_ref()
+    pub fn expr(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.expr
     }
 
     /// The data type to cast to
@@ -2576,8 +2576,8 @@ impl InListExpr {
         }
     }
 
-    pub fn expr(&self) -> &dyn PhysicalExpr {
-        self.expr.as_ref()
+    pub fn expr(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.expr
     }
 
     pub fn list(&self) -> &[Arc<dyn PhysicalExpr>] {

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1972,8 +1972,8 @@ impl CaseExpr {
     }
 
     /// Optional "else" expression
-    pub fn else_expr(&self) -> &Option<Arc<dyn PhysicalExpr>> {
-        &self.else_expr
+    pub fn else_expr(&self) -> Option<&Arc<dyn PhysicalExpr>> {
+        self.else_expr.as_ref()
     }
 }
 

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -17,6 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt;
 use std::sync::Arc;
@@ -91,6 +92,11 @@ impl fmt::Display for Column {
 }
 
 impl PhysicalExpr for Column {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         Ok(input_schema
@@ -1419,6 +1425,11 @@ fn binary_cast(
 }
 
 impl PhysicalExpr for BinaryExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         binary_operator_data_type(
             &self.left.data_type(input_schema)?,
@@ -1658,6 +1669,11 @@ impl fmt::Display for NotExpr {
 }
 
 impl PhysicalExpr for NotExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
@@ -1740,6 +1756,11 @@ impl fmt::Display for NegativeExpr {
 }
 
 impl PhysicalExpr for NegativeExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.arg.data_type(input_schema)
     }
@@ -1821,6 +1842,11 @@ impl fmt::Display for IsNullExpr {
     }
 }
 impl PhysicalExpr for IsNullExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
@@ -1871,7 +1897,13 @@ impl fmt::Display for IsNotNullExpr {
         write!(f, "{} IS NOT NULL", self.arg)
     }
 }
+
 impl PhysicalExpr for IsNotNullExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::Boolean)
     }
@@ -2288,6 +2320,11 @@ impl CaseExpr {
 }
 
 impl PhysicalExpr for CaseExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.when_then_expr[0].1.data_type(input_schema)
     }
@@ -2379,6 +2416,11 @@ impl fmt::Display for CastExpr {
 }
 
 impl PhysicalExpr for CastExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(self.cast_type.clone())
     }
@@ -2451,6 +2493,11 @@ impl fmt::Display for Literal {
 }
 
 impl PhysicalExpr for Literal {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(self.value.get_datatype())
     }
@@ -2667,6 +2714,11 @@ impl fmt::Display for InListExpr {
 }
 
 impl PhysicalExpr for InListExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::Boolean)
     }

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -63,6 +63,16 @@ impl FilterExec {
             ))),
         }
     }
+
+    /// The expression to filter on. This expression must evaluate to a boolean value.
+    pub fn predicate(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.predicate
+    }
+
+    /// The input plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -465,6 +465,22 @@ impl ScalarFunctionExpr {
             return_type: return_type.clone(),
         }
     }
+
+    pub fn fun(&self) -> &ScalarFunctionImplementation {
+        &self.fun
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn args(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.args
+    }
+
+    pub fn return_type(&self) -> &DataType {
+        &self.return_type
+    }
 }
 
 impl fmt::Display for ScalarFunctionExpr {

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -466,18 +466,22 @@ impl ScalarFunctionExpr {
         }
     }
 
+    /// Get the scalar function implementation
     pub fn fun(&self) -> &ScalarFunctionImplementation {
         &self.fun
     }
 
+    /// The name for this expression
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Input arguments
     pub fn args(&self) -> &[Arc<dyn PhysicalExpr>] {
         &self.args
     }
 
+    /// Data type produced by this expression
     pub fn return_type(&self) -> &DataType {
         &self.return_type
     }

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -47,7 +47,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use fmt::{Debug, Formatter};
-use std::{fmt, str::FromStr, sync::Arc};
+use std::{any::Any, fmt, str::FromStr, sync::Arc};
 
 /// A function's signature, which defines the function's supported argument types.
 #[derive(Debug, Clone, PartialEq)]
@@ -503,6 +503,11 @@ impl fmt::Display for ScalarFunctionExpr {
 }
 
 impl PhysicalExpr for ScalarFunctionExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(self.return_type.clone())
     }

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -124,6 +124,26 @@ impl HashAggregateExec {
             schema,
         })
     }
+
+    pub fn mode(&self) -> &AggregateMode {
+        &self.mode
+    }
+
+    pub fn group_expr(&self) -> &[(Arc<dyn PhysicalExpr>, String)] {
+        &self.group_expr
+    }
+
+    pub fn aggr_expr(&self) -> &[Arc<dyn AggregateExpr>] {
+        &self.aggr_expr
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -149,11 +149,6 @@ impl HashAggregateExec {
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input
     }
-
-    /// Schema after the aggregate is applied
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -64,10 +64,15 @@ pub enum AggregateMode {
 /// Hash aggregate execution plan
 #[derive(Debug)]
 pub struct HashAggregateExec {
+    /// Aggregation mode (full, partial)
     mode: AggregateMode,
+    /// Grouping expressions
     group_expr: Vec<(Arc<dyn PhysicalExpr>, String)>,
+    /// Aggregate expressions
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
+    /// Input plan
     input: Arc<dyn ExecutionPlan>,
+    /// Schema after the aggregate is applied
     schema: SchemaRef,
 }
 
@@ -125,22 +130,27 @@ impl HashAggregateExec {
         })
     }
 
+    /// Aggregation mode (full, partial)
     pub fn mode(&self) -> &AggregateMode {
         &self.mode
     }
 
+    /// Grouping expressions
     pub fn group_expr(&self) -> &[(Arc<dyn PhysicalExpr>, String)] {
         &self.group_expr
     }
 
+    /// Aggregate expressions
     pub fn aggr_expr(&self) -> &[Arc<dyn AggregateExpr>] {
         &self.aggr_expr
     }
 
+    /// Input plan
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input
     }
 
+    /// Schema after the aggregate is applied
     pub fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -126,6 +126,31 @@ impl HashJoinExec {
         })
     }
 
+    /// left (build) side which gets hashed
+    pub fn left(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.left
+    }
+
+    /// right (probe) side which are filtered by the hash table
+    pub fn right(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.right
+    }
+
+    /// Set of common columns used to join on
+    pub fn on(&self) -> &[(String, String)] {
+        &self.on
+    }
+
+    /// How the join is performed
+    pub fn join_type(&self) -> &JoinType {
+        &self.join_type
+    }
+
+    /// The schema once the join is applied
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
     /// Calculates column indices and left/right placement on input / output schemas and jointype
     fn column_indices_from_schema(&self) -> ArrowResult<Vec<ColumnIndex>> {
         let (primary_is_left, primary_schema, secondary_schema) = match self.join_type {

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -146,11 +146,6 @@ impl HashJoinExec {
         &self.join_type
     }
 
-    /// The schema once the join is applied
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
     /// Calculates column indices and left/right placement on input / output schemas and jointype
     fn column_indices_from_schema(&self) -> ArrowResult<Vec<ColumnIndex>> {
         let (primary_is_left, primary_schema, secondary_schema) = match self.join_type {

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -57,6 +57,16 @@ impl GlobalLimitExec {
             concurrency,
         }
     }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Maximum number of rows to return
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
 }
 
 #[async_trait]
@@ -123,7 +133,9 @@ impl ExecutionPlan for GlobalLimitExec {
 /// LocalLimitExec applies a limit to a single partition
 #[derive(Debug)]
 pub struct LocalLimitExec {
+    /// Input execution plan
     input: Arc<dyn ExecutionPlan>,
+    /// Maximum number of rows to return
     limit: usize,
 }
 
@@ -131,6 +143,16 @@ impl LocalLimitExec {
     /// Create a new LocalLimitExec partition
     pub fn new(input: Arc<dyn ExecutionPlan>, limit: usize) -> Self {
         Self { input, limit }
+    }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Maximum number of rows to return
+    pub fn limit(&self) -> usize {
+        self.limit
     }
 }
 

--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -55,6 +55,11 @@ impl MergeExec {
     pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
         MergeExec { input }
     }
+
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -185,6 +185,9 @@ impl ColumnarValue {
 /// Expression that can be evaluated against a RecordBatch
 /// A Physical expression knows its type, nullability and how to evaluate itself.
 pub trait PhysicalExpr: Send + Sync + Display + Debug {
+    /// Returns the physical expression as [`Any`](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Determine whether this expression is nullable, given the schema of the input

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -204,7 +204,39 @@ impl ParquetExec {
         }
     }
 
-    /// Provide access to the statistics
+    /// Parquet partitions to read
+    pub fn partitions(&self) -> &[ParquetPartition] {
+        &self.partitions
+    }
+
+    /// Schema after projection is applied
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    /// Projection for which columns to load
+    pub fn projection(&self) -> &[usize] {
+        &self.projection
+    }
+
+    /// Batch size
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// Statistics for the data set (sum of statistics for all partitions)
+    pub fn statistics(&self) -> &Statistics {
+        &self.statistics
+    }
+}
+
+impl ParquetPartition {
+    /// The Parquet filename for this partition
+    pub fn filenames(&self) -> &[String] {
+        &self.filenames
+    }
+
+    /// Statistics for this partition
     pub fn statistics(&self) -> &Statistics {
         &self.statistics
     }

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -209,11 +209,6 @@ impl ParquetExec {
         &self.partitions
     }
 
-    /// Schema after projection is applied
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
     /// Projection for which columns to load
     pub fn projection(&self) -> &[usize] {
         &self.projection

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -75,6 +75,21 @@ impl ProjectionExec {
             input: input.clone(),
         })
     }
+
+    /// The projection expressions stored as tuples of (expression, output column name)
+    pub fn expr(&self) -> &[(Arc<dyn PhysicalExpr>, String)] {
+        &self.expr
+    }
+
+    /// The schema once the projection has been applied to the input
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    /// The input plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
 }
 
 #[async_trait]

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -81,11 +81,6 @@ impl ProjectionExec {
         &self.expr
     }
 
-    /// The schema once the projection has been applied to the input
-    pub fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
     /// The input plan
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -53,6 +53,18 @@ pub struct RepartitionExec {
     channels: Arc<Mutex<Vec<(Sender<MaybeBatch>, Receiver<MaybeBatch>)>>>,
 }
 
+impl RepartitionExec {
+    /// Input execution plan
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Partitioning scheme to use
+    pub fn partitioning(&self) -> &Partitioning {
+        &self.partitioning
+    }
+}
+
 #[async_trait]
 impl ExecutionPlan for RepartitionExec {
     /// Return a reference to Any that can be used for downcasting

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -65,6 +65,16 @@ impl SortExec {
             concurrency,
         })
     }
+
+    /// Input schema
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Sort expressions
+    pub fn expr(&self) -> &[PhysicalSortExpr] {
+        &self.expr
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Physical operators and expressions should have public accessor methods so that other crates can walk the physical plan and extract the values used to construct the operators and expressions.

This allows other projects to translate the physical plan into a different form or to serialize a physical plan to support distributed queries in a cluster.