### PR TITLE
ARROW-11425: [C++][Compute] Optimize quantile kernel for integers

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <cmath>
+#include <vector>
 
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/kernels/common.h"
@@ -41,29 +42,46 @@ bool IsDataPoint(const QuantileOptions& options) {
          options.interpolation == QuantileOptions::NEAREST;
 }
 
-template <typename Dummy, typename InType>
-struct QuantileExecutor {
+// quantile to exact datapoint index (IsDataPoint == true)
+uint64_t QuantileToDataPoint(size_t length, double q,
+                             enum QuantileOptions::Interpolation interpolation) {
+  const double index = (length - 1) * q;
+  uint64_t datapoint_index = static_cast<uint64_t>(index);
+  const double fraction = index - datapoint_index;
+
+  if (interpolation == QuantileOptions::LINEAR ||
+      interpolation == QuantileOptions::MIDPOINT) {
+    DCHECK_EQ(fraction, 0);
+  }
+
+  // convert NEAREST interpolation method to LOWER or HIGHER
+  if (interpolation == QuantileOptions::NEAREST) {
+    if (fraction < 0.5) {
+      interpolation = QuantileOptions::LOWER;
+    } else if (fraction > 0.5) {
+      interpolation = QuantileOptions::HIGHER;
+    } else {
+      // round 0.5 to nearest even number, similar to numpy.around
+      interpolation =
+          (datapoint_index & 1) ? QuantileOptions::HIGHER : QuantileOptions::LOWER;
+    }
+  }
+
+  if (interpolation == QuantileOptions::HIGHER && fraction != 0) {
+    ++datapoint_index;
+  }
+
+  return datapoint_index;
+}
+
+// copy and sort approach, large memory footprint
+template <typename InType>
+struct SortQuantiler {
   using CType = typename InType::c_type;
   using Allocator = arrow::stl::allocator<CType>;
 
-  static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    // validate arguments
-    if (ctx->state() == nullptr) {
-      ctx->SetStatus(Status::Invalid("Quantile requires QuantileOptions"));
-      return;
-    }
-
+  void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     const QuantileOptions& options = QuantileState::Get(ctx);
-    if (options.q.empty()) {
-      ctx->SetStatus(Status::Invalid("Requires quantile argument"));
-      return;
-    }
-    for (double q : options.q) {
-      if (q < 0 || q > 1) {
-        ctx->SetStatus(Status::Invalid("Quantile must be between 0 and 1"));
-        return;
-      }
-    }
 
     // copy all chunks to a buffer, ignore nulls and nans
     std::vector<CType, Allocator> in_buffer(Allocator(ctx->memory_pool()));
@@ -94,12 +112,8 @@ struct QuantileExecutor {
     }
     // out type depends on options
     const bool is_datapoint = IsDataPoint(options);
-    std::shared_ptr<DataType> out_type;
-    if (is_datapoint) {
-      out_type = TypeTraits<InType>::type_singleton();
-    } else {
-      out_type = float64();
-    }
+    const std::shared_ptr<DataType> out_type =
+        is_datapoint ? TypeTraits<InType>::type_singleton() : float64();
     auto out_data = ArrayData::Make(out_type, out_length, 0);
     out_data->buffers.resize(2, nullptr);
 
@@ -140,7 +154,7 @@ struct QuantileExecutor {
     *out = Datum(std::move(out_data));
   }
 
-  static int64_t CopyArray(CType* buffer, const Array& array) {
+  int64_t CopyArray(CType* buffer, const Array& array) {
     const int64_t n = array.length() - array.null_count();
     if (n > 0) {
       int64_t index = 0;
@@ -157,34 +171,10 @@ struct QuantileExecutor {
   }
 
   // return quantile located exactly at some input data point
-  static CType GetQuantileAtDataPoint(std::vector<CType, Allocator>& in,
-                                      uint64_t* last_index, double q,
-                                      enum QuantileOptions::Interpolation interpolation) {
-    const double index = (in.size() - 1) * q;
-    uint64_t datapoint_index = static_cast<uint64_t>(index);
-    const double fraction = index - datapoint_index;
-
-    if (interpolation == QuantileOptions::LINEAR ||
-        interpolation == QuantileOptions::MIDPOINT) {
-      DCHECK_EQ(fraction, 0);
-    }
-
-    // convert NEAREST interpolation method to LOWER or HIGHER
-    if (interpolation == QuantileOptions::NEAREST) {
-      if (fraction < 0.5) {
-        interpolation = QuantileOptions::LOWER;
-      } else if (fraction > 0.5) {
-        interpolation = QuantileOptions::HIGHER;
-      } else {
-        // round 0.5 to nearest even number, similar to numpy.around
-        interpolation =
-            (datapoint_index & 1) ? QuantileOptions::HIGHER : QuantileOptions::LOWER;
-      }
-    }
-
-    if (interpolation == QuantileOptions::HIGHER && fraction != 0) {
-      ++datapoint_index;
-    }
+  CType GetQuantileAtDataPoint(std::vector<CType, Allocator>& in, uint64_t* last_index,
+                               double q,
+                               enum QuantileOptions::Interpolation interpolation) {
+    const uint64_t datapoint_index = QuantileToDataPoint(in.size(), q, interpolation);
 
     if (datapoint_index != *last_index) {
       DCHECK_LT(datapoint_index, *last_index);
@@ -197,9 +187,9 @@ struct QuantileExecutor {
   }
 
   // return quantile interpolated from adjacent input data points
-  static double GetQuantileByInterp(std::vector<CType, Allocator>& in,
-                                    uint64_t* last_index, double q,
-                                    enum QuantileOptions::Interpolation interpolation) {
+  double GetQuantileByInterp(std::vector<CType, Allocator>& in, uint64_t* last_index,
+                             double q,
+                             enum QuantileOptions::Interpolation interpolation) {
     const double index = (in.size() - 1) * q;
     const uint64_t lower_index = static_cast<uint64_t>(index);
     const double fraction = index - lower_index;
@@ -236,6 +226,243 @@ struct QuantileExecutor {
       DCHECK(false);
       return NAN;
     }
+  }
+};
+
+// histogram approach with constant memory, only for integers within limited value range
+template <typename InType>
+struct CountQuantiler {
+  using CType = typename InType::c_type;
+
+  CType min;
+  std::vector<uint64_t> counts;  // counts[i]: # of values equals i + min
+
+  // indices to adjacent non-empty bins covering current quantile
+  struct AdjacentBins {
+    int left_index;
+    int right_index;
+    uint64_t total_count;  // accumulated counts till left_index (inclusive)
+  };
+
+  CountQuantiler(CType min, CType max) {
+    uint32_t value_range = static_cast<uint32_t>(max - min) + 1;
+    DCHECK_LT(value_range, 1 << 30);
+    this->min = min;
+    this->counts.resize(value_range);
+  }
+
+  void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    const QuantileOptions& options = QuantileState::Get(ctx);
+
+    // count values in all chunks, ignore nulls
+    const Datum& datum = batch[0];
+    const int64_t in_length = datum.length() - datum.null_count();
+    if (in_length > 0) {
+      for (auto& c : this->counts) c = 0;
+      for (const auto& array : datum.chunks()) {
+        const ArrayData& data = *array->data();
+        const CType* values = data.GetValues<CType>(1);
+        VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
+                            [&](int64_t pos, int64_t len) {
+                              for (int64_t i = 0; i < len; ++i) {
+                                ++this->counts[values[pos + i] - this->min];
+                              }
+                            });
+      }
+    }
+
+    // prepare out array
+    int64_t out_length = options.q.size();
+    if (in_length == 0) {
+      out_length = 0;  // input is empty or only contains null, return empty array
+    }
+    // out type depends on options
+    const bool is_datapoint = IsDataPoint(options);
+    const std::shared_ptr<DataType> out_type =
+        is_datapoint ? TypeTraits<InType>::type_singleton() : float64();
+    auto out_data = ArrayData::Make(out_type, out_length, 0);
+    out_data->buffers.resize(2, nullptr);
+
+    // calculate quantiles
+    if (out_length > 0) {
+      const auto out_bit_width = checked_pointer_cast<NumberType>(out_type)->bit_width();
+      KERNEL_ASSIGN_OR_RAISE(out_data->buffers[1], ctx,
+                             ctx->Allocate(out_length * out_bit_width / 8));
+
+      // find quantiles in ascending order
+      std::vector<int64_t> q_indices(out_length);
+      std::iota(q_indices.begin(), q_indices.end(), 0);
+      std::sort(q_indices.begin(), q_indices.end(),
+                [&options](int64_t left_index, int64_t right_index) {
+                  return options.q[left_index] < options.q[right_index];
+                });
+
+      AdjacentBins bins{0, 0, this->counts[0]};
+      if (is_datapoint) {
+        CType* out_buffer = out_data->template GetMutableValues<CType>(1);
+        for (int64_t i = 0; i < out_length; ++i) {
+          const int64_t q_index = q_indices[i];
+          out_buffer[q_index] = GetQuantileAtDataPoint(
+              in_length, &bins, options.q[q_index], options.interpolation);
+        }
+      } else {
+        double* out_buffer = out_data->template GetMutableValues<double>(1);
+        for (int64_t i = 0; i < out_length; ++i) {
+          const int64_t q_index = q_indices[i];
+          out_buffer[q_index] = GetQuantileByInterp(in_length, &bins, options.q[q_index],
+                                                    options.interpolation);
+        }
+      }
+    }
+
+    *out = Datum(std::move(out_data));
+  }
+
+  // return quantile located exactly at some input data point
+  CType GetQuantileAtDataPoint(int64_t in_length, AdjacentBins* bins, double q,
+                               enum QuantileOptions::Interpolation interpolation) {
+    const uint64_t datapoint_index = QuantileToDataPoint(in_length, q, interpolation);
+    while (datapoint_index >= bins->total_count &&
+           static_cast<size_t>(bins->left_index) < this->counts.size() - 1) {
+      ++bins->left_index;
+      bins->total_count += this->counts[bins->left_index];
+    }
+    DCHECK_LT(datapoint_index, bins->total_count);
+    return static_cast<CType>(bins->left_index + this->min);
+  }
+
+  // return quantile interpolated from adjacent input data points
+  double GetQuantileByInterp(int64_t in_length, AdjacentBins* bins, double q,
+                             enum QuantileOptions::Interpolation interpolation) {
+    const double index = (in_length - 1) * q;
+    const uint64_t index_floor = static_cast<uint64_t>(index);
+    const double fraction = index - index_floor;
+
+    while (index_floor >= bins->total_count &&
+           static_cast<size_t>(bins->left_index) < this->counts.size() - 1) {
+      ++bins->left_index;
+      bins->total_count += this->counts[bins->left_index];
+    }
+    DCHECK_LT(index_floor, bins->total_count);
+    const double lower_value = static_cast<double>(bins->left_index + this->min);
+
+    // quantile lies in this bin, no interpolation needed
+    if (index <= bins->total_count - 1) {
+      return lower_value;
+    }
+
+    // quantile lies across two bins, locate next bin if not already done
+    DCHECK_EQ(index_floor, bins->total_count - 1);
+    if (bins->right_index <= bins->left_index) {
+      bins->right_index = bins->left_index + 1;
+      while (static_cast<size_t>(bins->right_index) < this->counts.size() - 1 &&
+             this->counts[bins->right_index] == 0) {
+        ++bins->right_index;
+      }
+    }
+    DCHECK_LT(static_cast<size_t>(bins->right_index), this->counts.size());
+    DCHECK_GT(this->counts[bins->right_index], 0);
+    const double higher_value = static_cast<double>(bins->right_index + this->min);
+
+    if (interpolation == QuantileOptions::LINEAR) {
+      return fraction * higher_value + (1 - fraction) * lower_value;
+    } else if (interpolation == QuantileOptions::MIDPOINT) {
+      return lower_value / 2 + higher_value / 2;
+    } else {
+      DCHECK(false);
+      return NAN;
+    }
+  }
+};
+
+// histogram or sort approach per value range and size, only for integers
+template <typename InType>
+struct CountOrSortQuantiler {
+  using CType = typename InType::c_type;
+
+  void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    // cross point to benefit from histogram approach
+    // parameters estimated from ad-hoc benchmarks manually
+    static constexpr int kMinArraySize = 65536 * sizeof(int) / sizeof(CType);
+    static constexpr int kMaxValueRange = 65536;
+
+    const Datum& datum = batch[0];
+    if (datum.length() - datum.null_count() >= kMinArraySize) {
+      CType min = std::numeric_limits<CType>::max();
+      CType max = std::numeric_limits<CType>::min();
+
+      for (const auto& array : datum.chunks()) {
+        const ArrayData& data = *array->data();
+        const CType* values = data.GetValues<CType>(1);
+        VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
+                            [&](int64_t pos, int64_t len) {
+                              for (int64_t i = 0; i < len; ++i) {
+                                min = std::min(min, values[pos + i]);
+                                max = std::max(max, values[pos + i]);
+                              }
+                            });
+      }
+
+      if (static_cast<uint64_t>(max) - static_cast<uint64_t>(min) <= kMaxValueRange) {
+        CountQuantiler<InType>(min, max).Exec(ctx, batch, out);
+        return;
+      }
+    }
+
+    SortQuantiler<InType>().Exec(ctx, batch, out);
+  }
+};
+
+template <typename InType, typename Enable = void>
+struct ExactQuantiler;
+
+template <>
+struct ExactQuantiler<UInt8Type> {
+  CountQuantiler<UInt8Type> impl;
+  ExactQuantiler() : impl(0, 255) {}
+};
+
+template <>
+struct ExactQuantiler<Int8Type> {
+  CountQuantiler<Int8Type> impl;
+  ExactQuantiler() : impl(-128, 127) {}
+};
+
+template <typename InType>
+struct ExactQuantiler<InType, enable_if_t<(is_integer_type<InType>::value &&
+                                           (sizeof(typename InType::c_type) > 1))>> {
+  CountOrSortQuantiler<InType> impl;
+};
+
+template <typename InType>
+struct ExactQuantiler<InType, enable_if_t<is_floating_type<InType>::value>> {
+  SortQuantiler<InType> impl;
+};
+
+template <typename _, typename InType>
+struct QuantileExecutor {
+  using CType = typename InType::c_type;
+
+  static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    // validate arguments
+    if (ctx->state() == nullptr) {
+      ctx->SetStatus(Status::Invalid("Quantile requires QuantileOptions"));
+      return;
+    }
+
+    const QuantileOptions& options = QuantileState::Get(ctx);
+    if (options.q.empty()) {
+      ctx->SetStatus(Status::Invalid("Requires quantile argument"));
+      return;
+    }
+    for (double q : options.q) {
+      if (q < 0 || q > 1) {
+        ctx->SetStatus(Status::Invalid("Quantile must be between 0 and 1"));
+        return;
+      }
+    }
+
+    ExactQuantiler<InType>().impl.Exec(ctx, batch, out);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1612,7 +1612,7 @@ class TestRandomQuantileKernel : public TestPrimitiveQuantileKernel<Int32Type> {
 };
 
 TEST_F(TestRandomQuantileKernel, Normal) {
-  // exercise copy and sort approach: size < 65536 int32
+  // exercise copy and sort approach: size < 65536
   this->CheckQuantiles(/*array_size=*/10000, /*num_quantiles=*/100);
 }
 
@@ -1622,7 +1622,7 @@ TEST_F(TestRandomQuantileKernel, Overlapped) {
 }
 
 TEST_F(TestRandomQuantileKernel, Histogram) {
-  // exercise histogram approach: size >= 65536 int32, range <= 65536
+  // exercise histogram approach: size >= 65536, range <= 65536
   this->CheckQuantiles(/*array_size=*/80000, /*num_quantiles=*/100);
 }
 #endif

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1423,20 +1423,14 @@ class TestPrimitiveQuantileKernel : public ::testing::Test {
       QuantileOptions::NEAREST, QuantileOptions::MIDPOINT};
 };
 
-template <typename ArrowType>
-class TestIntegerQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {};
-
-template <typename ArrowType>
-class TestFloatingQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {};
-
-template <typename ArrowType>
-class TestInt64QuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {};
-
 #define INTYPE(x) Datum(static_cast<typename TypeParam::c_type>(x))
 #define DOUBLE(x) Datum(static_cast<double>(x))
 // output type per interplation: linear, lower, higher, nearest, midpoint
 #define O(a, b, c, d, e) \
   { DOUBLE(a), INTYPE(b), INTYPE(c), INTYPE(d), DOUBLE(e) }
+
+template <typename ArrowType>
+class TestIntegerQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {};
 
 TYPED_TEST_SUITE(TestIntegerQuantileKernel, IntegralArrowTypes);
 TYPED_TEST(TestIntegerQuantileKernel, Basics) {
@@ -1471,6 +1465,9 @@ TYPED_TEST(TestIntegerQuantileKernel, Basics) {
   this->AssertQuantilesEmpty({"[null, null]", "[]", "[null]"}, {0.3, 0.4});
 }
 
+template <typename ArrowType>
+class TestFloatingQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {};
+
 #ifndef __MINGW32__
 TYPED_TEST_SUITE(TestFloatingQuantileKernel, RealArrowTypes);
 TYPED_TEST(TestFloatingQuantileKernel, Floats) {
@@ -1500,11 +1497,28 @@ TYPED_TEST(TestFloatingQuantileKernel, Floats) {
   this->AssertQuantilesEmpty("[null, NaN, null]", {0.1});
   this->AssertQuantilesEmpty({"[NaN, NaN]", "[]", "[null]"}, {0.3, 0.4});
 }
+
+class TestInt8QuantileKernel : public TestPrimitiveQuantileKernel<Int8Type> {};
+
+// Test histogram approach
+TEST_F(TestInt8QuantileKernel, Int8) {
+  using TypeParam = Int8Type;
+  this->AssertQuantilesAre(
+      "[127, -128, null, -128, 66, -88, 127]", {0, 0.3, 0.7, 1},
+      {O(-128, -128, -128, -128, -128), O(-108, -128, -88, -88, -108),
+       O(96.5, 66, 127, 127, 96.5), O(127, 127, 127, 127, 127)});
+  this->AssertQuantilesAre(
+      {"[null]", "[-88, 127]", "[]", "[66, -128, null, -128]", "[127]"}, {0, 0.3, 0.7, 1},
+      {O(-128, -128, -128, -128, -128), O(-108, -128, -88, -88, -108),
+       O(96.5, 66, 127, 127, 96.5), O(127, 127, 127, 127, 127)});
+}
 #endif
 
+class TestInt64QuantileKernel : public TestPrimitiveQuantileKernel<Int64Type> {};
+
 // Test big int64 numbers cannot be precisely presented by double
-TYPED_TEST_SUITE(TestInt64QuantileKernel, Int64Type);
-TYPED_TEST(TestInt64QuantileKernel, Int64) {
+TEST_F(TestInt64QuantileKernel, Int64) {
+  using TypeParam = Int64Type;
   this->AssertQuantileIs(
       "[9223372036854775806, 9223372036854775807]", 0.5,
       O(9.223372036854776e+18, 9223372036854775806, 9223372036854775807,
@@ -1520,7 +1534,7 @@ class TestRandomQuantileKernel : public TestPrimitiveQuantileKernel<Int32Type> {
  public:
   void CheckQuantiles(int64_t array_size, int64_t num_quantiles) {
     auto rand = random::RandomArrayGenerator(0x5487658);
-    // set a small value range to exercise input array with equal values
+    // small value range to exercise input array with equal values and histogram approach
     const auto array = rand.Numeric<Int32Type>(array_size, -100, 200, 0.1);
 
     std::vector<double> quantiles;
@@ -1598,12 +1612,18 @@ class TestRandomQuantileKernel : public TestPrimitiveQuantileKernel<Int32Type> {
 };
 
 TEST_F(TestRandomQuantileKernel, Normal) {
+  // exercise copy and sort approach: size < 65536 int32
   this->CheckQuantiles(/*array_size=*/10000, /*num_quantiles=*/100);
 }
 
 TEST_F(TestRandomQuantileKernel, Overlapped) {
   // much more quantiles than array size => many overlaps
   this->CheckQuantiles(/*array_size=*/999, /*num_quantiles=*/9999);
+}
+
+TEST_F(TestRandomQuantileKernel, Histogram) {
+  // exercise histogram approach: size >= 65536 int32, range <= 65536
+  this->CheckQuantiles(/*array_size=*/80000, /*num_quantiles=*/100);
 }
 #endif
 


### PR DESCRIPTION
For integers within limited value range, a histogram approach is useful
to reduce memory footprint and improve performance.