### PR TITLE
ARROW-11255: [Packaging][Conda][macOS] Fix Python version

### DIFF
--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
@@ -49,7 +49,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 re2:
 - 2020.10.01
 snappy:


### PR DESCRIPTION
This was introduced by a2c732da52e3814c3366d5366255386d84643250
unexpectedly.