### PR TITLE
ARROW-11439: [Rust] Add year support to temporal kernels

### DIFF
--- a/rust/arrow/src/compute/kernels/temporal.rs
+++ b/rust/arrow/src/compute/kernels/temporal.rs
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn test_temporal_array_date32_year() {
-        let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15248)].into();
+        let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15448)].into();
 
         let b = year(&a).unwrap();
         assert_eq!(2011, b.value(0));

--- a/rust/arrow/src/compute/kernels/temporal.rs
+++ b/rust/arrow/src/compute/kernels/temporal.rs
@@ -90,7 +90,7 @@ where
         dt => {
             return {
                 Err(ArrowError::ComputeError(format!(
-                    "hour does not support type {:?}",
+                    "year does not support type {:?}",
                     dt
                 )))
             }

--- a/rust/arrow/src/compute/kernels/temporal.rs
+++ b/rust/arrow/src/compute/kernels/temporal.rs
@@ -136,7 +136,8 @@ mod tests {
 
     #[test]
     fn test_temporal_array_time64_micro_hour() {
-        let a: PrimitiveArray<Time64MicrosecondType> = vec![37800000000, 86339000000].into();
+        let a: PrimitiveArray<Time64MicrosecondType> =
+            vec![37800000000, 86339000000].into();
 
         let b = hour(&a).unwrap();
         assert_eq!(10, b.value(0));

--- a/rust/arrow/src/compute/kernels/temporal.rs
+++ b/rust/arrow/src/compute/kernels/temporal.rs
@@ -19,9 +19,9 @@
 
 use chrono::{Datelike, Timelike};
 
+use crate::array::*;
 use crate::datatypes::*;
-use crate::error::Result;
-use crate::{array::*, error::ArrowError};
+use crate::error::{ArrowError, Result};
 /// Extracts the hours of a given temporal array as an array of integers
 pub fn hour<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where
@@ -136,8 +136,7 @@ mod tests {
 
     #[test]
     fn test_temporal_array_time64_micro_hour() {
-        let a: PrimitiveArray<Time64MicrosecondType> =
-            vec![37800000000, 86339000000].into();
+        let a: PrimitiveArray<Time64MicrosecondType> = vec![37800000000, 86339000000].into();
 
         let b = hour(&a).unwrap();
         assert_eq!(10, b.value(0));
@@ -146,8 +145,7 @@ mod tests {
 
     #[test]
     fn test_temporal_array_timestamp_micro_hour() {
-        let a: TimestampMicrosecondArray =
-            vec![37800000000, 86339000000].into();
+        let a: TimestampMicrosecondArray = vec![37800000000, 86339000000].into();
 
         let b = hour(&a).unwrap();
         assert_eq!(10, b.value(0));
@@ -177,7 +175,8 @@ mod tests {
 
     #[test]
     fn test_temporal_array_timestamp_micro_year() {
-        let a: TimestampMicrosecondArray = vec![Some(1612025847000000), None, Some(1722015847000000)].into();
+        let a: TimestampMicrosecondArray =
+            vec![Some(1612025847000000), None, Some(1722015847000000)].into();
 
         let b = year(&a).unwrap();
         assert_eq!(2021, b.value(0));

--- a/rust/arrow/src/compute/kernels/temporal.rs
+++ b/rust/arrow/src/compute/kernels/temporal.rs
@@ -17,12 +17,11 @@
 
 //! Defines temporal kernels for time and date related functions.
 
-use chrono::Timelike;
+use chrono::{Datelike, Timelike};
 
-use crate::array::*;
 use crate::datatypes::*;
 use crate::error::Result;
-
+use crate::{array::*, error::ArrowError};
 /// Extracts the hours of a given temporal array as an array of integers
 pub fn hour<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
 where
@@ -30,21 +29,70 @@ where
     i64: std::convert::From<T::Native>,
 {
     let mut b = Int32Builder::new(array.len());
-    for i in 0..array.len() {
-        if array.is_null(i) {
-            b.append_null()?;
-        } else {
-            match array.data_type() {
-                &DataType::Time32(_) | &DataType::Time64(_) => {
+    match array.data_type() {
+        &DataType::Time32(_) | &DataType::Time64(_) => {
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    b.append_null()?;
+                } else {
                     match array.value_as_time(i) {
                         Some(time) => b.append_value(time.hour() as i32)?,
                         None => b.append_null()?,
+                    };
+                }
+            }
+        }
+        &DataType::Date32 | &DataType::Date64 | &DataType::Timestamp(_, _) => {
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    b.append_null()?;
+                } else {
+                    match array.value_as_datetime(i) {
+                        Some(dt) => b.append_value(dt.hour() as i32)?,
+                        None => b.append_null()?,
                     }
                 }
-                _ => match array.value_as_datetime(i) {
-                    Some(dt) => b.append_value(dt.hour() as i32)?,
-                    None => b.append_null()?,
-                },
+            }
+        }
+        dt => {
+            return {
+                Err(ArrowError::ComputeError(format!(
+                    "hour does not support type {:?}",
+                    dt
+                )))
+            }
+        }
+    }
+
+    Ok(b.finish())
+}
+
+/// Extracts the years of a given temporal array as an array of integers
+pub fn year<T>(array: &PrimitiveArray<T>) -> Result<Int32Array>
+where
+    T: ArrowTemporalType + ArrowNumericType,
+    i64: std::convert::From<T::Native>,
+{
+    let mut b = Int32Builder::new(array.len());
+    match array.data_type() {
+        &DataType::Date32 | &DataType::Date64 | &DataType::Timestamp(_, _) => {
+            for i in 0..array.len() {
+                if array.is_null(i) {
+                    b.append_null()?;
+                } else {
+                    match array.value_as_datetime(i) {
+                        Some(dt) => b.append_value(dt.year() as i32)?,
+                        None => b.append_null()?,
+                    }
+                }
+            }
+        }
+        dt => {
+            return {
+                Err(ArrowError::ComputeError(format!(
+                    "hour does not support type {:?}",
+                    dt
+                )))
             }
         }
     }
@@ -61,7 +109,6 @@ mod tests {
         let a: PrimitiveArray<Date64Type> =
             vec![Some(1514764800000), None, Some(1550636625000)].into();
 
-        // get hour from temporal
         let b = hour(&a).unwrap();
         assert_eq!(0, b.value(0));
         assert_eq!(false, b.is_valid(1));
@@ -69,12 +116,72 @@ mod tests {
     }
 
     #[test]
+    fn test_temporal_array_date32_hour() {
+        let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15148)].into();
+
+        let b = hour(&a).unwrap();
+        assert_eq!(0, b.value(0));
+        assert_eq!(false, b.is_valid(1));
+        assert_eq!(0, b.value(2));
+    }
+
+    #[test]
     fn test_temporal_array_time32_second_hour() {
         let a: PrimitiveArray<Time32SecondType> = vec![37800, 86339].into();
 
-        // get hour from temporal
         let b = hour(&a).unwrap();
         assert_eq!(10, b.value(0));
         assert_eq!(23, b.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_time64_micro_hour() {
+        let a: PrimitiveArray<Time64MicrosecondType> =
+            vec![37800000000, 86339000000].into();
+
+        let b = hour(&a).unwrap();
+        assert_eq!(10, b.value(0));
+        assert_eq!(23, b.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_micro_hour() {
+        let a: TimestampMicrosecondArray =
+            vec![37800000000, 86339000000].into();
+
+        let b = hour(&a).unwrap();
+        assert_eq!(10, b.value(0));
+        assert_eq!(23, b.value(1));
+    }
+
+    #[test]
+    fn test_temporal_array_date64_year() {
+        let a: PrimitiveArray<Date64Type> =
+            vec![Some(1514764800000), None, Some(1550636625000)].into();
+
+        let b = year(&a).unwrap();
+        assert_eq!(2018, b.value(0));
+        assert_eq!(false, b.is_valid(1));
+        assert_eq!(2019, b.value(2));
+    }
+
+    #[test]
+    fn test_temporal_array_date32_year() {
+        let a: PrimitiveArray<Date32Type> = vec![Some(15147), None, Some(15248)].into();
+
+        let b = year(&a).unwrap();
+        assert_eq!(2011, b.value(0));
+        assert_eq!(false, b.is_valid(1));
+        assert_eq!(2012, b.value(2));
+    }
+
+    #[test]
+    fn test_temporal_array_timestamp_micro_year() {
+        let a: TimestampMicrosecondArray = vec![Some(1612025847000000), None, Some(1722015847000000)].into();
+
+        let b = year(&a).unwrap();
+        assert_eq!(2021, b.value(0));
+        assert_eq!(false, b.is_valid(1));
+        assert_eq!(2024, b.value(2));
     }
 }


### PR DESCRIPTION
This adds year support to the temporal module. Year support is something needed for some TCPH queries.
Together with `extract` support
https://github.com/apache/arrow/pull/9359

we should be able to add `EXTRACT (YEAR FROM dt)` support to DataFusion.

Other changes in the PR:
* Adding some more tests to `hour`
* Removing datatype check from inner loop (there is still one more check in `value_as_datetime` and `value_as_time`) but I leave that for a future PR, as well as further performance improvements (e.g. avoiding the `Int32Builder`, avoiding null checks, adding some microbenchmarks etc.).
* Returning an error message on unsupported datatypes (instead of returning an array with nulls). This is backwards incompatible, but I think this is reasonable.



