### PR TITLE
ARROW-11066: [Java][FlightRPC] fix zero-copy optimization

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -84,14 +84,18 @@ public class AddWritableBuffer {
   }
 
   /**
-   * Add the provided ByteBuf to the output stream if it is possible.
+   * Add the provided ByteBuf to the gRPC BufferChainOutputStream if possible, else copy the buffer to the stream.
    * @param buf The buffer to add.
    * @param stream The Candidate OutputStream to add to.
-   * @return True if added. False if not possible.
-   * @throws IOException on error
+   * @param tryZeroCopy If true, try to zero-copy append the buffer to the stream. This may not succeed.
+   * @return True if buffer was zero-copy added to the stream. False if the buffer was copied.
+   * @throws IOException if the fast path is not enabled and there was an error copying the buffer to the stream.
    */
-  public static boolean add(ByteBuf buf, OutputStream stream) throws IOException {
-    buf.readBytes(stream, buf.readableBytes());
+  public static boolean add(ByteBuf buf, OutputStream stream, boolean tryZeroCopy) throws IOException {
+    if (!tryZeroCopy) {
+      buf.getBytes(0, stream, buf.readableBytes());
+      return false;
+    }
 
     if (bufChainOut == null) {
       return false;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -63,6 +63,11 @@ import io.grpc.MethodDescriptor;
  */
 public class TestBasicOperation {
 
+  @Test
+  public void fastPathEnabledByDefault() {
+    Assert.assertTrue(ArrowMessage.ENABLE_ZERO_COPY);
+  }
+
   /**
    * ARROW-6017: we should be able to construct locations for unknown schemes.
    */

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -68,7 +68,7 @@ public class PerformanceTestServer implements AutoCloseable {
 
       @Override
       public WaitResult waitForListener(long timeout) {
-        while (!listener.isReady()) {
+        while (!listener.isReady() && !listener.isCancelled()) {
           // busy wait
         }
         return WaitResult.READY;


### PR DESCRIPTION
Flight's zero-copy optimization was not enabled previously due to an oversight. Additionally, enabling it exposed a use-after-free of a direct Netty ByteBuf that manifested as SIGSEGV. This fixes both issues: the fast path is truly enabled, and to avoid the use-after-free, the lifetimes of Netty ByteBufs in the Flight gRPC marshaller is now tied to the ArrowBuf lifetimes. Finally, an environment variable + property are added to disable the fast path in case the old behavior is desirable.