### PR TITLE
ARROW-11329: [Rust] Don't rerun build.rs on every file change

### DIFF
--- a/rust/arrow/build.rs
+++ b/rust/arrow/build.rs
@@ -18,6 +18,7 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
     // Setup cfg aliases
     cfg_aliases! {
         simd: { all(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"), feature = "simd") },


### PR DESCRIPTION
This speeds up development by avoiding rebuilding the whole library
when any file in the package directory is touched.