### PR TITLE
ARROW-11492: [Rust] Replaced many of the `Array::new` by `safe` counterparts

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -641,7 +641,7 @@ impl Array for DecimalArray {
 mod tests {
     use crate::{
         array::{LargeListArray, ListArray},
-        datatypes::Field,
+        datatypes::{Field, UInt32Type, UInt8Type},
     };
 
     use super::*;
@@ -762,10 +762,8 @@ mod tests {
         let values: [u8; 12] = [
             b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
         ];
-        let values_data = ArrayData::builder(DataType::UInt8)
-            .len(12)
-            .add_buffer(Buffer::from(&values[..]))
-            .build();
+        let values_data =
+            ArrayData::new_primitive::<UInt8Type>(Buffer::from_slice_ref(&values), None);
         let offsets: [i32; 4] = [0, 5, 5, 12];
 
         // Array data: ["hello", "", "parquet"]
@@ -779,7 +777,7 @@ mod tests {
         let array_data2 = ArrayData::builder(DataType::Binary)
             .len(3)
             .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_child_data(values_data)
+            .add_child_data(Arc::new(values_data))
             .build();
         let list_array = ListArray::from(array_data2);
         let binary_array2 = BinaryArray::from(list_array);
@@ -804,10 +802,9 @@ mod tests {
         let values: [u8; 12] = [
             b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
         ];
-        let values_data = ArrayData::builder(DataType::UInt8)
-            .len(12)
-            .add_buffer(Buffer::from(&values[..]))
-            .build();
+        let values_data =
+            ArrayData::new_primitive::<UInt8Type>(Buffer::from_slice_ref(&values), None);
+        let values_data = Arc::new(values_data);
         let offsets: [i64; 4] = [0, 5, 5, 12];
 
         // Array data: ["hello", "", "parquet"]
@@ -874,16 +871,14 @@ mod tests {
     )]
     fn test_binary_array_from_incorrect_list_array_type() {
         let values: [u32; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-        let values_data = ArrayData::builder(DataType::UInt32)
-            .len(12)
-            .add_buffer(Buffer::from_slice_ref(&values))
-            .build();
+        let values_data =
+            ArrayData::new_primitive::<UInt32Type>(Buffer::from_slice_ref(&values), None);
         let offsets: [i32; 4] = [0, 5, 5, 12];
 
         let array_data = ArrayData::builder(DataType::Utf8)
             .len(3)
             .add_buffer(Buffer::from_slice_ref(&offsets))
-            .add_child_data(values_data)
+            .add_child_data(Arc::new(values_data))
             .build();
         let list_array = ListArray::from(array_data);
         BinaryArray::from(list_array);

--- a/rust/arrow/src/array/array_dictionary.rs
+++ b/rust/arrow/src/array/array_dictionary.rs
@@ -269,12 +269,10 @@ mod tests {
     #[test]
     fn test_dictionary_array() {
         // Construct a value array
-        let value_data = ArrayData::builder(DataType::Int8)
-            .len(8)
-            .add_buffer(Buffer::from(
-                &[10_i8, 11, 12, 13, 14, 15, 16, 17].to_byte_slice(),
-            ))
-            .build();
+        let value_data = Arc::new(ArrayData::new_primitive::<Int8Type>(
+            Buffer::from(&[10_i8, 11, 12, 13, 14, 15, 16, 17].to_byte_slice()),
+            None,
+        ));
 
         // Construct a buffer for value offsets, for the nested array:
         let keys = Buffer::from(&[2_i16, 3, 4].to_byte_slice());

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -323,6 +323,8 @@ impl fmt::Debug for FixedSizeListArray {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::{
         array::ArrayData, array::Int32Array, buffer::Buffer, datatypes::Field, memory,
         util::bit_util,
@@ -333,10 +335,11 @@ mod tests {
     #[test]
     fn test_list_array() {
         // Construct a value array
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
-            .build();
+        let value_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4, 5, 6, 7]),
+            None,
+        );
+        let value_data = Arc::new(value_data);
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
@@ -815,10 +818,10 @@ mod tests {
     #[should_panic(expected = "assertion failed: (offset + length) <= self.len()")]
     fn test_fixed_size_list_array_index_out_of_bound() {
         // Construct a value array
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(10)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
-            .build();
+        let value_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            None,
+        );
 
         // Set null buts for the nested array:
         //  [[0, 1], null, null, [6, 7], [8, 9]]
@@ -835,7 +838,7 @@ mod tests {
         );
         let list_data = ArrayData::builder(list_data_type)
             .len(5)
-            .add_child_data(value_data)
+            .add_child_data(Arc::new(value_data))
             .null_bit_buffer(Buffer::from(null_bits))
             .build();
         let list_array = FixedSizeListArray::from(list_data);

--- a/rust/arrow/src/array/array_struct.rs
+++ b/rust/arrow/src/array/array_struct.rs
@@ -280,7 +280,7 @@ mod tests {
     };
     use crate::{
         array::Int64Array,
-        datatypes::{DataType, Field},
+        datatypes::{DataType, Field, Int32Type},
     };
     use crate::{buffer::Buffer, datatypes::ToByteSlice};
 
@@ -358,11 +358,10 @@ mod tests {
             .add_buffer(Buffer::from(b"joemark"))
             .build();
 
-        let expected_int_data = ArrayData::builder(DataType::Int32)
-            .len(4)
-            .null_bit_buffer(Buffer::from(&[11_u8]))
-            .add_buffer(Buffer::from(&[1, 2, 0, 4].to_byte_slice()))
-            .build();
+        let expected_int_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[1, 2, 0, 4]),
+            Some(Buffer::from(&[11_u8])),
+        );
 
         assert_eq!(expected_string_data, arr.column(0).data());
 
@@ -435,11 +434,12 @@ mod tests {
             .add_buffer(Buffer::from([0b00010000]))
             .null_bit_buffer(Buffer::from([0b00010001]))
             .build();
-        let int_data = ArrayData::builder(DataType::Int32)
-            .len(5)
-            .add_buffer(Buffer::from([0, 28, 42, 0, 0].to_byte_slice()))
-            .null_bit_buffer(Buffer::from([0b00000110]))
-            .build();
+
+        let int_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[0, 28, 42, 0, 0]),
+            Some(Buffer::from(&[0b00000110])),
+        );
+        let int_data = Arc::new(int_data);
 
         let mut field_types = vec![];
         field_types.push(Field::new("a", DataType::Boolean, false));

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -30,7 +30,9 @@ use num::{One, Zero};
 use crate::buffer::Buffer;
 #[cfg(simd)]
 use crate::buffer::MutableBuffer;
-use crate::compute::{kernels::arity::unary, util::combine_option_bitmap};
+#[cfg(not(simd))]
+use crate::compute::kernels::arity::unary;
+use crate::compute::util::combine_option_bitmap;
 use crate::datatypes;
 use crate::datatypes::ArrowNumericType;
 use crate::error::{ArrowError, Result};
@@ -78,14 +80,9 @@ where
         },
     );
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        array.len(),
-        None,
+    let data = ArrayData::new_primitive::<T>(
+        result.into(),
         array.data_ref().null_buffer().cloned(),
-        0,
-        vec![result.into()],
-        vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
@@ -127,14 +124,9 @@ where
         },
     );
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        array.len(),
-        None,
+    let data = ArrayData::new_primitive::<T>(
+        result.into(),
         array.data_ref().null_buffer().cloned(),
-        0,
-        vec![result.into()],
-        vec![],
     );
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
@@ -176,15 +168,7 @@ where
     //      `values` is an iterator with a known size.
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        left.len(),
-        None,
-        null_bit_buffer,
-        0,
-        vec![buffer],
-        vec![],
-    );
+    let data = ArrayData::new_primitive::<T>(buffer, null_bit_buffer);
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 
@@ -244,15 +228,7 @@ where
         unsafe { Buffer::try_from_trusted_len_iter(values) }
     }?;
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        left.len(),
-        None,
-        null_bit_buffer,
-        0,
-        vec![buffer],
-        vec![],
-    );
+    let data = ArrayData::new_primitive::<T>(buffer, null_bit_buffer);
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 
@@ -307,15 +283,7 @@ where
             *scalar_result = scalar_op(*scalar_left, *scalar_right);
         });
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        left.len(),
-        None,
-        null_bit_buffer,
-        0,
-        vec![result.into()],
-        vec![],
-    );
+    let data = ArrayData::new_primitive::<T>(result.into(), null_bit_buffer);
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 
@@ -494,15 +462,7 @@ where
         }
     }
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        left.len(),
-        None,
-        null_bit_buffer,
-        0,
-        vec![result.into()],
-        vec![],
-    );
+    let data = ArrayData::new_primitive::<T>(result.into(), null_bit_buffer);
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 

--- a/rust/arrow/src/compute/kernels/arity.rs
+++ b/rust/arrow/src/compute/kernels/arity.rs
@@ -21,22 +21,6 @@ use crate::array::{Array, ArrayData, PrimitiveArray};
 use crate::buffer::Buffer;
 use crate::datatypes::ArrowPrimitiveType;
 
-#[inline]
-fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
-    array: &PrimitiveArray<I>,
-    buffer: Buffer,
-) -> ArrayData {
-    ArrayData::new(
-        O::DATA_TYPE,
-        array.len(),
-        None,
-        array.data_ref().null_buffer().cloned(),
-        0,
-        vec![buffer],
-        vec![],
-    )
-}
-
 /// Applies an unary and infalible function to a primitive array.
 /// This is the fastest way to perform an operation on a primitive array when
 /// the benefits of a vectorized operation outweights the cost of branching nulls and non-nulls.
@@ -69,6 +53,7 @@ where
     //      `values` is an iterator with a known size because arrays are sized.
     let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
-    let data = into_primitive_array_data::<_, O>(array, buffer);
+    let data =
+        ArrayData::new_primitive::<O>(buffer, array.data_ref().null_buffer().cloned());
     PrimitiveArray::<O>::from(std::sync::Arc::new(data))
 }

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -2947,10 +2947,10 @@ mod tests {
 
     fn make_list_array() -> ListArray {
         // Construct a value array
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
-            .build();
+        let value_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4, 5, 6, 7]),
+            None,
+        );
 
         // Construct a buffer for value offsets, for the nested array:
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
@@ -2962,7 +2962,7 @@ mod tests {
         let list_data = ArrayData::builder(list_data_type)
             .len(3)
             .add_buffer(value_offsets)
-            .add_child_data(value_data)
+            .add_child_data(Arc::new(value_data))
             .build();
         ListArray::from(list_data)
     }

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -251,7 +251,7 @@ mod tests {
     use super::*;
     use crate::{
         buffer::Buffer,
-        datatypes::{DataType, Field},
+        datatypes::{DataType, Field, Int32Type},
     };
 
     macro_rules! def_temporal_test {
@@ -502,10 +502,11 @@ mod tests {
 
     #[test]
     fn test_filter_list_array() {
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(8)
-            .add_buffer(Buffer::from_slice_ref(&[0, 1, 2, 3, 4, 5, 6, 7]))
-            .build();
+        let value_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[0i32, 1, 2, 3, 4, 5, 6, 7]),
+            None,
+        );
+        let value_data = Arc::new(value_data);
 
         let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 8, 8]);
 
@@ -524,10 +525,11 @@ mod tests {
         let result = filter(&a, &b).unwrap();
 
         // expected: [[3, 4, 5], null]
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(3)
-            .add_buffer(Buffer::from_slice_ref(&[3, 4, 5]))
-            .build();
+        let value_data = ArrayData::new_primitive::<Int32Type>(
+            Buffer::from_slice_ref(&[3, 4, 5]),
+            None,
+        );
+        let value_data = Arc::new(value_data);
 
         let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 3]);
 

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -303,17 +303,9 @@ fn sort_boolean(
         result_slice[valids_len..].copy_from_slice(nulls.as_slice())
     }
 
-    let result_data = Arc::new(ArrayData::new(
-        DataType::UInt32,
-        values.len(),
-        Some(0),
-        None,
-        0,
-        vec![result.into()],
-        vec![],
-    ));
+    let result_data = ArrayData::new_primitive::<UInt32Type>(result.into(), None);
 
-    Ok(UInt32Array::from(result_data))
+    Ok(UInt32Array::from(Arc::new(result_data)))
 }
 
 /// Sort primitive values
@@ -369,17 +361,8 @@ where
         result_slice[valids_len..].copy_from_slice(nulls.as_slice())
     }
 
-    let result_data = Arc::new(ArrayData::new(
-        DataType::UInt32,
-        values.len(),
-        Some(0),
-        None,
-        0,
-        vec![result.into()],
-        vec![],
-    ));
-
-    Ok(UInt32Array::from(result_data))
+    let result_data = ArrayData::new_primitive::<UInt32Type>(result.into(), None);
+    Ok(UInt32Array::from(Arc::new(result_data)))
 }
 
 // insert valid and nan values in the correct order depending on the descending flag

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -320,15 +320,7 @@ where
         };
     }
 
-    let data = ArrayData::new(
-        T::DATA_TYPE,
-        indices.len(),
-        None,
-        nulls,
-        0,
-        vec![buffer.into()],
-        vec![],
-    );
+    let data = ArrayData::new_primitive::<T>(buffer.into(), nulls);
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 


### PR DESCRIPTION
## Rational

When `ArrayData::new` is used, we make no attempt to verify that its contents lead to sound code. In particular, for primitive arrays, the following must hold:

```
/// * `values.len()` is a multiple of `size_of::<T::Native>`
/// * `values.as_ptr()` is aligned with `T::Native`
/// * when `nulls` is `Some`, `nulls.len` is equal to `(ArrayData::len + 7) / 8`.
/// * `offset <= ArrayData::len`
```

* The first two conditions allow us to soundly transmute the `u8` buffer into `T::Native`.
* The third condition allow us to access bits on the null bitmap up to `ArrayData::len`.
* The last condition avoids out of bound accesses to the data when offsets are used.

## This PR

This PR introduces a method to create an `ArrayData` for primitives by verifying that the above assumptions hold.

This PR also migrates most of the `ArrayData::new` for primitive arrays to it.

While migrating code to this version, I found an out-of-bound access in the `nullif` kernel derived from passing a value buffer whose `len` is smaller than the necessary. This is not fixed here.

# Notes

Note that are two aspects of unsafety here:

1. it is `unsafe` to pass a `len` to `ArrayData::new` that goes beyond `Buffer::len / sizeo_of<T>`. This is somewhat equivalent to the `TrustedLen` trait that Rust offers to "prove" that the `len` of an iterator is trustworthy.

2. it is `unsafe` to pass a buffer to `ArrayData::new` that does not match the corresponding `DataType`. Doing so is unsound but it is not possible to prove, by calling `ArrayData::new`, that transmuting a `Buffer` to `T::Native` is sound.

So, in general, `ArrayData::new` is _very_ `unsafe`. This PR is an attempt to replace some of these calls by a `safe` counterpart, that verifies the necessary invariants for primitive types.

I am in generally in favor of either
* mark `ArrayData::new` as `unsafe`  (backward incompatible API)
* force `new` to verify all assumptions (backward incompatible performace) and offer an `unsafe unchecked` version

It is expensive to verify that `ArrayData` is safe because e.g. for strings, we need to verify that the value buffer contains valid utf8s.

Generally, the hindrance here is that `ArrayData` supports all types, and this leads to all kinds of unsafety as it requires an untyped, non-generic `Buffer`. If we had a `Buffer<T>`, this would all be safe because we would not have to verify the buffers at runtime, either when we downcast arrays, or when we create arrays. Currently, we (unsafely) assume that `ArrayData` is correctly built and thus can transmute its buffers to type `T`. All very risky stuff.