### PR TITLE
ARROW-11218: [R] Make SubTreeFileSystem print method more informative

### DIFF
--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -286,9 +286,15 @@ get_path_and_filesystem <- function(x, filesystem = NULL) {
     }
     FileSystem$from_uri(x)
   } else {
+    fs <- filesystem %||% LocalFileSystem$create()
+    path <- ifelse(
+      inherits(fs, "LocalFileSystem"),
+      clean_path_abs(x),
+      clean_path_rel(x)
+    )
     list(
-      fs = filesystem %||% LocalFileSystem$create(),
-      path = clean_path_abs(x)
+      fs = fs,
+      path = path
     )
   }
 }

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -402,6 +402,18 @@ s3_bucket <- function(bucket, ...) {
 #' @rdname FileSystem
 #' @export
 SubTreeFileSystem <- R6Class("SubTreeFileSystem", inherit = FileSystem,
+  public = list(
+    print = function(...) {
+      if (inherits(self$base_fs, "LocalFileSystem")) {
+        cat("SubTreeFileSystem: ", "file://", self$base_path, "\n", sep = "")
+      } else if (inherits(self$base_fs, "S3FileSystem")) {
+        cat("SubTreeFileSystem: ", "s3://", self$base_path, "\n", sep = "")
+      } else {
+        cat("SubTreeFileSystem", "\n", sep = "")
+      }
+      invisible(self)
+    }
+  ),
   active = list(
     base_fs = function() {
       fs___SubTreeFileSystem__base_fs(self)

--- a/r/tests/testthat/test-filesystem.R
+++ b/r/tests/testthat/test-filesystem.R
@@ -84,6 +84,10 @@ test_that("SubTreeFilesystem", {
   expect_is(st_fs, "SubTreeFileSystem")
   expect_is(st_fs, "FileSystem")
   expect_is(st_fs$base_fs, "LocalFileSystem")
+  expect_identical(
+    capture.output(print(st_fs)),
+    paste0("SubTreeFileSystem: ", "file://", st_fs$base_path)
+  )
 
   # FIXME windows has a trailing slash for one but not the other
   # expect_identical(normalizePath(st_fs$base_path), normalizePath(td))
@@ -142,6 +146,10 @@ test_that("SubTreeFileSystem$create() with URI", {
   skip_if_not_available("s3")
   fs <- SubTreeFileSystem$create("s3://ursa-labs-taxi-data")
   expect_is(fs, "SubTreeFileSystem")
+  expect_identical(
+    capture.output(print(fs)),
+    "SubTreeFileSystem: s3://ursa-labs-taxi-data/"
+  )
 })
 
 test_that("S3FileSystem", {
@@ -158,6 +166,10 @@ test_that("s3_bucket", {
   expect_is(bucket, "SubTreeFileSystem")
   expect_is(bucket$base_fs, "S3FileSystem")
   expect_identical(bucket$region, "us-west-2")
+  expect_identical(
+    capture.output(print(bucket)),
+    "SubTreeFileSystem: s3://ursa-labs-r-test/"
+  )
   skip_on_os("windows") # FIXME
   expect_identical(bucket$base_path, "ursa-labs-r-test/")
 })


### PR DESCRIPTION
Adds a print method for `SubTreeFileSystem` objects that prints the scheme and path when the base file system is local or S3.