### PR TITLE
ARROW-11379: [C++][Dataset] Better formatting for timestamp scalars

### DIFF
--- a/cpp/src/arrow/dataset/expression_test.cc
+++ b/cpp/src/arrow/dataset/expression_test.cc
@@ -160,7 +160,7 @@ TEST(Expression, ToString) {
             "\"617A\"");
 
   auto ts = *MakeScalar("1990-10-23 10:23:33")->CastTo(timestamp(TimeUnit::NANO));
-  EXPECT_EQ(literal(ts).ToString(), "656677413000000000");
+  EXPECT_EQ(literal(ts).ToString(), "1990-10-23 10:23:33.000000000");
 
   EXPECT_EQ(call("add", {literal(3), field_ref("beta")}).ToString(), "add(3, beta)");
 

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -516,20 +516,6 @@ Status CastImpl(const DateScalar<D>& from, TimestampScalar* to) {
       .Value(&to->value);
 }
 
-// timestamp to string
-Status CastImpl(const TimestampScalar& from, StringScalar* to) {
-  to->value = FormatToBuffer(internal::StringFormatter<Int64Type>{}, from);
-  return Status::OK();
-}
-
-// date to string
-template <typename D>
-Status CastImpl(const DateScalar<D>& from, StringScalar* to) {
-  TimestampScalar ts({}, timestamp(TimeUnit::MILLI));
-  RETURN_NOT_OK(CastImpl(from, &ts));
-  return CastImpl(ts, to);
-}
-
 // string to any
 template <typename ScalarType>
 Status CastImpl(const StringScalar& from, ScalarType* to) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -660,7 +660,7 @@ TEST(TestTimestampScalars, Cast) {
 
   ASSERT_OK_AND_ASSIGN(auto str,
                        TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(utf8()));
-  EXPECT_EQ(*str, StringScalar("1024"));
+  EXPECT_EQ(*str, StringScalar("1970-01-01 00:00:01.024"));
   ASSERT_OK_AND_ASSIGN(auto i64,
                        TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(int64()));
   EXPECT_EQ(*i64, Int64Scalar(1024));

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1805,7 +1805,6 @@ def test_open_dataset_from_fsspec(tempdir):
 @pytest.mark.pandas
 def test_filter_timestamp(tempdir):
     # ARROW-11379
-    import pyarrow.parquet as pq
     path = tempdir / "test_partition_timestamps"
 
     table = pa.table({

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1802,6 +1802,7 @@ def test_open_dataset_from_fsspec(tempdir):
     assert dataset.schema.equals(table.schema)
 
 
+@pytest.mark.pandas
 def test_filter_timestamp(tempdir):
     # ARROW-11379
     import pyarrow.parquet as pq
@@ -1821,6 +1822,11 @@ def test_filter_timestamp(tempdir):
     dataset = ds.dataset(path, format="feather", partitioning=part)
 
     condition = ds.field("dates") > pd.Timestamp("2012-01-01")
+    table = dataset.to_table(filter=condition)
+    assert table.column('id').to_pylist() == [1, 3, 5, 7, 9]
+
+    import datetime
+    condition = ds.field("dates") > datetime.datetime(2012, 1, 1)
     table = dataset.to_table(filter=condition)
     assert table.column('id').to_pylist() == [1, 3, 5, 7, 9]
 


### PR DESCRIPTION
The bug listed in ARROW-11379 was fixed in ARROW-8919, so I've added a test and better formatting for temporal scalars so that filters on timestamps are clearer:

```python
In [1]: ds.field("dates") > pd.Timestamp("2012-01-01")
Out[1]: <pyarrow.dataset.Expression (dates > 2012-01-01 00:00:00.000000)>
```