### PR TITLE
ARROW-11394: [Rust] Tests for Slice & Concat

### DIFF
--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -715,6 +715,48 @@ mod tests {
     }
 
     #[test]
+    fn test_struct_offset() {
+        let strings: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("joe"),
+            None,
+            None,
+            Some("mark"),
+            Some("doe"),
+        ]));
+        let ints: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+        ]));
+
+        let array =
+            StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
+                .unwrap()
+                .slice(1, 3)
+                .data();
+        let arrays = vec![array.as_ref()];
+        let mut mutable = MutableArrayData::new(arrays, false, 0);
+
+        mutable.extend(0, 1, 3);
+        let data = mutable.freeze();
+        let array = StructArray::from(Arc::new(data));
+
+        // Struct equality doesn't seem to work when using slices?
+
+        // let expected = StructArray::try_from(vec![
+        //     ("f1", strings.slice(2, 2)),
+        //     ("f2", ints.slice(2, 2)),
+        // ])
+        //     .unwrap();
+        //
+        // assert_eq!(array, expected)
+        // assert_eq!(array.column(0), &strings.slice(2, 2));
+        assert_eq!(array.column(1), &ints.slice(2, 2));
+    }
+
+    #[test]
     fn test_struct_nulls() {
         let strings: ArrayRef = Arc::new(StringArray::from(vec![
             Some("joe"),

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -743,8 +743,6 @@ mod tests {
         let data = mutable.freeze();
         let array = StructArray::from(Arc::new(data));
 
-        // Struct equality doesn't seem to work when using slices?
-
         let expected_strings: ArrayRef =
             Arc::new(StringArray::from(vec![None, Some("mark")]));
         let expected = StructArray::try_from(vec![

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -745,15 +745,14 @@ mod tests {
 
         // Struct equality doesn't seem to work when using slices?
 
-        // let expected = StructArray::try_from(vec![
-        //     ("f1", strings.slice(2, 2)),
-        //     ("f2", ints.slice(2, 2)),
-        // ])
-        //     .unwrap();
-        //
-        // assert_eq!(array, expected)
-        // assert_eq!(array.column(0), &strings.slice(2, 2));
-        assert_eq!(array.column(1), &ints.slice(2, 2));
+        let expected_strings: ArrayRef = Arc::new(StringArray::from(vec![None, Some("mark")]));
+        let expected = StructArray::try_from(vec![
+            ("f1", expected_strings),
+            ("f2", ints.slice(2, 2)),
+        ])
+            .unwrap();
+
+        assert_eq!(array, expected);
     }
 
     #[test]

--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -745,12 +745,13 @@ mod tests {
 
         // Struct equality doesn't seem to work when using slices?
 
-        let expected_strings: ArrayRef = Arc::new(StringArray::from(vec![None, Some("mark")]));
+        let expected_strings: ArrayRef =
+            Arc::new(StringArray::from(vec![None, Some("mark")]));
         let expected = StructArray::try_from(vec![
             ("f1", expected_strings),
             ("f2", ints.slice(2, 2)),
         ])
-            .unwrap();
+        .unwrap();
 
         assert_eq!(array, expected);
     }

--- a/rust/arrow/src/array/transform/structure.rs
+++ b/rust/arrow/src/array/transform/structure.rs
@@ -26,10 +26,13 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                   index: usize,
                   start: usize,
                   len: usize| {
-                mutable
-                    .child_data
-                    .iter_mut()
-                    .for_each(|child| child.extend(index, array.offset() + start, array.offset() + start + len))
+                mutable.child_data.iter_mut().for_each(|child| {
+                    child.extend(
+                        index,
+                        array.offset() + start,
+                        array.offset() + start + len,
+                    )
+                })
             },
         )
     } else {

--- a/rust/arrow/src/array/transform/structure.rs
+++ b/rust/arrow/src/array/transform/structure.rs
@@ -29,7 +29,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                 mutable
                     .child_data
                     .iter_mut()
-                    .for_each(|child| child.extend(index, start, start + len))
+                    .for_each(|child| child.extend(index, array.offset() + start, array.offset() + start + len))
             },
         )
     } else {
@@ -38,7 +38,7 @@ pub(super) fn build_extend(array: &ArrayData) -> Extend {
                   index: usize,
                   start: usize,
                   len: usize| {
-                (start..start + len).for_each(|i| {
+                (array.offset() + start..array.offset() + start + len).for_each(|i| {
                     if array.is_valid(i) {
                         mutable
                             .child_data

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -158,6 +158,38 @@ mod tests {
     }
 
     #[test]
+    fn test_concat_primitive_array_slices() -> Result<()> {
+        let input_1 = PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(-1),
+            Some(2),
+            None,
+            None,
+        ]).slice(1, 3);
+
+        let input_2 =     PrimitiveArray::<Int64Type>::from(vec![
+            Some(101),
+            Some(102),
+            Some(103),
+            None,
+        ]).slice(1, 3);
+        let arr = concat(&[input_1.as_ref(), input_2.as_ref()])?;
+
+        let expected_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(2),
+            None,
+            Some(102),
+            Some(103),
+            None,
+        ])) as ArrayRef;
+
+        assert_eq!(&arr, &expected_output);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_concat_boolean_primitive_arrays() -> Result<()> {
         let arr = concat(&[
             &BooleanArray::from(vec![
@@ -251,6 +283,96 @@ mod tests {
         let array_expected = Arc::new(builder_expected.finish()) as ArrayRef;
 
         assert_eq!(&array_result, &array_expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_concat_struct_arrays() -> Result<()> {
+        let field = Field::new("field", DataType::Int64, true);
+        let input_primitive_1: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(-1),
+            Some(2),
+            None,
+            None,
+        ]));
+        let input_struct_1 = StructArray::from(vec![(field.clone(), input_primitive_1)]);
+
+        let input_primitive_2: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(101),
+            Some(102),
+            Some(103),
+            None,
+        ]));
+        let input_struct_2 = StructArray::from(vec![(field.clone(), input_primitive_2)]);
+
+        let input_primitive_3: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![Some(256), Some(512), Some(1024)]));
+        let input_struct_3 = StructArray::from(vec![(field.clone(), input_primitive_3)]);
+
+        let arr = concat(&[
+            &input_struct_1,
+            &input_struct_2,
+            &input_struct_3,
+        ])?;
+
+        let expected_primitive_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(-1),
+            Some(2),
+            None,
+            None,
+            Some(101),
+            Some(102),
+            Some(103),
+            None,
+            Some(256),
+            Some(512),
+            Some(1024),
+        ])) as ArrayRef;
+
+        let actual_primitive = arr.as_any().downcast_ref::<StructArray>().unwrap().column(0);
+        assert_eq!(actual_primitive, &expected_primitive_output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_concat_struct_array_slices() -> Result<()> {
+        let field = Field::new("field", DataType::Int64, true);
+        let input_primitive_1: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(-1),
+            Some(2),
+            None,
+            None,
+        ]));
+        let input_struct_1 = StructArray::from(vec![(field.clone(), input_primitive_1)]);
+
+        let input_primitive_2: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(101),
+            Some(102),
+            Some(103),
+            None,
+        ]));
+        let input_struct_2 = StructArray::from(vec![(field.clone(), input_primitive_2)]);
+
+        let arr = concat(&[
+            input_struct_1.slice(1, 3).as_ref(),
+            input_struct_2.slice(1, 2).as_ref(),
+        ])?;
+
+        let expected_primitive_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(2),
+            None,
+            Some(102),
+            Some(103),
+            None,
+        ])) as ArrayRef;
+
+        let actual_primitive = arr.as_any().downcast_ref::<StructArray>().unwrap().column(0);
+        assert_eq!(actual_primitive, &expected_primitive_output);
 
         Ok(())
     }

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -165,14 +165,16 @@ mod tests {
             Some(2),
             None,
             None,
-        ]).slice(1, 3);
+        ])
+        .slice(1, 3);
 
-        let input_2 =     PrimitiveArray::<Int64Type>::from(vec![
+        let input_2 = PrimitiveArray::<Int64Type>::from(vec![
             Some(101),
             Some(102),
             Some(103),
             None,
-        ]).slice(1, 3);
+        ])
+        .slice(1, 3);
         let arr = concat(&[input_1.as_ref(), input_2.as_ref()])?;
 
         let expected_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
@@ -290,31 +292,34 @@ mod tests {
     #[test]
     fn test_concat_struct_arrays() -> Result<()> {
         let field = Field::new("field", DataType::Int64, true);
-        let input_primitive_1: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
-            Some(-1),
-            Some(-1),
-            Some(2),
-            None,
-            None,
-        ]));
+        let input_primitive_1: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(-1),
+                Some(-1),
+                Some(2),
+                None,
+                None,
+            ]));
         let input_struct_1 = StructArray::from(vec![(field.clone(), input_primitive_1)]);
 
-        let input_primitive_2: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
-            Some(101),
-            Some(102),
-            Some(103),
-            None,
-        ]));
+        let input_primitive_2: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(101),
+                Some(102),
+                Some(103),
+                None,
+            ]));
         let input_struct_2 = StructArray::from(vec![(field.clone(), input_primitive_2)]);
 
-        let input_primitive_3: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![Some(256), Some(512), Some(1024)]));
+        let input_primitive_3: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(256),
+                Some(512),
+                Some(1024),
+            ]));
         let input_struct_3 = StructArray::from(vec![(field.clone(), input_primitive_3)]);
 
-        let arr = concat(&[
-            &input_struct_1,
-            &input_struct_2,
-            &input_struct_3,
-        ])?;
+        let arr = concat(&[&input_struct_1, &input_struct_2, &input_struct_3])?;
 
         let expected_primitive_output = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
             Some(-1),
@@ -331,7 +336,11 @@ mod tests {
             Some(1024),
         ])) as ArrayRef;
 
-        let actual_primitive = arr.as_any().downcast_ref::<StructArray>().unwrap().column(0);
+        let actual_primitive = arr
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0);
         assert_eq!(actual_primitive, &expected_primitive_output);
 
         Ok(())
@@ -340,21 +349,23 @@ mod tests {
     #[test]
     fn test_concat_struct_array_slices() -> Result<()> {
         let field = Field::new("field", DataType::Int64, true);
-        let input_primitive_1: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
-            Some(-1),
-            Some(-1),
-            Some(2),
-            None,
-            None,
-        ]));
+        let input_primitive_1: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(-1),
+                Some(-1),
+                Some(2),
+                None,
+                None,
+            ]));
         let input_struct_1 = StructArray::from(vec![(field.clone(), input_primitive_1)]);
 
-        let input_primitive_2: ArrayRef = Arc::new(PrimitiveArray::<Int64Type>::from(vec![
-            Some(101),
-            Some(102),
-            Some(103),
-            None,
-        ]));
+        let input_primitive_2: ArrayRef =
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(101),
+                Some(102),
+                Some(103),
+                None,
+            ]));
         let input_struct_2 = StructArray::from(vec![(field.clone(), input_primitive_2)]);
 
         let arr = concat(&[
@@ -370,7 +381,11 @@ mod tests {
             Some(103),
         ])) as ArrayRef;
 
-        let actual_primitive = arr.as_any().downcast_ref::<StructArray>().unwrap().column(0);
+        let actual_primitive = arr
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0);
         assert_eq!(actual_primitive, &expected_primitive_output);
 
         Ok(())

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -317,7 +317,7 @@ mod tests {
                 Some(512),
                 Some(1024),
             ]));
-        let input_struct_3 = StructArray::from(vec![(field.clone(), input_primitive_3)]);
+        let input_struct_3 = StructArray::from(vec![(field, input_primitive_3)]);
 
         let arr = concat(&[&input_struct_1, &input_struct_2, &input_struct_3])?;
 
@@ -366,7 +366,7 @@ mod tests {
                 Some(103),
                 None,
             ]));
-        let input_struct_2 = StructArray::from(vec![(field.clone(), input_primitive_2)]);
+        let input_struct_2 = StructArray::from(vec![(field, input_primitive_2)]);
 
         let arr = concat(&[
             input_struct_1.slice(1, 3).as_ref(),

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -368,7 +368,6 @@ mod tests {
             None,
             Some(102),
             Some(103),
-            None,
         ])) as ArrayRef;
 
         let actual_primitive = arr.as_any().downcast_ref::<StructArray>().unwrap().column(0);


### PR DESCRIPTION
I took a stab at adding some tests for concat (and the underlying MutableArrayData) that cover the use case of the array having an offset. I had some problems with the assertions on the string array which makes me think this isn't fully fixed, but I wanted to put it up and see if anyone had suggestions for how to address this.