### PR TITLE
ARROW-11572: [Rust] Add a kernel for division by single scalar

### DIFF
--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -58,6 +58,11 @@ fn bench_divide(arr_a: &ArrayRef, arr_b: &ArrayRef) {
     criterion::black_box(divide(&arr_a, &arr_b).unwrap());
 }
 
+fn bench_divide_scalar(array: &ArrayRef, divisor: f32) {
+    let array = array.as_any().downcast_ref::<Float32Array>().unwrap();
+    criterion::black_box(divide_scalar(&array, divisor).unwrap());
+}
+
 fn bench_limit(arr_a: &ArrayRef, max: usize) {
     criterion::black_box(limit(arr_a, max));
 }
@@ -65,6 +70,7 @@ fn bench_limit(arr_a: &ArrayRef, max: usize) {
 fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_array(512, false);
     let arr_b = create_array(512, false);
+    let scalar = 1.12358;
 
     c.bench_function("add 512", |b| b.iter(|| bench_add(&arr_a, &arr_b)));
     c.bench_function("subtract 512", |b| {
@@ -74,6 +80,9 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_multiply(&arr_a, &arr_b))
     });
     c.bench_function("divide 512", |b| b.iter(|| bench_divide(&arr_a, &arr_b)));
+    c.bench_function("divide_scalar 512", |b| {
+        b.iter(|| bench_divide_scalar(&arr_a, scalar))
+    });
     c.bench_function("limit 512, 512", |b| b.iter(|| bench_limit(&arr_a, 512)));
 
     let arr_a_nulls = create_array(512, false);
@@ -83,6 +92,9 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("divide_nulls_512", |b| {
         b.iter(|| bench_divide(&arr_a_nulls, &arr_b_nulls))
+    });
+    c.bench_function("divide_scalar_nulls_512", |b| {
+        b.iter(|| bench_divide_scalar(&arr_a_nulls, scalar))
     });
 }
 

--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -18,15 +18,16 @@
 #[macro_use]
 extern crate criterion;
 use criterion::Criterion;
+use rand::Rng;
 
 use std::sync::Arc;
 
 extern crate arrow;
 
-use arrow::compute::kernels::arithmetic::*;
 use arrow::compute::kernels::limit::*;
 use arrow::util::bench_util::*;
 use arrow::{array::*, datatypes::Float32Type};
+use arrow::{compute::kernels::arithmetic::*, util::test_util::seedable_rng};
 
 fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
     let null_density = if with_nulls { 0.5 } else { 0.0 };
@@ -70,7 +71,7 @@ fn bench_limit(arr_a: &ArrayRef, max: usize) {
 fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_array(512, false);
     let arr_b = create_array(512, false);
-    let scalar = 1.12358;
+    let scalar = seedable_rng().gen();
 
     c.bench_function("add 512", |b| b.iter(|| bench_add(&arr_a, &arr_b)));
     c.bench_function("subtract 512", |b| {

--- a/rust/arrow/src/buffer/immutable.rs
+++ b/rust/arrow/src/buffer/immutable.rs
@@ -293,7 +293,7 @@ impl Buffer {
 
     /// Creates a [`Buffer`] from an [`Iterator`] with a trusted (upper) length or errors
     /// if any of the items of the iterator is an error.
-    /// Prefer this to `collect` whenever possible, as it is faster ~60% faster.
+    /// Prefer this to `collect` whenever possible, as it is ~60% faster.
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -462,9 +462,10 @@ where
     Ok(())
 }
 
-/// SIMD vectorized version of `divide`, the divide kernel needs it's own implementation as there
-/// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULL`
-/// slots and padding.
+/// SIMD vectorized version of `divide`.
+///
+/// The divide kernels need their own implementation as there is a need to handle situations
+/// where a divide by `0` occurs.  This is complicated by `NULL` slots and padding.
 #[cfg(simd)]
 fn simd_divide<T>(
     left: &PrimitiveArray<T>,

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -906,6 +906,18 @@ mod tests {
     }
 
     #[test]
+    fn test_primitive_array_divide_scalar() {
+        let a = Int32Array::from(vec![15, 14, 9, 8, 1]);
+        let b = 3;
+        let c = divide_scalar(&a, b).unwrap();
+        assert_eq!(5, c.value(0));
+        assert_eq!(4, c.value(1));
+        assert_eq!(3, c.value(2));
+        assert_eq!(2, c.value(3));
+        assert_eq!(0, c.value(4));
+    }
+
+    #[test]
     fn test_primitive_array_divide_sliced() {
         let a = Int32Array::from(vec![0, 0, 0, 15, 15, 8, 1, 9, 0]);
         let b = Int32Array::from(vec![0, 0, 0, 5, 6, 8, 9, 1, 0]);

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -269,29 +269,14 @@ where
         return Err(ArrowError::DivideByZero);
     }
 
-    let null_bit_buffer = array.data_ref().null_buffer().cloned();
-
-    let buffer = if let Some(b) = &null_bit_buffer {
-        let values = array.values().iter().enumerate().map(|(i, value)| {
-            let is_valid = unsafe { bit_util::get_bit_raw(b.as_ptr(), i) };
-            if is_valid {
-                *value / divisor
-            } else {
-                T::default_value()
-            }
-        });
-        unsafe { Buffer::from_trusted_len_iter(values) }
-    } else {
-        // no value is null
-        let values = array.values().iter().map(|value| *value / divisor);
-        unsafe { Buffer::from_trusted_len_iter(values) }
-    };
+    let values = array.values().iter().map(|value| *value / divisor);
+    let buffer = unsafe { Buffer::from_trusted_len_iter(values) };
 
     let data = ArrayData::new(
         T::DATA_TYPE,
         array.len(),
         None,
-        null_bit_buffer,
+        array.data_ref().null_buffer().cloned(),
         0,
         vec![buffer],
         vec![],
@@ -434,7 +419,6 @@ where
 #[cfg(simd)]
 #[inline]
 fn simd_checked_divide_scalar_remainder<T: ArrowNumericType>(
-    valid_mask: Option<u64>,
     array_chunks: ChunksExact<T::Native>,
     divisor: T::Native,
     result_chunks: ChunksExactMut<T::Native>,
@@ -452,11 +436,8 @@ where
     result_remainder
         .iter_mut()
         .zip(array_remainder.iter())
-        .enumerate()
-        .for_each(|(i, (result_scalar, array_scalar))| {
-            if valid_mask.map(|mask| mask & (1 << i) != 0).unwrap_or(true) {
-                *result_scalar = *array_scalar / divisor;
-            }
+        .for_each(|(result_scalar, array_scalar)| {
+            *result_scalar = *array_scalar / divisor;
         });
 
     Ok(())
@@ -596,84 +577,31 @@ where
         return Err(ArrowError::DivideByZero);
     }
 
-    // Get the bitmap of nulls for the array.
-    let null_bit_buffer = array.data_ref().null_buffer().cloned();
-
     let lanes = T::lanes();
     let buffer_size = array.len() * std::mem::size_of::<T::Native>();
     let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
 
-    match &null_bit_buffer {
-        Some(b) => {
-            // combine_option_bitmap returns a slice or new buffer starting at 0
-            let valid_chunks = b.bit_chunks(0, array.len());
+    let mut result_chunks = result.typed_data_mut().chunks_exact_mut(lanes);
+    let mut array_chunks = array.values().chunks_exact(lanes);
 
-            // process data in chunks of 64 elements since we also get 64 bits of validity information at a time
-            let mut result_chunks = result.typed_data_mut().chunks_exact_mut(64);
-            let mut array_chunks = array.values().chunks_exact(64);
+    result_chunks
+        .borrow_mut()
+        .zip(array_chunks.borrow_mut())
+        .for_each(|(result_slice, array_slice)| {
+            let simd_left = T::load(array_slice);
+            let simd_right = T::init(divisor);
 
-            valid_chunks
-                .iter()
-                .zip(result_chunks.borrow_mut().zip(array_chunks.borrow_mut()))
-                .for_each(|(mut mask, (result_slice, array_slice))| {
-                    // split chunks further into slices corresponding to the vector length
-                    // the compiler is able to unroll this inner loop and remove bounds checks
-                    // since the outer chunk size (64) is always a multiple of the number of lanes
-                    result_slice
-                        .chunks_exact_mut(lanes)
-                        .zip(array_slice.chunks_exact(lanes))
-                        .for_each(|(result_slice, array_slice)| {
-                            let simd_left = T::load(array_slice);
-                            let simd_right = T::init(divisor);
+            let simd_result = T::bin_op(simd_left, simd_right, |a, b| a / b);
+            T::write(simd_result, result_slice);
+        });
 
-                            // We know `divisor` is non-zero, so we can skip `simd_checked_divide()`
-                            // and just do the op.
-                            let simd_result =
-                                T::bin_op(simd_left, simd_right, |a, b| a / b);
-                            T::write(simd_result, result_slice);
-
-                            // skip the shift and avoid overflow for u8 type, which uses 64 lanes.
-                            mask >>= T::lanes() % 64;
-                        })
-                });
-
-            let valid_remainder = valid_chunks.remainder_bits();
-            simd_checked_divide_scalar_remainder::<T>(
-                Some(valid_remainder),
-                array_chunks,
-                divisor,
-                result_chunks,
-            )?;
-        }
-        None => {
-            let mut result_chunks = result.typed_data_mut().chunks_exact_mut(lanes);
-            let mut array_chunks = array.values().chunks_exact(lanes);
-
-            result_chunks
-                .borrow_mut()
-                .zip(array_chunks.borrow_mut())
-                .for_each(|(result_slice, array_slice)| {
-                    let simd_left = T::load(array_slice);
-                    let simd_right = T::init(divisor);
-
-                    let simd_result = T::bin_op(simd_left, simd_right, |a, b| a / b);
-                    T::write(simd_result, result_slice);
-                });
-
-            simd_checked_divide_scalar_remainder::<T>(
-                None,
-                array_chunks,
-                divisor,
-                result_chunks,
-            )?;
-        }
-    }
+    simd_checked_divide_scalar_remainder::<T>(array_chunks, divisor, result_chunks)?;
 
     let data = ArrayData::new(
         T::DATA_TYPE,
         array.len(),
         None,
-        null_bit_buffer,
+        array.data_ref().null_buffer().cloned(),
         0,
         vec![result.into()],
         vec![],

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -839,11 +839,8 @@ mod tests {
         let a = Int32Array::from(vec![15, 14, 9, 8, 1]);
         let b = 3;
         let c = divide_scalar(&a, b).unwrap();
-        assert_eq!(5, c.value(0));
-        assert_eq!(4, c.value(1));
-        assert_eq!(3, c.value(2));
-        assert_eq!(2, c.value(3));
-        assert_eq!(0, c.value(4));
+        let expected = Int32Array::from(vec![5, 4, 3, 2, 0]);
+        assert_eq!(c, expected);
     }
 
     #[test]
@@ -875,6 +872,16 @@ mod tests {
         assert_eq!(0, c.value(3));
         assert_eq!(true, c.is_null(4));
         assert_eq!(true, c.is_null(5));
+    }
+
+    #[test]
+    fn test_primitive_array_divide_scalar_with_nulls() {
+        let a = Int32Array::from(vec![Some(15), None, Some(8), Some(1), Some(9), None]);
+        let b = 3;
+        let c = divide_scalar(&a, b).unwrap();
+        let expected =
+            Int32Array::from(vec![Some(5), None, Some(2), Some(0), Some(3), None]);
+        assert_eq!(c, expected);
     }
 
     #[test]


### PR DESCRIPTION
This PR proposes a `divide_scalar` kernel that divides numeric arrays by a single scalar. 

Benchmarks show ~40-50% gains:
```
# features = []
divide 512              time:   [2.3210 us 2.3345 us 2.3490 us]
divide_scalar 512       time:   [1.4374 us 1.4425 us 1.4485 us] (-38%)
divide_nulls 512        time:   [2.1718 us 2.1799 us 2.1894 us]
divide_scalar_nulls 512 time:   [1.3888 us 1.3959 us 1.4036 us] (-36%)

# features = ["simd"]
divide 512              time:   [1.0221 us 1.0348 us 1.0481 us] 
divide_scalar 512       time:   [468.04 ns 471.36 ns 475.19 ns] (-54%)
divide_nulls 512        time:   [960.20 ns 964.30 ns 969.15 ns]
divide_scalar_nulls 512 time:   [471.33 ns 476.41 ns 482.09 ns] (-51%)
```

The speedups are due to:
- checking for `DivideByZero` only once;
- not having to combine two null bitmaps;
- using `Simd::splat()` to fill the divisor chunks.

Tests are pretty bare right now, if you think this is worth merging I'll write a few more. 