### PR TITLE
ARROW-11269: [Rust] [Parquet] Preserve timezone in int96 reader

### DIFF
--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1503,7 +1503,18 @@ impl<'a> ArrayReaderBuilder {
                 arrow_type,
             )?)),
             PhysicalType::INT96 => {
-                let converter = Int96Converter::new(Int96ArrayConverter {});
+                // get the optional timezone information from arrow type
+                let timezone = arrow_type
+                    .as_ref()
+                    .map(|data_type| {
+                        if let ArrowType::Timestamp(_, tz) = data_type {
+                            tz.clone()
+                        } else {
+                            None
+                        }
+                    })
+                    .flatten();
+                let converter = Int96Converter::new(Int96ArrayConverter { timezone });
                 Ok(Box::new(ComplexObjectArrayReader::<
                     Int96Type,
                     Int96Converter,


### PR DESCRIPTION
The Int96 timestamp was not using the specialised timestamp builder that takes the timezone as a paramenter.
This changes that to use the builder that preserves timezones.

I tested this change with the test file provided in the JIRA.
It looks like we don't have a way of writing int96 from the arrow writer, so there isn't an easy way to add a testcase.