### PR TITLE
ARROW-10520: [C++][R] Implement add/remove/replace for RecordBatch

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -104,6 +104,27 @@ class SimpleRecordBatch : public RecordBatch {
                              internal::AddVectorElement(columns_, i, column->data()));
   }
 
+  Result<std::shared_ptr<RecordBatch>> SetColumn(
+      int i, const std::shared_ptr<Field>& field,
+      const std::shared_ptr<Array>& column) const override {
+    ARROW_CHECK(field != nullptr);
+    ARROW_CHECK(column != nullptr);
+
+    if (!field->type()->Equals(column->type())) {
+      return Status::Invalid("Column data type ", field->type()->name(),
+                             " does not match field data type ", column->type()->name());
+    }
+    if (column->length() != num_rows_) {
+      return Status::Invalid(
+          "Added column's length must match record batch's length. Expected length ",
+          num_rows_, " but got length ", column->length());
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->SetField(i, field));
+    return RecordBatch::Make(new_schema, num_rows_,
+                             internal::ReplaceVectorElement(columns_, i, column->data()));
+  }
+
   Result<std::shared_ptr<RecordBatch>> RemoveColumn(int i) const override {
     ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->RemoveField(i));
 

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -89,8 +89,9 @@ class SimpleRecordBatch : public RecordBatch {
     ARROW_CHECK(column != nullptr);
 
     if (!field->type()->Equals(column->type())) {
-      return Status::Invalid("Column data type ", field->type()->name(),
-                             " does not match field data type ", column->type()->name());
+      return Status::TypeError("Column data type ", field->type()->name(),
+                               " does not match field data type ",
+                               column->type()->name());
     }
     if (column->length() != num_rows_) {
       return Status::Invalid(
@@ -111,8 +112,9 @@ class SimpleRecordBatch : public RecordBatch {
     ARROW_CHECK(column != nullptr);
 
     if (!field->type()->Equals(column->type())) {
-      return Status::Invalid("Column data type ", field->type()->name(),
-                             " does not match field data type ", column->type()->name());
+      return Status::TypeError("Column data type ", field->type()->name(),
+                               " does not match field data type ",
+                               column->type()->name());
     }
     if (column->length() != num_rows_) {
       return Status::Invalid(
@@ -183,8 +185,8 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
 Result<std::shared_ptr<RecordBatch>> RecordBatch::FromStructArray(
     const std::shared_ptr<Array>& array) {
   if (array->type_id() != Type::STRUCT) {
-    return Status::Invalid("Cannot construct record batch from array of type ",
-                           *array->type());
+    return Status::TypeError("Cannot construct record batch from array of type ",
+                             *array->type());
   }
   if (array->null_count() != 0) {
     return Status::Invalid(

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -130,6 +130,11 @@ class ARROW_EXPORT RecordBatch {
   virtual Result<std::shared_ptr<RecordBatch>> AddColumn(
       int i, std::string field_name, const std::shared_ptr<Array>& column) const;
 
+  /// \brief Replace a column in the table, producing a new Table
+  virtual Result<std::shared_ptr<RecordBatch>> SetColumn(
+      int i, const std::shared_ptr<Field>& field,
+      const std::shared_ptr<Array>& column) const = 0;
+
   /// \brief Remove column from the record batch, producing a new RecordBatch
   ///
   /// \param[in] i field index, does boundscheck

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -164,7 +164,7 @@ TEST_F(TestRecordBatch, AddColumn) {
   ASSERT_RAISES(Invalid, batch.AddColumn(0, field1, longer_col));
 
   // Negative test with mismatch type
-  ASSERT_RAISES(Invalid, batch.AddColumn(0, field1, array2));
+  ASSERT_RAISES(TypeError, batch.AddColumn(0, field1, array2));
 
   ASSERT_OK_AND_ASSIGN(auto new_batch, batch.AddColumn(0, field1, array1));
   AssertBatchesEqual(*new_batch, *batch1);
@@ -208,7 +208,7 @@ TEST_F(TestRecordBatch, SetColumn) {
   ASSERT_RAISES(Invalid, batch.SetColumn(0, field1, longer_col));
 
   // Negative test with mismatch type
-  ASSERT_RAISES(Invalid, batch.SetColumn(0, field1, array2));
+  ASSERT_RAISES(TypeError, batch.SetColumn(0, field1, array2));
 
   ASSERT_OK_AND_ASSIGN(auto new_batch, batch.SetColumn(1, field3, array3));
   AssertBatchesEqual(*new_batch, *batch2);
@@ -280,7 +280,7 @@ TEST_F(TestRecordBatch, ToFromEmptyStructArray) {
 }
 
 TEST_F(TestRecordBatch, FromStructArrayInvalidType) {
-  ASSERT_RAISES(Invalid, RecordBatch::FromStructArray(MakeRandomArray<Int32Array>(10)));
+  ASSERT_RAISES(TypeError, RecordBatch::FromStructArray(MakeRandomArray<Int32Array>(10)));
 }
 
 TEST_F(TestRecordBatch, FromStructArrayInvalidNullCount) {

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -15,18 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cstdint>
-#include <memory>
-#include <vector>
+#include "arrow/record_batch.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
 #include "arrow/array/util.h"
 #include "arrow/chunked_array.h"
-#include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_common.h"
@@ -175,6 +176,45 @@ TEST_F(TestRecordBatch, AddColumn) {
   AssertBatchesEqual(*new_batch2, *new_batch);
 
   ASSERT_TRUE(new_batch2->schema()->field(1)->nullable());
+}
+
+TEST_F(TestRecordBatch, SetColumn) {
+  const int length = 10;
+
+  auto field1 = field("f1", int32());
+  auto field2 = field("f2", uint8());
+  auto field3 = field("f3", int16());
+
+  auto schema1 = ::arrow::schema({field1, field2});
+  auto schema2 = ::arrow::schema({field1, field3});
+  auto schema3 = ::arrow::schema({field3, field2});
+
+  auto array1 = MakeRandomArray<Int32Array>(length);
+  auto array2 = MakeRandomArray<UInt8Array>(length);
+  auto array3 = MakeRandomArray<Int16Array>(length);
+
+  auto batch1 = RecordBatch::Make(schema1, length, {array1, array2});
+  auto batch2 = RecordBatch::Make(schema2, length, {array1, array3});
+  auto batch3 = RecordBatch::Make(schema3, length, {array3, array2});
+
+  const RecordBatch& batch = *batch1;
+
+  // Negative tests with invalid index
+  ASSERT_RAISES(Invalid, batch.SetColumn(5, field1, array1));
+  ASSERT_RAISES(Invalid, batch.SetColumn(-1, field1, array1));
+
+  // Negative test with wrong length
+  auto longer_col = MakeRandomArray<Int32Array>(length + 1);
+  ASSERT_RAISES(Invalid, batch.SetColumn(0, field1, longer_col));
+
+  // Negative test with mismatch type
+  ASSERT_RAISES(Invalid, batch.SetColumn(0, field1, array2));
+
+  ASSERT_OK_AND_ASSIGN(auto new_batch, batch.SetColumn(1, field3, array3));
+  AssertBatchesEqual(*new_batch, *batch2);
+
+  ASSERT_OK_AND_ASSIGN(new_batch, batch.SetColumn(0, field3, array3));
+  AssertBatchesEqual(*new_batch, *batch3);
 }
 
 TEST_F(TestRecordBatch, RemoveColumn) {

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,6 +21,7 @@
 
 * `value_counts()` to tabulate values in an `Array` or `ChunkedArray`, similar to `base::table()`.
 * `StructArray` objects gain data.frame-like methods, including `names()`, `$`, `[[`, and `dim()`.
+* RecordBatch columns can now be added, replaced, or removed by assigning (`<-`) with either `$` or `[[`
 
 # arrow 3.0.0
 

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1308,6 +1308,14 @@ RecordBatch__Equals <- function(self, other, check_metadata){
     .Call(`_arrow_RecordBatch__Equals`, self, other, check_metadata)
 }
 
+RecordBatch__AddColumn <- function(batch, i, field, column){
+    .Call(`_arrow_RecordBatch__AddColumn`, batch, i, field, column)
+}
+
+RecordBatch__SetColumn <- function(batch, i, field, column){
+    .Call(`_arrow_RecordBatch__SetColumn`, batch, i, field, column)
+}
+
 RecordBatch__RemoveColumn <- function(batch, i){
     .Call(`_arrow_RecordBatch__RemoveColumn`, batch, i)
 }

--- a/r/R/record-batch.R
+++ b/r/R/record-batch.R
@@ -86,10 +86,10 @@ RecordBatch <- R6Class("RecordBatch", inherit = ArrowTabular,
     },
     SelectColumns = function(indices) RecordBatch__SelectColumns(self, indices),
     AddColumn = function(i, new_field, value) {
-      stop("TODO: ARROW-10520", call. = FALSE)
+      RecordBatch__AddColumn(self, i, new_field, value)
     },
     SetColumn = function(i, new_field, value) {
-      stop("TODO: ARROW-10520", call. = FALSE)
+      RecordBatch__SetColumn(self, i, new_field, value)
     },
     RemoveColumn = function(i) RecordBatch__RemoveColumn(self, i),
     Slice = function(offset, length = NULL) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2852,6 +2852,28 @@ BEGIN_CPP11
 END_CPP11
 }
 // recordbatch.cpp
+std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
+extern "C" SEXP _arrow_RecordBatch__AddColumn(SEXP batch_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
+	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type column(column_sexp);
+	return cpp11::as_sexp(RecordBatch__AddColumn(batch, i, field, column));
+END_CPP11
+}
+// recordbatch.cpp
+std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
+extern "C" SEXP _arrow_RecordBatch__SetColumn(SEXP batch_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
+	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type column(column_sexp);
+	return cpp11::as_sexp(RecordBatch__SetColumn(batch, i, field, column));
+END_CPP11
+}
+// recordbatch.cpp
 std::shared_ptr<arrow::RecordBatch> RecordBatch__RemoveColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i);
 extern "C" SEXP _arrow_RecordBatch__RemoveColumn(SEXP batch_sexp, SEXP i_sexp){
 BEGIN_CPP11
@@ -3805,6 +3827,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_RecordBatch__GetColumnByName", (DL_FUNC) &_arrow_RecordBatch__GetColumnByName, 2}, 
 		{ "_arrow_RecordBatch__SelectColumns", (DL_FUNC) &_arrow_RecordBatch__SelectColumns, 2}, 
 		{ "_arrow_RecordBatch__Equals", (DL_FUNC) &_arrow_RecordBatch__Equals, 3}, 
+		{ "_arrow_RecordBatch__AddColumn", (DL_FUNC) &_arrow_RecordBatch__AddColumn, 4}, 
+		{ "_arrow_RecordBatch__SetColumn", (DL_FUNC) &_arrow_RecordBatch__SetColumn, 4}, 
 		{ "_arrow_RecordBatch__RemoveColumn", (DL_FUNC) &_arrow_RecordBatch__RemoveColumn, 2}, 
 		{ "_arrow_RecordBatch__column_name", (DL_FUNC) &_arrow_RecordBatch__column_name, 2}, 
 		{ "_arrow_RecordBatch__names", (DL_FUNC) &_arrow_RecordBatch__names, 1}, 

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -118,6 +118,22 @@ bool RecordBatch__Equals(const std::shared_ptr<arrow::RecordBatch>& self,
 }
 
 // [[arrow::export]]
+std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(
+    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i,
+    const std::shared_ptr<arrow::Field>& field,
+    const std::shared_ptr<arrow::Array>& column) {
+  return ValueOrStop(batch->AddColumn(i, field, column));
+}
+
+// [[arrow::export]]
+std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(
+    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i,
+    const std::shared_ptr<arrow::Field>& field,
+    const std::shared_ptr<arrow::Array>& column) {
+  return ValueOrStop(batch->SetColumn(i, field, column));
+}
+
+// [[arrow::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__RemoveColumn(
     const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i) {
   arrow::r::validate_index(i, batch->num_columns());


### PR DESCRIPTION
In C++, RecordBatch had AddColumn and RemoveColumn but no SetColumn; Table had all three. This adds the missing RecordBatch method and adds R bindings.