### PR TITLE
[Rust] [Experiment] [WIP]: Use SmallVec in ArrayData to optimize the common usecase of single-buffer arrays

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,6 +51,7 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
+smallvec = "1.6"
 
 [features]
 default = []

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,7 +51,6 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
-smallvec = "1.6"
 
 [features]
 default = []


### PR DESCRIPTION
Another experiement for speeding up `ArrayData`. Most array types only contain a single buffer (except for the validity buffer) and also at most one child data object. I think the only types this does not apply to are struct and union arrays. Using a `SmallVec` trades one comparison against an allocation and the resulting indirection in those cases.

The `ArrayData::new` method is left in place unchanged for compatibility.

TODO:

- [ ] Use the optimized `new_smallvec` method in kernels whenever applicable
- [ ] Run all benchmarks on a non-throttling machine

@jorgecarleitao @Dandandan this is also related to the discussion on #9271. I tried this initially some month ago and the benchmarks were not conclusive, but might be worth trying again or in combination with removing the Arc indirection.