### PR TITLE
ARROW-11556: [C++] Assorted benchmark-related improvements

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -343,8 +343,8 @@ struct BoxScalar<Decimal128Type> {
 // values, such as Decimal128 rather than util::string_view.
 
 template <typename T, typename VisitFunc, typename NullFunc>
-static void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& valid_func,
-                                   NullFunc&& null_func) {
+static inline void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& valid_func,
+                                          NullFunc&& null_func) {
   VisitArrayDataInline<T>(
       arr,
       [&](typename GetViewType<T>::PhysicalType v) {
@@ -356,8 +356,9 @@ static void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& valid_func,
 // Like VisitArrayValuesInline, but for binary functions.
 
 template <typename Arg0Type, typename Arg1Type, typename VisitFunc, typename NullFunc>
-static void VisitTwoArrayValuesInline(const ArrayData& arr0, const ArrayData& arr1,
-                                      VisitFunc&& valid_func, NullFunc&& null_func) {
+static inline void VisitTwoArrayValuesInline(const ArrayData& arr0, const ArrayData& arr1,
+                                             VisitFunc&& valid_func,
+                                             NullFunc&& null_func) {
   ArrayIterator<Arg0Type> arr0_it(arr0);
   ArrayIterator<Arg1Type> arr1_it(arr1);
 
@@ -442,7 +443,7 @@ namespace applicator {
 // static void Call(KernelContext*, const ArrayData& in, ArrayData* out)
 // static void Call(KernelContext*, const Scalar& in, Scalar* out)
 template <typename Operator>
-void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+inline void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   if (batch[0].kind() == Datum::SCALAR) {
     Operator::Call(ctx, *batch[0].scalar(), out->scalar().get());
   } else if (batch.length > 0) {
@@ -464,7 +465,7 @@ void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 // static void Call(KernelContext*, const Scalar& arg0, const Scalar& arg1,
 //                  Scalar* out)
 template <typename Operator>
-void SimpleBinary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+inline void SimpleBinary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   if (batch.length == 0) return;
 
   if (batch[0].kind() == Datum::ARRAY) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -343,8 +343,8 @@ struct BoxScalar<Decimal128Type> {
 // values, such as Decimal128 rather than util::string_view.
 
 template <typename T, typename VisitFunc, typename NullFunc>
-static inline void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& valid_func,
-                                          NullFunc&& null_func) {
+static void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& valid_func,
+                                   NullFunc&& null_func) {
   VisitArrayDataInline<T>(
       arr,
       [&](typename GetViewType<T>::PhysicalType v) {
@@ -356,9 +356,8 @@ static inline void VisitArrayValuesInline(const ArrayData& arr, VisitFunc&& vali
 // Like VisitArrayValuesInline, but for binary functions.
 
 template <typename Arg0Type, typename Arg1Type, typename VisitFunc, typename NullFunc>
-static inline void VisitTwoArrayValuesInline(const ArrayData& arr0, const ArrayData& arr1,
-                                             VisitFunc&& valid_func,
-                                             NullFunc&& null_func) {
+static void VisitTwoArrayValuesInline(const ArrayData& arr0, const ArrayData& arr1,
+                                      VisitFunc&& valid_func, NullFunc&& null_func) {
   ArrayIterator<Arg0Type> arr0_it(arr0);
   ArrayIterator<Arg1Type> arr1_it(arr1);
 
@@ -443,7 +442,7 @@ namespace applicator {
 // static void Call(KernelContext*, const ArrayData& in, ArrayData* out)
 // static void Call(KernelContext*, const Scalar& in, Scalar* out)
 template <typename Operator>
-inline void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+static void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   if (batch[0].kind() == Datum::SCALAR) {
     Operator::Call(ctx, *batch[0].scalar(), out->scalar().get());
   } else if (batch.length > 0) {
@@ -465,7 +464,7 @@ inline void SimpleUnary(KernelContext* ctx, const ExecBatch& batch, Datum* out) 
 // static void Call(KernelContext*, const Scalar& arg0, const Scalar& arg1,
 //                  Scalar* out)
 template <typename Operator>
-inline void SimpleBinary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+static void SimpleBinary(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   if (batch.length == 0) return;
 
   if (batch[0].kind() == Datum::ARRAY) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
@@ -107,10 +107,8 @@ static void ArrayArrayKernel(benchmark::State& state) {
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
-  for (const auto size : {kL1Size, kL2Size}) {
-    for (const auto inverse_null_proportion : std::vector<ArgsType>({100, 0})) {
-      bench->Args({static_cast<ArgsType>(size), inverse_null_proportion});
-    }
+  for (const auto inverse_null_proportion : std::vector<ArgsType>({100, 0})) {
+    bench->Args({static_cast<ArgsType>(kL2Size), inverse_null_proportion});
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -32,6 +32,9 @@ constexpr auto kSeed = 0x94378165;
 static void SetLookupBenchmarkString(benchmark::State& state,
                                      const std::string& func_name,
                                      const int64_t value_set_length) {
+  // As the set lookup functions don't support duplicate values in the value_set,
+  // we need to choose random generation parameters that minimize the risk of
+  // duplicates (including nulls).
   const int64_t array_length = 1 << 18;
   const int32_t value_min_size = (value_set_length < 64) ? 2 : 10;
   const int32_t value_max_size = 32;

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -32,10 +32,10 @@ constexpr auto kSeed = 0x94378165;
 static void SetLookupBenchmarkString(benchmark::State& state,
                                      const std::string& func_name,
                                      const int64_t value_set_length) {
-  const int64_t array_length = 1 << 20;
-  const int64_t value_min_size = 0;
-  const int64_t value_max_size = 32;
-  const double null_probability = 0.01;
+  const int64_t array_length = 1 << 18;
+  const int32_t value_min_size = (value_set_length < 64) ? 2 : 10;
+  const int32_t value_max_size = 32;
+  const double null_probability = 0.2 / value_set_length;
   random::RandomArrayGenerator rng(kSeed);
 
   auto values =
@@ -54,10 +54,10 @@ template <typename Type>
 static void SetLookupBenchmarkNumeric(benchmark::State& state,
                                       const std::string& func_name,
                                       const int64_t value_set_length) {
-  const int64_t array_length = 1 << 20;
+  const int64_t array_length = 1 << 18;
   const int64_t value_min = 0;
   const int64_t value_max = std::numeric_limits<typename Type::c_type>::max();
-  const double null_probability = 0.01;
+  const double null_probability = 0.1 / value_set_length;
   random::RandomArrayGenerator rng(kSeed);
 
   auto values = rng.Numeric<Type>(array_length, value_min, value_max, null_probability);
@@ -125,11 +125,13 @@ BENCHMARK(IsInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInStringLargeSet);
 BENCHMARK(IsInStringLargeSet);
 
-BENCHMARK(IndexInInt8SmallSet)->RangeMultiplier(4)->Range(2, 64);
+// XXX For Int8, the value_set length has to be capped at a lower value
+// in order to avoid duplicates.
+BENCHMARK(IndexInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IndexInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
-BENCHMARK(IsInInt8SmallSet)->RangeMultiplier(4)->Range(2, 64);
+BENCHMARK(IsInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IsInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -94,126 +94,128 @@ Result<std::shared_ptr<ArrayData>> GetTakeIndicesImpl(
     const ArrayData& filter, FilterOptions::NullSelectionBehavior null_selection,
     MemoryPool* memory_pool) {
   using T = typename IndexType::c_type;
-  typename TypeTraits<IndexType>::BuilderType builder(memory_pool);
 
   const uint8_t* filter_data = filter.buffers[1]->data();
-  BitBlockCounter data_counter(filter_data, filter.offset, filter.length);
+  const bool have_filter_nulls = filter.MayHaveNulls();
+  const uint8_t* filter_is_valid =
+      have_filter_nulls ? filter.buffers[0]->data() : nullptr;
 
-  // The position relative to the start of the filter
-  T position = 0;
+  if (have_filter_nulls && null_selection == FilterOptions::EMIT_NULL) {
+    // Most complex case: the filter may have nulls and we don't drop them.
+    // The logic is ternary:
+    // - filter is null: emit null
+    // - filter is valid and true: emit index
+    // - filter is valid and false: don't emit anything
 
-  // The current position taking the filter offset into account
-  int64_t position_with_offset = filter.offset;
-  if (filter.MayHaveNulls()) {
-    // The filter may have nulls, so we scan the validity bitmap and the filter
-    // data bitmap together, branching on the null selection type.
-    const uint8_t* filter_is_valid = filter.buffers[0]->data();
+    typename TypeTraits<IndexType>::BuilderType builder(memory_pool);
 
-    // To count blocks whether filter_data[i] || !filter_is_valid[i]
+    // The position relative to the start of the filter
+    T position = 0;
+    // The current position taking the filter offset into account
+    int64_t position_with_offset = filter.offset;
+
+    // To count blocks where filter_data[i] || !filter_is_valid[i]
     BinaryBitBlockCounter filter_counter(filter_data, filter.offset, filter_is_valid,
                                          filter.offset, filter.length);
-    if (null_selection == FilterOptions::DROP) {
-      while (position < filter.length) {
-        BitBlockCount and_block = filter_counter.NextAndWord();
-        RETURN_NOT_OK(builder.Reserve(and_block.popcount));
-        if (and_block.AllSet()) {
-          // All the values are selected and non-null
-          for (int64_t i = 0; i < and_block.length; ++i) {
-            builder.UnsafeAppend(position++);
-          }
-          position_with_offset += and_block.length;
-        } else if (!and_block.NoneSet()) {
-          // Some of the values are false or null
-          for (int64_t i = 0; i < and_block.length; ++i) {
-            if (BitUtil::GetBit(filter_is_valid, position_with_offset) &&
-                BitUtil::GetBit(filter_data, position_with_offset)) {
+    BitBlockCounter is_valid_counter(filter_is_valid, filter.offset, filter.length);
+    while (position < filter.length) {
+      // true OR NOT valid
+      BitBlockCount or_not_block = filter_counter.NextOrNotWord();
+      if (or_not_block.NoneSet()) {
+        position += or_not_block.length;
+        position_with_offset += or_not_block.length;
+        continue;
+      }
+      RETURN_NOT_OK(builder.Reserve(or_not_block.popcount));
+
+      // If the values are all valid and the or_not_block is full, then we
+      // can infer that all the values are true and skip the bit checking
+      BitBlockCount is_valid_block = is_valid_counter.NextWord();
+
+      if (or_not_block.AllSet() && is_valid_block.AllSet()) {
+        // All the values are selected and non-null
+        for (int64_t i = 0; i < or_not_block.length; ++i) {
+          builder.UnsafeAppend(position++);
+        }
+        position_with_offset += or_not_block.length;
+      } else {
+        // Some of the values are false or null
+        for (int64_t i = 0; i < or_not_block.length; ++i) {
+          if (BitUtil::GetBit(filter_is_valid, position_with_offset)) {
+            if (BitUtil::GetBit(filter_data, position_with_offset)) {
               builder.UnsafeAppend(position);
             }
-            ++position;
-            ++position_with_offset;
+          } else {
+            // Null slot, so append a null
+            builder.UnsafeAppendNull();
           }
-        } else {
-          position += and_block.length;
-          position_with_offset += and_block.length;
-        }
-      }
-    } else {
-      BitBlockCounter is_valid_counter(filter_is_valid, filter.offset, filter.length);
-      while (position < filter.length) {
-        // true OR NOT valid
-        BitBlockCount or_not_block = filter_counter.NextOrNotWord();
-        RETURN_NOT_OK(builder.Reserve(or_not_block.popcount));
-
-        // If the values are all valid and the or_not_block is full, then we
-        // can infer that all the values are true and skip the bit checking
-        BitBlockCount is_valid_block = is_valid_counter.NextWord();
-
-        if (or_not_block.AllSet() && is_valid_block.AllSet()) {
-          // All the values are selected and non-null
-          for (int64_t i = 0; i < or_not_block.length; ++i) {
-            builder.UnsafeAppend(position++);
-          }
-          position_with_offset += or_not_block.length;
-        } else {
-          // Some of the values are false or null
-          for (int64_t i = 0; i < or_not_block.length; ++i) {
-            if (BitUtil::GetBit(filter_is_valid, position_with_offset)) {
-              if (BitUtil::GetBit(filter_data, position_with_offset)) {
-                builder.UnsafeAppend(position);
-              }
-            } else {
-              // Null slot, so append a null
-              builder.UnsafeAppendNull();
-            }
-            ++position;
-            ++position_with_offset;
-          }
+          ++position;
+          ++position_with_offset;
         }
       }
     }
-  } else {
-    // The filter has no nulls, so we need only look for true values
-    BitBlockCount current_block = data_counter.NextWord();
+    std::shared_ptr<ArrayData> result;
+    RETURN_NOT_OK(builder.FinishInternal(&result));
+    return result;
+  }
+
+  // Other cases don't emit nulls and are therefore simpler.
+  TypedBufferBuilder<T> builder(memory_pool);
+
+  if (have_filter_nulls) {
+    // The filter may have nulls, so we scan the validity bitmap and the filter
+    // data bitmap together.
+    DCHECK_EQ(null_selection, FilterOptions::DROP);
+
+    // The position relative to the start of the filter
+    T position = 0;
+    // The current position taking the filter offset into account
+    int64_t position_with_offset = filter.offset;
+
+    BinaryBitBlockCounter filter_counter(filter_data, filter.offset, filter_is_valid,
+                                         filter.offset, filter.length);
     while (position < filter.length) {
-      if (current_block.AllSet()) {
-        int64_t run_length = 0;
-
-        // If we've found a all-true block, then we scan forward until we find
-        // a block that has some false values (or we reach the end)
-        while (current_block.length > 0 && current_block.AllSet()) {
-          run_length += current_block.length;
-          current_block = data_counter.NextWord();
-        }
-
-        // Append the consecutive run of indices
-        RETURN_NOT_OK(builder.Reserve(run_length));
-        for (int64_t i = 0; i < run_length; ++i) {
+      BitBlockCount and_block = filter_counter.NextAndWord();
+      RETURN_NOT_OK(builder.Reserve(and_block.popcount));
+      if (and_block.AllSet()) {
+        // All the values are selected and non-null
+        for (int64_t i = 0; i < and_block.length; ++i) {
           builder.UnsafeAppend(position++);
         }
-        position_with_offset += run_length;
-        // The current_block already computed, so advance to next loop
-        // iteration.
-        continue;
-      } else if (!current_block.NoneSet()) {
-        // Must do bitchecking on the current block
-        RETURN_NOT_OK(builder.Reserve(current_block.popcount));
-        for (int64_t i = 0; i < current_block.length; ++i) {
-          if (BitUtil::GetBit(filter_data, position_with_offset)) {
+        position_with_offset += and_block.length;
+      } else if (!and_block.NoneSet()) {
+        // Some of the values are false or null
+        for (int64_t i = 0; i < and_block.length; ++i) {
+          if (BitUtil::GetBit(filter_is_valid, position_with_offset) &&
+              BitUtil::GetBit(filter_data, position_with_offset)) {
             builder.UnsafeAppend(position);
           }
           ++position;
           ++position_with_offset;
         }
       } else {
-        position += current_block.length;
-        position_with_offset += current_block.length;
+        position += and_block.length;
+        position_with_offset += and_block.length;
       }
-      current_block = data_counter.NextWord();
     }
+  } else {
+    // The filter has no nulls, so we need only look for true values
+    RETURN_NOT_OK(::arrow::internal::VisitSetBitRuns(
+        filter_data, filter.offset, filter.length, [&](int64_t offset, int64_t length) {
+          // Append the consecutive run of indices
+          RETURN_NOT_OK(builder.Reserve(length));
+          for (int64_t i = 0; i < length; ++i) {
+            builder.UnsafeAppend(static_cast<T>(offset + i));
+          }
+          return Status::OK();
+        }));
   }
-  std::shared_ptr<ArrayData> result;
-  RETURN_NOT_OK(builder.FinishInternal(&result));
-  return result;
+
+  const int64_t length = builder.length();
+  std::shared_ptr<Buffer> out_buffer;
+  RETURN_NOT_OK(builder.Finish(&out_buffer));
+  return std::make_shared<ArrayData>(TypeTraits<IndexType>::type_singleton(), length,
+                                     BufferVector{nullptr, out_buffer}, /*null_count=*/0);
 }
 
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
@@ -267,6 +267,10 @@ static void FilterRecordBatchNoNulls(benchmark::State& state) {
   FilterBenchmark(state, false).BenchRecordBatch();
 }
 
+static void FilterRecordBatchWithNulls(benchmark::State& state) {
+  FilterBenchmark(state, true).BenchRecordBatch();
+}
+
 static void TakeInt64RandomIndicesNoNulls(benchmark::State& state) {
   TakeBenchmark(state, false).Int64();
 }
@@ -326,6 +330,7 @@ void FilterRecordBatchSetArgs(benchmark::internal::Benchmark* bench) {
   }
 }
 BENCHMARK(FilterRecordBatchNoNulls)->Apply(FilterRecordBatchSetArgs);
+BENCHMARK(FilterRecordBatchWithNulls)->Apply(FilterRecordBatchSetArgs);
 
 void TakeSetArgs(benchmark::internal::Benchmark* bench) {
   for (int64_t size : g_data_sizes) {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -23,6 +23,7 @@
 
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/test_util.h"
+#include "arrow/io/memory.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
@@ -30,6 +31,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/range.h"
+
 #include "parquet/arrow/writer.h"
 #include "parquet/metadata.h"
 

--- a/cpp/src/arrow/tensor/tensor_conversion_benchmark.cc
+++ b/cpp/src/arrow/tensor/tensor_conversion_benchmark.cc
@@ -159,7 +159,6 @@ class MatrixConversionFixture : public benchmark::Fixture {
       TensorConversionFixture<STRIDED, value_type_name##Type, IndexType>
 
 DEFINE_TYPED_TENSOR_CONVERSION_FIXTURE(Int8);
-DEFINE_TYPED_TENSOR_CONVERSION_FIXTURE(Int16);
 DEFINE_TYPED_TENSOR_CONVERSION_FIXTURE(Float);
 DEFINE_TYPED_TENSOR_CONVERSION_FIXTURE(Double);
 
@@ -175,7 +174,6 @@ DEFINE_TYPED_TENSOR_CONVERSION_FIXTURE(Double);
       MatrixConversionFixture<STRIDED, value_type_name##Type, IndexType>
 
 DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Int8);
-DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Int16);
 DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Float);
 DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Double);
 
@@ -191,6 +189,8 @@ DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Double);
                        .Value(&sparse_tensor));                                  \
     }                                                                            \
     benchmark::DoNotOptimize(sparse_tensor);                                     \
+    state.SetItemsProcessed(state.iterations() * this->tensor_->size());         \
+    state.SetBytesProcessed(state.iterations() * this->tensor_->data()->size()); \
   }
 
 #define BENCHMARK_CONVERT_TENSOR(kind, format, value_type_name, index_type_name)       \
@@ -199,71 +199,31 @@ DEFINE_TYPED_MATRIX_CONVERSION_FIXTURE(Double);
                             index_type_name);                                          \
   BENCHMARK_CONVERT_TENSOR_(Strided, kind, format, value_type_name, index_type_name)
 
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int8, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int8, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int8, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int8, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int16, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int16, Int16);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int16, Int32);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Int16, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Float, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Float, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Float, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Float, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Double, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, COO, Double, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Double, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, COO, Double, Int64);
 
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int8, Int8);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int8, Int16);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int8, Int32);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int8, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int16, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int16, Int16);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int16, Int32);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Int16, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Float, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Float, Int16);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Float, Int32);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Float, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Double, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Double, Int16);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Double, Int32);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSR, Double, Int64);
 
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int8, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int8, Int16);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int8, Int32);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int8, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int16, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int16, Int16);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int16, Int32);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Int16, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Float, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Float, Int16);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Float, Int32);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Float, Int64);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Double, Int8);
-BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Double, Int16);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Double, Int32);
 BENCHMARK_CONVERT_TENSOR(Matrix, CSC, Double, Int64);
 
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int8, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int8, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int8, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int8, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int16, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int16, Int16);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int16, Int32);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Int16, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Float, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Float, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Float, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Float, Int64);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Double, Int8);
-BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Double, Int16);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Double, Int32);
 BENCHMARK_CONVERT_TENSOR(Tensor, CSF, Double, Int64);
 

--- a/cpp/src/arrow/util/bit_block_counter.cc
+++ b/cpp/src/arrow/util/bit_block_counter.cc
@@ -22,25 +22,12 @@
 #include <type_traits>
 
 #include "arrow/buffer.h"
-#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
-#include "arrow/util/ubsan.h"
 
 namespace arrow {
 namespace internal {
 
-static inline uint64_t LoadWord(const uint8_t* bytes) {
-  return BitUtil::ToLittleEndian(util::SafeLoadAs<uint64_t>(bytes));
-}
-
-static inline uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
-  if (shift == 0) {
-    return current;
-  }
-  return (current >> shift) | (next << (64 - shift));
-}
-
-BitBlockCount BitBlockCounter::GetBlockSlow(int64_t block_size) {
+BitBlockCount BitBlockCounter::GetBlockSlow(int64_t block_size) noexcept {
   const int16_t run_length = static_cast<int16_t>(std::min(bits_remaining_, block_size));
   int16_t popcount = static_cast<int16_t>(CountSetBits(bitmap_, offset_, run_length));
   bits_remaining_ -= run_length;
@@ -48,67 +35,6 @@ BitBlockCount BitBlockCounter::GetBlockSlow(int64_t block_size) {
   // case, the first time the run length will be a multiple of 8 by construction
   bitmap_ += run_length / 8;
   return {run_length, popcount};
-}
-
-BitBlockCount BitBlockCounter::NextWord() {
-  if (!bits_remaining_) {
-    return {0, 0};
-  }
-  int64_t popcount = 0;
-  if (offset_ == 0) {
-    if (bits_remaining_ < kWordBits) {
-      return GetBlockSlow(kWordBits);
-    }
-    popcount = BitUtil::PopCount(LoadWord(bitmap_));
-  } else {
-    // When the offset is > 0, we need there to be a word beyond the last
-    // aligned word in the bitmap for the bit shifting logic.
-    if (bits_remaining_ < 2 * kWordBits - offset_) {
-      return GetBlockSlow(kWordBits);
-    }
-    popcount =
-        BitUtil::PopCount(ShiftWord(LoadWord(bitmap_), LoadWord(bitmap_ + 8), offset_));
-  }
-  bitmap_ += kWordBits / 8;
-  bits_remaining_ -= kWordBits;
-  return {64, static_cast<int16_t>(popcount)};
-}
-
-BitBlockCount BitBlockCounter::NextFourWords() {
-  if (!bits_remaining_) {
-    return {0, 0};
-  }
-  int64_t total_popcount = 0;
-  if (offset_ == 0) {
-    if (bits_remaining_ < kFourWordsBits) {
-      return GetBlockSlow(kFourWordsBits);
-    }
-    total_popcount += BitUtil::PopCount(LoadWord(bitmap_));
-    total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 8));
-    total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 16));
-    total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 24));
-  } else {
-    // When the offset is > 0, we need there to be a word beyond the last
-    // aligned word in the bitmap for the bit shifting logic.
-    if (bits_remaining_ < 5 * kFourWordsBits - offset_) {
-      return GetBlockSlow(kFourWordsBits);
-    }
-    auto current = LoadWord(bitmap_);
-    auto next = LoadWord(bitmap_ + 8);
-    total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
-    current = next;
-    next = LoadWord(bitmap_ + 16);
-    total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
-    current = next;
-    next = LoadWord(bitmap_ + 24);
-    total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
-    current = next;
-    next = LoadWord(bitmap_ + 32);
-    total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
-  }
-  bitmap_ += BitUtil::BytesForBits(kFourWordsBits);
-  bits_remaining_ -= kFourWordsBits;
-  return {256, static_cast<int16_t>(total_popcount)};
 }
 
 // Prevent pointer arithmetic on nullptr, which is undefined behavior even if the pointer
@@ -129,63 +55,6 @@ OptionalBitBlockCounter::OptionalBitBlockCounter(
     const std::shared_ptr<Buffer>& validity_bitmap, int64_t offset, int64_t length)
     : OptionalBitBlockCounter(validity_bitmap ? validity_bitmap->data() : nullptr, offset,
                               length) {}
-
-template <template <typename T> class Op>
-BitBlockCount BinaryBitBlockCounter::NextWord() {
-  if (!bits_remaining_) {
-    return {0, 0};
-  }
-  // When the offset is > 0, we need there to be a word beyond the last aligned
-  // word in the bitmap for the bit shifting logic.
-  constexpr int64_t kWordBits = BitBlockCounter::kWordBits;
-  const int64_t bits_required_to_use_words =
-      std::max(left_offset_ == 0 ? 64 : 64 + (64 - left_offset_),
-               right_offset_ == 0 ? 64 : 64 + (64 - right_offset_));
-  if (bits_remaining_ < bits_required_to_use_words) {
-    const int16_t run_length = static_cast<int16_t>(std::min(bits_remaining_, kWordBits));
-    int16_t popcount = 0;
-    for (int64_t i = 0; i < run_length; ++i) {
-      if (Op<bool>::Call(BitUtil::GetBit(left_bitmap_, left_offset_ + i),
-                         BitUtil::GetBit(right_bitmap_, right_offset_ + i))) {
-        ++popcount;
-      }
-    }
-    // This code path should trigger _at most_ 2 times. In the "two times"
-    // case, the first time the run length will be a multiple of 8.
-    left_bitmap_ += run_length / 8;
-    right_bitmap_ += run_length / 8;
-    bits_remaining_ -= run_length;
-    return {run_length, popcount};
-  }
-
-  int64_t popcount = 0;
-  if (left_offset_ == 0 && right_offset_ == 0) {
-    popcount = BitUtil::PopCount(
-        Op<uint64_t>::Call(LoadWord(left_bitmap_), LoadWord(right_bitmap_)));
-  } else {
-    auto left_word =
-        ShiftWord(LoadWord(left_bitmap_), LoadWord(left_bitmap_ + 8), left_offset_);
-    auto right_word =
-        ShiftWord(LoadWord(right_bitmap_), LoadWord(right_bitmap_ + 8), right_offset_);
-    popcount = BitUtil::PopCount(Op<uint64_t>::Call(left_word, right_word));
-  }
-  left_bitmap_ += kWordBits / 8;
-  right_bitmap_ += kWordBits / 8;
-  bits_remaining_ -= kWordBits;
-  return {64, static_cast<int16_t>(popcount)};
-}
-
-BitBlockCount BinaryBitBlockCounter::NextAndWord() {
-  return NextWord<detail::BitBlockAnd>();
-}
-
-BitBlockCount BinaryBitBlockCounter::NextOrWord() {
-  return NextWord<detail::BitBlockOr>();
-}
-
-BitBlockCount BinaryBitBlockCounter::NextOrNotWord() {
-  return NextWord<detail::BitBlockOrNot>();
-}
 
 OptionalBinaryBitBlockCounter::OptionalBinaryBitBlockCounter(const uint8_t* left_bitmap,
                                                              int64_t left_offset,

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -273,7 +273,7 @@ class ARROW_EXPORT BinaryBitBlockCounter {
 
  private:
   template <template <typename T> class Op>
-  inline BitBlockCount NextWord() {
+  BitBlockCount NextWord() {
     using detail::LoadWord;
     using detail::ShiftWord;
 
@@ -413,10 +413,9 @@ class ARROW_EXPORT OptionalBinaryBitBlockCounter {
 // Functional-style bit block visitors.
 
 template <typename VisitNotNull, typename VisitNull>
-static inline Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf,
-                                    int64_t offset, int64_t length,
-                                    VisitNotNull&& visit_not_null,
-                                    VisitNull&& visit_null) {
+static Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offset,
+                             int64_t length, VisitNotNull&& visit_not_null,
+                             VisitNull&& visit_null) {
   const uint8_t* bitmap = NULLPTR;
   if (bitmap_buf != NULLPTR) {
     bitmap = bitmap_buf->data();
@@ -447,10 +446,9 @@ static inline Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf,
 }
 
 template <typename VisitNotNull, typename VisitNull>
-static inline void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf,
-                                      int64_t offset, int64_t length,
-                                      VisitNotNull&& visit_not_null,
-                                      VisitNull&& visit_null) {
+static void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offset,
+                               int64_t length, VisitNotNull&& visit_not_null,
+                               VisitNull&& visit_null) {
   const uint8_t* bitmap = NULLPTR;
   if (bitmap_buf != NULLPTR) {
     bitmap = bitmap_buf->data();
@@ -480,12 +478,11 @@ static inline void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf,
 }
 
 template <typename VisitNotNull, typename VisitNull>
-static inline void VisitTwoBitBlocksVoid(const std::shared_ptr<Buffer>& left_bitmap_buf,
-                                         int64_t left_offset,
-                                         const std::shared_ptr<Buffer>& right_bitmap_buf,
-                                         int64_t right_offset, int64_t length,
-                                         VisitNotNull&& visit_not_null,
-                                         VisitNull&& visit_null) {
+static void VisitTwoBitBlocksVoid(const std::shared_ptr<Buffer>& left_bitmap_buf,
+                                  int64_t left_offset,
+                                  const std::shared_ptr<Buffer>& right_bitmap_buf,
+                                  int64_t right_offset, int64_t length,
+                                  VisitNotNull&& visit_not_null, VisitNull&& visit_null) {
   if (left_bitmap_buf == NULLPTR || right_bitmap_buf == NULLPTR) {
     // At most one bitmap is present
     if (left_bitmap_buf == NULLPTR) {

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -26,11 +26,23 @@
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/ubsan.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace internal {
 namespace detail {
+
+inline uint64_t LoadWord(const uint8_t* bytes) {
+  return BitUtil::ToLittleEndian(util::SafeLoadAs<uint64_t>(bytes));
+}
+
+inline uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
+  if (shift == 0) {
+    return current;
+  }
+  return (current >> shift) | (next << (64 - shift));
+}
 
 // These templates are here to help with unit tests
 
@@ -97,19 +109,82 @@ class ARROW_EXPORT BitBlockCounter {
   /// block will have a length less than 256 if the bitmap length is not a
   /// multiple of 256, and will return 0-length blocks in subsequent
   /// invocations.
-  BitBlockCount NextFourWords();
+  BitBlockCount NextFourWords() {
+    using detail::LoadWord;
+    using detail::ShiftWord;
+
+    if (!bits_remaining_) {
+      return {0, 0};
+    }
+    int64_t total_popcount = 0;
+    if (offset_ == 0) {
+      if (bits_remaining_ < kFourWordsBits) {
+        return GetBlockSlow(kFourWordsBits);
+      }
+      total_popcount += BitUtil::PopCount(LoadWord(bitmap_));
+      total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 8));
+      total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 16));
+      total_popcount += BitUtil::PopCount(LoadWord(bitmap_ + 24));
+    } else {
+      // When the offset is > 0, we need there to be a word beyond the last
+      // aligned word in the bitmap for the bit shifting logic.
+      if (bits_remaining_ < 5 * kFourWordsBits - offset_) {
+        return GetBlockSlow(kFourWordsBits);
+      }
+      auto current = LoadWord(bitmap_);
+      auto next = LoadWord(bitmap_ + 8);
+      total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
+      current = next;
+      next = LoadWord(bitmap_ + 16);
+      total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
+      current = next;
+      next = LoadWord(bitmap_ + 24);
+      total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
+      current = next;
+      next = LoadWord(bitmap_ + 32);
+      total_popcount += BitUtil::PopCount(ShiftWord(current, next, offset_));
+    }
+    bitmap_ += BitUtil::BytesForBits(kFourWordsBits);
+    bits_remaining_ -= kFourWordsBits;
+    return {256, static_cast<int16_t>(total_popcount)};
+  }
 
   /// \brief Return the next run of available bits, usually 64. The returned
   /// pair contains the size of run and the number of true values. The last
   /// block will have a length less than 64 if the bitmap length is not a
   /// multiple of 64, and will return 0-length blocks in subsequent
   /// invocations.
-  BitBlockCount NextWord();
+  BitBlockCount NextWord() {
+    using detail::LoadWord;
+    using detail::ShiftWord;
+
+    if (!bits_remaining_) {
+      return {0, 0};
+    }
+    int64_t popcount = 0;
+    if (offset_ == 0) {
+      if (bits_remaining_ < kWordBits) {
+        return GetBlockSlow(kWordBits);
+      }
+      popcount = BitUtil::PopCount(LoadWord(bitmap_));
+    } else {
+      // When the offset is > 0, we need there to be a word beyond the last
+      // aligned word in the bitmap for the bit shifting logic.
+      if (bits_remaining_ < 2 * kWordBits - offset_) {
+        return GetBlockSlow(kWordBits);
+      }
+      popcount =
+          BitUtil::PopCount(ShiftWord(LoadWord(bitmap_), LoadWord(bitmap_ + 8), offset_));
+    }
+    bitmap_ += kWordBits / 8;
+    bits_remaining_ -= kWordBits;
+    return {64, static_cast<int16_t>(popcount)};
+  }
 
  private:
   /// \brief Return block with the requested size when doing word-wise
   /// computation is not possible due to inadequate bits remaining.
-  BitBlockCount GetBlockSlow(int64_t block_size);
+  BitBlockCount GetBlockSlow(int64_t block_size) noexcept;
 
   const uint8_t* bitmap_;
   int64_t bits_remaining_;
@@ -188,17 +263,63 @@ class ARROW_EXPORT BinaryBitBlockCounter {
   /// the number of true values. The last block will have a length less than 64
   /// if the bitmap length is not a multiple of 64, and will return 0-length
   /// blocks in subsequent invocations.
-  BitBlockCount NextAndWord();
+  BitBlockCount NextAndWord() { return NextWord<detail::BitBlockAnd>(); }
 
   /// \brief Computes "x | y" block for each available run of bits.
-  BitBlockCount NextOrWord();
+  BitBlockCount NextOrWord() { return NextWord<detail::BitBlockOr>(); }
 
   /// \brief Computes "x | ~y" block for each available run of bits.
-  BitBlockCount NextOrNotWord();
+  BitBlockCount NextOrNotWord() { return NextWord<detail::BitBlockOrNot>(); }
 
  private:
   template <template <typename T> class Op>
-  BitBlockCount NextWord();
+  inline BitBlockCount NextWord() {
+    using detail::LoadWord;
+    using detail::ShiftWord;
+
+    if (!bits_remaining_) {
+      return {0, 0};
+    }
+    // When the offset is > 0, we need there to be a word beyond the last aligned
+    // word in the bitmap for the bit shifting logic.
+    constexpr int64_t kWordBits = BitBlockCounter::kWordBits;
+    const int64_t bits_required_to_use_words =
+        std::max(left_offset_ == 0 ? 64 : 64 + (64 - left_offset_),
+                 right_offset_ == 0 ? 64 : 64 + (64 - right_offset_));
+    if (bits_remaining_ < bits_required_to_use_words) {
+      const int16_t run_length =
+          static_cast<int16_t>(std::min(bits_remaining_, kWordBits));
+      int16_t popcount = 0;
+      for (int64_t i = 0; i < run_length; ++i) {
+        if (Op<bool>::Call(BitUtil::GetBit(left_bitmap_, left_offset_ + i),
+                           BitUtil::GetBit(right_bitmap_, right_offset_ + i))) {
+          ++popcount;
+        }
+      }
+      // This code path should trigger _at most_ 2 times. In the "two times"
+      // case, the first time the run length will be a multiple of 8.
+      left_bitmap_ += run_length / 8;
+      right_bitmap_ += run_length / 8;
+      bits_remaining_ -= run_length;
+      return {run_length, popcount};
+    }
+
+    int64_t popcount = 0;
+    if (left_offset_ == 0 && right_offset_ == 0) {
+      popcount = BitUtil::PopCount(
+          Op<uint64_t>::Call(LoadWord(left_bitmap_), LoadWord(right_bitmap_)));
+    } else {
+      auto left_word =
+          ShiftWord(LoadWord(left_bitmap_), LoadWord(left_bitmap_ + 8), left_offset_);
+      auto right_word =
+          ShiftWord(LoadWord(right_bitmap_), LoadWord(right_bitmap_ + 8), right_offset_);
+      popcount = BitUtil::PopCount(Op<uint64_t>::Call(left_word, right_word));
+    }
+    left_bitmap_ += kWordBits / 8;
+    right_bitmap_ += kWordBits / 8;
+    bits_remaining_ -= kWordBits;
+    return {64, static_cast<int16_t>(popcount)};
+  }
 
   const uint8_t* left_bitmap_;
   int64_t left_offset_;
@@ -292,9 +413,10 @@ class ARROW_EXPORT OptionalBinaryBitBlockCounter {
 // Functional-style bit block visitors.
 
 template <typename VisitNotNull, typename VisitNull>
-Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offset,
-                      int64_t length, VisitNotNull&& visit_not_null,
-                      VisitNull&& visit_null) {
+static inline Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf,
+                                    int64_t offset, int64_t length,
+                                    VisitNotNull&& visit_not_null,
+                                    VisitNull&& visit_null) {
   const uint8_t* bitmap = NULLPTR;
   if (bitmap_buf != NULLPTR) {
     bitmap = bitmap_buf->data();
@@ -325,9 +447,10 @@ Status VisitBitBlocks(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offset,
 }
 
 template <typename VisitNotNull, typename VisitNull>
-void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offset,
-                        int64_t length, VisitNotNull&& visit_not_null,
-                        VisitNull&& visit_null) {
+static inline void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf,
+                                      int64_t offset, int64_t length,
+                                      VisitNotNull&& visit_not_null,
+                                      VisitNull&& visit_null) {
   const uint8_t* bitmap = NULLPTR;
   if (bitmap_buf != NULLPTR) {
     bitmap = bitmap_buf->data();
@@ -357,11 +480,12 @@ void VisitBitBlocksVoid(const std::shared_ptr<Buffer>& bitmap_buf, int64_t offse
 }
 
 template <typename VisitNotNull, typename VisitNull>
-void VisitTwoBitBlocksVoid(const std::shared_ptr<Buffer>& left_bitmap_buf,
-                           int64_t left_offset,
-                           const std::shared_ptr<Buffer>& right_bitmap_buf,
-                           int64_t right_offset, int64_t length,
-                           VisitNotNull&& visit_not_null, VisitNull&& visit_null) {
+static inline void VisitTwoBitBlocksVoid(const std::shared_ptr<Buffer>& left_bitmap_buf,
+                                         int64_t left_offset,
+                                         const std::shared_ptr<Buffer>& right_bitmap_buf,
+                                         int64_t right_offset, int64_t length,
+                                         VisitNotNull&& visit_not_null,
+                                         VisitNull&& visit_null) {
   if (left_bitmap_buf == NULLPTR || right_bitmap_buf == NULLPTR) {
     // At most one bitmap is present
     if (left_bitmap_buf == NULLPTR) {

--- a/cpp/src/arrow/util/bit_util_benchmark.cc
+++ b/cpp/src/arrow/util/bit_util_benchmark.cc
@@ -106,7 +106,7 @@ class NaiveBitmapWriter {
 static std::shared_ptr<Buffer> CreateRandomBuffer(int64_t nbytes) {
   auto buffer = *AllocateBuffer(nbytes);
   memset(buffer->mutable_data(), 0, nbytes);
-  random_bytes(nbytes, 0, buffer->mutable_data());
+  random_bytes(nbytes, /*seed=*/0, buffer->mutable_data());
   return std::move(buffer);
 }
 

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -26,6 +26,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
@@ -488,60 +489,22 @@ static Status CheckIndexBoundsImpl(const ArrayData& indices, uint64_t upper_limi
     return ((IsSigned && val < 0) ||
             (val >= 0 && static_cast<uint64_t>(val) >= upper_limit));
   };
-  auto IsOutOfBoundsMaybeNull = [&](IndexCType val, bool is_valid) -> bool {
-    return is_valid && ((IsSigned && val < 0) ||
-                        (val >= 0 && static_cast<uint64_t>(val) >= upper_limit));
-  };
-  OptionalBitBlockCounter indices_bit_counter(bitmap, indices.offset, indices.length);
-  int64_t position = 0;
-  int64_t offset_position = indices.offset;
-  while (position < indices.length) {
-    BitBlockCount block = indices_bit_counter.NextBlock();
-    bool block_out_of_bounds = false;
-    if (block.popcount == block.length) {
-      // Fast path: branchless
-      for (int64_t i = 0; i < block.length; ++i) {
-        block_out_of_bounds |= IsOutOfBounds(indices_data[i]);
-      }
-    } else if (block.popcount > 0) {
-      // Indices have nulls, must only boundscheck non-null values
-      int64_t i = 0;
-      for (int64_t chunk = 0; chunk < block.length / 8; ++chunk) {
-        // Let the compiler unroll this
-        for (int j = 0; j < 8; ++j) {
-          block_out_of_bounds |= IsOutOfBoundsMaybeNull(
-              indices_data[i], BitUtil::GetBit(bitmap, offset_position + i));
-          ++i;
+  return VisitSetBitRuns(
+      bitmap, indices.offset, indices.length, [&](int64_t offset, int64_t length) {
+        bool block_out_of_bounds = false;
+        for (int64_t i = 0; i < length; ++i) {
+          block_out_of_bounds |= IsOutOfBounds(indices_data[offset + i]);
         }
-      }
-      for (; i < block.length; ++i) {
-        block_out_of_bounds |= IsOutOfBoundsMaybeNull(
-            indices_data[i], BitUtil::GetBit(bitmap, offset_position + i));
-      }
-    }
-    if (ARROW_PREDICT_FALSE(block_out_of_bounds)) {
-      if (indices.GetNullCount() > 0) {
-        for (int64_t i = 0; i < block.length; ++i) {
-          if (IsOutOfBoundsMaybeNull(indices_data[i],
-                                     BitUtil::GetBit(bitmap, offset_position + i))) {
-            return Status::IndexError("Index ", FormatInt(indices_data[i]),
-                                      " out of bounds");
+        if (ARROW_PREDICT_FALSE(block_out_of_bounds)) {
+          for (int64_t i = 0; i < length; ++i) {
+            if (IsOutOfBounds(indices_data[offset + i])) {
+              return Status::IndexError("Index ", FormatInt(indices_data[offset + i]),
+                                        " out of bounds");
+            }
           }
         }
-      } else {
-        for (int64_t i = 0; i < block.length; ++i) {
-          if (IsOutOfBounds(indices_data[i])) {
-            return Status::IndexError("Index ", FormatInt(indices_data[i]),
-                                      " out of bounds");
-          }
-        }
-      }
-    }
-    indices_data += block.length;
-    position += block.length;
-    offset_position += block.length;
-  }
-  return Status::OK();
+        return Status::OK();
+      });
 }
 
 /// \brief Branchless boundschecking of the indices. Processes batches of

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -31,6 +31,7 @@
 #include "arrow/array.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
 
 using arrow::ArrayFromVector;
 using arrow::Field;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -30,6 +30,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
@@ -68,6 +69,8 @@ using arrow::internal::Iota;
 using ParquetReader = parquet::ParquetFileReader;
 
 using parquet::internal::RecordReader;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 namespace arrow {

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -38,6 +38,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/base64.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/int_util_internal.h"
 #include "arrow/util/logging.h"
@@ -86,6 +87,8 @@ using parquet::schema::GroupNode;
 using parquet::schema::Node;
 using parquet::schema::PrimitiveNode;
 using ParquetType = parquet::Type;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 namespace arrow {

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -31,6 +31,7 @@
 
 #include "arrow/array.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/io/memory.h"
 #include "arrow/table.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/bitmap_ops.h"

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "arrow/extension_type.h"
+#include "arrow/io/memory.h"
 #include "arrow/ipc/api.h"
 #include "arrow/result_internal.h"
 #include "arrow/type.h"

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -32,6 +32,7 @@
 #include "arrow/type.h"
 #include "arrow/util/base64.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
 #include "arrow/visitor_inline.h"

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "arrow/result.h"
 #include "arrow/util/logging.h"
 #include "parquet/bloom_filter.h"
 #include "parquet/exception.h"
@@ -38,7 +39,7 @@ void BlockSplitBloomFilter::Init(uint32_t num_bytes) {
 
   // Get next power of 2 if it is not power of 2.
   if ((num_bytes & (num_bytes - 1)) != 0) {
-    num_bytes = static_cast<uint32_t>(BitUtil::NextPower2(num_bytes));
+    num_bytes = static_cast<uint32_t>(::arrow::BitUtil::NextPower2(num_bytes));
   }
 
   if (num_bytes > kMaximumBloomFilterBytes) {

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
 #include "parquet/hasher.h"
 #include "parquet/platform.h"

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -35,6 +35,7 @@
 #include "arrow/chunked_array.h"
 #include "arrow/type.h"
 #include "arrow/util/bit_stream_utils.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/int_util_internal.h"
@@ -56,6 +57,8 @@ using arrow::MemoryPool;
 using arrow::internal::AddWithOverflow;
 using arrow::internal::checked_cast;
 using arrow::internal::MultiplyWithOverflow;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 namespace {

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -29,10 +29,12 @@
 #include "arrow/array.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/compute/api.h"
+#include "arrow/io/memory.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_stream_utils.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
@@ -61,6 +63,8 @@ using arrow::BitUtil::BitWriter;
 using arrow::internal::checked_cast;
 using arrow::internal::checked_pointer_cast;
 using arrow::util::RleEncoder;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/io/buffered.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_builders.h"
 
 #include "parquet/column_reader.h"
@@ -34,6 +35,8 @@
 #include "parquet/test_util.h"
 #include "parquet/thrift_internal.h"
 #include "parquet/types.h"
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 

--- a/cpp/src/parquet/deprecated_io.cc
+++ b/cpp/src/parquet/deprecated_io.cc
@@ -20,6 +20,8 @@
 #include <cstdint>
 #include <utility>
 
+#include "arrow/result.h"
+
 #include "parquet/exception.h"
 
 namespace parquet {

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -32,7 +32,9 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_stream_utils.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/bitmap_writer.h"
 #include "arrow/util/byte_stream_split.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hashing.h"
@@ -45,6 +47,8 @@
 #include "parquet/platform.h"
 #include "parquet/schema.h"
 #include "parquet/types.h"
+
+namespace BitUtil = arrow::BitUtil;
 
 using arrow::Status;
 using arrow::VisitNullBitmapInline;

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -31,6 +31,7 @@
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_writer.h"
 #include "arrow/util/checked_cast.h"
 
 #include "parquet/encoding.h"
@@ -42,6 +43,8 @@
 using arrow::default_memory_pool;
 using arrow::MemoryPool;
 using arrow::internal::checked_cast;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -27,6 +27,7 @@
 
 #include "arrow/io/caching.h"
 #include "arrow/io/file.h"
+#include "arrow/io/memory.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"

--- a/cpp/src/parquet/level_conversion_inc.h
+++ b/cpp/src/parquet/level_conversion_inc.h
@@ -24,6 +24,7 @@
 
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_writer.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/simd.h"
 #include "parquet/exception.h"

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/io/memory.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string_view.h"
 #include "parquet/encryption_internal.h"

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "arrow/util/key_value_metadata.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
 #include "parquet/schema.h"

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/util/key_value_metadata.h"
 #include "parquet/schema.h"
 #include "parquet/statistics.h"
 #include "parquet/thrift_internal.h"

--- a/cpp/src/parquet/platform.h
+++ b/cpp/src/parquet/platform.h
@@ -20,16 +20,11 @@
 #include <cstdint>
 #include <memory>
 
-#include "arrow/buffer.h"              // IWYU pragma: export
-#include "arrow/io/interfaces.h"       // IWYU pragma: export
-#include "arrow/io/memory.h"           // IWYU pragma: export
-#include "arrow/memory_pool.h"         // IWYU pragma: export
-#include "arrow/status.h"              // IWYU pragma: export
-#include "arrow/util/bit_util.h"       // IWYU pragma: export
-#include "arrow/util/bitmap_writer.h"  // IWYU pragma: export
-#include "arrow/util/compression.h"    // IWYU pragma: export
-#include "arrow/util/macros.h"         // IWYU pragma: export
-#include "arrow/util/string_view.h"    // IWYU pragma: export
+#include "arrow/buffer.h"         // IWYU pragma: export
+#include "arrow/io/interfaces.h"  // IWYU pragma: export
+#include "arrow/status.h"         // IWYU pragma: export
+#include "arrow/type_fwd.h"       // IWYU pragma: export
+#include "arrow/util/macros.h"    // IWYU pragma: export
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 
@@ -90,8 +85,6 @@
 
 namespace parquet {
 
-namespace BitUtil = ::arrow::BitUtil;
-
 using Buffer = ::arrow::Buffer;
 using Codec = ::arrow::util::Codec;
 using Compression = ::arrow::Compression;
@@ -102,7 +95,6 @@ using ResizableBuffer = ::arrow::ResizableBuffer;
 using ArrowInputFile = ::arrow::io::RandomAccessFile;
 using ArrowInputStream = ::arrow::io::InputStream;
 using ArrowOutputStream = ::arrow::io::OutputStream;
-using string_view = ::arrow::util::string_view;
 
 constexpr int64_t kDefaultOutputStreamSize = 1024;
 

--- a/cpp/src/parquet/properties.cc
+++ b/cpp/src/parquet/properties.cc
@@ -21,6 +21,7 @@
 #include "parquet/properties.h"
 
 #include "arrow/io/buffered.h"
+#include "arrow/io/memory.h"
 #include "arrow/util/logging.h"
 
 namespace parquet {

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -28,6 +28,7 @@
 
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 
 #include "parquet/column_reader.h"
@@ -43,6 +44,8 @@
 
 using arrow::default_memory_pool;
 using arrow::MemoryPool;
+
+namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "arrow/io/file.h"
+#include "arrow/io/memory.h"
 #include "parquet/exception.h"
 
 namespace parquet {

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -31,6 +31,7 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/io/memory.h"
 #include "arrow/testing/util.h"
 
 #include "parquet/column_page.h"

--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "arrow/util/bit_util.h"
 #include "parquet/types.h"
 
 namespace parquet {


### PR DESCRIPTION
* Fix parquet-column-io-benchmark to actually enable compression

* Decrease runtime of set lookup benchmarks

* Inline more BitBlockCounter methods

* Improve RecordBatch and Table filter performance for common cases where no nulls have to be emitted

* Remove some header inclusions from Parquet headers

* Improve performance of CheckIndexBounds

* Reduce number of tensor conversion benchmarks
