### PR TITLE
ARROW-11489: [Rust][DataFusion] Make DataFrame be Send + Sync

### DIFF
--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -51,7 +51,7 @@ use async_trait::async_trait;
 /// # }
 /// ```
 #[async_trait]
-pub trait DataFrame {
+pub trait DataFrame: Send + Sync {
     /// Filter the DataFrame by column. Returns a new DataFrame only containing the
     /// specified columns.
     ///

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -315,6 +315,17 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn sendable() {
+        let df = test_table().unwrap();
+        // dataframes should be sendable between threads/tasks
+        let task = tokio::task::spawn(async move {
+            df.select_columns(&["c1"])
+                .expect("should be usable in a task")
+        });
+        task.await.expect("task completed successfully");
+    }
+
     /// Compare the formatted string representation of two plans for equality
     fn assert_same_plan(plan1: &LogicalPlan, plan2: &LogicalPlan) {
         assert_eq!(format!("{:?}", plan1), format!("{:?}", plan2));


### PR DESCRIPTION
Inspired by a question on the mailing list [link](
https://lists.apache.org/thread.html/r8f81fae08346817fa283804037ed79a4309bb54aa8ed77c354d7baf0%40%3Cuser.arrow.apache.org%3E)

Things need to be `Send` + `Sync` in order to be sent between threads (or async tasks). Thus we should make `DataFrame` require `Send` + `Sync` as well so as to be usable in async applications.