### PR TITLE
ARROW-11617: [C++][Gandiva] Fix nested if-else optimisation in gandiva

### DIFF
--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -119,11 +119,11 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
 
 // Decompose an IfNode
 Status ExprDecomposer::Visit(const IfNode& node) {
-  bool reuse_bitmap = false;
-  if (nested_if_else_) {
-    nested_if_else_ = false;
-    reuse_bitmap = true;
-  }
+  // nested_if_else_ might get overwritten when visiting the condition-node, so
+  // saving the value to a local variable and resetting nested_if_else_ to false
+  bool svd_nested_if_else = nested_if_else_;
+  nested_if_else_ = false;
+
   PushConditionEntry(node);
   auto status = node.condition()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
@@ -131,16 +131,15 @@ Status ExprDecomposer::Visit(const IfNode& node) {
   PopConditionEntry(node);
 
   // Add a local bitmap to track the output validity.
-  int local_bitmap_idx = PushThenEntry(node, reuse_bitmap);
+  int local_bitmap_idx = PushThenEntry(node, svd_nested_if_else);
   status = node.then_node()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
   auto then_vv = result();
   PopThenEntry(node);
 
   PushElseEntry(node, local_bitmap_idx);
-  if (auto if_node = dynamic_cast<IfNode*>(node.else_node().get())) {
-    nested_if_else_ = true;
-  }
+  nested_if_else_ = (dynamic_cast<IfNode*>(node.else_node().get()) != nullptr);
+
   status = node.else_node()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
   auto else_vv = result();
@@ -223,9 +222,13 @@ Status ExprDecomposer::Visit(const LiteralNode& node) {
 int ExprDecomposer::PushThenEntry(const IfNode& node, bool reuse_bitmap) {
   int local_bitmap_idx;
 
-  if (!if_entries_stack_.empty() &&
-      reuse_bitmap) {
-    DCHECK_EQ(if_entries_stack_.top()->entry_type_, kStackEntryElse) << "PushThenEntry: unexpected state";
+  if (reuse_bitmap) {
+    // we also need stack in addition to reuse_bitmap flag since we
+    // can also enter other if-else nodes when we visit the condition-node
+    // (which themselves might be nested) before we visit then-node
+    DCHECK_EQ(if_entries_stack_.empty(), false) << "PushThenEntry: stack is empty";
+    DCHECK_EQ(if_entries_stack_.top()->entry_type_, kStackEntryElse)
+        << "PushThenEntry: top of stack is not of type entry_else";
     auto top = if_entries_stack_.top().get();
 
     // inside a nested else statement (i.e if-else-if). use the parent's bitmap.

--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -119,6 +119,11 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
 
 // Decompose an IfNode
 Status ExprDecomposer::Visit(const IfNode& node) {
+  bool reuse_bitmap = false;
+  if (nested_if_else_) {
+    nested_if_else_ = false;
+    reuse_bitmap = true;
+  }
   PushConditionEntry(node);
   auto status = node.condition()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
@@ -126,13 +131,16 @@ Status ExprDecomposer::Visit(const IfNode& node) {
   PopConditionEntry(node);
 
   // Add a local bitmap to track the output validity.
-  int local_bitmap_idx = PushThenEntry(node);
+  int local_bitmap_idx = PushThenEntry(node, reuse_bitmap);
   status = node.then_node()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
   auto then_vv = result();
   PopThenEntry(node);
 
   PushElseEntry(node, local_bitmap_idx);
+  if (auto if_node = dynamic_cast<IfNode*>(node.else_node().get())) {
+    nested_if_else_ = true;
+  }
   status = node.else_node()->Accept(*this);
   ARROW_RETURN_NOT_OK(status);
   auto else_vv = result();
@@ -212,11 +220,12 @@ Status ExprDecomposer::Visit(const LiteralNode& node) {
 //    that has a match will do it).
 // Both of the above optimisations save CPU cycles during expression evaluation.
 
-int ExprDecomposer::PushThenEntry(const IfNode& node) {
+int ExprDecomposer::PushThenEntry(const IfNode& node, bool reuse_bitmap) {
   int local_bitmap_idx;
 
   if (!if_entries_stack_.empty() &&
-      if_entries_stack_.top()->entry_type_ == kStackEntryElse) {
+      reuse_bitmap) {
+    DCHECK_EQ(if_entries_stack_.top()->entry_type_, kStackEntryElse) << "PushThenEntry: unexpected state";
     auto top = if_entries_stack_.top().get();
 
     // inside a nested else statement (i.e if-else-if). use the parent's bitmap.

--- a/cpp/src/gandiva/expr_decomposer.h
+++ b/cpp/src/gandiva/expr_decomposer.h
@@ -38,7 +38,7 @@ class Annotator;
 class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
  public:
   explicit ExprDecomposer(const FunctionRegistry& registry, Annotator& annotator)
-      : registry_(registry), annotator_(annotator) {}
+      : registry_(registry), annotator_(annotator), nested_if_else_(false) {}
 
   Status Decompose(const Node& root, ValueValidityPairPtr* out) {
     auto status = root.Accept(*this);
@@ -98,7 +98,7 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
 
   // push 'then entry' to stack. returns either a new local bitmap or the parent's
   // bitmap (in case of nested if-else).
-  int PushThenEntry(const IfNode& node);
+  int PushThenEntry(const IfNode& node, bool reuse_bitmap);
 
   // pop 'then entry' from stack.
   void PopThenEntry(const IfNode& node);
@@ -116,6 +116,7 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   Annotator& annotator_;
   std::stack<std::unique_ptr<IfStackEntry>> if_entries_stack_;
   ValueValidityPairPtr result_;
+  bool nested_if_else_;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/expr_decomposer.h
+++ b/cpp/src/gandiva/expr_decomposer.h
@@ -56,6 +56,8 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   FRIEND_TEST(TestExprDecomposer, TestInternalIf);
   FRIEND_TEST(TestExprDecomposer, TestParallelIf);
   FRIEND_TEST(TestExprDecomposer, TestIfInCondition);
+  FRIEND_TEST(TestExprDecomposer, TestFunctionBetweenNestedIf);
+  FRIEND_TEST(TestExprDecomposer, TestComplexIfCondition);
 
   Status Visit(const FieldNode& node) override;
   Status Visit(const FunctionNode& node) override;

--- a/cpp/src/gandiva/expr_decomposer_test.cc
+++ b/cpp/src/gandiva/expr_decomposer_test.cc
@@ -19,8 +19,6 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
-
 #include "gandiva/annotator.h"
 #include "gandiva/dex.h"
 #include "gandiva/function_registry.h"

--- a/cpp/src/gandiva/expr_decomposer_test.cc
+++ b/cpp/src/gandiva/expr_decomposer_test.cc
@@ -18,6 +18,9 @@
 #include "gandiva/expr_decomposer.h"
 
 #include <gtest/gtest.h>
+
+#include <iostream>
+
 #include "gandiva/annotator.h"
 #include "gandiva/dex.h"
 #include "gandiva/function_registry.h"
@@ -45,7 +48,7 @@ TEST_F(TestExprDecomposer, TestStackSimple) {
   decomposer.PushConditionEntry(node_a);
   decomposer.PopConditionEntry(node_a);
 
-  int idx_a = decomposer.PushThenEntry(node_a);
+  int idx_a = decomposer.PushThenEntry(node_a, false);
   EXPECT_EQ(idx_a, 0);
   decomposer.PopThenEntry(node_a);
 
@@ -69,7 +72,7 @@ TEST_F(TestExprDecomposer, TestNested) {
   decomposer.PushConditionEntry(node_a);
   decomposer.PopConditionEntry(node_a);
 
-  int idx_a = decomposer.PushThenEntry(node_a);
+  int idx_a = decomposer.PushThenEntry(node_a, false);
   EXPECT_EQ(idx_a, 0);
   decomposer.PopThenEntry(node_a);
 
@@ -79,7 +82,7 @@ TEST_F(TestExprDecomposer, TestNested) {
     decomposer.PushConditionEntry(node_b);
     decomposer.PopConditionEntry(node_b);
 
-    int idx_b = decomposer.PushThenEntry(node_b);
+    int idx_b = decomposer.PushThenEntry(node_b, true);
     EXPECT_EQ(idx_b, 0);  // must reuse bitmap.
     decomposer.PopThenEntry(node_b);
 
@@ -108,14 +111,14 @@ TEST_F(TestExprDecomposer, TestInternalIf) {
   decomposer.PushConditionEntry(node_a);
   decomposer.PopConditionEntry(node_a);
 
-  int idx_a = decomposer.PushThenEntry(node_a);
+  int idx_a = decomposer.PushThenEntry(node_a, false);
   EXPECT_EQ(idx_a, 0);
 
   {  // start b
     decomposer.PushConditionEntry(node_b);
     decomposer.PopConditionEntry(node_b);
 
-    int idx_b = decomposer.PushThenEntry(node_b);
+    int idx_b = decomposer.PushThenEntry(node_b, false);
     EXPECT_EQ(idx_b, 1);  // must not reuse bitmap.
     decomposer.PopThenEntry(node_b);
 
@@ -147,7 +150,7 @@ TEST_F(TestExprDecomposer, TestParallelIf) {
   decomposer.PushConditionEntry(node_a);
   decomposer.PopConditionEntry(node_a);
 
-  int idx_a = decomposer.PushThenEntry(node_a);
+  int idx_a = decomposer.PushThenEntry(node_a, false);
   EXPECT_EQ(idx_a, 0);
 
   decomposer.PopThenEntry(node_a);
@@ -160,7 +163,7 @@ TEST_F(TestExprDecomposer, TestParallelIf) {
   decomposer.PushConditionEntry(node_b);
   decomposer.PopConditionEntry(node_b);
 
-  int idx_b = decomposer.PushThenEntry(node_b);
+  int idx_b = decomposer.PushThenEntry(node_b, false);
   EXPECT_EQ(idx_b, 1);  // must not reuse bitmap.
   decomposer.PopThenEntry(node_b);
 
@@ -194,7 +197,7 @@ TEST_F(TestExprDecomposer, TestIfInCondition) {
     decomposer.PushConditionEntry(cond_node_a);
     decomposer.PopConditionEntry(cond_node_a);
 
-    int idx_cond_a = decomposer.PushThenEntry(cond_node_a);
+    int idx_cond_a = decomposer.PushThenEntry(cond_node_a, false);
     EXPECT_EQ(idx_cond_a, 0);
     decomposer.PopThenEntry(cond_node_a);
 
@@ -204,7 +207,7 @@ TEST_F(TestExprDecomposer, TestIfInCondition) {
   }
   decomposer.PopConditionEntry(node_a);
 
-  int idx_a = decomposer.PushThenEntry(node_a);
+  int idx_a = decomposer.PushThenEntry(node_a, false);
   EXPECT_EQ(idx_a, 1);  // no re-use
   decomposer.PopThenEntry(node_a);
 
@@ -217,7 +220,7 @@ TEST_F(TestExprDecomposer, TestIfInCondition) {
       decomposer.PushConditionEntry(cond_node_b);
       decomposer.PopConditionEntry(cond_node_b);
 
-      int idx_cond_b = decomposer.PushThenEntry(cond_node_b);
+      int idx_cond_b = decomposer.PushThenEntry(cond_node_b, false);
       EXPECT_EQ(idx_cond_b, 2);  // no re-use
       decomposer.PopThenEntry(cond_node_b);
 
@@ -227,7 +230,7 @@ TEST_F(TestExprDecomposer, TestIfInCondition) {
     }
     decomposer.PopConditionEntry(node_b);
 
-    int idx_b = decomposer.PushThenEntry(node_b);
+    int idx_b = decomposer.PushThenEntry(node_b, true);
     EXPECT_EQ(idx_b, 1);  // must reuse bitmap.
     decomposer.PopThenEntry(node_b);
 
@@ -240,6 +243,169 @@ TEST_F(TestExprDecomposer, TestIfInCondition) {
   EXPECT_EQ(is_terminal_a, false);  // there was a nested if.
 
   EXPECT_EQ(decomposer.if_entries_stack_.empty(), true);
+}
+
+TEST_F(TestExprDecomposer, TestFunctionBetweenNestedIf) {
+  Annotator annotator;
+  ExprDecomposer decomposer(registry_, annotator);
+
+  // if (a) _
+  // else
+  //      function(
+  //          if (b) _
+  //          else _
+  //        )
+
+  IfNode node_a(nullptr, nullptr, nullptr, int32());
+  IfNode node_b(nullptr, nullptr, nullptr, int32());
+
+  // start outer if
+  decomposer.PushConditionEntry(node_a);
+  decomposer.PopConditionEntry(node_a);
+
+  int idx_a = decomposer.PushThenEntry(node_a, false);
+  EXPECT_EQ(idx_a, 0);
+  decomposer.PopThenEntry(node_a);
+
+  decomposer.PushElseEntry(node_a, idx_a);
+  {  // start b
+    decomposer.PushConditionEntry(node_b);
+    decomposer.PopConditionEntry(node_b);
+
+    int idx_b = decomposer.PushThenEntry(node_b, false);  // not else node of parent if
+    EXPECT_EQ(idx_b, 1);                                  // can't reuse bitmap.
+    decomposer.PopThenEntry(node_b);
+
+    decomposer.PushElseEntry(node_b, idx_b);
+    bool is_terminal_b = decomposer.PopElseEntry(node_b);
+    EXPECT_EQ(is_terminal_b, true);
+  }
+  bool is_terminal_a = decomposer.PopElseEntry(node_a);
+  EXPECT_EQ(is_terminal_a, true);  // a else is also terminal
+
+  EXPECT_TRUE(decomposer.if_entries_stack_.empty());
+}
+
+TEST_F(TestExprDecomposer, TestComplexIfCondition) {
+  Annotator annotator;
+  ExprDecomposer decomposer(registry_, annotator);
+
+  // if (if _
+  //     else
+  //        if _
+  //        else _
+  //    )
+  // then
+  //    if _
+  //     else
+  //        if _
+  //        else _
+  //
+  // else
+  //    if _
+  //    else
+  //        if _
+  //        else _
+
+  IfNode node_a(nullptr, nullptr, nullptr, int32());
+
+  IfNode cond_node_a(nullptr, nullptr, nullptr, int32());
+  IfNode cond_node_a_inner_if(nullptr, nullptr, nullptr, int32());
+
+  IfNode then_node_a(nullptr, nullptr, nullptr, int32());
+  IfNode then_node_a_inner_if(nullptr, nullptr, nullptr, int32());
+
+  IfNode else_node_a(nullptr, nullptr, nullptr, int32());
+  IfNode else_node_a_inner_if(nullptr, nullptr, nullptr, int32());
+
+  // start outer if
+  decomposer.PushConditionEntry(node_a);
+  {
+    // start the nested if inside the condition of a
+    decomposer.PushConditionEntry(cond_node_a);
+    decomposer.PopConditionEntry(cond_node_a);
+
+    int idx_cond_a = decomposer.PushThenEntry(cond_node_a, false);
+    EXPECT_EQ(idx_cond_a, 0);
+    decomposer.PopThenEntry(cond_node_a);
+
+    decomposer.PushElseEntry(cond_node_a, idx_cond_a);
+    {
+      decomposer.PushConditionEntry(cond_node_a_inner_if);
+      decomposer.PopConditionEntry(cond_node_a_inner_if);
+
+      int idx_cond_a_inner_if = decomposer.PushThenEntry(cond_node_a_inner_if, true);
+      EXPECT_EQ(idx_cond_a_inner_if,
+                0);  // expect bitmap to be resused since nested if else
+      decomposer.PopThenEntry(cond_node_a_inner_if);
+
+      decomposer.PushElseEntry(cond_node_a_inner_if, idx_cond_a_inner_if);
+      bool is_terminal = decomposer.PopElseEntry(cond_node_a_inner_if);
+      EXPECT_TRUE(is_terminal);
+    }
+    EXPECT_FALSE(decomposer.PopElseEntry(cond_node_a));
+  }
+  decomposer.PopConditionEntry(node_a);
+
+  int idx_a = decomposer.PushThenEntry(node_a, false);
+  EXPECT_EQ(idx_a, 1);
+
+  {
+    // start the nested if inside the then node of a
+    decomposer.PushConditionEntry(then_node_a);
+    decomposer.PopConditionEntry(then_node_a);
+
+    int idx_then_a = decomposer.PushThenEntry(then_node_a, false);
+    EXPECT_EQ(idx_then_a, 2);
+    decomposer.PopThenEntry(then_node_a);
+
+    decomposer.PushElseEntry(then_node_a, idx_then_a);
+    {
+      decomposer.PushConditionEntry(then_node_a_inner_if);
+      decomposer.PopConditionEntry(then_node_a_inner_if);
+
+      int idx_then_a_inner_if = decomposer.PushThenEntry(then_node_a_inner_if, true);
+      EXPECT_EQ(idx_then_a_inner_if,
+                2);  // expect bitmap to be resused since nested if else
+      decomposer.PopThenEntry(then_node_a_inner_if);
+
+      decomposer.PushElseEntry(then_node_a_inner_if, idx_then_a_inner_if);
+      bool is_terminal = decomposer.PopElseEntry(then_node_a_inner_if);
+      EXPECT_TRUE(is_terminal);
+    }
+    EXPECT_FALSE(decomposer.PopElseEntry(then_node_a));
+  }
+  decomposer.PopThenEntry(node_a);
+
+  decomposer.PushElseEntry(node_a, idx_a);
+  {
+    // start the nested if inside the else node of a
+    decomposer.PushConditionEntry(else_node_a);
+    decomposer.PopConditionEntry(else_node_a);
+
+    int idx_else_a =
+        decomposer.PushThenEntry(else_node_a, true);  // else node is another if-node
+    EXPECT_EQ(idx_else_a, 1);  // reuse the outer if node bitmap since nested if-else
+    decomposer.PopThenEntry(else_node_a);
+
+    decomposer.PushElseEntry(else_node_a, idx_else_a);
+    {
+      decomposer.PushConditionEntry(else_node_a_inner_if);
+      decomposer.PopConditionEntry(else_node_a_inner_if);
+
+      int idx_else_a_inner_if = decomposer.PushThenEntry(else_node_a_inner_if, true);
+      EXPECT_EQ(idx_else_a_inner_if,
+                1);  // expect bitmap to be resused since nested if else
+      decomposer.PopThenEntry(else_node_a_inner_if);
+
+      decomposer.PushElseEntry(else_node_a_inner_if, idx_else_a_inner_if);
+      bool is_terminal = decomposer.PopElseEntry(else_node_a_inner_if);
+      EXPECT_TRUE(is_terminal);
+    }
+    EXPECT_FALSE(decomposer.PopElseEntry(else_node_a));
+  }
+  EXPECT_FALSE(decomposer.PopElseEntry(node_a));
+  EXPECT_TRUE(decomposer.if_entries_stack_.empty());
 }
 
 }  // namespace gandiva


### PR DESCRIPTION
In gandiva, when we have nested if-else statements we reuse the local bitmap and treat it is a single logical if - elseif - .. - --else condition. However, when he have say another function between them like
IF
THEN
ELSE
   function(
     IF
     THEN
     ELSE
  )

in such cases also currently we are doing same thing which can lead to incorrect results