### PR TITLE
ARROW-11209: [Rust] DF - Better error message on unsupported GROUP BY

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -956,6 +956,12 @@ impl<T: ArrowNativeType> ToByteSlice for T {
     }
 }
 
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl DataType {
     /// Parse a data type from a JSON representation
     pub(crate) fn from(json: &Value) -> Result<DataType> {

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -828,9 +828,10 @@ pub(crate) fn create_group_by_values(
             }
             _ => {
                 // This is internal because we should have caught this before.
-                return Err(DataFusionError::Internal(
-                    "Unsupported GROUP BY data type".to_string(),
-                ));
+                return Err(DataFusionError::Internal(format!(
+                    "Unsupported GROUP BY for {}",
+                    col.data_type(),
+                )));
             }
         }
     }

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -449,9 +449,10 @@ pub(crate) fn create_key(
             }
             _ => {
                 // This is internal because we should have caught this before.
-                return Err(DataFusionError::Internal(
-                    "Unsupported GROUP BY data type".to_string(),
-                ));
+                return Err(DataFusionError::Internal(format!(
+                    "Unsupported GROUP BY for {}",
+                    col.data_type(),
+                )));
             }
         }
     }


### PR DESCRIPTION
I am getting error without details which type is not supported inside GROUP BY:

External error: Arrow error: External error: Internal error: Unsupported GROUP BY data type.

I added the column's DataType to the error message to make the investigation easier.