### PR TITLE
ARROW-10457: [CI] Fix Spark integration tests with branch-3.0

### DIFF
--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -23,12 +23,10 @@ FROM ${repo}:${arch}-conda-python-${python}
 ARG jdk=8
 ARG maven=3.5
 
-# The Spark tests currently break with pandas >= 1.0
 RUN conda install -q \
-        patch \
-        pandas=0.25.3 \
         openjdk=${jdk} \
-        maven=${maven} && \
+        maven=${maven} \
+        pandas && \
     conda clean --all
 
 # installing specific version of spark

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1945,8 +1945,9 @@ tasks:
       env:
         PYTHON: 3.7
         SPARK: "branch-3.0"
+        TEST_PYARROW_ONLY: "true"
       # use the branch-3.0 of spark, so prevent reusing any layers
-      run: --no-leaf-cache conda-python-spark-pyarrow-only
+      run: --no-leaf-cache conda-python-spark
 
   test-conda-python-3.8-spark-master:
     ci: github

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1945,7 +1945,7 @@ tasks:
       env:
         PYTHON: 3.7
         SPARK: "branch-3.0"
-      # use the master branch of spark, so prevent reusing any layers
+      # use the branch-3.0 of spark, so prevent reusing any layers
       run: --no-leaf-cache conda-python-spark-pyarrow-only
 
   test-conda-python-3.8-spark-master:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1946,7 +1946,7 @@ tasks:
         PYTHON: 3.7
         SPARK: "branch-3.0"
       # use the master branch of spark, so prevent reusing any layers
-      run: --no-leaf-cache conda-python-spark
+      run: --no-leaf-cache conda-python-spark-pyarrow-only
 
   test-conda-python-3.8-spark-master:
     ci: github

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,6 @@ x-hierarchy:
       - conda-python-turbodbc
       - conda-python-kartothek
       - conda-python-spark
-      - conda-python-spark-pyarrow-only
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -1340,35 +1339,4 @@ services:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         /arrow/ci/scripts/java_build.sh /arrow /build &&
-        /arrow/ci/scripts/integration_spark.sh /arrow /spark"]
-
-  conda-python-spark-pyarrow-only:
-    # Usage:
-    #   docker-compose build conda-cpp
-    #   docker-compose build conda-python
-    #   docker-compose build conda-python-spark-pyarrow-only
-    #   docker-compose run conda-python-spark-pyarrow-only
-    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-spark-${SPARK}-pyarrow-only
-    build:
-      context: .
-      dockerfile: ci/docker/conda-python-spark.dockerfile
-      cache_from:
-        - ${REPO}:${ARCH}-conda-python-${PYTHON}-spark-${SPARK}-pyarrow-only
-      args:
-        repo: ${REPO}
-        arch: ${ARCH}
-        python: ${PYTHON}
-        jdk: ${JDK}
-        # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
-        # be set to ${MAVEN}
-        maven: 3.5
-        spark: ${SPARK}
-    shm_size: *shm-size
-    environment:
-      <<: *ccache
-    volumes: *conda-maven-volumes
-    command:
-      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
-        /arrow/ci/scripts/python_build.sh /arrow /build &&
-        /arrow/ci/scripts/java_build.sh /arrow /build &&
-        /arrow/ci/scripts/integration_spark.sh /arrow /spark true"]
+        /arrow/ci/scripts/integration_spark.sh /arrow /spark ${TEST_PYARROW_ONLY:-false}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1340,3 +1340,34 @@ services:
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         /arrow/ci/scripts/java_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_spark.sh /arrow /spark"]
+
+  conda-python-spark-pyarrow-only:
+    # Usage:
+    #   docker-compose build conda-cpp
+    #   docker-compose build conda-python
+    #   docker-compose build conda-python-spark-pyarrow-only
+    #   docker-compose run conda-python-spark-pyarrow-only
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-spark-${SPARK}-pyarrow-only
+    build:
+      context: .
+      dockerfile: ci/docker/conda-python-spark.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-conda-python-${PYTHON}-spark-${SPARK}-pyarrow-only
+      args:
+        repo: ${REPO}
+        arch: ${ARCH}
+        python: ${PYTHON}
+        jdk: ${JDK}
+        # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
+        # be set to ${MAVEN}
+        maven: 3.5
+        spark: ${SPARK}
+    shm_size: *shm-size
+    environment:
+      <<: *ccache
+    volumes: *conda-maven-volumes
+    command:
+      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/python_build.sh /arrow /build &&
+        /arrow/ci/scripts/java_build.sh /arrow /build &&
+        /arrow/ci/scripts/integration_spark.sh /arrow /spark true"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ x-hierarchy:
       - conda-python-turbodbc
       - conda-python-kartothek
       - conda-python-spark
+      - conda-python-spark-pyarrow-only
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby


### PR DESCRIPTION
This adds an additional docker-compose task that will test a Spark branch with the latest PyArrow, instead of the default which also builds Spark with the latest Arrow Java. This is so existing Spark releases with fixed Arrow Java dependencies can still be tested with current PyArrow changes to ensure there is still compatibility. The nightly test against Spark branch-3.0 is changed to use this new task. 