### PR TITLE
ARROW-11481: [Rust] More cast implementations

### DIFF
--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -402,7 +402,7 @@ impl ArrayData {
     /// * the buffer is not byte-aligned with type T, or
     /// * the datatype is `Boolean` (it corresponds to a bit-packed buffer where the offset is not applicable)
     #[inline]
-    pub(super) fn buffer<T: ArrowNativeType>(&self, buffer: usize) -> &[T] {
+    pub(crate) fn buffer<T: ArrowNativeType>(&self, buffer: usize) -> &[T] {
         let values = unsafe { self.buffers[buffer].as_slice().align_to::<T>() };
         if !values.0.is_empty() || !values.2.is_empty() {
             panic!("The buffer is not byte-aligned with its interpretation")

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -70,6 +70,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         }
         (List(_), _) => false,
         (_, List(list_to)) => can_cast_types(from_type, list_to.data_type()),
+        (_, LargeList(list_to)) => can_cast_types(from_type, list_to.data_type()),
         (Dictionary(_, from_value_type), Dictionary(_, to_value_type)) => {
             can_cast_types(from_value_type, to_value_type)
         }


### PR DESCRIPTION
This PR adds some more cast implementations that I missed.

Included casts:

```
* LargeList -> List (of same child datatype)  (if not will return Error)
* List -> LargeList (of same child datatype) (if not will return Error)
* LargeList<A> -> LargeList<B>
* Int32 -> Date64
* Date32 -> Int64
* Int64 -> Date32 (lossy)
* Date64 -> Int32 (lossy)
```