### PR TITLE
ARROW-11229: [C++][Dataset] Fix static build failure

### DIFF
--- a/cpp/src/arrow/dataset/expression_internal.h
+++ b/cpp/src/arrow/dataset/expression_internal.h
@@ -34,7 +34,7 @@ using internal::checked_cast;
 
 namespace dataset {
 
-const Expression::Call* CallNotNull(const Expression& expr) {
+inline const Expression::Call* CallNotNull(const Expression& expr) {
   auto call = expr.call();
   DCHECK_NE(call, nullptr);
   return call;


### PR DESCRIPTION
This is caused by
https://github.com/apache/arrow/commit/57376d28cf433bed95f19fa44c1e90a780ba54e8
.

https://app.circleci.com/pipelines/github/ursa-labs/crossbow/68346/workflows/fad0ef52-c3be-4193-806d-c1d39a58391b/jobs/14491

    [469/638] Linking CXX executable debug/arrow-dataset-expression-testt.dir/level_conversion_test.cc.oKo.o.cc.oKKK
    FAILED: debug/arrow-dataset-expression-test
    : && /usr/bin/ccache /usr/bin/c++ ... && :
    debug/libarrow_dataset.a(expression.cc.o): In function `arrow::dataset::CallNotNull(arrow::dataset::Expression const&)':
    /arrow/cpp/src/arrow/dataset/expression_internal.h:37: multiple definition of `arrow::dataset::CallNotNull(arrow::dataset::Expression const&)'
    src/arrow/dataset/CMakeFiles/arrow-dataset-expression-test.dir/expression_test.cc.o:/arrow/cpp/src/arrow/dataset/expression_internal.h:37: first defined here
    collect2: error: ld returned 1 exit status