### PR TITLE
ARROW-11134: [CI][C++] Always run tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ jobs:
         # been received in the last 10m0s, this potentially indicates
         # a stalled build or something wrong with the build itself."
         # on Travis CI.
+        #
+        # Limiting CPP_MAKE_PARALLELISM is required to avoid random compiler
+        # crashes.
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
@@ -54,16 +57,7 @@ jobs:
           -e ARROW_S3=OFF
           -e ARROW_USE_GLOG=OFF
           -e CMAKE_UNITY_BUILD=ON
-          "
-        # We need to use smaller build when cache doesn't exist
-        # because Travis CI has "No output has been received in the
-        # last 10m0s" limitation. If we build many modules, we reach
-        # the limitation.
-        DOCKER_RUN_ARGS_NO_CACHE: >-
-          "
-          -e ARROW_BUILD_TESTS=OFF
-          -e ARROW_GANDIVA=OFF
-          -e ARROW_PARQUET=OFF
+          -e CPP_MAKE_PARALLELISM=4
           "
         # The LLVM's APT repository provides only arm64 binaries.
         # We should use LLVM provided by Ubuntu.
@@ -77,7 +71,6 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
-        # Can't use CMAKE_UNITY_BUILD=ON because of compiler crash.
         # Can't enable ARROW_MIMALLOC because of failures in memory pool tests.
         # Can't enable ARROW_S3 because compiler is killed while compiling
         # aws-sdk-cpp.
@@ -89,6 +82,8 @@ jobs:
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_S3=OFF
+          -e CMAKE_UNITY_BUILD=ON
+          -e CPP_MAKE_PARALLELISM=4
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF
           -e Protobuf_SOURCE=BUNDLED
@@ -148,10 +143,6 @@ script:
   #   /home/travis/.travis/functions: line 109: ulimit: core file size: cannot modify limit: Operation not permitted
   - |
     ulimit -c unlimited || :
-  - |
-    if [ $(ls $TRAVIS_BUILD_DIR/.docker | wc -l) -eq 0 ]; then
-      DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} ${DOCKER_RUN_ARGS_NO_CACHE}"
-    fi
   - |
     archery docker run \
       ${DOCKER_RUN_ARGS} \


### PR DESCRIPTION
Also try to fix a compiler crash issue by limiting build parallelism.