### PR TITLE
ARROW-11201: [Rust][DataFusion] create_batch_empty - support more types

### DIFF
--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -234,5 +234,52 @@ pub fn create_batch_empty(schema: &Schema) -> ArrowResult<RecordBatch> {
         })
         .collect::<Result<_>>()
         .map_err(DataFusionError::into_arrow_external_error)?;
+
     RecordBatch::try_new(Arc::new(schema.to_owned()), columns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::Field;
+
+    #[test]
+    fn test_create_batch_empty() {
+        let schema = Schema::new(vec![
+            Field::new("c1", DataType::Utf8, false),
+            Field::new("c2", DataType::UInt32, false),
+            Field::new("c3", DataType::Int8, false),
+            Field::new("c4", DataType::Int16, false),
+            Field::new("c5", DataType::Int32, false),
+            Field::new("c6", DataType::Int64, false),
+            Field::new("c7", DataType::UInt8, false),
+            Field::new("c8", DataType::UInt16, false),
+            Field::new("c9", DataType::UInt32, false),
+            Field::new("c10", DataType::UInt64, false),
+            Field::new("c11", DataType::Float32, false),
+            Field::new("c12", DataType::Float64, false),
+            Field::new("c13", DataType::Utf8, false),
+            Field::new("c14", DataType::Decimal(10, 10), false),
+            Field::new("c15", DataType::Timestamp(TimeUnit::Second, None), false),
+            Field::new(
+                "c16",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                false,
+            ),
+            Field::new(
+                "c17",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new(
+                "c18",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+            Field::new("c19", DataType::Boolean, false),
+        ]);
+
+        let batch = create_batch_empty(&schema).unwrap();
+        assert_eq!(batch.columns().len(), 19);
+    }
 }


### PR DESCRIPTION
The function called create_batch_empty is used inside hash_aggregate to make an empty batch from the provided schema which contains type for columns. In this PR I added support for:

- DataType::Decimal
- DataType::Timestamp with all TimeUnits with passing timezone
- DataType::Date32
- DataType::Date64
- DataType::Time32
- DataType::Time64
