### PR TITLE
ARROW-11510 : [Python] Add note that pip >= 19.0 is required to get binary packages

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -54,6 +54,9 @@ If you encounter any importing issues of the pip wheels on Windows, you may
 need to install the `Visual C++ Redistributable for Visual Studio 2015
 <https://www.microsoft.com/en-us/download/details.aspx?id=48145>`_.
 
+.. warning::
+   On Linux, you will need pip >= 19.0 to detect the prebuilt binary packages.
+
 Installing from source
 ----------------------
 


### PR DESCRIPTION
Added warning to Python install documentation mentioning required pip version