### PR TITLE
ARROW-11387: [Rust] fix build for conditional compilation of features 'simd + avx512'

### DIFF
--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -468,7 +468,7 @@ pub(super) fn buffer_bin_and(
     }
 }
 
-#[cfg(simd)]
+#[cfg(all(feature = "simd", not(feature = "avx512")))]
 pub(super) fn buffer_bin_and(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -579,7 +579,7 @@ pub(super) fn buffer_bin_or(
     }
 }
 
-#[cfg(simd)]
+#[cfg(all(feature = "simd", not(feature = "avx512")))]
 pub(super) fn buffer_bin_or(
     left: &Buffer,
     left_offset_in_bits: usize,


### PR DESCRIPTION
This fixes conditional compilation for `simd` and `avx512`. Currently compilation for both fails:

```
error[E0428]: the name `buffer_bin_and` is defined multiple times
   --> arrow/src/buffer.rs:472:1
    |
414 | / pub(super) fn buffer_bin_and(
415 | |     left: &Buffer,
416 | |     left_offset_in_bits: usize,
417 | |     right: &Buffer,
...   |
468 | |     }
469 | | }
    | |_- previous definition of the value `buffer_bin_and` here
...
472 | / pub(super) fn buffer_bin_and(
473 | |     left: &Buffer,
474 | |     left_offset_in_bits: usize,
475 | |     right: &Buffer,
...   |
501 | |     }
502 | | }
    | |_^ `buffer_bin_and` redefined here
    |
    = note: `buffer_bin_and` must be defined only once in the value namespace of this module

error[E0428]: the name `buffer_bin_or` is defined multiple times
   --> arrow/src/buffer.rs:583:1
    |
525 | / pub(super) fn buffer_bin_or(
526 | |     left: &Buffer,
527 | |     left_offset_in_bits: usize,
528 | |     right: &Buffer,
...   |
579 | |     }
580 | | }
    | |_- previous definition of the value `buffer_bin_or` here
...
583 | / pub(super) fn buffer_bin_or(
584 | |     left: &Buffer,
585 | |     left_offset_in_bits: usize,
586 | |     right: &Buffer,
...   |
612 | |     }
613 | | }
    | |_^ `buffer_bin_or` redefined here
    |
    = note: `buffer_bin_or` must be defined only once in the value namespace of this module

```

This PR is tested on:

`$ cargo c --features "simd"`

`$ cargo c --features "simd avx512"`

`$ cargo c --features "avx512"`

Maybe a check like used in [cargo hack](https://github.com/taiki-e/cargo-hack) can be added to the CI pipeline? This checks compilation for multiple feature combinations.