### PR TITLE
ARROW-11573: [Developer][Archery] Google benchmark now reports run type

### DIFF
--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -67,8 +67,7 @@ class GoogleBenchmarkCommand(Command):
 class GoogleBenchmarkObservation:
     """ Represents one run of a single (google c++) benchmark.
 
-    Observations are found when running with `--benchmark_repetitions`. Sadly,
-    the format mixes values and aggregates, e.g.
+    Aggregates are reported when running with `--repetitions`.
 
     RegressionSumKernel/32768/0                 1 us          1 us  25.8077GB/s
     RegressionSumKernel/32768/0                 1 us          1 us  25.7066GB/s
@@ -78,32 +77,25 @@ class GoogleBenchmarkObservation:
     RegressionSumKernel/32768/0_mean            1 us          1 us  25.6307GB/s
     RegressionSumKernel/32768/0_median          1 us          1 us  25.7066GB/s
     RegressionSumKernel/32768/0_stddev          0 us          0 us  288.046MB/s
-
-    As from benchmark v1.4.1 (2019-04-24), the only way to differentiate an
-    actual run from the aggregates, is to match on the benchmark name. The
-    aggregates will be appended with `_$agg_name`.
-
-    This class encapsulate the logic to separate runs from aggregate . This is
-    hopefully avoided in benchmark's master version with a separate json
-    attribute.
     """
 
-    def __init__(self, name, real_time, cpu_time, time_unit, size=None,
-                 bytes_per_second=None, items_per_second=None, **counters):
+    def __init__(self, name, real_time, cpu_time, time_unit, run_type,
+                 size=None, bytes_per_second=None, items_per_second=None,
+                 **counters):
         self._name = name
         self.real_time = real_time
         self.cpu_time = cpu_time
         self.time_unit = time_unit
+        self.run_type = run_type
         self.size = size
         self.bytes_per_second = bytes_per_second
         self.items_per_second = items_per_second
         self.counters = counters
 
     @property
-    def is_agg(self):
+    def is_aggregate(self):
         """ Indicate if the observation is a run or an aggregate. """
-        suffixes = ["_mean", "_median", "_stddev"]
-        return any(map(lambda x: self._name.endswith(x), suffixes))
+        return self.run_type == "aggregate"
 
     @property
     def is_realtime(self):
@@ -113,7 +105,7 @@ class GoogleBenchmarkObservation:
     @property
     def name(self):
         name = self._name
-        return name.rsplit("_", maxsplit=1)[0] if self.is_agg else name
+        return name.rsplit("_", maxsplit=1)[0] if self.is_aggregate else name
 
     @property
     def time(self):
@@ -153,7 +145,7 @@ class GoogleBenchmark(Benchmark):
         """
         self.name = name
         # exclude google benchmark aggregate artifacts
-        _, runs = partition(lambda b: b.is_agg, runs)
+        _, runs = partition(lambda b: b.is_aggregate, runs)
         self.runs = sorted(runs, key=lambda b: b.value)
         unit = self.runs[0].unit
         less_is_better = not unit.endswith("per_second")

--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -67,7 +67,11 @@ class GoogleBenchmarkCommand(Command):
 class GoogleBenchmarkObservation:
     """ Represents one run of a single (google c++) benchmark.
 
-    Aggregates are reported when running with `--repetitions`.
+    Aggregates are reported by Google Benchmark executables alongside
+    other observations whenever repetitions are specified (with
+    `--benchmark_repetitions` on the bare benchmark, or with the
+    archery option `--repetitions`). Aggregate observations are not
+    included in `GoogleBenchmark.runs`.
 
     RegressionSumKernel/32768/0                 1 us          1 us  25.8077GB/s
     RegressionSumKernel/32768/0                 1 us          1 us  25.7066GB/s

--- a/dev/archery/tests/test_benchmarks.py
+++ b/dev/archery/tests/test_benchmarks.py
@@ -15,8 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
+
 from archery.benchmark.core import Benchmark, median
 from archery.benchmark.compare import BenchmarkComparator
+from archery.benchmark.google import (
+    GoogleBenchmark, GoogleBenchmarkObservation
+)
+from archery.utils.codec import JsonEncoder
 
 
 def test_benchmark_comparator():
@@ -50,3 +56,44 @@ def test_benchmark_median():
         assert False
     except ValueError:
         pass
+
+
+def test_omits_aggregates():
+    name = "AllocateDeallocate<Jemalloc>/size:1048576/real_time"
+    google_aggregate = {
+        "aggregate_name": "mean",
+        "cpu_time": 1757.428694267678,
+        "iterations": 3,
+        "name": "AllocateDeallocate<Jemalloc>/size:1048576/real_time_mean",
+        "real_time": 1849.3869337041162,
+        "repetitions": 0,
+        "run_name": "AllocateDeallocate<Jemalloc>/size:1048576/real_time",
+        "run_type": "aggregate",
+        "threads": 1,
+        "time_unit": "ns",
+    }
+    google_result = {
+        "cpu_time": 1778.6004847419827,
+        "iterations": 352765,
+        "name": name,
+        "real_time": 1835.3137357788837,
+        "repetition_index": 0,
+        "repetitions": 0,
+        "run_name": "AllocateDeallocate<Jemalloc>/size:1048576/real_time",
+        "run_type": "iteration",
+        "threads": 1,
+        "time_unit": "ns",
+    }
+    archery_result = {
+        "name": name,
+        "unit": "ns",
+        "less_is_better": True,
+        "values": [1778.6004847419827],
+    }
+    assert google_aggregate["run_type"] == "aggregate"
+    assert google_result["run_type"] == "iteration"
+    observation1 = GoogleBenchmarkObservation(**google_aggregate)
+    observation2 = GoogleBenchmarkObservation(**google_result)
+    benchmark = GoogleBenchmark(name, [observation1, observation2])
+    result = json.dumps(benchmark, cls=JsonEncoder)
+    assert json.loads(result) == archery_result


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/ARROW-11573

Google Benchmark now reports run type [1], so the following code and comment can be updated.

```
    Observations are found when running with `--benchmark_repetitions`. Sadly,
    the format mixes values and aggregates, e.g.

    RegressionSumKernel/32768/0                 1 us          1 us  25.8077GB/s
    RegressionSumKernel/32768/0                 1 us          1 us  25.7066GB/s
    RegressionSumKernel/32768/0                 1 us          1 us  25.1481GB/s
    RegressionSumKernel/32768/0                 1 us          1 us  25.846GB/s
    RegressionSumKernel/32768/0                 1 us          1 us  25.6453GB/s
    RegressionSumKernel/32768/0_mean            1 us          1 us  25.6307GB/s
    RegressionSumKernel/32768/0_median          1 us          1 us  25.7066GB/s
    RegressionSumKernel/32768/0_stddev          0 us          0 us  288.046MB/s

    As from benchmark v1.4.1 (2019-04-24), the only way to differentiate an
    actual run from the aggregates, is to match on the benchmark name. The
    aggregates will be appended with `_$agg_name`.

    This class encapsulate the logic to separate runs from aggregate . This is
    hopefully avoided in benchmark's master version with a separate json
    attribute.
```

```
    @property
    def is_agg(self):
        """ Indicate if the observation is a run or an aggregate. """
        suffixes = ["_mean", "_median", "_stddev"]
        return any(map(lambda x: self._name.endswith(x), suffixes))
```


Here's example output (note the aggregate vs the actual observation):

```
 {'aggregate_name': 'mean',
  'cpu_time': 9818703.124999983,
  'items_per_second': 26700744.55186333,
  'iterations': 3,
  'name': 'TakeStringRandomIndicesWithNulls/262144/0_mean',
  'null_percent': 0.0,
  'real_time': 10138621.349445505,
  'repetitions': 0,
  'run_name': 'TakeStringRandomIndicesWithNulls/262144/0',
  'run_type': 'aggregate',
  'size': 262144.0,
  'threads': 1,
  'time_unit': 'ns'},
 {'cpu_time': 9718937.499999996,
  'items_per_second': 26972495.707478322,
  'iterations': 64,
  'name': 'TakeStringRandomIndicesWithNulls/262144/0',
  'null_percent': 0.0,
  'real_time': 10297947.859726265,
  'repetition_index': 2,
  'repetitions': 0,
  'run_name': 'TakeStringRandomIndicesWithNulls/262144/0',
  'run_type': 'iteration',
  'size': 262144.0,
  'threads': 1,
  'time_unit': 'ns'},
```

[1] https://github.com/google/benchmark/commit/8688c5c4cfa1527ceca2136b2a738d9712a01890

