### PR TITLE
ARROW-10056: [C++] Increase flatbuffers max_tables parameter in order to read wide tables

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1053,7 +1053,9 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
         file_->ReadAt(footer_offset_ - footer_length - file_end_size, footer_length));
 
     auto data = footer_buffer_->data();
-    flatbuffers::Verifier verifier(data, footer_buffer_->size(), 128);
+    flatbuffers::Verifier verifier(data, footer_buffer_->size(), /*max_depth=*/128,
+                                   /*max_tables=*/UINT_MAX);
+
     if (!flatbuf::VerifyFooterBuffer(verifier)) {
       return Status::IOError("Verification of flatbuffer-encoded Footer failed.");
     }


### PR DESCRIPTION
PyArrow fails to read (valid) Feather v2 files which it created as default flatbuffers::Verifier verifier number of columns argument is to low when creating a Feather file from a dataframe with 499999 columns

Increase the number of maximum allowed tables when verifying a FlatBuffer
from 1_000_000 to 10_000_000.

This allows reading back Feather v2 files with more than 1_000_000
columns (499_999 columns from Pandas dataframe ==> Feather v2).