### PR TITLE
ARROW-11427: [C++] On Windows, only use AVX512 when enabled by the OS

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -410,6 +410,10 @@ endif(BUILD_WARNING_FLAGS)
 
 # Only enable additional instruction sets if they are supported
 if(ARROW_CPU_FLAG STREQUAL "x86")
+  if(MINGW)
+    # Enable _xgetbv() intrinsic to query OS support for ZMM register saves
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -mxsave")
+  endif()
   if(ARROW_SIMD_LEVEL STREQUAL "AVX512")
     if(NOT CXX_SUPPORTS_AVX512)
       message(FATAL_ERROR "AVX512 required but compiler doesn't support it.")

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -45,6 +45,17 @@ struct BuildInfo {
   std::string package_kind;
 };
 
+struct RuntimeInfo {
+  /// The enabled SIMD level
+  ///
+  /// This can be less than `detected_simd_level` if the ARROW_USER_SIMD_LEVEL
+  /// environment variable is set to another value.
+  std::string simd_level;
+
+  /// The SIMD level available on the OS and CPU
+  std::string detected_simd_level;
+};
+
 /// \brief Get runtime build info.
 ///
 /// The returned values correspond to exact loaded version of the Arrow library,
@@ -52,5 +63,10 @@ struct BuildInfo {
 /// preprocessor definitions.
 ARROW_EXPORT
 const BuildInfo& GetBuildInfo();
+
+/// \brief Get runtime info.
+///
+ARROW_EXPORT
+RuntimeInfo GetRuntimeInfo();
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -31,11 +31,12 @@
 #endif
 
 #ifdef _WIN32
+#include <immintrin.h>
 #include <intrin.h>
 #include <array>
 #include <bitset>
-#include "arrow/util/windows_compatibility.h"
 
+#include "arrow/util/windows_compatibility.h"
 #endif
 
 #include <algorithm>
@@ -251,6 +252,13 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name,
     }
   }
 
+  bool zmm_enabled = false;
+  if (features_ECX[27]) {  // OSXSAVE
+    // Query if the OS supports saving ZMM registers when switching contexts
+    int64_t xcr0 = _xgetbv(0);
+    zmm_enabled = (xcr0 & 0xE0) == 0xE0;
+  }
+
   if (features_ECX[9]) *hardware_flags |= CpuInfo::SSSE3;
   if (features_ECX[19]) *hardware_flags |= CpuInfo::SSE4_1;
   if (features_ECX[20]) *hardware_flags |= CpuInfo::SSE4_2;
@@ -266,11 +274,14 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name,
     if (features_EBX[3]) *hardware_flags |= CpuInfo::BMI1;
     if (features_EBX[5]) *hardware_flags |= CpuInfo::AVX2;
     if (features_EBX[8]) *hardware_flags |= CpuInfo::BMI2;
-    if (features_EBX[16]) *hardware_flags |= CpuInfo::AVX512F;
-    if (features_EBX[17]) *hardware_flags |= CpuInfo::AVX512DQ;
-    if (features_EBX[28]) *hardware_flags |= CpuInfo::AVX512CD;
-    if (features_EBX[30]) *hardware_flags |= CpuInfo::AVX512BW;
-    if (features_EBX[31]) *hardware_flags |= CpuInfo::AVX512VL;
+    // ARROW-11427: only use AVX512 if enabled by the OS
+    if (zmm_enabled) {
+      if (features_EBX[16]) *hardware_flags |= CpuInfo::AVX512F;
+      if (features_EBX[17]) *hardware_flags |= CpuInfo::AVX512DQ;
+      if (features_EBX[28]) *hardware_flags |= CpuInfo::AVX512CD;
+      if (features_EBX[30]) *hardware_flags |= CpuInfo::AVX512BW;
+      if (features_EBX[31]) *hardware_flags |= CpuInfo::AVX512VL;
+    }
   }
 
   return true;

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -66,6 +66,12 @@ void __cpuidex(int CPUInfo[4], int function_id, int subfunction_id) {
                          "=d"(CPUInfo[3])
                        : "a"(function_id), "c"(subfunction_id));
 }
+
+int64_t _xgetbv(int xcr) {
+  int out = 0;
+  __asm__ __volatile__("xgetbv" : "=a"(out) : "c"(xcr) : "%edx");
+  return out;
+}
 #endif
 
 #if defined(__GNUC__) && defined(__linux__) && defined(__aarch64__)

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -61,16 +61,6 @@ class ARROW_EXPORT CpuInfo {
 
   enum class Vendor : int { Unknown = 0, Intel, AMD };
 
-  /// The SIMD level set by user
-  enum UserSimdLevel {
-    USER_SIMD_NONE = 0,
-    USER_SIMD_SSE4_2,
-    USER_SIMD_AVX,
-    USER_SIMD_AVX2,
-    USER_SIMD_AVX512,
-    USER_SIMD_MAX,
-  };
-
   static CpuInfo* GetInstance();
 
   /// Determine if the CPU meets the minimum CPU requirements and if not, issue an error
@@ -80,8 +70,17 @@ class ARROW_EXPORT CpuInfo {
   /// Returns all the flags for this cpu
   int64_t hardware_flags();
 
-  /// Returns whether or not the cpu supports all the flags
+  /// \brief Returns whether or not the given feature is enabled.
+  ///
+  /// IsSupported() is true iff IsDetected() is also true and the feature
+  /// wasn't disabled by the user (for example by setting the ARROW_USER_SIMD_LEVEL
+  /// environment variable).
   bool IsSupported(int64_t flags) const { return (hardware_flags_ & flags) == flags; }
+
+  /// Returns whether or not the given feature is available on the CPU.
+  bool IsDetected(int64_t flags) const {
+    return (original_hardware_flags_ & flags) == flags;
+  }
 
   /// \brief The processor supports SSE4.2 and the Arrow libraries are built
   /// with support for it
@@ -113,6 +112,15 @@ class ARROW_EXPORT CpuInfo {
 
  private:
   CpuInfo();
+
+  enum UserSimdLevel {
+    USER_SIMD_NONE = 0,
+    USER_SIMD_SSE4_2,
+    USER_SIMD_AVX,
+    USER_SIMD_AVX2,
+    USER_SIMD_AVX512,
+    USER_SIMD_MAX,
+  };
 
   void Init();
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -64,9 +64,9 @@ import pyarrow.lib as _lib
 if _gc_enabled:
     _gc.enable()
 
-from pyarrow.lib import (BuildInfo, VersionInfo,
+from pyarrow.lib import (BuildInfo, RuntimeInfo, VersionInfo,
                          cpp_build_info, cpp_version, cpp_version_info,
-                         cpu_count, set_cpu_count)
+                         runtime_info, cpu_count, set_cpu_count)
 
 
 def show_versions():

--- a/python/pyarrow/config.pxi
+++ b/python/pyarrow/config.pxi
@@ -28,6 +28,9 @@ BuildInfo = namedtuple(
      'compiler_id', 'compiler_version', 'compiler_flags',
      'git_id', 'git_description', 'package_kind'))
 
+RuntimeInfo = namedtuple('RuntimeInfo',
+                         ('simd_level', 'detected_simd_level'))
+
 cdef _build_info():
     cdef:
         const CBuildInfo* c_info
@@ -51,3 +54,21 @@ cdef _build_info():
 cpp_build_info = _build_info()
 cpp_version = cpp_build_info.version
 cpp_version_info = cpp_build_info.version_info
+
+
+def runtime_info():
+    """
+    Get runtime information.
+
+    Returns
+    -------
+    info : pyarrow.RuntimeInfo
+    """
+    cdef:
+        CRuntimeInfo c_info
+
+    c_info = GetRuntimeInfo()
+
+    return RuntimeInfo(
+        simd_level=frombytes(c_info.simd_level),
+        detected_simd_level=frombytes(c_info.detected_simd_level))

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -54,8 +54,7 @@ cdef extern from "arrow/util/decimal.h" namespace "arrow" nogil:
         c_string ToString(int32_t scale) const
 
 
-cdef extern from "arrow/api.h" namespace "arrow" nogil:
-
+cdef extern from "arrow/config.h" namespace "arrow" nogil:
     cdef cppclass CBuildInfo "arrow::BuildInfo":
         int version
         int version_major
@@ -73,6 +72,14 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     const CBuildInfo& GetBuildInfo()
 
+    cdef cppclass CRuntimeInfo "arrow::RuntimeInfo":
+        c_string simd_level
+        c_string detected_simd_level
+
+    CRuntimeInfo GetRuntimeInfo()
+
+
+cdef extern from "arrow/api.h" namespace "arrow" nogil:
     enum Type" arrow::Type::type":
         _Type_NA" arrow::Type::NA"
 

--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -16,6 +16,8 @@
 # under the License.
 
 import os
+import subprocess
+
 import pytest
 
 import pyarrow as pa
@@ -50,6 +52,27 @@ def test_build_info():
     assert pa.cpp_build_info.version_info == pa.cpp_version_info
 
     # assert pa.version == pa.__version__  # XXX currently false
+
+
+def test_runtime_info():
+    info = pa.runtime_info()
+    assert isinstance(info, pa.RuntimeInfo)
+    possible_simd_levels = ('none', 'sse4_2', 'avx', 'avx2', 'avx512')
+    assert info.simd_level in possible_simd_levels
+    assert info.detected_simd_level in possible_simd_levels
+
+    if info.simd_level != 'none':
+        env = os.environ.copy()
+        env['ARROW_USER_SIMD_LEVEL'] = 'none'
+        code = f"""if 1:
+            import pyarrow as pa
+
+            info = pa.runtime_info()
+            assert info.simd_level == 'none', info.simd_level
+            assert info.detected_simd_level == f{info.detected_simd_level!r},\
+                info.detected_simd_level
+            """
+        subprocess.check_call(["python", "-c", code], env=env)
 
 
 @pytest.mark.parametrize('klass', [


### PR DESCRIPTION
AVX512 may be supported by the CPU but not by the Windows kernel (which needs to save and restore 512-bit registers on context switch).

Also, add a `GetRuntimeInfo()` API and the corresponding Python function `pa.runtime_info()` to query the current SIMD level.