### PR TITLE
ARROW-11171: [Go] Fix building on s390x with noasm

### DIFF
--- a/go/arrow/math/Makefile
+++ b/go/arrow/math/Makefile
@@ -42,13 +42,13 @@ INTEL_SOURCES := \
 assembly: $(INTEL_SOURCES)
 
 generate: ../bin/tmpl
-	../bin/tmpl -i -data=float64.tmpldata type.go.tmpl=float64.go type_amd64.go.tmpl=float64_amd64.go type_noasm.go.tmpl=float64_noasm.go type_test.go.tmpl=float64_test.go
+	../bin/tmpl -i -data=float64.tmpldata type.go.tmpl=float64.go type_amd64.go.tmpl=float64_amd64.go type_s390x.go.tmpl=float64_s390x.go type_noasm.go.tmpl=float64_noasm.go type_test.go.tmpl=float64_test.go
 	../bin/tmpl -i -data=float64.tmpldata -d arch=avx2 type_simd_amd64.go.tmpl=float64_avx2_amd64.go
 	../bin/tmpl -i -data=float64.tmpldata -d arch=sse4 type_simd_amd64.go.tmpl=float64_sse4_amd64.go
-	../bin/tmpl -i -data=int64.tmpldata type.go.tmpl=int64.go type_amd64.go.tmpl=int64_amd64.go type_noasm.go.tmpl=int64_noasm.go type_test.go.tmpl=int64_test.go
+	../bin/tmpl -i -data=int64.tmpldata type.go.tmpl=int64.go type_amd64.go.tmpl=int64_amd64.go type_s390x.go.tmpl=int64_s390x.go type_noasm.go.tmpl=int64_noasm.go type_test.go.tmpl=int64_test.go
 	../bin/tmpl -i -data=int64.tmpldata -d arch=avx2 type_simd_amd64.go.tmpl=int64_avx2_amd64.go
 	../bin/tmpl -i -data=int64.tmpldata -d arch=sse4 type_simd_amd64.go.tmpl=int64_sse4_amd64.go
-	../bin/tmpl -i -data=uint64.tmpldata type.go.tmpl=uint64.go type_amd64.go.tmpl=uint64_amd64.go type_noasm.go.tmpl=uint64_noasm.go type_test.go.tmpl=uint64_test.go
+	../bin/tmpl -i -data=uint64.tmpldata type.go.tmpl=uint64.go type_amd64.go.tmpl=uint64_amd64.go type_s390x.go.tmpl=uint64_s390x.go type_noasm.go.tmpl=uint64_noasm.go type_test.go.tmpl=uint64_test.go
 	../bin/tmpl -i -data=uint64.tmpldata -d arch=avx2 type_simd_amd64.go.tmpl=uint64_avx2_amd64.go
 	../bin/tmpl -i -data=uint64.tmpldata -d arch=sse4 type_simd_amd64.go.tmpl=uint64_sse4_amd64.go
 

--- a/go/arrow/math/float64_s390x.go
+++ b/go/arrow/math/float64_s390x.go
@@ -16,6 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noasm
+
 package math
 
 func initFloat64Go() {

--- a/go/arrow/math/int64_s390x.go
+++ b/go/arrow/math/int64_s390x.go
@@ -16,6 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noasm
+
 package math
 
 func initInt64Go() {

--- a/go/arrow/math/math_s390x.go
+++ b/go/arrow/math/math_s390x.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noasm
 
 package math
 

--- a/go/arrow/math/type_s390x.go.tmpl
+++ b/go/arrow/math/type_s390x.go.tmpl
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noasm
 
 package math
 

--- a/go/arrow/math/uint64_s390x.go
+++ b/go/arrow/math/uint64_s390x.go
@@ -16,6 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noasm
+
 package math
 
 func initUint64Go() {


### PR DESCRIPTION
This PR fixes building the Go component on the s390x platform with the `noasm` build tag.
Before this change, running `make test-noasm` would fail with:
```go
$ make test-noasm
go test  -tags='noasm' ./...
# github.com/apache/arrow/go/arrow/math
math/float64_s390x.go:21:6: initFloat64Go redeclared in this block
        previous declaration at math/float64_noasm.go:23:6
math/int64_s390x.go:21:6: initInt64Go redeclared in this block
        previous declaration at math/int64_noasm.go:23:6
math/math_s390x.go:24:6: initGo redeclared in this block
        previous declaration at math/math_noasm.go:25:6
math/uint64_s390x.go:21:6: initUint64Go redeclared in this block
        previous declaration at math/uint64_noasm.go:23:6
...
```