### PR TITLE
ARROW-11571: [CI] Cancel stale Github Actions workflow runs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -24,7 +24,7 @@ on:
     types: ['requested']
 
 jobs:
-  cancel-duplicate-workflow-runs:
+  cancel-stale-workflow-runs:
     name: "Cancel stale workflow runs"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Cancel stale runs
+
+on:
+  workflow_run:
+    # The name of another workflow (whichever one) that always runs on PRs
+    workflows: ['Dev']
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel stale workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      # Unfortunately, we need to define a separate cancellation step for
+      # each workflow where we want to cancel stale runs.
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale C++ runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: cpp.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale C# runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: csharp.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Dev runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: dev.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Go runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: go.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Integration runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: integration.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Java JNI runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: java_jni.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Java runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: java.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale JS runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: js.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Julia runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: julia.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Python runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: python.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale R runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: r.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Ruby runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: ruby.yml
+          skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel stale Rust runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflowFileName: rust.yml
+          skipEventTypes: '["push", "schedule"]'


### PR DESCRIPTION
Github Actions doesn't have a built-in option to cancel stale runs (runs which are superseded by a newer changeset on a given PR), so we need to use a custom-built action https://github.com/potiuk/cancel-workflow-runs .