### PR TITLE
ARROW-11246: [Rust] Add type to Unexpected accumulator state error

### DIFF
--- a/rust/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/rust/datafusion/src/physical_plan/distinct_expressions.rs
@@ -132,9 +132,10 @@ impl Accumulator for DistinctCountAccumulator {
             .iter()
             .map(|state| match state {
                 ScalarValue::List(Some(values), _) => Ok(values),
-                _ => Err(DataFusionError::Internal(
-                    "Unexpected accumulator state".to_string(),
-                )),
+                _ => Err(DataFusionError::Internal(format!(
+                    "Unexpected accumulator state {:?}",
+                    state
+                ))),
             })
             .collect::<Result<Vec<_>>>()?;
 


### PR DESCRIPTION
I am getting a bug with an error: Unexpected accumulator state, but It's not possible to understand what value was passed when the exception is done on the user's side. I add type to the error message to make investigation of the bug more easy.