### PR TITLE
ARROW-11577: [Rust] Fix Array transform on strings

### DIFF
--- a/rust/arrow/src/array/transform/variable_size.rs
+++ b/rust/arrow/src/array/transform/variable_size.rs
@@ -41,7 +41,7 @@ fn extend_offset_values<T: OffsetSizeTrait>(
 
 pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
     let offsets = array.buffer::<T>(0);
-    let values = &array.buffers()[1].as_slice()[array.offset()..];
+    let values = array.buffers()[1].as_slice();
     if array.null_count() == 0 {
         // fast case where we can copy regions without null issues
         Box::new(
@@ -78,12 +78,10 @@ pub(super) fn build_extend<T: OffsetSizeTrait>(array: &ArrayData) -> Extend {
                         // compute the new offset
                         let length = offsets[i + 1] - offsets[i];
                         last_offset += length;
-                        let length = length.to_usize().unwrap();
 
                         // append value
-                        let start = offsets[i].to_usize().unwrap()
-                            - offsets[0].to_usize().unwrap();
-                        let bytes = &values[start..(start + length)];
+                        let bytes = &values[offsets[i].to_usize().unwrap()
+                            ..offsets[i + 1].to_usize().unwrap()];
                         values_buffer.extend_from_slice(bytes);
                     }
                     // offsets are always present

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -390,4 +390,35 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_string_array_slices() -> Result<()> {
+        let input_1 = StringArray::from(vec!["hello", "A", "B", "C"]);
+        let input_2 = StringArray::from(vec!["world", "D", "E", "Z"]);
+
+        let arr = concat(&[input_1.slice(1, 3).as_ref(), input_2.slice(1, 2).as_ref()])?;
+
+        let expected_output = StringArray::from(vec!["A", "B", "C", "D", "E"]);
+
+        let actual_output = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(actual_output, &expected_output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_array_with_null_slices() -> Result<()> {
+        let input_1 = StringArray::from(vec![Some("hello"), None, Some("A"), Some("C")]);
+        let input_2 = StringArray::from(vec![None, Some("world"), Some("D"), None]);
+
+        let arr = concat(&[input_1.slice(1, 3).as_ref(), input_2.slice(1, 2).as_ref()])?;
+
+        let expected_output =
+            StringArray::from(vec![None, Some("A"), Some("C"), Some("world"), Some("D")]);
+
+        let actual_output = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(actual_output, &expected_output);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Specifically, this fixes a bug found when applying `concat` to slices of
input `StringArray`.