### PR TITLE
ARROW-11358: [Rust] Add benchmark for concatenating small arrays

### DIFF
--- a/rust/arrow/benches/concatenate_kernel.rs
+++ b/rust/arrow/benches/concatenate_kernel.rs
@@ -76,6 +76,10 @@ fn bench_concat(v1: &ArrayRef, v2: &ArrayRef) {
     criterion::black_box(concat(&[v1.as_ref(), v2.as_ref()]).unwrap());
 }
 
+fn bench_concat_arrays(arrays: &[&dyn Array]) {
+    criterion::black_box(concat(arrays).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
     let v1 = create_primitive::<Int32Type>(1024, 0.0);
     let v2 = create_primitive::<Int32Type>(1024, 0.0);
@@ -85,6 +89,12 @@ fn add_benchmark(c: &mut Criterion) {
     let v2 = create_primitive::<Int32Type>(1024, 0.5);
     c.bench_function("concat i32 nulls 1024", |b| {
         b.iter(|| bench_concat(&v1, &v2))
+    });
+
+    let small_array = create_primitive::<Int32Type>(4, 0.0);
+    let arrays: Vec<_> = (0..1024).map(|_| small_array.as_ref()).collect();
+    c.bench_function("concat 1024 arrays i32 4", |b| {
+        b.iter(|| bench_concat_arrays(&arrays))
     });
 
     let v1 = create_strings(1024, 0.0);


### PR DESCRIPTION
This is a common usecase in DataFusion, for coalescing & hash aggregates.