### PR TITLE
ARROW-11357: [Rust]: Fix out-of-bounds reads in `take` and other undefined behavior

### DIFF
--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -311,7 +311,6 @@ where
         .enumerate()
         .map(|(i, index)| {
             let (index, value) = maybe_take::<T, I>(values_values, *index)?;
-            println!("{} {} {}", i, index, values.is_null(index));
             if values.is_null(index) {
                 null_count += 1;
                 bit_util::unset_bit(null_slice, i);
@@ -792,14 +791,16 @@ mod tests {
         index: &UInt32Array,
         options: Option<TakeOptions>,
         expected_data: Vec<Option<T::Native>>,
-    ) where
+    ) -> Result<()>
+    where
         T: ArrowPrimitiveType,
         PrimitiveArray<T>: From<Vec<Option<T::Native>>>,
     {
         let output = PrimitiveArray::<T>::from(data);
         let expected = Arc::new(PrimitiveArray::<T>::from(expected_data)) as ArrayRef;
-        let output = take(&output, index, options).unwrap();
-        assert_eq!(&output, &expected)
+        let output = take(&output, index, options)?;
+        assert_eq!(&output, &expected);
+        Ok(())
     }
 
     fn test_take_impl_primitive_arrays<T, I>(
@@ -843,7 +844,8 @@ mod tests {
             &index,
             None,
             vec![None, None, Some(2), Some(3), Some(3), Some(5)],
-        );
+        )
+        .unwrap();
     }
 
     #[test]
@@ -854,7 +856,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, Some(1), Some(3), Some(2)],
-        );
+        )
+        .unwrap();
     }
 
     #[test]
@@ -865,7 +868,8 @@ mod tests {
             &index,
             None,
             vec![Some(0), Some(1), Some(2), Some(3), Some(3), Some(5)],
-        );
+        )
+        .unwrap();
     }
 
     #[test]
@@ -878,7 +882,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // int16
         test_take_primitive_arrays::<Int16Type>(
@@ -886,7 +891,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // int32
         test_take_primitive_arrays::<Int32Type>(
@@ -894,7 +900,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // int64
         test_take_primitive_arrays::<Int64Type>(
@@ -902,7 +909,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // uint8
         test_take_primitive_arrays::<UInt8Type>(
@@ -910,7 +918,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // uint16
         test_take_primitive_arrays::<UInt16Type>(
@@ -918,7 +927,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // uint32
         test_take_primitive_arrays::<UInt32Type>(
@@ -926,7 +936,8 @@ mod tests {
             &index,
             None,
             vec![Some(3), None, None, Some(3), Some(2)],
-        );
+        )
+        .unwrap();
 
         // int64
         test_take_primitive_arrays::<Int64Type>(
@@ -934,7 +945,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // interval_year_month
         test_take_primitive_arrays::<IntervalYearMonthType>(
@@ -942,7 +954,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // interval_day_time
         test_take_primitive_arrays::<IntervalDayTimeType>(
@@ -950,7 +963,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // duration_second
         test_take_primitive_arrays::<DurationSecondType>(
@@ -958,7 +972,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // duration_millisecond
         test_take_primitive_arrays::<DurationMillisecondType>(
@@ -966,7 +981,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // duration_microsecond
         test_take_primitive_arrays::<DurationMicrosecondType>(
@@ -974,7 +990,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // duration_nanosecond
         test_take_primitive_arrays::<DurationNanosecondType>(
@@ -982,7 +999,8 @@ mod tests {
             &index,
             None,
             vec![Some(-15), None, None, Some(-15), Some(2)],
-        );
+        )
+        .unwrap();
 
         // float32
         test_take_primitive_arrays::<Float32Type>(
@@ -990,7 +1008,8 @@ mod tests {
             &index,
             None,
             vec![Some(-3.1), None, None, Some(-3.1), Some(2.21)],
-        );
+        )
+        .unwrap();
 
         // float64
         test_take_primitive_arrays::<Float64Type>(
@@ -998,7 +1017,8 @@ mod tests {
             &index,
             None,
             vec![Some(-3.1), None, None, Some(-3.1), Some(2.21)],
-        );
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1512,20 +1532,32 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Array index out of bounds, cannot get item at index 6 from 5 entries"
-    )]
     fn test_take_out_of_bounds() {
         let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(6)]);
         let take_opt = TakeOptions { check_bounds: true };
 
         // int64
-        test_take_primitive_arrays::<Int64Type>(
+        let result = test_take_primitive_arrays::<Int64Type>(
             vec![Some(0), None, Some(2), Some(3), None],
             &index,
             Some(take_opt),
             vec![None],
         );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is 4 but the index is 1000")]
+    fn test_take_out_of_bounds_panic() {
+        let index = UInt32Array::from(vec![Some(1000)]);
+
+        test_take_primitive_arrays::<Int64Type>(
+            vec![Some(0), None, Some(2), Some(3)],
+            &index,
+            None,
+            vec![None],
+        )
+        .unwrap();
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -1535,7 +1535,7 @@ mod tests {
         let index = UInt32Array::from(vec![Some(1000)]);
 
         test_take_primitive_arrays::<Int64Type>(
-            vec![Some(0), None, Some(2), Some(3)],
+            vec![Some(0), Some(1), Some(2), Some(3)],
             &index,
             None,
             vec![None],

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -420,8 +420,8 @@ where
     I: ArrowNumericType,
     I::Native: ToPrimitive,
 {
-    let indices_has_nulls = indices.null_count() != 0;
-    let values_has_nulls = values.null_count() != 0;
+    let indices_has_nulls = indices.null_count() > 0;
+    let values_has_nulls = values.null_count() > 0;
     // note: this function should only panic when "an index is not null and out of bounds".
     // if the index is null, its value is undefined and therefore we should not read from it.
 

--- a/rust/arrow/src/datatypes/native.rs
+++ b/rust/arrow/src/datatypes/native.rs
@@ -39,21 +39,25 @@ pub trait ArrowNativeType:
     + JsonSerializable
 {
     /// Convert native type from usize.
+    #[inline]
     fn from_usize(_: usize) -> Option<Self> {
         None
     }
 
     /// Convert native type to usize.
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         None
     }
 
     /// Convert native type from i32.
+    #[inline]
     fn from_i32(_: i32) -> Option<Self> {
         None
     }
 
     /// Convert native type from i64.
+    #[inline]
     fn from_i64(_: i64) -> Option<Self> {
         None
     }
@@ -94,10 +98,12 @@ impl JsonSerializable for i8 {
 }
 
 impl ArrowNativeType for i8 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -110,10 +116,12 @@ impl JsonSerializable for i16 {
 }
 
 impl ArrowNativeType for i16 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -126,15 +134,18 @@ impl JsonSerializable for i32 {
 }
 
 impl ArrowNativeType for i32 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
 
     /// Convert native type from i32.
+    #[inline]
     fn from_i32(val: i32) -> Option<Self> {
         Some(val)
     }
@@ -147,10 +158,12 @@ impl JsonSerializable for i64 {
 }
 
 impl ArrowNativeType for i64 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -168,10 +181,12 @@ impl JsonSerializable for u8 {
 }
 
 impl ArrowNativeType for u8 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -184,10 +199,12 @@ impl JsonSerializable for u16 {
 }
 
 impl ArrowNativeType for u16 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -200,10 +217,12 @@ impl JsonSerializable for u32 {
 }
 
 impl ArrowNativeType for u32 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
@@ -216,10 +235,12 @@ impl JsonSerializable for u64 {
 }
 
 impl ArrowNativeType for u64 {
+    #[inline]
     fn from_usize(v: usize) -> Option<Self> {
         num::FromPrimitive::from_usize(v)
     }
 
+    #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }

--- a/rust/arrow/src/datatypes/native.rs
+++ b/rust/arrow/src/datatypes/native.rs
@@ -169,6 +169,7 @@ impl ArrowNativeType for i64 {
     }
 
     /// Convert native type from i64.
+    #[inline]
     fn from_i64(val: i64) -> Option<Self> {
         Some(val)
     }


### PR DESCRIPTION
This PR fixes two major issues in our `take` kernel for primitive arrays.

Background

* When using `values()` from an array, it is important to remember that only certain values are not arbitrary (those whose null bit is set / no buffer).

* When reading values from an array using `array.value(i)`, it is important to remember that it currently performs no bound checks.

* `take` offers an option to deactivate bound checks, by turning an error in a panic. that option defaults to not check (i.e. `panic`)

however, `take` kernel respects none of the points above: 
* it reads and uses arbitrary indices
* it accesses out of bound values
* it does not panic when `check_bounds = false` (it instead reads out of bounds)

Specifically, it is currently doing something like the following (ignoring some details):

```rust
let indices = indices.values();
for index in indices {
    let index = index.to_usize();
    let taken_value = values.value(index)
}
```

I.e. 

* there is no check that `index` is a valid slot
* there is no check that `index < values.len()`. 

Independently, each of them is unsound. Combined, they allow for spectacular unbounded memory reads: reading from a pointer offsetted by an arbitrary value. 🤯 

This PR fixes this behavior. This PR also improves performance by 20-40% (thanks to @Dandandan and @tyrelr great suggestions).

```
Your branch is ahead of 'origin/take_fix' by 1 commit.
  (use "git push" to publish your local commits)
   Compiling arrow v4.0.0-SNAPSHOT (/Users/jorgecarleitao/projects/arrow/rust/arrow)
    Finished bench [optimized] target(s) in 1m 25s
     Running /Users/jorgecarleitao/projects/arrow/rust/target/release/deps/take_kernels-683d8fd1eeba5497
Gnuplot not found, using plotters backend
take i32 512            time:   [1.0477 us 1.0519 us 1.0564 us]                          
                        change: [-25.007% -23.339% -21.840%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

take i32 1024           time:   [1.4949 us 1.4996 us 1.5049 us]                           
                        change: [-34.066% -31.907% -29.853%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

take i32 nulls 512      time:   [976.65 ns 983.09 ns 991.99 ns]                                
                        change: [-45.076% -39.795% -35.157%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

take i32 nulls 1024     time:   [1.3249 us 1.3278 us 1.3309 us]                                 
                        change: [-32.887% -31.666% -30.524%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```