### PR TITLE
ARROW-11265: [Rust] Made bool not ArrowNativeType

### DIFF
--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -385,7 +385,7 @@ where
 }
 
 // insert valid and nan values in the correct order depending on the descending flag
-fn insert_valid_values<T: ArrowNativeType>(
+fn insert_valid_values<T>(
     result_slice: &mut [u32],
     offset: usize,
     valids: Vec<(u32, T)>,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -449,12 +449,10 @@ impl ArrowJsonBatch {
                     for i in 0..col.len() {
                         if col.is_null(i) {
                             validity.push(1);
-                            data.push(
-                                Int8Type::default_value().into_json_value().unwrap(),
-                            );
+                            data.push(0i8.into());
                         } else {
                             validity.push(0);
-                            data.push(col.value(i).into_json_value().unwrap());
+                            data.push(col.value(i).into());
                         }
                     }
 


### PR DESCRIPTION
This PR removes the risk of boolean values to be converted to bytes via `ToByteSlice` by explicitly making `ArrowNativeType` be only used in types whose in-memory representation in Rust equates to the in-memory representation in Arrow. `bool` in Rust is a byte and in Arrow it is a bit.

Overall, the direction of this PR is to have the traits represent one aspect of the type. In this case, `ArrowNativeType` is currently 
* a type that has the same in memory representation (ToByteSlice is implemented for it)
* a json serializable type
* something that can be casted to/from `usize`.

This poses a problem because:

1. bools are serializable, not castable to usize, have different memory representation
2. fixed size (iX, uX) are serializable, castable to usize, have the same memory representation
3. fixed floating (f32, f64) are serializable, not castable to usize, have the same memory representation

however, they all implement `ArrowNativeType`.

This PR focus on splitting the json-serializable part of it.