### PR TITLE
ARROW-11330: [Rust][DataFusion] add ExpressionVisitor to encode expression walking

### DIFF
--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -423,8 +423,8 @@ impl Expr {
         }
     }
 
-    /// Performs a depth first depth first walk of an expression and
-    /// its children, calling `visitor.pre_visit` and
+    /// Performs a depth first walk of an expression and
+    /// its children, calling [`ExpressionVisitor::pre_visit`] and
     /// `visitor.post_visit`.
     ///
     /// Implements the [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to
@@ -540,7 +540,7 @@ pub enum Recursion<V: ExpressionVisitor> {
 }
 
 /// Encode the traversal of an expression tree. When passed to
-/// `visit_expression`, `ExpressionVisitor::visit` is invoked
+/// `Expr::accept`, `ExpressionVisitor::visit` is invoked
 /// recursively on all nodes of an expression tree. See the comments
 /// on `Expr::accept` for details on its use
 pub trait ExpressionVisitor: Sized {

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -422,6 +422,136 @@ impl Expr {
             nulls_first,
         }
     }
+
+    /// Performs a depth first depth first walk of an expression and
+    /// its children, calling `visitor.pre_visit` and
+    /// `visitor.post_visit`.
+    ///
+    /// Implements the [visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to
+    /// separate expression algorithms from the structure of the
+    /// `Expr` tree and make it easier to add new types of expressions
+    /// and algorithms that walk the tree.
+    ///
+    /// For an expression tree such as
+    /// BinaryExpr (GT)
+    ///    left: Column("foo")
+    ///    right: Column("bar")
+    ///
+    /// The nodes are visited using the following order
+    /// ```text
+    /// pre_visit(BinaryExpr(GT))
+    /// pre_visit(Column("foo"))
+    /// pre_visit(Column("bar"))
+    /// post_visit(Column("bar"))
+    /// post_visit(Column("bar"))
+    /// post_visit(BinaryExpr(GT))
+    /// ```
+    ///
+    /// If an Err result is returned, recursion is stopped immediately
+    ///
+    /// If `Recursion::Stop` is returned on a call to pre_visit, no
+    /// children of that expression are visited, nor is post_visit
+    /// called on that expression
+    ///
+    pub fn accept<V: ExpressionVisitor>(&self, visitor: V) -> Result<V> {
+        let visitor = match visitor.pre_visit(self)? {
+            Recursion::Continue(visitor) => visitor,
+            // If the recursion should stop, do not visit children
+            Recursion::Stop(visitor) => return Ok(visitor),
+        };
+
+        // recurse (and cover all expression types)
+        let visitor = match self {
+            Expr::Alias(expr, _) => expr.accept(visitor),
+            Expr::Column(..) => Ok(visitor),
+            Expr::ScalarVariable(..) => Ok(visitor),
+            Expr::Literal(..) => Ok(visitor),
+            Expr::BinaryExpr { left, right, .. } => {
+                let visitor = left.accept(visitor)?;
+                right.accept(visitor)
+            }
+            Expr::Not(expr) => expr.accept(visitor),
+            Expr::IsNotNull(expr) => expr.accept(visitor),
+            Expr::IsNull(expr) => expr.accept(visitor),
+            Expr::Negative(expr) => expr.accept(visitor),
+            Expr::Between {
+                expr, low, high, ..
+            } => {
+                let visitor = expr.accept(visitor)?;
+                let visitor = low.accept(visitor)?;
+                high.accept(visitor)
+            }
+            Expr::Case {
+                expr,
+                when_then_expr,
+                else_expr,
+            } => {
+                let visitor = if let Some(expr) = expr.as_ref() {
+                    expr.accept(visitor)
+                } else {
+                    Ok(visitor)
+                }?;
+                let visitor = when_then_expr.iter().try_fold(
+                    visitor,
+                    |visitor, (when, then)| {
+                        let visitor = when.accept(visitor)?;
+                        then.accept(visitor)
+                    },
+                )?;
+                if let Some(else_expr) = else_expr.as_ref() {
+                    else_expr.accept(visitor)
+                } else {
+                    Ok(visitor)
+                }
+            }
+            Expr::Cast { expr, .. } => expr.accept(visitor),
+            Expr::Sort { expr, .. } => expr.accept(visitor),
+            Expr::ScalarFunction { args, .. } => args
+                .iter()
+                .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
+            Expr::ScalarUDF { args, .. } => args
+                .iter()
+                .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
+            Expr::AggregateFunction { args, .. } => args
+                .iter()
+                .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
+            Expr::AggregateUDF { args, .. } => args
+                .iter()
+                .try_fold(visitor, |visitor, arg| arg.accept(visitor)),
+            Expr::InList { expr, list, .. } => {
+                let visitor = expr.accept(visitor)?;
+                list.iter()
+                    .try_fold(visitor, |visitor, arg| arg.accept(visitor))
+            }
+            Expr::Wildcard => Ok(visitor),
+        }?;
+
+        visitor.post_visit(self)
+    }
+}
+
+/// Controls how the visitor recursion should proceed.
+pub enum Recursion<V: ExpressionVisitor> {
+    /// Attempt to visit all the children, recursively, of this expression.
+    Continue(V),
+    /// Do not visit the children of this expression, though the walk
+    /// of parents of this expression will not be affected
+    Stop(V),
+}
+
+/// Encode the traversal of an expression tree. When passed to
+/// `visit_expression`, `ExpressionVisitor::visit` is invoked
+/// recursively on all nodes of an expression tree. See the comments
+/// on `Expr::accept` for details on its use
+pub trait ExpressionVisitor: Sized {
+    /// Invoked before any children of `expr` are visisted.
+    fn pre_visit(self, expr: &Expr) -> Result<Recursion<Self>>;
+
+    /// Invoked after all children of `expr` are visited. Default
+    /// implementation does nothing.
+    fn post_visit(self, _expr: &Expr) -> Result<Self> {
+        Ok(self)
+    }
 }
 
 pub struct CaseBuilder {

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -38,7 +38,7 @@ pub use expr::{
     count, count_distinct, create_udaf, create_udf, exp, exprlist_to_fields, floor,
     in_list, length, lit, ln, log10, log2, lower, ltrim, max, md5, min, or, round, rtrim,
     sha224, sha256, sha384, sha512, signum, sin, sqrt, sum, tan, trim, trunc, upper,
-    when, Expr, Literal,
+    when, Expr, ExpressionVisitor, Literal, Recursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;


### PR DESCRIPTION
## Problem:
* There are several places in the DataFusion codebase where a walk of an Expression tree is needed
* The logic of how to walk the tree is replicated
* Adding new expression types often require many mechanically different but semantically the same changes in many places where no special treatment of such types is needed

This PR introduces a `ExpressionVisitor` trait and the `Expr::accept` function to consolidate this walking of the expression tree. It does not intend to change any functionality. 

If folks like this pattern, I have ideas for a similar type of trait `ExpressionRewriter` which can be used to rewrite expressions (much like `clone_with_replacement`) as a subsquent PR. I think this was mentioned by @Dandandan  in the [Rust roadmap](https://docs.google.com/document/d/1qspsOM_dknOxJKdGvKbC1aoVoO0M3i6x1CIo58mmN2Y/edit#heading=h.kstb571j5g5j)


cc @jorgecarleitao @Dandandan and @andygrove 