### PR TITLE
ARROW-11444: [Rust][DataFusion] Accept slices as parameters

### DIFF
--- a/rust/datafusion/examples/simple_udaf.rs
+++ b/rust/datafusion/examples/simple_udaf.rs
@@ -81,7 +81,7 @@ impl Accumulator for GeometricMean {
 
     // this function receives one entry per argument of this accumulator.
     // DataFusion calls this function on every row, and expects this function to update the accumulator's state.
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         // this is a one-argument UDAF, and thus we use `0`.
         let value = &values[0];
         match value {
@@ -100,7 +100,7 @@ impl Accumulator for GeometricMean {
 
     // this function receives states from other accumulators (Vec<ScalarValue>)
     // and updates the accumulator.
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         let prod = &states[0];
         let n = &states[1];
         match (prod, n) {

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -50,7 +50,7 @@ pub struct MemTable {
 // Calculates statistics based on partitions
 fn calculate_statistics(
     schema: &SchemaRef,
-    partitions: &Vec<Vec<RecordBatch>>,
+    partitions: &[Vec<RecordBatch>],
 ) -> Statistics {
     let num_rows: usize = partitions
         .iter()

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::float_cmp,
     clippy::module_inception,
     clippy::new_without_default,
-    clippy::ptr_arg,
     clippy::type_complexity
 )]
 

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -902,9 +902,9 @@ pub fn create_udaf(
 
 fn fmt_function(
     f: &mut fmt::Formatter,
-    fun: &String,
+    fun: &str,
     distinct: bool,
-    args: &Vec<Expr>,
+    args: &[Expr],
 ) -> fmt::Result {
     let args: Vec<String> = args.iter().map(|arg| format!("{:?}", arg)).collect();
     let distinct_str = match distinct {
@@ -1009,7 +1009,7 @@ impl fmt::Debug for Expr {
 }
 
 fn create_function_name(
-    fun: &String,
+    fun: &str,
     distinct: bool,
     args: &[Expr],
     input_schema: &DFSchema,

--- a/rust/datafusion/src/logical_plan/extension.rs
+++ b/rust/datafusion/src/logical_plan/extension.rs
@@ -73,7 +73,7 @@ pub trait UserDefinedLogicalNode: fmt::Debug {
     /// So, `self.from_template(exprs, ..).expressions() == exprs
     fn from_template(
         &self,
-        exprs: &Vec<Expr>,
-        inputs: &Vec<LogicalPlan>,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
     ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync>;
 }

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -278,7 +278,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             // optimize inner
             let new_input = optimize(input, state)?;
 
-            utils::from_plan(&plan, &expr, &vec![new_input])
+            utils::from_plan(&plan, &expr, &[new_input])
         }
         LogicalPlan::Aggregate {
             input, aggr_expr, ..
@@ -327,7 +327,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
 
             // create a new Join with the new `left` and `right`
             let expr = utils::expressions(&plan);
-            let plan = utils::from_plan(&plan, &expr, &vec![left, right])?;
+            let plan = utils::from_plan(&plan, &expr, &[left, right])?;
 
             if keep.0.is_empty() {
                 Ok(plan)

--- a/rust/datafusion/src/physical_plan/aggregates.rs
+++ b/rust/datafusion/src/physical_plan/aggregates.rs
@@ -89,10 +89,7 @@ impl FromStr for AggregateFunction {
 }
 
 /// Returns the datatype of the scalar function
-pub fn return_type(
-    fun: &AggregateFunction,
-    arg_types: &Vec<DataType>,
-) -> Result<DataType> {
+pub fn return_type(fun: &AggregateFunction, arg_types: &[DataType]) -> Result<DataType> {
     // Note that this function *must* return the same type that the respective physical expression returns
     // or the execution panics.
 
@@ -112,7 +109,7 @@ pub fn return_type(
 pub fn create_aggregate_expr(
     fun: &AggregateFunction,
     distinct: bool,
-    args: &Vec<Arc<dyn PhysicalExpr>>,
+    args: &[Arc<dyn PhysicalExpr>],
     input_schema: &Schema,
     name: String,
 ) -> Result<Arc<dyn AggregateExpr>> {
@@ -133,7 +130,7 @@ pub fn create_aggregate_expr(
         (AggregateFunction::Count, true) => {
             Arc::new(distinct_expressions::DistinctCount::new(
                 arg_types,
-                args.clone(),
+                args.to_vec(),
                 name,
                 return_type,
             ))
@@ -199,51 +196,51 @@ mod tests {
 
     #[test]
     fn test_min_max() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Min, &vec![DataType::Utf8])?;
+        let observed = return_type(&AggregateFunction::Min, &[DataType::Utf8])?;
         assert_eq!(DataType::Utf8, observed);
 
-        let observed = return_type(&AggregateFunction::Max, &vec![DataType::Int32])?;
+        let observed = return_type(&AggregateFunction::Max, &[DataType::Int32])?;
         assert_eq!(DataType::Int32, observed);
         Ok(())
     }
 
     #[test]
     fn test_sum_no_utf8() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Sum, &vec![DataType::Utf8]);
+        let observed = return_type(&AggregateFunction::Sum, &[DataType::Utf8]);
         assert!(observed.is_err());
         Ok(())
     }
 
     #[test]
     fn test_sum_upcasts() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Sum, &vec![DataType::UInt32])?;
+        let observed = return_type(&AggregateFunction::Sum, &[DataType::UInt32])?;
         assert_eq!(DataType::UInt64, observed);
         Ok(())
     }
 
     #[test]
     fn test_count_return_type() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Count, &vec![DataType::Utf8])?;
+        let observed = return_type(&AggregateFunction::Count, &[DataType::Utf8])?;
         assert_eq!(DataType::UInt64, observed);
 
-        let observed = return_type(&AggregateFunction::Count, &vec![DataType::Int8])?;
+        let observed = return_type(&AggregateFunction::Count, &[DataType::Int8])?;
         assert_eq!(DataType::UInt64, observed);
         Ok(())
     }
 
     #[test]
     fn test_avg_return_type() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Avg, &vec![DataType::Float32])?;
+        let observed = return_type(&AggregateFunction::Avg, &[DataType::Float32])?;
         assert_eq!(DataType::Float64, observed);
 
-        let observed = return_type(&AggregateFunction::Avg, &vec![DataType::Float64])?;
+        let observed = return_type(&AggregateFunction::Avg, &[DataType::Float64])?;
         assert_eq!(DataType::Float64, observed);
         Ok(())
     }
 
     #[test]
     fn test_avg_no_utf8() -> Result<()> {
-        let observed = return_type(&AggregateFunction::Avg, &vec![DataType::Utf8]);
+        let observed = return_type(&AggregateFunction::Avg, &[DataType::Utf8]);
         assert!(observed.is_err());
         Ok(())
     }

--- a/rust/datafusion/src/physical_plan/expressions/average.rs
+++ b/rust/datafusion/src/physical_plan/expressions/average.rs
@@ -128,7 +128,7 @@ impl Accumulator for AvgAccumulator {
         Ok(vec![ScalarValue::from(self.count), self.sum.clone()])
     }
 
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         let values = &values[0];
 
         self.count += (!values.is_null()) as u64;
@@ -137,7 +137,7 @@ impl Accumulator for AvgAccumulator {
         Ok(())
     }
 
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
 
         self.count += (values.len() - values.data().null_count()) as u64;
@@ -145,7 +145,7 @@ impl Accumulator for AvgAccumulator {
         Ok(())
     }
 
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         let count = &states[0];
         // counts are summed
         if let ScalarValue::UInt64(Some(c)) = count {
@@ -159,7 +159,7 @@ impl Accumulator for AvgAccumulator {
         Ok(())
     }
 
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         let counts = states[0].as_any().downcast_ref::<UInt64Array>().unwrap();
         // counts are summed
         self.count += compute::sum(counts).unwrap_or(0);

--- a/rust/datafusion/src/physical_plan/expressions/count.rs
+++ b/rust/datafusion/src/physical_plan/expressions/count.rs
@@ -92,13 +92,13 @@ impl CountAccumulator {
 }
 
 impl Accumulator for CountAccumulator {
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let array = &values[0];
         self.count += (array.len() - array.data().null_count()) as u64;
         Ok(())
     }
 
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         let value = &values[0];
         if !value.is_null() {
             self.count += 1;
@@ -106,7 +106,7 @@ impl Accumulator for CountAccumulator {
         Ok(())
     }
 
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         let count = &states[0];
         if let ScalarValue::UInt64(Some(delta)) = count {
             self.count += *delta;
@@ -116,7 +116,7 @@ impl Accumulator for CountAccumulator {
         Ok(())
     }
 
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         let counts = states[0].as_any().downcast_ref::<UInt64Array>().unwrap();
         let delta = &compute::sum(counts);
         if let Some(d) = delta {

--- a/rust/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/rust/datafusion/src/physical_plan/expressions/min_max.rs
@@ -258,24 +258,24 @@ impl MaxAccumulator {
 }
 
 impl Accumulator for MaxAccumulator {
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
         let delta = &max_batch(values)?;
         self.max = max(&self.max, delta)?;
         Ok(())
     }
 
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         let value = &values[0];
         self.max = max(&self.max, value)?;
         Ok(())
     }
 
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         self.update(states)
     }
 
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         self.update_batch(states)
     }
 
@@ -354,24 +354,24 @@ impl Accumulator for MinAccumulator {
         Ok(vec![self.min.clone()])
     }
 
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
         let delta = &min_batch(values)?;
         self.min = min(&self.min, delta)?;
         Ok(())
     }
 
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         let value = &values[0];
         self.min = min(&self.min, value)?;
         Ok(())
     }
 
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         self.update(states)
     }
 
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         self.update_batch(states)
     }
 

--- a/rust/datafusion/src/physical_plan/expressions/sum.rs
+++ b/rust/datafusion/src/physical_plan/expressions/sum.rs
@@ -230,24 +230,24 @@ pub(super) fn sum(lhs: &ScalarValue, rhs: &ScalarValue) -> Result<ScalarValue> {
 }
 
 impl Accumulator for SumAccumulator {
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         let values = &values[0];
         self.sum = sum(&self.sum, &sum_batch(values)?)?;
         Ok(())
     }
 
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()> {
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
         // sum(v1, v2, v3) = v1 + v2 + v3
         self.sum = sum(&self.sum, &values[0])?;
         Ok(())
     }
 
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()> {
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
         // sum(sum1, sum2) = sum1 + sum2
         self.update(states)
     }
 
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         // sum(sum1, sum2, sum3, ...) = sum1 + sum2 + sum3 + ...
         self.update_batch(states)
     }

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -208,7 +208,7 @@ impl FromStr for BuiltinScalarFunction {
 /// Returns the datatype of the scalar function
 pub fn return_type(
     fun: &BuiltinScalarFunction,
-    arg_types: &Vec<DataType>,
+    arg_types: &[DataType],
 ) -> Result<DataType> {
     // Note that this function *must* return the same type that the respective physical expression returns
     // or the execution panics.
@@ -362,7 +362,7 @@ pub fn return_type(
 /// This function errors when `args`' can't be coerced to a valid argument type of the function.
 pub fn create_physical_expr(
     fun: &BuiltinScalarFunction,
-    args: &Vec<Arc<dyn PhysicalExpr>>,
+    args: &[Arc<dyn PhysicalExpr>],
     input_schema: &Schema,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let fun_expr: ScalarFunctionImplementation = Arc::new(match fun {
@@ -648,8 +648,7 @@ mod tests {
 
         let arg = lit(value);
 
-        let expr =
-            create_physical_expr(&BuiltinScalarFunction::Exp, &vec![arg], &schema)?;
+        let expr = create_physical_expr(&BuiltinScalarFunction::Exp, &[arg], &schema)?;
 
         // type is correct
         assert_eq!(expr.data_type(&schema)?, DataType::Float64);
@@ -688,7 +687,7 @@ mod tests {
         // concat(value, value)
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Concat,
-            &vec![lit(value.clone()), lit(value)],
+            &[lit(value.clone()), lit(value)],
             &schema,
         )?;
 
@@ -715,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_concat_error() -> Result<()> {
-        let result = return_type(&BuiltinScalarFunction::Concat, &vec![]);
+        let result = return_type(&BuiltinScalarFunction::Concat, &[]);
         if result.is_ok() {
             Err(DataFusionError::Plan(
                 "Function 'concat' cannot accept zero arguments".to_string(),
@@ -737,7 +736,7 @@ mod tests {
 
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Array,
-            &vec![lit(value1), lit(value2)],
+            &[lit(value1), lit(value2)],
             &schema,
         )?;
 

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -85,8 +85,8 @@ pub struct HashAggregateExec {
 
 fn create_schema(
     input_schema: &Schema,
-    group_expr: &Vec<(Arc<dyn PhysicalExpr>, String)>,
-    aggr_expr: &Vec<Arc<dyn AggregateExpr>>,
+    group_expr: &[(Arc<dyn PhysicalExpr>, String)],
+    aggr_expr: &[Arc<dyn AggregateExpr>],
     mode: AggregateMode,
 ) -> Result<Schema> {
     let mut fields = Vec::with_capacity(group_expr.len() + aggr_expr.len());
@@ -261,11 +261,11 @@ pin_project! {
 
 fn group_aggregate_batch(
     mode: &AggregateMode,
-    group_expr: &Vec<Arc<dyn PhysicalExpr>>,
-    aggr_expr: &Vec<Arc<dyn AggregateExpr>>,
+    group_expr: &[Arc<dyn PhysicalExpr>],
+    aggr_expr: &[Arc<dyn AggregateExpr>],
     batch: RecordBatch,
     mut accumulators: Accumulators,
-    aggregate_expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
+    aggregate_expressions: &[Vec<Arc<dyn PhysicalExpr>>],
 ) -> Result<Accumulators> {
     // evaluate the grouping expressions
     let group_values = evaluate(group_expr, &batch)?;
@@ -379,7 +379,7 @@ fn group_aggregate_batch(
                                 // 2.3
                                 array.slice(offsets[0], offsets[1] - offsets[0])
                             })
-                            .collect(),
+                            .collect::<Vec<ArrayRef>>(),
                     )
                 })
                 .try_for_each(|(accumulator, values)| match mode {
@@ -556,9 +556,9 @@ impl GroupedHashAggregateStream {
     }
 }
 
-type AccumulatorSet = Vec<Box<dyn Accumulator>>;
+type AccumulatorItem = Box<dyn Accumulator>;
 type Accumulators =
-    HashMap<Vec<u8>, (Box<[GroupByScalar]>, AccumulatorSet, Vec<u32>), RandomState>;
+    HashMap<Vec<u8>, (Box<[GroupByScalar]>, Vec<AccumulatorItem>, Vec<u32>), RandomState>;
 
 impl Stream for GroupedHashAggregateStream {
     type Item = ArrowResult<RecordBatch>;
@@ -599,7 +599,7 @@ impl RecordBatchStream for GroupedHashAggregateStream {
 
 /// Evaluates expressions against a record batch.
 fn evaluate(
-    expr: &Vec<Arc<dyn PhysicalExpr>>,
+    expr: &[Arc<dyn PhysicalExpr>],
     batch: &RecordBatch,
 ) -> Result<Vec<ArrayRef>> {
     expr.iter()
@@ -610,7 +610,7 @@ fn evaluate(
 
 /// Evaluates expressions against a record batch.
 fn evaluate_many(
-    expr: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
+    expr: &[Vec<Arc<dyn PhysicalExpr>>],
     batch: &RecordBatch,
 ) -> Result<Vec<Vec<ArrayRef>>> {
     expr.iter()
@@ -679,7 +679,7 @@ async fn compute_hash_aggregate(
     // future is ready when all batches are computed
     while let Some(batch) = input.next().await {
         let batch = batch?;
-        accumulators = aggregate_batch(&mode, &batch, accumulators, &expressions)
+        aggregate_batch(&mode, &batch, &mut accumulators, &expressions)
             .map_err(DataFusionError::into_arrow_external_error)?;
     }
 
@@ -717,18 +717,18 @@ impl HashAggregateStream {
 fn aggregate_batch(
     mode: &AggregateMode,
     batch: &RecordBatch,
-    accumulators: AccumulatorSet,
-    expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
-) -> Result<AccumulatorSet> {
+    accumulators: &mut [AccumulatorItem],
+    expressions: &[Vec<Arc<dyn PhysicalExpr>>],
+) -> Result<()> {
     // 1.1 iterate accumulators and respective expressions together
     // 1.2 evaluate expressions
     // 1.3 update / merge accumulators with the expressions' values
 
     // 1.1
     accumulators
-        .into_iter()
+        .iter_mut()
         .zip(expressions)
-        .map(|(mut accum, expr)| {
+        .try_for_each(|(accum, expr)| {
             // 1.2
             let values = &expr
                 .iter()
@@ -745,9 +745,8 @@ fn aggregate_batch(
                     accum.merge_batch(values)?;
                 }
             }
-            Ok(accum)
+            Ok(())
         })
-        .collect::<Result<Vec<_>>>()
 }
 
 impl Stream for HashAggregateStream {
@@ -874,8 +873,8 @@ fn create_batch_from_map(
 }
 
 fn create_accumulators(
-    aggr_expr: &Vec<Arc<dyn AggregateExpr>>,
-) -> Result<AccumulatorSet> {
+    aggr_expr: &[Arc<dyn AggregateExpr>],
+) -> Result<Vec<AccumulatorItem>> {
     aggr_expr
         .iter()
         .map(|expr| expr.create_accumulator())
@@ -885,7 +884,7 @@ fn create_accumulators(
 /// returns a vector of ArrayRefs, where each entry corresponds to either the
 /// final value (mode = Final) or states (mode = Partial)
 fn finalize_aggregation(
-    accumulators: &AccumulatorSet,
+    accumulators: &[AccumulatorItem],
     mode: &AggregateMode,
 ) -> Result<Vec<ArrayRef>> {
     match mode {

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -738,14 +738,9 @@ fn aggregate_batch(
 
             // 1.3
             match mode {
-                AggregateMode::Partial => {
-                    accum.update_batch(values)?;
-                }
-                AggregateMode::Final => {
-                    accum.merge_batch(values)?;
-                }
+                AggregateMode::Partial => accum.update_batch(values),
+                AggregateMode::Final => accum.merge_batch(values),
             }
-            Ok(())
         })
 }
 

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -1008,7 +1008,7 @@ mod tests {
             build_table_i32(("a2", &vec![30]), ("b1", &vec![5]), ("c2", &vec![90]));
         let schema = batch1.schema();
         let right = Arc::new(
-            MemoryExec::try_new(&vec![vec![batch1], vec![batch2]], schema, None).unwrap(),
+            MemoryExec::try_new(&[vec![batch1], vec![batch2]], schema, None).unwrap(),
         );
 
         let on = &[("b1", "b1")];

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -817,7 +817,7 @@ mod tests {
     ) -> Arc<dyn ExecutionPlan> {
         let batch = build_table_i32(a, b, c);
         let schema = batch.schema();
-        Arc::new(MemoryExec::try_new(&vec![vec![batch]], schema, None).unwrap())
+        Arc::new(MemoryExec::try_new(&[vec![batch]], schema, None).unwrap())
     }
 
     fn join(
@@ -956,7 +956,7 @@ mod tests {
             build_table_i32(("a1", &vec![2]), ("b2", &vec![2]), ("c1", &vec![9]));
         let schema = batch1.schema();
         let left = Arc::new(
-            MemoryExec::try_new(&vec![vec![batch1], vec![batch2]], schema, None).unwrap(),
+            MemoryExec::try_new(&[vec![batch1], vec![batch2]], schema, None).unwrap(),
         );
 
         let right = build_table(

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -85,12 +85,12 @@ impl ExecutionPlan for MemoryExec {
 impl MemoryExec {
     /// Create a new execution plan for reading in-memory record batches
     pub fn try_new(
-        partitions: &Vec<Vec<RecordBatch>>,
+        partitions: &[Vec<RecordBatch>],
         schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         Ok(Self {
-            partitions: partitions.clone(),
+            partitions: partitions.to_vec(),
             schema,
             projection,
         })

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -232,10 +232,10 @@ pub trait Accumulator: Send + Sync + Debug {
     fn state(&self) -> Result<Vec<ScalarValue>>;
 
     /// updates the accumulator's state from a vector of scalars.
-    fn update(&mut self, values: &Vec<ScalarValue>) -> Result<()>;
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()>;
 
     /// updates the accumulator's state from a vector of arrays.
-    fn update_batch(&mut self, values: &Vec<ArrayRef>) -> Result<()> {
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         if values.is_empty() {
             return Ok(());
         };
@@ -249,10 +249,10 @@ pub trait Accumulator: Send + Sync + Debug {
     }
 
     /// updates the accumulator's state from a vector of scalars.
-    fn merge(&mut self, states: &Vec<ScalarValue>) -> Result<()>;
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()>;
 
     /// updates the accumulator's state from a vector of states.
-    fn merge_batch(&mut self, states: &Vec<ArrayRef>) -> Result<()> {
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
         if states.is_empty() {
             return Ok(());
         };

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -395,7 +395,7 @@ impl RowGroupPredicateBuilder {
 fn build_statistics_record_batch(
     row_groups: &[RowGroupMetaData],
     parquet_schema: &Schema,
-    stat_column_req: &Vec<(String, StatisticsType, Field)>,
+    stat_column_req: &[(String, StatisticsType, Field)],
 ) -> Result<RecordBatch> {
     let mut fields = Vec::<Field>::new();
     let mut arrays = Vec::<ArrayRef>::new();

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -1025,8 +1025,8 @@ mod tests {
 
         fn from_template(
             &self,
-            _exprs: &Vec<Expr>,
-            _inputs: &Vec<LogicalPlan>,
+            _exprs: &[Expr],
+            _inputs: &[LogicalPlan],
         ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
             unimplemented!("NoOp");
         }

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -134,7 +134,7 @@ impl ExecutionPlan for ProjectionExec {
 
 fn batch_project(
     batch: &RecordBatch,
-    expressions: &Vec<Arc<dyn PhysicalExpr>>,
+    expressions: &[Arc<dyn PhysicalExpr>],
     schema: &SchemaRef,
 ) -> ArrowResult<RecordBatch> {
     expressions

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -138,7 +138,7 @@ impl ExecutionPlan for SortExec {
 }
 
 fn sort_batches(
-    batches: &Vec<RecordBatch>,
+    batches: &[RecordBatch],
     schema: &SchemaRef,
     expr: &[PhysicalSortExpr],
 ) -> ArrowResult<Option<RecordBatch>> {
@@ -375,7 +375,7 @@ mod tests {
                     },
                 },
             ],
-            Arc::new(MemoryExec::try_new(&vec![vec![batch]], schema, None)?),
+            Arc::new(MemoryExec::try_new(&[vec![batch]], schema, None)?),
             2,
         )?);
 

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -42,7 +42,7 @@ use crate::physical_plan::expressions::cast;
 ///
 /// See the module level documentation for more detail on coercion.
 pub fn coerce(
-    expressions: &Vec<Arc<dyn PhysicalExpr>>,
+    expressions: &[Arc<dyn PhysicalExpr>],
     schema: &Schema,
     signature: &Signature,
 ) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
@@ -65,7 +65,7 @@ pub fn coerce(
 ///
 /// See the module level documentation for more detail on coercion.
 pub fn data_types(
-    current_types: &Vec<DataType>,
+    current_types: &[DataType],
     signature: &Signature,
 ) -> Result<Vec<DataType>> {
     let valid_types = match signature {
@@ -97,8 +97,8 @@ pub fn data_types(
         }
     };
 
-    if valid_types.contains(current_types) {
-        return Ok(current_types.clone());
+    if valid_types.contains(&current_types.to_owned()) {
+        return Ok(current_types.to_vec());
     }
 
     for valid_types in valid_types {
@@ -116,8 +116,8 @@ pub fn data_types(
 
 /// Try to coerce current_types into valid_types.
 fn maybe_data_types(
-    valid_types: &Vec<DataType>,
-    current_types: &Vec<DataType>,
+    valid_types: &[DataType],
+    current_types: &[DataType],
 ) -> Option<Vec<DataType>> {
     if valid_types.len() != current_types.len() {
         return None;

--- a/rust/datafusion/src/physical_plan/udaf.rs
+++ b/rust/datafusion/src/physical_plan/udaf.rs
@@ -102,7 +102,7 @@ impl AggregateUDF {
 /// This function errors when `args`' can't be coerced to a valid argument type of the UDAF.
 pub fn create_aggregate_expr(
     fun: &AggregateUDF,
-    args: &Vec<Arc<dyn PhysicalExpr>>,
+    args: &[Arc<dyn PhysicalExpr>],
     input_schema: &Schema,
     name: String,
 ) -> Result<Arc<dyn AggregateExpr>> {

--- a/rust/datafusion/src/physical_plan/udf.rs
+++ b/rust/datafusion/src/physical_plan/udf.rs
@@ -92,7 +92,7 @@ impl ScalarUDF {
 /// This function errors when `args`' can't be coerced to a valid argument type of the UDF.
 pub fn create_physical_expr(
     fun: &ScalarUDF,
-    args: &Vec<Arc<dyn PhysicalExpr>>,
+    args: &[Arc<dyn PhysicalExpr>],
     input_schema: &Schema,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     // coerce

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -186,7 +186,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         })
     }
 
-    fn build_schema(&self, columns: &Vec<SQLColumnDef>) -> Result<Schema> {
+    fn build_schema(&self, columns: &[SQLColumnDef]) -> Result<Schema> {
         let mut fields = Vec::new();
 
         for column in columns {
@@ -224,7 +224,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn plan_from_tables(&self, from: &Vec<TableWithJoins>) -> Result<Vec<LogicalPlan>> {
+    fn plan_from_tables(&self, from: &[TableWithJoins]) -> Result<Vec<LogicalPlan>> {
         match from.len() {
             0 => Ok(vec![LogicalPlanBuilder::empty(true).build()?]),
             _ => from
@@ -507,7 +507,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     fn prepare_select_exprs(
         &self,
         plan: &LogicalPlan,
-        projection: &Vec<SelectItem>,
+        projection: &[SelectItem],
     ) -> Result<Vec<Expr>> {
         let input_schema = plan.schema();
 

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -478,7 +478,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     // provided by the SELECT.
                     if !can_columns_satisfy_exprs(
                         &available_columns,
-                        &vec![having_expr.clone()],
+                        &[having_expr.clone()],
                     )? {
                         return Err(DataFusionError::Plan(
                             "Having references column(s) not provided by the select"
@@ -599,7 +599,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
             if !can_columns_satisfy_exprs(
                 &column_exprs_post_aggr,
-                &vec![having_expr_post_aggr.clone()],
+                &[having_expr_post_aggr.clone()],
             )? {
                 return Err(DataFusionError::Plan(
                     "Having references non-aggregate values".to_owned(),

--- a/rust/datafusion/src/sql/utils.rs
+++ b/rust/datafusion/src/sql/utils.rs
@@ -37,7 +37,7 @@ pub(crate) fn expand_wildcard(expr: &Expr, schema: &DFSchema) -> Vec<Expr> {
 /// Collect all deeply nested `Expr::AggregateFunction` and
 /// `Expr::AggregateUDF`. They are returned in order of occurrence (depth
 /// first), with duplicates omitted.
-pub(crate) fn find_aggregate_exprs(exprs: &Vec<Expr>) -> Vec<Expr> {
+pub(crate) fn find_aggregate_exprs(exprs: &[Expr]) -> Vec<Expr> {
     find_exprs_in_exprs(exprs, &|nested_expr| {
         matches!(
             nested_expr,
@@ -147,7 +147,7 @@ pub(crate) fn expr_as_column_expr(expr: &Expr, plan: &LogicalPlan) -> Result<Exp
 /// `a + b` found in the GROUP BY.
 pub(crate) fn rebase_expr(
     expr: &Expr,
-    base_exprs: &Vec<Expr>,
+    base_exprs: &[Expr],
     plan: &LogicalPlan,
 ) -> Result<Expr> {
     clone_with_replacement(expr, &|nested_expr| {
@@ -162,8 +162,8 @@ pub(crate) fn rebase_expr(
 /// Determines if the set of `Expr`'s are a valid projection on the input
 /// `Expr::Column`'s.
 pub(crate) fn can_columns_satisfy_exprs(
-    columns: &Vec<Expr>,
-    exprs: &Vec<Expr>,
+    columns: &[Expr],
+    exprs: &[Expr],
 ) -> Result<bool> {
     columns.iter().try_for_each(|c| match c {
         Expr::Column(_) => Ok(()),

--- a/rust/datafusion/src/test/user_defined.rs
+++ b/rust/datafusion/src/test/user_defined.rs
@@ -64,8 +64,8 @@ impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
 
     fn from_template(
         &self,
-        exprs: &Vec<Expr>,
-        inputs: &Vec<LogicalPlan>,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
     ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
         assert_eq!(inputs.len(), 1, "input size inconsistent");
         assert_eq!(exprs.len(), 0, "expression size inconsistent");

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -284,8 +284,8 @@ impl UserDefinedLogicalNode for TopKPlanNode {
 
     fn from_template(
         &self,
-        exprs: &Vec<Expr>,
-        inputs: &Vec<LogicalPlan>,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
     ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
         assert_eq!(inputs.len(), 1, "input size inconsistent");
         assert_eq!(exprs.len(), 1, "expression size inconsistent");


### PR DESCRIPTION
Changes the functions to accept `&[T]` instead of `&Vec[T]`. Besides being more idiomatic, in some cases this will allow not creating a `Vec` at all.

Most of it suggested by / guided by the now enabled `clippy::ptr_arg`.