### PR TITLE
ARROW-11066: [FlightRPC][Java] Make zero-copy writes a configurable option

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -104,4 +104,20 @@ public interface OutboundStreamListener {
    * Indicate that transmission is finished.
    */
   void completed();
+
+  /**
+   * Toggle whether to ues the zero-copy write optimization.
+   *
+   * <p>By default or when disabled, Arrow may copy data into a buffer for the underlying implementation to
+   * send. When enabled, Arrow will instead try to directly enqueue the Arrow buffer for sending. Not all
+   * implementations support this optimization, so even if enabled, you may not see a difference.
+   *
+   * <p>In this mode, buffers must not be reused after they are written with {@link #putNext()}. For example,
+   * you would have to call {@link VectorSchemaRoot#allocateNew()} after every call to {@link #putNext()}.
+   * Hence, this is not enabled by default.
+   *
+   * <p>The default value can be toggled globally by setting the JVM property arrow.flight.enable_zero_copy_write
+   * or the environment variable ARROW_FLIGHT_ENABLE_ZERO_COPY_WRITE.
+   */
+  default void setUseZeroCopy(boolean enabled) {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -84,14 +84,18 @@ public class AddWritableBuffer {
   }
 
   /**
-   * Add the provided ByteBuf to the output stream if it is possible.
+   * Add the provided ByteBuf to the gRPC BufferChainOutputStream if possible, else copy the buffer to the stream.
    * @param buf The buffer to add.
    * @param stream The Candidate OutputStream to add to.
-   * @return True if added. False if not possible.
-   * @throws IOException on error
+   * @param tryZeroCopy If true, try to zero-copy append the buffer to the stream. This may not succeed.
+   * @return True if buffer was zero-copy added to the stream. False if the buffer was copied.
+   * @throws IOException if the fast path is not enabled and there was an error copying the buffer to the stream.
    */
-  public static boolean add(ByteBuf buf, OutputStream stream) throws IOException {
-    buf.readBytes(stream, buf.readableBytes());
+  public static boolean add(ByteBuf buf, OutputStream stream, boolean tryZeroCopy) throws IOException {
+    if (!tryZeroCopy) {
+      buf.getBytes(0, stream, buf.readableBytes());
+      return false;
+    }
 
     if (bufChainOut == null) {
       return false;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -92,10 +92,14 @@ public class AddWritableBuffer {
    * @throws IOException if the fast path is not enabled and there was an error copying the buffer to the stream.
    */
   public static boolean add(ByteBuf buf, OutputStream stream, boolean tryZeroCopy) throws IOException {
-    if (!tryZeroCopy) {
+    if (!tryZeroCopy || !tryAddBuffer(buf, stream)) {
       buf.getBytes(0, stream, buf.readableBytes());
       return false;
     }
+    return true;
+  }
+
+  private static boolean tryAddBuffer(ByteBuf buf, OutputStream stream) throws IOException {
 
     if (bufChainOut == null) {
       return false;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -63,6 +63,11 @@ import io.grpc.MethodDescriptor;
  */
 public class TestBasicOperation {
 
+  @Test
+  public void fastPathEnabledByDefault() {
+    Assert.assertTrue(ArrowMessage.ENABLE_ZERO_COPY);
+  }
+
   /**
    * ARROW-6017: we should be able to construct locations for unknown schemes.
    */

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -64,8 +64,9 @@ import io.grpc.MethodDescriptor;
 public class TestBasicOperation {
 
   @Test
-  public void fastPathEnabledByDefault() {
-    Assert.assertTrue(ArrowMessage.ENABLE_ZERO_COPY);
+  public void fastPathDefaults() {
+    Assert.assertTrue(ArrowMessage.ENABLE_ZERO_COPY_READ);
+    Assert.assertFalse(ArrowMessage.ENABLE_ZERO_COPY_WRITE);
   }
 
   /**
@@ -359,7 +360,8 @@ public class TestBasicOperation {
       final VectorUnloader unloader = new VectorUnloader(root);
       root.setRowCount(0);
       final MethodDescriptor.Marshaller<ArrowMessage> marshaller = ArrowMessage.createMarshaller(allocator);
-      try (final ArrowMessage message = new ArrowMessage(unloader.getRecordBatch(), null, IpcOption.DEFAULT)) {
+      try (final ArrowMessage message = new ArrowMessage(
+              unloader.getRecordBatch(), /* appMetadata */ null, /* tryZeroCopy */ false, IpcOption.DEFAULT)) {
         Assert.assertEquals(ArrowMessage.HeaderType.RECORD_BATCH, message.getMessageType());
         // Should have at least one empty body buffer (there may be multiple for e.g. data and validity)
         Iterator<ArrowBuf> iterator = message.getBufs().iterator();

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -68,7 +68,7 @@ public class PerformanceTestServer implements AutoCloseable {
 
       @Override
       public WaitResult waitForListener(long timeout) {
-        while (!listener.isReady()) {
+        while (!listener.isReady() && !listener.isCancelled()) {
           // busy wait
         }
         return WaitResult.READY;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -120,6 +120,7 @@ public class PerformanceTestServer implements AutoCloseable {
           BigIntVector b = (BigIntVector) root.getVector("b");
           BigIntVector c = (BigIntVector) root.getVector("c");
           BigIntVector d = (BigIntVector) root.getVector("d");
+          listener.setUseZeroCopy(true);
           listener.start(root);
           root.allocateNew();
 


### PR DESCRIPTION
A user reported that in the write path in Flight/Java, we were still copying data instead of zero-copying it to the network. An initial patch was reverted because it had a use-after-free of a Netty buffer, which crashed the JVM in a test when Netty/gRPC used Unsafe. A second patch was reverted because we realized that this optimization is not safe to enable in general: gRPC buffers data before writing it to the network, so Flight applications that wish to use the zero-copy optimization must not overwrite that buffer before gRPC writes it. This patch reworks the earlier patches such that:
1. The zero-copy read and zero-copy write are controlled by separate flags that can be toggled, and
2. The zero-copy write can be toggled by the application on a per-call basis.
(Note that the zero-copy read optimization was always enabled and working, but in earlier PRs, it shared a flag with the zero-copy write optimization.)
This PR also adds a test and updates the benchmark to opt in to the zero-copy optimization explicitly at runtime.