### PR TITLE
ARROW-11308: [Rust][Parquet] Support decimal when writing parquet files

### DIFF
--- a/rust/parquet/src/arrow/levels.rs
+++ b/rust/parquet/src/arrow/levels.rs
@@ -188,7 +188,7 @@ impl LevelInfo {
                     | DataType::LargeBinary
                     | DataType::Utf8
                     | DataType::LargeUtf8
-                    | DataType::Dictionary(_, _) 
+                    | DataType::Dictionary(_, _)
                     | DataType::Decimal(_, _) => {
                         vec![list_level.calculate_child_levels(
                             child_offsets,

--- a/rust/parquet/src/arrow/levels.rs
+++ b/rust/parquet/src/arrow/levels.rs
@@ -135,7 +135,8 @@ impl LevelInfo {
             | DataType::Duration(_)
             | DataType::Interval(_)
             | DataType::Binary
-            | DataType::LargeBinary => {
+            | DataType::LargeBinary
+            | DataType::Decimal(_, _) => {
                 // we return a vector of 1 value to represent the primitive
                 vec![self.calculate_child_levels(
                     array_offsets,
@@ -145,7 +146,6 @@ impl LevelInfo {
                 )]
             }
             DataType::FixedSizeBinary(_) => unimplemented!(),
-            DataType::Decimal(_, _) => unimplemented!(),
             DataType::List(list_field) | DataType::LargeList(list_field) => {
                 // Calculate the list level
                 let list_level = self.calculate_child_levels(
@@ -188,7 +188,8 @@ impl LevelInfo {
                     | DataType::LargeBinary
                     | DataType::Utf8
                     | DataType::LargeUtf8
-                    | DataType::Dictionary(_, _) => {
+                    | DataType::Dictionary(_, _) 
+                    | DataType::Decimal(_, _) => {
                         vec![list_level.calculate_child_levels(
                             child_offsets,
                             child_mask,
@@ -197,7 +198,6 @@ impl LevelInfo {
                         )]
                     }
                     DataType::FixedSizeBinary(_) => unimplemented!(),
-                    DataType::Decimal(_, _) => unimplemented!(),
                     DataType::List(_) | DataType::LargeList(_) | DataType::Struct(_) => {
                         list_level.calculate_array_levels(&child_array, list_field)
                     }


### PR DESCRIPTION
Allows writing DecimalArray to parquet files.

The `i128` values of `DecimalArray` are written as big endian bytes with a fixed size, calculated from the precision. This assumes that precision defines the total length and scale is contained in the precision.