### PR TITLE
ARROW-11614: Fix round() logic to return positive zero when argument is zero

### DIFF
--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -119,10 +119,10 @@ FORCE_INLINE
 gdv_int64 round_int64(gdv_int64 num) { return num; }
 
 // rounds the number to the nearest integer
-#define ROUND_DECIMAL(TYPE)                                                \
-  FORCE_INLINE                                                             \
-  gdv_##TYPE round_##TYPE(gdv_##TYPE num) {                                \
-    return static_cast<gdv_##TYPE>(trunc(num + ((num > 0) ? 0.5 : -0.5))); \
+#define ROUND_DECIMAL(TYPE)                                                 \
+  FORCE_INLINE                                                              \
+  gdv_##TYPE round_##TYPE(gdv_##TYPE num) {                                 \
+    return static_cast<gdv_##TYPE>(trunc(num + ((num >= 0) ? 0.5 : -0.5))); \
   }
 
 ROUND_DECIMAL(float32)
@@ -134,7 +134,7 @@ ROUND_DECIMAL(float64)
   gdv_##TYPE round_##TYPE##_int32(gdv_##TYPE number, gdv_int32 out_scale) { \
     gdv_float64 scale_multiplier = get_scale_multiplier(out_scale);         \
     return static_cast<gdv_##TYPE>(                                         \
-        trunc(number * scale_multiplier + ((number > 0) ? 0.5 : -0.5)) /    \
+        trunc(number * scale_multiplier + ((number >= 0) ? 0.5 : -0.5)) /   \
         scale_multiplier);                                                  \
   }
 

--- a/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
@@ -91,12 +91,14 @@ TEST(TestExtendedMathOps, TestRoundDecimal) {
   EXPECT_FLOAT_EQ(round_float32(1234.245f), 1234);
   EXPECT_FLOAT_EQ(round_float32(-11.7892f), -12);
   EXPECT_FLOAT_EQ(round_float32(1.4999999f), 1);
+  EXPECT_EQ(signbit(round_float32(0)), 0);
   EXPECT_FLOAT_EQ(round_float32_int32(1234.789f, 2), 1234.79f);
   EXPECT_FLOAT_EQ(round_float32_int32(1234.12345f, -3), 1000);
   EXPECT_FLOAT_EQ(round_float32_int32(-1234.4567f, 3), -1234.457f);
   EXPECT_FLOAT_EQ(round_float32_int32(-1234.4567f, -3), -1000);
   EXPECT_FLOAT_EQ(round_float32_int32(1234.4567f, 0), 1234);
   EXPECT_FLOAT_EQ(round_float32_int32(1.5499999523162842f, 1), 1.5f);
+  EXPECT_EQ(signbit(round_float32_int32(0, 5)), 0);
   EXPECT_FLOAT_EQ(round_float32_int32(static_cast<float>(1.55), 1), 1.5f);
   EXPECT_FLOAT_EQ(round_float32_int32(static_cast<float>(9.134123), 2), 9.13f);
   EXPECT_FLOAT_EQ(round_float32_int32(static_cast<float>(-1.923), 1), -1.9f);
@@ -104,11 +106,13 @@ TEST(TestExtendedMathOps, TestRoundDecimal) {
   VerifyFuzzyEquals(round_float64(1234.245), 1234);
   VerifyFuzzyEquals(round_float64(-11.7892), -12);
   VerifyFuzzyEquals(round_float64(1.4999999), 1);
+  EXPECT_EQ(signbit(round_float64(0)), 0);
   VerifyFuzzyEquals(round_float64_int32(1234.789, 2), 1234.79);
   VerifyFuzzyEquals(round_float64_int32(1234.12345, -3), 1000);
   VerifyFuzzyEquals(round_float64_int32(-1234.4567, 3), -1234.457);
   VerifyFuzzyEquals(round_float64_int32(-1234.4567, -3), -1000);
   VerifyFuzzyEquals(round_float64_int32(1234.4567, 0), 1234);
+  EXPECT_EQ(signbit(round_float64_int32(0, -2)), 0);
   VerifyFuzzyEquals(round_float64_int32((double)INT_MAX + 1, 0), (double)INT_MAX + 1);
   VerifyFuzzyEquals(round_float64_int32((double)INT_MIN - 1, 0), (double)INT_MIN - 1);
 }


### PR DESCRIPTION
Previously, round(0.0) and round(0.0, out_scale) were returning -0.0, with this patch round() returns +0.0