### PR TITLE
ARROW-10297: [Rust] Parameter for parquet-read to output data in json format, add "cli" feature to parquet crate

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -43,6 +43,8 @@ chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "4.0.0-SNAPSHOT", optional = true }
 base64 = { version = "0.12", optional = true }
+clap = "2.33.3"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -43,7 +43,7 @@ chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "4.0.0-SNAPSHOT", optional = true }
 base64 = { version = "0.12", optional = true }
-clap = "2.33.3"
+clap = { version = "2.33.3", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 
 [dev-dependencies]
@@ -58,5 +58,16 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
-json_output = ["serde_json", "base64"]
+cli = ["serde_json", "base64", "clap"]
 
+[[ bin ]]
+name = "parquet-read"
+required-features = ["cli"]
+
+[[ bin ]]
+name = "parquet-schema"
+required-features = ["cli"]
+
+[[ bin ]]
+name = "parquet-rowcount"
+required-features = ["cli"]

--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -44,7 +44,7 @@ num-bigint = "0.3"
 arrow = { path = "../arrow", version = "4.0.0-SNAPSHOT", optional = true }
 base64 = { version = "0.12", optional = true }
 clap = "2.33.3"
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -58,3 +58,5 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
+json_output = ["serde_json", "base64"]
+

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -79,10 +79,10 @@ enabled by adding `RUSTFLAGS="-C target-feature=+sse4.2"` before the
 `cargo build` command.
 
 ## Test
-Run `cargo test` for unit tests.
+Run `cargo test` for unit tests. To also run tests related to the binaries, use `cargo test --features cli`.
 
 ## Binaries
-The following binaries are provided (use `cargo install` to install them):
+The following binaries are provided (use `cargo install --features cli` to install them):
 - **parquet-schema** for printing Parquet file schema and metadata.
 `Usage: parquet-schema <file-path>`, where `file-path` is the path to a Parquet file. Use `-v/--verbose` flag 
 to print full metadata or schema only (when not specified only schema will be printed).

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -90,8 +90,7 @@ to print full metadata or schema only (when not specified only schema will be pr
 - **parquet-read** for reading records from a Parquet file.
 `Usage: parquet-read <file-path> [num-records]`, where `file-path` is the path to a Parquet file,
 and `num-records` is the number of records to read from a file (when not specified all records will
-be printed). Use `cargo install --features json_output` to enable `-j/--json` flag for printing output
-in json lines format. 
+be printed). Use `-j/--json` to print records in JSON lines format.
 
 - **parquet-rowcount** for reporting the number of records in one or more Parquet files.
 `Usage: parquet-rowcount <file-paths>...`, where `<file-paths>...` is a space separated list of one or more 

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -84,18 +84,18 @@ Run `cargo test` for unit tests.
 ## Binaries
 The following binaries are provided (use `cargo install` to install them):
 - **parquet-schema** for printing Parquet file schema and metadata.
-`Usage: parquet-schema <file-path> [verbose]`, where `file-path` is the path to a Parquet file,
-and optional `verbose` is the boolean flag that allows to print full metadata or schema only
-(when not specified only schema will be printed).
+`Usage: parquet-schema <file-path>`, where `file-path` is the path to a Parquet file. Use `-v/--verbose` flag 
+to print full metadata or schema only (when not specified only schema will be printed).
 
 - **parquet-read** for reading records from a Parquet file.
 `Usage: parquet-read <file-path> [num-records]`, where `file-path` is the path to a Parquet file,
 and `num-records` is the number of records to read from a file (when not specified all records will
-be printed).
+be printed). Use `cargo install --features json_output` to enable `-j/--json` flag for printing output
+in json lines format. 
 
 - **parquet-rowcount** for reporting the number of records in one or more Parquet files.
-`Usage: parquet-rowcount <file-path> ...`, where `file-path` is the path to a Parquet file, and `...`
-indicates any number of additional parquet files.
+`Usage: parquet-rowcount <file-paths>...`, where `<file-paths>...` is a space separated list of one or more 
+files to read. 
 
 If you see `Library not loaded` error, please make sure `LD_LIBRARY_PATH` is set properly:
 ```

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -54,7 +54,7 @@ extern crate parquet;
 
 use std::{env, fs::File, path::Path};
 
-use clap::{App, Arg, crate_version, crate_authors};
+use clap::{crate_authors, crate_version, App, Arg};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::record::Row;
@@ -70,13 +70,15 @@ fn main() {
                 .value_name("file-path")
                 .required(true)
                 .index(1)
-                .help("Path to a parquet file")
+                .help("Path to a parquet file"),
         )
         .arg(
             Arg::with_name("num_records")
                 .value_name("num-records")
                 .index(2)
-                .help("Number of records to read. When not provided, all records are read.")
+                .help(
+                    "Number of records to read. When not provided, all records are read.",
+                ),
         );
 
     #[cfg(feature = "json_output")]
@@ -89,21 +91,23 @@ fn main() {
                 .value_name("file-path")
                 .required(true)
                 .index(1)
-                .help("Path to a parquet file")
+                .help("Path to a parquet file"),
         )
         .arg(
             Arg::with_name("num_records")
                 .value_name("num-records")
                 .index(2)
-                .help("Number of records to read. When not provided, all records are read.")
-        ).arg(
-        Arg::with_name("json")
-            .short("j")
-            .long("json")
-            .takes_value(false)
-            .help("Print parquet file in JSON lines Format")
+                .help(
+                    "Number of records to read. When not provided, all records are read.",
+                ),
+        )
+        .arg(
+            Arg::with_name("json")
+                .short("j")
+                .long("json")
+                .takes_value(false)
+                .help("Print parquet file in JSON lines Format"),
         );
-
 
     let matches = app.get_matches();
     let filename = matches.value_of("file_path").unwrap();
@@ -120,7 +124,6 @@ fn main() {
     if cfg!(feature = "json_output") {
         json = Some(matches.is_present("json"));
     }
-
 
     let path = Path::new(&filename);
     let file = File::open(&path).unwrap();

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -60,28 +60,6 @@ use parquet::file::reader::{FileReader, SerializedFileReader};
 use parquet::record::Row;
 
 fn main() {
-    #[cfg(not(feature = "json_output"))]
-    let app = App::new("parquet-read")
-        .version(crate_version!())
-        .author(crate_authors!())
-        .about("Read data from parquet file")
-        .arg(
-            Arg::with_name("file_path")
-                .value_name("file-path")
-                .required(true)
-                .index(1)
-                .help("Path to a parquet file"),
-        )
-        .arg(
-            Arg::with_name("num_records")
-                .value_name("num-records")
-                .index(2)
-                .help(
-                    "Number of records to read. When not provided, all records are read.",
-                ),
-        );
-
-    #[cfg(feature = "json_output")]
     let app = App::new("parquet-read")
         .version(crate_version!())
         .author(crate_authors!())
@@ -120,11 +98,7 @@ fn main() {
         None
     };
 
-    let mut json: Option<bool> = None;
-    if cfg!(feature = "json_output") {
-        json = Some(matches.is_present("json"));
-    }
-
+    let json = matches.is_present("json");
     let path = Path::new(&filename);
     let file = File::open(&path).unwrap();
     let parquet_reader = SerializedFileReader::new(file).unwrap();
@@ -145,18 +119,10 @@ fn main() {
     }
 }
 
-#[cfg(feature = "json_output")]
-fn print_row(row: &Row, json: Option<bool>) {
-    if let Some(j) = json {
-        if j {
-            println!("{}", row.to_json_value())
-        } else {
-            println!("{}", row.to_string());
-        }
+fn print_row(row: &Row, json: bool) {
+    if json {
+        println!("{}", row.to_json_value())
+    } else {
+        println!("{}", row.to_string());
     }
-}
-
-#[cfg(not(feature = "json_output"))]
-fn print_row(row: &Row, _json: Option<bool>) {
-    println!("{}", row.to_string());
 }

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -34,39 +34,68 @@
 //! ```
 //!
 //! # Usage
+//! ```
+//!  parquet-read <file-path> [num-records]
+//! ```
 //!
-//! ```
-//! parquet-read <file-path> [num-records]
-//! ```
-//! where `file-path` is the path to a Parquet file and `num-records` is the optional
-//! numeric option that allows to specify number of records to read from a file.
-//! When not provided, all records are read.
+//! ## Flags
+//!     -h, --help       Prints help information
+//!     -j, --json       Print parquet file in JSON lines Format
+//!     -V, --version    Prints version information
+//!
+//! ## Args
+//!     <file-path>      Path to a parquet file
+//!     <num-records>    Number of records to read. When not provided, all records are read.
 //!
 //! Note that `parquet-read` reads full file schema, no projection or filtering is
 //! applied.
 
 extern crate parquet;
 
-use std::{env, fs::File, path::Path, process};
+use std::{env, fs::File, path::Path};
+
+use clap::{App, Arg, crate_version, crate_authors};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::Row;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 && args.len() != 3 {
-        println!("Usage: parquet-read <file-path> [num-records]");
-        process::exit(1);
-    }
+    let matches = App::new("parquet-read")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("Read data from parquet file")
+        .arg(
+            Arg::with_name("file_path")
+                .value_name("file-path")
+                .required(true)
+                .index(1)
+                .help("Path to a parquet file")
+        )
+        .arg(
+            Arg::with_name("num_records")
+                .value_name("num-records")
+                .index(2)
+                .help("Number of records to read. When not provided, all records are read.")
+        ).arg(
+        Arg::with_name("json")
+            .short("j")
+            .long("json")
+            .takes_value(false)
+            .help("Print parquet file in JSON lines Format")
+    ).get_matches();
 
-    let mut num_records: Option<usize> = None;
-    if args.len() == 3 {
-        match args[2].parse() {
-            Ok(value) => num_records = Some(value),
+    let filename = matches.value_of("file_path").unwrap();
+    let num_records: Option<usize> = if matches.is_present("num_records") {
+        match matches.value_of("num_records").unwrap().parse() {
+            Ok(value) => Some(value),
             Err(e) => panic!("Error when reading value for [num-records], {}", e),
         }
-    }
+    } else {
+        None
+    };
+    let json = matches.is_present("json");
 
-    let path = Path::new(&args[1]);
+    let path = Path::new(&filename);
     let file = File::open(&path).unwrap();
     let parquet_reader = SerializedFileReader::new(file).unwrap();
 
@@ -79,9 +108,17 @@ fn main() {
 
     while all_records || start < end {
         match iter.next() {
-            Some(row) => println!("{}", row),
+            Some(row) => print_row(&row, json),
             None => break,
         }
         start += 1;
+    }
+}
+
+fn print_row(row: &Row, json: bool) {
+    if json {
+        println!("{}", row.to_json_value());
+    } else {
+        println!("{}", row.to_string());
     }
 }

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -35,16 +35,16 @@
 //!
 //! # Usage
 //! ```
-//!  parquet-read <file-path> [num-records]
+//! parquet-read <file-path> [num-records]
 //! ```
 //!
 //! ## Flags
 //!     -h, --help       Prints help information
-//!     -j, --json       Print parquet file in JSON lines Format
+//!     -j, --json       Print Parquet file in JSON lines Format
 //!     -V, --version    Prints version information
 //!
 //! ## Args
-//!     <file-path>      Path to a parquet file
+//!     <file-path>      Path to a Parquet file
 //!     <num-records>    Number of records to read. When not provided, all records are read.
 //!
 //! Note that `parquet-read` reads full file schema, no projection or filtering is
@@ -63,7 +63,7 @@ fn main() {
     let app = App::new("parquet-read")
         .version(crate_version!())
         .author(crate_authors!())
-        .about("Read data from parquet file")
+        .about("Read data from a Parquet file and print output in console, in either built-in or JSON format")
         .arg(
             Arg::with_name("file_path")
                 .value_name("file-path")
@@ -84,7 +84,7 @@ fn main() {
                 .short("j")
                 .long("json")
                 .takes_value(false)
-                .help("Print parquet file in JSON lines Format"),
+                .help("Print Parquet file in JSON lines format"),
         );
 
     let matches = app.get_matches();

--- a/rust/parquet/src/bin/parquet-rowcount.rs
+++ b/rust/parquet/src/bin/parquet-rowcount.rs
@@ -52,7 +52,7 @@ extern crate parquet;
 
 use std::{env, fs::File, path::Path};
 
-use clap::{App, Arg, crate_version, crate_authors};
+use clap::{crate_authors, crate_version, App, Arg};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
 
@@ -66,8 +66,9 @@ fn main() {
                 .value_name("file-paths")
                 .required(true)
                 .multiple(true)
-                .help("List of parquet files to read from")
-        ).get_matches();
+                .help("List of parquet files to read from"),
+        )
+        .get_matches();
 
     let filenames: Vec<&str> = matches.values_of("file_paths").unwrap().collect();
     for filename in &filenames {

--- a/rust/parquet/src/bin/parquet-rowcount.rs
+++ b/rust/parquet/src/bin/parquet-rowcount.rs
@@ -43,7 +43,7 @@
 //!     -V, --version    Prints version information
 //!
 //! ## Args
-//!     <file-paths>...    List of parquet files to read from
+//!     <file-paths>...    List of Parquet files to read from
 //!
 //! Note that `parquet-rowcount` reads full file schema, no projection or filtering is
 //! applied.
@@ -60,13 +60,13 @@ fn main() {
     let matches = App::new("parquet-rowcount")
         .version(crate_version!())
         .author(crate_authors!())
-        .about("Return number of rows in parquet file")
+        .about("Return number of rows in Parquet file")
         .arg(
             Arg::with_name("file_paths")
                 .value_name("file-paths")
                 .required(true)
                 .multiple(true)
-                .help("List of parquet files to read from"),
+                .help("List of Parquet files to read from separated by space"),
         )
         .get_matches();
 

--- a/rust/parquet/src/bin/parquet-rowcount.rs
+++ b/rust/parquet/src/bin/parquet-rowcount.rs
@@ -34,30 +34,43 @@
 //! ```
 //!
 //! # Usage
+//! ```
+//! parquet-rowcount <file-paths>...
+//! ```
 //!
-//! ```
-//! parquet-rowcount <file-path> ...
-//! ```
-//! where `file-path` is the path to a Parquet file and `...` is any additional number of
-//! parquet files to count the number of rows from.
+//! ## Flags
+//!     -h, --help       Prints help information
+//!     -V, --version    Prints version information
+//!
+//! ## Args
+//!     <file-paths>...    List of parquet files to read from
 //!
 //! Note that `parquet-rowcount` reads full file schema, no projection or filtering is
 //! applied.
 
 extern crate parquet;
 
-use std::{env, fs::File, path::Path, process};
+use std::{env, fs::File, path::Path};
+
+use clap::{App, Arg, crate_version, crate_authors};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        println!("Usage: parquet-rowcount <file-path> ...");
-        process::exit(1);
-    }
+    let matches = App::new("parquet-rowcount")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about("Return number of rows in parquet file")
+        .arg(
+            Arg::with_name("file_paths")
+                .value_name("file-paths")
+                .required(true)
+                .multiple(true)
+                .help("List of parquet files to read from")
+        ).get_matches();
 
-    for filename in &args[1..] {
+    let filenames: Vec<&str> = matches.values_of("file_paths").unwrap().collect();
+    for filename in &filenames {
         let path = Path::new(filename);
         let file = File::open(path).unwrap();
         let parquet_reader = SerializedFileReader::new(file).unwrap();

--- a/rust/parquet/src/bin/parquet-schema.rs
+++ b/rust/parquet/src/bin/parquet-schema.rs
@@ -34,17 +34,26 @@
 //! ```
 //!
 //! # Usage
+//! ```
+//! parquet-schema [FLAGS] <file-path>
+//! ```
 //!
-//! ```
-//! parquet-schema <file-path> [verbose]
-//! ```
-//! where `file-path` is the path to a Parquet file and `verbose` is the optional boolean
-//! flag that allows to print schema only, when set to `false` (default behaviour when
-//! not provided), or print full file metadata, when set to `true`.
+//! ## Flags
+//!     -h, --help       Prints help information
+//!     -V, --version    Prints version information
+//!     -v, --verbose    Enable printing full file metadata
+//!
+//! ## Args
+//!     <file-path>    Path to a parquet file
+//!
+//! Note that `verbose` is an optional boolean flag that allows to print schema only,
+//! when not provided or print full file metadata when provided.
 
 extern crate parquet;
 
-use std::{env, fs::File, path::Path, process};
+use std::{env, fs::File, path::Path};
+
+use clap::{App, Arg, crate_version, crate_authors};
 
 use parquet::{
     file::reader::{FileReader, SerializedFileReader},
@@ -52,31 +61,37 @@ use parquet::{
 };
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 && args.len() != 3 {
-        println!("Usage: parquet-schema <file-path> [verbose]");
-        process::exit(1);
-    }
-    let path = Path::new(&args[1]);
-    let mut verbose = false;
-    if args.len() == 3 {
-        match args[2].parse() {
-            Ok(b) => verbose = b,
-            Err(e) => panic!(
-                "Error when reading value for [verbose] (expected either 'true' or 'false'): {}",
-                e
-            ),
-        }
-    }
+    let matches = App::new("parquet-schema")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .arg(
+            Arg::with_name("file_path")
+                .value_name("file-path")
+                .required(true)
+                .index(1)
+                .help("Path to a parquet file")
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .takes_value(false)
+                .help("Enable printing full file metadata")
+        ).get_matches();
+
+    let filename = matches.value_of("file_path").unwrap();
+    let path = Path::new(&filename);
     let file = match File::open(&path) {
         Err(e) => panic!("Error when opening file {}: {}", path.display(), e),
         Ok(f) => f,
     };
+    let verbose = matches.is_present("verbose");
+
     match SerializedFileReader::new(file) {
         Err(e) => panic!("Error when parsing Parquet file: {}", e),
         Ok(parquet_reader) => {
             let metadata = parquet_reader.metadata();
-            println!("Metadata for file: {}", &args[1]);
+            println!("Metadata for file: {}", &filename);
             println!();
             if verbose {
                 print_parquet_metadata(&mut std::io::stdout(), &metadata);

--- a/rust/parquet/src/bin/parquet-schema.rs
+++ b/rust/parquet/src/bin/parquet-schema.rs
@@ -53,7 +53,7 @@ extern crate parquet;
 
 use std::{env, fs::File, path::Path};
 
-use clap::{App, Arg, crate_version, crate_authors};
+use clap::{crate_authors, crate_version, App, Arg};
 
 use parquet::{
     file::reader::{FileReader, SerializedFileReader},
@@ -69,15 +69,16 @@ fn main() {
                 .value_name("file-path")
                 .required(true)
                 .index(1)
-                .help("Path to a parquet file")
+                .help("Path to a parquet file"),
         )
         .arg(
             Arg::with_name("verbose")
                 .short("v")
                 .long("verbose")
                 .takes_value(false)
-                .help("Enable printing full file metadata")
-        ).get_matches();
+                .help("Enable printing full file metadata"),
+        )
+        .get_matches();
 
     let filename = matches.value_of("file_path").unwrap();
     let path = Path::new(&filename);

--- a/rust/parquet/src/bin/parquet-schema.rs
+++ b/rust/parquet/src/bin/parquet-schema.rs
@@ -44,7 +44,7 @@
 //!     -v, --verbose    Enable printing full file metadata
 //!
 //! ## Args
-//!     <file-path>    Path to a parquet file
+//!     <file-path>    Path to a Parquet file
 //!
 //! Note that `verbose` is an optional boolean flag that allows to print schema only,
 //! when not provided or print full file metadata when provided.
@@ -69,7 +69,7 @@ fn main() {
                 .value_name("file-path")
                 .required(true)
                 .index(1)
-                .help("Path to a parquet file"),
+                .help("Path to a Parquet file"),
         )
         .arg(
             Arg::with_name("verbose")

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -26,6 +26,8 @@ use crate::basic::{LogicalType, Type as PhysicalType};
 use crate::data_type::{ByteArray, Decimal, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
+
+#[cfg(feature = "json_output")]
 use serde_json::Value;
 
 /// Macro as a shortcut to generate 'not yet implemented' panic error.
@@ -77,6 +79,7 @@ impl Row {
         }
     }
 
+    #[cfg(feature = "json_output")]
     pub fn to_json_value(&self) -> Value {
         Value::Object(
             self.fields
@@ -646,6 +649,7 @@ impl Field {
         }
     }
 
+    #[cfg(feature = "json_output")]
     pub fn to_json_value(&self) -> Value {
         match &self {
             Field::Null => Value::Null,

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -697,7 +697,6 @@ impl Field {
             ),
         }
     }
-
 }
 
 impl fmt::Display for Field {

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -19,7 +19,7 @@
 
 use std::fmt;
 
-use chrono::{Local, TimeZone};
+use chrono::{TimeZone, Utc};
 use num_bigint::{BigInt, Sign};
 
 use crate::basic::{LogicalType, Type as PhysicalType};
@@ -773,7 +773,7 @@ impl fmt::Display for Field {
 #[inline]
 fn convert_date_to_string(value: u32) -> String {
     static NUM_SECONDS_IN_DAY: i64 = 60 * 60 * 24;
-    let dt = Local.timestamp(value as i64 * NUM_SECONDS_IN_DAY, 0).date();
+    let dt = Utc.timestamp(value as i64 * NUM_SECONDS_IN_DAY, 0).date();
     format!("{}", dt.format("%Y-%m-%d %:z"))
 }
 
@@ -782,7 +782,7 @@ fn convert_date_to_string(value: u32) -> String {
 /// Datetime is displayed in local timezone.
 #[inline]
 fn convert_timestamp_millis_to_string(value: u64) -> String {
-    let dt = Local.timestamp((value / 1000) as i64, 0);
+    let dt = Utc.timestamp((value / 1000) as i64, 0);
     format!("{}", dt.format("%Y-%m-%d %H:%M:%S %:z"))
 }
 
@@ -1046,7 +1046,7 @@ mod tests {
     fn test_convert_date_to_string() {
         fn check_date_conversion(y: u32, m: u32, d: u32) {
             let datetime = chrono::NaiveDate::from_ymd(y as i32, m, d).and_hms(0, 0, 0);
-            let dt = Local.from_utc_datetime(&datetime);
+            let dt = Utc.from_utc_datetime(&datetime);
             let res = convert_date_to_string((dt.timestamp() / 60 / 60 / 24) as u32);
             let exp = format!("{}", dt.format("%Y-%m-%d %:z"));
             assert_eq!(res, exp);
@@ -1063,7 +1063,7 @@ mod tests {
     fn test_convert_timestamp_to_string() {
         fn check_datetime_conversion(y: u32, m: u32, d: u32, h: u32, mi: u32, s: u32) {
             let datetime = chrono::NaiveDate::from_ymd(y as i32, m, d).and_hms(h, mi, s);
-            let dt = Local.from_utc_datetime(&datetime);
+            let dt = Utc.from_utc_datetime(&datetime);
             let res = convert_timestamp_millis_to_string(dt.timestamp_millis() as u64);
             let exp = format!("{}", dt.format("%Y-%m-%d %H:%M:%S %:z"));
             assert_eq!(res, exp);
@@ -1740,8 +1740,8 @@ mod tests {
             Value::String(String::from("AQID"))
         );
         assert_eq!(
-            Field::TimestampMicros(12345678).to_json_value(),
-            Value::String("1969-12-31 16:00:12 -08:00".to_string())
+            Field::TimestampMillis(12345678).to_json_value(),
+            Value::String("1970-01-01 03:25:45 +00:00".to_string())
         );
         assert_eq!(
             Field::TimestampMicros(12345678901).to_json_value(),


### PR DESCRIPTION
Add an option to print output in JSON format. in the parquet-read binary. Having json output allows for easy analysis using tools like [jq](https://stedolan.github.io/jq/). This PR builds on the changes implemented in https://github.com/apache/arrow/pull/8686 and incorporates the suggestions in that PR.

**Changelog**

* Update all three binaries `parquet-schema`, `parquet-rowcount` and `parquet-read` to use [clap](https://github.com/clap-rs/clap) for argument parsing
* Add `to_json_value()` method to get `serde_json::Value` from `Row` and `Field` structs (Thanks to @jhorstmann for these changes!)
* parquet-schema:
   * Convert verbose argument into `-v/--verbose` flag
 * parquet-read:
   * Add a new flag `-j/--json` that prints the file contents in json lines format
   * The feature is gated under the `json_output` cargo feature
* Update documentation and README with instructions for running
* The binaries now use version and author information as defined in Cargo.toml

Example output:

```
❯ parquet-read cities.parquet 3 --json
{"continent":"Europe","country":{"name":"France","city":["Paris","Nice","Marseilles","Cannes"]}}
{"continent":"Europe","country":{"name":"Greece","city":["Athens","Piraeus","Hania","Heraklion","Rethymnon","Fira"]}}
{"continent":"North America","country":{"name":"Canada","city":["Toronto","Vancouver","St. John's","Saint John","Montreal","Halifax","Winnipeg","Calgary","Saskatoon","Ottawa","Yellowknife"]}}
```