### PR TITLE
ARROW-11601: [C++][Python][Dataset] expose Parquet pre-buffer option

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -18,6 +18,7 @@
 #include "arrow/dataset/file_parquet.h"
 
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -54,12 +55,20 @@ class ParquetScanTask : public ScanTask {
  public:
   ParquetScanTask(int row_group, std::vector<int> column_projection,
                   std::shared_ptr<parquet::arrow::FileReader> reader,
+                  std::shared_ptr<std::once_flag> pre_buffer_once,
+                  std::vector<int> pre_buffer_row_groups,
+                  arrow::io::AsyncContext async_context,
+                  arrow::io::CacheOptions cache_options,
                   std::shared_ptr<ScanOptions> options,
                   std::shared_ptr<ScanContext> context)
       : ScanTask(std::move(options), std::move(context)),
         row_group_(row_group),
         column_projection_(std::move(column_projection)),
-        reader_(std::move(reader)) {}
+        reader_(std::move(reader)),
+        pre_buffer_once_(std::move(pre_buffer_once)),
+        pre_buffer_row_groups_(std::move(pre_buffer_row_groups)),
+        async_context_(async_context),
+        cache_options_(cache_options) {}
 
   Result<RecordBatchIterator> Execute() override {
     // The construction of parquet's RecordBatchReader is deferred here to
@@ -79,16 +88,41 @@ class ParquetScanTask : public ScanTask {
       std::unique_ptr<RecordBatchReader> record_batch_reader;
     } NextBatch;
 
+    RETURN_NOT_OK(EnsurePreBuffered());
     NextBatch.file_reader = reader_;
     RETURN_NOT_OK(reader_->GetRecordBatchReader({row_group_}, column_projection_,
                                                 &NextBatch.record_batch_reader));
     return MakeFunctionIterator(std::move(NextBatch));
   }
 
+  // Ensure that pre-buffering has been applied to the underlying Parquet reader
+  // exactly once (if needed). If we instead set pre_buffer on in the Arrow
+  // reader properties, each scan task will try to separately pre-buffer, which
+  // will lead to crashes as they trample the Parquet file reader's internal
+  // state. Instead, pre-buffer once at the file level. This also has the
+  // advantage that we can coalesce reads across row groups.
+  Status EnsurePreBuffered() {
+    if (pre_buffer_once_) {
+      BEGIN_PARQUET_CATCH_EXCEPTIONS
+      std::call_once(*pre_buffer_once_, [this]() {
+        reader_->parquet_reader()->PreBuffer(pre_buffer_row_groups_, column_projection_,
+                                             async_context_, cache_options_);
+      });
+      END_PARQUET_CATCH_EXCEPTIONS
+    }
+    return Status::OK();
+  }
+
  private:
   int row_group_;
   std::vector<int> column_projection_;
   std::shared_ptr<parquet::arrow::FileReader> reader_;
+  // Pre-buffering state. pre_buffer_once will be nullptr if no pre-buffering is
+  // to be done. We assume all scan tasks have the same column projection.
+  std::shared_ptr<std::once_flag> pre_buffer_once_;
+  std::vector<int> pre_buffer_row_groups_;
+  arrow::io::AsyncContext async_context_;
+  arrow::io::CacheOptions cache_options_;
 };
 
 static parquet::ReaderProperties MakeReaderProperties(
@@ -110,11 +144,6 @@ static parquet::ArrowReaderProperties MakeArrowReaderProperties(
   for (const std::string& name : format.reader_options.dict_columns) {
     auto column_index = metadata.schema()->ColumnIndex(name);
     properties.set_read_dictionary(column_index, true);
-  }
-  if (format.reader_options.pre_buffer) {
-    properties.set_pre_buffer(true);
-    properties.set_async_context(format.reader_options.async_context);
-    properties.set_cache_options(format.reader_options.cache_options);
   }
   return properties;
 }
@@ -325,9 +354,15 @@ Result<ScanTaskIterator> ParquetFileFormat::ScanFile(std::shared_ptr<ScanOptions
   auto column_projection = InferColumnProjection(*reader, *options);
   ScanTaskVector tasks(row_groups.size());
 
+  std::shared_ptr<std::once_flag> pre_buffer_once = nullptr;
+  if (reader_options.pre_buffer) {
+    pre_buffer_once = std::make_shared<std::once_flag>();
+  }
+
   for (size_t i = 0; i < row_groups.size(); ++i) {
-    tasks[i] = std::make_shared<ParquetScanTask>(row_groups[i], column_projection, reader,
-                                                 options, context);
+    tasks[i] = std::make_shared<ParquetScanTask>(
+        row_groups[i], column_projection, reader, pre_buffer_once, row_groups,
+        reader_options.async_context, reader_options.cache_options, options, context);
   }
 
   return MakeVectorIterator(std::move(tasks));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -111,6 +111,11 @@ static parquet::ArrowReaderProperties MakeArrowReaderProperties(
     auto column_index = metadata.schema()->ColumnIndex(name);
     properties.set_read_dictionary(column_index, true);
   }
+  if (format.reader_options.pre_buffer) {
+    properties.set_pre_buffer(true);
+    properties.set_async_context(format.reader_options.async_context);
+    properties.set_cache_options(format.reader_options.cache_options);
+  }
   return properties;
 }
 

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -29,6 +29,7 @@
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
+#include "arrow/io/caching.h"
 #include "arrow/util/optional.h"
 
 namespace parquet {
@@ -94,6 +95,9 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
     ///
     /// @{
     std::unordered_set<std::string> dict_columns;
+    bool pre_buffer = false;
+    arrow::io::CacheOptions cache_options = arrow::io::CacheOptions::Defaults();
+    arrow::io::AsyncContext async_context;
     /// @}
 
     /// EXPERIMENTAL: Parallelize conversion across columns. This option is ignored if a

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1120,6 +1120,10 @@ cdef class ParquetReadOptions(_Weakrefable):
     dictionary_columns : list of string, default None
         Names of columns which should be dictionary encoded as
         they are read.
+    pre_buffer : bool, default False
+        If enabled, pre-buffer the raw Parquet data instead of issuing one
+        read per column chunk. This can improve performance on high-latency
+        filesystems.
     enable_parallel_column_conversion : bool, default False
         EXPERIMENTAL: Parallelize conversion across columns. This option is
         ignored if a scan is already parallelized across input files to avoid
@@ -1131,17 +1135,20 @@ cdef class ParquetReadOptions(_Weakrefable):
         bint use_buffered_stream
         uint32_t buffer_size
         set dictionary_columns
+        bint pre_buffer
         bint enable_parallel_column_conversion
 
     def __init__(self, bint use_buffered_stream=False,
                  buffer_size=8192,
                  dictionary_columns=None,
+                 bint pre_buffer=False,
                  bint enable_parallel_column_conversion=False):
         self.use_buffered_stream = use_buffered_stream
         if buffer_size <= 0:
             raise ValueError("Buffer size must be larger than zero")
         self.buffer_size = buffer_size
         self.dictionary_columns = set(dictionary_columns or set())
+        self.pre_buffer = pre_buffer
         self.enable_parallel_column_conversion = \
             enable_parallel_column_conversion
 
@@ -1150,6 +1157,7 @@ cdef class ParquetReadOptions(_Weakrefable):
             self.use_buffered_stream == other.use_buffered_stream and
             self.buffer_size == other.buffer_size and
             self.dictionary_columns == other.dictionary_columns and
+            self.pre_buffer == other.pre_buffer and
             self.enable_parallel_column_conversion ==
             other.enable_parallel_column_conversion
         )
@@ -1261,6 +1269,7 @@ cdef class ParquetFileFormat(FileFormat):
         options = &(wrapped.get().reader_options)
         options.use_buffered_stream = read_options.use_buffered_stream
         options.buffer_size = read_options.buffer_size
+        options.pre_buffer = read_options.pre_buffer
         options.enable_parallel_column_conversion = \
             read_options.enable_parallel_column_conversion
         if read_options.dictionary_columns is not None:
@@ -1282,6 +1291,7 @@ cdef class ParquetFileFormat(FileFormat):
             buffer_size=options.buffer_size,
             dictionary_columns={frombytes(col)
                                 for col in options.dict_columns},
+            pre_buffer=options.pre_buffer,
             enable_parallel_column_conversion=(
                 options.enable_parallel_column_conversion
             )

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -241,6 +241,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         c_bool use_buffered_stream
         int64_t buffer_size
         unordered_set[c_string] dict_columns
+        c_bool pre_buffer
         c_bool enable_parallel_column_conversion
 
     cdef cppclass CParquetFileFormat "arrow::dataset::ParquetFileFormat"(

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -475,22 +475,33 @@ def test_parquet_read_options():
                                   dictionary_columns=['a', 'b'])
     opts3 = ds.ParquetReadOptions(buffer_size=2**13, use_buffered_stream=True,
                                   dictionary_columns={'a', 'b'})
+    opts4 = ds.ParquetReadOptions(buffer_size=2**13, pre_buffer=True,
+                                  dictionary_columns={'a', 'b'})
 
     assert opts1.use_buffered_stream is False
     assert opts1.buffer_size == 2**13
+    assert opts1.pre_buffer is False
     assert opts1.dictionary_columns == set()
 
     assert opts2.use_buffered_stream is False
     assert opts2.buffer_size == 2**12
+    assert opts2.pre_buffer is False
     assert opts2.dictionary_columns == {'a', 'b'}
 
     assert opts3.use_buffered_stream is True
     assert opts3.buffer_size == 2**13
+    assert opts3.pre_buffer is False
     assert opts3.dictionary_columns == {'a', 'b'}
+
+    assert opts4.use_buffered_stream is False
+    assert opts4.buffer_size == 2**13
+    assert opts4.pre_buffer is True
+    assert opts4.dictionary_columns == {'a', 'b'}
 
     assert opts1 == opts1
     assert opts1 != opts2
     assert opts2 != opts3
+    assert opts3 != opts4
 
 
 def test_file_format_pickling():
@@ -521,9 +532,11 @@ def test_file_format_pickling():
         'subdir/2/yyy/file1.parquet',
     ]
 ])
-def test_filesystem_factory(mockfs, paths_or_selector):
+@pytest.mark.parametrize('pre_buffer', [False, True])
+def test_filesystem_factory(mockfs, paths_or_selector, pre_buffer):
     format = ds.ParquetFileFormat(
-        read_options=ds.ParquetReadOptions(dictionary_columns={"str"})
+        read_options=ds.ParquetReadOptions(dictionary_columns={"str"},
+                                           pre_buffer=pre_buffer)
     )
 
     options = ds.FileSystemFactoryOptions('subdir')


### PR DESCRIPTION
This exposes the pre-buffering option that was implemented for the base Parquet reader in Datasets.

To summarize, the option coalesces and buffers ranges of a file based on the columns and row groups read, issuing a single read operation for multiple read requests, by combining adjacent and "nearby" ranges into a single request. This means it handles both cases where the entire file is being read, as well as a subset of columns and/or row groups.

There's not a benchmark for Datasets in the repo, but here's a quick comparison for loading data from S3:

```
Without buffering:
Data read: 1300.00 MiB
Mean     : 7.68 s
Median   : 7.48 s
Stdev    : 0.76 s
Mean rate: 170.57 MiB/s

With buffering:
Data read: 1300.00 MiB
Mean     : 3.88 s
Median   : 3.89 s
Stdev    : 0.21 s
Mean rate: 335.95 MiB/s
```

The code being benchmarked is essentially:

```python
dataset = pyarrow.dataset.FileSystemDataset.from_paths(
    paths,
    schema=schema,
    format=format,
    filesystem=fs,
)
table = dataset.to_table()
```