### PR TITLE
ARROW-11561: [Rust][DataFusion] Add Send + Sync to MemTable::load

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -142,12 +142,9 @@ async fn benchmark(opt: BenchmarkOpt) -> Result<Vec<arrow::record_batch::RecordB
             println!("Loading table '{}' into memory", table);
             let start = Instant::now();
 
-            let memtable = MemTable::load(
-                table_provider.as_ref(),
-                opt.batch_size,
-                Some(opt.partitions),
-            )
-            .await?;
+            let memtable =
+                MemTable::load(table_provider, opt.batch_size, Some(opt.partitions))
+                    .await?;
             println!(
                 "Loaded table '{}' into memory in {} ms",
                 table,

--- a/rust/datafusion/benches/sort_limit_query_sql.rs
+++ b/rust/datafusion/benches/sort_limit_query_sql.rs
@@ -74,7 +74,7 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
     let partitions = 16;
 
     rt.block_on(async {
-        let mem_table = MemTable::load(&csv, 16 * 1024, Some(partitions))
+        let mem_table = MemTable::load(Box::new(csv), 16 * 1024, Some(partitions))
             .await
             .unwrap();
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -107,7 +107,7 @@ impl MemTable {
 
     /// Create a mem table by reading from another data source
     pub async fn load(
-        t: &dyn TableProvider,
+        t: Box<dyn TableProvider + Send + Sync>,
         batch_size: usize,
         output_partitions: Option<usize>,
     ) -> Result<Self> {


### PR DESCRIPTION
This PR adds Send + Sync to the MemTable::load method to allow implementation of a `persist` method like Spark's Dataframe in an async function.