### PR TITLE
ARROW-11440: [Rust] [DataFusion] Add method to CsvExec to get CSV schema

### DIFF
--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -197,6 +197,11 @@ impl CsvExec {
         &self.file_extension
     }
 
+    /// Get the schema of the CSV file
+    pub fn file_schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
     /// Optional projection for which columns to load
     pub fn projection(&self) -> Option<&Vec<usize>> {
         self.projection.as_ref()
@@ -338,6 +343,7 @@ mod tests {
         )?;
         assert_eq!(13, csv.schema.fields().len());
         assert_eq!(3, csv.projected_schema.fields().len());
+        assert_eq!(13, csv.file_schema().fields().len());
         assert_eq!(3, csv.schema().fields().len());
         let mut stream = csv.execute(0).await?;
         let batch = stream.next().await.unwrap()?;
@@ -360,6 +366,7 @@ mod tests {
             CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
         assert_eq!(13, csv.schema.fields().len());
         assert_eq!(13, csv.projected_schema.fields().len());
+        assert_eq!(13, csv.file_schema().fields().len());
         assert_eq!(13, csv.schema().fields().len());
         let mut it = csv.execute(0).await?;
         let batch = it.next().await.unwrap()?;


### PR DESCRIPTION
I needed this in Ballista so that I could implement serde for the CsvExec operator.