### PR TITLE
ARROW-11342: [Python] [Gandiva] Expose ToString and result type information

### DIFF
--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -98,7 +98,7 @@ cdef class Node(_Weakrefable):
         return self.node.get().ToString().decode()
 
     def __repr__(self):
-        patype_format = object.__repr__(self)
+        type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
     def return_type(self):
@@ -115,12 +115,12 @@ cdef class Expression(_Weakrefable):
         return self.expression.get().ToString().decode()
 
     def __repr__(self):
-        patype_format = object.__repr__(self)
+        type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
     def root(self):
         return Node.create(self.expression.get().root())
-    
+
     def result(self):
         return pyarrow_wrap_field(self.expression.get().result())
 
@@ -140,15 +140,15 @@ cdef class Condition(_Weakrefable):
         return self
 
     def __str__(self):
-        return self.condition.ToString().decode()
+        return self.condition.get().ToString().decode()
 
     def __repr__(self):
-        patype_format = object.__repr__(self)
+        type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
     def root(self):
         return Node.create(self.condition.get().root())
-    
+
     def result(self):
         return pyarrow_wrap_field(self.condition.get().result())
 

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -30,7 +30,8 @@ from libc.stdint cimport int64_t, int32_t, uint8_t, uintptr_t
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport (Array, DataType, Field, MemoryPool, RecordBatch,
                           Schema, check_status, pyarrow_wrap_array,
-                          pyarrow_wrap_data_type, ensure_type, _Weakrefable)
+                          pyarrow_wrap_data_type, ensure_type, _Weakrefable,
+                          pyarrow_wrap_field)
 from pyarrow.lib import frombytes
 
 from pyarrow.includes.libgandiva cimport (
@@ -93,12 +94,35 @@ cdef class Node(_Weakrefable):
         self.node = node
         return self
 
+    def __str__(self):
+        return self.node.get().ToString().decode()
+
+    def __repr__(self):
+        patype_format = object.__repr__(self)
+        return '{0}\n{1}'.format(type_format, str(self))
+
+    def return_type(self):
+        return pyarrow_wrap_data_type(self.node.get().return_type())
+
 cdef class Expression(_Weakrefable):
     cdef:
         shared_ptr[CExpression] expression
 
     cdef void init(self, shared_ptr[CExpression] expression):
         self.expression = expression
+
+    def __str__(self):
+        return self.expression.get().ToString().decode()
+
+    def __repr__(self):
+        patype_format = object.__repr__(self)
+        return '{0}\n{1}'.format(type_format, str(self))
+
+    def root(self):
+        return Node.create(self.expression.get().root())
+    
+    def result(self):
+        return pyarrow_wrap_field(self.expression.get().result())
 
 cdef class Condition(_Weakrefable):
     cdef:
@@ -114,6 +138,19 @@ cdef class Condition(_Weakrefable):
         cdef Condition self = Condition.__new__(Condition)
         self.condition = condition
         return self
+
+    def __str__(self):
+        return self.condition.ToString().decode()
+
+    def __repr__(self):
+        patype_format = object.__repr__(self)
+        return '{0}\n{1}'.format(type_format, str(self))
+
+    def root(self):
+        return Node.create(self.condition.get().root())
+    
+    def result(self):
+        return pyarrow_wrap_field(self.condition.get().result())
 
 cdef class SelectionVector(_Weakrefable):
     cdef:

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -27,10 +27,13 @@ from pyarrow.includes.libarrow cimport *
 cdef extern from "gandiva/gandiva_aliases.h" namespace "gandiva" nogil:
 
     cdef cppclass CNode" gandiva::Node":
-        pass
+        c_string ToString()
+        shared_ptr[CDataType] return_type()
 
     cdef cppclass CExpression" gandiva::Expression":
-        pass
+        c_string ToString()
+        shared_ptr[CNode] root()
+        shared_ptr[CField] result()
 
     ctypedef vector[shared_ptr[CNode]] CNodeVector" gandiva::NodeVector"
 

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -24,7 +24,7 @@ from libc.stdint cimport int64_t, int32_t, uint8_t, uintptr_t
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
-cdef extern from "gandiva/gandiva_aliases.h" namespace "gandiva" nogil:
+cdef extern from "gandiva/node.h" namespace "gandiva" nogil:
 
     cdef cppclass CNode" gandiva::Node":
         c_string ToString()
@@ -98,7 +98,9 @@ cdef inline str _selection_mode_name(CSelectionVector_Mode ctype):
 cdef extern from "gandiva/condition.h" namespace "gandiva" nogil:
 
     cdef cppclass CCondition" gandiva::Condition":
-        pass
+        c_string ToString()
+        shared_ptr[CNode] root()
+        shared_ptr[CField] result()
 
 cdef extern from "gandiva/arrow.h" namespace "gandiva" nogil:
 

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -37,11 +37,15 @@ def test_tree_exp_builder():
     node_a = builder.make_field(field_a)
     node_b = builder.make_field(field_b)
 
+    assert node_a.return_type() == field_a.type
+
     condition = builder.make_function("greater_than", [node_a, node_b],
                                       pa.bool_())
     if_node = builder.make_if(condition, node_a, node_b, pa.int32())
 
     expr = builder.make_expression(if_node, field_result)
+
+    assert expr.result().type == pa.int32()
 
     projector = gandiva.make_projector(
         schema, [expr], pa.default_memory_pool())
@@ -97,6 +101,8 @@ def test_filter():
     thousand = builder.make_literal(1000.0, pa.float64())
     cond = builder.make_function("less_than", [node_a, thousand], pa.bool_())
     condition = builder.make_condition(cond)
+
+    assert condition.result().type == pa.bool_()
 
     filter = gandiva.make_filter(table.schema, condition)
     # Gandiva generates compute kernel function named `@expr_X`


### PR DESCRIPTION
These methods are intended to make it easier to work with and debug the Gandiva expression builder.

```python
import pyarrow
import pyarrow.gandiva as gandiva

builder = gandiva.TreeExprBuilder()

lit = builder.make_literal(1000.0, pyarrow.float64())
print(lit)
# Before: <pyarrow.gandiva.Node object at 0x7f36fd37ecf0>
# After: (const double) 1000 raw(408f400000000000)

field = builder.make_field(pyarrow.field('a', pyarrow.float64()))
print(field)
# Before: <pyarrow.gandiva.Node object at 0x7ff7daf99f90>
# After: (double) a

print(builder.make_function('greater_than', [field, lit], pyarrow.bool_()))
# Before: <pyarrow.gandiva.Node object at 0x7ff7d24bde70>
# After: bool greater_than((double) a, (const double) 1000 raw(408f400000000000))
```