### PR TITLE
ARROW-11462: [Developer] Remove needless quote from the default DOCKER_VOLUME_PREFIX

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@
 # a non-empty prefix means that directories from the host are bind-mounted
 # into the container, it should be set to ".docker/" on github actions to keep
 # the cache plugin functional
-DOCKER_VOLUME_PREFIX=""
+DOCKER_VOLUME_PREFIX=
 
 ULIMIT_CORE=-1
 REPO=apache/arrow-dev


### PR DESCRIPTION
If we use "", it means two characters string ('"' and '"') on
Linux (not on macOS. "" is an empty string on macOS). It's not an
empty string. We can use an empty string without quote on Linux.