### PR TITLE
ARROW-11361: [Rust] Build MutableBuffer/Buffer from iterator of bools

### DIFF
--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -49,7 +49,7 @@ fn mutable_buffer_iter_bitset(data: &[Vec<bool>]) -> Vec<Buffer> {
     criterion::black_box({
         data.iter()
             .map(|datum| {
-                let mut result = MutableBuffer::new(data.len() + 7 / 8)
+                let mut result = MutableBuffer::new((data.len() + 7) / 8)
                     .with_bitset(datum.len(), false);
                 for (i, value) in datum.iter().enumerate() {
                     if *value {

--- a/rust/arrow/benches/buffer_create.rs
+++ b/rust/arrow/benches/buffer_create.rs
@@ -29,6 +29,54 @@ use arrow::{
     datatypes::ToByteSlice,
 };
 
+fn mutable_buffer_from_iter(data: &[Vec<bool>]) -> Vec<Buffer> {
+    criterion::black_box(
+        data.iter()
+            .map(|vec| vec.iter().copied().collect::<MutableBuffer>().into())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn buffer_from_iter(data: &[Vec<bool>]) -> Vec<Buffer> {
+    criterion::black_box(
+        data.iter()
+            .map(|vec| vec.iter().copied().collect::<Buffer>())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn mutable_buffer_iter_bitset(data: &[Vec<bool>]) -> Vec<Buffer> {
+    criterion::black_box({
+        data.iter()
+            .map(|datum| {
+                let mut result = MutableBuffer::new(data.len() + 7 / 8)
+                    .with_bitset(datum.len(), false);
+                for (i, value) in datum.iter().enumerate() {
+                    if *value {
+                        unsafe {
+                            arrow::util::bit_util::set_bit_raw(result.as_mut_ptr(), i);
+                        }
+                    }
+                }
+                result.into()
+            })
+            .collect::<Vec<_>>()
+    })
+}
+
+fn mutable_iter_extend_from_slice(data: &[Vec<u32>], capacity: usize) -> Buffer {
+    criterion::black_box({
+        let mut result = MutableBuffer::new(capacity);
+
+        data.iter().for_each(|vec| {
+            vec.iter()
+                .for_each(|elem| result.extend_from_slice(elem.to_byte_slice()))
+        });
+
+        result.into()
+    })
+}
+
 fn mutable_buffer(data: &[Vec<u32>], capacity: usize) -> Buffer {
     criterion::black_box({
         let mut result = MutableBuffer::new(capacity);
@@ -75,25 +123,67 @@ fn create_data(size: usize) -> Vec<Vec<u32>> {
         .collect()
 }
 
+fn create_data_bool(size: usize) -> Vec<Vec<bool>> {
+    let rng = &mut seedable_rng();
+    let range = Uniform::new(0, 33);
+
+    (0..size)
+        .map(|_| {
+            let size = rng.sample(range);
+            seedable_rng()
+                .sample_iter(&range)
+                .take(size as usize)
+                .map(|x| x > 15)
+                .collect()
+        })
+        .collect()
+}
 fn benchmark(c: &mut Criterion) {
     let size = 2usize.pow(15);
     let data = create_data(size);
+
+    let bool_data = create_data_bool(size);
     let cap = data.iter().map(|i| i.len()).sum();
     let byte_cap = cap * std::mem::size_of::<u32>();
 
-    c.bench_function("mutable", |b| b.iter(|| mutable_buffer(&data, 0)));
+    c.bench_function("mutable iter extend_from_slice", |b| {
+        b.iter(|| {
+            mutable_iter_extend_from_slice(
+                criterion::black_box(&data),
+                criterion::black_box(0),
+            )
+        })
+    });
+    c.bench_function("mutable", |b| {
+        b.iter(|| mutable_buffer(criterion::black_box(&data), criterion::black_box(0)))
+    });
 
     c.bench_function("mutable extend", |b| {
         b.iter(|| mutable_buffer_extend(&data, 0))
     });
 
     c.bench_function("mutable prepared", |b| {
-        b.iter(|| mutable_buffer(&data, byte_cap))
+        b.iter(|| {
+            mutable_buffer(criterion::black_box(&data), criterion::black_box(byte_cap))
+        })
     });
 
-    c.bench_function("from_slice", |b| b.iter(|| from_slice(&data, 0)));
+    c.bench_function("from_slice", |b| {
+        b.iter(|| from_slice(criterion::black_box(&data), criterion::black_box(0)))
+    });
+    c.bench_function("from_slice prepared", |b| {
+        b.iter(|| from_slice(criterion::black_box(&data), criterion::black_box(cap)))
+    });
 
-    c.bench_function("from_slice prepared", |b| b.iter(|| from_slice(&data, cap)));
+    c.bench_function("MutableBuffer iter bitset", |b| {
+        b.iter(|| mutable_buffer_iter_bitset(criterion::black_box(&bool_data)))
+    });
+    c.bench_function("MutableBuffer::from_iter bool", |b| {
+        b.iter(|| mutable_buffer_from_iter(criterion::black_box(&bool_data)))
+    });
+    c.bench_function("Buffer::from_iter bool", |b| {
+        b.iter(|| buffer_from_iter(criterion::black_box(&bool_data)))
+    });
 }
 
 criterion_group!(benches, benchmark);


### PR DESCRIPTION
create a from_iter implementation for Buffer to collect boolean flags into a buffer that will:
* pre-allocate the appropriate size based on iterator site_hint()
* 'buffer' a byte in-memory until it's complete (at which point it is written)