### PR TITLE
ARROW-11349: [Rust] Add from_iter_values to create arrays from (non null) values

### DIFF
--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -96,10 +96,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     }
 
     /// Creates a PrimitiveArray based on an iterator of values without nulls
-    pub fn from_iter_values<Ptr, I: IntoIterator<Item = Ptr>>(iter: I) -> Self
-    where
-        Ptr: Borrow<<T as ArrowPrimitiveType>::Native>,
-    {
+    pub fn from_iter_values<I: IntoIterator<Item = T::Native>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (_, data_len) = iter.size_hint();
         let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
@@ -109,7 +106,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         );
 
         iter.for_each(|item| {
-            val_buf.push(*item.borrow());
+            val_buf.push(item);
         });
 
         let data = ArrayData::new(

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -101,13 +101,9 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let (_, data_len) = iter.size_hint();
         let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
 
-        let mut val_buf = MutableBuffer::new(
-            data_len * mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
-        );
+        let mut val_buf = MutableBuffer::new(data_len);
 
-        iter.for_each(|item| {
-            val_buf.push(item);
-        });
+        val_buf.extend(iter);
 
         let data = ArrayData::new(
             T::DATA_TYPE,

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -94,6 +94,35 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         let offset = i + self.offset();
         unsafe { *self.raw_values.as_ptr().add(offset) }
     }
+
+    /// Creates a PrimitiveArray based on an iterator of values without nulls
+    pub fn from_iter_values<Ptr, I: IntoIterator<Item = Ptr>>(iter: I) -> Self
+    where
+        Ptr: Borrow<<T as ArrowPrimitiveType>::Native>,
+    {
+        let iter = iter.into_iter();
+        let (_, data_len) = iter.size_hint();
+        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
+
+        let mut val_buf = MutableBuffer::new(
+            data_len * mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
+        );
+
+        iter.for_each(|item| {
+            val_buf.push(*item.borrow());
+        });
+
+        let data = ArrayData::new(
+            T::DATA_TYPE,
+            data_len,
+            None,
+            None,
+            0,
+            vec![val_buf.into()],
+            vec![],
+        );
+        PrimitiveArray::from(Arc::new(data))
+    }
 }
 
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
@@ -817,6 +846,18 @@ mod tests {
         assert_eq!(0, arr.null_count());
         for i in 0..3 {
             assert_eq!((i + 2) as i32, arr.value(i));
+        }
+    }
+
+    #[test]
+    fn test_primitive_from_iter_values() {
+        // Test building a primitive array with from_iter_values
+
+        let arr: PrimitiveArray<Int32Type> = PrimitiveArray::from_iter_values(0..10);
+        assert_eq!(10, arr.len());
+        assert_eq!(0, arr.null_count());
+        for i in 0..10i32 {
+            assert_eq!(i, arr.value(i as usize));
         }
     }
 

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -97,21 +97,14 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
 
     /// Creates a PrimitiveArray based on an iterator of values without nulls
     pub fn from_iter_values<I: IntoIterator<Item = T::Native>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let (_, data_len) = iter.size_hint();
-        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
-
-        let mut val_buf = MutableBuffer::new(data_len);
-
-        val_buf.extend(iter);
-
+        let val_buf: Buffer = iter.into_iter().collect();
         let data = ArrayData::new(
             T::DATA_TYPE,
-            data_len,
+            val_buf.len() / mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
             None,
             None,
             0,
-            vec![val_buf.into()],
+            vec![val_buf],
             vec![],
         );
         PrimitiveArray::from(Arc::new(data))

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -459,7 +459,6 @@ mod tests {
     #[test]
     fn test_string_array_from_iter_values() {
         let data = vec!["hello", "hello2"];
-        // from Vec<Option<&str>>
         let array1 = StringArray::from_iter_values(data.iter());
 
         assert_eq!(array1.value(0), "hello");

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -146,6 +146,36 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
     pub(crate) fn from_opt_vec(v: Vec<Option<&str>>) -> Self {
         v.into_iter().collect()
     }
+
+    /// Creates a `GenericStringArray` based on an iterator of values without nulls
+    pub fn from_iter_values<Ptr, I: IntoIterator<Item = Ptr>>(iter: I) -> Self
+    where
+        Ptr: AsRef<str>,
+    {
+        let iter = iter.into_iter();
+        let (_, data_len) = iter.size_hint();
+        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
+
+        let mut offsets =
+            MutableBuffer::new((data_len + 1) * std::mem::size_of::<OffsetSize>());
+        let mut values = MutableBuffer::new(0);
+
+        let mut length_so_far = OffsetSize::zero();
+        offsets.push(length_so_far);
+
+        for i in iter {
+            let s = i.as_ref();
+            length_so_far += OffsetSize::from_usize(s.len()).unwrap();
+            offsets.push(length_so_far);
+            values.extend_from_slice(s.as_bytes());
+        }
+        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
+            .len(data_len)
+            .add_buffer(offsets.into())
+            .add_buffer(values.into())
+            .build();
+        Self::from(array_data)
+    }
 }
 
 impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Option<Ptr>>
@@ -411,6 +441,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_string_array_from_iter() {
         let data = vec![Some("hello"), None, Some("arrow")];
         // from Vec<Option<&str>>
@@ -423,5 +454,15 @@ mod tests {
 
         assert_eq!(array1, array2);
         assert_eq!(array2, array3);
+    }
+
+    #[test]
+    fn test_string_array_from_iter_values() {
+        let data = vec!["hello", "hello2"];
+        // from Vec<Option<&str>>
+        let array1 = StringArray::from_iter_values(data.iter());
+
+        assert_eq!(array1.value(0), "hello");
+        assert_eq!(array1.value(1), "hello2");
     }
 }


### PR DESCRIPTION
The idea of this PR is to have a function `from_iter_values` that (just like `from_iter`) creates an array based on an iterator, but from `T` instead of `Option<T>`.

I have seen some places in DataFusion (especially `to_array_of_size`) where an `Array` is generated from a `Vec` of items, which could be replaced by this.
The other iterators have some memory / time overhead in both creating and manipulating the null buffer (and in the case of `Vec` for allocating / dropping the Vec) 

 