### PR TITLE
ARROW-11436: [Rust] Improved from_iter for primitive arrays (-20-30% for cast)

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -337,12 +337,6 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn append(&mut self, v: bool) {
-        self.push(v)
-    }
-
-    /// Adds a new element to the Builder.
-    #[inline]
-    pub fn push(&mut self, v: bool) {
         self.advance(1);
         if v {
             unsafe { bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len - 1) };
@@ -382,6 +376,7 @@ impl BooleanBufferBuilder {
 }
 
 impl From<BooleanBufferBuilder> for Buffer {
+    #[inline]
     fn from(builder: BooleanBufferBuilder) -> Self {
         builder.buffer.into()
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -297,14 +297,17 @@ impl BooleanBufferBuilder {
         Self { buffer, len: 0 }
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.buffer.capacity() * 8
     }
@@ -334,6 +337,12 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn append(&mut self, v: bool) {
+        self.push(v)
+    }
+
+    /// Adds a new element to the Builder.
+    #[inline]
+    pub fn push(&mut self, v: bool) {
         self.advance(1);
         if v {
             unsafe { bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len - 1) };
@@ -369,6 +378,12 @@ impl BooleanBufferBuilder {
         let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
         self.len = 0;
         buf.into()
+    }
+}
+
+impl From<BooleanBufferBuilder> for Buffer {
+    fn from(builder: BooleanBufferBuilder) -> Self {
+        builder.buffer.into()
     }
 }
 

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -45,6 +45,7 @@ impl<'a, T: ArrowPrimitiveType> PrimitiveIter<'a, T> {
 impl<'a, T: ArrowPrimitiveType> std::iter::Iterator for PrimitiveIter<'a, T> {
     type Item = Option<T::Native>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.current == self.current_end {
             None

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -994,6 +994,14 @@ impl MutableBuffer {
     pub fn extend_zeros(&mut self, additional: usize) {
         self.resize(self.len + additional, 0);
     }
+
+    /// # Safety
+    /// The caller must ensure that the buffer was properly initialized up to `len`.
+    #[inline]
+    pub(crate) unsafe fn set_len(&mut self, len: usize) {
+        assert!(len <= self.capacity());
+        self.len = len;
+    }
 }
 
 /// # Safety

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -25,3 +25,6 @@ pub mod pretty;
 pub(crate) mod serialization;
 pub mod string_writer;
 pub mod test_util;
+
+mod trusted_len;
+pub(crate) use trusted_len::trusted_len_unzip;

--- a/rust/arrow/src/util/trusted_len.rs
+++ b/rust/arrow/src/util/trusted_len.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::bit_util;
+use crate::{
+    buffer::{Buffer, MutableBuffer},
+    datatypes::ArrowNativeType,
+};
+
+/// Creates two [`Buffer`]s from an iterator of `Option`.
+/// The first buffer corresponds to a bitmap buffer, the second one
+/// corresponds to a values buffer.
+/// # Safety
+/// The caller must ensure that `iterator` is `TrustedLen`.
+#[inline]
+pub(crate) unsafe fn trusted_len_unzip<I, P, T>(iterator: I) -> (Buffer, Buffer)
+where
+    T: ArrowNativeType,
+    P: std::borrow::Borrow<Option<T>>,
+    I: Iterator<Item = P>,
+{
+    let (_, upper) = iterator.size_hint();
+    let upper = upper.expect("trusted_len_unzip requires an upper limit");
+    let len = upper * std::mem::size_of::<T>();
+
+    let mut null = MutableBuffer::from_len_zeroed(upper.saturating_add(7) / 8);
+    let mut buffer = MutableBuffer::new(len);
+
+    let dst_null = null.as_mut_ptr();
+    let mut dst = buffer.as_mut_ptr() as *mut T;
+    for (i, item) in iterator.enumerate() {
+        let item = item.borrow();
+        if let Some(item) = item {
+            std::ptr::write(dst, *item);
+            bit_util::set_bit_raw(dst_null, i);
+        } else {
+            std::ptr::write(dst, T::default());
+        }
+        dst = dst.add(1);
+    }
+    assert_eq!(
+        dst.offset_from(buffer.as_ptr() as *mut T) as usize,
+        upper,
+        "Trusted iterator length was not accurately reported"
+    );
+    buffer.set_len(len);
+    (null.into(), buffer.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trusted_len_unzip_good() {
+        let vec = vec![Some(1u32), None];
+        let (null, buffer) = unsafe { trusted_len_unzip(vec.iter()) };
+        assert_eq!(null.as_slice(), &[0b00000001]);
+        assert_eq!(buffer.as_slice(), &[1u8, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "trusted_len_unzip requires an upper limit")]
+    fn trusted_len_unzip_panic() {
+        let iter = std::iter::repeat(Some(4i32));
+        unsafe { trusted_len_unzip(iter) };
+    }
+}


### PR DESCRIPTION
This PR refactors `PrimitiveArray::from_iter` to support non-sized iterators, as that is the expectation from `Rust::FromIter`. This makes `from_iter` slower.

To compensate, this PR introduces a new method, `unsafe from_trusted_len_iter` to create an array from an iterator of `Option<T>` that has a trusted len. This is 20-30% faster than using the `from_iter` implemented in master.

This PR uses `from_trusted_len_iter` to speed up casting of `primitive -> primitive` and `bool -> primitive` by 20-30%.

Note that the added complexity (of having new functions and being unable to rely on `collect`) arises from two `unstable` features that we can't use:

1. `unsafe trait TrustedLen`
2. specialization

if we had both features, we could implement `TrustedLen` for all our iterators, and then use specialization to offer specialized `FromIter` for them. Once these features are stabilized, we can simplify our API by allowing users to call `collect` on an iterator and let the compiler conclude that the iterator is `TrustedLen` and therefore should use the specialized implementation. :)

```
Switched to branch 'iter_p'
   Compiling arrow v4.0.0-SNAPSHOT (/Users/jorgecarleitao/projects/arrow/rust/arrow)
    Finished bench [optimized] target(s) in 1m 11s
     Running /Users/jorgecarleitao/projects/arrow/rust/target/release/deps/cast_kernels-9a3b6d213a9f7a9a
Gnuplot not found, using plotters backend
cast int32 to int32 512 time:   [25.384 ns 25.415 ns 25.449 ns]                                     
                        change: [-2.1332% -1.4846% -0.7930%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

cast int32 to uint32 512                                                                             
                        time:   [2.1526 us 2.1576 us 2.1629 us]
                        change: [-24.823% -24.221% -23.610%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

cast int32 to float32 512                                                                             
                        time:   [2.4012 us 2.4083 us 2.4170 us]
                        change: [-20.381% -19.079% -17.860%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

cast int32 to float64 512                                                                             
                        time:   [2.4544 us 2.4608 us 2.4680 us]
                        change: [-24.689% -23.471% -22.441%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

cast int32 to int64 512 time:   [2.2424 us 2.2532 us 2.2663 us]                                     
                        change: [-28.692% -28.008% -27.316%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

cast float32 to int32 512                                                                             
                        time:   [2.4966 us 2.5063 us 2.5176 us]
                        change: [-26.820% -26.281% -25.755%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

cast float64 to float32 512                                                                             
                        time:   [2.4857 us 2.4954 us 2.5070 us]
                        change: [-22.439% -21.818% -21.222%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

cast float64 to uint64 512                                                                             
                        time:   [2.8313 us 2.8369 us 2.8427 us]
                        change: [-32.996% -32.605% -32.263%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

cast int64 to int32 512 time:   [2.2000 us 2.2073 us 2.2154 us]                                     
                        change: [-32.106% -31.271% -30.265%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

cast date64 to date32 512                                                                             
                        time:   [1.0772 us 1.0815 us 1.0866 us]
                        change: [+1.3054% +3.6485% +6.8389%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

cast date32 to date64 512                                                                             
                        time:   [838.20 ns 840.35 ns 842.74 ns]
                        change: [-1.2203% -0.3511% +0.5828%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

cast time32s to time32ms 512                                                                             
                        time:   [741.99 ns 745.21 ns 748.67 ns]
                        change: [-0.1386% +1.9748% +5.4043%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

cast time32s to time64us 512                                                                             
                        time:   [4.2476 us 4.2596 us 4.2747 us]
                        change: [-19.580% -18.601% -17.667%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

cast time64ns to time32s 512                                                                             
                        time:   [4.9276 us 4.9371 us 4.9489 us]
                        change: [-0.2071% +0.6046% +1.5380%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

cast timestamp_ns to timestamp_s 512                                                                             
                        time:   [25.938 ns 26.005 ns 26.079 ns]
                        change: [-2.0321% -1.2763% -0.4590%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

cast timestamp_ms to timestamp_ns 512                                                                             
                        time:   [2.0140 us 2.0187 us 2.0234 us]
                        change: [+0.4914% +1.5932% +2.6619%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

cast utf8 to f32        time:   [28.568 us 28.651 us 28.749 us]                              
                        change: [-5.4918% -4.8116% -4.1925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

cast i64 to string 512  time:   [50.182 us 50.270 us 50.366 us]                                    
                        change: [-2.7854% -1.4471% +0.2627%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

cast f32 to string 512  time:   [54.687 us 54.833 us 54.983 us]                                   
                        change: [+2.6122% +3.3716% +4.2074%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

cast timestamp_ms to i64 512                                                                            
                        time:   [424.64 ns 426.27 ns 428.09 ns]
                        change: [+1.3146% +2.0623% +2.7867%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

cast utf8 to date32 512 time:   [45.104 us 45.202 us 45.312 us]                                     
                        change: [-0.3430% +0.3110% +1.0109%] (p = 0.40 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

cast utf8 to date64 512 time:   [75.844 us 76.028 us 76.239 us]                                    
                        change: [-10.720% -10.018% -9.3075%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

```