### PR TITLE
ARROW-8919: [C++][Compute][Dataset] Add Function::DispatchBest to accomodate implicit casts

### DIFF
--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -225,5 +225,21 @@ bool CanCast(const DataType& from_type, const DataType& to_type) {
   return false;
 }
 
+Result<std::vector<Datum>> Cast(std::vector<Datum> datums, std::vector<ValueDescr> descrs,
+                                ExecContext* ctx) {
+  for (size_t i = 0; i != datums.size(); ++i) {
+    if (descrs[i] != datums[i].descr()) {
+      if (descrs[i].shape != datums[i].shape()) {
+        return Status::NotImplemented("casting between Datum shapes");
+      }
+
+      ARROW_ASSIGN_OR_RAISE(datums[i],
+                            Cast(datums[i], CastOptions::Safe(descrs[i].type), ctx));
+    }
+  }
+
+  return datums;
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -124,26 +124,15 @@ void RegisterScalarCast(FunctionRegistry* registry) {
 
 }  // namespace internal
 
-struct CastFunction::CastFunctionImpl {
-  Type::type out_type;
-  std::unordered_set<int> in_types;
-};
-
-CastFunction::CastFunction(std::string name, Type::type out_type)
-    : ScalarFunction(std::move(name), Arity::Unary(), /*doc=*/nullptr) {
-  impl_.reset(new CastFunctionImpl());
-  impl_->out_type = out_type;
-}
-
-CastFunction::~CastFunction() = default;
-
-Type::type CastFunction::out_type_id() const { return impl_->out_type; }
+CastFunction::CastFunction(std::string name, Type::type out_type_id)
+    : ScalarFunction(std::move(name), Arity::Unary(), /*doc=*/nullptr),
+      out_type_id_(out_type_id) {}
 
 Status CastFunction::AddKernel(Type::type in_type_id, ScalarKernel kernel) {
   // We use the same KernelInit for every cast
   kernel.init = internal::CastState::Init;
   RETURN_NOT_OK(ScalarFunction::AddKernel(kernel));
-  impl_->in_types.insert(static_cast<int>(in_type_id));
+  in_type_ids_.push_back(in_type_id);
   return Status::OK();
 }
 
@@ -159,19 +148,10 @@ Status CastFunction::AddKernel(Type::type in_type_id, std::vector<InputType> in_
   return AddKernel(in_type_id, std::move(kernel));
 }
 
-bool CastFunction::CanCastTo(const DataType& out_type) const {
-  return impl_->in_types.find(static_cast<int>(out_type.id())) != impl_->in_types.end();
-}
-
 Result<const Kernel*> CastFunction::DispatchExact(
     const std::vector<ValueDescr>& values) const {
-  const int passed_num_args = static_cast<int>(values.size());
+  RETURN_NOT_OK(CheckArity(values));
 
-  // Validate arity
-  if (passed_num_args != 1) {
-    return Status::Invalid("Cast functions accept 1 argument but passed ",
-                           passed_num_args);
-  }
   std::vector<const ScalarKernel*> candidate_kernels;
   for (const auto& kernel : kernels_) {
     if (kernel.signature->MatchesInputs(values)) {
@@ -181,25 +161,28 @@ Result<const Kernel*> CastFunction::DispatchExact(
 
   if (candidate_kernels.size() == 0) {
     return Status::NotImplemented("Unsupported cast from ", values[0].type->ToString(),
-                                  " to ", ToTypeName(impl_->out_type), " using function ",
+                                  " to ", ToTypeName(out_type_id_), " using function ",
                                   this->name());
-  } else if (candidate_kernels.size() == 1) {
+  }
+
+  if (candidate_kernels.size() == 1) {
     // One match, return it
     return candidate_kernels[0];
-  } else {
-    // Now we are in a casting scenario where we may have both a EXACT_TYPE and
-    // a SAME_TYPE_ID. So we will see if there is an exact match among the
-    // candidate kernels and if not we will just return the first one
-    for (auto kernel : candidate_kernels) {
-      const InputType& arg0 = kernel->signature->in_types()[0];
-      if (arg0.kind() == InputType::EXACT_TYPE) {
-        // Bingo. Return it
-        return kernel;
-      }
-    }
-    // We didn't find an exact match. So just return some kernel that matches
-    return candidate_kernels[0];
   }
+
+  // Now we are in a casting scenario where we may have both a EXACT_TYPE and
+  // a SAME_TYPE_ID. So we will see if there is an exact match among the
+  // candidate kernels and if not we will just return the first one
+  for (auto kernel : candidate_kernels) {
+    const InputType& arg0 = kernel->signature->in_types()[0];
+    if (arg0.kind() == InputType::EXACT_TYPE) {
+      // Bingo. Return it
+      return kernel;
+    }
+  }
+
+  // We didn't find an exact match. So just return some kernel that matches
+  return candidate_kernels[0];
 }
 
 Result<Datum> Cast(const Datum& value, const CastOptions& options, ExecContext* ctx) {
@@ -225,13 +208,21 @@ Result<std::shared_ptr<CastFunction>> GetCastFunction(
 }
 
 bool CanCast(const DataType& from_type, const DataType& to_type) {
-  // TODO
   internal::EnsureInitCastTable();
-  auto it = internal::g_cast_table.find(static_cast<int>(from_type.id()));
+  auto it = internal::g_cast_table.find(static_cast<int>(to_type.id()));
   if (it == internal::g_cast_table.end()) {
     return false;
   }
-  return it->second->CanCastTo(to_type);
+
+  const CastFunction* function = it->second.get();
+  DCHECK_EQ(function->out_type_id(), to_type.id());
+
+  for (auto from_id : function->in_type_ids()) {
+    // XXX should probably check the output type as well
+    if (from_type.id() == from_id) return true;
+  }
+
+  return false;
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -82,10 +82,10 @@ struct ARROW_EXPORT CastOptions : public FunctionOptions {
 // the same execution machinery
 class CastFunction : public ScalarFunction {
  public:
-  CastFunction(std::string name, Type::type out_type);
-  ~CastFunction() override;
+  CastFunction(std::string name, Type::type out_type_id);
 
-  Type::type out_type_id() const;
+  Type::type out_type_id() const { return out_type_id_; }
+  const std::vector<Type::type>& in_type_ids() const { return in_type_ids_; }
 
   Status AddKernel(Type::type in_type_id, std::vector<InputType> in_types,
                    OutputType out_type, ArrayKernelExec exec,
@@ -96,14 +96,12 @@ class CastFunction : public ScalarFunction {
   // function to CastInit
   Status AddKernel(Type::type in_type_id, ScalarKernel kernel);
 
-  bool CanCastTo(const DataType& out_type) const;
-
   Result<const Kernel*> DispatchExact(
       const std::vector<ValueDescr>& values) const override;
 
  private:
-  struct CastFunctionImpl;
-  std::unique_ptr<CastFunctionImpl> impl_;
+  std::vector<Type::type> in_type_ids_;
+  const Type::type out_type_id_;
 };
 
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -155,5 +155,17 @@ Result<Datum> Cast(const Datum& value, std::shared_ptr<DataType> to_type,
                    const CastOptions& options = CastOptions::Safe(),
                    ExecContext* ctx = NULLPTR);
 
+/// \brief Cast several values simultaneously. Safe cast options are used.
+/// \param[in] values datums to cast
+/// \param[in] descrs ValueDescrs to cast to
+/// \param[in] ctx the function execution context, optional
+/// \return the resulting datums
+///
+/// \since 1.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<std::vector<Datum>> Cast(std::vector<Datum> values, std::vector<ValueDescr> descrs,
+                                ExecContext* ctx = NULLPTR);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -161,7 +161,7 @@ Result<Datum> Cast(const Datum& value, std::shared_ptr<DataType> to_type,
 /// \param[in] ctx the function execution context, optional
 /// \return the resulting datums
 ///
-/// \since 1.0.0
+/// \since 4.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
 Result<std::vector<Datum>> Cast(std::vector<Datum> values, std::vector<ValueDescr> descrs,

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -132,6 +132,11 @@ class ARROW_EXPORT KernelExecutor {
 ARROW_EXPORT
 Status PropagateNulls(KernelContext* ctx, const ExecBatch& batch, ArrayData* out);
 
+/// \brief Look up a kernel in a function. If no Kernel is found, nullptr is returned.
+ARROW_EXPORT
+const Kernel* DispatchExactImpl(const Function* func,
+                                const std::vector<ValueDescr>& values);
+
 }  // namespace detail
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -132,11 +132,6 @@ class ARROW_EXPORT KernelExecutor {
 ARROW_EXPORT
 Status PropagateNulls(KernelContext* ctx, const ExecBatch& batch, ArrayData* out);
 
-/// \brief Look up a kernel in a function. If no Kernel is found, nullptr is returned.
-ARROW_EXPORT
-const Kernel* DispatchExactImpl(const Function* func,
-                                const std::vector<ValueDescr>& values);
-
 }  // namespace detail
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/exec_internal.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/datum.h"
 #include "arrow/util/cpu_info.h"
 

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -38,8 +38,8 @@ static const FunctionDoc kEmptyFunctionDoc{};
 
 const FunctionDoc& FunctionDoc::Empty() { return kEmptyFunctionDoc; }
 
-Status CheckArityImpl(const Function* function, int passed_num_args,
-                      const char* passed_num_args_label) {
+static Status CheckArityImpl(const Function* function, int passed_num_args,
+                             const char* passed_num_args_label) {
   if (function->arity().is_varargs && passed_num_args < function->arity().num_args) {
     return Status::Invalid("VarArgs function ", function->name(), " needs at least ",
                            function->arity().num_args, " arguments but ",

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -41,9 +41,9 @@ const FunctionDoc& FunctionDoc::Empty() { return kEmptyFunctionDoc; }
 Status CheckArityImpl(const Function* function, int passed_num_args,
                       const char* passed_num_args_label) {
   if (function->arity().is_varargs && passed_num_args < function->arity().num_args) {
-    return Status::Invalid("VarArgs function needs at least ", function->arity().num_args,
-                           " arguments but ", passed_num_args_label, " only ",
-                           passed_num_args);
+    return Status::Invalid("VarArgs function ", function->name(), " needs at least ",
+                           function->arity().num_args, " arguments but ",
+                           passed_num_args_label, " only ", passed_num_args);
   }
 
   if (!function->arity().is_varargs && passed_num_args != function->arity().num_args) {

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -199,7 +199,8 @@ class ARROW_EXPORT Function {
         doc_(doc ? doc : &FunctionDoc::Empty()),
         default_options_(default_options) {}
 
-  Status CheckArity(int passed_num_args) const;
+  Status CheckArity(const std::vector<InputType>&) const;
+  Status CheckArity(const std::vector<ValueDescr>&) const;
 
   std::string name_;
   Function::Kind kind_;

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -233,6 +233,14 @@ class FunctionImpl : public Function {
   std::vector<KernelType> kernels_;
 };
 
+/// \brief Look up a kernel in a function. If no Kernel is found, nullptr is returned.
+ARROW_EXPORT
+const Kernel* DispatchExactImpl(const Function* func, const std::vector<ValueDescr>&);
+
+/// \brief Return an error message if no Kernel is found.
+ARROW_EXPORT
+Status NoMatchingKernel(const Function* func, const std::vector<ValueDescr>&);
+
 }  // namespace detail
 
 /// \brief A function that executes elementwise operations on arrays or

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -566,7 +566,7 @@ struct Kernel {
 /// output array values (as opposed to scalar values in the case of aggregate
 /// functions).
 struct ArrayKernel : public Kernel {
-  ArrayKernel() {}
+  ArrayKernel() = default;
 
   ArrayKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExec exec,
               KernelInit init = NULLPTR)
@@ -614,7 +614,7 @@ using VectorFinalize = std::function<void(KernelContext*, std::vector<Datum>*)>;
 /// (which have different defaults from ScalarKernel), and some other
 /// execution-related options.
 struct VectorKernel : public ArrayKernel {
-  VectorKernel() {}
+  VectorKernel() = default;
 
   VectorKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExec exec)
       : ArrayKernel(std::move(sig), exec) {}

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -179,6 +179,28 @@ Result<ValueDescr> FirstType(KernelContext*, const std::vector<ValueDescr>& desc
   return descrs[0];
 }
 
+void EnsureDictionaryDecoded(std::vector<ValueDescr>* descrs) {
+  for (ValueDescr& descr : *descrs) {
+    if (descr.type->id() == Type::DICTIONARY) {
+      descr.type = checked_cast<const DictionaryType&>(*descr.type).value_type();
+    }
+  }
+}
+
+void ReplaceNullWithOtherType(std::vector<ValueDescr>* descrs) {
+  DCHECK_EQ(descrs->size(), 2);
+
+  if (descrs->at(0).type->id() == Type::NA) {
+    descrs->at(0).type = descrs->at(1).type;
+    return;
+  }
+
+  if (descrs->at(1).type->id() == Type::NA) {
+    descrs->at(1).type = descrs->at(0).type;
+    return;
+  }
+}
+
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
   for (const auto& descr : descrs) {
     auto id = descr.type->id();

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -215,6 +215,10 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
       // a common numeric type is only possible if all types are numeric
       return nullptr;
     }
+    if (id == Type::HALF_FLOAT) {
+      // float16 arithmetic is not currently supported
+      return nullptr;
+    }
   }
   for (const auto& descr : descrs) {
     if (descr.type->id() == Type::DOUBLE) return float64();

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -232,6 +232,28 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
   return at_least_one_signed ? int8() : uint8();
 }
 
+std::shared_ptr<DataType> CommonTimestamp(const std::vector<ValueDescr>& descrs) {
+  TimeUnit::type finest_unit = TimeUnit::SECOND;
+
+  for (const auto& descr : descrs) {
+    auto id = descr.type->id();
+    // a common timestamp is only possible if all types are timestamp like
+    switch (id) {
+      case Type::DATE32:
+      case Type::DATE64:
+        continue;
+      case Type::TIMESTAMP:
+        finest_unit =
+            std::max(finest_unit, checked_cast<const TimestampType&>(*descr.type).unit());
+        continue;
+      default:
+        return nullptr;
+    }
+  }
+
+  return timestamp(finest_unit);
+}
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -248,7 +248,7 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
   }
 
   if (max_width_signed <= max_width_unsigned) {
-    max_width_signed = BitUtil::NextPower2(max_width_unsigned + 1);
+    max_width_signed = static_cast<int>(BitUtil::NextPower2(max_width_unsigned + 1));
   }
 
   if (max_width_signed >= 64) return int64();

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -198,9 +198,9 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
   int max_width = 0;
 
   for (const auto& descr : descrs) {
-    at_least_one_signed |= is_signed_integer(descr.type->id());
-    max_width =
-        std::max(max_width, checked_cast<const IntegerType&>(*descr.type).bit_width());
+    auto id = descr.type->id();
+    at_least_one_signed |= is_signed_integer(id);
+    max_width = std::max(bit_width(id), max_width);
   }
 
   if (max_width == 64) return at_least_one_signed ? int64() : uint64();

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1193,10 +1193,16 @@ ARROW_EXPORT
 void ReplaceNullWithOtherType(std::vector<ValueDescr>* descrs);
 
 ARROW_EXPORT
+void ReplaceTypes(const std::shared_ptr<DataType>&, std::vector<ValueDescr>* descrs);
+
+ARROW_EXPORT
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs);
 
 ARROW_EXPORT
 std::shared_ptr<DataType> CommonTimestamp(const std::vector<ValueDescr>& descrs);
+
+ARROW_EXPORT
+std::shared_ptr<DataType> CommonBinary(const std::vector<ValueDescr>& descrs);
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1186,6 +1186,16 @@ ArrayKernelExec GenerateTemporal(detail::GetTypeId get_id) {
 // END of kernel generator-dispatchers
 // ----------------------------------------------------------------------
 
+inline void EnsureDictionaryDecoded(std::vector<ValueDescr>* descrs) {
+  for (ValueDescr& descr : *descrs) {
+    if (descr.type->id() == Type::DICTIONARY) {
+      descr.type = checked_cast<const DictionaryType&>(*descr.type).value_type();
+    }
+  }
+}
+
+std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs);
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1186,14 +1186,13 @@ ArrayKernelExec GenerateTemporal(detail::GetTypeId get_id) {
 // END of kernel generator-dispatchers
 // ----------------------------------------------------------------------
 
-inline void EnsureDictionaryDecoded(std::vector<ValueDescr>* descrs) {
-  for (ValueDescr& descr : *descrs) {
-    if (descr.type->id() == Type::DICTIONARY) {
-      descr.type = checked_cast<const DictionaryType&>(*descr.type).value_type();
-    }
-  }
-}
+ARROW_EXPORT
+void EnsureDictionaryDecoded(std::vector<ValueDescr>* descrs);
 
+ARROW_EXPORT
+void ReplaceNullWithOtherType(std::vector<ValueDescr>* descrs);
+
+ARROW_EXPORT
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs);
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1195,6 +1195,9 @@ void ReplaceNullWithOtherType(std::vector<ValueDescr>* descrs);
 ARROW_EXPORT
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs);
 
+ARROW_EXPORT
+std::shared_ptr<DataType> CommonTimestamp(const std::vector<ValueDescr>& descrs);
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/common.h
+++ b/cpp/src/arrow/compute/kernels/common.h
@@ -51,16 +51,4 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 
-namespace compute {
-namespace detail {
-
-/// \brief Look up a kernel in a function. If no Kernel is found, nullptr is returned.
-ARROW_EXPORT
-const Kernel* DispatchExactImpl(const Function* func, const std::vector<ValueDescr>&);
-
-ARROW_EXPORT
-Status NoMatchingKernel(const Function* func, const std::vector<ValueDescr>&);
-
-}  // namespace detail
-}  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/common.h
+++ b/cpp/src/arrow/compute/kernels/common.h
@@ -51,4 +51,16 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 
+namespace compute {
+namespace detail {
+
+/// \brief Look up a kernel in a function. If no Kernel is found, nullptr is returned.
+ARROW_EXPORT
+const Kernel* DispatchExactImpl(const Function* func, const std::vector<ValueDescr>&);
+
+ARROW_EXPORT
+Status NoMatchingKernel(const Function* func, const std::vector<ValueDescr>&);
+
+}  // namespace detail
+}  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -268,7 +268,7 @@ struct ArithmeticFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
   Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
-    RETURN_NOT_OK(CheckArity(static_cast<int>(values->size())));
+    RETURN_NOT_OK(CheckArity(*values));
 
     using arrow::compute::detail::DispatchExactImpl;
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
@@ -277,9 +277,7 @@ struct ArithmeticFunction : ScalarFunction {
     ReplaceNullWithOtherType(values);
 
     if (auto type = CommonNumeric(*values)) {
-      for (auto& descr : *values) {
-        descr.type = type;
-      }
+      ReplaceTypes(type, values);
     }
 
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -270,6 +270,9 @@ struct ArithmeticFunction : ScalarFunction {
   Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
     RETURN_NOT_OK(CheckArity(static_cast<int>(values->size())));
 
+    using arrow::compute::detail::DispatchExactImpl;
+    if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
+
     EnsureDictionaryDecoded(values);
     ReplaceNullWithOtherType(values);
 
@@ -279,9 +282,7 @@ struct ArithmeticFunction : ScalarFunction {
       }
     }
 
-    if (auto kernel = arrow::compute::detail::DispatchExactImpl(this, *values)) {
-      return kernel;
-    }
+    if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
     return arrow::compute::detail::NoMatchingKernel(this, *values);
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -268,7 +268,10 @@ struct ArithmeticFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
   Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
+    RETURN_NOT_OK(CheckArity(static_cast<int>(values->size())));
+
     EnsureDictionaryDecoded(values);
+    ReplaceNullWithOtherType(values);
 
     if (auto type = CommonNumeric(*values)) {
       for (auto& descr : *values) {
@@ -276,7 +279,10 @@ struct ArithmeticFunction : ScalarFunction {
       }
     }
 
-    return DispatchExact(*values);
+    if (auto kernel = arrow::compute::detail::DispatchExactImpl(this, *values)) {
+      return kernel;
+    }
+    return arrow::compute::detail::NoMatchingKernel(this, *values);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -656,5 +656,26 @@ TEST(TestBinaryArithmetic, DispatchBest) {
   }
 }
 
+TEST(TestBinaryArithmetic, AddWithImplicitCasts) {
+  CheckScalarBinary("add", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
+                    ArrayFromJSON(float64(), "[0.25, 0.5, 0.75, 1.0]"),
+                    ArrayFromJSON(float64(), "[0.25, 1.5, 2.75, null]"));
+
+  CheckScalarBinary("add", ArrayFromJSON(int8(), "[-16, 0, 16, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(int32(), "[-13, 4, 21, null]"));
+
+  CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int32()), "[0, 1, 2, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+
+  // Not currently implemented since it would invoke a double implicit cast:
+  // dictionary(int32, int8) -> int8 -> int32
+  //  CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2,
+  //  null]"),
+  //                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+  //                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -643,22 +643,28 @@ TEST(TestBinaryArithmetic, DispatchBest) {
       name += suffix;
 
       CheckDispatchBest(name, {int32(), int32()}, {int32(), int32()});
-
       CheckDispatchBest(name, {int32(), null()}, {int32(), int32()});
-
       CheckDispatchBest(name, {null(), int32()}, {int32(), int32()});
 
+      CheckDispatchBest(name, {int32(), int8()}, {int32(), int32()});
       CheckDispatchBest(name, {int32(), int16()}, {int32(), int32()});
+      CheckDispatchBest(name, {int32(), int32()}, {int32(), int32()});
+      CheckDispatchBest(name, {int32(), int64()}, {int64(), int64()});
+
+      CheckDispatchBest(name, {int32(), uint8()}, {int32(), int32()});
+      CheckDispatchBest(name, {int32(), uint16()}, {int32(), int32()});
+      CheckDispatchBest(name, {int32(), uint32()}, {int64(), int64()});
+      CheckDispatchBest(name, {int32(), uint64()}, {int64(), int64()});
+
+      CheckDispatchBest(name, {uint8(), uint8()}, {uint8(), uint8()});
+      CheckDispatchBest(name, {uint8(), uint16()}, {uint16(), uint16()});
 
       CheckDispatchBest(name, {int32(), float32()}, {float32(), float32()});
-
       CheckDispatchBest(name, {float32(), int64()}, {float32(), float32()});
-
       CheckDispatchBest(name, {float64(), int32()}, {float64(), float64()});
 
       CheckDispatchBest(name, {dictionary(int8(), float64()), float64()},
                         {float64(), float64()});
-
       CheckDispatchBest(name, {dictionary(int8(), float64()), int16()},
                         {float64(), float64()});
     }
@@ -672,12 +678,12 @@ TEST(TestBinaryArithmetic, AddWithImplicitCasts) {
 
   CheckScalarBinary("add", ArrayFromJSON(int8(), "[-16, 0, 16, null]"),
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
-                    ArrayFromJSON(int32(), "[-13, 4, 21, null]"));
+                    ArrayFromJSON(int64(), "[-13, 4, 21, null]"));
 
   CheckScalarBinary("add",
                     ArrayFromJSON(dictionary(int32(), int32()), "[8, 6, 3, null, 2]"),
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7, 0]"),
-                    ArrayFromJSON(int32(), "[11, 10, 8, null, 2]"));
+                    ArrayFromJSON(int64(), "[11, 10, 8, null, 2]"));
 
   CheckScalarBinary("add", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
                     std::make_shared<NullArray>(4),
@@ -685,7 +691,22 @@ TEST(TestBinaryArithmetic, AddWithImplicitCasts) {
 
   CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2, null]"),
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
-                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+                    ArrayFromJSON(int64(), "[3, 5, 7, null]"));
+}
+
+TEST(TestBinaryArithmetic, AddWithImplicitCastsUint64EdgeCase) {
+  // int64 is as wide as we can promote
+  CheckDispatchBest("add", {int8(), uint64()}, {int64(), int64()});
+
+  // this works sometimes
+  CheckScalarBinary("add", ArrayFromJSON(int8(), "[-1]"), ArrayFromJSON(uint64(), "[0]"),
+                    ArrayFromJSON(int64(), "[-1]"));
+
+  // ... but it can result in impossible implicit casts in  the presence of uint64, since
+  // some uint64 values cannot be cast to int64:
+  ASSERT_RAISES(Invalid,
+                CallFunction("add", {ArrayFromJSON(int64(), "[-1]"),
+                                     ArrayFromJSON(uint64(), "[18446744073709551615]")}));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -643,13 +643,22 @@ TEST(TestBinaryArithmetic, DispatchBest) {
       name += suffix;
 
       CheckDispatchBest(name, {int32(), int32()}, {int32(), int32()});
+
+      CheckDispatchBest(name, {int32(), null()}, {int32(), int32()});
+
+      CheckDispatchBest(name, {null(), int32()}, {int32(), int32()});
+
       CheckDispatchBest(name, {int32(), int16()}, {int32(), int32()});
+
       CheckDispatchBest(name, {int32(), float32()}, {float32(), float32()});
+
       CheckDispatchBest(name, {float32(), int64()}, {float32(), float32()});
+
       CheckDispatchBest(name, {float64(), int32()}, {float64(), float64()});
 
       CheckDispatchBest(name, {dictionary(int8(), float64()), float64()},
                         {float64(), float64()});
+
       CheckDispatchBest(name, {dictionary(int8(), float64()), int16()},
                         {float64(), float64()});
     }
@@ -668,6 +677,10 @@ TEST(TestBinaryArithmetic, AddWithImplicitCasts) {
   CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int32()), "[0, 1, 2, null]"),
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
                     ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+
+  CheckScalarBinary("add", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
+                    std::make_shared<NullArray>(4),
+                    ArrayFromJSON(int32(), "[null, null, null, null]"));
 
   // Not currently implemented since it would invoke a double implicit cast:
   // dictionary(int32, int8) -> int8 -> int32

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -674,20 +674,18 @@ TEST(TestBinaryArithmetic, AddWithImplicitCasts) {
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
                     ArrayFromJSON(int32(), "[-13, 4, 21, null]"));
 
-  CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int32()), "[0, 1, 2, null]"),
-                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
-                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+  CheckScalarBinary("add",
+                    ArrayFromJSON(dictionary(int32(), int32()), "[8, 6, 3, null, 2]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7, 0]"),
+                    ArrayFromJSON(int32(), "[11, 10, 8, null, 2]"));
 
   CheckScalarBinary("add", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
                     std::make_shared<NullArray>(4),
                     ArrayFromJSON(int32(), "[null, null, null, null]"));
 
-  // Not currently implemented since it would invoke a double implicit cast:
-  // dictionary(int32, int8) -> int8 -> int32
-  //  CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2,
-  //  null]"),
-  //                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
-  //                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
+  CheckScalarBinary("add", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(int32(), "[3, 5, 7, null]"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -50,6 +50,7 @@ struct ParseBooleanString {
 std::vector<std::shared_ptr<CastFunction>> GetBooleanCasts() {
   auto func = std::make_shared<CastFunction>("cast_boolean", Type::BOOL);
   AddCommonCasts(Type::BOOL, boolean(), func.get());
+  AddZeroCopyCast(Type::BOOL, boolean(), boolean(), func.get());
 
   for (const auto& ty : NumericTypes()) {
     ArrayKernelExec exec =

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -149,17 +149,13 @@ void CastNumberToNumberUnsafe(Type::type in_type, Type::type out_type, const Dat
 // ----------------------------------------------------------------------
 
 void UnpackDictionary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  if (out->is_scalar()) {
-    KERNEL_ASSIGN_OR_RAISE(*out, ctx,
-                           batch[0].scalar_as<DictionaryScalar>().GetEncodedValue());
-    return;
-  }
+  DCHECK(out->is_array());
 
   DictionaryArray dict_arr(batch[0].array());
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
 
   const auto& dict_type = *dict_arr.dictionary()->type();
-  if (!dict_type.Equals(options.to_type)) {
+  if (!dict_type.Equals(options.to_type) && !CanCast(dict_type, *options.to_type)) {
     ctx->SetStatus(Status::Invalid("Cast type ", options.to_type->ToString(),
                                    " incompatible with dictionary type ",
                                    dict_type.ToString()));
@@ -169,6 +165,10 @@ void UnpackDictionary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   KERNEL_ASSIGN_OR_RAISE(*out, ctx,
                          Take(Datum(dict_arr.dictionary()), Datum(dict_arr.indices()),
                               TakeOptions::Defaults(), ctx->exec_context()));
+
+  if (!dict_type.Equals(options.to_type)) {
+    KERNEL_ASSIGN_OR_RAISE(*out, ctx, Cast(*out, options));
+  }
 }
 
 void OutputAllNull(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
@@ -224,28 +224,23 @@ Result<ValueDescr> ResolveOutputFromOptions(KernelContext* ctx,
 OutputType kOutputTargetType(ResolveOutputFromOptions);
 
 void ZeroCopyCastExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  if (batch[0].kind() == Datum::ARRAY) {
-    // Make a copy of the buffers into a destination array without carrying
-    // the type
-    const ArrayData& input = *batch[0].array();
-    ArrayData* output = out->mutable_array();
-    output->length = input.length;
-    output->SetNullCount(input.null_count);
-    output->buffers = input.buffers;
-    output->offset = input.offset;
-    output->child_data = input.child_data;
-  } else {
-    ctx->SetStatus(
-        Status::NotImplemented("This cast not yet implemented for "
-                               "scalar input"));
-  }
+  DCHECK_EQ(batch[0].kind(), Datum::ARRAY);
+  // Make a copy of the buffers into a destination array without carrying
+  // the type
+  const ArrayData& input = *batch[0].array();
+  ArrayData* output = out->mutable_array();
+  output->length = input.length;
+  output->SetNullCount(input.null_count);
+  output->buffers = input.buffers;
+  output->offset = input.offset;
+  output->child_data = input.child_data;
 }
 
 void AddZeroCopyCast(Type::type in_type_id, InputType in_type, OutputType out_type,
                      CastFunction* func) {
   auto sig = KernelSignature::Make({in_type}, out_type);
   ScalarKernel kernel;
-  kernel.exec = ZeroCopyCastExec;
+  kernel.exec = TrivialScalarUnaryAsArraysExec(ZeroCopyCastExec);
   kernel.signature = sig;
   kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
@@ -268,7 +263,8 @@ void AddCommonCasts(Type::type out_type_id, OutputType out_ty, CastFunction* fun
     // XXX: Uses Take and does its own memory allocation for the moment. We can
     // fix this later.
     DCHECK_OK(func->AddKernel(Type::DICTIONARY, {InputType(Type::DICTIONARY)}, out_ty,
-                              UnpackDictionary, NullHandling::COMPUTED_NO_PREALLOCATE,
+                              TrivialScalarUnaryAsArraysExec(UnpackDictionary),
+                              NullHandling::COMPUTED_NO_PREALLOCATE,
                               MemAllocation::NO_PREALLOCATE));
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -62,7 +62,7 @@ Status CheckFloatTruncation(const Datum& input, const Datum& output) {
     return is_valid && static_cast<InT>(out_val) != in_val;
   };
   auto GetErrorMessage = [&](InT val) {
-    return Status::Invalid("Float value ", val, " was truncated converting to",
+    return Status::Invalid("Float value ", val, " was truncated converting to ",
                            *output.type());
   };
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -215,9 +215,17 @@ void AddBinaryToBinaryCast(CastFunction* func) {
   auto out_ty = TypeTraits<OutType>::type_singleton();
 
   DCHECK_OK(func->AddKernel(
-      OutType::type_id, {in_ty}, out_ty,
+      InType::type_id, {in_ty}, out_ty,
       TrivialScalarUnaryAsArraysExec(BinaryToBinaryCastFunctor<OutType, InType>::Exec),
       NullHandling::COMPUTED_NO_PREALLOCATE));
+}
+
+template <typename OutType>
+void AddBinaryToBinaryCast(CastFunction* func) {
+  AddBinaryToBinaryCast<OutType, StringType>(func);
+  AddBinaryToBinaryCast<OutType, BinaryType>(func);
+  AddBinaryToBinaryCast<OutType, LargeStringType>(func);
+  AddBinaryToBinaryCast<OutType, LargeBinaryType>(func);
 }
 
 }  // namespace
@@ -225,31 +233,23 @@ void AddBinaryToBinaryCast(CastFunction* func) {
 std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   auto cast_binary = std::make_shared<CastFunction>("cast_binary", Type::BINARY);
   AddCommonCasts(Type::BINARY, binary(), cast_binary.get());
-  AddBinaryToBinaryCast<BinaryType, StringType>(cast_binary.get());
-  AddBinaryToBinaryCast<BinaryType, LargeBinaryType>(cast_binary.get());
-  AddBinaryToBinaryCast<BinaryType, LargeStringType>(cast_binary.get());
+  AddBinaryToBinaryCast<BinaryType>(cast_binary.get());
 
   auto cast_large_binary =
       std::make_shared<CastFunction>("cast_large_binary", Type::LARGE_BINARY);
   AddCommonCasts(Type::LARGE_BINARY, large_binary(), cast_large_binary.get());
-  AddBinaryToBinaryCast<LargeBinaryType, BinaryType>(cast_large_binary.get());
-  AddBinaryToBinaryCast<LargeBinaryType, StringType>(cast_large_binary.get());
-  AddBinaryToBinaryCast<LargeBinaryType, LargeStringType>(cast_large_binary.get());
+  AddBinaryToBinaryCast<LargeBinaryType>(cast_large_binary.get());
 
   auto cast_string = std::make_shared<CastFunction>("cast_string", Type::STRING);
   AddCommonCasts(Type::STRING, utf8(), cast_string.get());
   AddNumberToStringCasts<StringType>(cast_string.get());
-  AddBinaryToBinaryCast<StringType, BinaryType>(cast_string.get());
-  AddBinaryToBinaryCast<StringType, LargeBinaryType>(cast_string.get());
-  AddBinaryToBinaryCast<StringType, LargeStringType>(cast_string.get());
+  AddBinaryToBinaryCast<StringType>(cast_string.get());
 
   auto cast_large_string =
       std::make_shared<CastFunction>("cast_large_string", Type::LARGE_STRING);
   AddCommonCasts(Type::LARGE_STRING, large_utf8(), cast_large_string.get());
   AddNumberToStringCasts<LargeStringType>(cast_large_string.get());
-  AddBinaryToBinaryCast<LargeStringType, BinaryType>(cast_large_string.get());
-  AddBinaryToBinaryCast<LargeStringType, StringType>(cast_large_string.get());
-  AddBinaryToBinaryCast<LargeStringType, LargeBinaryType>(cast_large_string.get());
+  AddBinaryToBinaryCast<LargeStringType>(cast_large_string.get());
 
   auto cast_fsb =
       std::make_shared<CastFunction>("cast_fixed_size_binary", Type::FIXED_SIZE_BINARY);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -322,7 +322,7 @@ struct CastFunctor<TimestampType, I, enable_if_t<is_base_binary_type<I>::value>>
 template <typename Type>
 void AddCrossUnitCast(CastFunction* func) {
   ScalarKernel kernel;
-  kernel.exec = CastFunctor<Type, Type>::Exec;
+  kernel.exec = TrivialScalarUnaryAsArraysExec(CastFunctor<Type, Type>::Exec);
   kernel.signature = KernelSignature::Make({InputType(Type::type_id)}, kOutputTargetType);
   DCHECK_OK(func->AddKernel(Type::type_id, std::move(kernel)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -75,6 +75,9 @@ static std::vector<std::shared_ptr<DataType>> kNumericTypes = {
     uint8(), int8(),   uint16(), int16(),   uint32(),
     int32(), uint64(), int64(),  float32(), float64()};
 
+static std::vector<std::shared_ptr<DataType>> kBaseBinaryTypes = {
+    binary(), utf8(), large_binary(), large_utf8()};
+
 static void AssertBufferSame(const Array& left, const Array& right, int buffer_index) {
   ASSERT_EQ(left.data()->buffers[buffer_index].get(),
             right.data()->buffers[buffer_index].get());
@@ -402,6 +405,77 @@ class TestCast : public TestBase {
     // Edge cases are tested in Decimal128::ToReal()
   }
 };
+
+TEST_F(TestCast, CanCast) {
+  auto ExpectCanCast = [](std::shared_ptr<DataType> from,
+                          std::vector<std::shared_ptr<DataType>> to_set,
+                          bool expected = true) {
+    for (auto to : to_set) {
+      EXPECT_EQ(CanCast(*from, *to), expected) << "  from: " << from->ToString() << "\n"
+                                               << "    to: " << to->ToString();
+    }
+  };
+
+  auto ExpectCannotCast = [ExpectCanCast](std::shared_ptr<DataType> from,
+                                          std::vector<std::shared_ptr<DataType>> to_set) {
+    ExpectCanCast(from, to_set, /*expected=*/false);
+  };
+
+  ExpectCanCast(null(), {boolean()});
+  ExpectCanCast(null(), kNumericTypes);
+  ExpectCanCast(null(), kBaseBinaryTypes);
+  ExpectCanCast(
+      null(), {date32(), date64(), time32(TimeUnit::MILLI), timestamp(TimeUnit::SECOND)});
+  ExpectCanCast(dictionary(uint16(), null()), {null()});
+
+  ExpectCanCast(boolean(), {boolean()});
+  ExpectCanCast(boolean(), kNumericTypes);
+  ExpectCanCast(boolean(), {utf8(), large_utf8()});
+  ExpectCanCast(dictionary(int32(), boolean()), {boolean()});
+
+  ExpectCannotCast(boolean(), {null()});
+  ExpectCannotCast(boolean(), {binary(), large_binary()});
+  ExpectCannotCast(boolean(), {date32(), date64(), time32(TimeUnit::MILLI),
+                               timestamp(TimeUnit::SECOND)});
+
+  for (auto from_numeric : kNumericTypes) {
+    ExpectCanCast(from_numeric, {boolean()});
+    ExpectCanCast(from_numeric, kNumericTypes);
+    ExpectCanCast(from_numeric, {utf8(), large_utf8()});
+    ExpectCanCast(dictionary(int32(), from_numeric), {from_numeric});
+
+    ExpectCannotCast(from_numeric, {null()});
+  }
+
+  for (auto from_base_binary : kBaseBinaryTypes) {
+    ExpectCanCast(from_base_binary, {boolean()});
+    ExpectCanCast(from_base_binary, kNumericTypes);
+    ExpectCanCast(from_base_binary, kBaseBinaryTypes);
+    ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
+
+    // any cast which is valid for the dictionary is valid for the DictionaryArray
+    ExpectCanCast(dictionary(uint32(), from_base_binary), kBaseBinaryTypes);
+    ExpectCanCast(dictionary(int16(), from_base_binary), kNumericTypes);
+
+    ExpectCannotCast(from_base_binary, {null()});
+  }
+
+  ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI)});
+  ExpectCanCast(large_utf8(), {timestamp(TimeUnit::NANO)});
+  ExpectCannotCast(timestamp(TimeUnit::MICRO),
+                   kBaseBinaryTypes);  // no formatting supported
+
+  ExpectCannotCast(fixed_size_binary(3),
+                   {fixed_size_binary(3)});  // FIXME missing identity cast
+
+  auto smallint = std::make_shared<SmallintType>();
+  ASSERT_OK(RegisterExtensionType(smallint));
+  ExpectCanCast(smallint, {int16()});  // cast storage
+  ExpectCanCast(smallint,
+                kNumericTypes);  // any cast which is valid for storage is supported
+  ExpectCannotCast(null(), {smallint});  // FIXME missing common cast from null
+  ASSERT_OK(UnregisterExtensionType("smallint"));
+}
 
 TEST_F(TestCast, SameTypeZeroCopy) {
   std::shared_ptr<Array> arr = ArrayFromJSON(int32(), "[0, null, 2, 3, 4]");

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -468,13 +468,11 @@ TEST_F(TestCast, CanCast) {
   ExpectCannotCast(fixed_size_binary(3),
                    {fixed_size_binary(3)});  // FIXME missing identity cast
 
-  auto smallint = std::make_shared<SmallintType>();
-  ASSERT_OK(RegisterExtensionType(smallint));
-  ExpectCanCast(smallint, {int16()});  // cast storage
-  ExpectCanCast(smallint,
+  ExtensionTypeGuard smallint_guard(smallint());
+  ExpectCanCast(smallint(), {int16()});  // cast storage
+  ExpectCanCast(smallint(),
                 kNumericTypes);  // any cast which is valid for storage is supported
-  ExpectCannotCast(null(), {smallint});  // FIXME missing common cast from null
-  ASSERT_OK(UnregisterExtensionType("smallint"));
+  ExpectCannotCast(null(), {smallint()});  // FIXME missing common cast from null
 }
 
 TEST_F(TestCast, SameTypeZeroCopy) {
@@ -1929,7 +1927,7 @@ std::shared_ptr<Array> SmallintArrayFromJSON(const std::string& json_data) {
 
 TEST_F(TestCast, ExtensionTypeToIntDowncast) {
   auto smallint = std::make_shared<SmallintType>();
-  ASSERT_OK(RegisterExtensionType(smallint));
+  ExtensionTypeGuard smallint_guard(smallint);
 
   CastOptions options;
   options.allow_int_overflow = false;
@@ -1965,8 +1963,6 @@ TEST_F(TestCast, ExtensionTypeToIntDowncast) {
   // disallow overflow
   options.allow_int_overflow = false;
   ASSERT_RAISES(Invalid, Cast(*v3, uint8(), options));
-
-  ASSERT_OK(UnregisterExtensionType("smallint"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -78,6 +78,9 @@ struct CompareFunction : ScalarFunction {
   Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
     RETURN_NOT_OK(CheckArity(static_cast<int>(values->size())));
 
+    using arrow::compute::detail::DispatchExactImpl;
+    if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
+
     EnsureDictionaryDecoded(values);
     ReplaceNullWithOtherType(values);
 
@@ -87,9 +90,7 @@ struct CompareFunction : ScalarFunction {
       }
     }
 
-    if (auto kernel = arrow::compute::detail::DispatchExactImpl(this, *values)) {
-      return kernel;
-    }
+    if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
     return arrow::compute::detail::NoMatchingKernel(this, *values);
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -88,6 +88,10 @@ struct CompareFunction : ScalarFunction {
       for (auto& descr : *values) {
         descr.type = type;
       }
+    } else if (auto type = CommonTimestamp(*values)) {
+      for (auto& descr : *values) {
+        descr.type = type;
+      }
     }
 
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -451,6 +451,23 @@ TEST(TestCompareTimestamps, Basics) {
   CheckArrayCase(seconds_utc, CompareOperator::EQUAL, "[false, false, true]");
 }
 
+TEST(TestCompareKernel, DispatchBest) {
+  for (std::string name :
+       {"equal", "not_equal", "less", "less_equal", "greater", "greater_equal"}) {
+    CheckDispatchBest(name, {int32(), int32()}, {int32(), int32()});
+    CheckDispatchBest(name, {int32(), int16()}, {int32(), int32()});
+    CheckDispatchBest(name, {int32(), float32()}, {float32(), float32()});
+    CheckDispatchBest(name, {float32(), int64()}, {float32(), float32()});
+    CheckDispatchBest(name, {float64(), int32()}, {float64(), float64()});
+
+    CheckDispatchBest(name, {dictionary(int8(), float64()), float64()},
+                      {float64(), float64()});
+    CheckDispatchBest(name, {dictionary(int8(), float64()), int16()},
+                      {float64(), float64()});
+    CheckDispatchBest(name, {dictionary(int8(), utf8()), utf8()}, {utf8(), utf8()});
+  }
+}
+
 class TestStringCompareKernel : public ::testing::Test {};
 
 TEST_F(TestStringCompareKernel, SimpleCompareArrayScalar) {
@@ -459,85 +476,74 @@ TEST_F(TestStringCompareKernel, SimpleCompareArrayScalar) {
   CompareOptions eq(CompareOperator::EQUAL);
   ValidateCompare<StringType>(eq, "[]", one, "[]");
   ValidateCompare<StringType>(eq, "[null]", one, "[null]");
-  ValidateCompare<StringType>(eq, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[0,0,1,1,0,0]");
-  ValidateCompare<StringType>(
-      eq, "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]", one, "[0,1,0,0,0,0]");
-  ValidateCompare<StringType>(
-      eq, "[\"five\",\"four\",\"three\",\"two\",\"one\",\"zero\"]", one, "[0,0,0,0,1,0]");
-  ValidateCompare<StringType>(eq, "[null,\"zero\",\"one\",\"one\"]", one, "[null,0,1,1]");
+  ValidateCompare<StringType>(eq, R"(["zero","zero","one","one","two","two"])", one,
+                              "[0,0,1,1,0,0]");
+  ValidateCompare<StringType>(eq, R"(["zero","one","two","three","four","five"])", one,
+                              "[0,1,0,0,0,0]");
+  ValidateCompare<StringType>(eq, R"(["five","four","three","two","one","zero"])", one,
+                              "[0,0,0,0,1,0]");
+  ValidateCompare<StringType>(eq, R"([null,"zero","one","one"])", one, "[null,0,1,1]");
 
   Datum na(std::make_shared<StringScalar>());
-  ValidateCompare<StringType>(eq, "[null,\"zero\",\"one\",\"one\"]", na,
+  ValidateCompare<StringType>(eq, R"([null,"zero","one","one"])", na,
                               "[null,null,null,null]");
-  ValidateCompare<StringType>(eq, na, "[null,\"zero\",\"one\",\"one\"]",
+  ValidateCompare<StringType>(eq, na, R"([null,"zero","one","one"])",
                               "[null,null,null,null]");
 
   CompareOptions neq(CompareOperator::NOT_EQUAL);
   ValidateCompare<StringType>(neq, "[]", one, "[]");
   ValidateCompare<StringType>(neq, "[null]", one, "[null]");
-  ValidateCompare<StringType>(neq, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[1,1,0,0,1,1]");
-  ValidateCompare<StringType>(neq,
-                              "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]",
-                              one, "[1,0,1,1,1,1]");
-  ValidateCompare<StringType>(neq,
-                              "[\"five\",\"four\",\"three\",\"two\",\"one\",\"zero\"]",
-                              one, "[1,1,1,1,0,1]");
-  ValidateCompare<StringType>(neq, "[null,\"zero\",\"one\",\"one\"]", one,
-                              "[null,1,0,0]");
+  ValidateCompare<StringType>(neq, R"(["zero","zero","one","one","two","two"])", one,
+                              "[1,1,0,0,1,1]");
+  ValidateCompare<StringType>(neq, R"(["zero","one","two","three","four","five"])", one,
+                              "[1,0,1,1,1,1]");
+  ValidateCompare<StringType>(neq, R"(["five","four","three","two","one","zero"])", one,
+                              "[1,1,1,1,0,1]");
+  ValidateCompare<StringType>(neq, R"([null,"zero","one","one"])", one, "[null,1,0,0]");
 
   CompareOptions gt(CompareOperator::GREATER);
   ValidateCompare<StringType>(gt, "[]", one, "[]");
   ValidateCompare<StringType>(gt, "[null]", one, "[null]");
-  ValidateCompare<StringType>(gt, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[1,1,0,0,1,1]");
-  ValidateCompare<StringType>(
-      gt, "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]", one, "[1,0,1,1,0,0]");
-  ValidateCompare<StringType>(gt,
-                              "[\"four\",\"five\",\"six\",\"seven\",\"eight\",\"nine\"]",
-                              one, "[0,0,1,1,0,0]");
-  ValidateCompare<StringType>(gt, "[null,\"zero\",\"one\",\"one\"]", one, "[null,1,0,0]");
+  ValidateCompare<StringType>(gt, R"(["zero","zero","one","one","two","two"])", one,
+                              "[1,1,0,0,1,1]");
+  ValidateCompare<StringType>(gt, R"(["zero","one","two","three","four","five"])", one,
+                              "[1,0,1,1,0,0]");
+  ValidateCompare<StringType>(gt, R"(["four","five","six","seven","eight","nine"])", one,
+                              "[0,0,1,1,0,0]");
+  ValidateCompare<StringType>(gt, R"([null,"zero","one","one"])", one, "[null,1,0,0]");
 
   CompareOptions gte(CompareOperator::GREATER_EQUAL);
   ValidateCompare<StringType>(gte, "[]", one, "[]");
   ValidateCompare<StringType>(gte, "[null]", one, "[null]");
-  ValidateCompare<StringType>(gte, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[1,1,1,1,1,1]");
-  ValidateCompare<StringType>(gte,
-                              "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]",
-                              one, "[1,1,1,1,0,0]");
-  ValidateCompare<StringType>(gte,
-                              "[\"four\",\"five\",\"six\",\"seven\",\"eight\",\"nine\"]",
-                              one, "[0,0,1,1,0,0]");
-  ValidateCompare<StringType>(gte, "[null,\"zero\",\"one\",\"one\"]", one,
-                              "[null,1,1,1]");
+  ValidateCompare<StringType>(gte, R"(["zero","zero","one","one","two","two"])", one,
+                              "[1,1,1,1,1,1]");
+  ValidateCompare<StringType>(gte, R"(["zero","one","two","three","four","five"])", one,
+                              "[1,1,1,1,0,0]");
+  ValidateCompare<StringType>(gte, R"(["four","five","six","seven","eight","nine"])", one,
+                              "[0,0,1,1,0,0]");
+  ValidateCompare<StringType>(gte, R"([null,"zero","one","one"])", one, "[null,1,1,1]");
 
   CompareOptions lt(CompareOperator::LESS);
   ValidateCompare<StringType>(lt, "[]", one, "[]");
   ValidateCompare<StringType>(lt, "[null]", one, "[null]");
-  ValidateCompare<StringType>(lt, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[0,0,0,0,0,0]");
-  ValidateCompare<StringType>(
-      lt, "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]", one, "[0,0,0,0,1,1]");
-  ValidateCompare<StringType>(lt,
-                              "[\"four\",\"five\",\"six\",\"seven\",\"eight\",\"nine\"]",
-                              one, "[1,1,0,0,1,1]");
-  ValidateCompare<StringType>(lt, "[null,\"zero\",\"one\",\"one\"]", one, "[null,0,0,0]");
+  ValidateCompare<StringType>(lt, R"(["zero","zero","one","one","two","two"])", one,
+                              "[0,0,0,0,0,0]");
+  ValidateCompare<StringType>(lt, R"(["zero","one","two","three","four","five"])", one,
+                              "[0,0,0,0,1,1]");
+  ValidateCompare<StringType>(lt, R"(["four","five","six","seven","eight","nine"])", one,
+                              "[1,1,0,0,1,1]");
+  ValidateCompare<StringType>(lt, R"([null,"zero","one","one"])", one, "[null,0,0,0]");
 
   CompareOptions lte(CompareOperator::LESS_EQUAL);
   ValidateCompare<StringType>(lte, "[]", one, "[]");
   ValidateCompare<StringType>(lte, "[null]", one, "[null]");
-  ValidateCompare<StringType>(lte, "[\"zero\",\"zero\",\"one\",\"one\",\"two\",\"two\"]",
-                              one, "[0,0,1,1,0,0]");
-  ValidateCompare<StringType>(lte,
-                              "[\"zero\",\"one\",\"two\",\"three\",\"four\",\"five\"]",
-                              one, "[0,1,0,0,1,1]");
-  ValidateCompare<StringType>(lte,
-                              "[\"four\",\"five\",\"six\",\"seven\",\"eight\",\"nine\"]",
-                              one, "[1,1,0,0,1,1]");
-  ValidateCompare<StringType>(lte, "[null,\"zero\",\"one\",\"one\"]", one,
-                              "[null,0,1,1]");
+  ValidateCompare<StringType>(lte, R"(["zero","zero","one","one","two","two"])", one,
+                              "[0,0,1,1,0,0]");
+  ValidateCompare<StringType>(lte, R"(["zero","one","two","three","four","five"])", one,
+                              "[0,1,0,0,1,1]");
+  ValidateCompare<StringType>(lte, R"(["four","five","six","seven","eight","nine"])", one,
+                              "[1,1,0,0,1,1]");
+  ValidateCompare<StringType>(lte, R"([null,"zero","one","one"])", one, "[null,0,1,1]");
 }
 
 TEST_F(TestStringCompareKernel, RandomCompareArrayScalar) {
@@ -563,7 +569,7 @@ TEST_F(TestStringCompareKernel, RandomCompareArrayArray) {
   for (size_t i = 3; i < 5; i++) {
     for (auto null_probability : {0.0, 0.01, 0.1, 0.25, 0.5, 1.0}) {
       for (auto op : {EQUAL, NOT_EQUAL, GREATER, LESS_EQUAL}) {
-        const int64_t length = static_cast<int64_t>(1ULL << i);
+        auto length = static_cast<int64_t>(1ULL << i);
         auto lhs = Datum(rand.String(length << i, 0, 16, null_probability));
         auto rhs = Datum(rand.String(length << i, 0, 16, null_probability));
         auto options = CompareOptions(op);

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -455,15 +455,25 @@ TEST(TestCompareKernel, DispatchBest) {
   for (std::string name :
        {"equal", "not_equal", "less", "less_equal", "greater", "greater_equal"}) {
     CheckDispatchBest(name, {int32(), int32()}, {int32(), int32()});
+
+    CheckDispatchBest(name, {int32(), null()}, {int32(), int32()});
+
+    CheckDispatchBest(name, {null(), int32()}, {int32(), int32()});
+
     CheckDispatchBest(name, {int32(), int16()}, {int32(), int32()});
+
     CheckDispatchBest(name, {int32(), float32()}, {float32(), float32()});
+
     CheckDispatchBest(name, {float32(), int64()}, {float32(), float32()});
+
     CheckDispatchBest(name, {float64(), int32()}, {float64(), float64()});
 
     CheckDispatchBest(name, {dictionary(int8(), float64()), float64()},
                       {float64(), float64()});
+
     CheckDispatchBest(name, {dictionary(int8(), float64()), int16()},
                       {float64(), float64()});
+
     CheckDispatchBest(name, {dictionary(int8(), utf8()), utf8()}, {utf8(), utf8()});
   }
 }
@@ -481,6 +491,10 @@ TEST(TestCompareKernel, GreaterWithImplicitCasts) {
                     ArrayFromJSON(dictionary(int32(), int32()), "[0, 1, 2, null]"),
                     ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
                     ArrayFromJSON(boolean(), "[false, false, false, null]"));
+
+  CheckScalarBinary("greater", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
+                    std::make_shared<NullArray>(4),
+                    ArrayFromJSON(boolean(), "[null, null, null, null]"));
 
   // Not currently implemented since it would invoke a double implicit cast:
   // dictionary(int32, int8) -> int8 -> int32

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -511,12 +511,10 @@ TEST(TestCompareKernel, GreaterWithImplicitCasts) {
                     ArrayFromJSON(date64(), "[86400000, 0, 86400000]"),
                     ArrayFromJSON(boolean(), "[false, true, false]"));
 
-  // Not currently implemented since it would invoke a double implicit cast:
-  // dictionary(int32, int8) -> int8 -> int32
-  //  CheckScalarBinary("greater",
-  //                    ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2, null]"),
-  //                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
-  //                    ArrayFromJSON(boolean(), "[false, false, false, null]"));
+  CheckScalarBinary("greater",
+                    ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(boolean(), "[false, false, false, null]"));
 }
 
 class TestStringCompareKernel : public ::testing::Test {};

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -475,6 +475,12 @@ TEST(TestCompareKernel, DispatchBest) {
                       {float64(), float64()});
 
     CheckDispatchBest(name, {dictionary(int8(), utf8()), utf8()}, {utf8(), utf8()});
+
+    CheckDispatchBest(name, {timestamp(TimeUnit::MICRO), date64()},
+                      {timestamp(TimeUnit::MICRO), timestamp(TimeUnit::MICRO)});
+
+    CheckDispatchBest(name, {timestamp(TimeUnit::MILLI), timestamp(TimeUnit::MICRO)},
+                      {timestamp(TimeUnit::MICRO), timestamp(TimeUnit::MICRO)});
   }
 }
 
@@ -496,10 +502,16 @@ TEST(TestCompareKernel, GreaterWithImplicitCasts) {
                     std::make_shared<NullArray>(4),
                     ArrayFromJSON(boolean(), "[null, null, null, null]"));
 
+  CheckScalarBinary("greater",
+                    ArrayFromJSON(timestamp(TimeUnit::SECOND),
+                                  R"(["1970-01-01","2000-02-29","1900-02-28"])"),
+                    ArrayFromJSON(date64(), "[86400000, 0, 86400000]"),
+                    ArrayFromJSON(boolean(), "[false, true, false]"));
+
   // Not currently implemented since it would invoke a double implicit cast:
   // dictionary(int32, int8) -> int8 -> int32
-  //  CheckScalarBinary("greater", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2,
-  //  null]"),
+  //  CheckScalarBinary("greater",
+  //                    ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2, null]"),
   //                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
   //                    ArrayFromJSON(boolean(), "[false, false, false, null]"));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -468,6 +468,28 @@ TEST(TestCompareKernel, DispatchBest) {
   }
 }
 
+TEST(TestCompareKernel, GreaterWithImplicitCasts) {
+  CheckScalarBinary("greater", ArrayFromJSON(int32(), "[0, 1, 2, null]"),
+                    ArrayFromJSON(float64(), "[0.5, 1.0, 1.5, 2.0]"),
+                    ArrayFromJSON(boolean(), "[false, false, true, null]"));
+
+  CheckScalarBinary("greater", ArrayFromJSON(int8(), "[-16, 0, 16, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(boolean(), "[false, false, true, null]"));
+
+  CheckScalarBinary("greater",
+                    ArrayFromJSON(dictionary(int32(), int32()), "[0, 1, 2, null]"),
+                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+                    ArrayFromJSON(boolean(), "[false, false, false, null]"));
+
+  // Not currently implemented since it would invoke a double implicit cast:
+  // dictionary(int32, int8) -> int8 -> int32
+  //  CheckScalarBinary("greater", ArrayFromJSON(dictionary(int32(), int8()), "[0, 1, 2,
+  //  null]"),
+  //                    ArrayFromJSON(uint32(), "[3, 4, 5, 7]"),
+  //                    ArrayFromJSON(boolean(), "[false, false, false, null]"));
+}
+
 class TestStringCompareKernel : public ::testing::Test {};
 
 TEST_F(TestStringCompareKernel, SimpleCompareArrayScalar) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -481,6 +481,9 @@ TEST(TestCompareKernel, DispatchBest) {
 
     CheckDispatchBest(name, {timestamp(TimeUnit::MILLI), timestamp(TimeUnit::MICRO)},
                       {timestamp(TimeUnit::MICRO), timestamp(TimeUnit::MICRO)});
+
+    CheckDispatchBest(name, {utf8(), binary()}, {binary(), binary()});
+    CheckDispatchBest(name, {large_utf8(), binary()}, {large_binary(), large_binary()});
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -450,7 +450,8 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
   {
     ScalarKernel isin_base;
     isin_base.init = InitSetLookup;
-    isin_base.exec = TrivialScalarUnaryAsArraysExec(ExecIsIn);
+    isin_base.exec =
+        TrivialScalarUnaryAsArraysExec(ExecIsIn, NullHandling::OUTPUT_NOT_NULL);
     isin_base.null_handling = NullHandling::OUTPUT_NOT_NULL;
     auto is_in = std::make_shared<SetLookupFunction>("is_in", Arity::Unary(), &is_in_doc);
 
@@ -467,7 +468,8 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
   {
     ScalarKernel index_in_base;
     index_in_base.init = InitSetLookup;
-    index_in_base.exec = TrivialScalarUnaryAsArraysExec(ExecIndexIn);
+    index_in_base.exec = TrivialScalarUnaryAsArraysExec(
+        ExecIndexIn, NullHandling::COMPUTED_NO_PREALLOCATE);
     index_in_base.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
     index_in_base.mem_allocation = MemAllocation::NO_PREALLOCATE;
     auto index_in =

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -595,10 +595,10 @@ TEST(TestSetLookup, DispatchBest) {
 }
 
 TEST(TestSetLookup, IsInWithImplicitCasts) {
-  SetLookupOptions opts{ArrayFromJSON(utf8(), R"(["b", "d"])")};
+  SetLookupOptions opts{ArrayFromJSON(utf8(), R"(["b", null])")};
   CheckScalarUnary("is_in",
                    ArrayFromJSON(dictionary(int32(), utf8()), R"(["a", "b", "c", null])"),
-                   ArrayFromJSON(boolean(), "[0, 1, 0, null]"), &opts);
+                   ArrayFromJSON(boolean(), "[0, 1, 0, 1]"), &opts);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -85,6 +85,21 @@ TEST_F(TestIsInKernel, CallBinary) {
   AssertArraysEqual(*expected, *out.make_array());
 }
 
+TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
+  auto input = ArrayFromJSON(int8(), "[0, 1, 2, 3, 4, 5, 6, 7, 8]");
+
+  SetLookupOptions opts{ArrayFromJSON(int32(), "[2, 3, 5, 7]")};
+  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("is_in", {input}, &opts));
+
+  auto expected = ArrayFromJSON(boolean(), ("[false, false, true, true, false,"
+                                            "true, false, true, false]"));
+  AssertArraysEqual(*expected, *out.make_array());
+
+  // fails; value_set cannot be cast to int8
+  opts = SetLookupOptions{ArrayFromJSON(float32(), "[2.5, 3.1, 5.0]")};
+  ASSERT_RAISES(Invalid, CallFunction("is_in", {input}, &opts));
+}
+
 template <typename Type>
 class TestIsInKernelPrimitive : public ::testing::Test {};
 

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -587,5 +587,19 @@ TEST_F(TestIndexInKernel, ChunkedArrayInvoke) {
   CheckIndexInChunked(input, value_set, expected, /*skip_nulls=*/true);
 }
 
+TEST(TestSetLookup, DispatchBest) {
+  for (std::string name : {"is_in", "index_in"}) {
+    CheckDispatchBest(name, {int32()}, {int32()});
+    CheckDispatchBest(name, {dictionary(int32(), utf8())}, {utf8()});
+  }
+}
+
+TEST(TestSetLookup, IsInWithImplicitCasts) {
+  SetLookupOptions opts{ArrayFromJSON(utf8(), R"(["b", "d"])")};
+  CheckScalarUnary("is_in",
+                   ArrayFromJSON(dictionary(int32(), utf8()), R"(["a", "b", "c", null])"),
+                   ArrayFromJSON(boolean(), "[0, 1, 0, null]"), &opts);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -24,6 +24,8 @@
 #include "arrow/array.h"
 #include "arrow/chunked_array.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/function.h"
+#include "arrow/compute/registry.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/testing/gtest_util.h"
@@ -171,6 +173,36 @@ void CheckScalarBinary(std::string func_name, std::shared_ptr<Array> left_input,
                        std::shared_ptr<Array> right_input,
                        std::shared_ptr<Array> expected, const FunctionOptions* options) {
   CheckScalar(std::move(func_name), {left_input, right_input}, expected, options);
+}
+
+void CheckDispatchBest(std::string func_name, std::vector<ValueDescr> original_values,
+                       std::vector<ValueDescr> expected_equivalent_values) {
+  ASSERT_OK_AND_ASSIGN(auto function, GetFunctionRegistry()->GetFunction(func_name));
+
+  auto values = original_values;
+  ASSERT_OK_AND_ASSIGN(auto actual_kernel, function->DispatchBest(&values));
+
+  ASSERT_OK_AND_ASSIGN(auto expected_kernel,
+                       function->DispatchExact(expected_equivalent_values));
+
+  auto Format = [](const std::vector<ValueDescr>& descrs) {
+    std::stringstream ss;
+    ss << "(";
+    for (size_t i = 0; i < descrs.size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      ss << descrs[i].ToString();
+    }
+    ss << ")";
+    return ss.str();
+  };
+
+  EXPECT_EQ(actual_kernel, expected_kernel)
+      << "DispatchBest" << Format(original_values) << " => "
+      << actual_kernel->signature->ToString() << "\n"
+      << "DispatchExact" << Format(expected_equivalent_values) << " => "
+      << expected_kernel->signature->ToString();
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -185,23 +185,10 @@ void CheckDispatchBest(std::string func_name, std::vector<ValueDescr> original_v
   ASSERT_OK_AND_ASSIGN(auto expected_kernel,
                        function->DispatchExact(expected_equivalent_values));
 
-  auto Format = [](const std::vector<ValueDescr>& descrs) {
-    std::stringstream ss;
-    ss << "(";
-    for (size_t i = 0; i < descrs.size(); ++i) {
-      if (i > 0) {
-        ss << ", ";
-      }
-      ss << descrs[i].ToString();
-    }
-    ss << ")";
-    return ss.str();
-  };
-
   EXPECT_EQ(actual_kernel, expected_kernel)
-      << "DispatchBest" << Format(original_values) << " => "
+      << "DispatchBest" << ValueDescr::ToString(original_values) << " => "
       << actual_kernel->signature->ToString() << "\n"
-      << "DispatchExact" << Format(expected_equivalent_values) << " => "
+      << "DispatchExact" << ValueDescr::ToString(expected_equivalent_values) << " => "
       << expected_kernel->signature->ToString();
 }
 

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -186,9 +186,9 @@ void CheckDispatchBest(std::string func_name, std::vector<ValueDescr> original_v
                        function->DispatchExact(expected_equivalent_values));
 
   EXPECT_EQ(actual_kernel, expected_kernel)
-      << "DispatchBest" << ValueDescr::ToString(original_values) << " => "
+      << "  DispatchBest" << ValueDescr::ToString(original_values) << " => "
       << actual_kernel->signature->ToString() << "\n"
-      << "DispatchExact" << ValueDescr::ToString(expected_equivalent_values) << " => "
+      << "  DispatchExact" << ValueDescr::ToString(expected_equivalent_values) << " => "
       << expected_kernel->signature->ToString();
 }
 

--- a/cpp/src/arrow/compute/kernels/test_util.h
+++ b/cpp/src/arrow/compute/kernels/test_util.h
@@ -143,5 +143,10 @@ void TestRandomPrimitiveCTypes() {
   DoTestFunctor<DurationType>::Test(duration(TimeUnit::MILLI));
 }
 
+// Check that DispatchBest on a given function yields the same Kernel as
+// produced by DispatchExact on another set of ValueDescrs.
+void CheckDispatchBest(std::string func_name, std::vector<ValueDescr> descrs,
+                       std::vector<ValueDescr> exact_descrs);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -57,13 +57,14 @@ PrimitiveArg GetPrimitiveArg(const ArrayData& arr) {
   return arg;
 }
 
-ArrayKernelExec TrivialScalarUnaryAsArraysExec(ArrayKernelExec exec) {
-  return [exec](KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+ArrayKernelExec TrivialScalarUnaryAsArraysExec(ArrayKernelExec exec,
+                                               NullHandling::type null_handling) {
+  return [=](KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     if (out->is_array()) {
       return exec(ctx, batch, out);
     }
 
-    if (!batch[0].scalar()->is_valid) {
+    if (null_handling == NullHandling::INTERSECTION && !batch[0].scalar()->is_valid) {
       out->scalar()->is_valid = false;
       return;
     }

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -59,7 +59,8 @@ PrimitiveArg GetPrimitiveArg(const ArrayData& arr);
 // the original exec, then the only element of the resulting array will be extracted as
 // the output scalar. This could be far more efficient, but instead of optimizing this
 // it'd be better to support scalar inputs "upstream" in original exec.
-ArrayKernelExec TrivialScalarUnaryAsArraysExec(ArrayKernelExec exec);
+ArrayKernelExec TrivialScalarUnaryAsArraysExec(
+    ArrayKernelExec exec, NullHandling::type null_handling = NullHandling::INTERSECTION);
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/dataset/expression.cc
+++ b/cpp/src/arrow/dataset/expression.cc
@@ -391,111 +391,78 @@ Result<std::unique_ptr<compute::KernelState>> InitKernelState(
   return std::move(kernel_state);
 }
 
-Status InsertImplicitCasts(Expression::Call* call);
+Status ImplicitCastFunctionOptions(Expression::Call* call) {
+  if (auto options = GetSetLookupOptions(*call)) {
+    if (options->value_set.type()->Equals(call->arguments[0].type())) {
+      return Status::OK();
+    }
+
+    // The value_set is assumed smaller than inputs, casting it should be cheaper.
+    auto new_options = std::make_shared<compute::SetLookupOptions>(*options);
+    ARROW_ASSIGN_OR_RAISE(
+        new_options->value_set,
+        compute::Cast(std::move(new_options->value_set), call->arguments[0].type()));
+    options = new_options.get();
+    call->options = std::move(new_options);
+    return Status::OK();
+  }
+
+  return Status::OK();
+}
 
 // Produce a bound Expression from unbound Call and bound arguments.
-Result<Expression> BindNonRecursive(const Expression::Call& call,
-                                    std::vector<Expression> arguments,
-                                    bool insert_implicit_casts,
+Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_casts,
                                     compute::ExecContext* exec_context) {
-  DCHECK(std::all_of(arguments.begin(), arguments.end(),
+  DCHECK(std::all_of(call.arguments.begin(), call.arguments.end(),
                      [](const Expression& argument) { return argument.IsBound(); }));
 
-  auto bound_call = call;
-  bound_call.arguments = std::move(arguments);
+  auto descrs = GetDescriptors(call.arguments);
+  ARROW_ASSIGN_OR_RAISE(call.function, GetFunction(call, exec_context));
 
-  if (insert_implicit_casts) {
-    RETURN_NOT_OK(InsertImplicitCasts(&bound_call));
+  if (!insert_implicit_casts) {
+    ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchExact(descrs));
+  } else {
+    ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchBest(&descrs));
+
+    for (size_t i = 0; i < descrs.size(); ++i) {
+      if (descrs[i] == call.arguments[i].descr()) continue;
+
+      if (descrs[i].shape != call.arguments[i].descr().shape) {
+        return Status::NotImplemented(
+            "Automatic broadcasting of scalars arguments to arrays in ",
+            Expression(std::move(call)).ToString());
+      }
+
+      if (auto lit = call.arguments[i].literal()) {
+        ARROW_ASSIGN_OR_RAISE(Datum new_lit, compute::Cast(*lit, descrs[i].type));
+        call.arguments[i] = literal(std::move(new_lit));
+        continue;
+      }
+
+      // construct an implicit cast Expression with which to replace this argument
+      Expression::Call implicit_cast;
+      implicit_cast.function_name = "cast";
+      implicit_cast.arguments = {std::move(call.arguments[i])};
+      implicit_cast.options = std::make_shared<compute::CastOptions>(
+          compute::CastOptions::Safe(descrs[i].type));
+
+      ARROW_ASSIGN_OR_RAISE(
+          call.arguments[i],
+          BindNonRecursive(std::move(implicit_cast),
+                           /*insert_implicit_casts=*/false, exec_context));
+    }
+
+    RETURN_NOT_OK(ImplicitCastFunctionOptions(&call));
   }
-
-  ARROW_ASSIGN_OR_RAISE(bound_call.function, GetFunction(bound_call, exec_context));
-
-  auto descrs = GetDescriptors(bound_call.arguments);
-  ARROW_ASSIGN_OR_RAISE(bound_call.kernel, bound_call.function->DispatchExact(descrs));
 
   compute::KernelContext kernel_context(exec_context);
-  ARROW_ASSIGN_OR_RAISE(bound_call.kernel_state,
-                        InitKernelState(bound_call, exec_context));
-  kernel_context.SetState(bound_call.kernel_state.get());
+  ARROW_ASSIGN_OR_RAISE(call.kernel_state, InitKernelState(call, exec_context));
+  kernel_context.SetState(call.kernel_state.get());
 
   ARROW_ASSIGN_OR_RAISE(
-      bound_call.descr,
-      bound_call.kernel->signature->out_type().Resolve(&kernel_context, descrs));
+      call.descr, call.kernel->signature->out_type().Resolve(&kernel_context, descrs));
 
-  return Expression(std::move(bound_call));
-}
-
-Status MaybeInsertCast(std::shared_ptr<DataType> to_type, Expression* expr) {
-  if (expr->type()->Equals(to_type)) {
-    return Status::OK();
-  }
-
-  if (auto lit = expr->literal()) {
-    ARROW_ASSIGN_OR_RAISE(Datum new_lit, compute::Cast(*lit, to_type));
-    *expr = literal(std::move(new_lit));
-    return Status::OK();
-  }
-
-  Expression::Call with_cast;
-  with_cast.function_name = "cast";
-  with_cast.options = std::make_shared<compute::CastOptions>(
-      compute::CastOptions::Safe(std::move(to_type)));
-
-  compute::ExecContext exec_context;
-  ARROW_ASSIGN_OR_RAISE(*expr,
-                        BindNonRecursive(with_cast, {std::move(*expr)},
-                                         /*insert_implicit_casts=*/false, &exec_context));
-  return Status::OK();
-}
-
-Status InsertImplicitCasts(Expression::Call* call) {
-  DCHECK(std::all_of(call->arguments.begin(), call->arguments.end(),
-                     [](const Expression& argument) { return argument.IsBound(); }));
-
-  if (IsSameTypesBinary(call->function_name)) {
-    for (auto&& argument : call->arguments) {
-      if (auto value_type = GetDictionaryValueType(argument.type())) {
-        RETURN_NOT_OK(MaybeInsertCast(std::move(value_type), &argument));
-      }
-    }
-
-    if (call->arguments[0].descr().shape == ValueDescr::SCALAR) {
-      // argument 0 is scalar so casting is cheap
-      return MaybeInsertCast(call->arguments[1].type(), &call->arguments[0]);
-    }
-
-    // cast argument 1 unconditionally
-    return MaybeInsertCast(call->arguments[0].type(), &call->arguments[1]);
-  }
-
-  if (auto options = GetSetLookupOptions(*call)) {
-    if (auto value_type = GetDictionaryValueType(call->arguments[0].type())) {
-      // DICTIONARY input is not supported; decode it.
-      RETURN_NOT_OK(MaybeInsertCast(std::move(value_type), &call->arguments[0]));
-    }
-
-    if (options->value_set.type()->id() == Type::DICTIONARY) {
-      // DICTIONARY value_set is not supported; decode it.
-      auto new_options = std::make_shared<compute::SetLookupOptions>(*options);
-      RETURN_NOT_OK(EnsureNotDictionary(&new_options->value_set));
-      options = new_options.get();
-      call->options = std::move(new_options);
-    }
-
-    if (!options->value_set.type()->Equals(call->arguments[0].type())) {
-      // The value_set is assumed smaller than inputs, casting it should be cheaper.
-      auto new_options = std::make_shared<compute::SetLookupOptions>(*options);
-      ARROW_ASSIGN_OR_RAISE(
-          new_options->value_set,
-          compute::Cast(std::move(new_options->value_set), call->arguments[0].type()));
-      options = new_options.get();
-      call->options = std::move(new_options);
-    }
-
-    return Status::OK();
-  }
-
-  return Status::OK();
+  return Expression(std::move(call));
 }
 
 struct FieldPathGetDatumImpl {
@@ -554,14 +521,11 @@ Result<Expression> Expression::Bind(ValueDescr in,
     return Expression{Parameter{*ref, std::move(descr)}};
   }
 
-  auto call = CallNotNull(*this);
-
-  std::vector<Expression> bound_arguments(call->arguments.size());
-  for (size_t i = 0; i < bound_arguments.size(); ++i) {
-    ARROW_ASSIGN_OR_RAISE(bound_arguments[i], call->arguments[i].Bind(in, exec_context));
+  auto call = *CallNotNull(*this);
+  for (auto& argument : call.arguments) {
+    ARROW_ASSIGN_OR_RAISE(argument, argument.Bind(in, exec_context));
   }
-
-  return BindNonRecursive(*call, std::move(bound_arguments),
+  return BindNonRecursive(std::move(call),
                           /*insert_implicit_casts=*/true, exec_context);
 }
 
@@ -899,7 +863,7 @@ Result<Expression> Canonicalize(Expression expr, compute::ExecContext* exec_cont
             flipped_call.function_name =
                 Comparison::GetName(Comparison::GetFlipped(*cmp));
 
-            return BindNonRecursive(flipped_call, std::move(flipped_call.arguments),
+            return BindNonRecursive(flipped_call,
                                     /*insert_implicit_casts=*/false, exec_context);
           }
         }
@@ -925,7 +889,10 @@ Result<Expression> DirectComparisonSimplification(Expression expr,
 
         if (!cmp) return expr;
         if (!cmp_guarantee) return expr;
-        if (call->arguments[0] != guarantee.arguments[0]) return expr;
+
+        const auto& lhs = Comparison::StripOrderPreservingCasts(call->arguments[0]);
+        const auto& guarantee_lhs = guarantee.arguments[0];
+        if (lhs != guarantee_lhs) return expr;
 
         auto rhs = call->arguments[1].literal();
         auto guarantee_rhs = guarantee.arguments[1].literal();

--- a/cpp/src/arrow/dataset/expression.h
+++ b/cpp/src/arrow/dataset/expression.h
@@ -104,6 +104,7 @@ class ARROW_DS_EXPORT Expression {
 
   /// The type and shape to which this expression will evaluate
   ValueDescr descr() const;
+  std::shared_ptr<DataType> type() const { return descr().type; }
   // XXX someday
   // NullGeneralization::type nullable() const;
 

--- a/cpp/src/arrow/dataset/expression.h
+++ b/cpp/src/arrow/dataset/expression.h
@@ -50,8 +50,8 @@ class ARROW_DS_EXPORT Expression {
     std::shared_ptr<std::atomic<size_t>> hash;
 
     // post-Bind properties:
-    const compute::Kernel* kernel = NULLPTR;
     std::shared_ptr<compute::Function> function;
+    const compute::Kernel* kernel = NULLPTR;
     std::shared_ptr<compute::KernelState> kernel_state;
     ValueDescr descr;
   };

--- a/cpp/src/arrow/dataset/expression_internal.h
+++ b/cpp/src/arrow/dataset/expression_internal.h
@@ -86,14 +86,10 @@ struct Comparison {
     return nullptr;
   }
 
-  // Execute a simple Comparison between scalars, casting the RHS if types disagree
+  // Execute a simple Comparison between scalars
   static Result<type> Execute(Datum l, Datum r) {
     if (!l.is_scalar() || !r.is_scalar()) {
       return Status::Invalid("Cannot Execute Comparison on non-scalars");
-    }
-
-    if (!l.type()->Equals(r.type())) {
-      ARROW_ASSIGN_OR_RAISE(r, compute::Cast(r, l.type()));
     }
 
     std::vector<Datum> arguments{std::move(l), std::move(r)};

--- a/cpp/src/arrow/dataset/expression_internal.h
+++ b/cpp/src/arrow/dataset/expression_internal.h
@@ -105,6 +105,10 @@ struct Comparison {
     return less.scalar_as<BooleanScalar>().value ? LESS : GREATER;
   }
 
+  // Given an Expression wrapped in casts which preserve ordering
+  // (for example, cast(field_ref("i16"), to_type=int32())), unwrap the inner Expression.
+  // This is used to destructure implicitly cast field_refs during Expression
+  // simplification.
   static const Expression& StripOrderPreservingCasts(const Expression& expr) {
     auto call = expr.call();
     if (!call) return expr;

--- a/cpp/src/arrow/dataset/expression_internal.h
+++ b/cpp/src/arrow/dataset/expression_internal.h
@@ -214,26 +214,10 @@ inline std::shared_ptr<DataType> GetDictionaryValueType(
   return nullptr;
 }
 
-inline Status EnsureNotDictionary(ValueDescr* descr) {
-  if (auto value_type = GetDictionaryValueType(descr->type)) {
-    descr->type = std::move(value_type);
-  }
-  return Status::OK();
-}
-
 inline Status EnsureNotDictionary(Datum* datum) {
   if (datum->type()->id() == Type::DICTIONARY) {
     const auto& type = checked_cast<const DictionaryType&>(*datum->type()).value_type();
     ARROW_ASSIGN_OR_RAISE(*datum, compute::Cast(*datum, type));
-  }
-  return Status::OK();
-}
-
-inline Status EnsureNotDictionary(Expression::Call* call) {
-  if (auto options = GetSetLookupOptions(*call)) {
-    auto new_options = *options;
-    RETURN_NOT_OK(EnsureNotDictionary(&new_options.value_set));
-    call->options.reset(new compute::SetLookupOptions(std::move(new_options)));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/dataset/expression_test.cc
+++ b/cpp/src/arrow/dataset/expression_test.cc
@@ -128,6 +128,11 @@ TEST(ExpressionUtils, StripOrderPreservingCasts) {
   Expect(cast(field_ref("u32"), uint16()), no_change);
   Expect(cast(field_ref("u32"), uint8()), no_change);
 
+  Expect(cast(field_ref("u32"), int64()), field_ref("u32"));
+  Expect(cast(field_ref("u32"), int32()), field_ref("u32"));
+  Expect(cast(field_ref("u32"), int16()), no_change);
+  Expect(cast(field_ref("u32"), int8()), no_change);
+
   // Casting float to int can affect ordering.
   // For example, let
   //   a = 3.5, b = 3.0, assert(a > b)
@@ -411,7 +416,7 @@ TEST(Expression, BindWithImplicitCasts) {
                   cmp(cast(field_ref("i32"), int64()), field_ref("i64")));
 
     ExpectBindsTo(cmp(field_ref("i8"), field_ref("u32")),
-                  cmp(cast(field_ref("i8"), int32()), cast(field_ref("u32"), int32())));
+                  cmp(cast(field_ref("i8"), int64()), cast(field_ref("u32"), int64())));
 
     // cast dictionary to value type
     ExpectBindsTo(cmp(field_ref("dict_str"), field_ref("str")),

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -50,14 +50,16 @@ namespace arrow {
 namespace dataset {
 
 const std::shared_ptr<Schema> kBoringSchema = schema({
+    field("bool", boolean()),
+    field("i8", int8()),
     field("i32", int32()),
     field("i32_req", int32(), /*nullable=*/false),
+    field("u32", uint32()),
     field("i64", int64()),
-    field("date64", date64()),
     field("f32", float32()),
     field("f32_req", float32(), /*nullable=*/false),
     field("f64", float64()),
-    field("bool", boolean()),
+    field("date64", date64()),
     field("str", utf8()),
     field("dict_str", dictionary(int32(), utf8())),
     field("ts_ns", timestamp(TimeUnit::NANO)),

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -62,6 +62,7 @@ const std::shared_ptr<Schema> kBoringSchema = schema({
     field("date64", date64()),
     field("str", utf8()),
     field("dict_str", dictionary(int32(), utf8())),
+    field("dict_i32", dictionary(int32(), int32())),
     field("ts_ns", timestamp(TimeUnit::NANO)),
 });
 

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -211,6 +211,19 @@ static std::string FormatValueDescr(const ValueDescr& descr) {
 
 std::string ValueDescr::ToString() const { return FormatValueDescr(*this); }
 
+std::string ValueDescr::ToString(const std::vector<ValueDescr>& descrs) {
+  std::stringstream ss;
+  ss << "(";
+  for (size_t i = 0; i < descrs.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << descrs[i].ToString();
+  }
+  ss << ")";
+  return ss.str();
+}
+
 void PrintTo(const ValueDescr& descr, std::ostream* os) { *os << descr.ToString(); }
 
 std::string Datum::ToString() const {

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -89,6 +89,7 @@ struct ARROW_EXPORT ValueDescr {
   bool operator!=(const ValueDescr& other) const { return !(*this == other); }
 
   std::string ToString() const;
+  static std::string ToString(const std::vector<ValueDescr>&);
 
   ARROW_EXPORT friend void PrintTo(const ValueDescr&, std::ostream*);
 };

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -317,6 +317,7 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
     return ValueUnsafe();
   }
   const T& operator*() const& { return ValueOrDie(); }
+  const T* operator->() const& { return &ValueOrDie(); }
 
   /// Gets a mutable reference to the stored `T` value.
   ///
@@ -331,6 +332,7 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
     return ValueUnsafe();
   }
   T& operator*() & { return ValueOrDie(); }
+  T* operator->() & { return &ValueOrDie(); }
 
   /// Moves and returns the internally-stored `T` value.
   ///
@@ -453,9 +455,9 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
   }
 };
 
-#define ARROW_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr) \
-  auto&& result_name = (rexpr);                             \
-  ARROW_RETURN_NOT_OK((result_name).status());              \
+#define ARROW_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr)                              \
+  auto&& result_name = (rexpr);                                                          \
+  ARROW_RETURN_IF_(!(result_name).ok(), (result_name).status(), ARROW_STRINGIFY(rexpr)); \
   lhs = std::move(result_name).ValueUnsafe();
 
 #define ARROW_ASSIGN_OR_RAISE_NAME(x, y) ARROW_CONCAT(x, y)

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -268,6 +268,13 @@ Result<std::shared_ptr<Scalar>> DictionaryScalar::GetEncodedValue() const {
   return value.dictionary->GetScalar(index_value);
 }
 
+std::shared_ptr<DictionaryScalar> DictionaryScalar::Make(std::shared_ptr<Scalar> index,
+                                                         std::shared_ptr<Array> dict) {
+  auto type = dictionary(index->type, dict->type());
+  return std::make_shared<DictionaryScalar>(ValueType{std::move(index), std::move(dict)},
+                                            std::move(type));
+}
+
 template <typename T>
 using scalar_constructor_has_arrow_type =
     std::is_constructible<typename TypeTraits<T>::ScalarType, std::shared_ptr<DataType>>;

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -448,6 +448,9 @@ struct ARROW_EXPORT DictionaryScalar : public Scalar {
   DictionaryScalar(ValueType value, std::shared_ptr<DataType> type, bool is_valid = true)
       : Scalar(std::move(type), is_valid), value(std::move(value)) {}
 
+  static std::shared_ptr<DictionaryScalar> Make(std::shared_ptr<Scalar> index,
+                                                std::shared_ptr<Array> dict);
+
   Result<std::shared_ptr<Scalar>> GetEncodedValue() const;
 };
 

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -132,7 +132,7 @@ void Status::Abort(const std::string& message) const {
 void Status::AddContextLine(const char* filename, int line, const char* expr) {
   ARROW_CHECK(!ok()) << "Cannot add context line to ok status";
   std::stringstream ss;
-  ss << "\nIn " << filename << ", line " << line << ", code: " << expr;
+  ss << "\n" << filename << ":" << line << "  " << expr;
   state_->msg += ss.str();
 }
 #endif

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -963,6 +963,12 @@ static inline int bit_width(Type::type type_id) {
       return 32;
     case Type::INTERVAL_DAY_TIME:
       return 64;
+
+    case Type::DECIMAL128:
+      return 128;
+    case Type::DECIMAL256:
+      return 256;
+
     default:
       break;
   }

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -929,6 +929,46 @@ static inline bool is_fixed_width(Type::type type_id) {
   return is_primitive(type_id) || is_dictionary(type_id) || is_fixed_size_binary(type_id);
 }
 
+static inline int bit_width(Type::type type_id) {
+  switch (type_id) {
+    case Type::BOOL:
+      return 1;
+    case Type::UINT8:
+    case Type::INT8:
+      return 8;
+    case Type::UINT16:
+    case Type::INT16:
+      return 16;
+    case Type::UINT32:
+    case Type::INT32:
+    case Type::DATE32:
+    case Type::TIME32:
+      return 32;
+    case Type::UINT64:
+    case Type::INT64:
+    case Type::DATE64:
+    case Type::TIME64:
+    case Type::TIMESTAMP:
+    case Type::DURATION:
+      return 64;
+
+    case Type::HALF_FLOAT:
+      return 16;
+    case Type::FLOAT:
+      return 32;
+    case Type::DOUBLE:
+      return 64;
+
+    case Type::INTERVAL_MONTHS:
+      return 32;
+    case Type::INTERVAL_DAY_TIME:
+      return 64;
+    default:
+      break;
+  }
+  return 0;
+}
+
 static inline bool is_nested(Type::type type_id) {
   switch (type_id) {
     case Type::LIST:

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -766,6 +766,8 @@ is signed, and its width is the maximum width of any input. For example:
 +===================+======================+===========================================+
 | int32, int32      | int32                |                                           |
 +-------------------+----------------------+-------------------------------------------+
+| uint32, int32     | int32                | One input signed, override unsigned       |
++-------------------+----------------------+-------------------------------------------+
 | int16, int32      | int32                | Max width is 32, promote LHS to int32     |
 +-------------------+----------------------+-------------------------------------------+
 | uint16, uint32    | uint32               | All inputs unsigned, maintain unsigned    |
@@ -780,3 +782,8 @@ is signed, and its width is the maximum width of any input. For example:
 +-------------------+----------------------+-------------------------------------------+
 | float32, int64    | float32              | int64 is wider, still promotes to float32 |
 +-------------------+----------------------+-------------------------------------------+
+
+In particulary, note that comparing a `uint32` column to an `int32` column may
+emit an error if one of the LHS' values cannot be expressed as the common type
+`int32` (for example, `2 ** 31`). This tradeoff is made to keep the results of
+arithmetic operations narrow.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -143,7 +143,7 @@ is signed. For example:
 +-------------------+----------------------+------------------------------------------------+
 | int16, uint32     | int64                |                                                |
 +-------------------+----------------------+------------------------------------------------+
-| uint64, int16     | int64                | NB: int64 cannot accommodate all uint64 values |
+| uint64, int16     | int64                | int64 cannot accommodate all uint64 values     |
 +-------------------+----------------------+------------------------------------------------+
 | float32, int32    | float32              | Promote RHS to float32                         |
 +-------------------+----------------------+------------------------------------------------+
@@ -152,9 +152,9 @@ is signed. For example:
 | float32, int64    | float32              | int64 is wider, still promotes to float32      |
 +-------------------+----------------------+------------------------------------------------+
 
-In particulary, note that comparing a `uint64` column to an `int16` column may
-emit an error if one of the LHS' values cannot be expressed as the common type
-`int64` (for example, `2 ** 63`).
+In particulary, note that comparing a ``uint64`` column to an ``int16`` column
+may emit an error if one of the ``uint64`` values cannot be expressed as the
+common type ``int64`` (for example, ``2 ** 63``).
 
 .. _compute-function-list:
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -191,6 +191,11 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
         ['string', string_keys],
         ['boolean', boolean_keys]
     ]
+    schema = pa.schema({
+        'integer': pa.int32(),
+        'string': pa.string(),
+        'boolean', pa.boolean()
+    })
 
     df = pd.DataFrame({
         'integer': np.array(integer_keys, dtype='i4').repeat(15),
@@ -204,7 +209,7 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
     # Old filters syntax:
     #  integer == 1 AND string != b AND boolean == True
     dataset = pq.ParquetDataset(
-        base_path, filesystem=fs,
+        base_path, filesystem=fs, schema=schema,
         filters=[('integer', '=', 1), ('string', '!=', 'b'),
                  ('boolean', '==', True)],
         use_legacy_dataset=use_legacy_dataset,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -191,11 +191,6 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
         ['string', string_keys],
         ['boolean', boolean_keys]
     ]
-    schema = pa.schema({
-        'integer': pa.int32(),
-        'string': pa.string(),
-        'boolean', pa.boolean()
-    })
 
     df = pd.DataFrame({
         'integer': np.array(integer_keys, dtype='i4').repeat(15),
@@ -209,9 +204,9 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
     # Old filters syntax:
     #  integer == 1 AND string != b AND boolean == True
     dataset = pq.ParquetDataset(
-        base_path, filesystem=fs, schema=schema,
+        base_path, filesystem=fs,
         filters=[('integer', '=', 1), ('string', '!=', 'b'),
-                 ('boolean', '==', True)],
+                 ('boolean', '==', 'True')],
         use_legacy_dataset=use_legacy_dataset,
     )
     table = dataset.read()

--- a/r/R/array.R
+++ b/r/R/array.R
@@ -62,6 +62,7 @@
 #' - `$type_id()`: type id
 #' - `$Equals(other)` : is this array equal to `other`
 #' - `$ApproxEquals(other)` :
+#' - `$Diff(other)` : return a string expressing the difference between two arrays
 #' - `$data()`: return the underlying [ArrayData][ArrayData]
 #' - `$as_vector()`: convert to an R vector
 #' - `$ToString()`: string representation of the array
@@ -94,6 +95,12 @@ Array <- R6Class("Array",
     },
     ApproxEquals = function(other) {
       inherits(other, "Array") && Array__ApproxEquals(self, other)
+    },
+    Diff = function(other) {
+      if (!inherits(other, "Array")) {
+        other <- Array$create(other)
+      }
+      Array__Diff(self, other)
     },
     data = function() Array__data(self),
     as_vector = function() Array__as_vector(self),

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -48,6 +48,10 @@ Array__ApproxEquals <- function(lhs, rhs){
     .Call(`_arrow_Array__ApproxEquals`, lhs, rhs)
 }
 
+Array__Diff <- function(lhs, rhs){
+    .Call(`_arrow_Array__Diff`, lhs, rhs)
+}
+
 Array__data <- function(array){
     .Call(`_arrow_Array__data`, array)
 }

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -144,16 +144,6 @@ eval_array_expression <- function(x) {
       a
     }
   })
-  if (length(x$args) == 2L) {
-    # Insert implicit casts
-    if (inherits(x$args[[1]], "Scalar")) {
-      x$args[[1]] <- x$args[[1]]$cast(x$args[[2]]$type)
-    } else if (inherits(x$args[[2]], "Scalar")) {
-      x$args[[2]] <- x$args[[2]]$cast(x$args[[1]]$type)
-    } else if (x$fun == "is_in_meta_binary" && inherits(x$args[[2]], "Array")) {
-      x$args[[2]] <- x$args[[2]]$cast(x$args[[1]]$type)
-    }
-  }
   call_function(x$fun, args = x$args, options = x$options %||% empty_named_list())
 }
 

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -97,6 +97,7 @@ cast_array_expression <- function(x, to_type, safe = TRUE, ...) {
 .wrap_arrow <- function(arg, fun) {
   if (!inherits(arg, c("ArrowObject", "array_expression"))) {
     # TODO: Array$create if lengths are equal?
+    # TODO: these kernels should autocast like the dataset ones do (e.g. int vs. float)
     if (fun == "%in%") {
       arg <- Array$create(arg)
     } else {

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -97,7 +97,6 @@ cast_array_expression <- function(x, to_type, safe = TRUE, ...) {
 .wrap_arrow <- function(arg, fun) {
   if (!inherits(arg, c("ArrowObject", "array_expression"))) {
     # TODO: Array$create if lengths are equal?
-    # TODO: these kernels should autocast like the dataset ones do (e.g. int vs. float)
     if (fun == "%in%") {
       arg <- Array$create(arg)
     } else {

--- a/r/man/array.Rd
+++ b/r/man/array.Rd
@@ -60,6 +60,7 @@ a == a
 \item \verb{$type_id()}: type id
 \item \verb{$Equals(other)} : is this array equal to \code{other}
 \item \verb{$ApproxEquals(other)} :
+\item \verb{$Diff(other)} : return a string expressing the difference between two arrays
 \item \verb{$data()}: return the underlying \link{ArrayData}
 \item \verb{$as_vector()}: convert to an R vector
 \item \verb{$ToString()}: string representation of the array

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -142,6 +142,12 @@ bool Array__ApproxEquals(const std::shared_ptr<arrow::Array>& lhs,
 }
 
 // [[arrow::export]]
+std::string Array__Diff(const std::shared_ptr<arrow::Array>& lhs,
+                        const std::shared_ptr<arrow::Array>& rhs) {
+  return lhs->Diff(*rhs);
+}
+
+// [[arrow::export]]
 std::shared_ptr<arrow::ArrayData> Array__data(
     const std::shared_ptr<arrow::Array>& array) {
   return array->data();

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -108,6 +108,15 @@ BEGIN_CPP11
 END_CPP11
 }
 // array.cpp
+std::string Array__Diff(const std::shared_ptr<arrow::Array>& lhs, const std::shared_ptr<arrow::Array>& rhs);
+extern "C" SEXP _arrow_Array__Diff(SEXP lhs_sexp, SEXP rhs_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type lhs(lhs_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type rhs(rhs_sexp);
+	return cpp11::as_sexp(Array__Diff(lhs, rhs));
+END_CPP11
+}
+// array.cpp
 std::shared_ptr<arrow::ArrayData> Array__data(const std::shared_ptr<arrow::Array>& array);
 extern "C" SEXP _arrow_Array__data(SEXP array_sexp){
 BEGIN_CPP11
@@ -3512,6 +3521,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Array__type_id", (DL_FUNC) &_arrow_Array__type_id, 1}, 
 		{ "_arrow_Array__Equals", (DL_FUNC) &_arrow_Array__Equals, 2}, 
 		{ "_arrow_Array__ApproxEquals", (DL_FUNC) &_arrow_Array__ApproxEquals, 2}, 
+		{ "_arrow_Array__Diff", (DL_FUNC) &_arrow_Array__Diff, 2}, 
 		{ "_arrow_Array__data", (DL_FUNC) &_arrow_Array__data, 1}, 
 		{ "_arrow_Array__RangeEquals", (DL_FUNC) &_arrow_Array__RangeEquals, 5}, 
 		{ "_arrow_Array__View", (DL_FUNC) &_arrow_Array__View, 2}, 

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -18,32 +18,31 @@
 test_that("Addition", {
   a <- Array$create(c(1:4, NA_integer_))
   expect_type_equal(a, int32())
-  expect_type_equal(a + 4, int32())
-  expect_equal(a + 4, Array$create(c(5:8, NA_integer_)))
-  expect_identical(as.vector(a + 4), c(5:8, NA_integer_))
+  expect_type_equal(a + 4L, int32())
+  expect_type_equal(a + 4, float64())
+  expect_equal(a + 4L, Array$create(c(5:8, NA_integer_)))
+  expect_identical(as.vector(a + 4L), c(5:8, NA_integer_))
   expect_equal(a + 4L, Array$create(c(5:8, NA_integer_)))
   expect_vector(a + 4L, c(5:8, NA_integer_))
   expect_equal(a + NA_integer_, Array$create(rep(NA_integer_, 5)))
 
-  # overflow errors — this is slightly different from R's `NA` coercion when
-  # overflowing, but better than the alternative of silently restarting
-  casted <- a$cast(int8())
-  expect_error(casted + 127)
-  expect_error(casted + 200)
+  a8 <- a$cast(int8())
+  expect_type_equal(a8 + Scalar$create(1, int8()), int8())
+  expect_type_equal(a8 + 127L, int32())
+  expect_type_equal(a8 + 200L, int32())
 
-  skip("autocasting should happen in compute kernels; R workaround fails on this ARROW-8919")
   expect_type_equal(a + 4.1, float64())
   expect_equal(a + 4.1, Array$create(c(5.1, 6.1, 7.1, 8.1, NA_real_)))
 })
 
 test_that("Subtraction", {
   a <- Array$create(c(1:4, NA_integer_))
-  expect_equal(a - 3, Array$create(c(-2:1, NA_integer_)))
+  expect_equal(a - 3L, Array$create(c(-2:1, NA_integer_)))
 })
 
 test_that("Multiplication", {
   a <- Array$create(c(1:4, NA_integer_))
-  expect_equal(a * 2, Array$create(c(1:4 * 2L, NA_integer_)))
+  expect_equal(a * 2L, Array$create(c(1:4 * 2L, NA_integer_)))
 })
 
 test_that("Division", {

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -28,8 +28,14 @@ test_that("Addition", {
 
   a8 <- a$cast(int8())
   expect_type_equal(a8 + Scalar$create(1, int8()), int8())
+
+  # int8 will be promoted to int32 when added to int32
   expect_type_equal(a8 + 127L, int32())
-  expect_type_equal(a8 + 200L, int32())
+  expect_equal(a8 + 127L, Array$create(c(128:131, NA_integer_)))
+
+  b <- Array$create(c(4:1, NA_integer_))
+  expect_type_equal(a8 + b, int32())
+  expect_equal(a8 + b, Array$create(c(5L, 5L, 5L, 5L, NA_integer_)))
 
   expect_type_equal(a + 4.1, float64())
   expect_equal(a + 4.1, Array$create(c(5.1, 6.1, 7.1, 8.1, NA_real_)))
@@ -38,11 +44,17 @@ test_that("Addition", {
 test_that("Subtraction", {
   a <- Array$create(c(1:4, NA_integer_))
   expect_equal(a - 3L, Array$create(c(-2:1, NA_integer_)))
+
+  expect_equal(Array$create(c(5.1, 6.1, 7.1, 8.1, NA_real_)) - a,
+               Array$create(c(4.1, 4.1, 4.1, 4.1, NA_real_)))
 })
 
 test_that("Multiplication", {
   a <- Array$create(c(1:4, NA_integer_))
   expect_equal(a * 2L, Array$create(c(1:4 * 2L, NA_integer_)))
+
+  expect_equal((a * 0.5) * 3L,
+               Array$create(c(1.5, 3, 4.5, 6, NA_real_)))
 })
 
 test_that("Division", {

--- a/r/tests/testthat/test-compute-vector.R
+++ b/r/tests/testthat/test-compute-vector.R
@@ -43,6 +43,7 @@ test_that("compare ops with Array", {
   expect_array_compares(Array$create(c(NA, 1:5)), 4)
   expect_array_compares(Array$create(as.numeric(c(NA, 1:5))), 4)
   expect_array_compares(Array$create(c(NA, 1:5)), Array$create(rev(c(NA, 1:5))))
+  expect_array_compares(Array$create(c(NA, 1:5)), Array$create(rev(c(NA, 1:5)), type=double()))
 })
 
 test_that("compare ops with ChunkedArray", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -554,7 +554,7 @@ test_that("filter() on timestamp columns", {
   )
 
   # Now with bare string date
-  skip("Implement more aggressive implicit casting for scalars")
+  skip("Implement more aggressive implicit casting for scalars (ARROW-11402)")
   expect_equivalent(
     ds %>%
       filter(ts >= "2015-05-04") %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -554,6 +554,7 @@ test_that("filter() on timestamp columns", {
   )
 
   # Now with bare string date
+  skip("Implement more aggressive implicit casting for scalars")
   expect_equivalent(
     ds %>%
       filter(ts >= "2015-05-04") %>%
@@ -666,8 +667,6 @@ test_that("filter() with expressions", {
     )
   )
 
-  skip("Implicit casts aren't being inserted everywhere they need to be (ARROW-8919)")
-  # Error: NotImplemented: Function multiply_checked has no kernel matching input types (scalar[double], array[int32])
   expect_equivalent(
     ds %>%
       select(chr, dbl, int) %>%
@@ -680,8 +679,6 @@ test_that("filter() with expressions", {
     )
   )
 
-  skip("Implicit casts are only inserted for scalars (ARROW-8919)")
-  # Error: NotImplemented: Function add_checked has no kernel matching input types (array[double], array[int32])
   expect_equivalent(
     ds %>%
       select(chr, dbl, int) %>%
@@ -700,7 +697,7 @@ test_that("filter scalar validation doesn't crash (ARROW-7772)", {
     ds %>%
       filter(int == "fff", part == 1) %>%
       collect(),
-    "Failed to parse string: 'fff' as a scalar of type int32"
+    "equal has no kernel matching input types .array.int32., scalar.string.."
   )
 })
 


### PR DESCRIPTION
`Function::DispatchBest` looks up a kernel with approximate type match; it may indicate that casts are required before execution can proceed:

```c++
const Function* add = ...
Int64Array lhs = ...
FloatArray rhs = ...
std::vector<ValueDescr> descrs{lhs.type(), rhs.type()};
ARROW_ASSIGN_OR_RAISE(auto kernel, add->DispatchBest(&descrs));
assert(descrs[0].type->Equals(float32()) && "lhs must be cast to float32 before the arrays may be added");
```

CallFunction now uses DispatchBest and performs implicit casts if necessary, so any consumer of CallFunction inherits support for autocasting:

```python
import pyarrow as pa
import pyarrow.compute as pc
assert pc.add(pa.array([1]), pa.array([1.5])).equals(pa.array([2.5])) # cast lhs to float32
```

The DispatchBest API is also consumed by `dataset::Expression::Bind`, replacing the implicit cast special cases there.