### PR TITLE
ARROW-11446: [DataFusion] Added support for scalarValue in Builtin functions.

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -619,8 +619,8 @@ impl FunctionRegistry for ExecutionContextState {
 mod tests {
 
     use super::*;
+    use crate::physical_plan::functions::make_scalar_function;
     use crate::physical_plan::{collect, collect_partitioned};
-    use crate::physical_plan::{functions::ScalarFunctionImplementation, ColumnarValue};
     use crate::test;
     use crate::variable::VarType;
     use crate::{
@@ -631,7 +631,7 @@ mod tests {
         datasource::MemTable, logical_plan::create_udaf,
         physical_plan::expressions::AvgAccumulator,
     };
-    use arrow::array::{Float64Array, Int32Array};
+    use arrow::array::{ArrayRef, Float64Array, Int32Array};
     use arrow::compute::add;
     use arrow::datatypes::*;
     use arrow::record_batch::RecordBatch;
@@ -1618,24 +1618,18 @@ mod tests {
         let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
         ctx.register_table("t", Box::new(provider));
 
-        let myfunc: ScalarFunctionImplementation =
-            Arc::new(|args: &[ColumnarValue]| {
-                if let (ColumnarValue::Array(l), ColumnarValue::Array(r)) =
-                    (&args[0], &args[1])
-                {
-                    let l = l
-                        .as_any()
-                        .downcast_ref::<Int32Array>()
-                        .expect("cast failed");
-                    let r = r
-                        .as_any()
-                        .downcast_ref::<Int32Array>()
-                        .expect("cast failed");
-                    Ok(ColumnarValue::Array(Arc::new(add(l, r)?)))
-                } else {
-                    unimplemented!()
-                }
-            });
+        let myfunc = |args: &[ArrayRef]| {
+            let l = &args[0]
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("cast failed");
+            let r = &args[1]
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("cast failed");
+            Ok(Arc::new(add(l, r)?) as ArrayRef)
+        };
+        let myfunc = make_scalar_function(myfunc);
 
         ctx.register_udf(create_udf(
             "my_add",

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -158,11 +158,11 @@ impl DataFrame for DataFrameImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datasource::csv::CsvReadOptions;
     use crate::execution::context::ExecutionContext;
     use crate::logical_plan::*;
+    use crate::{datasource::csv::CsvReadOptions, physical_plan::ColumnarValue};
     use crate::{physical_plan::functions::ScalarFunctionImplementation, test};
-    use arrow::{array::ArrayRef, datatypes::DataType};
+    use arrow::datatypes::DataType;
 
     #[test]
     fn select_columns() -> Result<()> {
@@ -287,7 +287,7 @@ mod tests {
 
         // declare the udf
         let my_fn: ScalarFunctionImplementation =
-            Arc::new(|_: &[ArrayRef]| unimplemented!("my_fn is not implemented"));
+            Arc::new(|_: &[ColumnarValue]| unimplemented!("my_fn is not implemented"));
 
         // create and register the udf
         ctx.register_udf(create_udf(

--- a/rust/datafusion/src/physical_plan/array_expressions.rs
+++ b/rust/datafusion/src/physical_plan/array_expressions.rs
@@ -22,6 +22,8 @@ use arrow::array::*;
 use arrow::datatypes::DataType;
 use std::sync::Arc;
 
+use super::ColumnarValue;
+
 macro_rules! downcast_vec {
     ($ARGS:expr, $ARRAY_TYPE:ident) => {{
         $ARGS
@@ -58,8 +60,7 @@ macro_rules! array {
     }};
 }
 
-/// put values in an array.
-pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
+fn array_array(args: &[&dyn Array]) -> Result<ArrayRef> {
     // do not accept 0 arguments.
     if args.is_empty() {
         return Err(DataFusionError::Internal(
@@ -86,6 +87,24 @@ pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
             data_type
         ))),
     }
+}
+
+/// put values in an array.
+pub fn array(values: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let arrays: Vec<&dyn Array> = values
+        .iter()
+        .map(|value| {
+            if let ColumnarValue::Array(value) = value {
+                Ok(value.as_ref())
+            } else {
+                Err(DataFusionError::NotImplemented(
+                    "Array is not implemented for scalar values.".to_string(),
+                ))
+            }
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(ColumnarValue::Array(array_array(&arrays)?))
 }
 
 /// Currently supported types by the array function.

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -17,17 +17,26 @@
 
 //! Crypto expressions
 
+use std::sync::Arc;
+
 use md5::Md5;
 use sha2::{
     digest::Output as SHA2DigestOutput, Digest as SHA2Digest, Sha224, Sha256, Sha384,
     Sha512,
 };
 
-use crate::error::{DataFusionError, Result};
-use arrow::array::{
-    ArrayRef, GenericBinaryArray, GenericStringArray, StringOffsetSizeTrait,
+use crate::{
+    error::{DataFusionError, Result},
+    scalar::ScalarValue,
+};
+use arrow::{
+    array::{Array, GenericBinaryArray, GenericStringArray, StringOffsetSizeTrait},
+    datatypes::DataType,
 };
 
+use super::{string_expressions::unary_string_function, ColumnarValue};
+
+/// Computes the md5 of a string.
 fn md5_process(input: &str) -> String {
     let mut digest = Md5::default();
     digest.update(&input);
@@ -49,58 +58,136 @@ fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
     digest.finalize()
 }
 
-macro_rules! crypto_unary_string_function {
-    ($NAME:ident, $FUNC:expr) => {
-        /// crypto function that accepts Utf8 or LargeUtf8 and returns Utf8 string
-        pub fn $NAME<T: StringOffsetSizeTrait>(
-            args: &[ArrayRef],
-        ) -> Result<GenericStringArray<i32>> {
-            if args.len() != 1 {
-                return Err(DataFusionError::Internal(format!(
-                    "{:?} args were supplied but {} takes exactly one argument",
-                    args.len(),
-                    String::from(stringify!($NAME)),
-                )));
-            }
+fn unary_binary_function<T, R, F>(
+    args: &[&dyn Array],
+    op: F,
+    name: &str,
+) -> Result<GenericBinaryArray<i32>>
+where
+    R: AsRef<[u8]>,
+    T: StringOffsetSizeTrait,
+    F: Fn(&str) -> R,
+{
+    if args.len() != 1 {
+        return Err(DataFusionError::Internal(format!(
+            "{:?} args were supplied but {} takes exactly one argument",
+            args.len(),
+            name,
+        )));
+    }
 
-            let array = args[0]
-                .as_any()
-                .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
+    let array = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .unwrap();
 
-            // first map is the iterator, second is for the `Option<_>`
-            Ok(array.iter().map(|x| x.map(|x| $FUNC(x))).collect())
-        }
-    };
+    // first map is the iterator, second is for the `Option<_>`
+    Ok(array.iter().map(|x| x.map(|x| op(x))).collect())
 }
 
-macro_rules! crypto_unary_binary_function {
-    ($NAME:ident, $FUNC:expr) => {
-        /// crypto function that accepts Utf8 or LargeUtf8 and returns Binary
-        pub fn $NAME<T: StringOffsetSizeTrait>(
-            args: &[ArrayRef],
-        ) -> Result<GenericBinaryArray<i32>> {
-            if args.len() != 1 {
-                return Err(DataFusionError::Internal(format!(
-                    "{:?} args were supplied but {} takes exactly one argument",
-                    args.len(),
-                    String::from(stringify!($NAME)),
-                )));
+fn handle<F, R>(args: &[ColumnarValue], op: F, name: &str) -> Result<ColumnarValue>
+where
+    R: AsRef<[u8]>,
+    F: Fn(&str) -> R,
+{
+    match &args[0] {
+        ColumnarValue::Array(a) => match a.data_type() {
+            DataType::Utf8 => {
+                Ok(ColumnarValue::Array(Arc::new(unary_binary_function::<
+                    i32,
+                    _,
+                    _,
+                >(
+                    &[a.as_ref()], op, name
+                )?)))
             }
-
-            let array = args[0]
-                .as_any()
-                .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
-
-            // first map is the iterator, second is for the `Option<_>`
-            Ok(array.iter().map(|x| x.map(|x| $FUNC(x))).collect())
-        }
-    };
+            DataType::LargeUtf8 => {
+                Ok(ColumnarValue::Array(Arc::new(unary_binary_function::<
+                    i64,
+                    _,
+                    _,
+                >(
+                    &[a.as_ref()], op, name
+                )?)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+        ColumnarValue::Scalar(scalar) => match scalar {
+            ScalarValue::Utf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x).as_ref().to_vec());
+                Ok(ColumnarValue::Scalar(ScalarValue::Binary(result)))
+            }
+            ScalarValue::LargeUtf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x).as_ref().to_vec());
+                Ok(ColumnarValue::Scalar(ScalarValue::Binary(result)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+    }
 }
 
-crypto_unary_string_function!(md5, md5_process);
-crypto_unary_binary_function!(sha224, sha_process::<Sha224>);
-crypto_unary_binary_function!(sha256, sha_process::<Sha256>);
-crypto_unary_binary_function!(sha384, sha_process::<Sha384>);
-crypto_unary_binary_function!(sha512, sha_process::<Sha512>);
+fn md5_array<T: StringOffsetSizeTrait>(
+    args: &[&dyn Array],
+) -> Result<GenericStringArray<i32>> {
+    unary_string_function::<T, i32, _, _>(args, md5_process, "md5")
+}
+
+/// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    match &args[0] {
+        ColumnarValue::Array(a) => match a.data_type() {
+            DataType::Utf8 => Ok(ColumnarValue::Array(Arc::new(md5_array::<i32>(&[
+                a.as_ref()
+            ])?))),
+            DataType::LargeUtf8 => {
+                Ok(ColumnarValue::Array(Arc::new(md5_array::<i64>(&[
+                    a.as_ref()
+                ])?)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+        ColumnarValue::Scalar(scalar) => match scalar {
+            ScalarValue::Utf8(a) => {
+                let result = a.as_ref().map(|x| md5_process(x));
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
+            }
+            ScalarValue::LargeUtf8(a) => {
+                let result = a.as_ref().map(|x| md5_process(x));
+                Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(result)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+    }
+}
+
+/// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+pub fn sha224(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, sha_process::<Sha224>, "ssh224")
+}
+
+/// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+pub fn sha256(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, sha_process::<Sha256>, "sha256")
+}
+
+/// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+pub fn sha384(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, sha_process::<Sha384>, "sha384")
+}
+
+/// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+pub fn sha512(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, sha_process::<Sha512>, "sha512")
+}

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -380,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn date_trunc_test() -> Result<()> {
+    fn date_trunc_test() {
         let cases = vec![
             (
                 "2020-09-08T13:42:29.190855Z",
@@ -435,7 +435,6 @@ mod tests {
             let result = date_trunc_single(granularity, original).unwrap();
             assert_eq!(result, expected);
         });
-        Ok(())
     }
 
     #[test]

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -19,163 +19,323 @@
 
 use std::sync::Arc;
 
-use crate::error::{DataFusionError, Result};
+use crate::{
+    error::{DataFusionError, Result},
+    scalar::{ScalarType, ScalarValue},
+};
+use arrow::temporal_conversions::timestamp_ns_to_datetime;
 use arrow::{
-    array::{Array, ArrayData, ArrayRef, StringArray, TimestampNanosecondArray},
-    buffer::Buffer,
-    compute::kernels::cast_utils::string_to_timestamp_nanos,
-    datatypes::{DataType, TimeUnit, ToByteSlice},
+    array::{
+        Array, GenericStringArray, PrimitiveArray, StringOffsetSizeTrait,
+        TimestampNanosecondArray,
+    },
+    datatypes::{ArrowPrimitiveType, DataType, TimestampNanosecondType},
 };
 use chrono::prelude::*;
 use chrono::Duration;
+use chrono::LocalResult;
 
-/// convert an array of strings into `Timestamp(Nanosecond, None)`
-pub fn to_timestamp(args: &[ArrayRef]) -> Result<TimestampNanosecondArray> {
-    let num_rows = args[0].len();
-    let string_args =
-        &args[0]
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| {
-                DataFusionError::Internal(
-                    "could not cast to_timestamp input to StringArray".to_string(),
-                )
-            })?;
+use super::ColumnarValue;
 
-    let result = (0..num_rows)
-        .map(|i| {
-            if string_args.is_null(i) {
-                // NB: Since we use the same null bitset as the input,
-                // the output for this value will be ignored, but we
-                // need some value in the array we are building.
-                Ok(0)
-            } else {
-                string_to_timestamp_nanos(string_args.value(i))
-                    .map_err(DataFusionError::ArrowError)
+#[inline]
+/// Accepts a string in RFC3339 / ISO8601 standard format and some
+/// variants and converts it to a nanosecond precision timestamp.
+///
+/// Implements the `to_timestamp` function to convert a string to a
+/// timestamp, following the model of spark SQL’s to_`timestamp`.
+///
+/// In addition to RFC3339 / ISO8601 standard timestamps, it also
+/// accepts strings that use a space ` ` to separate the date and time
+/// as well as strings that have no explicit timezone offset.
+///
+/// Examples of accepted inputs:
+/// * `1997-01-31T09:26:56.123Z`        # RCF3339
+/// * `1997-01-31T09:26:56.123-05:00`   # RCF3339
+/// * `1997-01-31 09:26:56.123-05:00`   # close to RCF3339 but with a space rather than T
+/// * `1997-01-31T09:26:56.123`         # close to RCF3339 but no timezone offset specified
+/// * `1997-01-31 09:26:56.123`         # close to RCF3339 but uses a space and no timezone offset
+/// * `1997-01-31 09:26:56`             # close to RCF3339, no fractional seconds
+//
+/// Internally, this function uses the `chrono` library for the
+/// datetime parsing
+///
+/// We hope to extend this function in the future with a second
+/// parameter to specifying the format string.
+///
+/// ## Timestamp Precision
+///
+/// DataFusion uses the maximum precision timestamps supported by
+/// Arrow (nanoseconds stored as a 64-bit integer) timestamps. This
+/// means the range of dates that timestamps can represent is ~1677 AD
+/// to 2262 AM
+///
+///
+/// ## Timezone / Offset Handling
+///
+/// By using the Arrow format, DataFusion inherits Arrow’s handling of
+/// timestamp values. Specifically, the stored numerical values of
+/// timestamps are stored compared to offset UTC.
+///
+/// This function intertprets strings without an explicit time zone as
+/// timestamps with offsets of the local time on the machine that ran
+/// the datafusion query
+///
+/// For example, `1997-01-31 09:26:56.123Z` is interpreted as UTC, as
+/// it has an explicit timezone specifier (“Z” for Zulu/UTC)
+///
+/// `1997-01-31T09:26:56.123` is interpreted as a local timestamp in
+/// the timezone of the machine that ran DataFusion. For example, if
+/// the system timezone is set to Americas/New_York (UTC-5) the
+/// timestamp will be interpreted as though it were
+/// `1997-01-31T09:26:56.123-05:00`
+fn string_to_timestamp_nanos(s: &str) -> Result<i64> {
+    // Fast path:  RFC3339 timestamp (with a T)
+    // Example: 2020-09-08T13:42:29.190855Z
+    if let Ok(ts) = DateTime::parse_from_rfc3339(s) {
+        return Ok(ts.timestamp_nanos());
+    }
+
+    // Implement quasi-RFC3339 support by trying to parse the
+    // timestamp with various other format specifiers to to support
+    // separating the date and time with a space ' ' rather than 'T' to be
+    // (more) compatible with Apache Spark SQL
+
+    // timezone offset, using ' ' as a separator
+    // Example: 2020-09-08 13:42:29.190855-05:00
+    if let Ok(ts) = DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f%:z") {
+        return Ok(ts.timestamp_nanos());
+    }
+
+    // with an explicit Z, using ' ' as a separator
+    // Example: 2020-09-08 13:42:29Z
+    if let Ok(ts) = Utc.datetime_from_str(s, "%Y-%m-%d %H:%M:%S%.fZ") {
+        return Ok(ts.timestamp_nanos());
+    }
+
+    // Support timestamps without an explicit timezone offset, again
+    // to be compatible with what Apache Spark SQL does.
+
+    // without a timezone specifier as a local time, using T as a separator
+    // Example: 2020-09-08T13:42:29.190855
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S.%f") {
+        return naive_datetime_to_timestamp(s, ts);
+    }
+
+    // without a timezone specifier as a local time, using T as a
+    // separator, no fractional seconds
+    // Example: 2020-09-08T13:42:29
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return naive_datetime_to_timestamp(s, ts);
+    }
+
+    // without a timezone specifier as a local time, using ' ' as a separator
+    // Example: 2020-09-08 13:42:29.190855
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S.%f") {
+        return naive_datetime_to_timestamp(s, ts);
+    }
+
+    // without a timezone specifier as a local time, using ' ' as a
+    // separator, no fractional seconds
+    // Example: 2020-09-08 13:42:29
+    if let Ok(ts) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return naive_datetime_to_timestamp(s, ts);
+    }
+
+    // Note we don't pass along the error message from the underlying
+    // chrono parsing because we tried several different format
+    // strings and we don't know which the user was trying to
+    // match. Ths any of the specific error messages is likely to be
+    // be more confusing than helpful
+    Err(DataFusionError::Execution(format!(
+        "Error parsing '{}' as timestamp",
+        s
+    )))
+}
+
+/// Converts the naive datetime (which has no specific timezone) to a
+/// nanosecond epoch timestamp relative to UTC.
+fn naive_datetime_to_timestamp(s: &str, datetime: NaiveDateTime) -> Result<i64> {
+    let l = Local {};
+
+    match l.from_local_datetime(&datetime) {
+        LocalResult::None => Err(DataFusionError::Execution(format!(
+            "Error parsing '{}' as timestamp: local time representation is invalid",
+            s
+        ))),
+        LocalResult::Single(local_datetime) => {
+            Ok(local_datetime.with_timezone(&Utc).timestamp_nanos())
+        }
+        // Ambiguous times can happen if the timestamp is exactly when
+        // a daylight savings time transition occurs, for example, and
+        // so the datetime could validly be said to be in two
+        // potential offsets. However, since we are about to convert
+        // to UTC anyways, we can pick one arbitrarily
+        LocalResult::Ambiguous(local_datetime, _) => {
+            Ok(local_datetime.with_timezone(&Utc).timestamp_nanos())
+        }
+    }
+}
+
+pub(crate) fn unary_string_to_primitive_function<'a, T, O, F>(
+    args: &[&'a dyn Array],
+    op: F,
+    name: &str,
+) -> Result<PrimitiveArray<O>>
+where
+    O: ArrowPrimitiveType,
+    T: StringOffsetSizeTrait,
+    F: Fn(&'a str) -> Result<O::Native>,
+{
+    if args.len() != 1 {
+        return Err(DataFusionError::Internal(format!(
+            "{:?} args were supplied but {} takes exactly one argument",
+            args.len(),
+            name,
+        )));
+    }
+
+    let array = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .unwrap();
+
+    // first map is the iterator, second is for the `Option<_>`
+    array.iter().map(|x| x.map(|x| op(x)).transpose()).collect()
+}
+
+fn handle<'a, O, F, S>(
+    args: &'a [ColumnarValue],
+    op: F,
+    name: &str,
+) -> Result<ColumnarValue>
+where
+    O: ArrowPrimitiveType,
+    S: ScalarType<O::Native>,
+    F: Fn(&'a str) -> Result<O::Native>,
+{
+    match &args[0] {
+        ColumnarValue::Array(a) => match a.data_type() {
+            DataType::Utf8 => Ok(ColumnarValue::Array(Arc::new(
+                unary_string_to_primitive_function::<i32, O, _>(&[a.as_ref()], op, name)?,
+            ))),
+            DataType::LargeUtf8 => Ok(ColumnarValue::Array(Arc::new(
+                unary_string_to_primitive_function::<i64, O, _>(&[a.as_ref()], op, name)?,
+            ))),
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function {}",
+                other, name,
+            ))),
+        },
+        ColumnarValue::Scalar(scalar) => match scalar {
+            ScalarValue::Utf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x)).transpose()?;
+                Ok(ColumnarValue::Scalar(S::into_scalar(result)))
             }
-        })
-        .collect::<Result<Vec<_>>>()?;
+            ScalarValue::LargeUtf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x)).transpose()?;
+                Ok(ColumnarValue::Scalar(S::into_scalar(result)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function {}",
+                other, name
+            ))),
+        },
+    }
+}
 
-    let data = ArrayData::new(
-        DataType::Timestamp(TimeUnit::Nanosecond, None),
-        num_rows,
-        Some(string_args.null_count()),
-        string_args.data().null_buffer().cloned(),
-        0,
-        vec![Buffer::from(result.to_byte_slice())],
-        vec![],
-    );
+/// to_timestamp SQL function
+pub fn to_timestamp(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle::<TimestampNanosecondType, _, TimestampNanosecondType>(
+        args,
+        string_to_timestamp_nanos,
+        "to_timestamp",
+    )
+}
 
-    Ok(TimestampNanosecondArray::from(Arc::new(data)))
+fn date_trunc_single(granularity: &str, value: i64) -> Result<i64> {
+    let value = timestamp_ns_to_datetime(value).with_nanosecond(0);
+    let value = match granularity {
+        "second" => value,
+        "minute" => value.and_then(|d| d.with_second(0)),
+        "hour" => value
+            .and_then(|d| d.with_second(0))
+            .and_then(|d| d.with_minute(0)),
+        "day" => value
+            .and_then(|d| d.with_second(0))
+            .and_then(|d| d.with_minute(0))
+            .and_then(|d| d.with_hour(0)),
+        "week" => value
+            .and_then(|d| d.with_second(0))
+            .and_then(|d| d.with_minute(0))
+            .and_then(|d| d.with_hour(0))
+            .map(|d| d - Duration::seconds(60 * 60 * 24 * d.weekday() as i64)),
+        "month" => value
+            .and_then(|d| d.with_second(0))
+            .and_then(|d| d.with_minute(0))
+            .and_then(|d| d.with_hour(0))
+            .and_then(|d| d.with_day0(0)),
+        "year" => value
+            .and_then(|d| d.with_second(0))
+            .and_then(|d| d.with_minute(0))
+            .and_then(|d| d.with_hour(0))
+            .and_then(|d| d.with_day0(0))
+            .and_then(|d| d.with_month0(0)),
+        unsupported => {
+            return Err(DataFusionError::Execution(format!(
+                "Unsupported date_trunc granularity: {}",
+                unsupported
+            )))
+        }
+    };
+    // `with_x(0)` are infalible because `0` are always a valid
+    Ok(value.unwrap().timestamp_nanos())
 }
 
 /// date_trunc SQL function
-pub fn date_trunc(args: &[ArrayRef]) -> Result<TimestampNanosecondArray> {
-    let granularity_array =
-        &args[0]
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| {
-                DataFusionError::Execution(
-                    "Could not cast date_trunc granularity input to StringArray"
-                        .to_string(),
-                )
-            })?;
+pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let (granularity, array) = (&args[0], &args[1]);
 
-    let array = &args[1]
-        .as_any()
-        .downcast_ref::<TimestampNanosecondArray>()
-        .ok_or_else(|| {
-            DataFusionError::Execution(
-                "Could not cast date_trunc array input to TimestampNanosecondArray"
-                    .to_string(),
-            )
-        })?;
+    let granularity =
+        if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) = granularity {
+            v
+        } else {
+            return Err(DataFusionError::Execution(
+                "Granularity of `date_trunc` must be non-null scalar Utf8".to_string(),
+            ));
+        };
 
-    let range = 0..array.len();
-    let result = range
-        .map(|i| {
-            if array.is_null(i) {
-                Ok(0_i64)
+    let f = |x: Option<i64>| x.map(|x| date_trunc_single(granularity, x)).transpose();
+
+    Ok(match array {
+        ColumnarValue::Scalar(scalar) => {
+            if let ScalarValue::TimeNanosecond(v) = scalar {
+                ColumnarValue::Scalar(ScalarValue::TimeNanosecond((f)(*v)?))
             } else {
-                let date_time = match granularity_array.value(i) {
-                    "second" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0)),
-                    "minute" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0)),
-                    "hour" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0))
-                        .and_then(|d| d.with_minute(0)),
-                    "day" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0))
-                        .and_then(|d| d.with_minute(0))
-                        .and_then(|d| d.with_hour(0)),
-                    "week" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0))
-                        .and_then(|d| d.with_minute(0))
-                        .and_then(|d| d.with_hour(0))
-                        .map(|d| {
-                            d - Duration::seconds(60 * 60 * 24 * d.weekday() as i64)
-                        }),
-                    "month" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0))
-                        .and_then(|d| d.with_minute(0))
-                        .and_then(|d| d.with_hour(0))
-                        .and_then(|d| d.with_day0(0)),
-                    "year" => array
-                        .value_as_datetime(i)
-                        .and_then(|d| d.with_nanosecond(0))
-                        .and_then(|d| d.with_second(0))
-                        .and_then(|d| d.with_minute(0))
-                        .and_then(|d| d.with_hour(0))
-                        .and_then(|d| d.with_day0(0))
-                        .and_then(|d| d.with_month0(0)),
-                    unsupported => {
-                        return Err(DataFusionError::Execution(format!(
-                            "Unsupported date_trunc granularity: {}",
-                            unsupported
-                        )))
-                    }
-                };
-                date_time.map(|d| d.timestamp_nanos()).ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "Can't truncate date time: {:?}",
-                        array.value_as_datetime(i)
-                    ))
-                })
+                return Err(DataFusionError::Execution(
+                    "array of `date_trunc` must be non-null scalar Utf8".to_string(),
+                ));
             }
-        })
-        .collect::<Result<Vec<_>>>()?;
+        }
+        ColumnarValue::Array(array) => {
+            let array = array
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .unwrap();
+            let array = array
+                .iter()
+                .map(f)
+                .collect::<Result<TimestampNanosecondArray>>()?;
 
-    let data = ArrayData::new(
-        DataType::Timestamp(TimeUnit::Nanosecond, None),
-        array.len(),
-        Some(array.null_count()),
-        array.data().null_buffer().cloned(),
-        0,
-        vec![Buffer::from(result.to_byte_slice())],
-        vec![],
-    );
-
-    Ok(TimestampNanosecondArray::from(Arc::new(data)))
+            ColumnarValue::Array(Arc::new(array))
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{Int64Array, StringBuilder};
+    use arrow::array::{ArrayRef, Int64Array, StringBuilder};
 
     use super::*;
 
@@ -191,73 +351,77 @@ mod tests {
 
         string_builder.append_null()?;
         ts_builder.append_null()?;
+        let expected_timestamps = &ts_builder.finish() as &dyn Array;
 
-        let string_array = Arc::new(string_builder.finish());
+        let string_array =
+            ColumnarValue::Array(Arc::new(string_builder.finish()) as ArrayRef);
         let parsed_timestamps = to_timestamp(&[string_array])
             .expect("that to_timestamp parsed values without error");
-
-        let expected_timestamps = ts_builder.finish();
-
-        assert_eq!(parsed_timestamps.len(), 2);
-        assert_eq!(expected_timestamps, parsed_timestamps);
+        if let ColumnarValue::Array(parsed_array) = parsed_timestamps {
+            assert_eq!(parsed_array.len(), 2);
+            assert_eq!(expected_timestamps, parsed_array.as_ref());
+        } else {
+            panic!("Expected a columnar array")
+        }
         Ok(())
     }
 
     #[test]
     fn date_trunc_test() -> Result<()> {
-        let mut ts_builder = StringBuilder::new(2);
-        let mut truncated_builder = StringBuilder::new(2);
-        let mut string_builder = StringBuilder::new(2);
+        let cases = vec![
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "second",
+                "2020-09-08T13:42:29.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "minute",
+                "2020-09-08T13:42:00.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "hour",
+                "2020-09-08T13:00:00.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "day",
+                "2020-09-08T00:00:00.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "week",
+                "2020-09-07T00:00:00.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "month",
+                "2020-09-01T00:00:00.000000Z",
+            ),
+            (
+                "2020-09-08T13:42:29.190855Z",
+                "year",
+                "2020-01-01T00:00:00.000000Z",
+            ),
+            (
+                "2021-01-01T13:42:29.190855Z",
+                "week",
+                "2020-12-28T00:00:00.000000Z",
+            ),
+            (
+                "2020-01-01T13:42:29.190855Z",
+                "week",
+                "2019-12-30T00:00:00.000000Z",
+            ),
+        ];
 
-        ts_builder.append_null()?;
-        truncated_builder.append_null()?;
-        string_builder.append_value("second")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-08T13:42:29.000000Z")?;
-        string_builder.append_value("second")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-08T13:42:00.000000Z")?;
-        string_builder.append_value("minute")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-08T13:00:00.000000Z")?;
-        string_builder.append_value("hour")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-08T00:00:00.000000Z")?;
-        string_builder.append_value("day")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-07T00:00:00.000000Z")?;
-        string_builder.append_value("week")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-09-01T00:00:00.000000Z")?;
-        string_builder.append_value("month")?;
-
-        ts_builder.append_value("2020-09-08T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-01-01T00:00:00.000000Z")?;
-        string_builder.append_value("year")?;
-
-        ts_builder.append_value("2021-01-01T13:42:29.190855Z")?;
-        truncated_builder.append_value("2020-12-28T00:00:00.000000Z")?;
-        string_builder.append_value("week")?;
-
-        ts_builder.append_value("2020-01-01T13:42:29.190855Z")?;
-        truncated_builder.append_value("2019-12-30T00:00:00.000000Z")?;
-        string_builder.append_value("week")?;
-
-        let string_array = Arc::new(string_builder.finish());
-        let ts_array = Arc::new(to_timestamp(&[Arc::new(ts_builder.finish())]).unwrap());
-        let date_trunc_array = date_trunc(&[string_array, ts_array])
-            .expect("that to_timestamp parsed values without error");
-
-        let expected_timestamps =
-            to_timestamp(&[Arc::new(truncated_builder.finish())]).unwrap();
-
-        assert_eq!(date_trunc_array, expected_timestamps);
+        cases.iter().for_each(|(original, granularity, expected)| {
+            let original = string_to_timestamp_nanos(original).unwrap();
+            let expected = string_to_timestamp_nanos(expected).unwrap();
+            let result = date_trunc_single(granularity, original).unwrap();
+            assert_eq!(result, expected);
+        });
         Ok(())
     }
 
@@ -268,10 +432,10 @@ mod tests {
 
         let mut builder = Int64Array::builder(1);
         builder.append_value(1)?;
-        let int64array = Arc::new(builder.finish());
+        let int64array = ColumnarValue::Array(Arc::new(builder.finish()));
 
         let expected_err =
-            "Internal error: could not cast to_timestamp input to StringArray";
+            "Internal error: Unsupported data type Int64 for function to_timestamp";
         match to_timestamp(&[int64array]) {
             Ok(_) => panic!("Expected error but got success"),
             Err(e) => {

--- a/rust/datafusion/src/physical_plan/expressions/binary.rs
+++ b/rust/datafusion/src/physical_plan/expressions/binary.rs
@@ -211,6 +211,7 @@ macro_rules! binary_primitive_array_op {
 
 /// The binary_array_op_scalar macro includes types that extend beyond the primitive,
 /// such as Utf8 strings.
+#[macro_export]
 macro_rules! binary_array_op_scalar {
     ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
         let result = match $LEFT.data_type() {

--- a/rust/datafusion/src/physical_plan/expressions/mod.rs
+++ b/rust/datafusion/src/physical_plan/expressions/mod.rs
@@ -22,16 +22,7 @@ use std::sync::Arc;
 use super::ColumnarValue;
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::PhysicalExpr;
-use arrow::array::Array;
-use arrow::array::{
-    ArrayRef, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array,
-    Int16Array, Int32Array, Int64Array, Int8Array, StringArray, TimestampNanosecondArray,
-    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-};
-use arrow::compute::kernels::boolean::nullif;
-use arrow::compute::kernels::comparison::{eq, eq_utf8};
 use arrow::compute::kernels::sort::{SortColumn, SortOptions};
-use arrow::datatypes::{DataType, TimeUnit};
 use arrow::record_batch::RecordBatch;
 
 mod average;
@@ -49,6 +40,7 @@ mod literal;
 mod min_max;
 mod negative;
 mod not;
+mod nullif;
 mod sum;
 
 pub use average::{avg_return_type, Avg, AvgAccumulator};
@@ -64,86 +56,13 @@ pub use literal::{lit, Literal};
 pub use min_max::{Max, Min};
 pub use negative::{negative, NegativeExpr};
 pub use not::{not, NotExpr};
+pub use nullif::{nullif_func, SUPPORTED_NULLIF_TYPES};
 pub use sum::{sum_return_type, Sum};
 
 /// returns the name of the state
 pub fn format_state_name(name: &str, state_name: &str) -> String {
     format!("{}[{}]", name, state_name)
 }
-
-/// Invoke a compute kernel on a primitive array and a Boolean Array
-macro_rules! compute_bool_array_op {
-    ($LEFT:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
-        let ll = $LEFT
-            .as_any()
-            .downcast_ref::<$DT>()
-            .expect("compute_op failed to downcast array");
-        let rr = $RIGHT
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .expect("compute_op failed to downcast array");
-        Ok(Arc::new($OP(&ll, &rr)?))
-    }};
-}
-
-/// Binary op between primitive and boolean arrays
-macro_rules! primitive_bool_array_op {
-    ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
-        match $LEFT.data_type() {
-            DataType::Int8 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int8Array),
-            DataType::Int16 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int16Array),
-            DataType::Int32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int32Array),
-            DataType::Int64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int64Array),
-            DataType::UInt8 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt8Array),
-            DataType::UInt16 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt16Array),
-            DataType::UInt32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt32Array),
-            DataType::UInt64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt64Array),
-            DataType::Float32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Float32Array),
-            DataType::Float64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Float64Array),
-            other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?} for NULLIF/primitive/boolean operator",
-                other
-            ))),
-        }
-    }};
-}
-
-///
-/// Implements NULLIF(expr1, expr2)
-/// Args: 0 - left expr is any array
-///       1 - if the left is equal to this expr2, then the result is NULL, otherwise left value is passed.
-///
-pub fn nullif_func(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() != 2 {
-        return Err(DataFusionError::Internal(format!(
-            "{:?} args were supplied but NULLIF takes exactly two args",
-            args.len(),
-        )));
-    }
-
-    // Get args0 == args1 evaluated and produce a boolean array
-    let cond_array = binary_array_op!(args[0], args[1], eq)?;
-
-    // Now, invoke nullif on the result
-    primitive_bool_array_op!(args[0], *cond_array, nullif)
-}
-
-/// Currently supported types by the nullif function.
-/// The order of these types correspond to the order on which coercion applies
-/// This should thus be from least informative to most informative
-pub static SUPPORTED_NULLIF_TYPES: &[DataType] = &[
-    DataType::Boolean,
-    DataType::UInt8,
-    DataType::UInt16,
-    DataType::UInt32,
-    DataType::UInt64,
-    DataType::Int8,
-    DataType::Int16,
-    DataType::Int32,
-    DataType::Int64,
-    DataType::Float32,
-    DataType::Float64,
-];
 
 /// Represents Sort operation for a column in a RecordBatch
 #[derive(Clone, Debug)]
@@ -178,8 +97,6 @@ impl PhysicalSortExpr {
 mod tests {
     use super::*;
     use crate::{error::Result, physical_plan::AggregateExpr, scalar::ScalarValue};
-    use arrow::array::PrimitiveArray;
-    use arrow::datatypes::*;
 
     /// macro to perform an aggregation and verify the result.
     #[macro_export]
@@ -200,70 +117,6 @@ mod tests {
         }};
     }
 
-    #[test]
-    fn nullif_int32() -> Result<()> {
-        let a = Int32Array::from(vec![
-            Some(1),
-            Some(2),
-            None,
-            None,
-            Some(3),
-            None,
-            None,
-            Some(4),
-            Some(5),
-        ]);
-        let a = Arc::new(a);
-        let a_len = a.len();
-
-        let lit_array = Arc::new(Int32Array::from(vec![2; a.len()]));
-
-        let result = nullif_func(&[a, lit_array])?;
-
-        assert_eq!(result.len(), a_len);
-
-        let expected = Int32Array::from(vec![
-            Some(1),
-            None,
-            None,
-            None,
-            Some(3),
-            None,
-            None,
-            Some(4),
-            Some(5),
-        ]);
-        assert_array_eq::<Int32Type>(expected, result);
-        Ok(())
-    }
-
-    #[test]
-    // Ensure that arrays with no nulls can also invoke NULLIF() correctly
-    fn nullif_int32_nonulls() -> Result<()> {
-        let a = Int32Array::from(vec![1, 3, 10, 7, 8, 1, 2, 4, 5]);
-        let a = Arc::new(a);
-        let a_len = a.len();
-
-        let lit_array = Arc::new(Int32Array::from(vec![1; a.len()]));
-
-        let result = nullif_func(&[a, lit_array])?;
-        assert_eq!(result.len(), a_len);
-
-        let expected = Int32Array::from(vec![
-            None,
-            Some(3),
-            Some(10),
-            Some(7),
-            Some(8),
-            None,
-            Some(2),
-            Some(4),
-            Some(5),
-        ]);
-        assert_array_eq::<Int32Type>(expected, result);
-        Ok(())
-    }
-
     pub fn aggregate(
         batch: &RecordBatch,
         agg: Arc<dyn AggregateExpr>,
@@ -277,23 +130,5 @@ mod tests {
             .collect::<Result<Vec<_>>>()?;
         accum.update_batch(&values)?;
         accum.evaluate()
-    }
-
-    fn assert_array_eq<T: ArrowNumericType>(
-        expected: PrimitiveArray<T>,
-        actual: ArrayRef,
-    ) {
-        let actual = actual
-            .as_any()
-            .downcast_ref::<PrimitiveArray<T>>()
-            .expect("Actual array should unwrap to type of expected array");
-
-        for i in 0..expected.len() {
-            if expected.is_null(i) {
-                assert!(actual.is_null(i));
-            } else {
-                assert_eq!(expected.value(i), actual.value(i));
-            }
-        }
     }
 }

--- a/rust/datafusion/src/physical_plan/expressions/nullif.rs
+++ b/rust/datafusion/src/physical_plan/expressions/nullif.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use super::ColumnarValue;
+use crate::error::{DataFusionError, Result};
+use crate::scalar::ScalarValue;
+use arrow::array::Array;
+use arrow::array::{
+    ArrayRef, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array,
+    Int16Array, Int32Array, Int64Array, Int8Array, StringArray, TimestampNanosecondArray,
+    UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::compute::kernels::boolean::nullif;
+use arrow::compute::kernels::comparison::{eq, eq_scalar, eq_utf8, eq_utf8_scalar};
+use arrow::datatypes::{DataType, TimeUnit};
+
+/// Invoke a compute kernel on a primitive array and a Boolean Array
+macro_rules! compute_bool_array_op {
+    ($LEFT:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
+        let ll = $LEFT
+            .as_any()
+            .downcast_ref::<$DT>()
+            .expect("compute_op failed to downcast array");
+        let rr = $RIGHT
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("compute_op failed to downcast array");
+        Ok(Arc::new($OP(&ll, &rr)?) as ArrayRef)
+    }};
+}
+
+/// Binary op between primitive and boolean arrays
+macro_rules! primitive_bool_array_op {
+    ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
+        match $LEFT.data_type() {
+            DataType::Int8 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int8Array),
+            DataType::Int16 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int16Array),
+            DataType::Int32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int32Array),
+            DataType::Int64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Int64Array),
+            DataType::UInt8 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt8Array),
+            DataType::UInt16 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt16Array),
+            DataType::UInt32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt32Array),
+            DataType::UInt64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, UInt64Array),
+            DataType::Float32 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Float32Array),
+            DataType::Float64 => compute_bool_array_op!($LEFT, $RIGHT, $OP, Float64Array),
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for NULLIF/primitive/boolean operator",
+                other
+            ))),
+        }
+    }};
+}
+
+/// Implements NULLIF(expr1, expr2)
+/// Args: 0 - left expr is any array
+///       1 - if the left is equal to this expr2, then the result is NULL, otherwise left value is passed.
+///
+pub fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    if args.len() != 2 {
+        return Err(DataFusionError::Internal(format!(
+            "{:?} args were supplied but NULLIF takes exactly two args",
+            args.len(),
+        )));
+    }
+
+    let (lhs, rhs) = (&args[0], &args[1]);
+
+    match (lhs, rhs) {
+        (ColumnarValue::Array(lhs), ColumnarValue::Scalar(rhs)) => {
+            let cond_array = binary_array_op_scalar!(lhs, rhs.clone(), eq).unwrap()?;
+
+            let array = primitive_bool_array_op!(lhs, *cond_array, nullif)?;
+
+            Ok(ColumnarValue::Array(array))
+        }
+        (ColumnarValue::Array(lhs), ColumnarValue::Array(rhs)) => {
+            // Get args0 == args1 evaluated and produce a boolean array
+            let cond_array = binary_array_op!(lhs, rhs, eq)?;
+
+            // Now, invoke nullif on the result
+            let array = primitive_bool_array_op!(lhs, *cond_array, nullif)?;
+            Ok(ColumnarValue::Array(array))
+        }
+        _ => Err(DataFusionError::NotImplemented(
+            "nullif does not support a literal as first argument".to_string(),
+        )),
+    }
+}
+
+/// Currently supported types by the nullif function.
+/// The order of these types correspond to the order on which coercion applies
+/// This should thus be from least informative to most informative
+pub static SUPPORTED_NULLIF_TYPES: &[DataType] = &[
+    DataType::Boolean,
+    DataType::UInt8,
+    DataType::UInt16,
+    DataType::UInt32,
+    DataType::UInt64,
+    DataType::Int8,
+    DataType::Int16,
+    DataType::Int32,
+    DataType::Int64,
+    DataType::Float32,
+    DataType::Float64,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Result;
+
+    #[test]
+    fn nullif_int32() -> Result<()> {
+        let a = Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            None,
+            None,
+            Some(3),
+            None,
+            None,
+            Some(4),
+            Some(5),
+        ]);
+        let a = ColumnarValue::Array(Arc::new(a));
+
+        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
+
+        let result = nullif_func(&[a, lit_array])?;
+        let result = result.into_array(0);
+
+        let expected = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            None,
+            None,
+            Some(3),
+            None,
+            None,
+            Some(4),
+            Some(5),
+        ])) as ArrayRef;
+        assert_eq!(expected.as_ref(), result.as_ref());
+        Ok(())
+    }
+
+    #[test]
+    // Ensure that arrays with no nulls can also invoke NULLIF() correctly
+    fn nullif_int32_nonulls() -> Result<()> {
+        let a = Int32Array::from(vec![1, 3, 10, 7, 8, 1, 2, 4, 5]);
+        let a = ColumnarValue::Array(Arc::new(a));
+
+        let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(1i32)));
+
+        let result = nullif_func(&[a, lit_array])?;
+        let result = result.into_array(0);
+
+        let expected = Arc::new(Int32Array::from(vec![
+            None,
+            Some(3),
+            Some(10),
+            Some(7),
+            Some(8),
+            None,
+            Some(2),
+            Some(4),
+            Some(5),
+        ])) as ArrayRef;
+        assert_eq!(expected.as_ref(), result.as_ref());
+        Ok(())
+    }
+}

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -722,7 +722,7 @@ mod tests {
 
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Array,
-            &vec![col("a"), col("b")],
+            &[col("a"), col("b")],
             &schema,
         )?;
 

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -159,6 +159,7 @@ pub enum Distribution {
 }
 
 /// Represents the result from an expression
+#[derive(Clone)]
 pub enum ColumnarValue {
     /// Array of values
     Array(ArrayRef),

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -17,27 +17,100 @@
 
 //! String expressions
 
-use crate::error::{DataFusionError, Result};
-use arrow::array::{
-    Array, ArrayRef, GenericStringArray, StringArray, StringBuilder,
-    StringOffsetSizeTrait,
+use std::sync::Arc;
+
+use crate::{
+    error::{DataFusionError, Result},
+    scalar::ScalarValue,
+};
+use arrow::{
+    array::{Array, GenericStringArray, StringArray, StringOffsetSizeTrait},
+    datatypes::DataType,
 };
 
-macro_rules! downcast_vec {
-    ($ARGS:expr, $ARRAY_TYPE:ident) => {{
-        $ARGS
-            .iter()
-            .map(|e| match e.as_any().downcast_ref::<$ARRAY_TYPE>() {
-                Some(array) => Ok(array),
-                _ => Err(DataFusionError::Internal("failed to downcast".to_string())),
-            })
-    }};
+use super::ColumnarValue;
+
+pub(crate) fn unary_string_function<'a, T, O, F, R>(
+    args: &[&'a dyn Array],
+    op: F,
+    name: &str,
+) -> Result<GenericStringArray<O>>
+where
+    R: AsRef<str>,
+    O: StringOffsetSizeTrait,
+    T: StringOffsetSizeTrait,
+    F: Fn(&'a str) -> R,
+{
+    if args.len() != 1 {
+        return Err(DataFusionError::Internal(format!(
+            "{:?} args were supplied but {} takes exactly one argument",
+            args.len(),
+            name,
+        )));
+    }
+
+    let array = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .unwrap();
+
+    // first map is the iterator, second is for the `Option<_>`
+    Ok(array.iter().map(|x| x.map(|x| op(x))).collect())
+}
+
+fn handle<'a, F, R>(args: &'a [ColumnarValue], op: F, name: &str) -> Result<ColumnarValue>
+where
+    R: AsRef<str>,
+    F: Fn(&'a str) -> R,
+{
+    match &args[0] {
+        ColumnarValue::Array(a) => match a.data_type() {
+            DataType::Utf8 => {
+                Ok(ColumnarValue::Array(Arc::new(unary_string_function::<
+                    i32,
+                    i32,
+                    _,
+                    _,
+                >(
+                    &[a.as_ref()], op, name
+                )?)))
+            }
+            DataType::LargeUtf8 => {
+                Ok(ColumnarValue::Array(Arc::new(unary_string_function::<
+                    i64,
+                    i64,
+                    _,
+                    _,
+                >(
+                    &[a.as_ref()], op, name
+                )?)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+        ColumnarValue::Scalar(scalar) => match scalar {
+            ScalarValue::Utf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x).as_ref().to_string());
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
+            }
+            ScalarValue::LargeUtf8(a) => {
+                let result = a.as_ref().map(|x| (op)(x).as_ref().to_string());
+                Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(result)))
+            }
+            other => Err(DataFusionError::Internal(format!(
+                "Unsupported data type {:?} for function md5",
+                other,
+            ))),
+        },
+    }
 }
 
 /// concatenate string columns together.
-pub fn concatenate(args: &[ArrayRef]) -> Result<StringArray> {
+pub fn concatenate(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     // downcast all arguments to strings
-    let args = downcast_vec!(args, StringArray).collect::<Result<Vec<&StringArray>>>()?;
+    //let args = downcast_vec!(args, StringArray).collect::<Result<Vec<&StringArray>>>()?;
     // do not accept 0 arguments.
     if args.is_empty() {
         return Err(DataFusionError::Internal(
@@ -46,48 +119,93 @@ pub fn concatenate(args: &[ArrayRef]) -> Result<StringArray> {
         ));
     }
 
-    let mut builder = StringBuilder::new(args.len());
-    // for each entry in the array
-    for index in 0..args[0].len() {
-        let mut owned_string: String = "".to_owned();
+    // first, decide whether to return a scalar or a vector.
+    let mut return_array = args.iter().filter_map(|x| match x {
+        ColumnarValue::Array(array) => Some(array.len()),
+        _ => None,
+    });
+    if let Some(size) = return_array.next() {
+        let iter = (0..size).map(|index| {
+            let mut owned_string: String = "".to_owned();
 
-        // if any is null, the result is null
-        let mut is_null = false;
-        for arg in &args {
-            if arg.is_null(index) {
-                is_null = true;
-                break; // short-circuit as we already know the result
-            } else {
-                owned_string.push_str(&arg.value(index));
+            // if any is null, the result is null
+            let mut is_null = false;
+            for arg in args {
+                match arg {
+                    ColumnarValue::Scalar(ScalarValue::Utf8(maybe_value)) => {
+                        if let Some(value) = maybe_value {
+                            owned_string.push_str(value);
+                        } else {
+                            is_null = true;
+                            break; // short-circuit as we already know the result
+                        }
+                    }
+                    ColumnarValue::Array(v) => {
+                        if v.is_null(index) {
+                            is_null = true;
+                            break; // short-circuit as we already know the result
+                        } else {
+                            let v = v.as_any().downcast_ref::<StringArray>().unwrap();
+                            owned_string.push_str(&v.value(index));
+                        }
+                    }
+                    _ => unreachable!(),
+                }
             }
-        }
-        if is_null {
-            builder.append_null()?;
-        } else {
-            builder.append_value(&owned_string)?;
-        }
+            if is_null {
+                None
+            } else {
+                Some(owned_string)
+            }
+        });
+        let array = iter.collect::<StringArray>();
+
+        Ok(ColumnarValue::Array(Arc::new(array)))
+    } else {
+        // short avenue with only scalars
+        let initial = Some("".to_string());
+        let result = args.iter().fold(initial, |mut acc, rhs| {
+            match acc {
+                Some(ref mut inner) => {
+                    match rhs {
+                        ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) => {
+                            inner.push_str(v);
+                        }
+                        ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {
+                            acc = None;
+                        }
+                        _ => unreachable!(""),
+                    };
+                }
+                None => {}
+            };
+            acc
+        });
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
     }
-    Ok(builder.finish())
 }
 
-macro_rules! string_unary_function {
-    ($NAME:ident, $FUNC:ident) => {
-        /// string function that accepts Utf8 or LargeUtf8 and returns Utf8 or LargeUtf8
-        pub fn $NAME<T: StringOffsetSizeTrait>(
-            args: &[ArrayRef],
-        ) -> Result<GenericStringArray<T>> {
-            let array = args[0]
-                .as_any()
-                .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
-            // first map is the iterator, second is for the `Option<_>`
-            Ok(array.iter().map(|x| x.map(|x| x.$FUNC())).collect())
-        }
-    };
+/// lower
+pub fn lower(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, |x| x.to_ascii_lowercase(), "lower")
 }
 
-string_unary_function!(lower, to_ascii_lowercase);
-string_unary_function!(upper, to_ascii_uppercase);
-string_unary_function!(trim, trim);
-string_unary_function!(ltrim, trim_start);
-string_unary_function!(rtrim, trim_end);
+/// upper
+pub fn upper(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, |x| x.to_ascii_uppercase(), "upper")
+}
+
+/// trim
+pub fn trim(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, |x: &str| x.trim(), "trim")
+}
+
+/// ltrim
+pub fn ltrim(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, |x| x.trim_start(), "ltrim")
+}
+
+/// rtrim
+pub fn rtrim(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    handle(args, |x| x.trim_end(), "rtrim")
+}

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -165,19 +165,16 @@ pub fn concatenate(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         // short avenue with only scalars
         let initial = Some("".to_string());
         let result = args.iter().fold(initial, |mut acc, rhs| {
-            match acc {
-                Some(ref mut inner) => {
-                    match rhs {
-                        ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) => {
-                            inner.push_str(v);
-                        }
-                        ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {
-                            acc = None;
-                        }
-                        _ => unreachable!(""),
-                    };
-                }
-                None => {}
+            if let Some(ref mut inner) = acc {
+                match rhs {
+                    ColumnarValue::Scalar(ScalarValue::Utf8(Some(v))) => {
+                        inner.push_str(v);
+                    }
+                    ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {
+                        acc = None;
+                    }
+                    _ => unreachable!(""),
+                };
             };
             acc
         });

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -682,20 +682,20 @@ impl fmt::Debug for ScalarValue {
     }
 }
 
-/// Trait used to map
+/// Trait used to map a NativeTime to a ScalarType.
 pub trait ScalarType<T: ArrowNativeType> {
     /// returns a scalar from an optional T
-    fn into_scalar(r: Option<T>) -> ScalarValue;
+    fn scalar(r: Option<T>) -> ScalarValue;
 }
 
 impl ScalarType<f32> for Float32Type {
-    fn into_scalar(r: Option<f32>) -> ScalarValue {
+    fn scalar(r: Option<f32>) -> ScalarValue {
         ScalarValue::Float32(r)
     }
 }
 
 impl ScalarType<i64> for TimestampNanosecondType {
-    fn into_scalar(r: Option<i64>) -> ScalarValue {
+    fn scalar(r: Option<i64>) -> ScalarValue {
         ScalarValue::TimeNanosecond(r)
     }
 }

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -520,7 +520,23 @@ impl TryFrom<ScalarValue> for i32 {
     }
 }
 
-impl_try_from!(Int64, i64);
+// special implementation for i64 because of TimeNanosecond
+impl TryFrom<ScalarValue> for i64 {
+    type Error = DataFusionError;
+
+    fn try_from(value: ScalarValue) -> Result<Self> {
+        match value {
+            ScalarValue::Int64(Some(inner_value))
+            | ScalarValue::TimeNanosecond(Some(inner_value)) => Ok(inner_value),
+            _ => Err(DataFusionError::Internal(format!(
+                "Cannot convert {:?} to {}",
+                value,
+                std::any::type_name::<Self>()
+            ))),
+        }
+    }
+}
+
 impl_try_from!(UInt8, u8);
 impl_try_from!(UInt16, u16);
 impl_try_from!(UInt32, u32);

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -19,8 +19,11 @@
 
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
-use arrow::array::*;
 use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+use arrow::{
+    array::*,
+    datatypes::{ArrowNativeType, Float32Type, TimestampNanosecondType},
+};
 
 use crate::error::{DataFusionError, Result};
 
@@ -660,6 +663,24 @@ impl fmt::Debug for ScalarValue {
                 write!(f, "IntervalYearMonth(\"{}\")", self)
             }
         }
+    }
+}
+
+/// Trait used to map
+pub trait ScalarType<T: ArrowNativeType> {
+    /// returns a scalar from an optional T
+    fn into_scalar(r: Option<T>) -> ScalarValue;
+}
+
+impl ScalarType<f32> for Float32Type {
+    fn into_scalar(r: Option<f32>) -> ScalarValue {
+        ScalarValue::Float32(r)
+    }
+}
+
+impl ScalarType<i64> for TimestampNanosecondType {
+    fn into_scalar(r: Option<i64>) -> ScalarValue {
+        ScalarValue::TimeNanosecond(r)
     }
 }
 


### PR DESCRIPTION
This PR adds support for `ScalarValue` to all builtin-functions and UDFs from DataFusion.

This allows to execute builtin functions without having to create arrays and pass then to the kernels.

With this change, coding a new kernel and UDFs is a more time consuming, as it is necessary to cater for both the scalar and array case. OTOH, this leads to a major performance improvement as we only need to perform 1 operation instead of the usual number of rows operations.