### PR TITLE
ARROW-11448: [C++] Fix tdigest build failure on Windows with Visual Studio

### DIFF
--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -21,8 +21,8 @@
 #include <cmath>
 #include <iostream>
 #include <queue>
-#include <vector>
 #include <tuple>
+#include <vector>
 
 #include "arrow/status.h"
 

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <queue>
 #include <vector>
+#include <tuple>
 
 #include "arrow/status.h"
 


### PR DESCRIPTION
CMake args (run from Visual Studio command prompt):
```
C:\Git\arrow3.0.0\cpp\build>cmake .. 
-DARROW_PARQUET=ON 
-DARROW_WITH_SNAPPY=ON 
-DARROW_BUILD_STATIC=OFF 
-DSnappy_LIB=%SNAPPY_INSTALL%\lib\snappy.lib 
-DSnappy_INCLUDE_DIR=%SNAPPY_INSTALL%\include 
-DCMAKE_INSTALL_PREFIX=%BUILD_HOME%
```
Missing `include <tuple>`:
```
24>C:\Git\arrow3.0.0\cpp\src\arrow\util\tdigest.cc(224,12): error C2039: 'tie': is not a member of 'std'
24>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\queue(22): message : see declaration of 'std'
24>C:\Git\arrow3.0.0\cpp\src\arrow\util\tdigest.cc(224,1): error C3861: 'tie': identifier not found
24>C:\Git\arrow3.0.0\cpp\src\arrow\util\tdigest.cc(233,12): error C2039: 'tie': is not a member of 'std'
24>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\queue(22): message : see declaration of 'std'
24>C:\Git\arrow3.0.0\cpp\src\arrow\util\tdigest.cc(233,1): error C3861: 'tie': identifier not found
```
Arrow version:
```
C:\Git\arrow3.0.0\cpp\build>git describe
apache-arrow-3.0.0-94-g51e911892
```