### PR TITLE
ARROW-11345: [Rust] Made most ops not rely on `value(i)`

### DIFF
--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -259,27 +259,27 @@ impl<T: ArrowPrimitiveType> fmt::Debug for PrimitiveArray<T> {
         write!(f, "PrimitiveArray<{:?}>\n[\n", T::DATA_TYPE)?;
         print_long_array(self, f, |array, index, f| match T::DATA_TYPE {
             DataType::Date32(_) | DataType::Date64(_) => {
-                let v = self.value(index).to_usize().unwrap() as i64;
+                let v = self.values()[index].to_usize().unwrap() as i64;
                 match as_date::<T>(v) {
                     Some(date) => write!(f, "{:?}", date),
                     None => write!(f, "null"),
                 }
             }
             DataType::Time32(_) | DataType::Time64(_) => {
-                let v = self.value(index).to_usize().unwrap() as i64;
+                let v = self.values()[index].to_usize().unwrap() as i64;
                 match as_time::<T>(v) {
                     Some(time) => write!(f, "{:?}", time),
                     None => write!(f, "null"),
                 }
             }
             DataType::Timestamp(_, _) => {
-                let v = self.value(index).to_usize().unwrap() as i64;
+                let v = self.values()[index].to_usize().unwrap() as i64;
                 match as_datetime::<T>(v) {
                     Some(datetime) => write!(f, "{:?}", datetime),
                     None => write!(f, "null"),
                 }
             }
-            _ => fmt::Debug::fmt(&array.value(index), f),
+            _ => fmt::Debug::fmt(&array.values()[index], f),
         })?;
         write!(f, "]")
     }

--- a/rust/arrow/src/array/equal_json.rs
+++ b/rust/arrow/src/array/equal_json.rs
@@ -39,13 +39,14 @@ pub trait JsonEqual {
 impl<T: ArrowPrimitiveType> JsonEqual for PrimitiveArray<T> {
     fn equals_json(&self, json: &[&Value]) -> bool {
         self.len() == json.len()
-            && (0..self.len()).all(|i| match json[i] {
-                Value::Null => self.is_null(i),
-                v => {
-                    self.is_valid(i)
-                        && Some(v) == self.value(i).into_json_value().as_ref()
-                }
-            })
+            && json
+                .iter()
+                .zip(self.iter())
+                .all(|(lhs, rhs)| match (lhs, rhs) {
+                    (Value::Null, None) => true,
+                    (lhs, Some(rhs)) => Some(*lhs) == rhs.into_json_value().as_ref(),
+                    _ => false,
+                })
     }
 }
 

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -48,7 +48,9 @@ where
 {
     let left = left.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
     let right = right.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
-    Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
+    let left = left.values();
+    let right = right.values();
+    Box::new(move |i, j| left[i].cmp(&right[j]))
 }
 
 fn compare_boolean<'a>(left: &'a Array, right: &'a Array) -> DynComparator<'a> {
@@ -66,7 +68,9 @@ where
 {
     let left = left.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
     let right = right.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
-    Box::new(move |i, j| cmp_nans_last(&left.value(i), &right.value(j)))
+    let left = left.values();
+    let right = right.values();
+    Box::new(move |i, j| cmp_nans_last(&left[i], &right[j]))
 }
 
 fn compare_string<'a, T>(left: &'a Array, right: &'a Array) -> DynComparator<'a>
@@ -90,15 +94,15 @@ where
 {
     let left = left.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
     let right = right.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
-    let left_keys = left.keys_array();
-    let right_keys = right.keys_array();
+    let left_keys = left.keys().values();
+    let right_keys = right.keys().values();
 
     let left_values = StringArray::from(left.values().data());
     let right_values = StringArray::from(left.values().data());
 
     Box::new(move |i: usize, j: usize| {
-        let key_left = left_keys.value(i).to_usize().unwrap();
-        let key_right = right_keys.value(j).to_usize().unwrap();
+        let key_left = left_keys[i].to_usize().unwrap();
+        let key_right = right_keys[j].to_usize().unwrap();
         let left = left_values.value(key_left);
         let right = right_values.value(key_right);
         left.cmp(&right)


### PR DESCRIPTION
# Problem

Currently, a lot of our code relies on `PrimitiveArray::value(usize)`, however, that method is `unsafe` (but not marked as such!): any `usize` larger than the length of the array allows to read arbitrary memory regions due to the lack of bound checks.

# This PR:

This PR changes some of our kernels to not rely on it for this operation, replacing by a safe alternative. This PR is expected to affect the performance of the touched kernels, either improving as we already have alternatives to efficiently create an array out of an iterator, or decreasing (when the index bound is indeed unknown).

todo: benchmark