### PR TITLE
ARROW-11435: [Datafusion] allow creating ParquetPartition from external crate, make  combine_filters public

### DIFF
--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::*;
 use crate::datasource::datasource::Statistics;
 use crate::datasource::TableProvider;
 use crate::error::Result;
-use crate::logical_plan::Expr;
+use crate::logical_plan::{combine_filters, Expr};
 use crate::physical_plan::parquet::ParquetExec;
 use crate::physical_plan::ExecutionPlan;
 
@@ -97,22 +97,6 @@ impl TableProvider for ParquetTable {
     fn statistics(&self) -> Statistics {
         self.statistics.clone()
     }
-}
-
-/// Combines an array of filter expressions into a single filter expression
-/// consisting of the input filter expressions joined with logical AND.
-/// Returns None if the filters array is empty.
-fn combine_filters(filters: &[Expr]) -> Option<Expr> {
-    if filters.is_empty() {
-        return None;
-    }
-    let combined_filter = filters
-        .iter()
-        .skip(1)
-        .fold(filters[0].clone(), |acc, filter| {
-            crate::logical_plan::and(acc, filter.clone())
-        });
-    Some(combined_filter)
 }
 
 #[cfg(test)]

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -661,6 +661,20 @@ pub fn and(left: Expr, right: Expr) -> Expr {
     }
 }
 
+/// Combines an array of filter expressions into a single filter expression
+/// consisting of the input filter expressions joined with logical AND.
+/// Returns None if the filters array is empty.
+pub fn combine_filters(filters: &[Expr]) -> Option<Expr> {
+    if filters.is_empty() {
+        return None;
+    }
+    let combined_filter = filters
+        .iter()
+        .skip(1)
+        .fold(filters[0].clone(), |acc, filter| and(acc, filter.clone()));
+    Some(combined_filter)
+}
+
 /// return a new expression with a logical OR
 pub fn or(left: Expr, right: Expr) -> Expr {
     Expr::BinaryExpr {

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -34,11 +34,11 @@ pub use builder::LogicalPlanBuilder;
 pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
-    abs, acos, and, array, asin, atan, avg, binary_expr, case, ceil, col, concat, cos,
-    count, count_distinct, create_udaf, create_udf, exp, exprlist_to_fields, floor,
-    in_list, length, lit, ln, log10, log2, lower, ltrim, max, md5, min, or, round, rtrim,
-    sha224, sha256, sha384, sha512, signum, sin, sqrt, sum, tan, trim, trunc, upper,
-    when, Expr, ExpressionVisitor, Literal, Recursion,
+    abs, acos, and, array, asin, atan, avg, binary_expr, case, ceil, col,
+    combine_filters, concat, cos, count, count_distinct, create_udaf, create_udf, exp,
+    exprlist_to_fields, floor, in_list, length, lit, ln, log10, log2, lower, ltrim, max,
+    md5, min, or, round, rtrim, sha224, sha256, sha384, sha512, signum, sin, sqrt, sum,
+    tan, trim, trunc, upper, when, Expr, ExpressionVisitor, Literal, Recursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -267,6 +267,14 @@ impl ParquetExec {
 }
 
 impl ParquetPartition {
+    /// Create a new parquet partition
+    pub fn new(filenames: Vec<String>, statistics: Statistics) -> Self {
+        Self {
+            filenames,
+            statistics,
+        }
+    }
+
     /// The Parquet filename for this partition
     pub fn filenames(&self) -> &[String] {
         &self.filenames


### PR DESCRIPTION
Without this, it's not possible to create TableProvider in external crate that tagets parquet format because `ParquetExec::new` takes `ParquetPartition` as argument.