### PR TITLE
ARROW-10370: [Python] Clean-up filesystem handling in write_dataset

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -678,7 +678,7 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
     max_partitions : int, default 1024
         Maximum number of partitions any batch may be written into.
     """
-    from pyarrow.fs import LocalFileSystem, _ensure_filesystem
+    from pyarrow.fs import _resolve_filesystem_and_path
 
     if isinstance(data, Dataset):
         schema = schema or data.schema
@@ -714,11 +714,7 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
 
     partitioning = _ensure_write_partitioning(partitioning)
 
-    if filesystem is None:
-        # fall back to local file system as the default
-        filesystem = LocalFileSystem()
-    else:
-        filesystem = _ensure_filesystem(filesystem)
+    filesystem, base_dir = _resolve_filesystem_and_path(base_dir, filesystem)
 
     _filesystemdataset_write(
         data, base_dir, basename_template, schema,

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -140,13 +140,20 @@ def _resolve_filesystem_and_path(
             )
         return filesystem, path
 
-    path = _stringify_path(path)
-
     if filesystem is not None:
         filesystem = _ensure_filesystem(
             filesystem, allow_legacy_filesystem=allow_legacy_filesystem
         )
+        if isinstance(filesystem, LocalFileSystem):
+            path = _stringify_path(path)
+        elif not isinstance(path, str):
+            raise TypeError(
+                "Expected string path; path-like objects are only allowed "
+                "with a local filesystem"
+            )
         return filesystem, path
+
+    path = _stringify_path(path)
 
     # if filesystem is not given, try to automatically determine one
     # first check if the file exists as a local (relative) file path

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1289,14 +1289,14 @@ def test_write_to_dataset_pathlib(tempdir, use_legacy_dataset):
 def test_write_to_dataset_pathlib_nonlocal(
     tempdir, s3_example_s3fs, use_legacy_dataset
 ):
-   # pathlib paths are only accepted for local files
-   fs, _ = s3_example_s3fs
+    # pathlib paths are only accepted for local files
+    fs, _ = s3_example_s3fs
 
-   with pytest.raises(TypeError, match="path-like objects are only allowed"):
+    with pytest.raises(TypeError, match="path-like objects are only allowed"):
         _test_write_to_dataset_with_partitions(
             tempdir / "test1", use_legacy_dataset, filesystem=fs)
 
-   with pytest.raises(TypeError, match="path-like objects are only allowed"):
+    with pytest.raises(TypeError, match="path-like objects are only allowed"):
         _test_write_to_dataset_no_partitions(
             tempdir / "test2", use_legacy_dataset, filesystem=fs)
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1283,23 +1283,22 @@ def test_write_to_dataset_pathlib(tempdir, use_legacy_dataset):
         tempdir / "test2", use_legacy_dataset)
 
 
-# Those tests are failing - see ARROW-10370
-# @pytest.mark.pandas
-# @pytest.mark.s3
-# @parametrize_legacy_dataset
-# def test_write_to_dataset_pathlib_nonlocal(
-#     tempdir, s3_example_s3fs, use_legacy_dataset
-# ):
-#    # pathlib paths are only accepted for local files
-#    fs, _ = s3_example_s3fs
+@pytest.mark.pandas
+@pytest.mark.s3
+@parametrize_legacy_dataset
+def test_write_to_dataset_pathlib_nonlocal(
+    tempdir, s3_example_s3fs, use_legacy_dataset
+):
+   # pathlib paths are only accepted for local files
+   fs, _ = s3_example_s3fs
 
-#    with pytest.raises(TypeError, match="path-like objects are only allowed"):
-#         _test_write_to_dataset_with_partitions(
-#             tempdir / "test1", use_legacy_dataset, filesystem=fs)
+   with pytest.raises(TypeError, match="path-like objects are only allowed"):
+        _test_write_to_dataset_with_partitions(
+            tempdir / "test1", use_legacy_dataset, filesystem=fs)
 
-#    with pytest.raises(TypeError, match="path-like objects are only allowed"):
-#         _test_write_to_dataset_no_partitions(
-#             tempdir / "test2", use_legacy_dataset, filesystem=fs)
+   with pytest.raises(TypeError, match="path-like objects are only allowed"):
+        _test_write_to_dataset_no_partitions(
+            tempdir / "test2", use_legacy_dataset, filesystem=fs)
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
* This fixed the commented-out test mentioned in ARROW-10370 
* Use the general filesystem-resolve utility code in `write_dataset` (+add check for pathlib paths not being allowed for filesystems other than local filesystem, this is checked in the legacy filesystems)
* Add S3 tests for `write_dataset` to cover the new functionality by properly resolving the path/URI now