### PR TITLE
ARROW-11355: [Rust] Aligned Date DataType with specification.

### DIFF
--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -160,10 +160,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| cast_array(&i64_array, DataType::Int32))
     });
     c.bench_function("cast date64 to date32 512", |b| {
-        b.iter(|| cast_array(&date64_array, DataType::Date32(DateUnit::Day)))
+        b.iter(|| cast_array(&date64_array, DataType::Date32))
     });
     c.bench_function("cast date32 to date64 512", |b| {
-        b.iter(|| cast_array(&date32_array, DataType::Date64(DateUnit::Millisecond)))
+        b.iter(|| cast_array(&date32_array, DataType::Date64))
     });
     c.bench_function("cast time32s to time32ms 512", |b| {
         b.iter(|| cast_array(&time32s_array, DataType::Time32(TimeUnit::Millisecond)))
@@ -204,15 +204,10 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| cast_array(&time_ms_array, DataType::Int64))
     });
     c.bench_function("cast utf8 to date32 512", |b| {
-        b.iter(|| cast_array(&utf8_date_array, DataType::Date32(DateUnit::Day)))
+        b.iter(|| cast_array(&utf8_date_array, DataType::Date32))
     });
     c.bench_function("cast utf8 to date64 512", |b| {
-        b.iter(|| {
-            cast_array(
-                &utf8_date_time_array,
-                DataType::Date64(DateUnit::Millisecond),
-            )
-        })
+        b.iter(|| cast_array(&utf8_date_time_array, DataType::Date64))
     });
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -230,10 +230,8 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::Float16 => panic!("Float16 datatype not supported"),
         DataType::Float32 => Arc::new(Float32Array::from(data)) as ArrayRef,
         DataType::Float64 => Arc::new(Float64Array::from(data)) as ArrayRef,
-        DataType::Date32(DateUnit::Day) => Arc::new(Date32Array::from(data)) as ArrayRef,
-        DataType::Date64(DateUnit::Millisecond) => {
-            Arc::new(Date64Array::from(data)) as ArrayRef
-        }
+        DataType::Date32 => Arc::new(Date32Array::from(data)) as ArrayRef,
+        DataType::Date64 => Arc::new(Date64Array::from(data)) as ArrayRef,
         DataType::Time32(TimeUnit::Second) => {
             Arc::new(Time32SecondArray::from(data)) as ArrayRef
         }

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -137,11 +137,11 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
 
 fn as_datetime<T: ArrowPrimitiveType>(v: i64) -> Option<NaiveDateTime> {
     match T::DATA_TYPE {
-        DataType::Date32(_) => {
+        DataType::Date32 => {
             // convert days into seconds
             Some(NaiveDateTime::from_timestamp(v as i64 * SECONDS_IN_DAY, 0))
         }
-        DataType::Date64(_) => Some(NaiveDateTime::from_timestamp(
+        DataType::Date64 => Some(NaiveDateTime::from_timestamp(
             // extract seconds from milliseconds
             v / MILLISECONDS,
             // discard extracted seconds and convert milliseconds to nanoseconds
@@ -221,7 +221,7 @@ fn as_time<T: ArrowPrimitiveType>(v: i64) -> Option<NaiveTime> {
             }
         }
         DataType::Timestamp(_, _) => as_datetime::<T>(v).map(|datetime| datetime.time()),
-        DataType::Date32(_) | DataType::Date64(_) => Some(NaiveTime::from_hms(0, 0, 0)),
+        DataType::Date32 | DataType::Date64 => Some(NaiveTime::from_hms(0, 0, 0)),
         DataType::Interval(_) => None,
         _ => None,
     }
@@ -258,7 +258,7 @@ impl<T: ArrowPrimitiveType> fmt::Debug for PrimitiveArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "PrimitiveArray<{:?}>\n[\n", T::DATA_TYPE)?;
         print_long_array(self, f, |array, index, f| match T::DATA_TYPE {
-            DataType::Date32(_) | DataType::Date64(_) => {
+            DataType::Date32 | DataType::Date64 => {
                 let v = self.value(index).to_usize().unwrap() as i64;
                 match as_date::<T>(v) {
                     Some(date) => write!(f, "{:?}", date),
@@ -821,7 +821,7 @@ mod tests {
     fn test_date32_fmt_debug() {
         let arr: PrimitiveArray<Date32Type> = vec![12356, 13548].into();
         assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  2003-10-31,\n  2007-02-04,\n]",
+            "PrimitiveArray<Date32>\n[\n  2003-10-31,\n  2007-02-04,\n]",
             format!("{:?}", arr)
         );
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1342,8 +1342,8 @@ pub fn make_builder(datatype: &DataType, capacity: usize) -> Box<ArrayBuilder> {
             Box::new(DecimalBuilder::new(capacity, *precision, *scale))
         }
         DataType::Utf8 => Box::new(StringBuilder::new(capacity)),
-        DataType::Date32(DateUnit::Day) => Box::new(Date32Builder::new(capacity)),
-        DataType::Date64(DateUnit::Millisecond) => Box::new(Date64Builder::new(capacity)),
+        DataType::Date32 => Box::new(Date32Builder::new(capacity)),
+        DataType::Date64 => Box::new(Date64Builder::new(capacity)),
         DataType::Time32(TimeUnit::Second) => {
             Box::new(Time32SecondBuilder::new(capacity))
         }
@@ -1569,14 +1569,14 @@ impl FieldData {
             DataType::Int8 => self.append_null::<Int8Type>()?,
             DataType::Int16 => self.append_null::<Int16Type>()?,
             DataType::Int32
-            | DataType::Date32(_)
+            | DataType::Date32
             | DataType::Time32(_)
             | DataType::Interval(IntervalUnit::YearMonth) => {
                 self.append_null::<Int32Type>()?
             }
             DataType::Int64
             | DataType::Timestamp(_, _)
-            | DataType::Date64(_)
+            | DataType::Date64
             | DataType::Time64(_)
             | DataType::Interval(IntervalUnit::DayTime)
             | DataType::Duration(_) => self.append_null::<Int64Type>()?,

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -95,11 +95,11 @@ pub(crate) fn new_buffers(data_type: &DataType, capacity: usize) -> [MutableBuff
             MutableBuffer::new(capacity * mem::size_of::<f64>()),
             empty_buffer,
         ],
-        DataType::Date32(_) | DataType::Time32(_) => [
+        DataType::Date32 | DataType::Time32(_) => [
             MutableBuffer::new(capacity * mem::size_of::<i32>()),
             empty_buffer,
         ],
-        DataType::Date64(_)
+        DataType::Date64
         | DataType::Time64(_)
         | DataType::Duration(_)
         | DataType::Timestamp(_, _) => [
@@ -430,8 +430,8 @@ impl ArrayData {
             | DataType::Int64
             | DataType::Float32
             | DataType::Float64
-            | DataType::Date32(_)
-            | DataType::Date64(_)
+            | DataType::Date32
+            | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_)
             | DataType::Duration(_)

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -181,12 +181,12 @@ fn equal_values(
         DataType::Float64 => primitive_equal::<f64>(
             lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
         ),
-        DataType::Date32(_)
+        DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => primitive_equal::<i32>(
             lhs, rhs, lhs_nulls, rhs_nulls, lhs_start, rhs_start, len,
         ),
-        DataType::Date64(_)
+        DataType::Date64
         | DataType::Interval(IntervalUnit::DayTime)
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -146,8 +146,8 @@ pub fn build_compare<'a>(left: &'a Array, right: &'a Array) -> Result<DynCompara
         (Int64, Int64) => compare_primitives::<Int64Type>(left, right),
         (Float32, Float32) => compare_float::<Float32Type>(left, right),
         (Float64, Float64) => compare_float::<Float64Type>(left, right),
-        (Date32(_), Date32(_)) => compare_primitives::<Date32Type>(left, right),
-        (Date64(_), Date64(_)) => compare_primitives::<Date64Type>(left, right),
+        (Date32, Date32) => compare_primitives::<Date32Type>(left, right),
+        (Date64, Date64) => compare_primitives::<Date64Type>(left, right),
         (Time32(Second), Time32(Second)) => {
             compare_primitives::<Time32SecondType>(left, right)
         }

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -183,12 +183,12 @@ fn build_extend(array: &ArrayData) -> Extend {
         DataType::Int64 => primitive::build_extend::<i64>(array),
         DataType::Float32 => primitive::build_extend::<f32>(array),
         DataType::Float64 => primitive::build_extend::<f64>(array),
-        DataType::Date32(_)
+        DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => {
             primitive::build_extend::<i32>(array)
         }
-        DataType::Date64(_)
+        DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
         | DataType::Duration(_)
@@ -238,10 +238,10 @@ fn build_extend_nulls(data_type: &DataType) -> ExtendNulls {
         DataType::Int64 => primitive::extend_nulls::<i64>,
         DataType::Float32 => primitive::extend_nulls::<f32>,
         DataType::Float64 => primitive::extend_nulls::<f64>,
-        DataType::Date32(_)
+        DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => primitive::extend_nulls::<i32>,
-        DataType::Date64(_)
+        DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
         | DataType::Duration(_)
@@ -304,8 +304,8 @@ impl<'a> MutableArrayData<'a> {
             | DataType::Int64
             | DataType::Float32
             | DataType::Float64
-            | DataType::Date32(_)
-            | DataType::Date64(_)
+            | DataType::Date32
+            | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_)
             | DataType::Duration(_)

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -106,12 +106,8 @@ pub fn sort_to_indices(
         DataType::Float64 => {
             sort_primitive::<Float64Type, _>(values, v, n, total_cmp_64, &options)
         }
-        DataType::Date32(_) => {
-            sort_primitive::<Date32Type, _>(values, v, n, cmp, &options)
-        }
-        DataType::Date64(_) => {
-            sort_primitive::<Date64Type, _>(values, v, n, cmp, &options)
-        }
+        DataType::Date32 => sort_primitive::<Date32Type, _>(values, v, n, cmp, &options),
+        DataType::Date64 => sort_primitive::<Date64Type, _>(values, v, n, cmp, &options),
         DataType::Time32(Second) => {
             sort_primitive::<Time32SecondType, _>(values, v, n, cmp, &options)
         }

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -128,8 +128,8 @@ where
         DataType::UInt64 => downcast_take!(UInt64Type, values, indices),
         DataType::Float32 => downcast_take!(Float32Type, values, indices),
         DataType::Float64 => downcast_take!(Float64Type, values, indices),
-        DataType::Date32(_) => downcast_take!(Date32Type, values, indices),
-        DataType::Date64(_) => downcast_take!(Date64Type, values, indices),
+        DataType::Date32 => downcast_take!(Date32Type, values, indices),
+        DataType::Date64 => downcast_take!(Date64Type, values, indices),
         DataType::Time32(Second) => downcast_take!(Time32SecondType, values, indices),
         DataType::Time32(Millisecond) => {
             downcast_take!(Time32MillisecondType, values, indices)

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -85,9 +85,9 @@ fn infer_field_schema(string: &str) -> DataType {
     } else if INTEGER_RE.is_match(string) {
         DataType::Int64
     } else if DATETIME_RE.is_match(string) {
-        DataType::Date64(DateUnit::Millisecond)
+        DataType::Date64
     } else if DATE_RE.is_match(string) {
-        DataType::Date32(DateUnit::Day)
+        DataType::Date32
     } else {
         DataType::Utf8
     }
@@ -443,10 +443,10 @@ fn parse(
                 &DataType::Float64 => {
                     build_primitive_array::<Float64Type>(line_number, rows, i)
                 }
-                &DataType::Date32(_) => {
+                &DataType::Date32 => {
                     build_primitive_array::<Date32Type>(line_number, rows, i)
                 }
-                &DataType::Date64(_) => {
+                &DataType::Date64 => {
                     build_primitive_array::<Date64Type>(line_number, rows, i)
                 }
                 &DataType::Timestamp(TimeUnit::Microsecond, _) => {
@@ -520,7 +520,7 @@ impl Parser for Date32Type {
         use chrono::Datelike;
 
         match Self::DATA_TYPE {
-            DataType::Date32(DateUnit::Day) => {
+            DataType::Date32 => {
                 let date = string.parse::<chrono::NaiveDate>().ok()?;
                 Self::Native::from_i32(date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
             }
@@ -532,7 +532,7 @@ impl Parser for Date32Type {
 impl Parser for Date64Type {
     fn parse(string: &str) -> Option<i64> {
         match Self::DATA_TYPE {
-            DataType::Date64(DateUnit::Millisecond) => {
+            DataType::Date64 => {
                 let date_time = string.parse::<chrono::NaiveDateTime>().ok()?;
                 Self::Native::from_i64(date_time.timestamp_millis())
             }
@@ -1012,14 +1012,8 @@ mod tests {
         assert_eq!(&DataType::Float64, schema.field(1).data_type());
         assert_eq!(&DataType::Float64, schema.field(2).data_type());
         assert_eq!(&DataType::Boolean, schema.field(3).data_type());
-        assert_eq!(
-            &DataType::Date32(DateUnit::Day),
-            schema.field(4).data_type()
-        );
-        assert_eq!(
-            &DataType::Date64(DateUnit::Millisecond),
-            schema.field(5).data_type()
-        );
+        assert_eq!(&DataType::Date32, schema.field(4).data_type());
+        assert_eq!(&DataType::Date64, schema.field(5).data_type());
 
         let names: Vec<&str> =
             schema.fields().iter().map(|x| x.name().as_str()).collect();
@@ -1088,14 +1082,8 @@ mod tests {
         assert_eq!(infer_field_schema("10.2"), DataType::Float64);
         assert_eq!(infer_field_schema("true"), DataType::Boolean);
         assert_eq!(infer_field_schema("false"), DataType::Boolean);
-        assert_eq!(
-            infer_field_schema("2020-11-08"),
-            DataType::Date32(DateUnit::Day)
-        );
-        assert_eq!(
-            infer_field_schema("2020-11-08T14:20:01"),
-            DataType::Date64(DateUnit::Millisecond)
-        );
+        assert_eq!(infer_field_schema("2020-11-08"), DataType::Date32);
+        assert_eq!(infer_field_schema("2020-11-08T14:20:01"), DataType::Date64);
     }
 
     #[test]

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -156,14 +156,14 @@ impl<W: Write> Writer<W> {
                     let c = col.as_any().downcast_ref::<StringArray>().unwrap();
                     c.value(row_index).to_owned()
                 }
-                DataType::Date32(DateUnit::Day) => {
+                DataType::Date32 => {
                     let c = col.as_any().downcast_ref::<Date32Array>().unwrap();
                     c.value_as_date(row_index)
                         .unwrap()
                         .format(&self.date_format)
                         .to_string()
                 }
-                DataType::Date64(DateUnit::Millisecond) => {
+                DataType::Date64 => {
                     let c = col.as_any().downcast_ref::<Date64Array>().unwrap();
                     c.value_as_date(row_index)
                         .unwrap()

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -86,7 +86,7 @@ use std::{
 };
 
 use crate::buffer::Buffer;
-use crate::datatypes::{DataType, DateUnit, TimeUnit};
+use crate::datatypes::{DataType, TimeUnit};
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
 
@@ -187,8 +187,8 @@ fn to_datatype(format: &str) -> Result<DataType> {
         "Z" => DataType::LargeBinary,
         "u" => DataType::Utf8,
         "U" => DataType::LargeUtf8,
-        "tdD" => DataType::Date32(DateUnit::Day),
-        "tdm" => DataType::Date64(DateUnit::Millisecond),
+        "tdD" => DataType::Date32,
+        "tdm" => DataType::Date64,
         "tts" => DataType::Time32(TimeUnit::Second),
         "ttm" => DataType::Time32(TimeUnit::Millisecond),
         "ttu" => DataType::Time64(TimeUnit::Microsecond),
@@ -222,8 +222,8 @@ fn from_datatype(datatype: &DataType) -> Result<String> {
         DataType::LargeBinary => "Z",
         DataType::Utf8 => "u",
         DataType::LargeUtf8 => "U",
-        DataType::Date32(DateUnit::Day) => "tdD",
-        DataType::Date64(DateUnit::Millisecond) => "tdm",
+        DataType::Date32 => "tdD",
+        DataType::Date64 => "tdm",
         DataType::Time32(TimeUnit::Second) => "tts",
         DataType::Time32(TimeUnit::Millisecond) => "ttm",
         DataType::Time64(TimeUnit::Microsecond) => "ttu",
@@ -252,8 +252,8 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
         (DataType::UInt64, 1) => size_of::<u64>() * 8,
         (DataType::Int8, 1) => size_of::<i8>() * 8,
         (DataType::Int16, 1) => size_of::<i16>() * 8,
-        (DataType::Int32, 1) | (DataType::Date32(_), 1) | (DataType::Time32(_), 1) => size_of::<i32>() * 8,
-        (DataType::Int64, 1) | (DataType::Date64(_), 1) | (DataType::Time64(_), 1) => size_of::<i64>() * 8,
+        (DataType::Int32, 1) | (DataType::Date32, 1) | (DataType::Time32(_), 1) => size_of::<i32>() * 8,
+        (DataType::Int64, 1) | (DataType::Date64, 1) | (DataType::Time64(_), 1) => size_of::<i64>() * 8,
         (DataType::Float32, 1) => size_of::<f32>() * 8,
         (DataType::Float64, 1) => size_of::<f64>() * 8,
         // primitive types have a single buffer
@@ -264,8 +264,8 @@ fn bit_width(data_type: &DataType, i: usize) -> Result<usize> {
         (DataType::UInt64, _) |
         (DataType::Int8, _) |
         (DataType::Int16, _) |
-        (DataType::Int32, _) | (DataType::Date32(_), _) | (DataType::Time32(_), _) |
-        (DataType::Int64, _) | (DataType::Date64(_), _) | (DataType::Time64(_), _) |
+        (DataType::Int32, _) | (DataType::Date32, _) | (DataType::Time32(_), _) |
+        (DataType::Int64, _) | (DataType::Date64, _) | (DataType::Time64(_), _) |
         (DataType::Float32, _) |
         (DataType::Float64, _) => {
             return Err(ArrowError::CDataInterface(format!(

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -17,7 +17,7 @@
 
 //! Utilities for converting between IPC types and native Arrow types
 
-use crate::datatypes::{DataType, DateUnit, Field, IntervalUnit, Schema, TimeUnit};
+use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 
@@ -217,8 +217,8 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
         ipc::Type::Date => {
             let date = field.type_as_date().unwrap();
             match date.unit() {
-                ipc::DateUnit::DAY => DataType::Date32(DateUnit::Day),
-                ipc::DateUnit::MILLISECOND => DataType::Date64(DateUnit::Millisecond),
+                ipc::DateUnit::DAY => DataType::Date32,
+                ipc::DateUnit::MILLISECOND => DataType::Date64,
                 z => panic!("Date type with unit of {:?} not supported", z),
             }
         }
@@ -480,7 +480,7 @@ pub(crate) fn get_fb_field_type<'a>(
                 children: Some(fbb.create_vector(&empty_fields[..])),
             }
         }
-        Date32(_) => {
+        Date32 => {
             let mut builder = ipc::DateBuilder::new(fbb);
             builder.add_unit(ipc::DateUnit::DAY);
             FBFieldType {
@@ -489,7 +489,7 @@ pub(crate) fn get_fb_field_type<'a>(
                 children: Some(fbb.create_vector(&empty_fields[..])),
             }
         }
-        Date64(_) => {
+        Date64 => {
             let mut builder = ipc::DateBuilder::new(fbb);
             builder.add_unit(ipc::DateUnit::MILLISECOND);
             FBFieldType {
@@ -714,8 +714,8 @@ mod tests {
                 Field::new("float64", DataType::Float64, true),
                 Field::new("null", DataType::Null, false),
                 Field::new("bool", DataType::Boolean, false),
-                Field::new("date32", DataType::Date32(DateUnit::Day), false),
-                Field::new("date64", DataType::Date64(DateUnit::Millisecond), true),
+                Field::new("date32", DataType::Date32, false),
+                Field::new("date64", DataType::Date64, true),
                 Field::new("time32[s]", DataType::Time32(TimeUnit::Second), true),
                 Field::new("time32[ms]", DataType::Time32(TimeUnit::Millisecond), false),
                 Field::new("time64[us]", DataType::Time64(TimeUnit::Microsecond), false),
@@ -782,11 +782,7 @@ mod tests {
                             DataType::List(Box::new(Field::new(
                                 "struct",
                                 DataType::Struct(vec![
-                                    Field::new(
-                                        "date32",
-                                        DataType::Date32(DateUnit::Day),
-                                        true,
-                                    ),
+                                    Field::new("date32", DataType::Date32, true),
                                     Field::new(
                                         "list[struct<>]",
                                         DataType::List(Box::new(Field::new(

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -250,7 +250,7 @@ fn create_primitive_array(
         | UInt16
         | UInt32
         | Time32(_)
-        | Date32(_)
+        | Date32
         | Interval(IntervalUnit::YearMonth) => {
             if buffers[1].len() / 8 == length && length != 1 {
                 // interpret as a signed i64, and cast appropriately
@@ -307,7 +307,7 @@ fn create_primitive_array(
         | Float64
         | Time64(_)
         | Timestamp(_, _)
-        | Date64(_)
+        | Date64
         | Duration(_)
         | Interval(IntervalUnit::DayTime) => {
             let mut builder = ArrayData::builder(data_type.clone())

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -931,8 +931,8 @@ impl Decoder {
             DataType::Float32 => self.read_primitive_list_values::<Float32Type>(rows),
             DataType::Float64 => self.read_primitive_list_values::<Float64Type>(rows),
             DataType::Timestamp(_, _)
-            | DataType::Date32(_)
-            | DataType::Date64(_)
+            | DataType::Date32
+            | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_) => {
                 return Err(ArrowError::JsonError(
@@ -1084,10 +1084,10 @@ impl Decoder {
                                 field.name(),
                             ),
                     },
-                    DataType::Date64(_) => {
+                    DataType::Date64 => {
                         self.build_primitive_array::<Date64Type>(rows, field.name())
                     }
-                    DataType::Date32(_) => {
+                    DataType::Date32 => {
                         self.build_primitive_array::<Date32Type>(rows, field.name())
                     }
                     DataType::Time64(unit) => match unit {
@@ -2602,11 +2602,7 @@ mod tests {
 
     #[test]
     fn test_date_from_json_milliseconds() {
-        let schema = Schema::new(vec![Field::new(
-            "a",
-            DataType::Date64(DateUnit::Millisecond),
-            true,
-        )]);
+        let schema = Schema::new(vec![Field::new("a", DataType::Date64, true)]);
 
         let builder = ReaderBuilder::new()
             .with_schema(Arc::new(schema))
@@ -2624,7 +2620,7 @@ mod tests {
         assert_eq!(schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
-        assert_eq!(&DataType::Date64(DateUnit::Millisecond), a.1.data_type());
+        assert_eq!(&DataType::Date64, a.1.data_type());
 
         let aa = batch
             .column(a.0)

--- a/rust/arrow/src/util/display.rs
+++ b/rust/arrow/src/util/display.rs
@@ -166,8 +166,8 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
         DataType::Timestamp(unit, _) if *unit == TimeUnit::Nanosecond => {
             make_string_datetime!(array::TimestampNanosecondArray, column, row)
         }
-        DataType::Date32(_) => make_string_date!(array::Date32Array, column, row),
-        DataType::Date64(_) => make_string_date!(array::Date64Array, column, row),
+        DataType::Date32 => make_string_date!(array::Date32Array, column, row),
+        DataType::Date64 => make_string_date!(array::Date64Array, column, row),
         DataType::Time32(unit) if *unit == TimeUnit::Second => {
             make_string_time!(array::Time32SecondArray, column, row)
         }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -237,12 +237,12 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<Int16Array>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Int32 | DataType::Date32(_) | DataType::Time32(_) => {
+                    DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
                         let arr = Int32Array::from(arr.data());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Int64
-                    | DataType::Date64(_)
+                    | DataType::Date64
                     | DataType::Time64(_)
                     | DataType::Timestamp(_, _)
                     | DataType::Duration(_) => {
@@ -494,7 +494,7 @@ fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
         DataType::Struct(fields) => json_from_struct_col(col, fields),
         DataType::Int64
         | DataType::UInt64
-        | DataType::Date64(_)
+        | DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
         | DataType::Duration(_) => {
@@ -762,8 +762,8 @@ mod tests {
             Field::new("uint64s", DataType::UInt64, true),
             Field::new("float32s", DataType::Float32, true),
             Field::new("float64s", DataType::Float64, true),
-            Field::new("date_days", DataType::Date32(DateUnit::Day), true),
-            Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
+            Field::new("date_days", DataType::Date32, true),
+            Field::new("date_millis", DataType::Date64, true),
             Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
             Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
             Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -20,7 +20,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use arrow::datatypes::{DataType, DateUnit, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema};
 use arrow::util::pretty;
 use datafusion::datasource::parquet::ParquetTable;
 use datafusion::datasource::{CsvFile, MemTable, TableProvider};
@@ -1185,7 +1185,7 @@ fn get_schema(table: &str) -> Schema {
             Field::new("o_custkey", DataType::Int32, false),
             Field::new("o_orderstatus", DataType::Utf8, false),
             Field::new("o_totalprice", DataType::Float64, false),
-            Field::new("o_orderdate", DataType::Date32(DateUnit::Day), false),
+            Field::new("o_orderdate", DataType::Date32, false),
             Field::new("o_orderpriority", DataType::Utf8, false),
             Field::new("o_clerk", DataType::Utf8, false),
             Field::new("o_shippriority", DataType::Int32, false),
@@ -1203,9 +1203,9 @@ fn get_schema(table: &str) -> Schema {
             Field::new("l_tax", DataType::Float64, false),
             Field::new("l_returnflag", DataType::Utf8, false),
             Field::new("l_linestatus", DataType::Utf8, false),
-            Field::new("l_shipdate", DataType::Date32(DateUnit::Day), false),
-            Field::new("l_commitdate", DataType::Date32(DateUnit::Day), false),
-            Field::new("l_receiptdate", DataType::Date32(DateUnit::Day), false),
+            Field::new("l_shipdate", DataType::Date32, false),
+            Field::new("l_commitdate", DataType::Date32, false),
+            Field::new("l_receiptdate", DataType::Date32, false),
             Field::new("l_shipinstruct", DataType::Utf8, false),
             Field::new("l_shipmode", DataType::Utf8, false),
             Field::new("l_comment", DataType::Utf8, false),
@@ -1421,7 +1421,7 @@ mod tests {
             3 => Schema::new(vec![
                 Field::new("l_orderkey", DataType::Int32, true),
                 Field::new("revenue", DataType::Float64, true),
-                Field::new("o_orderdat", DataType::Date32(DateUnit::Day), true),
+                Field::new("o_orderdat", DataType::Date32, true),
                 Field::new("o_shippriority", DataType::Int32, true),
             ]),
 
@@ -1499,7 +1499,7 @@ mod tests {
                 Field::new("c_name", DataType::Utf8, true),
                 Field::new("c_custkey", DataType::Int32, true),
                 Field::new("o_orderkey", DataType::Int32, true),
-                Field::new("o_orderdat", DataType::Date32(DateUnit::Day), true),
+                Field::new("o_orderdat", DataType::Date32, true),
                 Field::new("o_totalprice", DataType::Float64, true),
                 Field::new("sum_l_quantity", DataType::Float64, true),
             ]),

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -123,9 +123,9 @@ are mapped to Arrow types according to the following table
 | `REAL`          | `Float64`                        |
 | `DOUBLE`        | `Float64`                        |
 | `BOOLEAN`       | `Boolean`                        |
-| `DATE`          | `Date64(DateUnit::Day)`          |
+| `DATE`          | `Date32`                         |
 | `TIME`          | `Time64(TimeUnit::Millisecond)`  |
-| `TIMESTAMP`     | `Date64(DateUnit::Millisecond)`  |
+| `TIMESTAMP`     | `Date64`                         |
 | `INTERVAL`      | *Not yet supported*              |
 | `REGCLASS`      | *Not yet supported*              |
 | `TEXT`          | *Not yet supported*              |

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -48,7 +48,7 @@ use arrow::compute::kernels::comparison::{
     neq_utf8_scalar,
 };
 use arrow::compute::kernels::sort::{SortColumn, SortOptions};
-use arrow::datatypes::{DataType, DateUnit, Schema, TimeUnit};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use arrow::{
     array::{
@@ -1089,7 +1089,7 @@ macro_rules! binary_array_op_scalar {
             DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, TimestampNanosecondArray)
             }
-            DataType::Date32(DateUnit::Day) => {
+            DataType::Date32 => {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, Date32Array)
             }
             other => Err(DataFusionError::Internal(format!(
@@ -1120,10 +1120,10 @@ macro_rules! binary_array_op {
             DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                 compute_op!($LEFT, $RIGHT, $OP, TimestampNanosecondArray)
             }
-            DataType::Date32(DateUnit::Day) => {
+            DataType::Date32 => {
                 compute_op!($LEFT, $RIGHT, $OP, Date32Array)
             }
-            DataType::Date64(DateUnit::Millisecond) => {
+            DataType::Date64 => {
                 compute_op!($LEFT, $RIGHT, $OP, Date64Array)
             }
             other => Err(DataFusionError::Internal(format!(
@@ -1238,10 +1238,10 @@ fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType>
 fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
     match (lhs_type, rhs_type) {
-        (Utf8, Date32(DateUnit::Day)) => Some(Date32(DateUnit::Day)),
-        (Date32(DateUnit::Day), Utf8) => Some(Date32(DateUnit::Day)),
-        (Utf8, Date64(DateUnit::Millisecond)) => Some(Date64(DateUnit::Millisecond)),
-        (Date64(DateUnit::Millisecond), Utf8) => Some(Date64(DateUnit::Millisecond)),
+        (Utf8, Date32) => Some(Date32),
+        (Date32, Utf8) => Some(Date32),
+        (Utf8, Date64) => Some(Date64),
+        (Date64, Utf8) => Some(Date64),
         _ => None,
     }
 }
@@ -3014,7 +3014,7 @@ mod tests {
             DataType::Utf8,
             vec!["1994-12-13", "1995-01-26"],
             Date32Array,
-            DataType::Date32(DateUnit::Day),
+            DataType::Date32,
             vec![9112, 9156],
             Operator::Eq,
             BooleanArray,
@@ -3026,7 +3026,7 @@ mod tests {
             DataType::Utf8,
             vec!["1994-12-13", "1995-01-26"],
             Date32Array,
-            DataType::Date32(DateUnit::Day),
+            DataType::Date32,
             vec![9113, 9154],
             Operator::Lt,
             BooleanArray,
@@ -3038,7 +3038,7 @@ mod tests {
             DataType::Utf8,
             vec!["1994-12-13T12:34:56", "1995-01-26T01:23:45"],
             Date64Array,
-            DataType::Date64(DateUnit::Millisecond),
+            DataType::Date64,
             vec![787322096000, 791083425000],
             Operator::Eq,
             BooleanArray,
@@ -3050,7 +3050,7 @@ mod tests {
             DataType::Utf8,
             vec!["1994-12-13T12:34:56", "1995-01-26T01:23:45"],
             Date64Array,
-            DataType::Date64(DateUnit::Millisecond),
+            DataType::Date64,
             vec![787322096001, 791083424999],
             Operator::Lt,
             BooleanArray,

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -20,6 +20,11 @@
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
 use arrow::array::{
+    Array, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, LargeStringArray, ListArray, StringArray, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::array::{
     Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder,
     TimestampMicrosecondArray, TimestampNanosecondArray, UInt16Builder, UInt32Builder,
     UInt64Builder, UInt8Builder,
@@ -27,14 +32,6 @@ use arrow::array::{
 use arrow::{
     array::ArrayRef,
     datatypes::{DataType, Field},
-};
-use arrow::{
-    array::{
-        Array, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array,
-        Int32Array, Int64Array, Int8Array, LargeStringArray, ListArray, StringArray,
-        UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-    },
-    datatypes::DateUnit,
 };
 
 use crate::error::{DataFusionError, Result};
@@ -150,7 +147,7 @@ impl ScalarValue {
             ScalarValue::List(_, data_type) => {
                 DataType::List(Box::new(Field::new("item", data_type.clone(), true)))
             }
-            ScalarValue::Date32(_) => DataType::Date32(DateUnit::Day),
+            ScalarValue::Date32(_) => DataType::Date32,
         }
     }
 
@@ -358,7 +355,7 @@ impl ScalarValue {
                 };
                 ScalarValue::List(value, nested_type.data_type().clone())
             }
-            DataType::Date32(DateUnit::Day) => {
+            DataType::Date32 => {
                 typed_cast!(array, index, Date32Array, Date32)
             }
             other => {

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -214,9 +214,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             SQLDataType::Float(_) => Ok(DataType::Float32),
             SQLDataType::Real | SQLDataType::Double => Ok(DataType::Float64),
             SQLDataType::Boolean => Ok(DataType::Boolean),
-            SQLDataType::Date => Ok(DataType::Date32(DateUnit::Day)),
+            SQLDataType::Date => Ok(DataType::Date32),
             SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
-            SQLDataType::Timestamp => Ok(DataType::Date64(DateUnit::Millisecond)),
+            SQLDataType::Timestamp => Ok(DataType::Date64),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "The SQL data type {:?} is not implemented",
                 sql_type
@@ -996,7 +996,7 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
         SQLDataType::Double => Ok(DataType::Float64),
         SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
-        SQLDataType::Date => Ok(DataType::Date32(DateUnit::Day)),
+        SQLDataType::Date => Ok(DataType::Date32),
         other => Err(DataFusionError::NotImplemented(format!(
             "Unsupported SQL type {:?}",
             other
@@ -1147,7 +1147,7 @@ mod tests {
             "SELECT state FROM person WHERE birth_date < CAST ('2020-01-01' as date)";
 
         let expected = "Projection: #state\
-            \n  Filter: #birth_date Lt CAST(Utf8(\"2020-01-01\") AS Date32(Day))\
+            \n  Filter: #birth_date Lt CAST(Utf8(\"2020-01-01\") AS Date32)\
             \n    TableScan: person projection=None";
 
         quick_test(sql, expected);
@@ -1765,7 +1765,7 @@ mod tests {
     #[test]
     fn select_typedstring() {
         let sql = "SELECT date '2020-12-10' AS date FROM person";
-        let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32(Day)) AS date\
+        let expected = "Projection: CAST(Utf8(\"2020-12-10\") AS Date32) AS date\
             \n  TableScan: person projection=None";
         quick_test(sql, expected);
     }

--- a/rust/integration-testing/src/lib.rs
+++ b/rust/integration-testing/src/lib.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use arrow::util::integration_util::ArrowJsonBatch;
 
 use arrow::array::*;
-use arrow::datatypes::{DataType, DateUnit, Field, IntervalUnit, Schema};
+use arrow::datatypes::{DataType, Field, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::record_batch::RecordBatch;
 use arrow::{
@@ -163,7 +163,7 @@ fn array_from_json(
             Ok(Arc::new(b.finish()))
         }
         DataType::Int32
-        | DataType::Date32(DateUnit::Day)
+        | DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => {
             let mut b = Int32Builder::new(json_col.count);
@@ -183,7 +183,7 @@ fn array_from_json(
             arrow::compute::cast(&array, field.data_type())
         }
         DataType::Int64
-        | DataType::Date64(DateUnit::Millisecond)
+        | DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
         | DataType::Duration(_)

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -33,7 +33,7 @@ use arrow::array::{
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::datatypes::{
     ArrowPrimitiveType, BooleanType as ArrowBooleanType, DataType as ArrowType,
-    Date32Type as ArrowDate32Type, Date64Type as ArrowDate64Type, DateUnit,
+    Date32Type as ArrowDate32Type, Date64Type as ArrowDate64Type,
     DurationMicrosecondType as ArrowDurationMicrosecondType,
     DurationMillisecondType as ArrowDurationMillisecondType,
     DurationNanosecondType as ArrowDurationNanosecondType,
@@ -345,9 +345,9 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
         // - date64: we should cast int32 to date32, then date32 to date64.
         let target_type = self.get_data_type();
         let array = match target_type {
-            ArrowType::Date64(_) => {
+            ArrowType::Date64 => {
                 // this is cheap as it internally reinterprets the data
-                let a = arrow::compute::cast(&array, &ArrowType::Date32(DateUnit::Day))?;
+                let a = arrow::compute::cast(&array, &ArrowType::Date32)?;
                 arrow::compute::cast(&a, target_type)?
             }
             ArrowType::Decimal(p, s) => {
@@ -719,10 +719,10 @@ fn remove_indices(
                 indices
             )
         }
-        ArrowType::Date32(_) => {
+        ArrowType::Date32 => {
             remove_primitive_array_indices!(arr, ArrowDate32Type, indices)
         }
-        ArrowType::Date64(_) => {
+        ArrowType::Date64 => {
             remove_primitive_array_indices!(arr, ArrowDate64Type, indices)
         }
         ArrowType::Time32(ArrowTimeUnit::Second) => {

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use arrow::array as arrow_array;
-use arrow::datatypes::{DataType as ArrowDataType, DateUnit, IntervalUnit, SchemaRef};
+use arrow::datatypes::{DataType as ArrowDataType, IntervalUnit, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use arrow_array::Array;
 
@@ -134,8 +134,8 @@ fn write_leaves(
         | ArrowDataType::Float32
         | ArrowDataType::Float64
         | ArrowDataType::Timestamp(_, _)
-        | ArrowDataType::Date32(_)
-        | ArrowDataType::Date64(_)
+        | ArrowDataType::Date32
+        | ArrowDataType::Date64
         | ArrowDataType::Time32(_)
         | ArrowDataType::Time64(_)
         | ArrowDataType::Duration(_)
@@ -204,9 +204,8 @@ fn write_leaf(
     let written = match writer {
         ColumnWriter::Int32ColumnWriter(ref mut typed) => {
             // If the column is a Date64, we cast it to a Date32, and then interpret that as Int32
-            let array = if let ArrowDataType::Date64(_) = column.data_type() {
-                let array =
-                    arrow::compute::cast(column, &ArrowDataType::Date32(DateUnit::Day))?;
+            let array = if let ArrowDataType::Date64 = column.data_type() {
+                let array = arrow::compute::cast(column, &ArrowDataType::Date32)?;
                 Arc::new(arrow_array::Int32Array::from(array.data()))
             } else {
                 arrow::compute::cast(column, &ArrowDataType::Int32)?

--- a/rust/parquet/src/arrow/levels.rs
+++ b/rust/parquet/src/arrow/levels.rs
@@ -128,8 +128,8 @@ impl LevelInfo {
             | DataType::Utf8
             | DataType::LargeUtf8
             | DataType::Timestamp(_, _)
-            | DataType::Date32(_)
-            | DataType::Date64(_)
+            | DataType::Date32
+            | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_)
             | DataType::Duration(_)
@@ -178,8 +178,8 @@ impl LevelInfo {
                     | DataType::Float32
                     | DataType::Float64
                     | DataType::Timestamp(_, _)
-                    | DataType::Date32(_)
-                    | DataType::Date64(_)
+                    | DataType::Date32
+                    | DataType::Date64
                     | DataType::Time32(_)
                     | DataType::Time64(_)
                     | DataType::Duration(_)
@@ -588,8 +588,8 @@ impl LevelInfo {
             | DataType::Float32
             | DataType::Float64
             | DataType::Timestamp(_, _)
-            | DataType::Date32(_)
-            | DataType::Date64(_)
+            | DataType::Date32
+            | DataType::Date64
             | DataType::Time32(_)
             | DataType::Time64(_)
             | DataType::Duration(_)

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -26,7 +26,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use arrow::datatypes::{DataType, DateUnit, Field, IntervalUnit, Schema, TimeUnit};
+use arrow::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
 use arrow::ipc::writer;
 
 use crate::errors::{ParquetError::ArrowError, Result};
@@ -371,12 +371,12 @@ fn arrow_to_parquet_type(field: &Field) -> Result<Type> {
                 .with_repetition(repetition)
                 .build()
         }
-        DataType::Date32(_) => Type::primitive_type_builder(name, PhysicalType::INT32)
+        DataType::Date32 => Type::primitive_type_builder(name, PhysicalType::INT32)
             .with_logical_type(LogicalType::DATE)
             .with_repetition(repetition)
             .build(),
         // date64 is cast to date32
-        DataType::Date64(_) => Type::primitive_type_builder(name, PhysicalType::INT32)
+        DataType::Date64 => Type::primitive_type_builder(name, PhysicalType::INT32)
             .with_logical_type(LogicalType::DATE)
             .with_repetition(repetition)
             .build(),
@@ -585,7 +585,7 @@ impl ParquetTypeConverter<'_> {
             LogicalType::INT_8 => Ok(DataType::Int8),
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
-            LogicalType::DATE => Ok(DataType::Date32(DateUnit::Day)),
+            LogicalType::DATE => Ok(DataType::Date32),
             LogicalType::TIME_MILLIS => Ok(DataType::Time32(TimeUnit::Millisecond)),
             LogicalType::DECIMAL => Ok(self.to_decimal()),
             other => Err(ArrowError(format!(
@@ -797,7 +797,7 @@ mod tests {
 
     use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 
-    use arrow::datatypes::{DataType, DateUnit, Field, IntervalUnit, TimeUnit};
+    use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
 
     use crate::file::{metadata::KeyValue, reader::SerializedFileReader};
     use crate::{
@@ -1416,7 +1416,7 @@ mod tests {
                 DataType::List(Box::new(Field::new("bools", DataType::Boolean, true))),
                 true,
             ),
-            Field::new("date", DataType::Date32(DateUnit::Day), true),
+            Field::new("date", DataType::Date32, true),
             Field::new("time_milli", DataType::Time32(TimeUnit::Millisecond), true),
             Field::new("time_micro", DataType::Time64(TimeUnit::Microsecond), true),
             Field::new(
@@ -1496,7 +1496,7 @@ mod tests {
                 DataType::List(Box::new(Field::new("element", DataType::Boolean, false))),
                 false,
             ),
-            Field::new("date", DataType::Date32(DateUnit::Day), true),
+            Field::new("date", DataType::Date32, true),
             Field::new("time_milli", DataType::Time32(TimeUnit::Millisecond), true),
             Field::new("time_micro", DataType::Time64(TimeUnit::Microsecond), true),
             Field::new(
@@ -1598,8 +1598,8 @@ mod tests {
                 Field::new("c2", DataType::Binary, false),
                 Field::new("c3", DataType::FixedSizeBinary(3), false),
                 Field::new("c4", DataType::Boolean, false),
-                Field::new("c5", DataType::Date32(DateUnit::Day), false),
-                Field::new("c6", DataType::Date64(DateUnit::Millisecond), false),
+                Field::new("c5", DataType::Date32, false),
+                Field::new("c6", DataType::Date64, false),
                 Field::new("c7", DataType::Time32(TimeUnit::Second), false),
                 Field::new("c8", DataType::Time32(TimeUnit::Millisecond), false),
                 Field::new("c13", DataType::Time64(TimeUnit::Microsecond), false),


### PR DESCRIPTION
The arrow spec states that `Date32` represents a date in number of days, and `Date64` represents a date in milliseconds. 

However, our current implementation allows `Date32(Milliseconds)` and `Date64(Days)`.

This PR fixes this by removing the `DateUnit` altogether, i.e. `Date32(_) -> Date32` and `Date64(_) -> Date64`. This choice is based on how this is offered on pyarrow's API: https://arrow.apache.org/docs/python/generated/pyarrow.date32.html

Please note that this has a major backward incompatibility to all code that uses this datatype. Unfortunately, there is no way to solve this out of spec without an incompatible change. :(