### PR TITLE
ARROW-11396: [JAVA] Update the private access permission from private to protected

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.types.pojo.Field;
  */
 public class VectorLoader {
 
-  private final VectorSchemaRoot root;
+  protected final VectorSchemaRoot root;
 
   /**
    * Construct with a root to load and will create children in root based on schema.
@@ -67,7 +67,7 @@ public class VectorLoader {
     }
   }
 
-  private void loadBuffers(
+  protected void loadBuffers(
       FieldVector vector,
       Field field,
       Iterator<ArrowBuf> buffers,

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -229,6 +229,10 @@ public class VectorSchemaRoot implements AutoCloseable {
     return rowCount;
   }
 
+  public void setRootRowCount(int rowCount) {
+    this.rowCount = rowCount;
+  }
+
   /**
    * Set the row count of all the vectors in this container. Also sets the value
    * count for each root level contained FieldVector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -44,8 +44,8 @@ import org.apache.arrow.vector.util.VectorBatchAppender;
 public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
 
   protected final BufferAllocator allocator;
-  private VectorLoader loader;
-  private VectorSchemaRoot root;
+  protected VectorLoader loader;
+  protected VectorSchemaRoot root;
   protected Map<Long, Dictionary> dictionaries;
   private boolean initialized = false;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -41,9 +41,9 @@ import org.apache.arrow.vector.validate.MetadataV4UnionChecker;
  */
 public class ArrowStreamReader extends ArrowReader {
 
-  private MessageChannelReader messageReader;
+  protected MessageChannelReader messageReader;
 
-  private int loadedDictionaryCount;
+  protected int loadedDictionaryCount;
 
   /**
    * Constructs a streaming reader using a MessageChannelReader. Non-blocking.
@@ -138,7 +138,7 @@ public class ArrowStreamReader extends ArrowReader {
   /**
    * When read a record batch, check whether its dictionaries are available.
    */
-  private void checkDictionaries() throws IOException {
+  protected void checkDictionaries() throws IOException {
     // if all dictionaries are loaded, return.
     if (loadedDictionaryCount == dictionaries.size()) {
       return;
@@ -177,7 +177,7 @@ public class ArrowStreamReader extends ArrowReader {
   }
 
 
-  private ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
+  protected ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
 
     ArrowBuf bodyBuffer = result.getBodyBuffer();
 


### PR DESCRIPTION
When using Arrow as the 3rd library, it is hard to add the custom function due to the private access permission. 
This PR update the private access permission from private to protected. Then we can easily expand new functions in the subclass.