### PR TITLE
ARROW-11500: [R] Allow bundled build script to run on Solaris

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -39,7 +39,7 @@ ARROW_R_DEV=`echo $ARROW_R_DEV | tr '[:upper:]' '[:lower:]'`
 FORCE_AUTOBREW=`echo $FORCE_AUTOBREW | tr '[:upper:]' '[:lower:]'`
 ARROW_USE_PKG_CONFIG=`echo $ARROW_USE_PKG_CONFIG | tr '[:upper:]' '[:lower:]'`
 
-VERSION=`grep ^Version DESCRIPTION | sed s/Version:\ //`
+VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
 
 # generate code
@@ -116,7 +116,7 @@ else
         fi
         # autobrew sets `PKG_LIBS` and `PKG_CFLAGS`
       fi
-    elif [ "$UNAME" = "Linux" ]; then
+    else
       # Set some default values/backwards compatibility
       if [ "${LIBARROW_DOWNLOAD}" = "" ] && [ "${NOT_CRAN}" != "" ]; then
         LIBARROW_DOWNLOAD=$NOT_CRAN; export LIBARROW_DOWNLOAD

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -36,13 +36,6 @@ set -x
 SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd)"
 DEST_DIR="$(mkdir -p "${DEST_DIR}" && cd "${DEST_DIR}" && pwd)"
 
-if [ "$CMAKE_GENERATOR" = "" ]; then
-  # Look for ninja, prefer it
-  if which ninja >/dev/null 2>&1; then
-    CMAKE_GENERATOR="Ninja"
-  fi
-fi
-
 if [ "$LIBARROW_MINIMAL" = "false" ]; then
   ARROW_DEFAULT_PARAM="ON"
 else

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -322,6 +322,10 @@ build_libarrow <- function(src_dir, dst_dir) {
   env_vars <- paste0(names(env_var_list), '="', env_var_list, '"', collapse = " ")
   env_vars <- with_s3_support(env_vars)
   env_vars <- with_mimalloc(env_vars)
+  if (tolower(Sys.info()[["sysname"]]) %in% "sunos") {
+    # jemalloc doesn't seem to build on Solaris
+    env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF")
+  }
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
   status <- system(
     paste(env_vars, "inst/build_arrow_static.sh"),


### PR DESCRIPTION
The build fails, but it gets farther than before. This patch also includes the fix for the `grep` command from CRAN/Ripley.