### PR TITLE
ARROW-11576: [Rust] Fix unused variable in Rust code example

### DIFF
--- a/rust/parquet/src/file/mod.rs
+++ b/rust/parquet/src/file/mod.rs
@@ -67,7 +67,6 @@
 //!
 //! let path = Path::new("/path/to/sample.parquet");
 //! if let Ok(file) = File::open(&path) {
-//!     let file = File::open(&path).unwrap();
 //!     let reader = SerializedFileReader::new(file).unwrap();
 //!
 //!     let parquet_metadata = reader.metadata();


### PR DESCRIPTION
Port of https://github.com/apache/arrow/pull/9308 from @Joey9801 -- that PR got messed up with all the rebasing nonsense that happened as part of the 3.0.0 release. 