### PR TITLE
ARROW-11309: [Release][C#] Use .NET 3.1 for verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -313,7 +313,7 @@ test_csharp() {
       fi
     fi
   else
-    local dotnet_version=2.2.300
+    local dotnet_version=3.1.405
     local dotnet_platform=
     case "$(uname)" in
       Linux)


### PR DESCRIPTION
Because we require .NET 3 or later since 3.0.0.