### PR TITLE
ARROW-11496: [Rust] WIP aggregation on NaN values.

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -968,6 +968,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_float_aggregation_paths() {
         let a = Float64Array::from_iter_values(vec![1.0, 2.0, f64::NAN]);
         let b = Float64Array::from_iter_values(vec![f64::NAN, 1.0, 2.0]);

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -44,7 +44,7 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
 // implements comparison using IEEE 754 total ordering for f32
 // Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
 // TODO to change to use std when it becomes stable
-fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
+pub(crate) fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
     let mut left = l.to_bits() as i32;
     let mut right = r.to_bits() as i32;
 
@@ -57,7 +57,7 @@ fn total_cmp_32(l: f32, r: f32) -> std::cmp::Ordering {
 // implements comparison using IEEE 754 total ordering for f64
 // Original implementation from https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
 // TODO to change to use std when it becomes stable
-fn total_cmp_64(l: f64, r: f64) -> std::cmp::Ordering {
+pub(crate) fn total_cmp_64(l: f64, r: f64) -> std::cmp::Ordering {
     let mut left = l.to_bits() as i64;
     let mut right = r.to_bits() as i64;
 


### PR DESCRIPTION
@jorgecarleitao @Dandandan @nevi-me @alamb 

Before I continue on this I want to start a discussion on what the behavior of aggregation should be. I started this after I got this issue: https://github.com/ritchie46/polars/issues/328. 

It boils down to this:

```rust
        let a = Float64Array::from_iter_values(vec![1.0, f64::NAN]);
        dbg!(min(&a));
        dbg!(max(&a));
```
```
[arrow/src/compute/kernels/aggregate.rs:905] min(&a) = Some(
    1.0,
)
[arrow/src/compute/kernels/aggregate.rs:906] max(&a) = Some(
    NaN,
)

```


I initially thought this was a bug, but then I saw that this behavior is asserted in the tests as being valid. 

However this is different behavior than that of most numerical tools I know (e.g. numpy, tensorflow, torch, etc.). [The IEEE 754](https://en.wikipedia.org/wiki/IEEE_754) standard states that _"Any comparison with a NaN is treated as unordered."_. 

But if a max aggregation, differs from a min aggregation with regards to NaN this implies to me that we currently treat NaN as ordered and that NaN is larger than any number.

IMO we should return NaN for both the max and the min kernel and may also add a variant that excludes the NaNs. 