### PR TITLE
ARROW-11066: Revert "ARROW-11066: [Java][FlightRPC] fix zero-copy opt…

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.flight.grpc;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -87,8 +88,11 @@ public class AddWritableBuffer {
    * @param buf The buffer to add.
    * @param stream The Candidate OutputStream to add to.
    * @return True if added. False if not possible.
+   * @throws IOException on error
    */
-  public static boolean add(ByteBuf buf, OutputStream stream) {
+  public static boolean add(ByteBuf buf, OutputStream stream) throws IOException {
+    buf.readBytes(stream, buf.readableBytes());
+
     if (bufChainOut == null) {
       return false;
     }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -68,7 +68,7 @@ public class PerformanceTestServer implements AutoCloseable {
 
       @Override
       public WaitResult waitForListener(long timeout) {
-        while (!listener.isReady() && !listener.isCancelled()) {
+        while (!listener.isReady()) {
           // busy wait
         }
         return WaitResult.READY;


### PR DESCRIPTION
…imization"

This reverts commit c3e307355a16287893dcb78353807ef5222ac30c.

This breaks causes JVM crash on the mac.