### PR TITLE
ARROW-11470: [C++] Detect overflow on computation of tensor strides

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -86,6 +86,7 @@ if [ "${ARROW_FUZZING}" == "ON" ]; then
     ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/crash-*
     ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/*-testcase-*
     ${binary_output_dir}/arrow-ipc-file-fuzz ${ARROW_TEST_DATA}/arrow-ipc-file/*-testcase-*
+    ${binary_output_dir}/arrow-ipc-tensor-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-tensor-stream/*-testcase-*
     if [ "${ARROW_PARQUET}" == "ON" ]; then
       ${binary_output_dir}/parquet-arrow-fuzz ${ARROW_TEST_DATA}/parquet/fuzzing/*-testcase-*
     fi

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -1045,9 +1045,9 @@ Status MakeRandomTensor(const std::shared_ptr<DataType>& type,
   const auto& element_type = internal::checked_cast<const FixedWidthType&>(*type);
   std::vector<int64_t> strides;
   if (row_major_p) {
-    internal::ComputeRowMajorStrides(element_type, shape, &strides);
+    RETURN_NOT_OK(internal::ComputeRowMajorStrides(element_type, shape, &strides));
   } else {
-    internal::ComputeColumnMajorStrides(element_type, shape, &strides);
+    RETURN_NOT_OK(internal::ComputeColumnMajorStrides(element_type, shape, &strides));
   }
 
   const int64_t element_size = element_type.bit_width() / CHAR_BIT;

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -53,8 +53,7 @@ Status ComputeRowMajorStrides(const FixedWidthType& type,
     for (size_t i = 1; i < ndim; ++i) {
       if (internal::MultiplyWithOverflow(remaining, shape[i], &remaining)) {
         return Status::Invalid(
-            "Given shape involves overflow in integer multiplication to compute "
-            "row-major strides");
+            "Row-major strides computed from shape would not fit in 64-bit integer");
       }
     }
   }
@@ -85,8 +84,8 @@ Status ComputeColumnMajorStrides(const FixedWidthType& type,
     for (size_t i = 0; i < ndim - 1; ++i) {
       if (internal::MultiplyWithOverflow(total, shape[i], &total)) {
         return Status::Invalid(
-            "Given shape involves overflow in integer multiplication to compute "
-            "column-major strides");
+            "Column-major strides computed from shape would not fit in 64-bit "
+            "integer");
       }
     }
   }

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -189,6 +189,10 @@ Status ValidateTensorParameters(const std::shared_ptr<DataType>& type,
   RETURN_NOT_OK(CheckTensorValidity(type, data, shape));
   if (!strides.empty()) {
     RETURN_NOT_OK(CheckTensorStridesValidity(data, shape, strides, type));
+  } else {
+    std::vector<int64_t> tmp_strides;
+    RETURN_NOT_OK(ComputeRowMajorStrides(checked_cast<const FixedWidthType&>(*type),
+                                         shape, &tmp_strides));
   }
   if (dim_names.size() > shape.size()) {
     return Status::Invalid("too many dim_names are supplied");

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -167,15 +167,13 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
   int64_t largest_offset = 0;
   for (size_t i = 0; i < ndim; ++i) {
     if (shape[i] == 0) continue;
+    if (strides[i] < 0) {
+      // TODO(mrkn): Support negative strides for sharing views
+      return Status::Invalid("negative strides not supported");
+    }
 
     int64_t dim_offset;
     if (!internal::MultiplyWithOverflow(shape[i] - 1, strides[i], &dim_offset)) {
-      if (dim_offset <= 0) {
-        // Ignore the negative dim_offset here because we are interested in only the
-        // largest offset
-        continue;
-      }
-
       if (!internal::AddWithOverflow(largest_offset, dim_offset, &largest_offset)) {
         continue;
       }

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -45,12 +45,12 @@ Status ComputeRowMajorStrides(const FixedWidthType& type,
                               const std::vector<int64_t>& shape,
                               std::vector<int64_t>* strides) {
   const int byte_width = GetByteWidth(type);
-  const auto ndim = shape.size();
+  const size_t ndim = shape.size();
 
   int64_t remaining = 0;
   if (!shape.empty() && shape.front() > 0) {
     remaining = byte_width;
-    for (auto i = decltype(ndim){1}; i < ndim; ++i) {
+    for (size_t i = 1; i < ndim; ++i) {
       if (internal::MultiplyWithOverflow(remaining, shape[i], &remaining)) {
         return Status::Invalid(
             "Given shape involves overflow in integer multiplication to compute "
@@ -65,7 +65,7 @@ Status ComputeRowMajorStrides(const FixedWidthType& type,
   }
 
   strides->push_back(remaining);
-  for (auto i = decltype(ndim){1}; i < ndim; ++i) {
+  for (size_t i = 1; i < ndim; ++i) {
     remaining /= shape[i];
     strides->push_back(remaining);
   }
@@ -77,12 +77,12 @@ Status ComputeColumnMajorStrides(const FixedWidthType& type,
                                  const std::vector<int64_t>& shape,
                                  std::vector<int64_t>* strides) {
   const int byte_width = internal::GetByteWidth(type);
-  const auto ndim = shape.size();
+  const size_t ndim = shape.size();
 
   int64_t total = 0;
   if (!shape.empty() && shape.back() > 0) {
     total = byte_width;
-    for (auto i = decltype(ndim){0}; i < ndim - 1; ++i) {
+    for (size_t i = 0; i < ndim - 1; ++i) {
       if (internal::MultiplyWithOverflow(total, shape[i], &total)) {
         return Status::Invalid(
             "Given shape involves overflow in integer multiplication to compute "
@@ -97,7 +97,7 @@ Status ComputeColumnMajorStrides(const FixedWidthType& type,
   }
 
   total = byte_width;
-  for (auto i = decltype(ndim){0}; i < ndim - 1; ++i) {
+  for (size_t i = 0; i < ndim - 1; ++i) {
     strides->push_back(total);
     total *= shape[i];
   }
@@ -164,9 +164,9 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
   }
 
   // Check the largest offset can be computed without overflow
-  const auto ndim = shape.size();
+  const size_t ndim = shape.size();
   int64_t largest_offset = 0;
-  for (auto i = decltype(ndim){0}; i < ndim; ++i) {
+  for (size_t i = 0; i < ndim; ++i) {
     if (strides[i] <= 0) continue;
 
     int64_t dim_offset;

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -184,7 +184,7 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
   }
 
   const int byte_width = internal::GetByteWidth(*type);
-  if (largest_offset + byte_width > data->size()) {
+  if (largest_offset > data->size() - byte_width) {
     return Status::Invalid("strides must not involve buffer over run");
   }
   return Status::OK();

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -56,13 +56,14 @@ static inline bool is_tensor_supported(Type::type type_id) {
 namespace internal {
 
 ARROW_EXPORT
-void ComputeRowMajorStrides(const FixedWidthType& type, const std::vector<int64_t>& shape,
-                            std::vector<int64_t>* strides);
+Status ComputeRowMajorStrides(const FixedWidthType& type,
+                              const std::vector<int64_t>& shape,
+                              std::vector<int64_t>* strides);
 
 ARROW_EXPORT
-void ComputeColumnMajorStrides(const FixedWidthType& type,
-                               const std::vector<int64_t>& shape,
-                               std::vector<int64_t>* strides);
+Status ComputeColumnMajorStrides(const FixedWidthType& type,
+                                 const std::vector<int64_t>& shape,
+                                 std::vector<int64_t>* strides);
 
 ARROW_EXPORT
 bool IsTensorStridesContiguous(const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/tensor/coo_converter.cc
+++ b/cpp/src/arrow/tensor/coo_converter.cc
@@ -213,9 +213,9 @@ class SparseCOOTensorConverter : private SparseTensorConverterMixin {
     // make results
     const std::vector<int64_t> indices_shape = {nonzero_count, ndim};
     std::vector<int64_t> indices_strides;
-    internal::ComputeRowMajorStrides(
+    RETURN_NOT_OK(internal::ComputeRowMajorStrides(
         checked_cast<const FixedWidthType&>(*index_value_type_), indices_shape,
-        &indices_strides);
+        &indices_strides));
     auto coords = std::make_shared<Tensor>(index_value_type_, std::move(indices_buffer),
                                            indices_shape, indices_strides);
     ARROW_ASSIGN_OR_RAISE(sparse_index, SparseCOOIndex::Make(coords, true));
@@ -305,7 +305,7 @@ Result<std::shared_ptr<Tensor>> MakeTensorFromSparseCOOTensor(
   std::fill_n(values, value_elsize * sparse_tensor->size(), 0);
 
   std::vector<int64_t> strides;
-  ComputeRowMajorStrides(value_type, sparse_tensor->shape(), &strides);
+  RETURN_NOT_OK(ComputeRowMajorStrides(value_type, sparse_tensor->shape(), &strides));
 
   const auto* raw_data = sparse_tensor->raw_data();
   const int ndim = sparse_tensor->ndim();

--- a/cpp/src/arrow/tensor/csf_converter.cc
+++ b/cpp/src/arrow/tensor/csf_converter.cc
@@ -211,7 +211,7 @@ class TensorBuilderFromSparseCSFTensor : private SparseTensorConverterMixin {
   }
 
   Result<std::shared_ptr<Tensor>> Build() {
-    internal::ComputeRowMajorStrides(value_type_, shape_, &strides_);
+    RETURN_NOT_OK(internal::ComputeRowMajorStrides(value_type_, shape_, &strides_));
 
     ARROW_ASSIGN_OR_RAISE(values_buffer_,
                           AllocateBuffer(value_elsize_ * tensor_size_, pool_));

--- a/cpp/src/arrow/tensor/csx_converter.cc
+++ b/cpp/src/arrow/tensor/csx_converter.cc
@@ -177,7 +177,7 @@ Result<std::shared_ptr<Tensor>> MakeTensorFromSparseCSXMatrix(
   std::fill_n(values, value_elsize * tensor_size, 0);
 
   std::vector<int64_t> strides;
-  ComputeRowMajorStrides(fw_value_type, shape, &strides);
+  RETURN_NOT_OK(ComputeRowMajorStrides(fw_value_type, shape, &strides));
 
   const auto nc = shape[1];
 

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -77,7 +77,9 @@ TEST(TestComputeRowMajorStrides, OverflowCase) {
 
   std::vector<int64_t> strides;
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("overflow"),
+      Invalid,
+      testing::HasSubstr(
+          "Row-major strides computed from shape would not fit in 64-bit integer"),
       arrow::internal::ComputeRowMajorStrides(Int16Type(), shape, &strides));
   EXPECT_EQ(0, strides.size());
 }
@@ -120,7 +122,9 @@ TEST(TestComputeColumnMajorStrides, OverflowCase) {
 
   std::vector<int64_t> strides;
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("overflow"),
+      Invalid,
+      testing::HasSubstr(
+          "Column-major strides computed from shape would not fit in 64-bit integer"),
       arrow::internal::ComputeColumnMajorStrides(Int16Type(), shape, &strides));
   EXPECT_EQ(0, strides.size());
 }
@@ -243,7 +247,9 @@ TEST(TestTensor, MakeFailureCases) {
   constexpr uint64_t total_length =
       1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("overflow"),
+      Invalid,
+      testing::HasSubstr(
+          "Row-major strides computed from shape would not fit in 64-bit integer"),
       Tensor::Make(float64(), data, {2, 2, static_cast<int64_t>(total_length / 4)}));
 
   // overflow by negative multiplication in strides validity check

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -243,7 +243,7 @@ TEST(TestTensor, MakeFailureCases) {
   // negative items in shape
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));
 
-  // overflow in stride computation
+  // overflow in positive strides computation
   constexpr uint64_t total_length =
       1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
   EXPECT_RAISES_WITH_MESSAGE_THAT(
@@ -252,12 +252,10 @@ TEST(TestTensor, MakeFailureCases) {
           "Row-major strides computed from shape would not fit in 64-bit integer"),
       Tensor::Make(float64(), data, {2, 2, static_cast<int64_t>(total_length / 4)}));
 
-  // overflow by negative multiplication in strides validity check
+  // negative strides are prohibited
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("would not fit in 64-bit integer"),
-      Tensor::Make(
-          float64(), data, {0, 4, 0},
-          {sizeof(double), -static_cast<int64_t>(total_length / 2), sizeof(double)}));
+      Invalid, testing::HasSubstr("negative strides not supported"),
+      Tensor::Make(float64(), data, {18}, {-(int)sizeof(double)}));
 
   // invalid stride length
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -239,6 +239,13 @@ TEST(TestTensor, MakeFailureCases) {
   // negative items in shape
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));
 
+  // overflow in stride computation
+  constexpr uint64_t total_length =
+      1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("overflow"),
+      Tensor::Make(float64(), data, {2, 2, static_cast<int64_t>(total_length / 4)}));
+
   // invalid stride length
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -246,6 +246,13 @@ TEST(TestTensor, MakeFailureCases) {
       Invalid, testing::HasSubstr("overflow"),
       Tensor::Make(float64(), data, {2, 2, static_cast<int64_t>(total_length / 4)}));
 
+  // overflow by negative multiplication in strides validity check
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("would not fit in 64-bit integer"),
+      Tensor::Make(
+          float64(), data, {0, 4, 0},
+          {sizeof(double), -static_cast<int64_t>(total_length / 2), sizeof(double)}));
+
   // invalid stride length
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include "arrow/buffer.h"
@@ -36,6 +37,92 @@ namespace arrow {
 void AssertCountNonZero(const Tensor& t, int64_t expected) {
   ASSERT_OK_AND_ASSIGN(int64_t count, t.CountNonZero());
   ASSERT_EQ(count, expected);
+}
+
+TEST(TestComputeRowMajorStrides, ZeroDimension) {
+  std::vector<int64_t> strides;
+
+  std::vector<int64_t> shape1 = {0, 2, 3};
+  ASSERT_OK(arrow::internal::ComputeRowMajorStrides(DoubleType(), shape1, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+
+  std::vector<int64_t> shape2 = {2, 0, 3};
+  strides.clear();
+  ASSERT_OK(arrow::internal::ComputeRowMajorStrides(DoubleType(), shape2, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+
+  std::vector<int64_t> shape3 = {2, 3, 0};
+  strides.clear();
+  ASSERT_OK(arrow::internal::ComputeRowMajorStrides(DoubleType(), shape3, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+}
+
+TEST(TestComputeRowMajorStrides, MaximumSize) {
+  constexpr uint64_t total_length =
+      1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> shape = {2, 2, static_cast<int64_t>(total_length / 4)};
+
+  std::vector<int64_t> strides;
+  ASSERT_OK(arrow::internal::ComputeRowMajorStrides(Int8Type(), shape, &strides));
+  EXPECT_THAT(strides, testing::ElementsAre(2 * shape[2], shape[2], 1));
+}
+
+TEST(TestComputeRowMajorStrides, OverflowCase) {
+  constexpr uint64_t total_length =
+      1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> shape = {2, 2, static_cast<int64_t>(total_length / 4)};
+
+  std::vector<int64_t> strides;
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("overflow"),
+      arrow::internal::ComputeRowMajorStrides(Int16Type(), shape, &strides));
+  EXPECT_EQ(0, strides.size());
+}
+
+TEST(TestComputeColumnMajorStrides, ZeroDimension) {
+  std::vector<int64_t> strides;
+
+  std::vector<int64_t> shape1 = {0, 2, 3};
+  ASSERT_OK(arrow::internal::ComputeColumnMajorStrides(DoubleType(), shape1, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+
+  std::vector<int64_t> shape2 = {2, 0, 3};
+  strides.clear();
+  ASSERT_OK(arrow::internal::ComputeColumnMajorStrides(DoubleType(), shape2, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+
+  std::vector<int64_t> shape3 = {2, 3, 0};
+  strides.clear();
+  ASSERT_OK(arrow::internal::ComputeColumnMajorStrides(DoubleType(), shape3, &strides));
+  EXPECT_THAT(strides,
+              testing::ElementsAre(sizeof(double), sizeof(double), sizeof(double)));
+}
+
+TEST(TestComputeColumnMajorStrides, MaximumSize) {
+  constexpr uint64_t total_length =
+      1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> shape = {static_cast<int64_t>(total_length / 4), 2, 2};
+
+  std::vector<int64_t> strides;
+  ASSERT_OK(arrow::internal::ComputeColumnMajorStrides(Int8Type(), shape, &strides));
+  EXPECT_THAT(strides, testing::ElementsAre(1, shape[0], 2 * shape[0]));
+}
+
+TEST(TestComputeColumnMajorStrides, OverflowCase) {
+  constexpr uint64_t total_length =
+      1 + static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> shape = {static_cast<int64_t>(total_length / 4), 2, 2};
+
+  std::vector<int64_t> strides;
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("overflow"),
+      arrow::internal::ComputeColumnMajorStrides(Int16Type(), shape, &strides));
+  EXPECT_EQ(0, strides.size());
 }
 
 TEST(TestTensor, MakeRowMajor) {


### PR DESCRIPTION
The overflow by integer multiplication are occurred in `ComputeRowMajorStrides`, `ComputeColumnMajorStrides`, and `CheckTensorStridesValidity`.

This should fix the following issues:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29748
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29745

Found by OSS-Fuzz.