### PR TITLE
ARROW-11428: [Rust] Add power_scalar kernel

### DIFF
--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -558,8 +558,8 @@ where
     return Ok(unary(array, |x| -x));
 }
 
-/// Raise array to the power of a scalar.
-pub fn pow_scalar<T>(
+/// Raise array with floating point values to the power of a scalar.
+pub fn powf_scalar<T>(
     array: &PrimitiveArray<T>,
     raise: T::Native,
 ) -> Result<PrimitiveArray<T>>
@@ -853,11 +853,11 @@ mod tests {
     #[test]
     fn test_primitive_array_raise_power_scalar() {
         let a = Float64Array::from(vec![1.0, 2.0, 3.0]);
-        let actual = pow_scalar(&a, 2.0).unwrap();
+        let actual = powf_scalar(&a, 2.0).unwrap();
         let expected = Float64Array::from(vec![1.0, 4.0, 9.0]);
         assert_eq!(expected, actual);
         let a = Float64Array::from(vec![Some(1.0), None, Some(3.0)]);
-        let actual = pow_scalar(&a, 2.0).unwrap();
+        let actual = powf_scalar(&a, 2.0).unwrap();
         let expected = Float64Array::from(vec![Some(1.0), None, Some(9.0)]);
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
Adds a SISD and SIMD kernel to raise a `Float32/64` array to a power of a `scalar` of the same type. We could also make a thin `sqrt` wrapper. 

I also added a `unary_op` fn to `ArrowNumeric` type as this seemed the most generic way to implement this. Next PR I could add support for a binary version of this (e.g. array to the power of array).

_edit_: 
The `ArrowFloatNumericType` trait was added because the [Simd::powf](https://rust-lang.github.io/packed_simd/packed_simd_2/struct.Simd.html#method.powf-6) is only available for float arrays (e.g. `[f32, N]`, `[f64, N]`). However, the *packed_simd* crate doesn't expose this functionality via a trait, but directly on the type, hence the extra trait.
