### PR TITLE
ARROW-11244: [Packaging][wheel][macOS] Use bundled Protobuf for gRPC

### DIFF
--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -63,7 +63,6 @@ jobs:
             git \
             openblas \
             openssl@1.1 \
-            protobuf \
             python@3.8 \
             thrift \
             wget

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -68,14 +68,12 @@ function build_wheel {
           -DARROW_DEPENDENCY_SOURCE=BUNDLED \
           -DARROW_FLIGHT=ON \
           -DARROW_GANDIVA=OFF \
-          -DARROW_GRPC_USE_SHARED=OFF \
           -DARROW_HDFS=ON \
           -DARROW_JEMALLOC=ON \
           -DARROW_OPENSSL_USE_SHARED=OFF \
           -DARROW_ORC=OFF \
           -DARROW_PARQUET=ON \
           -DARROW_PLASMA=ON \
-          -DARROW_PROTOBUF_USE_SHARED=OFF \
           -DARROW_PYTHON=ON \
           -DARROW_RPATH_ORIGIN=ON \
           -DARROW_S3=${ARROW_S3} \
@@ -90,7 +88,6 @@ function build_wheel {
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
           -DMAKE=make \
-          -DProtobuf_SOURCE=SYSTEM \
           ..
     make -j$(sysctl -n hw.logicalcpu)
     make install


### PR DESCRIPTION
Because Protobuf provided by Homebrew doesn't include
protobuf-config.cmake.