### PR TITLE
ARROW-11517: [Developer][Archery] Report both items and bytes per second

### DIFF
--- a/dev/archery/tests/test_benchmarks.py
+++ b/dev/archery/tests/test_benchmarks.py
@@ -17,6 +17,7 @@
 
 from archery.benchmark.core import Benchmark, median
 from archery.benchmark.compare import BenchmarkComparator
+from archery.benchmark.google import add_unit_to_name, extend_payload
 
 
 def test_benchmark_comparator():
@@ -50,3 +51,148 @@ def test_benchmark_median():
         assert False
     except ValueError:
         pass
+
+
+def test_add_unit_to_name_no_params():
+    name = add_unit_to_name("Something", "Unit")
+    assert name == "SomethingUnit"
+
+
+def test_add_unit_to_name_params():
+    name = add_unit_to_name("Something/1000", "Unit")
+    assert name == "SomethingUnit/1000"
+
+
+def test_add_unit_to_name_many_params():
+    name = add_unit_to_name("Something/1000/33", "Unit")
+    assert name == "SomethingUnit/1000/33"
+
+
+def test_add_unit_to_name_kind():
+    name = add_unit_to_name("Something<Repetition::OPTIONAL>", "Unit")
+    assert name == "SomethingUnit<Repetition::OPTIONAL>"
+
+
+def test_add_unit_to_name_kind_and_params():
+    name = add_unit_to_name("Something<Repetition::OPTIONAL>/1000/33", "Unit")
+    assert name == "SomethingUnit<Repetition::OPTIONAL>/1000/33"
+
+
+def test_extend_payload():
+    payload = [
+        {
+            "bytes_per_second": 281772039.9844759,
+            "cpu_time": 116292.58886653671,
+            "items_per_second": 281772039.9844759,
+            "iterations": 5964,
+            "name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+    ]
+    assert extend_payload(payload) == [
+        {
+            "bytes_per_second": 281772039.9844759,
+            "cpu_time": 116292.58886653671,
+            "iterations": 5964,
+            "name": "ArrayArrayKernelBytes<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+        {
+            "cpu_time": 116292.58886653671,
+            "items_per_second": 281772039.9844759,
+            "iterations": 5964,
+            "name": "ArrayArrayKernelItems<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+    ]
+
+
+def test_munge_payload():
+    payload = [
+        {
+            "cpu_time": 116292.58886653671,
+            "items_per_second": 281772039.9844759,
+            "iterations": 5964,
+            "name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+        {
+            "bytes_per_second": 281772039.9844759,
+            "cpu_time": 116292.58886653671,
+            "iterations": 5964,
+            "name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+    ]
+    assert extend_payload(payload) == [
+        {
+            "cpu_time": 116292.58886653671,
+            "items_per_second": 281772039.9844759,
+            "iterations": 5964,
+            "name": "ArrayArrayKernelItems<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+        {
+            "bytes_per_second": 281772039.9844759,
+            "cpu_time": 116292.58886653671,
+            "iterations": 5964,
+            "name": "ArrayArrayKernelBytes<AddChecked, UInt8Type>/32768/0",
+            "null_percent": 0.0,
+            "real_time": 119811.77313729875,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": "ArrayArrayKernel<AddChecked, UInt8Type>/32768/0",
+            "run_type": "iteration",
+            "size": 32768.0,
+            "threads": 1,
+            "time_unit": "ns",
+        },
+    ]


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/ARROW-11517

If google bench yields all 3 observations: bytes, items, and execution time, archery will report just `bytes_per_second` (it trumps `items_per_second` in archery).

Enhance archery to yield results for both `bytes_per_second` & `items_per_second` (if present).

Before:
`"ArrayArrayKernel<Add, UInt64Type>/262144/0"`

After:
`"ArrayArrayKernelItems<Add, UInt64Type>/262144/0"`
`"ArrayArrayKernelBytes<Add, UInt64Type>/262144/0"`