### PR TITLE
ARROW-11438: [Rust] [DataFusion] Support literal boolean values in DataFusion SQL

### DIFF
--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -630,6 +630,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             },
             SQLExpr::Value(Value::SingleQuotedString(ref s)) => Ok(lit(s.clone())),
 
+            SQLExpr::Value(Value::Boolean(n)) => Ok(lit(*n)),
+
             SQLExpr::Value(Value::Null) => Ok(Expr::Literal(ScalarValue::Utf8(None))),
 
             SQLExpr::Identifier(ref id) => {

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1928,6 +1928,20 @@ async fn string_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+async fn boolean_expressions() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    let sql = "SELECT
+        true AS val_1,
+        false AS val_2
+    ";
+    let actual = execute(&mut ctx, sql).await;
+
+    let expected = vec![vec!["true", "false"]];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn crypto_expressions() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     let sql = "SELECT


### PR DESCRIPTION
While testing Data Fusion I found that It didn't support boolean expr inside SQL. I am getting an error: NotImplemented("Unsupported ast node Value(Boolean(true)) in sqltorel")', datafusion/tests/sql.rs:1414:46.
