### PR TITLE
ARROW-11223: [Java] Fix: BaseVariableWidthVector/BaseLargeVariableWidthVector setNull() and getBufferSizeFor() trigger offset buffer overflow

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -187,7 +187,8 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
   }
 
   /**
-   * Get the current value capacity for the vector.
+   * Get the current capacity which does not exceed either validity buffer or offset buffer.
+   * Note: Here the `getValueCapacity` has no relationship with the value buffer.
    * @return number of elements that vector can hold.
    */
   @Override
@@ -903,6 +904,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    */
   @Override
   public void setIndexDefined(int index) {
+    // We need to check and realloc both validity and offset buffer
     while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
@@ -1056,6 +1058,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    * @param index   position of element
    */
   public void setNull(int index) {
+    // We need to check and realloc both validity and offset buffer
     while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -903,7 +903,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    */
   @Override
   public void setIndexDefined(int index) {
-    while (index >= getValidityBufferValueCapacity()) {
+    while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
     BitVectorHelper.setBit(validityBuffer, index);
@@ -1056,7 +1056,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    * @param index   position of element
    */
   public void setNull(int index) {
-    while (index >= getValidityBufferValueCapacity()) {
+    while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
     BitVectorHelper.unsetBit(validityBuffer, index);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -941,7 +941,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public void setIndexDefined(int index) {
-    while (index >= getValidityBufferValueCapacity()) {
+    while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
     BitVectorHelper.setBit(validityBuffer, index);
@@ -1094,7 +1094,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @param index   position of element
    */
   public void setNull(int index) {
-    while (index >= getValidityBufferValueCapacity()) {
+    while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
     BitVectorHelper.unsetBit(validityBuffer, index);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -205,7 +205,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   }
 
   /**
-   * Get the current value capacity for the vector.
+   * Get the current capacity which does not exceed either validity buffer or offset buffer.
+   * Note: Here the `getValueCapacity` has no relationship with the value buffer.
    * @return number of elements that vector can hold.
    */
   @Override
@@ -941,6 +942,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public void setIndexDefined(int index) {
+    // We need to check and realloc both validity and offset buffer
     while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
@@ -1094,6 +1096,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @param index   position of element
    */
   public void setNull(int index) {
+    // We need to check and realloc both validity and offset buffer
     while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.*;
+import  static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
 
@@ -157,7 +157,7 @@ public class TestVectorReAlloc {
     BaseVariableWidthVector v1 = new VarCharVector("var1", allocator);
     v1.setInitialCapacity(512);
     v1.allocateNew();
-    long numNullValues1 = v1.getOffsetBuffer().capacity() / v1.OFFSET_WIDTH + 1;
+    long numNullValues1 = v1.getValueCapacity() + 1;
     for (int i = 0; i < numNullValues1; i++) {
       v1.setNull(i);
     }
@@ -166,7 +166,7 @@ public class TestVectorReAlloc {
     BaseLargeVariableWidthVector v2 = new LargeVarCharVector("var2", allocator);
     v2.setInitialCapacity(512);
     v2.allocateNew();
-    long numNullValues2 = v2.getOffsetBuffer().capacity() / v2.OFFSET_WIDTH + 1;
+    long numNullValues2 = v2.getValueCapacity() + 1;
     for (int i = 0; i < numNullValues2; i++) {
       v2.setNull(i);
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -152,6 +152,28 @@ public class TestVectorReAlloc {
   }
 
   @Test
+  public void testVariableWidthTypeSetNullValues() {
+    // Test ARROW-11223 bug is fixed
+    BaseVariableWidthVector v1 = new VarCharVector("var1", allocator);
+    v1.setInitialCapacity(512);
+    v1.allocateNew();
+    long numNullValues1 = v1.getOffsetBuffer().capacity() / v1.OFFSET_WIDTH + 1;
+    for (int i = 0; i < numNullValues1; i++) {
+      v1.setNull(i);
+    }
+    Assert.assertTrue(v1.getBufferSizeFor((int)numNullValues1) > 0);
+
+    BaseLargeVariableWidthVector v2 = new LargeVarCharVector("var2", allocator);
+    v2.setInitialCapacity(512);
+    v2.allocateNew();
+    long numNullValues2 = v2.getOffsetBuffer().capacity() / v2.OFFSET_WIDTH + 1;
+    for (int i = 0; i < numNullValues2; i++) {
+      v2.setNull(i);
+    }
+    Assert.assertTrue(v2.getBufferSizeFor((int)numNullValues2) > 0);
+  }
+
+  @Test
   public void testFixedAllocateAfterReAlloc() throws Exception {
     try (final IntVector vector = new IntVector("", allocator)) {
       /*

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -157,20 +157,20 @@ public class TestVectorReAlloc {
     BaseVariableWidthVector v1 = new VarCharVector("var1", allocator);
     v1.setInitialCapacity(512);
     v1.allocateNew();
-    long numNullValues1 = v1.getValueCapacity() + 1;
+    int numNullValues1 = v1.getValueCapacity() + 1;
     for (int i = 0; i < numNullValues1; i++) {
       v1.setNull(i);
     }
-    Assert.assertTrue(v1.getBufferSizeFor((int)numNullValues1) > 0);
+    Assert.assertTrue(v1.getBufferSizeFor(numNullValues1) > 0);
 
     BaseLargeVariableWidthVector v2 = new LargeVarCharVector("var2", allocator);
     v2.setInitialCapacity(512);
     v2.allocateNew();
-    long numNullValues2 = v2.getValueCapacity() + 1;
+    int numNullValues2 = v2.getValueCapacity() + 1;
     for (int i = 0; i < numNullValues2; i++) {
       v2.setNull(i);
     }
-    Assert.assertTrue(v2.getBufferSizeFor((int)numNullValues2) > 0);
+    Assert.assertTrue(v2.getBufferSizeFor(numNullValues2) > 0);
   }
 
   @Test

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector;
 
-import  static org.junit.Assert.*;
+import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
 
@@ -154,23 +154,25 @@ public class TestVectorReAlloc {
   @Test
   public void testVariableWidthTypeSetNullValues() {
     // Test ARROW-11223 bug is fixed
-    BaseVariableWidthVector v1 = new VarCharVector("var1", allocator);
-    v1.setInitialCapacity(512);
-    v1.allocateNew();
-    int numNullValues1 = v1.getValueCapacity() + 1;
-    for (int i = 0; i < numNullValues1; i++) {
-      v1.setNull(i);
+    try (final BaseVariableWidthVector v1 = new VarCharVector("var1", allocator)) {
+      v1.setInitialCapacity(512);
+      v1.allocateNew();
+      int numNullValues1 = v1.getValueCapacity() + 1;
+      for (int i = 0; i < numNullValues1; i++) {
+        v1.setNull(i);
+      }
+      Assert.assertTrue(v1.getBufferSizeFor(numNullValues1) > 0);
     }
-    Assert.assertTrue(v1.getBufferSizeFor(numNullValues1) > 0);
 
-    BaseLargeVariableWidthVector v2 = new LargeVarCharVector("var2", allocator);
-    v2.setInitialCapacity(512);
-    v2.allocateNew();
-    int numNullValues2 = v2.getValueCapacity() + 1;
-    for (int i = 0; i < numNullValues2; i++) {
-      v2.setNull(i);
+    try (final BaseLargeVariableWidthVector v2 = new LargeVarCharVector("var2", allocator)) {
+      v2.setInitialCapacity(512);
+      v2.allocateNew();
+      int numNullValues2 = v2.getValueCapacity() + 1;
+      for (int i = 0; i < numNullValues2; i++) {
+        v2.setNull(i);
+      }
+      Assert.assertTrue(v2.getBufferSizeFor(numNullValues2) > 0);
     }
-    Assert.assertTrue(v2.getBufferSizeFor(numNullValues2) > 0);
   }
 
   @Test


### PR DESCRIPTION
Fix: BaseVariableWidthVector/BaseLargeVariableWidthVector setNull() and getBufferSizeFor() trigger offset buffer overflow:

the issue is caused by the different allocated size of a validity buffer which is N/8 from the offset buffer (N+1)*OFFSET_WIDTH. When the ration of null versus non-null values is large and the offset buffer gets filled up before the validity buffer, the getBufferSizeFor call will trigger the overflow error.

Reproduce it by:

~~~java
BaseVariableWidthVector v1 = new VarCharVector("var1", allocator)) 
v1.setInitialCapacity(512);
v1.allocateNew();
int numNullValues1 = v1.getValueCapacity() + 1;
for (int i = 0; i < numNullValues1; i++) {
  v1.setNull(i);
}
v1.getBufferSizeFor(numNullValues1) // Raise error of buffer overflow
~~~