### PR TITLE
ARROW-11511: [Rust] Replace `Arc<ArrayData>` by `ArrayData` in all arrays

### DIFF
--- a/rust/arrow/examples/dynamic_types.rs
+++ b/rust/arrow/examples/dynamic_types.rs
@@ -95,7 +95,7 @@ fn process(batch: &RecordBatch) {
         Arc::new(projected_schema),
         vec![
             id.clone(), // NOTE: this is cloning the Arc not the array data
-            Arc::new(Float64Array::from(nested_c.data())),
+            Arc::new(Float64Array::from(nested_c.data().clone())),
         ],
     );
 }

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -15,16 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::convert::{From, TryInto};
 use std::fmt;
 use std::mem;
 use std::{any::Any, iter::FromIterator};
-use std::{
-    convert::{From, TryInto},
-    sync::Arc,
-};
 
 use super::{
-    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
+    array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData,
     FixedSizeListArray, GenericBinaryIter, GenericListArray, OffsetSizeTrait,
 };
 use crate::buffer::Buffer;
@@ -47,7 +44,7 @@ impl BinaryOffsetSizeTrait for i64 {
 }
 
 pub struct GenericBinaryArray<OffsetSize: BinaryOffsetSizeTrait> {
-    data: ArrayDataRef,
+    data: ArrayData,
     value_offsets: RawPtrBox<OffsetSize>,
     value_data: RawPtrBox<u8>,
 }
@@ -199,11 +196,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> Array for GenericBinaryArray<OffsetSize>
         self
     }
 
-    fn data(&self) -> ArrayDataRef {
-        self.data.clone()
-    }
-
-    fn data_ref(&self) -> &ArrayDataRef {
+    fn data(&self) -> &ArrayData {
         &self.data
     }
 
@@ -218,10 +211,10 @@ impl<OffsetSize: BinaryOffsetSizeTrait> Array for GenericBinaryArray<OffsetSize>
     }
 }
 
-impl<OffsetSize: BinaryOffsetSizeTrait> From<ArrayDataRef>
+impl<OffsetSize: BinaryOffsetSizeTrait> From<ArrayData>
     for GenericBinaryArray<OffsetSize>
 {
-    fn from(data: ArrayDataRef) -> Self {
+    fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.data_type(),
             &<OffsetSize as BinaryOffsetSizeTrait>::DATA_TYPE,
@@ -324,7 +317,7 @@ impl<T: BinaryOffsetSizeTrait> From<GenericListArray<T>> for GenericBinaryArray<
 
 /// A type of `FixedSizeListArray` whose elements are binaries.
 pub struct FixedSizeBinaryArray {
-    data: ArrayDataRef,
+    data: ArrayData,
     value_data: RawPtrBox<u8>,
     length: i32,
 }
@@ -453,7 +446,7 @@ impl FixedSizeBinaryArray {
             vec![buffer.into()],
             vec![],
         );
-        Ok(FixedSizeBinaryArray::from(Arc::new(array_data)))
+        Ok(FixedSizeBinaryArray::from(array_data))
     }
 
     /// Create an array from an iterable argument of byte slices.
@@ -521,8 +514,8 @@ impl FixedSizeBinaryArray {
     }
 }
 
-impl From<ArrayDataRef> for FixedSizeBinaryArray {
-    fn from(data: ArrayDataRef) -> Self {
+impl From<ArrayData> for FixedSizeBinaryArray {
+    fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.buffers().len(),
             1,
@@ -583,11 +576,7 @@ impl Array for FixedSizeBinaryArray {
         self
     }
 
-    fn data(&self) -> ArrayDataRef {
-        self.data.clone()
-    }
-
-    fn data_ref(&self) -> &ArrayDataRef {
+    fn data(&self) -> &ArrayData {
         &self.data
     }
 
@@ -604,7 +593,7 @@ impl Array for FixedSizeBinaryArray {
 
 /// A type of `DecimalArray` whose elements are binaries.
 pub struct DecimalArray {
-    data: ArrayDataRef,
+    data: ArrayData,
     value_data: RawPtrBox<u8>,
     precision: usize,
     scale: usize,
@@ -692,8 +681,8 @@ impl DecimalArray {
     }
 }
 
-impl From<ArrayDataRef> for DecimalArray {
-    fn from(data: ArrayDataRef) -> Self {
+impl From<ArrayData> for DecimalArray {
+    fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.buffers().len(),
             1,
@@ -730,11 +719,7 @@ impl Array for DecimalArray {
         self
     }
 
-    fn data(&self) -> ArrayDataRef {
-        self.data.clone()
-    }
-
-    fn data_ref(&self) -> &ArrayDataRef {
+    fn data(&self) -> &ArrayData {
         &self.data
     }
 

--- a/rust/arrow/src/array/array_boolean.rs
+++ b/rust/arrow/src/array/array_boolean.rs
@@ -16,10 +16,10 @@
 // under the License.
 
 use std::borrow::Borrow;
+use std::convert::From;
 use std::iter::{FromIterator, IntoIterator};
 use std::mem;
 use std::{any::Any, fmt};
-use std::{convert::From, sync::Arc};
 
 use super::*;
 use super::{array::print_long_array, raw_pointer::RawPtrBox};
@@ -28,7 +28,7 @@ use crate::util::bit_util;
 
 /// Array of bools
 pub struct BooleanArray {
-    data: ArrayDataRef,
+    data: ArrayData,
     /// Pointer to the value array. The lifetime of this must be <= to the value buffer
     /// stored in `data`, so it's safe to store.
     raw_values: RawPtrBox<u8>,
@@ -81,11 +81,7 @@ impl Array for BooleanArray {
         self
     }
 
-    fn data(&self) -> ArrayDataRef {
-        self.data.clone()
-    }
-
-    fn data_ref(&self) -> &ArrayDataRef {
+    fn data(&self) -> &ArrayData {
         &self.data
     }
 
@@ -125,8 +121,8 @@ impl From<Vec<Option<bool>>> for BooleanArray {
     }
 }
 
-impl From<ArrayDataRef> for BooleanArray {
-    fn from(data: ArrayDataRef) -> Self {
+impl From<ArrayData> for BooleanArray {
+    fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.buffers().len(),
             1,
@@ -187,7 +183,7 @@ impl<Ptr: Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray {
             vec![val_buf.into()],
             vec![],
         );
-        BooleanArray::from(Arc::new(data))
+        BooleanArray::from(data)
     }
 }
 

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -671,7 +671,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         if null_count > 0 {
             builder = builder.null_bit_buffer(null_bit_buffer.unwrap());
         }
-        builder = builder.add_child_data(values.data());
+        builder = builder.add_child_data(values.data().clone());
         DictionaryArray::<T>::from(builder.build())
     }
 
@@ -802,7 +802,7 @@ where
         let data = ArrayData::builder(data_type)
             .len(len)
             .add_buffer(offset_buffer)
-            .add_child_data(values_data)
+            .add_child_data(values_data.clone())
             .null_bit_buffer(null_bit_buffer)
             .build();
 
@@ -931,7 +931,7 @@ where
             self.list_len,
         ))
         .len(len)
-        .add_child_data(values_data)
+        .add_child_data(values_data.clone())
         .null_bit_buffer(null_bit_buffer)
         .build();
 
@@ -1481,7 +1481,7 @@ impl StructBuilder {
         let mut child_data = Vec::with_capacity(self.field_builders.len());
         for f in &mut self.field_builders {
             let arr = f.finish();
-            child_data.push(arr.data());
+            child_data.push(arr.data().clone());
         }
 
         let null_bit_buffer = self.bitmap_builder.finish();
@@ -2883,7 +2883,7 @@ mod tests {
             .add_buffer(Buffer::from_slice_ref(&[1, 2, 0, 4]))
             .build();
 
-        assert_eq!(expected_string_data, arr.column(0).data());
+        assert_eq!(&expected_string_data, arr.column(0).data());
 
         // TODO: implement equality for ArrayData
         assert_eq!(expected_int_data.len(), arr.column(1).data().len());

--- a/rust/arrow/src/array/equal/dictionary.rs
+++ b/rust/arrow/src/array/equal/dictionary.rs
@@ -34,8 +34,8 @@ pub(super) fn dictionary_equal<T: ArrowNativeType>(
     let lhs_keys = lhs.buffer::<T>(0);
     let rhs_keys = rhs.buffer::<T>(0);
 
-    let lhs_values = lhs.child_data()[0].as_ref();
-    let rhs_values = rhs.child_data()[0].as_ref();
+    let lhs_values = &lhs.child_data()[0];
+    let rhs_values = &rhs.child_data()[0];
 
     let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
     let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);

--- a/rust/arrow/src/array/equal/fixed_list.rs
+++ b/rust/arrow/src/array/equal/fixed_list.rs
@@ -36,8 +36,8 @@ pub(super) fn fixed_list_equal(
         _ => unreachable!(),
     };
 
-    let lhs_values = lhs.child_data()[0].as_ref();
-    let rhs_values = rhs.child_data()[0].as_ref();
+    let lhs_values = &lhs.child_data()[0];
+    let rhs_values = &rhs.child_data()[0];
 
     let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
     let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);

--- a/rust/arrow/src/array/equal/list.rs
+++ b/rust/arrow/src/array/equal/list.rs
@@ -115,8 +115,8 @@ pub(super) fn list_equal<T: OffsetSizeTrait>(
         return true;
     }
 
-    let lhs_values = lhs.child_data()[0].as_ref();
-    let rhs_values = rhs.child_data()[0].as_ref();
+    let lhs_values = &lhs.child_data()[0];
+    let rhs_values = &rhs.child_data()[0];
 
     let lhs_null_count = count_nulls(lhs_nulls, lhs_start, len);
     let rhs_null_count = count_nulls(rhs_nulls, rhs_start, len);

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -59,73 +59,73 @@ use variable_size::variable_sized_equal;
 
 impl PartialEq for dyn Array {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl<T: Array> PartialEq<T> for dyn Array {
     fn eq(&self, other: &T) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for NullArray {
     fn eq(&self, other: &NullArray) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl<T: ArrowPrimitiveType> PartialEq for PrimitiveArray<T> {
     fn eq(&self, other: &PrimitiveArray<T>) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for BooleanArray {
     fn eq(&self, other: &BooleanArray) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl<OffsetSize: StringOffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl<OffsetSize: BinaryOffsetSizeTrait> PartialEq for GenericBinaryArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for FixedSizeBinaryArray {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for DecimalArray {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericListArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for FixedSizeListArray {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
 impl PartialEq for StructArray {
     fn eq(&self, other: &Self) -> bool {
-        equal(self.data().as_ref(), other.data().as_ref())
+        equal(self.data(), other.data())
     }
 }
 
@@ -290,10 +290,10 @@ mod tests {
     use std::sync::Arc;
 
     use crate::array::{
-        array::Array, ArrayDataBuilder, ArrayDataRef, ArrayRef, BinaryOffsetSizeTrait,
-        BooleanArray, DecimalBuilder, FixedSizeBinaryBuilder, FixedSizeListBuilder,
-        GenericBinaryArray, Int32Builder, ListBuilder, NullArray, PrimitiveBuilder,
-        StringArray, StringDictionaryBuilder, StringOffsetSizeTrait, StructArray,
+        array::Array, ArrayDataBuilder, ArrayRef, BinaryOffsetSizeTrait, BooleanArray,
+        DecimalBuilder, FixedSizeBinaryBuilder, FixedSizeListBuilder, GenericBinaryArray,
+        Int32Builder, ListBuilder, NullArray, PrimitiveBuilder, StringArray,
+        StringDictionaryBuilder, StringOffsetSizeTrait, StructArray,
     };
     use crate::array::{GenericStringArray, Int32Array};
     use crate::buffer::Buffer;
@@ -303,11 +303,14 @@ mod tests {
 
     #[test]
     fn test_null_equal() {
-        let a = NullArray::new(12).data();
-        let b = NullArray::new(12).data();
+        let a = NullArray::new(12);
+        let a = a.data();
+        let b = NullArray::new(12);
+        let b = b.data();
         test_equal(&a, &b, true);
 
-        let b = NullArray::new(10).data();
+        let b = NullArray::new(10);
+        let b = b.data();
         test_equal(&a, &b, false);
 
         // Test the case where offset != 0
@@ -323,36 +326,43 @@ mod tests {
 
     #[test]
     fn test_boolean_equal() {
-        let a = BooleanArray::from(vec![false, false, true]).data();
-        let b = BooleanArray::from(vec![false, false, true]).data();
-        test_equal(a.as_ref(), b.as_ref(), true);
+        let a = BooleanArray::from(vec![false, false, true]);
+        let a = a.data();
+        let b = BooleanArray::from(vec![false, false, true]);
+        let b = b.data();
+        test_equal(&a, &b, true);
 
-        let b = BooleanArray::from(vec![false, false, false]).data();
-        test_equal(a.as_ref(), b.as_ref(), false);
+        let b = BooleanArray::from(vec![false, false, false]);
+        let b = b.data();
+        test_equal(&a, &b, false);
     }
 
     #[test]
-    fn test_boolean_equal_null() {
-        let a = BooleanArray::from(vec![Some(false), None, None, Some(true)]).data();
-        let b = BooleanArray::from(vec![Some(false), None, None, Some(true)]).data();
-        test_equal(a.as_ref(), b.as_ref(), true);
+    fn test_boolean_equal_nulls() {
+        let a = BooleanArray::from(vec![Some(false), None, None, Some(true)]);
+        let a = a.data();
+        let b = BooleanArray::from(vec![Some(false), None, None, Some(true)]);
+        let b = b.data();
+        test_equal(&a, &b, true);
 
-        let b = BooleanArray::from(vec![None, None, None, Some(true)]).data();
-        test_equal(a.as_ref(), b.as_ref(), false);
+        let b = BooleanArray::from(vec![None, None, None, Some(true)]);
+        let b = b.data();
+        test_equal(&a, &b, false);
 
-        let b = BooleanArray::from(vec![Some(true), None, None, Some(true)]).data();
-        test_equal(a.as_ref(), b.as_ref(), false);
+        let b = BooleanArray::from(vec![Some(true), None, None, Some(true)]);
+        let b = b.data();
+        test_equal(&a, &b, false);
     }
 
     #[test]
     fn test_boolean_equal_offset() {
-        let a =
-            BooleanArray::from(vec![false, true, false, true, false, false, true]).data();
+        let a = BooleanArray::from(vec![false, true, false, true, false, false, true]);
+        let a = a.data();
         let b =
-            BooleanArray::from(vec![true, false, false, false, true, false, true, true])
-                .data();
-        assert_eq!(equal(a.as_ref(), b.as_ref()), false);
-        assert_eq!(equal(b.as_ref(), a.as_ref()), false);
+            BooleanArray::from(vec![true, false, false, false, true, false, true, true]);
+        let b = b.data();
+        assert_eq!(equal(a, b), false);
+        assert_eq!(equal(b, a), false);
 
         let a_slice = a.slice(2, 3);
         let b_slice = b.slice(3, 3);
@@ -368,15 +378,19 @@ mod tests {
 
         // Elements fill in `u8`'s exactly.
         let mut vector = vec![false, false, true, true, true, true, true, true];
-        let a = BooleanArray::from(vector.clone()).data();
-        let b = BooleanArray::from(vector.clone()).data();
-        test_equal(a.as_ref(), b.as_ref(), true);
+        let a = BooleanArray::from(vector.clone());
+        let a = a.data();
+        let b = BooleanArray::from(vector.clone());
+        let b = b.data();
+        test_equal(&a, &b, true);
 
         // Elements fill in `u8`s + suffix bits.
         vector.push(true);
-        let a = BooleanArray::from(vector.clone()).data();
-        let b = BooleanArray::from(vector).data();
-        test_equal(a.as_ref(), b.as_ref(), true);
+        let a = BooleanArray::from(vector.clone());
+        let a = a.data();
+        let b = BooleanArray::from(vector);
+        let b = b.data();
+        test_equal(&a, &b, true);
     }
 
     #[test]
@@ -410,8 +424,10 @@ mod tests {
         ];
 
         for (lhs, rhs, expected) in cases {
-            let lhs = Int32Array::from(lhs).data();
-            let rhs = Int32Array::from(rhs).data();
+            let lhs = Int32Array::from(lhs);
+            let lhs = lhs.data();
+            let rhs = Int32Array::from(rhs);
+            let rhs = rhs.data();
             test_equal(&lhs, &rhs, expected);
         }
     }
@@ -457,9 +473,11 @@ mod tests {
         ];
 
         for (lhs, slice_lhs, rhs, slice_rhs, expected) in cases {
-            let lhs = Int32Array::from(lhs).data();
+            let lhs = Int32Array::from(lhs);
+            let lhs = lhs.data();
             let lhs = lhs.slice(slice_lhs.0, slice_lhs.1);
-            let rhs = Int32Array::from(rhs).data();
+            let rhs = Int32Array::from(rhs);
+            let rhs = rhs.data();
             let rhs = rhs.slice(slice_rhs.0, slice_rhs.1);
 
             test_equal(&lhs, &rhs, expected);
@@ -514,9 +532,11 @@ mod tests {
         for (lhs, rhs, expected) in cases {
             let lhs = lhs.iter().map(|x| x.as_deref()).collect();
             let rhs = rhs.iter().map(|x| x.as_deref()).collect();
-            let lhs = GenericStringArray::<OffsetSize>::from_opt_vec(lhs).data();
-            let rhs = GenericStringArray::<OffsetSize>::from_opt_vec(rhs).data();
-            test_equal(lhs.as_ref(), rhs.as_ref(), expected);
+            let lhs = GenericStringArray::<OffsetSize>::from_opt_vec(lhs);
+            let lhs = lhs.data();
+            let rhs = GenericStringArray::<OffsetSize>::from_opt_vec(rhs);
+            let rhs = rhs.data();
+            test_equal(lhs, rhs, expected);
         }
     }
 
@@ -542,9 +562,11 @@ mod tests {
                 .iter()
                 .map(|x| x.as_deref().map(|x| x.as_bytes()))
                 .collect();
-            let lhs = GenericBinaryArray::<OffsetSize>::from_opt_vec(lhs).data();
-            let rhs = GenericBinaryArray::<OffsetSize>::from_opt_vec(rhs).data();
-            test_equal(lhs.as_ref(), rhs.as_ref(), expected);
+            let lhs = GenericBinaryArray::<OffsetSize>::from_opt_vec(lhs);
+            let lhs = lhs.data();
+            let rhs = GenericBinaryArray::<OffsetSize>::from_opt_vec(rhs);
+            let rhs = rhs.data();
+            test_equal(lhs, rhs, expected);
         }
     }
 
@@ -560,18 +582,21 @@ mod tests {
 
     #[test]
     fn test_string_offset() {
-        let a = StringArray::from(vec![Some("a"), None, Some("b")]).data();
+        let a = StringArray::from(vec![Some("a"), None, Some("b")]);
+        let a = a.data();
         let a = a.slice(2, 1);
-        let b = StringArray::from(vec![Some("b")]).data();
+        let b = StringArray::from(vec![Some("b")]);
+        let b = b.data();
 
-        test_equal(&a, b.as_ref(), true);
+        test_equal(&a, &b, true);
     }
 
     #[test]
     fn test_string_offset_larger() {
-        let a =
-            StringArray::from(vec![Some("a"), None, Some("b"), None, Some("c")]).data();
-        let b = StringArray::from(vec![None, Some("b"), None, Some("c")]).data();
+        let a = StringArray::from(vec![Some("a"), None, Some("b"), None, Some("c")]);
+        let a = a.data();
+        let b = StringArray::from(vec![None, Some("b"), None, Some("c")]);
+        let b = b.data();
 
         test_equal(&a.slice(2, 2), &b.slice(0, 2), false);
         test_equal(&a.slice(2, 2), &b.slice(1, 2), true);
@@ -580,17 +605,18 @@ mod tests {
 
     #[test]
     fn test_null() {
-        let a = NullArray::new(2).data();
-        let b = NullArray::new(2).data();
-        test_equal(a.as_ref(), b.as_ref(), true);
+        let a = NullArray::new(2);
+        let a = a.data();
+        let b = NullArray::new(2);
+        let b = b.data();
+        test_equal(&a, &b, true);
 
-        let b = NullArray::new(1).data();
-        test_equal(a.as_ref(), b.as_ref(), false);
+        let b = NullArray::new(1);
+        let b = b.data();
+        test_equal(&a, &b, false);
     }
 
-    fn create_list_array<U: AsRef<[i32]>, T: AsRef<[Option<U>]>>(
-        data: T,
-    ) -> ArrayDataRef {
+    fn create_list_array<U: AsRef<[i32]>, T: AsRef<[Option<U>]>>(data: T) -> ArrayData {
         let mut builder = ListBuilder::new(Int32Builder::new(10));
         for d in data.as_ref() {
             if let Some(v) = d {
@@ -600,17 +626,17 @@ mod tests {
                 builder.append(false).unwrap()
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
     fn test_list_equal() {
         let a = create_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 6])]);
         let b = create_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 6])]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 7])]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     // Test the case where null_count > 0
@@ -620,7 +646,7 @@ mod tests {
             create_list_array(&[Some(&[1, 2]), None, None, Some(&[3, 4]), None, None]);
         let b =
             create_list_array(&[Some(&[1, 2]), None, None, Some(&[3, 4]), None, None]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_list_array(&[
             Some(&[1, 2]),
@@ -630,11 +656,11 @@ mod tests {
             None,
             None,
         ]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         let b =
             create_list_array(&[Some(&[1, 2]), None, None, Some(&[3, 5]), None, None]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         // a list where the nullness of values is determined by the list's bitmap
         let c_values = Int32Array::from(vec![1, 2, -1, -2, 3, 4, -3, -4]);
@@ -645,7 +671,7 @@ mod tests {
         ))))
         .len(6)
         .add_buffer(Buffer::from(vec![0i32, 2, 3, 4, 6, 7, 8].to_byte_slice()))
-        .add_child_data(c_values.data())
+        .add_child_data(c_values.data().clone())
         .null_bit_buffer(Buffer::from(vec![0b00001001]))
         .build();
 
@@ -666,10 +692,10 @@ mod tests {
         ))))
         .len(6)
         .add_buffer(Buffer::from(vec![0i32, 2, 3, 4, 6, 7, 8].to_byte_slice()))
-        .add_child_data(d_values.data())
+        .add_child_data(d_values.data().clone())
         .null_bit_buffer(Buffer::from(vec![0b00001001]))
         .build();
-        test_equal(c.as_ref(), d.as_ref(), true);
+        test_equal(&c, &d, true);
     }
 
     // Test the case where offset != 0
@@ -695,7 +721,7 @@ mod tests {
 
     fn create_fixed_size_binary_array<U: AsRef<[u8]>, T: AsRef<[Option<U>]>>(
         data: T,
-    ) -> ArrayDataRef {
+    ) -> ArrayData {
         let mut builder = FixedSizeBinaryBuilder::new(15, 5);
 
         for d in data.as_ref() {
@@ -705,17 +731,17 @@ mod tests {
                 builder.append_null().unwrap();
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
     fn test_fixed_size_binary_equal() {
         let a = create_fixed_size_binary_array(&[Some(b"hello"), Some(b"world")]);
         let b = create_fixed_size_binary_array(&[Some(b"hello"), Some(b"world")]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_fixed_size_binary_array(&[Some(b"hello"), Some(b"arrow")]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     // Test the case where null_count > 0
@@ -723,13 +749,13 @@ mod tests {
     fn test_fixed_size_binary_null() {
         let a = create_fixed_size_binary_array(&[Some(b"hello"), None, Some(b"world")]);
         let b = create_fixed_size_binary_array(&[Some(b"hello"), None, Some(b"world")]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_fixed_size_binary_array(&[Some(b"hello"), Some(b"world"), None]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         let b = create_fixed_size_binary_array(&[Some(b"hello"), None, Some(b"arrow")]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     #[test]
@@ -769,7 +795,7 @@ mod tests {
         test_equal(&a_slice, &b_slice, false);
     }
 
-    fn create_decimal_array(data: &[Option<i128>]) -> ArrayDataRef {
+    fn create_decimal_array(data: &[Option<i128>]) -> ArrayData {
         let mut builder = DecimalBuilder::new(20, 23, 6);
 
         for d in data {
@@ -779,17 +805,17 @@ mod tests {
                 builder.append_null().unwrap();
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
     fn test_decimal_equal() {
         let a = create_decimal_array(&[Some(8_887_000_000), Some(-8_887_000_000)]);
         let b = create_decimal_array(&[Some(8_887_000_000), Some(-8_887_000_000)]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_decimal_array(&[Some(15_887_000_000), Some(-8_887_000_000)]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     // Test the case where null_count > 0
@@ -797,13 +823,13 @@ mod tests {
     fn test_decimal_null() {
         let a = create_decimal_array(&[Some(8_887_000_000), None, Some(-8_887_000_000)]);
         let b = create_decimal_array(&[Some(8_887_000_000), None, Some(-8_887_000_000)]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_decimal_array(&[Some(8_887_000_000), Some(-8_887_000_000), None]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         let b = create_decimal_array(&[Some(15_887_000_000), None, Some(-8_887_000_000)]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     #[test]
@@ -863,7 +889,7 @@ mod tests {
     /// Create a fixed size list of 2 value lengths
     fn create_fixed_size_list_array<U: AsRef<[i32]>, T: AsRef<[Option<U>]>>(
         data: T,
-    ) -> ArrayDataRef {
+    ) -> ArrayData {
         let mut builder = FixedSizeListBuilder::new(Int32Builder::new(10), 3);
 
         for d in data.as_ref() {
@@ -877,17 +903,17 @@ mod tests {
                 builder.append(false).unwrap()
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
     fn test_fixed_size_list_equal() {
         let a = create_fixed_size_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 6])]);
         let b = create_fixed_size_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 6])]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_fixed_size_list_array(&[Some(&[1, 2, 3]), Some(&[4, 5, 7])]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     // Test the case where null_count > 0
@@ -909,7 +935,7 @@ mod tests {
             None,
             None,
         ]);
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         let b = create_fixed_size_list_array(&[
             Some(&[1, 2, 3]),
@@ -919,7 +945,7 @@ mod tests {
             None,
             None,
         ]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         let b = create_fixed_size_list_array(&[
             Some(&[1, 2, 3]),
@@ -929,7 +955,7 @@ mod tests {
             None,
             None,
         ]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     #[test]
@@ -984,14 +1010,13 @@ mod tests {
 
         let a =
             StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
-                .unwrap()
-                .data();
+                .unwrap();
+        let a = a.data();
 
-        let b = StructArray::try_from(vec![("f1", strings), ("f2", ints)])
-            .unwrap()
-            .data();
+        let b = StructArray::try_from(vec![("f1", strings), ("f2", ints)]).unwrap();
+        let b = b.data();
 
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
     }
 
     #[test]
@@ -1159,7 +1184,7 @@ mod tests {
         test_equal(a.data_ref(), c.data_ref(), false);
     }
 
-    fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayDataRef {
+    fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayData {
         let values = StringArray::from(values.to_vec());
         let mut builder = StringDictionaryBuilder::new_with_dictionary(
             PrimitiveBuilder::<Int16Type>::new(3),
@@ -1173,7 +1198,7 @@ mod tests {
                 builder.append_null().unwrap()
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
@@ -1188,26 +1213,26 @@ mod tests {
             &["a", "c", "b"],
             &[Some("a"), Some("b"), Some("a"), Some("c")],
         );
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         // different len
         let b =
             create_dictionary_array(&["a", "c", "b"], &[Some("a"), Some("b"), Some("a")]);
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         // different key
         let b = create_dictionary_array(
             &["a", "c", "b"],
             &[Some("a"), Some("b"), Some("a"), Some("a")],
         );
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         // different values, same keys
         let b = create_dictionary_array(
             &["a", "b", "d"],
             &[Some("a"), Some("b"), Some("a"), Some("d")],
         );
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 
     #[test]
@@ -1219,34 +1244,34 @@ mod tests {
         );
 
         // equal to self
-        test_equal(a.as_ref(), a.as_ref(), true);
+        test_equal(&a, &a, true);
 
         // different representation (values and keys are swapped), same result
         let b = create_dictionary_array(
             &["a", "c", "b"],
             &[Some("a"), None, Some("a"), Some("c")],
         );
-        test_equal(a.as_ref(), b.as_ref(), true);
+        test_equal(&a, &b, true);
 
         // different null position
         let b = create_dictionary_array(
             &["a", "c", "b"],
             &[Some("a"), Some("b"), Some("a"), None],
         );
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         // different key
         let b = create_dictionary_array(
             &["a", "c", "b"],
             &[Some("a"), None, Some("a"), Some("a")],
         );
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
 
         // different values, same keys
         let b = create_dictionary_array(
             &["a", "b", "d"],
             &[Some("a"), None, Some("a"), Some("d")],
         );
-        test_equal(a.as_ref(), b.as_ref(), false);
+        test_equal(&a, &b, false);
     }
 }

--- a/rust/arrow/src/array/ffi.rs
+++ b/rust/arrow/src/array/ffi.rs
@@ -105,19 +105,22 @@ mod tests {
 
     #[test]
     fn test_u32() -> Result<()> {
-        let data = UInt32Array::from(vec![Some(2), None, Some(1), None]).data();
-        test_round_trip(data.as_ref())
+        let array = UInt32Array::from(vec![Some(2), None, Some(1), None]);
+        let data = array.data();
+        test_round_trip(data)
     }
 
     #[test]
     fn test_u64() -> Result<()> {
-        let data = UInt64Array::from(vec![Some(2), None, Some(1), None]).data();
-        test_round_trip(data.as_ref())
+        let array = UInt64Array::from(vec![Some(2), None, Some(1), None]);
+        let data = array.data();
+        test_round_trip(data)
     }
 
     #[test]
     fn test_i64() -> Result<()> {
-        let data = Int64Array::from(vec![Some(2), None, Some(1), None]).data();
-        test_round_trip(data.as_ref())
+        let array = Int64Array::from(vec![Some(2), None, Some(1), None]);
+        let data = array.data();
+        test_round_trip(data)
     }
 }

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -38,12 +38,12 @@ use std::any::Any;
 use std::fmt;
 use std::mem;
 
-use crate::array::{Array, ArrayData, ArrayDataRef};
+use crate::array::{Array, ArrayData};
 use crate::datatypes::*;
 
 /// An Array where all elements are nulls
 pub struct NullArray {
-    data: ArrayDataRef,
+    data: ArrayData,
 }
 
 impl NullArray {
@@ -59,11 +59,7 @@ impl Array for NullArray {
         self
     }
 
-    fn data(&self) -> ArrayDataRef {
-        self.data.clone()
-    }
-
-    fn data_ref(&self) -> &ArrayDataRef {
+    fn data(&self) -> &ArrayData {
         &self.data
     }
 
@@ -92,12 +88,12 @@ impl Array for NullArray {
 
     /// Returns the total number of bytes of memory occupied physically by this [NullArray].
     fn get_array_memory_size(&self) -> usize {
-        self.data.get_array_memory_size() + mem::size_of_val(self)
+        mem::size_of_val(self)
     }
 }
 
-impl From<ArrayDataRef> for NullArray {
-    fn from(data: ArrayDataRef) -> Self {
+impl From<ArrayData> for NullArray {
+    fn from(data: ArrayData) -> Self {
         assert_eq!(
             data.data_type(),
             &DataType::Null,
@@ -135,9 +131,8 @@ mod tests {
         assert_eq!(null_arr.is_valid(0), false);
 
         assert_eq!(0, null_arr.get_buffer_memory_size());
-        let internals_of_null_array = 64; // Arc<ArrayData>
         assert_eq!(
-            null_arr.get_buffer_memory_size() + internals_of_null_array,
+            null_arr.get_buffer_memory_size() + std::mem::size_of::<NullArray>(),
             null_arr.get_array_memory_size()
         );
     }

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -93,8 +93,8 @@ where
     let left_keys = left.keys_array();
     let right_keys = right.keys_array();
 
-    let left_values = StringArray::from(left.values().data());
-    let right_values = StringArray::from(left.values().data());
+    let left_values = StringArray::from(left.values().data().clone());
+    let right_values = StringArray::from(left.values().data().clone());
 
     Box::new(move |i: usize, j: usize| {
         let key_left = left_keys.value(i).to_usize().unwrap();

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -15,13 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
-
 use crate::{buffer::MutableBuffer, datatypes::DataType, util::bit_util};
 
 use super::{
     data::{into_buffers, new_buffers},
-    ArrayData, ArrayDataRef,
+    ArrayData,
 };
 
 mod boolean;
@@ -58,7 +56,7 @@ struct _MutableArrayData<'a> {
 }
 
 impl<'a> _MutableArrayData<'a> {
-    fn freeze(self, dictionary: Option<ArrayDataRef>) -> ArrayData {
+    fn freeze(self, dictionary: Option<ArrayData>) -> ArrayData {
         let buffers = into_buffers(&self.data_type, self.buffer1, self.buffer2);
 
         let child_data = match self.data_type {
@@ -66,7 +64,7 @@ impl<'a> _MutableArrayData<'a> {
             _ => {
                 let mut child_data = Vec::with_capacity(self.child_data.len());
                 for child in self.child_data {
-                    child_data.push(Arc::new(child.freeze()));
+                    child_data.push(child.freeze());
                 }
                 child_data
             }
@@ -120,18 +118,18 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits 
 /// # Example:
 ///
 /// ```
-/// use std::sync::Arc;
 /// use arrow::{array::{Int32Array, Array, MutableArrayData}};
 ///
-/// let array = Int32Array::from(vec![1, 2, 3, 4, 5]).data();
+/// let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+/// let array = array.data();
 /// // Create a new `MutableArrayData` from an array and with a capacity of 4.
 /// // Capacity here is equivalent to `Vec::with_capacity`
-/// let arrays = vec![array.as_ref()];
+/// let arrays = vec![array];
 /// let mut mutable = MutableArrayData::new(arrays, false, 4);
 /// mutable.extend(0, 1, 3); // extend from the slice [1..3], [2,3]
 /// mutable.extend(0, 0, 3); // extend from the slice [0..3], [1,2,3]
 /// // `.freeze()` to convert `MutableArrayData` into a `ArrayData`.
-/// let new_array = Int32Array::from(Arc::new(mutable.freeze()));
+/// let new_array = Int32Array::from(mutable.freeze());
 /// assert_eq!(Int32Array::from(vec![2, 3, 1, 2, 3]), new_array);
 /// ```
 pub struct MutableArrayData<'a> {
@@ -145,7 +143,7 @@ pub struct MutableArrayData<'a> {
     // the child data of the `Array` in Dictionary arrays.
     // This is not stored in `MutableArrayData` because these values constant and only needed
     // at the end, when freezing [_MutableArrayData].
-    dictionary: Option<ArrayDataRef>,
+    dictionary: Option<ArrayData>,
 
     // function used to extend values from arrays. This function's lifetime is bound to the array
     // because it reads values from it.
@@ -319,7 +317,7 @@ impl<'a> MutableArrayData<'a> {
             DataType::List(_) | DataType::LargeList(_) => {
                 let childs = arrays
                     .iter()
-                    .map(|array| array.child_data()[0].as_ref())
+                    .map(|array| &array.child_data()[0])
                     .collect::<Vec<_>>();
                 vec![MutableArrayData::new(childs, use_nulls, capacity)]
             }
@@ -330,7 +328,7 @@ impl<'a> MutableArrayData<'a> {
                 .map(|i| {
                     let child_arrays = arrays
                         .iter()
-                        .map(|array| array.child_data()[i].as_ref())
+                        .map(|array| &array.child_data()[i])
                         .collect::<Vec<_>>();
                     MutableArrayData::new(child_arrays, use_nulls, capacity)
                 })
@@ -400,15 +398,16 @@ impl<'a> MutableArrayData<'a> {
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, sync::Arc};
 
     use super::*;
 
     use crate::{
         array::{
-            Array, ArrayDataRef, ArrayRef, BooleanArray, DictionaryArray,
+            Array, ArrayData, ArrayRef, BooleanArray, DictionaryArray,
             FixedSizeBinaryArray, Int16Array, Int16Type, Int32Array, Int64Array,
             Int64Builder, ListBuilder, NullArray, PrimitiveBuilder, StringArray,
             StringDictionaryBuilder, StructArray, UInt8Array,
@@ -424,12 +423,13 @@ mod tests {
     /// tests extending from a primitive array w/ offset nor nulls
     #[test]
     fn test_primitive() {
-        let b = UInt8Array::from(vec![Some(1), Some(2), Some(3)]).data();
-        let arrays = vec![b.as_ref()];
+        let b = UInt8Array::from(vec![Some(1), Some(2), Some(3)]);
+        let b = b.data();
+        let arrays = vec![b];
         let mut a = MutableArrayData::new(arrays, false, 3);
         a.extend(0, 0, 2);
         let result = a.freeze();
-        let array = UInt8Array::from(Arc::new(result));
+        let array = UInt8Array::from(result);
         let expected = UInt8Array::from(vec![Some(1), Some(2)]);
         assert_eq!(array, expected);
     }
@@ -438,12 +438,13 @@ mod tests {
     #[test]
     fn test_primitive_offset() {
         let b = UInt8Array::from(vec![Some(1), Some(2), Some(3)]);
-        let b = b.slice(1, 2).data();
-        let arrays = vec![b.as_ref()];
+        let b = b.slice(1, 2);
+        let b = b.data();
+        let arrays = vec![b];
         let mut a = MutableArrayData::new(arrays, false, 2);
         a.extend(0, 0, 2);
         let result = a.freeze();
-        let array = UInt8Array::from(Arc::new(result));
+        let array = UInt8Array::from(result);
         let expected = UInt8Array::from(vec![Some(2), Some(3)]);
         assert_eq!(array, expected);
     }
@@ -453,11 +454,11 @@ mod tests {
     fn test_primitive_null_offset() {
         let b = UInt8Array::from(vec![Some(1), None, Some(3)]);
         let b = b.slice(1, 2).data();
-        let arrays = vec![b.as_ref()];
+        let arrays = vec![b];
         let mut a = MutableArrayData::new(arrays, false, 2);
         a.extend(0, 0, 2);
         let result = a.freeze();
-        let array = UInt8Array::from(Arc::new(result));
+        let array = UInt8Array::from(result);
         let expected = UInt8Array::from(vec![None, Some(3)]);
         assert_eq!(array, expected);
     }
@@ -466,13 +467,13 @@ mod tests {
     fn test_primitive_null_offset_nulls() {
         let b = UInt8Array::from(vec![Some(1), Some(2), Some(3)]);
         let b = b.slice(1, 2).data();
-        let arrays = vec![b.as_ref()];
+        let arrays = vec![b];
         let mut a = MutableArrayData::new(arrays, true, 2);
         a.extend(0, 0, 2);
         a.extend_nulls(3);
         a.extend(0, 1, 2);
         let result = a.freeze();
-        let array = UInt8Array::from(Arc::new(result));
+        let array = UInt8Array::from(result);
         let expected =
             UInt8Array::from(vec![Some(2), Some(3), None, None, None, Some(3)]);
         assert_eq!(array, expected);
@@ -489,13 +490,13 @@ mod tests {
         builder.values().append_slice(&[6, 7, 8])?;
         builder.append(true)?;
         let array = builder.finish().data();
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![array];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
         mutable.extend(0, 0, 1);
 
         let result = mutable.freeze();
-        let array = ListArray::from(Arc::new(result));
+        let array = ListArray::from(result);
 
         let int_builder = Int64Builder::new(24);
         let mut builder = ListBuilder::<Int64Builder>::new(int_builder);
@@ -513,14 +514,14 @@ mod tests {
     fn test_variable_sized_nulls() {
         let array =
             StringArray::from(vec![Some("a"), Some("bc"), None, Some("defh")]).data();
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![array];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
 
         let result = mutable.freeze();
-        let result = StringArray::from(Arc::new(result));
+        let result = StringArray::from(result);
 
         let expected = StringArray::from(vec![Some("bc"), None]);
         assert_eq!(result, expected);
@@ -541,7 +542,7 @@ mod tests {
         mutable.extend(0, 0, 3);
 
         let result = mutable.freeze();
-        let result = StringArray::from(Arc::new(result));
+        let result = StringArray::from(result);
 
         let expected = StringArray::from(vec![Some("bc"), None, Some("defh")]);
         assert_eq!(result, expected);
@@ -560,7 +561,7 @@ mod tests {
         mutable.extend(0, 0, 3);
 
         let result = mutable.freeze();
-        let result = StringArray::from(Arc::new(result));
+        let result = StringArray::from(result);
 
         let expected = StringArray::from(vec![Some("bc"), None, Some("defh")]);
         assert_eq!(result, expected);
@@ -571,7 +572,7 @@ mod tests {
         let array1 = StringArray::from(vec!["hello", "world"]).data();
         let array2 = StringArray::from(vec![Some("1"), None]).data();
 
-        let arrays = vec![array1.as_ref(), array2.as_ref()];
+        let arrays = vec![array1, array2];
 
         let mut mutable = MutableArrayData::new(arrays, false, 5);
 
@@ -579,7 +580,7 @@ mod tests {
         mutable.extend(1, 0, 2);
 
         let result = mutable.freeze();
-        let result = StringArray::from(Arc::new(result));
+        let result = StringArray::from(result);
 
         let expected =
             StringArray::from(vec![Some("hello"), Some("world"), Some("1"), None]);
@@ -600,7 +601,7 @@ mod tests {
         mutable.extend_nulls(1);
 
         let result = mutable.freeze();
-        let result = StringArray::from(Arc::new(result));
+        let result = StringArray::from(result);
 
         let expected = StringArray::from(vec![None, Some("defh"), None]);
         assert_eq!(result, expected);
@@ -610,14 +611,14 @@ mod tests {
     fn test_bool() {
         let array =
             BooleanArray::from(vec![Some(false), Some(true), None, Some(false)]).data();
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![array];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
 
         let result = mutable.freeze();
-        let result = BooleanArray::from(Arc::new(result));
+        let result = BooleanArray::from(result);
 
         let expected = BooleanArray::from(vec![Some(true), None]);
         assert_eq!(result, expected);
@@ -627,7 +628,7 @@ mod tests {
     fn test_null() {
         let array1 = NullArray::new(10).data();
         let array2 = NullArray::new(5).data();
-        let arrays = vec![array1.as_ref(), array2.as_ref()];
+        let arrays = vec![array1, array2];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
@@ -635,13 +636,13 @@ mod tests {
         mutable.extend(1, 0, 1);
 
         let result = mutable.freeze();
-        let result = NullArray::from(Arc::new(result));
+        let result = NullArray::from(result);
 
         let expected = NullArray::new(3);
         assert_eq!(result, expected);
     }
 
-    fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayDataRef {
+    fn create_dictionary_array(values: &[&str], keys: &[Option<&str>]) -> ArrayData {
         let values = StringArray::from(values.to_vec());
         let mut builder = StringDictionaryBuilder::new_with_dictionary(
             PrimitiveBuilder::<Int16Type>::new(3),
@@ -655,7 +656,7 @@ mod tests {
                 builder.append_null().unwrap()
             }
         }
-        builder.finish().data()
+        builder.finish().data().clone()
     }
 
     #[test]
@@ -665,14 +666,14 @@ mod tests {
             &["a", "b", "c"],
             &[Some("a"), Some("b"), None, Some("c")],
         );
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![&array];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
 
         let result = mutable.freeze();
-        let result = DictionaryArray::from(Arc::new(result));
+        let result = DictionaryArray::from(result);
 
         let expected = Int16Array::from(vec![Some(1), None]);
         assert_eq!(result.keys(), &expected);
@@ -699,12 +700,12 @@ mod tests {
             StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
                 .unwrap()
                 .data();
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![array];
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
         let data = mutable.freeze();
-        let array = StructArray::from(Arc::new(data));
+        let array = StructArray::from(data);
 
         let expected = StructArray::try_from(vec![
             ("f1", strings.slice(1, 2)),
@@ -775,13 +776,13 @@ mod tests {
             StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
                 .unwrap()
                 .data();
-        let arrays = vec![array.as_ref()];
+        let arrays = vec![array];
 
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
         let data = mutable.freeze();
-        let array = StructArray::from(Arc::new(data));
+        let array = StructArray::from(data);
 
         let expected_string = Arc::new(StringArray::from(vec![None, None])) as ArrayRef;
         let expected_int = Arc::new(Int32Array::from(vec![Some(2), None])) as ArrayRef;
@@ -813,13 +814,13 @@ mod tests {
             StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
                 .unwrap()
                 .data();
-        let arrays = vec![array.as_ref(), array.as_ref()];
+        let arrays = vec![array, array];
         let mut mutable = MutableArrayData::new(arrays, false, 0);
 
         mutable.extend(0, 1, 3);
         mutable.extend(1, 0, 2);
         let data = mutable.freeze();
-        let array = StructArray::from(Arc::new(data));
+        let array = StructArray::from(data);
 
         let expected_string =
             Arc::new(StringArray::from(vec![None, None, Some("joe"), None])) as ArrayRef;
@@ -850,7 +851,7 @@ mod tests {
         mutable.extend(0, 0, 1);
 
         let result = mutable.freeze();
-        let result = FixedSizeBinaryArray::from(Arc::new(result));
+        let result = FixedSizeBinaryArray::from(result);
 
         let expected =
             FixedSizeBinaryArray::try_from_iter(vec![vec![0, 2], vec![0, 1]].into_iter())
@@ -882,8 +883,7 @@ mod tests {
         let b = b.data();
         let c = b.slice(1, 2);
 
-        let mut mutable =
-            MutableArrayData::new(vec![a.as_ref(), b.as_ref(), &c], false, 1);
+        let mut mutable = MutableArrayData::new(vec![a, b, &c], false, 1);
         mutable.extend(0, 0, a.len());
         mutable.extend(1, 0, b.len());
         mutable.extend(2, 0, c.len());
@@ -920,7 +920,7 @@ mod tests {
             None,
             0,
             vec![list_value_offsets],
-            vec![expected_int_array.data()],
+            vec![expected_int_array.data().clone()],
         );
         assert_eq!(finished, expected_list_data);
 
@@ -957,8 +957,7 @@ mod tests {
         let c = b.slice(1, 2);
         let d = b.slice(2, 2);
 
-        let mut mutable =
-            MutableArrayData::new(vec![a.as_ref(), b.as_ref(), &c, &d], false, 10);
+        let mut mutable = MutableArrayData::new(vec![a, b, &c, &d], false, 10);
 
         mutable.extend(0, 0, a.len());
         mutable.extend(1, 0, b.len());
@@ -1002,7 +1001,7 @@ mod tests {
             Some(Buffer::from(&[0b11011011, 0b1110])),
             0,
             vec![list_value_offsets],
-            vec![expected_int_array.data()],
+            vec![expected_int_array.data().clone()],
         );
         assert_eq!(result, expected_list_data);
 
@@ -1032,7 +1031,7 @@ mod tests {
         builder.append(true)?;
         let b = builder.finish().data();
 
-        let mut mutable = MutableArrayData::new(vec![a.as_ref(), b.as_ref()], false, 10);
+        let mut mutable = MutableArrayData::new(vec![a, b], false, 10);
 
         mutable.extend(0, 0, a.len());
         mutable.extend(1, 0, b.len());
@@ -1073,7 +1072,7 @@ mod tests {
             None,
             0,
             vec![list_value_offsets],
-            vec![expected_string_array.data()],
+            vec![expected_string_array.data().clone()],
         );
         assert_eq!(result, expected_list_data);
         Ok(())
@@ -1098,7 +1097,7 @@ mod tests {
             .expect("Failed to create FixedSizeBinaryArray from iterable")
             .data();
 
-        let mut mutable = MutableArrayData::new(vec![a.as_ref(), b.as_ref()], false, 10);
+        let mut mutable = MutableArrayData::new(vec![a, b], false, 10);
 
         mutable.extend(0, 0, a.len());
         mutable.extend(1, 0, b.len());
@@ -1213,7 +1212,7 @@ mod tests {
             vec![expected_int_array.data()],
         );
         let expected_list =
-            FixedSizeListArray::from(Arc::new(expected_list_data) as ArrayDataRef);
+            FixedSizeListArray::from(Arc::new(expected_list_data) as ArrayData);
         assert_eq!(&expected_list.values(), &finished.values());
         assert_eq!(expected_list.len(), finished.len());
 
@@ -1221,3 +1220,4 @@ mod tests {
     }
     */
 }
+ */

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -23,14 +23,15 @@
 //! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use std::sync::Arc;
 
 use num::{One, Zero};
 
 use crate::buffer::Buffer;
 #[cfg(simd)]
 use crate::buffer::MutableBuffer;
-use crate::compute::{kernels::arity::unary, util::combine_option_bitmap};
+use crate::compute::util::combine_option_bitmap;
+#[cfg(not(simd))]
+use crate::compute::kernels::arity::unary;
 use crate::datatypes;
 use crate::datatypes::ArrowNumericType;
 use crate::error::{ArrowError, Result};
@@ -87,7 +88,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 #[cfg(simd)]
@@ -136,7 +137,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// Helper function to perform math lambda function on values from two arrays. If either
@@ -185,7 +186,7 @@ where
         vec![buffer],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// Helper function to divide two arrays.
@@ -253,7 +254,7 @@ where
         vec![buffer],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// Scalar-divisor version of `math_divide`.
@@ -281,7 +282,7 @@ where
         vec![buffer],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// SIMD vectorized version of `math_op` above.
@@ -344,7 +345,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// SIMD vectorized implementation of `left / right`.
@@ -560,7 +561,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// SIMD vectorized version of `divide_scalar`.
@@ -606,7 +607,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 /// Perform `left + right` operation on two arrays. If either left or right value is null

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -29,9 +29,9 @@ use num::{One, Zero};
 use crate::buffer::Buffer;
 #[cfg(simd)]
 use crate::buffer::MutableBuffer;
-use crate::compute::util::combine_option_bitmap;
 #[cfg(not(simd))]
 use crate::compute::kernels::arity::unary;
+use crate::compute::util::combine_option_bitmap;
 use crate::datatypes;
 use crate::datatypes::ArrowNumericType;
 use crate::error::{ArrowError, Result};

--- a/rust/arrow/src/compute/kernels/arity.rs
+++ b/rust/arrow/src/compute/kernels/arity.rs
@@ -70,5 +70,5 @@ where
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
     let data = into_primitive_array_data::<_, O>(array, buffer);
-    PrimitiveArray::<O>::from(std::sync::Arc::new(data))
+    PrimitiveArray::<O>::from(data)
 }

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -23,7 +23,6 @@
 //! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
 use std::ops::Not;
-use std::sync::Arc;
 
 use crate::array::{Array, ArrayData, BooleanArray, PrimitiveArray};
 use crate::buffer::{
@@ -71,7 +70,7 @@ where
         vec![values],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Performs `AND` operation on two arrays. If either left or right value is null then the
@@ -153,7 +152,7 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray> {
         vec![values],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Returns a non-null [BooleanArray] with whether each value of the array is null.
@@ -185,7 +184,7 @@ pub fn is_null(input: &Array) -> Result<BooleanArray> {
     let data =
         ArrayData::new(DataType::Boolean, len, None, None, 0, vec![output], vec![]);
 
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Returns a non-null [BooleanArray] with whether each value of the array is not null.
@@ -219,7 +218,7 @@ pub fn is_not_null(input: &Array) -> Result<BooleanArray> {
     let data =
         ArrayData::new(DataType::Boolean, len, None, None, 0, vec![output], vec![]);
 
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Copies original array, setting null bit to true if a secondary comparison boolean array is set to true.
@@ -310,11 +309,13 @@ where
         data_buffers,
         left_data.child_data().to_vec(),
     );
-    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+    Ok(PrimitiveArray::<T>::from(data))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::array::{ArrayRef, Int32Array};
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -24,7 +24,6 @@
 
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::array::*;
 use crate::buffer::{Buffer, MutableBuffer};
@@ -60,7 +59,7 @@ macro_rules! compare_op {
             vec![buffer],
             vec![],
         );
-        Ok(BooleanArray::from(Arc::new(data)))
+        Ok(BooleanArray::from(data))
     }};
 }
 
@@ -81,7 +80,7 @@ macro_rules! compare_op_scalar {
             vec![buffer],
             vec![],
         );
-        Ok(BooleanArray::from(Arc::new(data)))
+        Ok(BooleanArray::from(data))
     }};
 }
 
@@ -176,7 +175,7 @@ pub fn like_utf8<OffsetSize: StringOffsetSizeTrait>(
         vec![result.finish()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 fn is_like_pattern(c: char) -> bool {
@@ -246,7 +245,7 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
         vec![bool_buf.into()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
@@ -298,7 +297,7 @@ pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
         vec![result.finish()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
@@ -351,7 +350,7 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
         vec![result.finish()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Perform `left == right` operation on [`StringArray`] / [`LargeStringArray`].
@@ -537,7 +536,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Helper function to perform boolean lambda function on values from an array and a scalar value using
@@ -620,7 +619,7 @@ where
         vec![result.into()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Perform `left == right` operation on two arrays.
@@ -822,7 +821,7 @@ where
         vec![bool_buf.into()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 /// Checks if a [`GenericListArray`] contains a value in the [`GenericStringArray`]
@@ -880,7 +879,7 @@ where
         vec![bool_buf.into()],
         vec![],
     );
-    Ok(BooleanArray::from(Arc::new(data)))
+    Ok(BooleanArray::from(data))
 }
 
 // create a buffer and fill it with valid bits
@@ -1198,7 +1197,8 @@ mod tests {
             None,
             Some(7),
         ])
-        .data();
+        .data()
+        .clone();
         let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 6, 9]);
         let list_data_type =
             DataType::LargeList(Box::new(Field::new("item", DataType::Int32, true)));

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -30,8 +30,6 @@
 //! assert_eq!(arr.len(), 3);
 //! ```
 
-use std::sync::Arc;
-
 use crate::array::*;
 use crate::error::{ArrowError, Result};
 
@@ -56,10 +54,7 @@ pub fn concat(arrays: &[&Array]) -> Result<ArrayRef> {
     let lengths = arrays.iter().map(|array| array.len()).collect::<Vec<_>>();
     let capacity = lengths.iter().sum();
 
-    let arrays = arrays
-        .iter()
-        .map(|a| a.data_ref().as_ref())
-        .collect::<Vec<_>>();
+    let arrays = arrays.iter().map(|a| a.data()).collect::<Vec<_>>();
 
     let mut mutable = MutableArrayData::new(arrays, false, capacity);
 
@@ -67,7 +62,7 @@ pub fn concat(arrays: &[&Array]) -> Result<ArrayRef> {
         mutable.extend(i, 0, *len)
     }
 
-    Ok(make_array(Arc::new(mutable.freeze())))
+    Ok(make_array(mutable.freeze()))
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -20,7 +20,7 @@
 use crate::error::Result;
 use crate::record_batch::RecordBatch;
 use crate::{array::*, util::bit_chunk_iterator::BitChunkIterator};
-use std::{iter::Enumerate, sync::Arc};
+use std::iter::Enumerate;
 
 /// Function that can filter arbitrary arrays
 pub type Filter<'a> = Box<Fn(&ArrayData) -> ArrayData + 'a>;
@@ -227,7 +227,7 @@ pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
         MutableArrayData::new(vec![array.data_ref()], false, iter.filter_count);
     iter.for_each(|(start, end)| mutable.extend(0, start, end));
     let data = mutable.freeze();
-    Ok(make_array(Arc::new(data)))
+    Ok(make_array(data))
 }
 
 /// Returns a new [RecordBatch] with arrays containing only values matching the filter.
@@ -241,7 +241,7 @@ pub fn filter_record_batch(
     let filtered_arrays = record_batch
         .columns()
         .iter()
-        .map(|a| make_array(Arc::new(filter(&a.data()))))
+        .map(|a| make_array(filter(&a.data())))
         .collect();
     RecordBatch::try_new(record_batch.schema(), filtered_arrays)
 }

--- a/rust/arrow/src/compute/kernels/length.rs
+++ b/rust/arrow/src/compute/kernels/length.rs
@@ -26,7 +26,6 @@ use crate::{
     datatypes::{DataType, Int32Type, Int64Type},
     error::{ArrowError, Result},
 };
-use std::sync::Arc;
 
 fn unary_offsets_string<O, F>(
     array: &GenericStringArray<O>,
@@ -67,7 +66,7 @@ where
         vec![buffer],
         vec![],
     );
-    make_array(Arc::new(data))
+    make_array(data)
 }
 
 fn octet_length<O: StringOffsetSizeTrait, T: ArrowPrimitiveType>(

--- a/rust/arrow/src/compute/kernels/limit.rs
+++ b/rust/arrow/src/compute/kernels/limit.rs
@@ -164,8 +164,8 @@ mod tests {
 
         assert_eq!(5, struct_array.len());
         assert_eq!(1, struct_array.null_count());
-        assert_eq!(boolean_data, struct_array.column(0).data());
-        assert_eq!(int_data, struct_array.column(1).data());
+        assert_eq!(&boolean_data, struct_array.column(0).data());
+        assert_eq!(&int_data, struct_array.column(1).data());
 
         let array: ArrayRef = Arc::new(struct_array);
 

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -18,7 +18,6 @@
 //! Defines sort kernel for `ArrayRef`
 
 use std::cmp::Ordering;
-use std::sync::Arc;
 
 use crate::array::*;
 use crate::buffer::MutableBuffer;
@@ -440,7 +439,7 @@ fn sort_boolean(
         }
     }
 
-    let result_data = Arc::new(ArrayData::new(
+    let result_data = ArrayData::new(
         DataType::UInt32,
         len,
         Some(0),
@@ -448,7 +447,7 @@ fn sort_boolean(
         0,
         vec![result.into()],
         vec![],
-    ));
+    );
 
     Ok(UInt32Array::from(result_data))
 }
@@ -517,7 +516,7 @@ where
         }
     }
 
-    let result_data = Arc::new(ArrayData::new(
+    let result_data = ArrayData::new(
         DataType::UInt32,
         len,
         Some(0),
@@ -525,7 +524,7 @@ where
         0,
         vec![result.into()],
         vec![],
-    ));
+    );
 
     Ok(UInt32Array::from(result_data))
 }
@@ -808,7 +807,7 @@ pub fn lexsort_to_indices(
     let flat_columns = columns
         .iter()
         .map(
-            |column| -> Result<(&ArrayDataRef, DynComparator, SortOptions)> {
+            |column| -> Result<(&ArrayData, DynComparator, SortOptions)> {
                 // flatten and convert build comparators
                 // use ArrayData for is_valid checks later to avoid dynamic call
                 let values = column.values.as_ref();
@@ -820,7 +819,7 @@ pub fn lexsort_to_indices(
                 ))
             },
         )
-        .collect::<Result<Vec<(&ArrayDataRef, DynComparator, SortOptions)>>>()?;
+        .collect::<Result<Vec<(&ArrayData, DynComparator, SortOptions)>>>()?;
 
     let lex_comparator = |a_idx: &usize, b_idx: &usize| -> Ordering {
         for (data, comparator, sort_option) in flat_columns.iter() {

--- a/rust/arrow/src/compute/kernels/substring.rs
+++ b/rust/arrow/src/compute/kernels/substring.rs
@@ -22,7 +22,6 @@ use crate::{
     datatypes::DataType,
     error::{ArrowError, Result},
 };
-use std::sync::Arc;
 
 #[allow(clippy::unnecessary_wraps)]
 fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
@@ -87,7 +86,7 @@ fn generic_substring<OffsetSize: StringOffsetSizeTrait>(
         ],
         vec![],
     );
-    Ok(make_array(Arc::new(data)))
+    Ok(make_array(data))
 }
 
 /// Returns an ArrayRef with a substring starting from `start` and with optional length `length` of each of the elements in `array`.

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -19,7 +19,6 @@
 
 use crate::compute::concat;
 use num::{abs, clamp};
-use std::sync::Arc;
 
 use crate::{
     array::{make_array, ArrayData, PrimitiveArray},
@@ -74,7 +73,7 @@ where
     );
 
     // Concatenate both arrays, add nulls after if shift > 0 else before
-    let null_arr = make_array(Arc::new(null_data));
+    let null_arr = make_array(null_data);
     if offset > 0 {
         concat(&[null_arr.as_ref(), slice.as_ref()])
     } else {

--- a/rust/arrow/src/compute/kernels/zip.rs
+++ b/rust/arrow/src/compute/kernels/zip.rs
@@ -18,7 +18,6 @@
 use crate::array::*;
 use crate::compute::SlicesIterator;
 use crate::error::{ArrowError, Result};
-use std::sync::Arc;
 
 /// Zip two arrays by some boolean mask. Where the mask evaluates `true` values of `truthy`
 /// are taken, where the mask evaluates `false` values of `falsy` are taken.
@@ -68,7 +67,7 @@ pub fn zip(
     }
 
     let data = mutable.freeze();
-    Ok(make_array(Arc::new(data)))
+    Ok(make_array(data))
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -29,8 +29,8 @@ use std::ops::Add;
 /// This function is useful when implementing operations on higher level arrays.
 #[allow(clippy::unnecessary_wraps)]
 pub(super) fn combine_option_bitmap(
-    left_data: &ArrayDataRef,
-    right_data: &ArrayDataRef,
+    left_data: &ArrayData,
+    right_data: &ArrayData,
     len_in_bits: usize,
 ) -> Result<Option<Buffer>> {
     let left_offset_in_bits = left_data.offset();
@@ -63,8 +63,8 @@ pub(super) fn combine_option_bitmap(
 /// This function is useful when implementing operations on higher level arrays.
 #[allow(clippy::unnecessary_wraps)]
 pub(super) fn compare_option_bitmap(
-    left_data: &ArrayDataRef,
-    right_data: &ArrayDataRef,
+    left_data: &ArrayData,
+    right_data: &ArrayData,
     len_in_bits: usize,
 ) -> Result<Option<Buffer>> {
     let left_offset_in_bits = left_data.offset();
@@ -302,7 +302,7 @@ pub(super) mod tests {
             offset.push(values.len() as i64);
         }
 
-        let value_data = PrimitiveArray::<T>::from(values).data();
+        let value_data = PrimitiveArray::<T>::from(values).data().clone();
         let (list_data_type, value_offsets) = if TypeId::of::<S>() == TypeId::of::<i32>()
         {
             (
@@ -391,7 +391,7 @@ pub(super) mod tests {
             length,
         );
 
-        let child_data = PrimitiveArray::<T>::from(values).data();
+        let child_data = PrimitiveArray::<T>::from(values).data().clone();
 
         let list_data = ArrayData::builder(list_data_type)
             .len(list_len)

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -643,7 +643,6 @@ mod tests {
     };
     use crate::compute::kernels;
     use std::convert::TryFrom;
-    use std::sync::Arc;
 
     #[test]
     fn test_round_trip() -> Result<()> {
@@ -651,10 +650,10 @@ mod tests {
         let array = Int32Array::from(vec![1, 2, 3]);
 
         // export it
-        let array = ArrowArray::try_from(array.data().as_ref().clone())?;
+        let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = Arc::new(ArrayData::try_from(array)?);
+        let data = ArrayData::try_from(array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -675,10 +674,10 @@ mod tests {
             GenericStringArray::<Offset>::from(vec![Some("a"), None, Some("aaa")]);
 
         // export it
-        let array = ArrowArray::try_from(array.data().as_ref().clone())?;
+        let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = Arc::new(ArrayData::try_from(array)?);
+        let data = ArrayData::try_from(array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -719,10 +718,10 @@ mod tests {
         let array = GenericBinaryArray::<Offset>::from(array);
 
         // export it
-        let array = ArrowArray::try_from(array.data().as_ref().clone())?;
+        let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = Arc::new(ArrayData::try_from(array)?);
+        let data = ArrayData::try_from(array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -764,10 +763,10 @@ mod tests {
         let array = BooleanArray::from(vec![None, Some(true), Some(false)]);
 
         // export it
-        let array = ArrowArray::try_from(array.data().as_ref().clone())?;
+        let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = Arc::new(ArrayData::try_from(array)?);
+        let data = ArrayData::try_from(array)?;
         let array = make_array(data);
 
         // perform some operation
@@ -790,10 +789,10 @@ mod tests {
         let array = Time32MillisecondArray::from(vec![None, Some(1), Some(2)]);
 
         // export it
-        let array = ArrowArray::try_from(array.data().as_ref().clone())?;
+        let array = ArrowArray::try_from(array.data().clone())?;
 
         // (simulate consumer) import it
-        let data = Arc::new(ArrayData::try_from(array)?);
+        let data = ArrayData::try_from(array)?;
         let array = make_array(data);
 
         // perform some operation

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -264,7 +264,7 @@ fn create_primitive_array(
                 let values = Arc::new(Int64Array::from(builder.build())) as ArrayRef;
                 // this cast is infallible, the unwrap is safe
                 let casted = cast(&values, data_type).unwrap();
-                casted.data()
+                casted.data().clone()
             } else {
                 let mut builder = ArrayData::builder(data_type.clone())
                     .len(length)
@@ -289,7 +289,7 @@ fn create_primitive_array(
                 let values = Arc::new(Float64Array::from(builder.build())) as ArrayRef;
                 // this cast is infallible, the unwrap is safe
                 let casted = cast(&values, data_type).unwrap();
-                casted.data()
+                casted.data().clone()
             } else {
                 let mut builder = ArrayData::builder(data_type.clone())
                     .len(length)
@@ -350,7 +350,7 @@ fn create_list_array(
             .len(field_node.length() as usize)
             .buffers(buffers[1..2].to_vec())
             .offset(0)
-            .child_data(vec![child_array.data()]);
+            .child_data(vec![child_array.data().clone()]);
         if null_count > 0 {
             builder = builder.null_bit_buffer(buffers[0].clone())
         }
@@ -361,7 +361,7 @@ fn create_list_array(
             .len(field_node.length() as usize)
             .buffers(buffers[1..2].to_vec())
             .offset(0)
-            .child_data(vec![child_array.data()]);
+            .child_data(vec![child_array.data().clone()]);
         if null_count > 0 {
             builder = builder.null_bit_buffer(buffers[0].clone())
         }
@@ -372,7 +372,7 @@ fn create_list_array(
             .len(field_node.length() as usize)
             .buffers(buffers[1..1].to_vec())
             .offset(0)
-            .child_data(vec![child_array.data()]);
+            .child_data(vec![child_array.data().clone()]);
         if null_count > 0 {
             builder = builder.null_bit_buffer(buffers[0].clone())
         }
@@ -396,7 +396,7 @@ fn create_dictionary_array(
             .len(field_node.length() as usize)
             .buffers(buffers[1..2].to_vec())
             .offset(0)
-            .child_data(vec![value_array.data()]);
+            .child_data(vec![value_array.data().clone()]);
         if null_count > 0 {
             builder = builder.null_bit_buffer(buffers[0].clone())
         }

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -25,7 +25,7 @@ use std::io::{BufWriter, Write};
 
 use flatbuffers::FlatBufferBuilder;
 
-use crate::array::{ArrayDataRef, ArrayRef};
+use crate::array::{ArrayData, ArrayRef};
 use crate::buffer::{Buffer, MutableBuffer};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
@@ -233,7 +233,7 @@ impl IpcDataGenerator {
     fn dictionary_batch_to_bytes(
         &self,
         dict_id: i64,
-        array_data: &ArrayDataRef,
+        array_data: &ArrayData,
         write_options: &IpcWriteOptions,
     ) -> EncodedData {
         let mut fbb = FlatBufferBuilder::new();
@@ -656,7 +656,7 @@ fn write_continuation<W: Write>(
 
 /// Write array data to a vector of bytes
 fn write_array_data(
-    array_data: &ArrayDataRef,
+    array_data: &ArrayData,
     mut buffers: &mut Vec<ipc::Buffer>,
     mut arrow_data: &mut Vec<u8>,
     mut nodes: &mut Vec<ipc::FieldNode>,

--- a/rust/arrow/src/json/writer.rs
+++ b/rust/arrow/src/json/writer.rs
@@ -623,7 +623,7 @@ mod tests {
         let a_list_data = ArrayData::builder(field_c1.data_type().clone())
             .len(5)
             .add_buffer(a_value_offsets)
-            .add_child_data(a_values.data())
+            .add_child_data(a_values.data().clone())
             .null_bit_buffer(Buffer::from(vec![0b00011111]))
             .build();
         let a = ListArray::from(a_list_data);
@@ -675,7 +675,7 @@ mod tests {
             .len(3)
             .add_buffer(a_value_offsets)
             .null_bit_buffer(Buffer::from(vec![0b00000111]))
-            .add_child_data(a_values.data())
+            .add_child_data(a_values.data().clone())
             .build();
 
         let c1_value_offsets = Buffer::from(&[0, 2, 2, 3].to_byte_slice());
@@ -755,7 +755,7 @@ mod tests {
         let c1_list_data = ArrayData::builder(field_c1.data_type().clone())
             .len(3)
             .add_buffer(c1_value_offsets)
-            .add_child_data(struct_values.data())
+            .add_child_data(struct_values.data().clone())
             .null_bit_buffer(Buffer::from(vec![0b00000101]))
             .build();
         let c1 = ListArray::from(c1_list_data);

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -367,7 +367,7 @@ mod tests {
             DataType::Int8,
             false,
         ))))
-        .add_child_data(a2_child.data())
+        .add_child_data(a2_child.data().clone())
         .len(2)
         .add_buffer(Buffer::from(vec![0i32, 3, 4].to_byte_slice()))
         .build();
@@ -376,8 +376,8 @@ mod tests {
             Field::new("aa1", DataType::Int32, false),
             Field::new("a2", a2.data_type().clone(), false),
         ]))
-        .add_child_data(a1.data())
-        .add_child_data(a2.data())
+        .add_child_data(a1.data().clone())
+        .add_child_data(a2.data().clone())
         .len(2)
         .build();
         let a: ArrayRef = Arc::new(StructArray::from(a));

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -238,7 +238,7 @@ impl ArrowJsonBatch {
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
-                        let arr = Int32Array::from(arr.data());
+                        let arr = Int32Array::from(arr.data().clone());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Int64
@@ -246,15 +246,15 @@ impl ArrowJsonBatch {
                     | DataType::Time64(_)
                     | DataType::Timestamp(_, _)
                     | DataType::Duration(_) => {
-                        let arr = Int64Array::from(arr.data());
+                        let arr = Int64Array::from(arr.data().clone());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Interval(IntervalUnit::YearMonth) => {
-                        let arr = IntervalYearMonthArray::from(arr.data());
+                        let arr = IntervalYearMonthArray::from(arr.data().clone());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Interval(IntervalUnit::DayTime) => {
-                        let arr = IntervalDayTimeArray::from(arr.data());
+                        let arr = IntervalDayTimeArray::from(arr.data().clone());
                         let x = json_array
                             .iter()
                             .map(|v| {
@@ -892,7 +892,7 @@ mod tests {
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
-            .add_child_data(value_data.data())
+            .add_child_data(value_data.data().clone())
             .build();
         let lists = ListArray::from(list_data);
 

--- a/rust/datafusion/src/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/physical_plan/math_expressions.rs
@@ -17,8 +17,6 @@
 
 //! Math expressions
 
-use std::sync::Arc;
-
 use arrow::array::{make_array, Array, ArrayData, Float32Array, Float64Array};
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, ToByteSlice};
@@ -41,7 +39,7 @@ macro_rules! compute_op {
             vec![Buffer::from(result.to_byte_slice())],
             vec![],
         );
-        Ok(make_array(Arc::new(data)))
+        Ok(make_array(data))
     }};
 }
 

--- a/rust/integration-testing/src/lib.rs
+++ b/rust/integration-testing/src/lib.rs
@@ -419,7 +419,7 @@ fn array_from_json(
                 .len(json_col.count)
                 .offset(0)
                 .add_buffer(Buffer::from(&offsets.to_byte_slice()))
-                .add_child_data(child_array.data())
+                .add_child_data(child_array.data().clone())
                 .null_bit_buffer(null_buf)
                 .build();
             Ok(Arc::new(ListArray::from(list_data)))
@@ -446,7 +446,7 @@ fn array_from_json(
                 .len(json_col.count)
                 .offset(0)
                 .add_buffer(Buffer::from(&offsets.to_byte_slice()))
-                .add_child_data(child_array.data())
+                .add_child_data(child_array.data().clone())
                 .null_bit_buffer(null_buf)
                 .build();
             Ok(Arc::new(LargeListArray::from(list_data)))
@@ -461,7 +461,7 @@ fn array_from_json(
             let null_buf = create_null_buf(&json_col);
             let list_data = ArrayData::builder(field.data_type().clone())
                 .len(json_col.count)
-                .add_child_data(child_array.data())
+                .add_child_data(child_array.data().clone())
                 .null_bit_buffer(null_buf)
                 .build();
             Ok(Arc::new(FixedSizeListArray::from(list_data)))
@@ -475,7 +475,7 @@ fn array_from_json(
 
             for (field, col) in fields.iter().zip(json_col.children.unwrap()) {
                 let array = array_from_json(field, col, dictionaries)?;
-                array_data = array_data.add_child_data(array.data());
+                array_data = array_data.add_child_data(array.data().clone());
             }
 
             let array = StructArray::from(array_data.build());
@@ -556,7 +556,7 @@ fn dictionary_array_from_json(
                 .len(keys.len())
                 .add_buffer(keys.data().buffers()[0].clone())
                 .null_bit_buffer(null_buf)
-                .add_child_data(values.data())
+                .add_child_data(values.data().clone())
                 .build();
 
             let array = match dict_key {

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -24,11 +24,11 @@ use std::sync::Arc;
 use std::vec::Vec;
 
 use arrow::array::{
-    new_empty_array, Array, ArrayData, ArrayDataBuilder, ArrayDataRef, ArrayRef,
-    BinaryArray, BinaryBuilder, BooleanArray, BooleanBufferBuilder, BooleanBuilder,
-    DecimalBuilder, FixedSizeBinaryArray, FixedSizeBinaryBuilder, GenericListArray,
-    Int16BufferBuilder, Int32Array, Int64Array, OffsetSizeTrait, PrimitiveArray,
-    PrimitiveBuilder, StringArray, StringBuilder, StructArray,
+    new_empty_array, Array, ArrayData, ArrayDataBuilder, ArrayRef, BinaryArray,
+    BinaryBuilder, BooleanArray, BooleanBufferBuilder, BooleanBuilder, DecimalBuilder,
+    FixedSizeBinaryArray, FixedSizeBinaryBuilder, GenericListArray, Int16BufferBuilder,
+    Int32Array, Int64Array, OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder,
+    StringArray, StringBuilder, StructArray,
 };
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::datatypes::{
@@ -890,7 +890,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayReader for ListArrayReader<OffsetSize> {
         let list_data = ArrayData::builder(self.get_data_type().clone())
             .len(offsets.len() - 1)
             .add_buffer(value_offsets)
-            .add_child_data(batch_values.data())
+            .add_child_data(batch_values.data().clone())
             .null_bit_buffer(null_buf.into())
             .offset(next_batch_array.offset())
             .build();
@@ -1039,8 +1039,8 @@ impl ArrayReader for StructArrayReader {
             .child_data(
                 children_array
                     .iter()
-                    .map(|x| x.data())
-                    .collect::<Vec<ArrayDataRef>>(),
+                    .map(|x| x.data().clone())
+                    .collect::<Vec<ArrayData>>(),
             )
             .build();
 

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -208,7 +208,7 @@ fn write_leaf(
             // If the column is a Date64, we cast it to a Date32, and then interpret that as Int32
             let array = if let ArrowDataType::Date64 = column.data_type() {
                 let array = arrow::compute::cast(column, &ArrowDataType::Date32)?;
-                Arc::new(arrow_array::Int32Array::from(array.data()))
+                arrow::compute::cast(&array, &ArrowDataType::Int32)?
             } else {
                 arrow::compute::cast(column, &ArrowDataType::Int32)?
             };
@@ -223,7 +223,10 @@ fn write_leaf(
             )?
         }
         ColumnWriter::BoolColumnWriter(ref mut typed) => {
-            let array = arrow_array::BooleanArray::from(column.data());
+            let array = column
+                .as_any()
+                .downcast_ref::<arrow_array::BooleanArray>()
+                .expect("Unable to get boolean array");
             typed.write_batch(
                 get_bool_array_slice(&array, &indices).as_slice(),
                 Some(levels.definition.as_slice()),
@@ -231,9 +234,25 @@ fn write_leaf(
             )?
         }
         ColumnWriter::Int64ColumnWriter(ref mut typed) => {
-            let array = arrow_array::Int64Array::from(column.data());
+            let values = match column.data_type() {
+                ArrowDataType::Int64 => {
+                    let array = column
+                        .as_any()
+                        .downcast_ref::<arrow_array::Int64Array>()
+                        .expect("Unable to get i64 array");
+                    get_numeric_array_slice::<Int64Type, _>(&array, &indices)
+                }
+                _ => {
+                    let array = arrow::compute::cast(column, &ArrowDataType::Int64)?;
+                    let array = array
+                        .as_any()
+                        .downcast_ref::<arrow_array::Int64Array>()
+                        .expect("Unable to get i64 array");
+                    get_numeric_array_slice::<Int64Type, _>(&array, &indices)
+                }
+            };
             typed.write_batch(
-                get_numeric_array_slice::<Int64Type, _>(&array, &indices).as_slice(),
+                values.as_slice(),
                 Some(levels.definition.as_slice()),
                 levels.repetition.as_deref(),
             )?
@@ -242,7 +261,10 @@ fn write_leaf(
             unreachable!("Currently unreachable because data type not supported")
         }
         ColumnWriter::FloatColumnWriter(ref mut typed) => {
-            let array = arrow_array::Float32Array::from(column.data());
+            let array = column
+                .as_any()
+                .downcast_ref::<arrow_array::Float32Array>()
+                .expect("Unable to get Float32 array");
             typed.write_batch(
                 get_numeric_array_slice::<FloatType, _>(&array, &indices).as_slice(),
                 Some(levels.definition.as_slice()),
@@ -250,7 +272,10 @@ fn write_leaf(
             )?
         }
         ColumnWriter::DoubleColumnWriter(ref mut typed) => {
-            let array = arrow_array::Float64Array::from(column.data());
+            let array = column
+                .as_any()
+                .downcast_ref::<arrow_array::Float64Array>()
+                .expect("Unable to get Float64 array");
             typed.write_batch(
                 get_numeric_array_slice::<DoubleType, _>(&array, &indices).as_slice(),
                 Some(levels.definition.as_slice()),
@@ -259,7 +284,10 @@ fn write_leaf(
         }
         ColumnWriter::ByteArrayColumnWriter(ref mut typed) => match column.data_type() {
             ArrowDataType::Binary => {
-                let array = arrow_array::BinaryArray::from(column.data());
+                let array = column
+                    .as_any()
+                    .downcast_ref::<arrow_array::BinaryArray>()
+                    .expect("Unable to get BinaryArray array");
                 typed.write_batch(
                     get_binary_array(&array).as_slice(),
                     Some(levels.definition.as_slice()),
@@ -267,7 +295,10 @@ fn write_leaf(
                 )?
             }
             ArrowDataType::Utf8 => {
-                let array = arrow_array::StringArray::from(column.data());
+                let array = column
+                    .as_any()
+                    .downcast_ref::<arrow_array::StringArray>()
+                    .expect("Unable to get LargeBinaryArray array");
                 typed.write_batch(
                     get_string_array(&array).as_slice(),
                     Some(levels.definition.as_slice()),
@@ -275,7 +306,10 @@ fn write_leaf(
                 )?
             }
             ArrowDataType::LargeBinary => {
-                let array = arrow_array::LargeBinaryArray::from(column.data());
+                let array = column
+                    .as_any()
+                    .downcast_ref::<arrow_array::LargeBinaryArray>()
+                    .expect("Unable to get LargeBinaryArray array");
                 typed.write_batch(
                     get_large_binary_array(&array).as_slice(),
                     Some(levels.definition.as_slice()),
@@ -283,7 +317,10 @@ fn write_leaf(
                 )?
             }
             ArrowDataType::LargeUtf8 => {
-                let array = arrow_array::LargeStringArray::from(column.data());
+                let array = column
+                    .as_any()
+                    .downcast_ref::<arrow_array::LargeStringArray>()
+                    .expect("Unable to get LargeUtf8 array");
                 typed.write_batch(
                     get_large_string_array(&array).as_slice(),
                     Some(levels.definition.as_slice()),
@@ -532,8 +569,8 @@ mod tests {
         assert_eq!(expected_batch.num_columns(), actual_batch.num_columns());
         assert_eq!(expected_batch.num_rows(), actual_batch.num_rows());
         for i in 0..expected_batch.num_columns() {
-            let expected_data = expected_batch.column(i).data();
-            let actual_data = actual_batch.column(i).data();
+            let expected_data = expected_batch.column(i).data().clone();
+            let actual_data = actual_batch.column(i).data().clone();
 
             assert_eq!(expected_data, actual_data);
         }
@@ -582,7 +619,7 @@ mod tests {
         ))))
         .len(5)
         .add_buffer(a_value_offsets)
-        .add_child_data(a_values.data())
+        .add_child_data(a_values.data().clone())
         .null_bit_buffer(Buffer::from(vec![0b00011011]))
         .build();
         let a = ListArray::from(a_list_data);
@@ -742,7 +779,7 @@ mod tests {
         let g_list_data = ArrayData::builder(struct_field_g.data_type().clone())
             .len(5)
             .add_buffer(g_value_offsets)
-            .add_child_data(g_value.data())
+            .add_child_data(g_value.data().clone())
             // .null_bit_buffer(Buffer::from(vec![0b00011011])) // TODO: add to test after resolving other issues
             .build();
         let g = ListArray::from(g_list_data);
@@ -780,13 +817,13 @@ mod tests {
         let b_data = ArrayDataBuilder::new(field_b.data_type().clone())
             .len(6)
             .null_bit_buffer(Buffer::from(vec![0b00100111]))
-            .add_child_data(c.data())
+            .add_child_data(c.data().clone())
             .build();
         let b = StructArray::from(b_data);
         let a_data = ArrayDataBuilder::new(field_a.data_type().clone())
             .len(6)
             .null_bit_buffer(Buffer::from(vec![0b00101111]))
-            .add_child_data(b.data())
+            .add_child_data(b.data().clone())
             .build();
         let a = StructArray::from(a_data);
 
@@ -811,12 +848,12 @@ mod tests {
         let c = Int32Array::from(vec![1, 2, 3, 4, 5, 6]);
         let b_data = ArrayDataBuilder::new(field_b.data_type().clone())
             .len(6)
-            .add_child_data(c.data())
+            .add_child_data(c.data().clone())
             .build();
         let b = StructArray::from(b_data);
         let a_data = ArrayDataBuilder::new(field_a.data_type().clone())
             .len(6)
-            .add_child_data(b.data())
+            .add_child_data(b.data().clone())
             .build();
         let a = StructArray::from(a_data);
 
@@ -843,13 +880,13 @@ mod tests {
         let b_data = ArrayDataBuilder::new(field_b.data_type().clone())
             .len(6)
             .null_bit_buffer(Buffer::from(vec![0b00100111]))
-            .add_child_data(c.data())
+            .add_child_data(c.data().clone())
             .build();
         let b = StructArray::from(b_data);
         // a intentionally has no null buffer, to test that this is handled correctly
         let a_data = ArrayDataBuilder::new(field_a.data_type().clone())
             .len(6)
-            .add_child_data(b.data())
+            .add_child_data(b.data().clone())
             .build();
         let a = StructArray::from(a_data);
 
@@ -1219,7 +1256,7 @@ mod tests {
         .len(5)
         .add_buffer(a_value_offsets)
         .null_bit_buffer(Buffer::from(vec![0b00011011]))
-        .add_child_data(a_values.data())
+        .add_child_data(a_values.data().clone())
         .build();
 
         assert_eq!(a_list_data.null_count(), 1);
@@ -1242,7 +1279,7 @@ mod tests {
         ))))
         .len(5)
         .add_buffer(a_value_offsets)
-        .add_child_data(a_values.data())
+        .add_child_data(a_values.data().clone())
         .null_bit_buffer(Buffer::from(vec![0b00011011]))
         .build();
 

--- a/rust/parquet/src/arrow/levels.rs
+++ b/rust/parquet/src/arrow/levels.rs
@@ -1174,7 +1174,7 @@ mod tests {
             .len(5)
             .add_buffer(a_value_offsets)
             .null_bit_buffer(Buffer::from(vec![0b00011011]))
-            .add_child_data(a_values.data())
+            .add_child_data(a_values.data().clone())
             .build();
 
         assert_eq!(a_list_data.null_count(), 1);
@@ -1278,7 +1278,7 @@ mod tests {
         let g_list_data = ArrayData::builder(struct_field_g.data_type().clone())
             .len(5)
             .add_buffer(g_value_offsets)
-            .add_child_data(g_value.data())
+            .add_child_data(g_value.data().clone())
             .build();
         let g = ListArray::from(g_list_data);
 


### PR DESCRIPTION
# Rational

Currently, all our arrays use an `Arc<ArrayData>`, which they expose via `Array::data` and `Array::data_ref`. This adds a level of indirection. Now, it happens that, afaik, in the current code base `Arc<>` is not needed.

On #9271 we are observing some performace issues with small arrays, and one of the ideas that came up was to get rid of `Arc` and see what happens.

# This PR

Well, this PR replaces all `Arc<ArrayData>` by `ArrayData`. On the one hand, this means that cloning an array is a tad more expensive (`Arc` vs `ArrayData`). On the other hand, it means that often the compiler can optimize out.

The gist of the benchmarks below is:
* ~10%-20% improvement over basically everything
* ~20%-100% improvement in `take`

There is some noise, as there are benches that are not expected to be affected and are being affected.

Personally, I like this PR because it makes working with `ArrayData` and arrays simpler: no need for `Arc::new` or `as_ref` and company (besides the speed).

# questions

* does anyone knows why we are using `Arc<ArrayData>` in all arrays?
* Do you envision an issue with removing the `Arc`?
* Would someone be so kind and run the benches independently, just to be sure.

# Benchmarks

```bash
# modify cargo.toml by adding `bench = false` to the section [lib]

git checkout master
cargo bench --benches -- --save-baseline `git branch --show-current`-`git rev-parse --short HEAD`

git checkout arcless
cargo bench --benches -- --save-baseline `git branch --show-current`-`git rev-parse --short HEAD`
```

```
Jorges-MacBook-Pro-2:arrow jorgecarleitao$ critcmp master-437c8c944 arcless-3dbcaca49 -t 10
group                                         arcless-3dbcaca49                       master-437c8c944
-----                                         -----------------                       ----------------
add 512                                       1.00    435.3±8.19ns        ? B/sec     1.30   565.7±81.95ns        ? B/sec
add_nulls_512                                 1.00   451.9±15.41ns        ? B/sec     1.29   581.9±98.83ns        ? B/sec
and                                           1.00  1516.9±39.34ns        ? B/sec     1.21  1842.4±190.71ns        ? B/sec
array_from_vec 128                            1.00   932.0±35.13ns        ? B/sec     1.51  1411.2±475.00ns        ? B/sec
array_from_vec 256                            1.00  1125.6±24.63ns        ? B/sec     1.23  1382.1±201.90ns        ? B/sec
array_from_vec 512                            1.00  1519.9±52.92ns        ? B/sec     1.24  1877.9±368.40ns        ? B/sec
array_slice 128                               1.00    293.3±4.85ns        ? B/sec     1.61   471.3±94.42ns        ? B/sec
array_slice 2048                              1.00    319.7±8.25ns        ? B/sec     1.50  478.2±293.70ns        ? B/sec
array_slice 512                               1.00    293.8±5.91ns        ? B/sec     1.69  496.1±145.06ns        ? B/sec
array_string_from_vec 128                     1.00      3.2±0.10µs        ? B/sec     1.35      4.3±1.68µs        ? B/sec
array_string_from_vec 256                     1.00      4.1±0.13µs        ? B/sec     1.18      4.9±0.94µs        ? B/sec
array_string_from_vec 512                     1.00      5.9±0.11µs        ? B/sec     1.26      7.4±5.14µs        ? B/sec
bench_bool/bench_bool                         1.00      2.0±0.03ms   245.8 MB/sec     1.12      2.3±0.30ms   219.7 MB/sec
buffer_bit_ops and                            1.00   577.0±11.19ns        ? B/sec     1.14  658.5±185.85ns        ? B/sec
cast date32 to date64 512                     1.00      6.8±0.21µs        ? B/sec     1.18      8.0±1.25µs        ? B/sec
cast date64 to date32 512                     1.00      6.8±0.42µs        ? B/sec     1.27      8.6±2.22µs        ? B/sec
cast f32 to string 512                        1.00     52.2±1.37µs        ? B/sec     1.17     61.0±9.24µs        ? B/sec
cast float32 to int32 512                     1.00      2.9±0.07µs        ? B/sec     1.20      3.4±0.52µs        ? B/sec
cast float64 to float32 512                   1.00      3.0±0.07µs        ? B/sec     1.18      3.6±0.47µs        ? B/sec
cast float64 to uint64 512                    1.00      3.4±0.19µs        ? B/sec     1.45      5.0±0.72µs        ? B/sec
cast int32 to float32 512                     1.00      2.9±0.09µs        ? B/sec     1.11      3.3±0.52µs        ? B/sec
cast int32 to float64 512                     1.00      2.7±0.12µs        ? B/sec     1.27      3.4±0.77µs        ? B/sec
cast int32 to int64 512                       1.00      2.9±0.06µs        ? B/sec     1.26      3.6±0.67µs        ? B/sec
cast int32 to uint32 512                      1.00      2.7±0.08µs        ? B/sec     1.23      3.3±0.32µs        ? B/sec
cast int64 to int32 512                       1.00      2.7±0.05µs        ? B/sec     1.23      3.3±0.89µs        ? B/sec
cast time32s to time32ms 512                  1.00  1487.8±52.94ns        ? B/sec     1.11  1648.3±145.69ns        ? B/sec
cast time32s to time64us 512                  1.00      4.8±0.12µs        ? B/sec     1.26      6.0±0.82µs        ? B/sec
cast time64ns to time32s 512                  1.00      9.9±0.24µs        ? B/sec     1.24     12.3±1.87µs        ? B/sec
cast timestamp_ms to i64 512                  1.00   286.7±13.15ns        ? B/sec     1.66   474.9±72.34ns        ? B/sec
cast timestamp_ms to timestamp_ns 512         1.00  1961.6±38.52ns        ? B/sec     1.41      2.8±4.01µs        ? B/sec
cast timestamp_ns to timestamp_s 512          1.00     26.2±0.31ns        ? B/sec     1.12     29.4±3.74ns        ? B/sec
cast utf8 to date32 512                       1.00     43.9±1.05µs        ? B/sec     1.15    50.7±10.33µs        ? B/sec
cast utf8 to f32                              1.00     30.9±0.81µs        ? B/sec     1.21     37.5±5.32µs        ? B/sec
concat str 1024                               1.00      9.9±0.54µs        ? B/sec     1.34     13.2±5.26µs        ? B/sec
divide 512                                    1.00  1411.3±40.15ns        ? B/sec     1.13  1599.1±200.00ns        ? B/sec
divide_nulls_512                              1.00  1419.2±28.43ns        ? B/sec     1.12  1587.9±142.46ns        ? B/sec
eq Float32                                    1.00    103.3±3.33µs        ? B/sec     1.25   129.4±19.72µs        ? B/sec
equal_512                                     1.00     19.2±1.00ns        ? B/sec     2.58    49.5±12.56ns        ? B/sec
equal_bool_512                                1.00     19.1±1.39ns        ? B/sec     2.17     41.5±2.29ns        ? B/sec
equal_bool_513                                1.00     21.1±0.70ns        ? B/sec     2.15     45.4±3.84ns        ? B/sec
equal_nulls_512                               1.00      2.4±0.11µs        ? B/sec     1.11      2.7±0.37µs        ? B/sec
equal_string_512                              1.00     84.5±5.08ns        ? B/sec     1.32    111.9±5.30ns        ? B/sec
equal_string_nulls_512                        1.00      3.6±0.48µs        ? B/sec     1.11      4.0±1.29µs        ? B/sec
filter context f32 high selectivity           1.00   308.9±10.81µs        ? B/sec     1.11   343.2±57.50µs        ? B/sec
filter context f32 low selectivity            1.00      2.7±0.08µs        ? B/sec     1.10      3.0±0.43µs        ? B/sec
filter context string high selectivity        1.00  1091.3±26.04µs        ? B/sec     1.13  1238.6±174.82µs        ? B/sec
filter context u8                             1.00    231.6±4.05µs        ? B/sec     1.21  281.0±112.36µs        ? B/sec
filter context u8 w NULLs                     1.00   500.1±20.38µs        ? B/sec     1.17  586.5±155.02µs        ? B/sec
filter context u8 w NULLs high selectivity    1.00    295.2±5.91µs        ? B/sec     1.17   344.2±63.42µs        ? B/sec
filter context u8 w NULLs low selectivity     1.00      2.9±0.51µs        ? B/sec     1.21      3.5±5.02µs        ? B/sec
filter f32                                    1.00   797.4±33.25µs        ? B/sec     1.22  971.4±135.07µs        ? B/sec
filter u8 low selectivity                     1.00      7.9±0.73µs        ? B/sec     1.12      8.9±1.47µs        ? B/sec
from_slice prepared                           1.15   961.1±24.81µs        ? B/sec     1.00   834.2±59.41µs        ? B/sec
gt Float32                                    1.00    66.2±14.03µs        ? B/sec     1.28     84.6±9.31µs        ? B/sec
gt scalar Float32                             1.49     60.9±8.59µs        ? B/sec     1.00     40.8±4.06µs        ? B/sec
gt_eq Float32                                 1.00   117.3±31.66µs        ? B/sec     1.10   129.6±25.35µs        ? B/sec
json_list_primitive_to_record_batch           1.00     63.3±2.09µs        ? B/sec     1.16    73.4±11.01µs        ? B/sec
json_primitive_to_record_batch                1.00     25.1±0.82µs        ? B/sec     1.11     27.7±4.88µs        ? B/sec
length                                        1.00      2.9±0.10µs        ? B/sec     1.30      3.7±0.77µs        ? B/sec
like_utf8 scalar ends with                    1.00   246.5±13.62µs        ? B/sec     1.19   294.5±45.77µs        ? B/sec
like_utf8 scalar equals                       1.17     98.3±7.08µs        ? B/sec     1.00    83.7±10.13µs        ? B/sec
limit 512, 512                                1.00    291.9±5.45ns        ? B/sec     1.55  451.1±130.11ns        ? B/sec
lt Float32                                    1.00    70.0±19.63µs        ? B/sec     1.26    88.3±12.27µs        ? B/sec
lt scalar Float32                             1.00     62.6±3.01µs        ? B/sec     1.39    87.3±25.97µs        ? B/sec
lt_eq Float32                                 1.00    104.8±8.32µs        ? B/sec     1.43   149.9±56.97µs        ? B/sec
lt_eq scalar Float32                          1.00     82.1±3.59µs        ? B/sec     1.11    91.3±12.27µs        ? B/sec
max nulls 512                                 1.00  1378.4±51.28ns        ? B/sec     1.32  1820.6±260.46ns        ? B/sec
min 512                                       1.00  1510.6±13.17ns        ? B/sec     1.28  1938.2±515.72ns        ? B/sec
min nulls 512                                 1.00  1380.2±51.78ns        ? B/sec     1.44  1980.7±259.55ns        ? B/sec
min nulls string 512                          1.00      7.1±0.12µs        ? B/sec     1.25      8.9±1.66µs        ? B/sec
multiply 512                                  1.00   461.5±42.95ns        ? B/sec     1.30  601.0±102.46ns        ? B/sec
mutable                                       1.00   475.9±15.21µs        ? B/sec     1.19   566.7±77.31µs        ? B/sec
mutable prepared                              1.00   530.8±21.36µs        ? B/sec     1.17   621.0±60.61µs        ? B/sec
mutable str 1024                              1.00  1493.7±56.88µs        ? B/sec     1.19  1776.6±329.88µs        ? B/sec
mutable str nulls 1024                        1.00      4.6±0.30ms        ? B/sec     1.13      5.2±0.51ms        ? B/sec
neq Float32                                   1.00     65.8±1.70µs        ? B/sec     1.39    91.5±20.30µs        ? B/sec
neq scalar Float32                            1.47    97.6±50.68µs        ? B/sec     1.00     66.4±6.21µs        ? B/sec
nlike_utf8 scalar contains                    1.00      2.4±0.03ms        ? B/sec     1.16      2.8±0.41ms        ? B/sec
nlike_utf8 scalar equals                      1.00   218.8±19.42µs        ? B/sec     1.14   249.2±24.71µs        ? B/sec
not                                           1.00   955.5±27.28ns        ? B/sec     1.15  1102.4±153.08ns        ? B/sec
or                                            1.00  1497.9±37.68ns        ? B/sec     1.15  1726.6±88.42ns        ? B/sec
sort 2^10                                     1.00   153.9±11.62µs        ? B/sec     1.14   175.6±25.84µs        ? B/sec
sort 2^12                                     1.00   748.9±51.51µs        ? B/sec     1.13  849.8±109.51µs        ? B/sec
struct_array_from_vec 256                     1.00      7.6±0.23µs        ? B/sec     1.12      8.5±2.51µs        ? B/sec
struct_array_from_vec 512                     1.00     10.0±0.73µs        ? B/sec     1.24     12.4±3.51µs        ? B/sec
subtract 512                                  1.00    434.8±9.25ns        ? B/sec     1.32   574.3±37.34ns        ? B/sec
sum 512                                       1.00   524.8±12.74ns        ? B/sec     1.19  626.2±156.66ns        ? B/sec
take bool 1024                                1.00      3.6±0.27µs        ? B/sec     1.45      5.2±3.11µs        ? B/sec
take bool 512                                 1.00      2.1±0.10µs        ? B/sec     1.23      2.6±0.32µs        ? B/sec
take bool nulls 1024                          1.00      5.1±2.09µs        ? B/sec     1.60      8.1±2.08µs        ? B/sec
take bool nulls 512                           1.00      2.1±0.14µs        ? B/sec     1.82      3.9±0.77µs        ? B/sec
take i32 1024                                 1.00  1583.0±111.03ns        ? B/sec    1.49      2.4±0.58µs        ? B/sec
take i32 512                                  1.00  1058.3±88.60ns        ? B/sec     1.29  1364.4±97.02ns        ? B/sec
take i32 nulls 1024                           1.00  1527.5±54.16ns        ? B/sec     1.82      2.8±1.00µs        ? B/sec
take i32 nulls 512                            1.00  1086.4±124.91ns        ? B/sec    2.34      2.5±1.64µs        ? B/sec
take str 1024                                 1.00      5.9±0.51µs        ? B/sec     1.20      7.1±1.30µs        ? B/sec
take str 512                                  1.00      3.8±0.36µs        ? B/sec     1.21      4.6±0.96µs        ? B/sec
take str null indices 1024                    1.00      5.6±0.16µs        ? B/sec     1.27      7.2±1.63µs        ? B/sec
take str null indices 512                     1.00      3.7±0.31µs        ? B/sec     1.23      4.6±1.32µs        ? B/sec
take str null values 1024                     1.00      5.7±0.14µs        ? B/sec     1.25      7.1±1.02µs        ? B/sec
take str null values null indices 1024        1.00     12.8±0.39µs        ? B/sec     1.14     14.6±1.85µs        ? B/sec
```