### PR TITLE
ARROW-11242: [CI] Remove CMake 3.2 job

### DIFF
--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -49,7 +49,6 @@ jobs:
           - amd64-fedora-33-cpp
           - amd64-ubuntu-16.04-cpp
           - amd64-ubuntu-18.04-cpp
-          - amd64-ubuntu-18.04-cpp-cmake32
         include:
           - name: amd64-debian-10-cpp
             image: debian-cpp

--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -67,10 +67,6 @@ jobs:
             image: ubuntu-cpp
             title: AMD64 Ubuntu 18.04 C++
             ubuntu: 18.04
-          - name: amd64-ubuntu-18.04-cpp-cmake32
-            image: ubuntu-cpp-cmake32
-            title: AMD64 Ubuntu 18.04 C++ CMake 3.2
-            ubuntu: 18.04
     env:
       # the defaults here should correspond to the values in .env
       ARCH: 'amd64'


### PR DESCRIPTION
Because we dropped support for CMake 3.2.