### PR TITLE
ARROW-11300: [Rust][DataFusion] Further performance improvements on hash aggregation with small groups

### DIFF
--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -358,6 +358,7 @@ fn group_aggregate_batch(
                     accumulator.merge_batch(&values)
                 }
             })
+            // 2.5
             .and({
                 indices.clear();
                 Ok(())

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -43,8 +43,8 @@ use arrow::{
 };
 use arrow::{
     array::{
-        ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-        StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+        ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+        Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
     },
     compute,
 };
@@ -332,7 +332,7 @@ fn group_aggregate_batch(
         offsets.push(offset_so_far);
     }
     let batch_indices = batch_indices.finish();
-    
+
     // `Take` all values based on indices into Arrays
     let values: Vec<Vec<Arc<dyn Array>>> = aggr_input_values
         .iter()
@@ -369,10 +369,13 @@ fn group_aggregate_batch(
                 .map(|(accumulator, aggr_array)| {
                     (
                         accumulator,
-                        aggr_array.iter().map(|array| {
-                            // 2.3
-                            array.slice(offsets[0], offsets[1] - offsets[0])
-                        }).collect(),
+                        aggr_array
+                            .iter()
+                            .map(|array| {
+                                // 2.3
+                                array.slice(offsets[0], offsets[1] - offsets[0])
+                            })
+                            .collect(),
                     )
                 })
                 .try_for_each(|(accumulator, values)| match mode {
@@ -526,9 +529,14 @@ impl GroupedHashAggregateStream {
 
         let schema_clone = schema.clone();
         tokio::spawn(async move {
-            let result =
-                compute_grouped_hash_aggregate(mode, schema_clone, group_expr, aggr_expr, input)
-                    .await;
+            let result = compute_grouped_hash_aggregate(
+                mode,
+                schema_clone,
+                group_expr,
+                aggr_expr,
+                input,
+            )
+            .await;
             tx.send(result)
         });
 
@@ -541,12 +549,16 @@ impl GroupedHashAggregateStream {
 }
 
 type AccumulatorSet = Vec<Box<dyn Accumulator>>;
-type Accumulators = HashMap<Vec<u8>, (Box<[GroupByScalar]>, AccumulatorSet, Vec<u32>), RandomState>;
+type Accumulators =
+    HashMap<Vec<u8>, (Box<[GroupByScalar]>, AccumulatorSet, Vec<u32>), RandomState>;
 
 impl Stream for GroupedHashAggregateStream {
     type Item = ArrowResult<RecordBatch>;
 
-    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if self.finished {
             return Poll::Ready(None);
         }
@@ -578,7 +590,10 @@ impl RecordBatchStream for GroupedHashAggregateStream {
 }
 
 /// Evaluates expressions against a record batch.
-fn evaluate(expr: &Vec<Arc<dyn PhysicalExpr>>, batch: &RecordBatch) -> Result<Vec<ArrayRef>> {
+fn evaluate(
+    expr: &Vec<Arc<dyn PhysicalExpr>>,
+    batch: &RecordBatch,
+) -> Result<Vec<ArrayRef>> {
     expr.iter()
         .map(|expr| expr.evaluate(&batch))
         .map(|r| r.map(|v| v.into_array(batch.num_rows())))
@@ -596,7 +611,9 @@ fn evaluate_many(
 }
 
 /// uses `state_fields` to build a vec of expressions required to merge the AggregateExpr' accumulator's state.
-fn merge_expressions(expr: &Arc<dyn AggregateExpr>) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+fn merge_expressions(
+    expr: &Arc<dyn AggregateExpr>,
+) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
     Ok(expr
         .state_fields()?
         .iter()
@@ -616,7 +633,9 @@ fn aggregate_expressions(
     mode: &AggregateMode,
 ) -> Result<Vec<Vec<Arc<dyn PhysicalExpr>>>> {
     match mode {
-        AggregateMode::Partial => Ok(aggr_expr.iter().map(|agg| agg.expressions()).collect()),
+        AggregateMode::Partial => {
+            Ok(aggr_expr.iter().map(|agg| agg.expressions()).collect())
+        }
         // in this mode, we build the merge expressions of the aggregation
         AggregateMode::Final => Ok(aggr_expr
             .iter()
@@ -640,8 +659,8 @@ async fn compute_hash_aggregate(
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     mut input: SendableRecordBatchStream,
 ) -> ArrowResult<RecordBatch> {
-    let mut accumulators =
-        create_accumulators(&aggr_expr).map_err(DataFusionError::into_arrow_external_error)?;
+    let mut accumulators = create_accumulators(&aggr_expr)
+        .map_err(DataFusionError::into_arrow_external_error)?;
 
     let expressions = aggregate_expressions(&aggr_expr, &mode)
         .map_err(DataFusionError::into_arrow_external_error)?;
@@ -674,7 +693,8 @@ impl HashAggregateStream {
 
         let schema_clone = schema.clone();
         tokio::spawn(async move {
-            let result = compute_hash_aggregate(mode, schema_clone, aggr_expr, input).await;
+            let result =
+                compute_hash_aggregate(mode, schema_clone, aggr_expr, input).await;
             tx.send(result)
         });
 
@@ -725,7 +745,10 @@ fn aggregate_batch(
 impl Stream for HashAggregateStream {
     type Item = ArrowResult<RecordBatch>;
 
-    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if self.finished {
             return Poll::Ready(None);
         }
@@ -790,12 +813,16 @@ fn create_batch_from_map(
             let mut groups = (0..num_group_expr)
                 .map(|i| match &group_by_values[i] {
                     GroupByScalar::Float32(n) => {
-                        Arc::new(Float32Array::from(vec![(*n).into()] as Vec<f32>)) as ArrayRef
+                        Arc::new(Float32Array::from(vec![(*n).into()] as Vec<f32>))
+                            as ArrayRef
                     }
                     GroupByScalar::Float64(n) => {
-                        Arc::new(Float64Array::from(vec![(*n).into()] as Vec<f64>)) as ArrayRef
+                        Arc::new(Float64Array::from(vec![(*n).into()] as Vec<f64>))
+                            as ArrayRef
                     }
-                    GroupByScalar::Int8(n) => Arc::new(Int8Array::from(vec![*n])) as ArrayRef,
+                    GroupByScalar::Int8(n) => {
+                        Arc::new(Int8Array::from(vec![*n])) as ArrayRef
+                    }
                     GroupByScalar::Int16(n) => Arc::new(Int16Array::from(vec![*n])),
                     GroupByScalar::Int32(n) => Arc::new(Int32Array::from(vec![*n])),
                     GroupByScalar::Int64(n) => Arc::new(Int64Array::from(vec![*n])),
@@ -837,7 +864,9 @@ fn create_batch_from_map(
     Ok(batch)
 }
 
-fn create_accumulators(aggr_expr: &Vec<Arc<dyn AggregateExpr>>) -> Result<AccumulatorSet> {
+fn create_accumulators(
+    aggr_expr: &Vec<Arc<dyn AggregateExpr>>,
+) -> Result<AccumulatorSet> {
     aggr_expr
         .iter()
         .map(|expr| expr.create_accumulator())
@@ -857,7 +886,9 @@ fn finalize_aggregation(
                 .iter()
                 .map(|accumulator| accumulator.state())
                 .map(|value| {
-                    value.map(|e| e.iter().map(|v| v.to_array()).collect::<Vec<ArrayRef>>())
+                    value.map(|e| {
+                        e.iter().map(|v| v.to_array()).collect::<Vec<ArrayRef>>()
+                    })
                 })
                 .collect::<Result<Vec<_>>>()?;
             Ok(a.iter().flatten().cloned().collect::<Vec<_>>())
@@ -1000,7 +1031,8 @@ mod tests {
 
     /// build the aggregates on the data from some_data() and check the results
     async fn check_aggregates(input: Arc<dyn ExecutionPlan>) -> Result<()> {
-        let groups: Vec<(Arc<dyn PhysicalExpr>, String)> = vec![(col("a"), "a".to_string())];
+        let groups: Vec<(Arc<dyn PhysicalExpr>, String)> =
+            vec![(col("a"), "a".to_string())];
 
         let aggregates: Vec<Arc<dyn AggregateExpr>> = vec![Arc::new(Avg::new(
             col("b"),
@@ -1155,14 +1187,16 @@ mod tests {
 
     #[tokio::test]
     async fn aggregate_source_not_yielding() -> Result<()> {
-        let input: Arc<dyn ExecutionPlan> = Arc::new(TestYieldingExec { yield_first: false });
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(TestYieldingExec { yield_first: false });
 
         check_aggregates(input).await
     }
 
     #[tokio::test]
     async fn aggregate_source_with_yielding() -> Result<()> {
-        let input: Arc<dyn ExecutionPlan> = Arc::new(TestYieldingExec { yield_first: true });
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(TestYieldingExec { yield_first: true });
 
         check_aggregates(input).await
     }

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -31,10 +31,7 @@ use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalExpr};
 
-use arrow::{datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit}, record_batch::RecordBatch};
-use arrow::{
-    array::BooleanArray,
-};
+use arrow::array::BooleanArray;
 use arrow::{
     array::{Array, UInt32Builder},
     error::{ArrowError, Result as ArrowResult},
@@ -46,6 +43,10 @@ use arrow::{
     },
     compute,
 };
+use arrow::{
+    datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
+    record_batch::RecordBatch,
+};
 use hashbrown::HashMap;
 use ordered_float::OrderedFloat;
 use pin_project_lite::pin_project;
@@ -53,7 +54,10 @@ use pin_project_lite::pin_project;
 use arrow::array::{TimestampMicrosecondArray, TimestampNanosecondArray};
 use async_trait::async_trait;
 
-use super::{RecordBatchStream, SendableRecordBatchStream, expressions::Column, group_scalar::GroupByScalar};
+use super::{
+    expressions::Column, group_scalar::GroupByScalar, RecordBatchStream,
+    SendableRecordBatchStream,
+};
 
 /// Hash aggregate modes
 #[derive(Debug, Copy, Clone)]

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -21,6 +21,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use ahash::RandomState;
 use futures::{
     stream::{Stream, StreamExt},
     Future,
@@ -30,16 +31,13 @@ use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalExpr};
 
-use super::{ expressions::Column, group_scalar::GroupByScalar,
-    RecordBatchStream, SendableRecordBatchStream,
-};
-use ahash::RandomState;
-use arrow::array::{Array, UInt32Builder};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-use arrow::error::{ArrowError, Result as ArrowResult};
-use arrow::record_batch::RecordBatch;
+use arrow::{datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit}, record_batch::RecordBatch};
 use arrow::{
     array::BooleanArray,
+};
+use arrow::{
+    array::{Array, UInt32Builder},
+    error::{ArrowError, Result as ArrowResult},
 };
 use arrow::{
     array::{
@@ -54,6 +52,8 @@ use pin_project_lite::pin_project;
 
 use arrow::array::{TimestampMicrosecondArray, TimestampNanosecondArray};
 use async_trait::async_trait;
+
+use super::{RecordBatchStream, SendableRecordBatchStream, expressions::Column, group_scalar::GroupByScalar};
 
 /// Hash aggregate modes
 #[derive(Debug, Copy, Clone)]

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -358,7 +358,6 @@ fn group_aggregate_batch(
                     accumulator.merge_batch(&values)
                 }
             })
-            // 2.5
             .and({
                 indices.clear();
                 Ok(())


### PR DESCRIPTION
Based on https://github.com/apache/arrow/pull/9234, this PR improves the situation described in https://issues.apache.org/jira/browse/ARROW-11300.

The current situation is that we call `take` on arrays, which is fine, but causes a lot of small `Arrays` to be created / allocated. when we have only a small number of rows in each group.

This improves the results on the group by queries on db-benchmark:

PR:
```
q1 took 32 ms
q2 took 422 ms
q3 took 3468 ms
q4 took 44 ms
q5 took 3166 ms
q7 took 3081 ms
```

https://github.com/apache/arrow/pull/9234 (different results from that PR description as this has now partitioning enabled and a custom allocator)

```
q1 took 34 ms
q2 took 389 ms
q3 took 4590 ms
q4 took 47 ms
q5 took 5152 ms
q7 took 3941 ms
```
The PR changes the algorithm to:

* Create indices / offsets of all keys / indices new in the batch.
* `take` the arrays based on indices in one go (so it only requires one bigger allocation for each array)
* Use `slice` based on the offsets to take values from the arrays and pass it to the accumulators.
