### PR TITLE
ARROW-11277: [C++] Workaround macOS 10.11: don't default construct consts

### DIFF
--- a/cpp/src/arrow/dataset/expression.cc
+++ b/cpp/src/arrow/dataset/expression.cc
@@ -681,7 +681,7 @@ Result<Expression> FoldConstants(Expression expr) {
         if (std::all_of(call->arguments.begin(), call->arguments.end(),
                         [](const Expression& argument) { return argument.literal(); })) {
           // all arguments are literal; we can evaluate this subexpression *now*
-          static const Datum ignored_input;
+          static const Datum ignored_input = Datum{};
           ARROW_ASSIGN_OR_RAISE(Datum constant,
                                 ExecuteScalarExpression(expr, ignored_input));
 

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -95,8 +95,8 @@ class ARROW_EXPORT Executor {
   Result<FutureType> Submit(TaskHints hints, Function&& func, Args&&... args) {
     auto future = FutureType::Make();
 
-    auto task = std::bind(::arrow::detail::Continue, future, std::forward<Function>(func),
-                          std::forward<Args>(args)...);
+    auto task = std::bind(::arrow::detail::ContinueFuture{}, future,
+                          std::forward<Function>(func), std::forward<Args>(args)...);
     ARROW_RETURN_NOT_OK(SpawnReal(hints, std::move(task)));
 
     return future;


### PR DESCRIPTION
```c++
/tmp/apache-arrow-20210116-6233-1jyrhk8/apache-arrow-3.0.0/cpp/src/arrow/dataset/expression.cc
/tmp/apache-arrow-20210116-6233-1jyrhk8/apache-arrow-3.0.0/cpp/src/arrow/dataset/expression.cc:684:30:
error: default initialization of an object of const type 'const arrow::Datum' without a user-provided default constructor
          static const Datum ignored_input;
```
Datum defines a default constructor but it doesn't seem to be found for const/constexpr decls