### PR TITLE
ARROW-11411: [Packaging][Linux] Disable arm64 nightly builds

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -118,9 +118,9 @@ groups:
   ######################## Tasks to run regularly #############################
 
   nightly:
-    - centos-*
-    - debian-*
-    - ubuntu-*
+    - debian-*-amd64
+    - ubuntu-*-amd64
+    - centos-*-amd64
     - conda-*
     - gandiva-*
     # List the homebrews explicitly because we don't care about running homebrew-cpp-autobrew


### PR DESCRIPTION
We'll re-enable them with new CI configuration by the next release.