### PR TITLE
ARROW-11291: [Rust] Add extend to MutableBuffer (-20% for arithmetic, -97% for length)

### DIFF
--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -39,6 +39,28 @@ fn mutable_buffer(data: &[Vec<u32>], capacity: usize) -> Buffer {
     })
 }
 
+fn mutable_buffer_extend(data: &[Vec<u32>], capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut result = MutableBuffer::new(capacity);
+
+        data.iter().for_each(|vec| result.extend(vec.iter().copied()));
+
+        result.into()
+    })
+}
+
+fn mutable_buffer_extend_trusted(data: &[Vec<u32>], capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut result = MutableBuffer::new(capacity);
+
+        data.iter().for_each(|vec| unsafe {
+            result.extend_from_trusted_len_iter(vec.iter().copied())
+        });
+
+        result.into()
+    })
+}
+
 fn from_slice(data: &[Vec<u32>], capacity: usize) -> Buffer {
     criterion::black_box({
         let mut a = Vec::<u32>::with_capacity(capacity);
@@ -71,6 +93,10 @@ fn benchmark(c: &mut Criterion) {
     let byte_cap = cap * std::mem::size_of::<u32>();
 
     c.bench_function("mutable", |b| b.iter(|| mutable_buffer(&data, 0)));
+
+    c.bench_function("mutable extend", |b| b.iter(|| mutable_buffer_extend(&data, 0)));
+
+    c.bench_function("mutable extend trusted", |b| b.iter(|| mutable_buffer_extend_trusted(&data, 0)));
 
     c.bench_function("mutable prepared", |b| {
         b.iter(|| mutable_buffer(&data, byte_cap))

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -50,18 +50,6 @@ fn mutable_buffer_extend(data: &[Vec<u32>], capacity: usize) -> Buffer {
     })
 }
 
-fn mutable_buffer_extend_trusted(data: &[Vec<u32>], capacity: usize) -> Buffer {
-    criterion::black_box({
-        let mut result = MutableBuffer::new(capacity);
-
-        data.iter().for_each(|vec| unsafe {
-            result.extend_from_trusted_len_iter(vec.iter().copied())
-        });
-
-        result.into()
-    })
-}
-
 fn from_slice(data: &[Vec<u32>], capacity: usize) -> Buffer {
     criterion::black_box({
         let mut a = Vec::<u32>::with_capacity(capacity);
@@ -97,10 +85,6 @@ fn benchmark(c: &mut Criterion) {
 
     c.bench_function("mutable extend", |b| {
         b.iter(|| mutable_buffer_extend(&data, 0))
-    });
-
-    c.bench_function("mutable extend trusted", |b| {
-        b.iter(|| mutable_buffer_extend_trusted(&data, 0))
     });
 
     c.bench_function("mutable prepared", |b| {

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -43,7 +43,8 @@ fn mutable_buffer_extend(data: &[Vec<u32>], capacity: usize) -> Buffer {
     criterion::black_box({
         let mut result = MutableBuffer::new(capacity);
 
-        data.iter().for_each(|vec| result.extend(vec.iter().copied()));
+        data.iter()
+            .for_each(|vec| result.extend(vec.iter().copied()));
 
         result.into()
     })
@@ -94,9 +95,13 @@ fn benchmark(c: &mut Criterion) {
 
     c.bench_function("mutable", |b| b.iter(|| mutable_buffer(&data, 0)));
 
-    c.bench_function("mutable extend", |b| b.iter(|| mutable_buffer_extend(&data, 0)));
+    c.bench_function("mutable extend", |b| {
+        b.iter(|| mutable_buffer_extend(&data, 0))
+    });
 
-    c.bench_function("mutable extend trusted", |b| b.iter(|| mutable_buffer_extend_trusted(&data, 0)));
+    c.bench_function("mutable extend trusted", |b| {
+        b.iter(|| mutable_buffer_extend_trusted(&data, 0))
+    });
 
     c.bench_function("mutable prepared", |b| {
         b.iter(|| mutable_buffer(&data, byte_cap))

--- a/rust/arrow/benches/length_kernel.rs
+++ b/rust/arrow/benches/length_kernel.rs
@@ -24,25 +24,23 @@ extern crate arrow;
 use arrow::array::*;
 use arrow::compute::kernels::length::length;
 
-fn bench_length() {
+fn bench_length(array: &StringArray) {
+    criterion::black_box(length(array).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
     fn double_vec<T: Clone>(v: Vec<T>) -> Vec<T> {
         [&v[..], &v[..]].concat()
     }
 
     // double ["hello", " ", "world", "!"] 10 times
     let mut values = vec!["one", "on", "o", ""];
-    let mut expected = vec![3, 2, 1, 0];
     for _ in 0..10 {
         values = double_vec(values);
-        expected = double_vec(expected);
     }
     let array = StringArray::from(values);
 
-    criterion::black_box(length(&array).unwrap());
-}
-
-fn add_benchmark(c: &mut Criterion) {
-    c.bench_function("length", |b| b.iter(bench_length));
+    c.bench_function("length", |b| b.iter(|| bench_length(&array)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/src/array/transform/fixed_binary.rs
+++ b/rust/arrow/src/array/transform/fixed_binary.rs
@@ -46,7 +46,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                         let bytes = &values[i * size..(i + 1) * size];
                         values_buffer.extend_from_slice(bytes);
                     } else {
-                        values_buffer.extend(size);
+                        values_buffer.extend_zeros(size);
                     }
                 })
             },
@@ -61,5 +61,5 @@ pub(super) fn extend_nulls(mutable: &mut _MutableArrayData, len: usize) {
     };
 
     let values_buffer = &mut mutable.buffer1;
-    values_buffer.extend(len * size);
+    values_buffer.extend_zeros(len * size);
 }

--- a/rust/arrow/src/array/transform/primitive.rs
+++ b/rust/arrow/src/array/transform/primitive.rs
@@ -36,5 +36,5 @@ pub(super) fn extend_nulls<T: ArrowNativeType>(
     mutable: &mut _MutableArrayData,
     len: usize,
 ) {
-    mutable.buffer1.extend(len * size_of::<T>());
+    mutable.buffer1.extend_zeros(len * size_of::<T>());
 }

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -1063,6 +1063,11 @@ impl Buffer {
             std::ptr::write(dst, item);
             dst = dst.add(1);
         }
+        assert_eq!(
+            dst.offset_from(buffer.data.as_ptr() as *mut T) as usize,
+            upper,
+            "Trusted iterator length was not accurately reported"
+        );
         buffer.len = len;
         buffer.into()
     }
@@ -1092,6 +1097,11 @@ impl Buffer {
             std::ptr::write(dst, item?);
             dst = dst.add(1);
         }
+        assert_eq!(
+            dst.offset_from(buffer.data.as_ptr() as *mut T) as usize,
+            upper,
+            "Trusted iterator length was not accurately reported"
+        );
         buffer.len = len;
         Ok(buffer.into())
     }

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -1058,7 +1058,7 @@ impl MutableBuffer {
 
         let mut dst = self.data.as_ptr().add(self.len) as *mut T;
         for item in iterator {
-            // note how there is not reserve here (compared with `extend_from_iter`)
+            // note how there is no reserve here (compared with `extend_from_iter`)
             std::ptr::write(dst, item);
             dst = dst.add(1);
         }

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -1008,7 +1008,7 @@ impl MutableBuffer {
         let mut dst = unsafe { ptr.as_ptr().add(len) as *mut T };
 
         while let Some(item) = iterator.next() {
-            if len >= capacity {
+            if len + size >= capacity {
                 let (lower, _) = iterator.size_hint();
                 let additional = (lower + 1) * size;
                 let (new_ptr, new_capacity) =
@@ -1035,7 +1035,8 @@ impl MutableBuffer {
     /// # Example
     /// ```
     /// # use arrow::buffer::MutableBuffer;
-    /// let iter = vec![1u32].iter().map(|x| x * 2);
+    /// let v = vec![1u32];
+    /// let iter = v.iter().map(|x| x * 2);
     /// let mut buffer = MutableBuffer::new(0);
     /// unsafe { buffer.extend_from_trusted_len_iter(iter) };
     /// assert_eq!(buffer.len(), 4) // u32 has 4 bytes

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -1133,7 +1133,10 @@ struct SetLenOnDrop<'a> {
 impl<'a> SetLenOnDrop<'a> {
     #[inline]
     fn new(len: &'a mut usize) -> Self {
-        SetLenOnDrop { local_len: *len, len }
+        SetLenOnDrop {
+            local_len: *len,
+            len,
+        }
     }
 }
 

--- a/rust/arrow/src/bytes.rs
+++ b/rust/arrow/src/bytes.rs
@@ -79,6 +79,7 @@ impl Bytes {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// bytes. If the `ptr` and `capacity` come from a `Buffer`, then this is guaranteed.
+    #[inline]
     pub unsafe fn new(
         ptr: std::ptr::NonNull<u8>,
         len: usize,

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -55,7 +55,7 @@ where
     //  Benefit
     //      ~30% speedup
     //  Soundness
-    //      `windows` is an iterator with a known size.
+    //      `values` is an iterator with a known size.
     unsafe { buffer.extend_from_trusted_len_iter(values) };
 
     let data = ArrayData::new(
@@ -150,6 +150,11 @@ where
         .zip(right.values().iter())
         .map(|(l, r)| op(*l, *r));
     let mut buffer = MutableBuffer::new(0);
+    // JUSTIFICATION
+    //  Benefit
+    //      ~60% speedup
+    //  Soundness
+    //      `values` is an iterator with a known size.
     unsafe { buffer.extend_from_trusted_len_iter(values) };
 
     let data = ArrayData::new(

--- a/rust/arrow/src/compute/kernels/length.rs
+++ b/rust/arrow/src/compute/kernels/length.rs
@@ -17,7 +17,7 @@
 
 //! Defines kernel for length of a string array
 
-use crate::{array::*, buffer::MutableBuffer};
+use crate::{array::*, buffer::Buffer};
 use crate::{
     datatypes::DataType,
     error::{ArrowError, Result},
@@ -37,13 +37,12 @@ where
 
     let lengths = slice.windows(2).map(|offset| offset[1] - offset[0]);
 
-    let mut buffer = MutableBuffer::new(0);
     // JUSTIFICATION
     //  Benefit
-    //      ~30% speedup
+    //      ~60% speedup
     //  Soundness
-    //      `windows` is an iterator with a known size.
-    unsafe { buffer.extend_from_trusted_len_iter(lengths) };
+    //      `values` is an iterator with a known size.
+    let buffer = unsafe { Buffer::from_trusted_len_iter(lengths) };
 
     let null_bit_buffer = array
         .data_ref()
@@ -57,7 +56,7 @@ where
         None,
         null_bit_buffer,
         0,
-        vec![buffer.into()],
+        vec![buffer],
         vec![],
     );
     Ok(make_array(Arc::new(data)))


### PR DESCRIPTION
# Rational

Rust forbids safely accessing uninitialized memory because it is undefined behavior. However, when building `Buffer`s, it is important to be able to _write_ to uninitialized memory regions, thereby avoiding the need to write _something_ to it before using it.

Currently, all our initializations are zeroed, which is expensive. #9076 modifies our allocator to allocate uninitialized regions. However, by itself, this is not useful if we do not offer any methods to write to those (uninitialized) regions.

# This PR

This PR is built on top of #9076 and introduces methods to extend a `MutableBuffer` from an iterator, thereby offering an API to efficiently grow `MutableBuffer` without having to initialize memory regions with zeros (i.e. without `with_bitset` and the like).

This PR also introduces methods to create a `Buffer` from an iterator and a `trusted_len` iterator.

The design is inspired in `Vec`, with the catch that we use stable Rust (i.e. no trait specialization, no `TrustedLen`), and thus have to expose a bit more methods than what `Vec` exposes. This means that we can't use that (nicer) API for trustedlen iterators based on `collect()`.

Note that, as before, there are still `unsafe` uses of the `MutableBuffer` derived from the fact that it is not a generic over a type `T` (and thus people can mix types and grow the buffer in unsound ways).

Special thanks to @mbrubeck for all the help on this, originally discussed [here](https://users.rust-lang.org/t/collect-for-exactsizediterator/54367/6).

```bash
git checkout master
cargo bench --bench arithmetic_kernels
git checkout length_faster
cargo bench --bench arithmetic_kernels

git checkout 16bc7200f3baa6e526aea7135c60dcc949c9b592
cargo bench --bench length_kernel
git checkout length_faster
```

```
Switched to branch 'length_faster'
  (use "git pull" to merge the remote branch into yours)
   Compiling arrow v3.0.0-SNAPSHOT (/Users/jorgecarleitao/projects/arrow/rust/arrow)
    Finished bench [optimized] target(s) in 1m 02s
     Running /Users/jorgecarleitao/projects/arrow/rust/target/release/deps/arithmetic_kernels-ec2cc20ce07d9b83
Gnuplot not found, using plotters backend
add 512                 time:   [522.24 ns 523.67 ns 525.26 ns]                     
                        change: [-21.738% -20.960% -20.233%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  9 (9.00%) high mild
  3 (3.00%) high severe

subtract 512            time:   [503.18 ns 504.93 ns 506.81 ns]                          
                        change: [-21.741% -21.075% -20.308%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

multiply 512            time:   [508.25 ns 512.04 ns 516.06 ns]                          
                        change: [-22.569% -21.946% -21.305%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

divide 512              time:   [1.4711 us 1.4753 us 1.4799 us]                        
                        change: [-24.783% -23.305% -22.176%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

limit 512, 512          time:   [373.47 ns 377.76 ns 382.21 ns]                           
                        change: [+3.3055% +4.4193% +5.5923%] (p = 0.00 < 0.05)
                        Performance has regressed.

add_nulls_512           time:   [502.94 ns 504.51 ns 506.28 ns]                           
                        change: [-24.876% -24.299% -23.709%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

divide_nulls_512        time:   [1.4843 us 1.4931 us 1.5053 us]                              
                        change: [-22.968% -22.243% -21.420%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 24 outliers among 100 measurements (24.00%)
  15 (15.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe
```

Length (against the commit that fixes the bench, `16bc7200f3baa6e526aea7135c60dcc949c9b592`, not master):

```
length                  time:   [1.5379 us 1.5408 us 1.5437 us]                    
                        change: [-97.311% -97.295% -97.278%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
```