### PR TITLE
ARROW-7288: [C++] Replace boost::regex with re2 in Parquet

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -129,11 +129,11 @@ else()
   set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_shared arrow_shared)
 endif()
 
-set(PARQUET_BOOST_LINK_LIBS)
+set(PARQUET_RE2_LINK_LIBS)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-  add_definitions(-DPARQUET_USE_BOOST_REGEX)
-  list(APPEND PARQUET_BOOST_LINK_LIBS ${BOOST_REGEX_LIBRARY})
+if(MINGW OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9"))
+  add_definitions(-DPARQUET_USE_RE2)
+  list(APPEND PARQUET_RE2_LINK_LIBS re2::re2)
 endif()
 
 set(PARQUET_MIN_TEST_LIBS GTest::gtest_main GTest::gtest)
@@ -236,11 +236,11 @@ if(NOT PARQUET_MINIMAL_DEPENDENCY)
 
   # These are libraries that we will link privately with parquet_shared (as they
   # do not need to be linked transitively by other linkers)
-  set(PARQUET_SHARED_PRIVATE_LINK_LIBS ${PARQUET_BOOST_LINK_LIBS} thrift::thrift)
+  set(PARQUET_SHARED_PRIVATE_LINK_LIBS ${PARQUET_RE2_LINK_LIBS} thrift::thrift)
 
   # Link publicly with parquet_static (because internal users need to
   # transitively link all dependencies)
-  set(PARQUET_STATIC_LINK_LIBS ${PARQUET_STATIC_LINK_LIBS} ${PARQUET_BOOST_LINK_LIBS}
+  set(PARQUET_STATIC_LINK_LIBS ${PARQUET_STATIC_LINK_LIBS} ${PARQUET_RE2_LINK_LIBS}
                                thrift::thrift)
 
   # Although we don't link parquet_objlib against anything, we need it to depend

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -33,11 +33,9 @@
 #include "parquet/statistics.h"
 #include "parquet/thrift_internal.h"
 
-// ARROW-6096: The boost regex library must be used when compiling with gcc < 4.9
-#if defined(PARQUET_USE_BOOST_REGEX)
-#include <boost/regex.hpp>  // IWYU pragma: keep
-using ::boost::regex;
-using ::boost::smatch;
+// ARROW-6096, ARROW-7288: can't use std::regex with gcc < 4.9 or mingw
+#if defined(PARQUET_USE_RE2)
+#include <re2/re2.h>  // IWYU pragma: keep
 
 template <typename... Args>
 static bool regex_match(Args&&... args) {

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -20,13 +20,7 @@
 #include "arrow/util/windows_compatibility.h"
 
 #include <cstdint>
-// Check if thrift version < 0.11.0
-// or if FORCE_BOOST_SMART_PTR is defined. Ref: https://thrift.apache.org/lib/cpp
-#if defined(PARQUET_THRIFT_USE_BOOST) || defined(FORCE_BOOST_SMART_PTR)
-#include <boost/shared_ptr.hpp>
-#else
 #include <memory>
-#endif
 #include <string>
 #include <vector>
 
@@ -54,13 +48,7 @@
 
 namespace parquet {
 
-// Check if thrift version < 0.11.0
-// or if FORCE_BOOST_SMART_PTR is defined. Ref: https://thrift.apache.org/lib/cpp
-#if defined(PARQUET_THRIFT_USE_BOOST) || defined(FORCE_BOOST_SMART_PTR)
-using ::boost::shared_ptr;
-#else
 using ::std::shared_ptr;
-#endif
 
 // ----------------------------------------------------------------------
 // Convert Thrift enums to Parquet enums


### PR DESCRIPTION
I started on this and think I got the cmake bits worked out, but since re2 doesn't look like a drop-in replacement for std::regex, I think there's more C++ refactoring required, which I don't feel competent enough to take on.