### PR TITLE
ARROW-11594: [Rust] Support pretty printing of  NullArray

### DIFF
--- a/rust/arrow/src/util/display.rs
+++ b/rust/arrow/src/util/display.rs
@@ -197,6 +197,9 @@ macro_rules! make_string_from_list {
 /// Note this function is quite inefficient and is unlikely to be
 /// suitable for converting large arrays or record batches.
 pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<String> {
+    if column.is_null(row) {
+        return Ok("".to_string());
+    }
     match column.data_type() {
         DataType::Utf8 => make_string!(array::StringArray, column, row),
         DataType::LargeUtf8 => make_string!(array::LargeStringArray, column, row),


### PR DESCRIPTION
As pointed out by @tustvold  on https://github.com/influxdata/influxdb_iox/pull/783#discussion_r574414243, it would seem the whole point of `NullArray::new_with_type`, is to cheaply construct entirely null columns, with a smaller memory footprint.

Currently trying to print them out causes a panic:

```
    #[test]
    fn test_pretty_format_null() -> Result<()> {
        // define a schema.
        let schema = Arc::new(Schema::new(vec![
            Field::new("a", DataType::Utf8, true),
            Field::new("b", DataType::Int32, true),
        ]));

        let num_rows = 4;

        // define data (null)
        let batch = RecordBatch::try_new(
            schema,
            vec![
                Arc::new(NullArray::new_with_type(num_rows, DataType::Utf8)),
                Arc::new(NullArray::new_with_type(num_rows, DataType::Int32)),
            ],
        )?;

        let table = pretty_format_batches(&[batch])?;
}

```

Panics:

```
failures:

---- util::pretty::tests::test_pretty_format_null stdout ----
thread 'util::pretty::tests::test_pretty_format_null' panicked at 'called `Option::unwrap()` on a `None` value', arrow/src/util/display.rs:201:27
```

# Note

_Update: the issue with  `NullArray` claiming to be types such as  `Int32` has been fixed by @nevi-me  in https://github.com/apache/arrow/pull/9469 _