### PR TITLE
ARROW-9634: [C++][Python] Restore non-UTC time zones when reading Parquet file that was previously Arrow

### DIFF
--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -270,6 +270,17 @@ def test_timestamp_restore_timezone():
     _check_roundtrip(t)
 
 
+def test_timestamp_restore_timezone_nanosecond():
+    # ARROW-9634, also restore timezone for nanosecond data that get stored
+    # as microseconds in the parquet file
+    ty = pa.timestamp('ns', tz='America/New_York')
+    arr = pa.array([1000, 2000, 3000], type=ty)
+    table = pa.table([arr], names=['f0'])
+    ty_us = pa.timestamp('us', tz='America/New_York')
+    expected = pa.table([arr.cast(ty_us)], names=['f0'])
+    _check_roundtrip(table, expected=expected)
+
+
 @pytest.mark.pandas
 def test_list_of_datetime_time_roundtrip():
     # ARROW-4135


### PR DESCRIPTION
Currently we required an exact match for the time unit to restore the timezone, but I don't think there any problem in restoring the timezone also when the unit is different (the timezone is purely metadata, and should be transferable as is accross units). 

Specifically, this solves the case of having nanosecond unit data as a start, which (by default) get stored as microsecond data in parquet, and thus currently didn't restore the timezone on roundtrip.