### PR TITLE
ARROW-11414: [Rust] Reduce copies in Schema::try_merge

### DIFF
--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -222,7 +222,7 @@ pub fn infer_schema_from_files(
         }
     }
 
-    Schema::try_merge(&schemas)
+    Schema::try_merge(schemas)
 }
 
 // optional bounds of the reader, of the form (min line, max line).

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1836,7 +1836,7 @@ impl Schema {
     /// ```
     /// use arrow::datatypes::*;
     ///
-    /// let merged = Schema::try_merge(&vec![
+    /// let merged = Schema::try_merge(vec![
     ///     Schema::new(vec![
     ///         Field::new("c1", DataType::Int64, false),
     ///         Field::new("c2", DataType::Utf8, false),
@@ -1857,44 +1857,40 @@ impl Schema {
     ///     ]),
     /// );
     /// ```
-    pub fn try_merge(schemas: &[Self]) -> Result<Self> {
-        let mut merged = Self::empty();
-
-        for schema in schemas {
-            for (key, value) in schema.metadata.iter() {
-                // merge metadata
-                match merged.metadata.get(key) {
-                    Some(old_val) => {
-                        if old_val != value {
+    pub fn try_merge(schemas: impl IntoIterator<Item = Self>) -> Result<Self> {
+        schemas
+            .into_iter()
+            .try_fold(Self::empty(), |mut merged, schema| {
+                let Schema { metadata, fields } = schema;
+                for (key, value) in metadata.into_iter() {
+                    // merge metadata
+                    if let Some(old_val) = merged.metadata.get(&key) {
+                        if old_val != &value {
                             return Err(ArrowError::SchemaError(
-                                "Fail to merge schema due to conflicting metadata"
+                                "Fail to merge schema due to conflicting metadata."
                                     .to_string(),
                             ));
                         }
                     }
-                    None => {
-                        merged.metadata.insert(key.clone(), value.clone());
+                    merged.metadata.insert(key, value);
+                }
+                // merge fields
+                for field in fields.into_iter() {
+                    let mut new_field = true;
+                    for merged_field in &mut merged.fields {
+                        if field.name != merged_field.name {
+                            continue;
+                        }
+                        new_field = false;
+                        merged_field.try_merge(&field)?
+                    }
+                    // found a new field, add to field list
+                    if new_field {
+                        merged.fields.push(field);
                     }
                 }
-            }
-            // merge fields
-            for field in &schema.fields {
-                let mut new_field = true;
-                for merged_field in &mut merged.fields {
-                    if field.name != merged_field.name {
-                        continue;
-                    }
-                    new_field = false;
-                    merged_field.try_merge(field)?
-                }
-                // found a new field, add to field list
-                if new_field {
-                    merged.fields.push(field.clone());
-                }
-            }
-        }
-
-        Ok(merged)
+                Ok(merged)
+            })
     }
 
     /// Returns an immutable reference of the vector of `Field` instances.
@@ -3044,7 +3040,8 @@ mod tests {
         f2.set_metadata(Some(metadata2));
 
         assert!(
-            Schema::try_merge(&[Schema::new(vec![f1]), Schema::new(vec![f2])]).is_err()
+            Schema::try_merge(vec![Schema::new(vec![f1]), Schema::new(vec![f2])])
+                .is_err()
         );
 
         // 2. None + Some
@@ -3118,7 +3115,7 @@ mod tests {
 
     #[test]
     fn test_schema_merge() -> Result<()> {
-        let merged = Schema::try_merge(&[
+        let merged = Schema::try_merge(vec![
             Schema::new(vec![
                 Field::new("first_name", DataType::Utf8, false),
                 Field::new("last_name", DataType::Utf8, false),
@@ -3177,7 +3174,7 @@ mod tests {
 
         // support merge union fields
         assert_eq!(
-            Schema::try_merge(&[
+            Schema::try_merge(vec![
                 Schema::new(vec![Field::new(
                     "c1",
                     DataType::Union(vec![
@@ -3207,7 +3204,7 @@ mod tests {
         );
 
         // incompatible field should throw error
-        assert!(Schema::try_merge(&[
+        assert!(Schema::try_merge(vec![
             Schema::new(vec![
                 Field::new("first_name", DataType::Utf8, false),
                 Field::new("last_name", DataType::Utf8, false),
@@ -3217,7 +3214,7 @@ mod tests {
         .is_err());
 
         // incompatible metadata should throw error
-        assert!(Schema::try_merge(&[
+        assert!(Schema::try_merge(vec![
             Schema::new_with_metadata(
                 vec![Field::new("first_name", DataType::Utf8, false)],
                 [("foo".to_string(), "bar".to_string()),]


### PR DESCRIPTION
I was looking at this code yesterday while using it in IOx -- https://github.com/influxdata/influxdb_iox/pull/703

## Rationale:
Even though `Schema::try_merge` requires a slice of `Schema`s (not schema refs) ownership of its inputs,  it copies all of its fields. This is inefficient ideal in the common case where most of the fields in the merged `Schema` will be the same

## Changes:
This PR proposes to change the implementation so that `try_merge` takes something  (like a `Vec`) that can iterate over the Schemas passed in and consume them, avoiding at least one copy per unique field. I intend no algorithmic changes, only performance improvement.

