### PR TITLE
ARROW-11546: [Rust][Experiment][WIP] Experiment with a TypedArray trait

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -212,6 +212,32 @@ pub trait Array: fmt::Debug + Send + Sync + JsonEqual {
     }
 }
 
+pub trait TypedArray {
+    type Value: ?Sized;
+
+    /// Creates a PrimitiveArray based on an iterator of values without nulls
+    fn from_iter_values<I: IntoIterator<Item = Self::Value>>(iter: I) -> Self
+    where
+        Self::Value: Sized;
+}
+
+pub trait TypedArrayRef: IntoIterator {
+    type ValueRef;
+    type ValueIter: Iterator<Item = Self::ValueRef>;
+    type OptionValueIter: Iterator<Item = Option<Self::ValueRef>>;
+    fn iter(self) -> Self::OptionValueIter;
+
+    fn iter_values(self) -> Self::ValueIter;
+
+    /// Returns the element at index `i` as bytes slice
+    /// # Safety
+    /// Caller is responsible for ensuring that the index is within the bounds of the array
+    unsafe fn value_unchecked(self, i: usize) -> Self::ValueRef;
+
+    /// Returns the element at index `i`
+    fn value(self, i: usize) -> Self::ValueRef;
+}
+
 /// A reference-counted reference to a generic `Array`.
 pub type ArrayRef = Arc<Array>;
 

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -25,7 +25,8 @@ use std::{
 
 use super::{
     array::print_long_array, raw_pointer::RawPtrBox, Array, ArrayData, ArrayDataRef,
-    FixedSizeListArray, GenericBinaryIter, GenericListArray, OffsetSizeTrait,
+    FixedSizeListArray, GenericBinaryIter, GenericBinaryValueIter, GenericListArray,
+    OffsetSizeTrait, TypedArrayRef,
 };
 use crate::buffer::Buffer;
 use crate::util::bit_util;
@@ -159,6 +160,34 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
 
         let data = builder.build();
         Self::from(data)
+    }
+}
+
+impl<'a, OffsetSize: BinaryOffsetSizeTrait> TypedArrayRef
+    for &'a GenericBinaryArray<OffsetSize>
+{
+    type ValueRef = &'a [u8];
+    type ValueIter = GenericBinaryValueIter<'a, OffsetSize>;
+    type OptionValueIter = GenericBinaryIter<'a, OffsetSize>;
+
+    fn iter(self) -> Self::OptionValueIter {
+        IntoIterator::into_iter(self)
+    }
+
+    fn iter_values(self) -> Self::ValueIter {
+        Self::ValueIter::new(&self)
+    }
+
+    /// Returns the element at index `i` as bytes slice
+    /// # Safety
+    /// Caller is responsible for ensuring that the index is within the bounds of the array
+    unsafe fn value_unchecked(self, i: usize) -> &'a [u8] {
+        GenericBinaryArray::value_unchecked(self, i)
+    }
+
+    /// Returns the element at index `i` as bytes slice
+    fn value(self, i: usize) -> &'a [u8] {
+        GenericBinaryArray::value(self, i)
     }
 }
 

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -24,7 +24,7 @@ use num::Num;
 
 use super::{
     array::print_long_array, make_array, raw_pointer::RawPtrBox, Array, ArrayDataRef,
-    ArrayRef, GenericListArrayIter,
+    ArrayRef, GenericListArrayIter, GenericListArrayValueIter, TypedArrayRef,
 };
 use crate::datatypes::ArrowNativeType;
 use crate::datatypes::*;
@@ -178,6 +178,32 @@ impl<OffsetSize: 'static + OffsetSizeTrait> Array for GenericListArray<OffsetSiz
     /// Returns the total number of bytes of memory occupied physically by this [ListArray].
     fn get_array_memory_size(&self) -> usize {
         self.data.get_array_memory_size() + mem::size_of_val(self)
+    }
+}
+
+impl<'a, OffsetSize: OffsetSizeTrait> TypedArrayRef for &'a GenericListArray<OffsetSize> {
+    type ValueRef = ArrayRef;
+    type ValueIter = GenericListArrayValueIter<'a, OffsetSize>;
+    type OptionValueIter = GenericListArrayIter<'a, OffsetSize>;
+
+    fn iter(self) -> Self::OptionValueIter {
+        IntoIterator::into_iter(self)
+    }
+
+    fn iter_values(self) -> Self::ValueIter {
+        Self::ValueIter::new(self)
+    }
+
+    /// Returns ith value of this list array.
+    /// # Safety
+    /// Caller must ensure that the index is within the array bounds
+    unsafe fn value_unchecked(self, i: usize) -> ArrayRef {
+        GenericListArray::value_unchecked(self, i)
+    }
+
+    /// Returns ith value of this list array.
+    fn value(self, i: usize) -> ArrayRef {
+        GenericListArray::value(self, i)
     }
 }
 

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -102,6 +102,7 @@ mod null;
 mod ord;
 mod raw_pointer;
 mod transform;
+mod value_iterator;
 
 use crate::datatypes::*;
 
@@ -109,6 +110,8 @@ use crate::datatypes::*;
 
 pub use self::array::Array;
 pub use self::array::ArrayRef;
+pub use self::array::TypedArray;
+pub use self::array::TypedArrayRef;
 pub use self::data::ArrayData;
 pub use self::data::ArrayDataBuilder;
 pub use self::data::ArrayDataRef;
@@ -260,6 +263,7 @@ pub use self::transform::MutableArrayData;
 // --------------------- Array Iterator ---------------------
 
 pub use self::iterator::*;
+pub use self::value_iterator::*;
 
 // --------------------- Array Equality ---------------------
 

--- a/rust/arrow/src/array/value_iterator.rs
+++ b/rust/arrow/src/array/value_iterator.rs
@@ -1,0 +1,301 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::{
+    Array, ArrayRef, BinaryOffsetSizeTrait, BooleanArray, GenericBinaryArray,
+    GenericListArray, GenericStringArray, OffsetSizeTrait, StringOffsetSizeTrait,
+};
+
+/// an iterator that returns Some(bool) or None.
+// Note: This implementation is based on std's [Vec]s' [IntoIter].
+#[derive(Debug)]
+pub struct BooleanValueIter<'a> {
+    array: &'a BooleanArray,
+    current: usize,
+    current_end: usize,
+}
+
+impl<'a> BooleanValueIter<'a> {
+    /// create a new iterator
+    pub fn new(array: &'a BooleanArray) -> Self {
+        BooleanValueIter {
+            array,
+            current: 0,
+            current_end: array.len(),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for BooleanValueIter<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.current_end {
+            None
+        } else {
+            let old = self.current;
+            self.current += 1;
+            Some(self.array.value(old))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.array.len() - self.current,
+            Some(self.array.len() - self.current),
+        )
+    }
+}
+
+impl<'a> std::iter::DoubleEndedIterator for BooleanValueIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.current_end == self.current {
+            None
+        } else {
+            self.current_end -= 1;
+            Some(self.array.value(self.current_end))
+        }
+    }
+}
+
+/// all arrays have known size.
+impl<'a> std::iter::ExactSizeIterator for BooleanValueIter<'a> {}
+
+/// an iterator that returns `Some(&str)` or `None`, for string arrays
+#[derive(Debug)]
+pub struct GenericStringValueIter<'a, T>
+where
+    T: StringOffsetSizeTrait,
+{
+    array: &'a GenericStringArray<T>,
+    i: usize,
+    len: usize,
+}
+
+impl<'a, T: StringOffsetSizeTrait> GenericStringValueIter<'a, T> {
+    /// create a new iterator
+    pub fn new(array: &'a GenericStringArray<T>) -> Self {
+        GenericStringValueIter::<T> {
+            array,
+            i: 0,
+            len: array.len(),
+        }
+    }
+}
+
+impl<'a, T: StringOffsetSizeTrait> std::iter::Iterator for GenericStringValueIter<'a, T> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        if i >= self.len {
+            None
+        } else {
+            self.i += 1;
+            Some(self.array.value(i))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len - self.i, Some(self.len - self.i))
+    }
+}
+
+/// all arrays have known size.
+impl<'a, T: StringOffsetSizeTrait> std::iter::ExactSizeIterator
+    for GenericStringValueIter<'a, T>
+{
+}
+
+/// an iterator that returns `Some(&[u8])` or `None`, for binary arrays
+#[derive(Debug)]
+pub struct GenericBinaryValueIter<'a, T>
+where
+    T: BinaryOffsetSizeTrait,
+{
+    array: &'a GenericBinaryArray<T>,
+    i: usize,
+    len: usize,
+}
+
+impl<'a, T: BinaryOffsetSizeTrait> GenericBinaryValueIter<'a, T> {
+    /// create a new iterator
+    pub fn new(array: &'a GenericBinaryArray<T>) -> Self {
+        GenericBinaryValueIter::<T> {
+            array,
+            i: 0,
+            len: array.len(),
+        }
+    }
+}
+
+impl<'a, T: BinaryOffsetSizeTrait> std::iter::Iterator for GenericBinaryValueIter<'a, T> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        if i >= self.len {
+            None
+        } else {
+            self.i += 1;
+            Some(self.array.value(i))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len - self.i, Some(self.len - self.i))
+    }
+}
+
+#[derive(Debug)]
+pub struct GenericListArrayValueIter<'a, S>
+where
+    S: OffsetSizeTrait,
+{
+    array: &'a GenericListArray<S>,
+    i: usize,
+    len: usize,
+}
+
+impl<'a, S: OffsetSizeTrait> GenericListArrayValueIter<'a, S> {
+    pub fn new(array: &'a GenericListArray<S>) -> Self {
+        GenericListArrayValueIter::<S> {
+            array,
+            i: 0,
+            len: array.len(),
+        }
+    }
+}
+
+impl<'a, S: OffsetSizeTrait> std::iter::Iterator for GenericListArrayValueIter<'a, S> {
+    type Item = ArrayRef;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        if i >= self.len {
+            None
+        } else {
+            self.i += 1;
+            Some(self.array.value(i))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len - self.i, Some(self.len - self.i))
+    }
+}
+
+/// all arrays have known size.
+impl<'a, T: BinaryOffsetSizeTrait> std::iter::ExactSizeIterator
+    for GenericBinaryValueIter<'a, T>
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::array::{
+        ArrayRef, BinaryArray, BooleanArray, Int32Array, StringArray, TypedArrayRef,
+    };
+
+    #[test]
+    fn test_primitive_value_array_iter_round_trip() {
+        let array = Int32Array::from(vec![Some(0), None, Some(2), None, Some(4)]);
+        let array = Arc::new(array) as ArrayRef;
+
+        let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        // to and from iter, with a +1
+        let result: Int32Array = array.iter_values().map(|e| e + 1).map(Some).collect();
+
+        let expected = Int32Array::from(vec![1, 1, 3, 1, 5]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_primitive_value_array_double_ended() {
+        let array = Int32Array::from(vec![Some(0), None, Some(2), None, Some(4)]);
+        let mut a = array.iter_values();
+        assert_eq!(a.next(), Some(0));
+        assert_eq!(a.next(), Some(i32::default()));
+        assert_eq!(a.next_back(), Some(4));
+        assert_eq!(a.next_back(), Some(0));
+        assert_eq!(a.next_back(), Some(2));
+        // the two sides have met: None is returned by both
+        assert_eq!(a.next_back(), None);
+        assert_eq!(a.next(), None);
+    }
+
+    #[test]
+    fn test_string_array_iter_round_trip() {
+        let array =
+            StringArray::from(vec![Some("a"), None, Some("aaa"), None, Some("aaaaa")]);
+        let array = Arc::new(array) as ArrayRef;
+
+        let array = array.as_any().downcast_ref::<StringArray>().unwrap();
+
+        // to and from iter, with a +1
+        let result: StringArray = array
+            .iter_values()
+            .map(|e| {
+                let mut a = e.to_string();
+                a.push('b');
+                Some(a)
+            })
+            .collect();
+
+        let expected = StringArray::from(vec!["ab", "b", "aaab", "b", "aaaaab"]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_binary_array_iter_round_trip() {
+        let array = BinaryArray::from(vec![
+            Some(b"a" as &[u8]),
+            None,
+            Some(b"aaa"),
+            None,
+            Some(b"aaaaa"),
+        ]);
+
+        // to and from iter
+        let result: BinaryArray = array.iter_values().map(Some).collect();
+
+        let expected = BinaryArray::from(vec![
+            Some(b"a" as &[u8]),
+            Some(b""),
+            Some(b"aaa"),
+            Some(b""),
+            Some(b"aaaaa"),
+        ]);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_boolean_array_iter_approx_round_trip() {
+        let array = BooleanArray::from(vec![Some(true), None, Some(false)]);
+
+        // to and from iter
+        let result: BooleanArray = array.iter_values().map(Some).collect();
+
+        let expected = BooleanArray::from(vec![Some(true), Some(false), Some(false)]);
+
+        assert_eq!(result, expected);
+    }
+}

--- a/rust/arrow/src/compute/kernels/arity.rs
+++ b/rust/arrow/src/compute/kernels/arity.rs
@@ -17,13 +17,15 @@
 
 //! Defines kernels suitable to perform operations to primitive arrays.
 
-use crate::array::{Array, ArrayData, PrimitiveArray};
+use crate::array::{Array, ArrayData, PrimitiveArray, TypedArray, TypedArrayRef};
 use crate::buffer::Buffer;
+use crate::compute::util::combine_option_bitmap;
 use crate::datatypes::ArrowPrimitiveType;
+use crate::error::{ArrowError, Result};
 
 #[inline]
-fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
-    array: &PrimitiveArray<I>,
+fn into_primitive_array_data<I: Array, O: ArrowPrimitiveType>(
+    array: &I,
     buffer: Buffer,
 ) -> ArrayData {
     ArrayData::new(
@@ -31,6 +33,23 @@ fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
         array.len(),
         None,
         array.data_ref().null_buffer().cloned(),
+        0,
+        vec![buffer],
+        vec![],
+    )
+}
+
+#[inline]
+fn into_primitive_array_data_with_nulls<I: Array, O: ArrowPrimitiveType>(
+    array: &I,
+    null_buffer: Option<Buffer>,
+    buffer: Buffer,
+) -> ArrayData {
+    ArrayData::new(
+        O::DATA_TYPE,
+        array.len(),
+        None,
+        null_buffer,
         0,
         vec![buffer],
         vec![],
@@ -55,13 +74,14 @@ fn into_primitive_array_data<I: ArrowPrimitiveType, O: ArrowPrimitiveType>(
 /// assert_eq!(c, Int32Array::from(vec![Some(11), Some(15), None]));
 /// # }
 /// ```
-pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F) -> PrimitiveArray<O>
+pub fn unary<'a, I, F, O>(array: &'a I, op: F) -> PrimitiveArray<O>
 where
-    I: ArrowPrimitiveType,
+    I: Array + TypedArray,
+    &'a I: TypedArrayRef,
     O: ArrowPrimitiveType,
-    F: Fn(I::Native) -> O::Native,
+    F: Fn(<&'a I as TypedArrayRef>::ValueRef) -> O::Native,
 {
-    let values = array.values().iter().map(|v| op(*v));
+    let values = array.iter_values().map(op);
     // JUSTIFICATION
     //  Benefit
     //      ~60% speedup
@@ -71,4 +91,63 @@ where
 
     let data = into_primitive_array_data::<_, O>(array, buffer);
     PrimitiveArray::<O>::from(std::sync::Arc::new(data))
+}
+
+/// Applies an binary and infalible function to a primitive array.
+/// This is the fastest way to perform an operation on a primitive array when
+/// the benefits of a vectorized operation outweights the cost of branching nulls and non-nulls.
+/// # Implementation
+/// This will apply the function for all values, including those on null slots.
+/// This implies that the operation must be infalible for any value of the corresponding type
+/// or this function may panic.
+/// # Example
+/// ```rust
+/// # use arrow::array::{Int32Array,Float32Array};
+/// # use arrow::datatypes::Int32Type;
+/// # use arrow::compute::kernels::arity::binary;
+/// # fn main() {
+/// let array_int = Int32Array::from(vec![Some(5), Some(7), None, Some(-1), None]);
+/// let array_float = Float32Array::from(vec![Some(5.0f32), Some(7.0f32), Some(11.0f32), None, None]);
+/// let c = binary::<_, _, _, Int32Type>(&array_int, &array_float, |x,y| (((x as f32) * y) as i32 + 1) ).unwrap();
+/// assert_eq!(c, Int32Array::from(vec![Some(26), Some(50), None, None, None]));
+/// # }
+/// ```
+pub fn binary<'a, I, J, F, O>(
+    left: &'a I,
+    right: &'a J,
+    op: F,
+) -> Result<PrimitiveArray<O>>
+where
+    I: Array + TypedArray,
+    &'a I: TypedArrayRef,
+    J: Array + TypedArray,
+    &'a J: TypedArrayRef,
+    O: ArrowPrimitiveType,
+    F: Fn(
+        <&'a I as TypedArrayRef>::ValueRef,
+        <&'a J as TypedArrayRef>::ValueRef,
+    ) -> O::Native,
+{
+    if left.len() != right.len() {
+        return Err(ArrowError::ComputeError(
+            "Cannot perform operation on arrays of different length".to_string(),
+        ));
+    };
+
+    let null_buffer =
+        combine_option_bitmap(left.data_ref(), right.data_ref(), left.len())?;
+
+    let values = left
+        .iter_values()
+        .zip(right.iter_values())
+        .map(|(l, r)| op(l, r));
+    // JUSTIFICATION
+    //  Benefit
+    //      ~60% speedup
+    //  Soundness
+    //      `values` is an iterator with a known size because arrays are sized.
+    let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
+
+    let data = into_primitive_array_data_with_nulls::<_, O>(left, null_buffer, buffer);
+    Ok(PrimitiveArray::<O>::from(std::sync::Arc::new(data)))
 }


### PR DESCRIPTION
A few of the arrow kernels rely on macros to iterate over values using a common `.value()` function, but:
* this function is safe on some array types (string, binary), but unsafe on other array types (primitive, boolean - although it is not currently marked as such)
* this forces iteration by index, which requires unsafe code to guarantee bounds checks are avoided (which can be dangerous for multi-array operations)

This PR is an experiment with a TypedArray trait, which provides access to array values using an associated type.  This will NOT remove the need for downcasting, but for simple re-usable implementations should provide a simpler interface.

There are a few trade-offs with this API:
* Associated types with references need a lifetime, whereas from_iter implementations need a concrete type...  So I was forced to split the trait into 2 traits
* For consistency, the TypedArrayRef value() functions are all safe.  If the Primitive/Boolean inherent impl's shadow the trait implementation it could cause surprises.
* The 'backing' type for a TypedArray/TypedArrayRef was selected based on the existing value/iter() API, rather than using any 
  * A higher level API could provide access to logical records that aren't necessarily reflected in NativeType (ex: timestamps)
  * A lower level API (const-sized-slot for Primitive, static-sized-slot for FixedList, dynamic-sized-slot for List,String,etc.) could provide access to 'byte-chunks' without requiring users to monomorphize functions for every high-level type being handled  (ex: parts of the filter & take logic do not need to know whether it's a float64 vs. a u64)
* For PrimitiveArray, it may make more sense for value() to return a reference, but that causes a cascade of changes on many parts of the code base
* I stopped short of implementing all the 'from_iter()' implementations once I went far enough to believe it could work.
  * Constructing arrays efficiently would require an TypedArray function `unsafe fn from_trusted_len_iter<I>(iter: I) -> Self` so that the various arrays can select the correct buffer collect method.   I stopped short from actually implementing anything around that.
* Using the same function names as existing inherent impl functions seems dangerous (particularly PrimitiveArray/BooleanArray, as they have different safety for value() trait vs. inherent impl).  It may make more sense to find non-conflicting function names instead.
  * for value in particular, it would be possible to implement std::ops::Index instead.

The kernels touched to use this api are:
* arity 
  * unary (loosened parameter restrictions to accept any TypedArray instead of any PrimitiveArray)
  * new binary (same idea as unary, but accepting 2 arrays and calling a function accepting 2 parameters)
* arithmetic (to use the binary kernel above)
* comparison (replace compare_ops/compare_ops_scalar macros with generic functions)
  * I couldn't use unary/binary because they output a PrimitiveArray (and making it generic would require TypedArray::from_trusted_iter)