### PR TITLE
ARROW-11544: [Rust] [DataFusion] Implement as_any for AggregateExpr

### DIFF
--- a/rust/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/rust/datafusion/src/physical_plan/distinct_expressions.rs
@@ -17,6 +17,7 @@
 
 //! Implementations for DISTINCT expressions, e.g. `COUNT(DISTINCT c)`
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -70,6 +71,11 @@ impl DistinctCount {
 }
 
 impl AggregateExpr for DistinctCount {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(&self.name, self.data_type.clone(), true))
     }

--- a/rust/datafusion/src/physical_plan/expressions/average.rs
+++ b/rust/datafusion/src/physical_plan/expressions/average.rs
@@ -17,6 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -74,6 +75,11 @@ impl Avg {
 }
 
 impl AggregateExpr for Avg {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(&self.name, DataType::Float64, true))
     }

--- a/rust/datafusion/src/physical_plan/expressions/count.rs
+++ b/rust/datafusion/src/physical_plan/expressions/count.rs
@@ -17,6 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
+use std::any::Any;
 use std::sync::Arc;
 
 use crate::error::Result;
@@ -54,6 +55,11 @@ impl Count {
 }
 
 impl AggregateExpr for Count {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,

--- a/rust/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/rust/datafusion/src/physical_plan/expressions/min_max.rs
@@ -17,6 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -58,6 +59,11 @@ impl Max {
 }
 
 impl AggregateExpr for Max {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,
@@ -310,6 +316,11 @@ impl Min {
 }
 
 impl AggregateExpr for Min {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,

--- a/rust/datafusion/src/physical_plan/expressions/sum.rs
+++ b/rust/datafusion/src/physical_plan/expressions/sum.rs
@@ -17,6 +17,7 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -75,6 +76,11 @@ impl Sum {
 }
 
 impl AggregateExpr for Sum {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn field(&self) -> Result<Field> {
         Ok(Field::new(
             &self.name,

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -202,6 +202,9 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
 /// * knows its accumulator's state's field
 /// * knows the expressions from whose its accumulator will receive values
 pub trait AggregateExpr: Send + Sync + Debug {
+    /// Returns the aggregate expression as [`Any`](std::any::Any) so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
     /// the field of the final result of this aggregation.
     fn field(&self) -> Result<Field>;
 

--- a/rust/datafusion/src/physical_plan/udaf.rs
+++ b/rust/datafusion/src/physical_plan/udaf.rs
@@ -18,6 +18,7 @@
 //! This module contains functions and structs supporting user-defined aggregate functions.
 
 use fmt::{Debug, Formatter};
+use std::any::Any;
 use std::fmt;
 
 use arrow::{
@@ -132,6 +133,11 @@ pub struct AggregateFunctionExpr {
 }
 
 impl AggregateExpr for AggregateFunctionExpr {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn expressions(&self) -> Vec<Arc<dyn PhysicalExpr>> {
         self.args.clone()
     }


### PR DESCRIPTION
Implement as_any for AggregateExpr so it can be downcast to a known implementation. This is consistent with the downcasting support we already had for PhysicalExpr.