### PR TITLE
ARROW-11479: [Rust] [Parquet] Add Method to get compressed size of columns from row group metadata

### DIFF
--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -741,6 +741,31 @@ mod tests {
         assert_eq!(col_chunk_res, col_chunk_exp);
     }
 
+    #[test]
+    fn test_compressed_size() {
+        let schema_descr = get_test_schema_descr();
+
+        let mut columns = vec![];
+        for column_descr in schema_descr.columns() {
+            let column = ColumnChunkMetaData::builder(column_descr.clone())
+                .set_total_compressed_size(500)
+                .set_total_uncompressed_size(700)
+                .build()
+                .unwrap();
+            columns.push(column);
+        }
+        let row_group_meta = RowGroupMetaData::builder(schema_descr)
+            .set_num_rows(1000)
+            .set_column_metadata(columns)
+            .build()
+            .unwrap();
+
+        let compressed_size_res: i64 = row_group_meta.compressed_size();
+        let compressed_size_exp: i64 = 1000;
+
+        assert_eq!(compressed_size_res, compressed_size_exp);
+    }
+
     /// Returns sample schema descriptor so we can create column metadata.
     fn get_test_schema_descr() -> SchemaDescPtr {
         let schema = SchemaType::group_type_builder("schema")

--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -226,6 +226,11 @@ impl RowGroupMetaData {
         self.total_byte_size
     }
 
+    /// Total size of all compressed column data in this row group.
+    pub fn compressed_size(&self) -> i64 {
+        self.columns.iter().map(|c| c.total_compressed_size).sum()
+    }
+
     /// Returns reference to a schema descriptor.
     pub fn schema_descr(&self) -> &SchemaDescriptor {
         self.schema_descr.as_ref()


### PR DESCRIPTION
Add method `compressed_size()` to get compressed column data size in a row group. The JVM [parquet-mr](https://github.com/apache/parquet-mr) library provides a method to get the same [here](https://github.com/apache/parquet-mr/blob/0a4e3eea991f7588c9c5e056e9d7b32a76eed5da/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/BlockMetaData.java#L114) . This would help in calculating the total compressed size alongside the uncompressed size of the Parquet file.