### PR TITLE
ARROW-11447: [Rust] Add shift kernel for primitive types

### DIFF
--- a/rust/arrow/src/compute/kernels/mod.rs
+++ b/rust/arrow/src/compute/kernels/mod.rs
@@ -31,3 +31,4 @@ pub mod sort;
 pub mod substring;
 pub mod take;
 pub mod temporal;
+pub mod window;

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -44,7 +44,7 @@ use crate::{
 /// // shift array 1 element to the left
 /// let res = shift(&a, 1).unwrap();
 /// let expected: Int32Array = vec![None, Some(1), None].into();
-/// assert_eq!(res.as_ref, &expected)
+/// assert_eq!(res.as_ref(), &expected)
 /// ```
 pub fn shift<T>(values: &PrimitiveArray<T>, offset: i64) -> Result<ArrayRef>
 where

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines windowing functions, like `shift`ing
+
+use crate::compute::concat;
+use num::{abs, clamp};
+use std::sync::Arc;
+
+use crate::{
+    array::{make_array, ArrayData, PrimitiveArray},
+    datatypes::ArrowPrimitiveType,
+    error::Result,
+};
+use crate::{
+    array::{Array, ArrayRef},
+    buffer::MutableBuffer,
+};
+
+/// Shifts array by defined number of items (to left or right)
+pub fn shift<T>(values: &PrimitiveArray<T>, shift: i64) -> Result<ArrayRef>
+where
+    T: ArrowPrimitiveType,
+{
+    // Compute slice
+    let offset = clamp(shift, 0, values.len() as i64) as usize;
+    println!("{}", offset);
+    let length = values.len() - abs(shift) as usize;
+    let slice = values.slice(offset, length);
+
+    // Generate array with remaining `null` items
+    let nulls = abs(shift as i64) as usize;
+
+    let mut null_array = MutableBuffer::new(nulls);
+    let mut null_data = MutableBuffer::new(nulls * T::get_byte_width());
+    null_array.extend_zeros(nulls);
+    null_data.extend_zeros(nulls * T::get_byte_width());
+
+    let null_data = ArrayData::new(
+        T::DATA_TYPE,
+        nulls as usize,
+        Some(nulls),
+        Some(null_array.into()),
+        0,
+        vec![null_data.into()],
+        vec![],
+    );
+
+    // Concatenate both arrays, add nulls after if shift > 0 else before
+    let null_arr = make_array(Arc::new(null_data));
+    if shift > 0 {
+        concat(&[slice.as_ref(), null_arr.as_ref()])
+    } else {
+        concat(&[null_arr.as_ref(), slice.as_ref()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::Int32Array;
+
+    use super::*;
+
+    #[test]
+    fn test_shift_neg() {
+        let a: Int32Array = vec![Some(1), None, Some(4)].into();
+        let res = shift(&a, -1).unwrap();
+
+        let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(a.len(), res.len());
+        assert_eq!(false, b.is_valid(0));
+        assert_eq!(1, b.value(1));
+        assert_eq!(false, b.is_valid(2));
+    }
+
+    #[test]
+    fn test_shift_pos() {
+        let a: Int32Array = vec![Some(1), None, Some(4)].into();
+        let res = shift(&a, 1).unwrap();
+
+        let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(a.len(), res.len());
+        assert_eq!(false, b.is_valid(0));
+        assert_eq!(4, b.value(1));
+        assert_eq!(false, b.is_valid(2));
+    }
+}

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -32,6 +32,21 @@ use crate::{
 };
 
 /// Shifts array by defined number of items (to left or right)
+/// A positive value
+/// # Examples
+/// ```
+/// use arrow::array::Int32Array;
+/// use arrow::error::Result;
+/// use arrow::compute::shift;
+///
+/// let a: Int32Array = vec![Some(1), None, Some(4)].into();
+/// // shift array 1 element to the left
+/// let res = shift(&a, 1).unwrap();
+/// let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
+/// let expected: Int32Array = vec![None, Some(1), None].into();
+/// assert_eq!(b, &expected)
+/// ```
+
 pub fn shift<T>(values: &PrimitiveArray<T>, offset: i64) -> Result<ArrayRef>
 where
     T: ArrowPrimitiveType,
@@ -80,7 +95,6 @@ mod tests {
         let res = shift(&a, -1).unwrap();
 
         let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
-        assert_eq!(a.len(), res.len());
         let expected: Int32Array = vec![None, Some(4), None].into();
 
         assert_eq!(b, &expected);

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -41,7 +41,7 @@ use crate::{
 /// use arrow::compute::shift;
 ///
 /// let a: Int32Array = vec![Some(1), None, Some(4)].into();
-/// // shift array 1 element to the left
+/// // shift array 1 element to the right
 /// let res = shift(&a, 1).unwrap();
 /// let expected: Int32Array = vec![None, Some(1), None].into();
 /// assert_eq!(res.as_ref, &expected)

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 /// Shifts array by defined number of items (to left or right)
-/// A positive value for `offset` shifts the array to the left (LAG)
+/// A positive value for `offset` shifts the array to the right
 /// a negative value shifts the array to the left.
 /// # Examples
 /// ```

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -37,7 +37,7 @@ where
     T: ArrowPrimitiveType,
 {
     // Compute slice
-    let slice_offset = clamp(offset, 0, values.len() as i64) as usize;
+    let slice_offset = clamp(-offset, 0, values.len() as i64) as usize;
     let length = values.len() - abs(offset) as usize;
     let slice = values.slice(slice_offset, length);
 
@@ -62,9 +62,9 @@ where
     // Concatenate both arrays, add nulls after if shift > 0 else before
     let null_arr = make_array(Arc::new(null_data));
     if offset > 0 {
-        concat(&[slice.as_ref(), null_arr.as_ref()])
-    } else {
         concat(&[null_arr.as_ref(), slice.as_ref()])
+    } else {
+        concat(&[slice.as_ref(), null_arr.as_ref()])
     }
 }
 
@@ -81,7 +81,7 @@ mod tests {
 
         let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(a.len(), res.len());
-        let expected: Int32Array = vec![None, Some(1), None].into();
+        let expected: Int32Array = vec![None, Some(4), None].into();
 
         assert_eq!(b, &expected);
     }

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -92,9 +92,8 @@ mod tests {
         let res = shift(&a, 1).unwrap();
 
         let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
-        assert_eq!(a.len(), res.len());
-        assert_eq!(false, b.is_valid(0));
-        assert_eq!(4, b.value(1));
-        assert_eq!(false, b.is_valid(2));
+        let expected: Int32Array = vec![None, Some(1), None].into();
+
+        assert_eq!(b, &expected);
     }
 }

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -81,9 +81,9 @@ mod tests {
 
         let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(a.len(), res.len());
-        assert_eq!(false, b.is_valid(0));
-        assert_eq!(1, b.value(1));
-        assert_eq!(false, b.is_valid(2));
+        let expected: Int32Array = vec![None, Some(1), None].into();
+
+        assert_eq!(b, &expected);
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -32,7 +32,8 @@ use crate::{
 };
 
 /// Shifts array by defined number of items (to left or right)
-/// A positive value
+/// A positive value for `offset` shifts the array to the left (LAG)
+/// a negative value shifts the array to the left.
 /// # Examples
 /// ```
 /// use arrow::array::Int32Array;
@@ -42,9 +43,8 @@ use crate::{
 /// let a: Int32Array = vec![Some(1), None, Some(4)].into();
 /// // shift array 1 element to the left
 /// let res = shift(&a, 1).unwrap();
-/// let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
 /// let expected: Int32Array = vec![None, Some(1), None].into();
-/// assert_eq!(b, &expected)
+/// assert_eq!(res.as_ref, &expected)
 /// ```
 pub fn shift<T>(values: &PrimitiveArray<T>, offset: i64) -> Result<ArrayRef>
 where
@@ -93,10 +93,9 @@ mod tests {
         let a: Int32Array = vec![Some(1), None, Some(4)].into();
         let res = shift(&a, -1).unwrap();
 
-        let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
         let expected: Int32Array = vec![None, Some(4), None].into();
 
-        assert_eq!(b, &expected);
+        assert_eq!(res.as_ref(), &expected);
     }
 
     #[test]
@@ -104,9 +103,8 @@ mod tests {
         let a: Int32Array = vec![Some(1), None, Some(4)].into();
         let res = shift(&a, 1).unwrap();
 
-        let b = res.as_any().downcast_ref::<Int32Array>().unwrap();
         let expected: Int32Array = vec![None, Some(1), None].into();
 
-        assert_eq!(b, &expected);
+        assert_eq!(res.as_ref(), &expected);
     }
 }

--- a/rust/arrow/src/compute/kernels/window.rs
+++ b/rust/arrow/src/compute/kernels/window.rs
@@ -46,7 +46,6 @@ use crate::{
 /// let expected: Int32Array = vec![None, Some(1), None].into();
 /// assert_eq!(b, &expected)
 /// ```
-
 pub fn shift<T>(values: &PrimitiveArray<T>, offset: i64) -> Result<ArrayRef>
 where
     T: ArrowPrimitiveType,

--- a/rust/arrow/src/compute/mod.rs
+++ b/rust/arrow/src/compute/mod.rs
@@ -32,3 +32,4 @@ pub use self::kernels::limit::*;
 pub use self::kernels::sort::*;
 pub use self::kernels::take::*;
 pub use self::kernels::temporal::*;
+pub use self::kernels::window::*;


### PR DESCRIPTION
This adds a `shift` function (now only accept primitive arrays) that shifts an array left or right by `offset`.

This is something that could be used to implement `LAG` `LEAD` etc. in DataFusion and other crates.