### PR TITLE
ARROW-11491: [Rust] support JSON schema inference for nested list and struct

### DIFF
--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
-use serde_json::Value;
+use serde_json::{map::Map as JsonMap, Value};
 
 use crate::buffer::MutableBuffer;
 use crate::datatypes::*;
@@ -57,137 +57,114 @@ use crate::record_batch::RecordBatch;
 use crate::util::bit_util;
 use crate::{array::*, buffer::Buffer};
 
+#[derive(Debug, Clone)]
+enum InferredType {
+    Scalar(HashSet<DataType>),
+    Array(Box<InferredType>),
+    Object(HashMap<String, InferredType>),
+    Any,
+}
+
+impl InferredType {
+    fn merge(&mut self, other: InferredType) -> Result<()> {
+        match (self, other) {
+            (InferredType::Array(s), InferredType::Array(o)) => {
+                s.merge(*o)?;
+            }
+            (InferredType::Scalar(self_hs), InferredType::Scalar(other_hs)) => {
+                other_hs.into_iter().for_each(|v| {
+                    self_hs.insert(v);
+                });
+            }
+            (InferredType::Object(self_map), InferredType::Object(other_map)) => {
+                for (k, v) in other_map {
+                    self_map.entry(k).or_insert(InferredType::Any).merge(v)?;
+                }
+            }
+            (s @ InferredType::Any, v) => {
+                *s = v;
+            }
+            (_, InferredType::Any) => {}
+            // convert a scalar type to a single-item scalar array type.
+            (
+                InferredType::Array(self_inner_type),
+                other_scalar @ InferredType::Scalar(_),
+            ) => {
+                self_inner_type.merge(other_scalar)?;
+            }
+            (s @ InferredType::Scalar(_), InferredType::Array(mut other_inner_type)) => {
+                other_inner_type.merge(s.clone())?;
+                *s = InferredType::Array(other_inner_type);
+            }
+            // incompatible types
+            (s, o) => {
+                return Err(ArrowError::JsonError(format!(
+                    "Incompatible type found during schema inference: {:?} v.s. {:?}",
+                    s, o,
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Coerce data type during inference
 ///
 /// * `Int64` and `Float64` should be `Float64`
 /// * Lists and scalars are coerced to a list of a compatible scalar
 /// * All other types are coerced to `Utf8`
-fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
-    match dt.len() {
-        1 => Ok(dt[0].clone()),
-        2 => {
-            // there can be a case where a list and scalar both exist
-            if dt.contains(&&DataType::List(Box::new(Field::new(
+fn coerce_data_type(dt: Vec<&DataType>) -> DataType {
+    let mut dt_iter = dt.into_iter().cloned();
+    let dt_init = dt_iter.next().unwrap_or(DataType::Utf8);
+
+    dt_iter.fold(dt_init, |l, r| match (l, r) {
+        (DataType::Boolean, DataType::Boolean) => DataType::Boolean,
+        (DataType::Int64, DataType::Int64) => DataType::Int64,
+        (DataType::Float64, DataType::Float64)
+        | (DataType::Float64, DataType::Int64)
+        | (DataType::Int64, DataType::Float64) => DataType::Float64,
+        (DataType::List(l), DataType::List(r)) => DataType::List(Box::new(Field::new(
+            "item",
+            coerce_data_type(vec![l.data_type(), r.data_type()]),
+            true,
+        ))),
+        // coerce scalar and scalar array into scalar array
+        (DataType::List(e), not_list) | (not_list, DataType::List(e)) => {
+            DataType::List(Box::new(Field::new(
                 "item",
-                DataType::Float64,
+                coerce_data_type(vec![e.data_type(), &not_list]),
                 true,
-            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
-                "item",
-                DataType::Int64,
-                true,
-            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
-                "item",
-                DataType::Boolean,
-                true,
-            )))) || dt.contains(&&DataType::List(Box::new(Field::new(
-                "item",
-                DataType::Utf8,
-                true,
-            )))) {
-                // we have a list and scalars, so we should get the values and coerce them
-                let mut dt = dt;
-                // sorting guarantees that the list will be the second value
-                dt.sort();
-                match (dt[0], dt[1]) {
-                    (t1, DataType::List(e)) if e.data_type() == &DataType::Float64 => {
-                        if t1 == &DataType::Float64 {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                DataType::Float64,
-                                true,
-                            ))))
-                        } else {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                coerce_data_type(vec![t1, &DataType::Float64])?,
-                                true,
-                            ))))
-                        }
-                    }
-                    (t1, DataType::List(e)) if e.data_type() == &DataType::Int64 => {
-                        if t1 == &DataType::Int64 {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                DataType::Int64,
-                                true,
-                            ))))
-                        } else {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                coerce_data_type(vec![t1, &DataType::Int64])?,
-                                true,
-                            ))))
-                        }
-                    }
-                    (t1, DataType::List(e)) if e.data_type() == &DataType::Boolean => {
-                        if t1 == &DataType::Boolean {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                DataType::Boolean,
-                                true,
-                            ))))
-                        } else {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                coerce_data_type(vec![t1, &DataType::Boolean])?,
-                                true,
-                            ))))
-                        }
-                    }
-                    (t1, DataType::List(e)) if e.data_type() == &DataType::Utf8 => {
-                        if t1 == &DataType::Utf8 {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                DataType::Utf8,
-                                true,
-                            ))))
-                        } else {
-                            Ok(DataType::List(Box::new(Field::new(
-                                "item",
-                                coerce_data_type(vec![t1, &DataType::Utf8])?,
-                                true,
-                            ))))
-                        }
-                    }
-                    (t1, t2) => Err(ArrowError::JsonError(format!(
-                        "Cannot coerce data types for {:?} and {:?}",
-                        t1, t2
-                    ))),
-                }
-            } else if dt.contains(&&DataType::Float64) && dt.contains(&&DataType::Int64) {
-                Ok(DataType::Float64)
-            } else {
-                Ok(DataType::Utf8)
-            }
+            )))
         }
-        _ => {
-            // TODO(nevi_me) It's possible to have [float, int, list(float)], which should
-            // return list(float). Will hash this out later
-            Ok(DataType::List(Box::new(Field::new(
-                "item",
-                DataType::Utf8,
-                true,
-            ))))
-        }
-    }
+        _ => DataType::Utf8,
+    })
+}
+
+fn generate_datatype(t: &InferredType) -> Result<DataType> {
+    Ok(match t {
+        InferredType::Scalar(hs) => coerce_data_type(hs.iter().collect()),
+        InferredType::Object(spec) => DataType::Struct(generate_fields(spec)?),
+        InferredType::Array(ele_type) => DataType::List(Box::new(Field::new(
+            "item",
+            generate_datatype(ele_type)?,
+            true,
+        ))),
+        InferredType::Any => DataType::Null,
+    })
+}
+
+fn generate_fields(spec: &HashMap<String, InferredType>) -> Result<Vec<Field>> {
+    spec.iter()
+        .map(|(k, types)| Ok(Field::new(k, generate_datatype(types)?, true)))
+        .collect()
 }
 
 /// Generate schema from JSON field names and inferred data types
-fn generate_schema(spec: HashMap<String, HashSet<DataType>>) -> Result<SchemaRef> {
-    let fields: Result<Vec<Field>> = spec
-        .iter()
-        .map(|(k, hs)| {
-            let v: Vec<&DataType> = hs.iter().collect();
-            coerce_data_type(v).map(|t| Field::new(k, t, true))
-        })
-        .collect();
-    match fields {
-        Ok(fields) => {
-            let schema = Schema::new(fields);
-            Ok(Arc::new(schema))
-        }
-        Err(e) => Err(e),
-    }
+fn generate_schema(spec: HashMap<String, InferredType>) -> Result<SchemaRef> {
+    let fields = generate_fields(&spec)?;
+    let schema = Schema::new(fields);
+    Ok(Arc::new(schema))
 }
 
 /// JSON file reader that produces a serde_json::Value iterator from a Read trait
@@ -330,136 +307,237 @@ pub fn infer_json_schema<R: Read>(
     infer_json_schema_from_iterator(ValueIter::new(reader, max_read_records))
 }
 
+fn set_object_scalar_field_type(
+    field_types: &mut HashMap<String, InferredType>,
+    key: &str,
+    ftype: DataType,
+) -> Result<()> {
+    if !field_types.contains_key(key) {
+        field_types.insert(key.to_string(), InferredType::Scalar(HashSet::new()));
+    }
+
+    match field_types.get_mut(key).unwrap() {
+        InferredType::Scalar(hs) => {
+            hs.insert(ftype);
+            Ok(())
+        }
+        // in case of column contains both scalar type and scalar array type, we convert type of
+        // this column to scalar array.
+        scalar_array @ InferredType::Array(_) => {
+            let mut hs = HashSet::new();
+            hs.insert(ftype);
+            scalar_array.merge(InferredType::Scalar(hs))?;
+            Ok(())
+        }
+        t => Err(ArrowError::JsonError(format!(
+            "Expected scalar or scalar array JSON type, found: {:?}",
+            t,
+        ))),
+    }
+}
+
+fn infer_scalar_array_type(array: &[Value]) -> Result<InferredType> {
+    let mut hs = HashSet::new();
+
+    for v in array {
+        match v {
+            Value::Null => {}
+            Value::Number(n) => {
+                if n.is_i64() {
+                    hs.insert(DataType::Int64);
+                } else {
+                    hs.insert(DataType::Float64);
+                }
+            }
+            Value::Bool(_) => {
+                hs.insert(DataType::Boolean);
+            }
+            Value::String(_) => {
+                hs.insert(DataType::Utf8);
+            }
+            Value::Array(_) | Value::Object(_) => {
+                return Err(ArrowError::JsonError(format!(
+                    "Expected scalar value for scalar array, got: {:?}",
+                    v
+                )));
+            }
+        }
+    }
+
+    Ok(InferredType::Scalar(hs))
+}
+
+fn infer_nested_array_type(array: &[Value]) -> Result<InferredType> {
+    let mut inner_ele_type = InferredType::Any;
+
+    for v in array {
+        match v {
+            Value::Array(inner_array) => {
+                inner_ele_type.merge(infer_array_element_type(inner_array)?)?;
+            }
+            x => {
+                return Err(ArrowError::JsonError(format!(
+                    "Got non array element in nested array: {:?}",
+                    x
+                )));
+            }
+        }
+    }
+
+    Ok(InferredType::Array(Box::new(inner_ele_type)))
+}
+
+fn infer_struct_array_type(array: &[Value]) -> Result<InferredType> {
+    let mut field_types = HashMap::new();
+
+    for v in array {
+        match v {
+            Value::Object(map) => {
+                collect_field_types_from_object(&mut field_types, map)?;
+            }
+            _ => {
+                return Err(ArrowError::JsonError(format!(
+                    "Expected struct value for struct array, got: {:?}",
+                    v
+                )));
+            }
+        }
+    }
+
+    Ok(InferredType::Object(field_types))
+}
+
+fn infer_array_element_type(array: &[Value]) -> Result<InferredType> {
+    match array.iter().take(1).next() {
+        None => Ok(InferredType::Any), // empty array, return any type that can be updated later
+        Some(a) => match a {
+            Value::Array(_) => infer_nested_array_type(array),
+            Value::Object(_) => infer_struct_array_type(array),
+            _ => infer_scalar_array_type(array),
+        },
+    }
+}
+
+fn collect_field_types_from_object(
+    field_types: &mut HashMap<String, InferredType>,
+    map: &JsonMap<String, Value>,
+) -> Result<()> {
+    for (k, v) in map {
+        match v {
+            Value::Array(array) => {
+                let ele_type = infer_array_element_type(array)?;
+
+                if !field_types.contains_key(k) {
+                    match ele_type {
+                        InferredType::Scalar(_) => {
+                            field_types.insert(
+                                k.to_string(),
+                                InferredType::Array(Box::new(InferredType::Scalar(
+                                    HashSet::new(),
+                                ))),
+                            );
+                        }
+                        InferredType::Object(_) => {
+                            field_types.insert(
+                                k.to_string(),
+                                InferredType::Array(Box::new(InferredType::Object(
+                                    HashMap::new(),
+                                ))),
+                            );
+                        }
+                        InferredType::Any | InferredType::Array(_) => {
+                            // set inner type to any for nested array as well
+                            // so it can be updated properly from subsequent type merges
+                            field_types.insert(
+                                k.to_string(),
+                                InferredType::Array(Box::new(InferredType::Any)),
+                            );
+                        }
+                    }
+                }
+
+                match field_types.get_mut(k).unwrap() {
+                    InferredType::Array(inner_type) => {
+                        inner_type.merge(ele_type)?;
+                    }
+                    // in case of column contains both scalar type and scalar array type, we
+                    // convert type of this column to scalar array.
+                    field_type @ InferredType::Scalar(_) => {
+                        field_type.merge(ele_type)?;
+                        *field_type = InferredType::Array(Box::new(field_type.clone()));
+                    }
+                    t => {
+                        return Err(ArrowError::JsonError(format!(
+                            "Expected array json type, found: {:?}",
+                            t,
+                        )));
+                    }
+                }
+            }
+            Value::Bool(_) => {
+                set_object_scalar_field_type(field_types, k, DataType::Boolean)?;
+            }
+            Value::Null => {
+                // do nothing, we treat json as nullable by default when
+                // inferring
+            }
+            Value::Number(n) => {
+                if n.is_f64() {
+                    set_object_scalar_field_type(field_types, k, DataType::Float64)?;
+                } else {
+                    // default to i64
+                    set_object_scalar_field_type(field_types, k, DataType::Int64)?;
+                }
+            }
+            Value::String(_) => {
+                set_object_scalar_field_type(field_types, k, DataType::Utf8)?;
+            }
+            Value::Object(inner_map) => {
+                if !field_types.contains_key(k) {
+                    field_types
+                        .insert(k.to_string(), InferredType::Object(HashMap::new()));
+                }
+                match field_types.get_mut(k).unwrap() {
+                    InferredType::Object(inner_field_types) => {
+                        collect_field_types_from_object(inner_field_types, inner_map)?;
+                    }
+                    t => {
+                        return Err(ArrowError::JsonError(format!(
+                            "Expected object json type, found: {:?}",
+                            t,
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Infer the fields of a JSON file by reading all items from the JSON Value Iterator.
+///
+/// The following type coercion logic is implemented:
+/// * `Int64` and `Float64` are converted to `Float64`
+/// * Lists and scalars are coerced to a list of a compatible scalar
+/// * All other cases are coerced to `Utf8` (String)
+///
+/// Note that the above coercion logic is different from what Spark has, where it would default to
+/// String type in case of List and Scalar values appeared in the same field.
+///
+/// The reason we diverge here is because we don't have utilities to deal with JSON data once it's
+/// interpreted as Strings. We should match Spark's behavior once we added more JSON parsing
+/// kernels in the future.
 pub fn infer_json_schema_from_iterator<I>(value_iter: I) -> Result<SchemaRef>
 where
     I: Iterator<Item = Result<Value>>,
 {
-    let mut values: HashMap<String, HashSet<DataType>> = HashMap::new();
+    let mut field_types: HashMap<String, InferredType> = HashMap::new();
 
     for record in value_iter {
         match record? {
             Value::Object(map) => {
-                let res = map.iter().try_for_each(|(k, v)| {
-                    match v {
-                        Value::Array(a) => {
-                            // collect the data types in array
-                            let types: Result<Vec<Option<&DataType>>> = a
-                                .iter()
-                                .map(|a| match a {
-                                    Value::Null => Ok(None),
-                                    Value::Number(n) => {
-                                        if n.is_i64() {
-                                            Ok(Some(&DataType::Int64))
-                                        } else {
-                                            Ok(Some(&DataType::Float64))
-                                        }
-                                    }
-                                    Value::Bool(_) => Ok(Some(&DataType::Boolean)),
-                                    Value::String(_) => Ok(Some(&DataType::Utf8)),
-                                    Value::Array(_) | Value::Object(_) => {
-                                        Err(ArrowError::JsonError(
-                                            "Nested lists and structs not supported"
-                                                .to_string(),
-                                        ))
-                                    }
-                                })
-                                .collect();
-                            match types {
-                                Ok(types) => {
-                                    // unwrap the Option and discard None values (from
-                                    // JSON nulls)
-                                    let mut types: Vec<&DataType> =
-                                        types.into_iter().filter_map(|t| t).collect();
-                                    types.dedup();
-                                    // if a record contains only nulls, it is not
-                                    // added to values
-                                    if !types.is_empty() {
-                                        let dt = coerce_data_type(types)?;
-
-                                        if values.contains_key(k) {
-                                            let x = values.get_mut(k).unwrap();
-                                            x.insert(DataType::List(Box::new(
-                                                Field::new("item", dt, true),
-                                            )));
-                                        } else {
-                                            // create hashset and add value type
-                                            let mut hs = HashSet::new();
-                                            hs.insert(DataType::List(Box::new(
-                                                Field::new("item", dt, true),
-                                            )));
-                                            values.insert(k.to_string(), hs);
-                                        }
-                                    }
-                                    Ok(())
-                                }
-                                Err(e) => Err(e),
-                            }
-                        }
-                        Value::Bool(_) => {
-                            if values.contains_key(k) {
-                                let x = values.get_mut(k).unwrap();
-                                x.insert(DataType::Boolean);
-                            } else {
-                                // create hashset and add value type
-                                let mut hs = HashSet::new();
-                                hs.insert(DataType::Boolean);
-                                values.insert(k.to_string(), hs);
-                            }
-                            Ok(())
-                        }
-                        Value::Null => {
-                            // do nothing, we treat json as nullable by default when
-                            // inferring
-                            Ok(())
-                        }
-                        Value::Number(n) => {
-                            if n.is_f64() {
-                                if values.contains_key(k) {
-                                    let x = values.get_mut(k).unwrap();
-                                    x.insert(DataType::Float64);
-                                } else {
-                                    // create hashset and add value type
-                                    let mut hs = HashSet::new();
-                                    hs.insert(DataType::Float64);
-                                    values.insert(k.to_string(), hs);
-                                }
-                            } else {
-                                // default to i64
-                                if values.contains_key(k) {
-                                    let x = values.get_mut(k).unwrap();
-                                    x.insert(DataType::Int64);
-                                } else {
-                                    // create hashset and add value type
-                                    let mut hs = HashSet::new();
-                                    hs.insert(DataType::Int64);
-                                    values.insert(k.to_string(), hs);
-                                }
-                            }
-                            Ok(())
-                        }
-                        Value::String(_) => {
-                            if values.contains_key(k) {
-                                let x = values.get_mut(k).unwrap();
-                                x.insert(DataType::Utf8);
-                            } else {
-                                // create hashset and add value type
-                                let mut hs = HashSet::new();
-                                hs.insert(DataType::Utf8);
-                                values.insert(k.to_string(), hs);
-                            }
-                            Ok(())
-                        }
-                        Value::Object(_) => Err(ArrowError::JsonError(
-                            "Inferring schema from nested JSON structs currently not supported"
-                                .to_string(),
-                        )),
-                    }
-                });
-                match res {
-                    Ok(()) => {}
-                    Err(e) => return Err(e),
-                }
+                collect_field_types_from_object(&mut field_types, &map)?;
             }
             value => {
                 return Err(ArrowError::JsonError(format!(
@@ -470,7 +548,7 @@ where
         };
     }
 
-    generate_schema(values)
+    generate_schema(field_types)
 }
 
 /// JSON values to Arrow record batch decoder. Decoder's next_batch method takes a JSON Value
@@ -1806,7 +1884,6 @@ mod tests {
                 &Float64,
                 &List(Box::new(Field::new("item", Float64, true)))
             ])
-            .unwrap()
         );
         assert_eq!(
             List(Box::new(Field::new("item", Float64, true))),
@@ -1814,7 +1891,6 @@ mod tests {
                 &Float64,
                 &List(Box::new(Field::new("item", Int64, true)))
             ])
-            .unwrap()
         );
         assert_eq!(
             List(Box::new(Field::new("item", Int64, true))),
@@ -1822,7 +1898,6 @@ mod tests {
                 &Int64,
                 &List(Box::new(Field::new("item", Int64, true)))
             ])
-            .unwrap()
         );
         // boolean and number are incompatible, return utf8
         assert_eq!(
@@ -1831,7 +1906,6 @@ mod tests {
                 &Boolean,
                 &List(Box::new(Field::new("item", Float64, true)))
             ])
-            .unwrap()
         );
     }
 
@@ -2520,6 +2594,116 @@ mod tests {
         let file = File::open("test/data/mixed_arrays.json.gz").unwrap();
         let mut reader = BufReader::new(GzDecoder::new(&file));
         let inferred_schema = infer_json_schema(&mut reader, None).unwrap();
+
+        assert_eq!(inferred_schema, Arc::new(schema));
+    }
+
+    #[test]
+    fn test_json_infer_schema_nested_structs() {
+        let schema = Schema::new(vec![
+            Field::new(
+                "c1",
+                DataType::Struct(vec![
+                    Field::new("a", DataType::Boolean, true),
+                    Field::new(
+                        "b",
+                        DataType::Struct(vec![Field::new("c", DataType::Utf8, true)]),
+                        true,
+                    ),
+                ]),
+                true,
+            ),
+            Field::new("c2", DataType::Int64, true),
+            Field::new("c3", DataType::Utf8, true),
+        ]);
+
+        let inferred_schema = infer_json_schema_from_iterator(
+            vec![
+                Ok(serde_json::json!({"c1": {"a": true, "b": {"c": "text"}}, "c2": 1})),
+                Ok(serde_json::json!({"c1": {"a": false, "b": null}, "c2": 0})),
+                Ok(serde_json::json!({"c1": {"a": true, "b": {"c": "text"}}, "c3": "ok"})),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
+
+        assert_eq!(inferred_schema, Arc::new(schema));
+    }
+
+    #[test]
+    fn test_json_infer_schema_struct_in_list() {
+        let schema = Schema::new(vec![
+            Field::new(
+                "c1",
+                DataType::List(Box::new(Field::new(
+                    "item",
+                    DataType::Struct(vec![
+                        Field::new("a", DataType::Utf8, true),
+                        Field::new("b", DataType::Int64, true),
+                        Field::new("c", DataType::Boolean, true),
+                    ]),
+                    true,
+                ))),
+                true,
+            ),
+            Field::new("c2", DataType::Float64, true),
+            Field::new(
+                "c3",
+                // empty json array's inner types are inferred as null
+                DataType::List(Box::new(Field::new("item", DataType::Null, true))),
+                true,
+            ),
+        ]);
+
+        let inferred_schema = infer_json_schema_from_iterator(
+            vec![
+                Ok(serde_json::json!({
+                    "c1": [{"a": "foo", "b": 100}], "c2": 1, "c3": [],
+                })),
+                Ok(serde_json::json!({
+                    "c1": [{"a": "bar", "b": 2}, {"a": "foo", "c": true}], "c2": 0, "c3": [],
+                })),
+                Ok(serde_json::json!({"c1": [], "c2": 0.5, "c3": []})),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
+
+        assert_eq!(inferred_schema, Arc::new(schema));
+    }
+
+    #[test]
+    fn test_json_infer_schema_nested_list() {
+        let schema = Schema::new(vec![
+            Field::new(
+                "c1",
+                DataType::List(Box::new(Field::new(
+                    "item",
+                    DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+                    true,
+                ))),
+                true,
+            ),
+            Field::new("c2", DataType::Float64, true),
+        ]);
+
+        let inferred_schema = infer_json_schema_from_iterator(
+            vec![
+                Ok(serde_json::json!({
+                    "c1": [],
+                    "c2": 12,
+                })),
+                Ok(serde_json::json!({
+                    "c1": [["a", "b"], ["c"]],
+                })),
+                Ok(serde_json::json!({
+                    "c1": [["foo"]],
+                    "c2": 0.11,
+                })),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
 
         assert_eq!(inferred_schema, Arc::new(schema));
     }


### PR DESCRIPTION
Not optimized for performance because if one needs performance, runtime schema inference shouldn't be used in the first place.