### PR TITLE
ARROW-11459: [Rust] Added API to build ListArray of Primitives from an iterator

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -337,12 +337,6 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn append(&mut self, v: bool) {
-        self.push(v)
-    }
-
-    /// Adds a new element to the Builder.
-    #[inline]
-    pub fn push(&mut self, v: bool) {
         self.advance(1);
         if v {
             unsafe { bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len - 1) };

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -337,6 +337,12 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn append(&mut self, v: bool) {
+        self.push(v)
+    }
+
+    /// Adds a new element to the Builder.
+    #[inline]
+    pub fn push(&mut self, v: bool) {
         self.advance(1);
         if v {
             unsafe { bit_util::set_bit_raw(self.buffer.as_mut_ptr(), self.len - 1) };

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -223,66 +223,36 @@ mod tests {
 
     #[test]
     fn test_concat_primitive_list_arrays() -> Result<()> {
-        fn populate_list1(
-            b: &mut ListBuilder<PrimitiveBuilder<Int64Type>>,
-        ) -> Result<()> {
-            b.values().append_value(-1)?;
-            b.values().append_value(-1)?;
-            b.values().append_value(2)?;
-            b.values().append_null()?;
-            b.values().append_null()?;
-            b.append(true)?;
-            b.append(true)?;
-            b.append(false)?;
-            b.values().append_value(10)?;
-            b.append(true)?;
-            Ok(())
-        }
+        let list1 = vec![
+            Some(vec![Some(-1), Some(-1), Some(2), None, None]),
+            Some(vec![]),
+            None,
+            Some(vec![Some(10)]),
+        ];
+        let list1_array =
+            ListArray::from_iter_primitive::<Int64Type, _, _>(list1.clone());
 
-        fn populate_list2(
-            b: &mut ListBuilder<PrimitiveBuilder<Int64Type>>,
-        ) -> Result<()> {
-            b.append(false)?;
-            b.values().append_value(100)?;
-            b.values().append_null()?;
-            b.values().append_value(101)?;
-            b.append(true)?;
-            b.values().append_value(102)?;
-            b.append(true)?;
-            Ok(())
-        }
+        let list2 = vec![
+            None,
+            Some(vec![Some(100), None, Some(101)]),
+            Some(vec![Some(102)]),
+        ];
+        let list2_array =
+            ListArray::from_iter_primitive::<Int64Type, _, _>(list2.clone());
 
-        fn populate_list3(
-            b: &mut ListBuilder<PrimitiveBuilder<Int64Type>>,
-        ) -> Result<()> {
-            b.values().append_value(1000)?;
-            b.values().append_value(1001)?;
-            b.append(true)?;
-            Ok(())
-        }
+        let list3 = vec![Some(vec![Some(1000), Some(1001)])];
+        let list3_array =
+            ListArray::from_iter_primitive::<Int64Type, _, _>(list3.clone());
 
-        let mut builder_in1 = ListBuilder::new(PrimitiveArray::<Int64Type>::builder(0));
-        let mut builder_in2 = ListBuilder::new(PrimitiveArray::<Int64Type>::builder(0));
-        let mut builder_in3 = ListBuilder::new(PrimitiveArray::<Int64Type>::builder(0));
-        populate_list1(&mut builder_in1)?;
-        populate_list2(&mut builder_in2)?;
-        populate_list3(&mut builder_in3)?;
+        let array_result = concat(&[&list1_array, &list2_array, &list3_array])?;
 
-        let mut builder_expected =
-            ListBuilder::new(PrimitiveArray::<Int64Type>::builder(0));
-        populate_list1(&mut builder_expected)?;
-        populate_list2(&mut builder_expected)?;
-        populate_list3(&mut builder_expected)?;
+        let expected = list1
+            .into_iter()
+            .chain(list2.into_iter())
+            .chain(list3.into_iter());
+        let array_expected = ListArray::from_iter_primitive::<Int64Type, _, _>(expected);
 
-        let array_result = concat(&[
-            &builder_in1.finish(),
-            &builder_in2.finish(),
-            &builder_in3.finish(),
-        ])?;
-
-        let array_expected = Arc::new(builder_expected.finish()) as ArrayRef;
-
-        assert_eq!(&array_result, &array_expected);
+        assert_eq!(array_result.as_ref(), &array_expected as &dyn Array);
 
         Ok(())
     }


### PR DESCRIPTION
This PR enables creating a `ListArray` of primitive types out of a an iterator of options, as follows:

```rust
use arrow::array::ListArray;
use arrow::datatypes::Int32Type;
let data = vec![
    Some(vec![Some(0), Some(1), Some(2)]),
    None,
    Some(vec![Some(3), None, Some(5)]),
    Some(vec![Some(6), Some(7)]),
];
let list_array = ListArray::from_iter_primitive::<Int32Type, _, _>(data);
println!("{:?#}", list_array);
```

which simplifies some code around building these, as well enabling kernels that operate on `ListArrays` (which are currently a bit painful to write).

Note that this is built on top of #9370 , as this requires the `PrimitiveArray::from_iter` to be growable. We can wait for that to be reviewed.