### PR TITLE
ARROW-11288: [Rust][DataFusion] Update hashbrown to 0.10

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -46,7 +46,7 @@ simd = ["arrow/simd"]
 
 [dependencies]
 ahash = "0.6"
-hashbrown = "0.9"
+hashbrown = "0.10"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", features = ["prettyprint"] }
 parquet = { path = "../parquet", version = "3.0.0-SNAPSHOT", features = ["arrow"] }
 sqlparser = "0.7.0"


### PR DESCRIPTION
Nothing big has changed, has some small performance tweaks + keeps it up to date.