### PR TITLE
ARROW-11620: [Rust][DataFusion] Consistently use Arc<dyn TableProvider> rather than Box and Arc

### DIFF
--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -150,7 +150,7 @@ fn create_context(
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, partitions)?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
 
     Ok(Arc::new(Mutex::new(ctx)))
 }

--- a/rust/datafusion/benches/filter_query_sql.rs
+++ b/rust/datafusion/benches/filter_query_sql.rs
@@ -62,7 +62,7 @@ fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContex
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
 
     Ok(ctx)
 }

--- a/rust/datafusion/benches/math_query_sql.rs
+++ b/rust/datafusion/benches/math_query_sql.rs
@@ -72,7 +72,7 @@ fn create_context(
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
 
     Ok(Arc::new(Mutex::new(ctx)))
 }

--- a/rust/datafusion/benches/sort_limit_query_sql.rs
+++ b/rust/datafusion/benches/sort_limit_query_sql.rs
@@ -74,14 +74,14 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
     let partitions = 16;
 
     rt.block_on(async {
-        let mem_table = MemTable::load(Box::new(csv), 16 * 1024, Some(partitions))
+        let mem_table = MemTable::load(Arc::new(csv), 16 * 1024, Some(partitions))
             .await
             .unwrap();
 
         // create local execution context
         let mut ctx = ExecutionContext::new();
         ctx.state.lock().unwrap().config.concurrency = 1;
-        ctx.register_table("aggregate_test_100", Box::new(mem_table));
+        ctx.register_table("aggregate_test_100", Arc::new(mem_table));
         ctx_holder.lock().unwrap().push(Arc::new(Mutex::new(ctx)))
     });
 

--- a/rust/datafusion/examples/dataframe_in_memory.rs
+++ b/rust/datafusion/examples/dataframe_in_memory.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::boxed::Box;
 use std::sync::Arc;
 
 use arrow::array::{Int32Array, StringArray};
@@ -50,7 +49,7 @@ async fn main() -> Result<()> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
     let df = ctx.table("t")?;
 
     // construct an expression corresponding to "SELECT a, b FROM t WHERE b = 10" in SQL

--- a/rust/datafusion/examples/simple_udaf.rs
+++ b/rust/datafusion/examples/simple_udaf.rs
@@ -48,7 +48,7 @@ fn create_context() -> Result<ExecutionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
     Ok(ctx)
 }
 

--- a/rust/datafusion/examples/simple_udf.rs
+++ b/rust/datafusion/examples/simple_udf.rs
@@ -50,7 +50,7 @@ fn create_context() -> Result<ExecutionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;
-    ctx.register_table("t", Box::new(provider));
+    ctx.register_table("t", Arc::new(provider));
     Ok(ctx)
 }
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -107,7 +107,7 @@ impl MemTable {
 
     /// Create a mem table by reading from another data source
     pub async fn load(
-        t: Box<dyn TableProvider + Send + Sync>,
+        t: Arc<dyn TableProvider + Send + Sync>,
         batch_size: usize,
         output_partitions: Option<usize>,
     ) -> Result<Self> {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -326,15 +326,15 @@ mod tests {
         Ok(())
     }
 
-    fn load_table(name: &str) -> Result<Box<dyn TableProvider>> {
+    fn load_table(name: &str) -> Result<Arc<dyn TableProvider>> {
         let testdata = arrow::util::test_util::parquet_test_data();
         let filename = format!("{}/{}", testdata, name);
         let table = ParquetTable::try_new(&filename, 2)?;
-        Ok(Box::new(table))
+        Ok(Arc::new(table))
     }
 
     async fn get_first_batch(
-        table: Box<dyn TableProvider>,
+        table: Arc<dyn TableProvider>,
         projection: &Option<Vec<usize>>,
     ) -> Result<RecordBatch> {
         let exec = table.scan(projection, 1024, &[])?;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -273,18 +273,22 @@ impl ExecutionContext {
         Ok(())
     }
 
-    /// Registers a table using a custom TableProvider so that it can be referenced from SQL
-    /// statements executed against this context.
+    /// Registers a named table using a custom `TableProvider` so that
+    /// it can be referenced from SQL statements executed against this
+    /// context.
+    ///
+    /// Returns the `TableProvider` previously registered for this
+    /// name, if any
     pub fn register_table(
         &mut self,
         name: &str,
         provider: Arc<dyn TableProvider + Send + Sync>,
-    ) {
+    ) -> Option<Arc<dyn TableProvider + Send + Sync>> {
         self.state
             .lock()
             .unwrap()
             .datasources
-            .insert(name.to_string(), provider);
+            .insert(name.to_string(), provider)
     }
 
     /// Deregisters the named table.

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -29,7 +29,7 @@ use std::io::{BufReader, BufWriter};
 use std::sync::Arc;
 use tempfile::TempDir;
 
-pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
+pub fn create_table_dual() -> Arc<dyn TableProvider + Send + Sync> {
     let dual_schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, false),
@@ -43,7 +43,7 @@ pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
     )
     .unwrap();
     let provider = MemTable::try_new(dual_schema, vec![vec![batch]]).unwrap();
-    Box::new(provider)
+    Arc::new(provider)
 }
 
 /// Generated partitioned copy of a CSV file

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -61,11 +61,11 @@ async fn join() -> Result<()> {
     let table1 = MemTable::try_new(schema1, vec![vec![batch1]])?;
     let table2 = MemTable::try_new(schema2, vec![vec![batch2]])?;
 
-    ctx.register_table("aa", Box::new(table1));
+    ctx.register_table("aa", Arc::new(table1));
 
     let df1 = ctx.table("aa")?;
 
-    ctx.register_table("aaa", Box::new(table2));
+    ctx.register_table("aaa", Arc::new(table2));
 
     let df2 = ctx.table("aaa")?;
 

--- a/rust/datafusion/tests/provider_filter_pushdown.rs
+++ b/rust/datafusion/tests/provider_filter_pushdown.rs
@@ -155,7 +155,7 @@ async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()
     let result_col: &UInt64Array = as_primitive_array(results[0].column(0));
     assert_eq!(result_col.value(0), expected_count);
 
-    ctx.register_table("data", Box::new(provider));
+    ctx.register_table("data", Arc::new(provider));
     let sql_results = ctx
         .sql(&format!("select count(*) from data where flag = {}", value))?
         .collect()


### PR DESCRIPTION
NOTE: This is a backwards incompatible change in DataFusion

Inspired by a conversation with @seddonm1  https://github.com/apache/arrow/pull/9448#discussion_r573289996 and https://github.com/apache/arrow/pull/9445 as well as some upcoming needs in IOx (a consumer of DataFusion)

# Rationale:
* No `TableProvider` APIs actually require ownership of the `TableProvider` (they all take `&self`)
* Internally DataFusion was storing the TableProvider as an Arc already and inconsistently uses `Box`d and `Arc`d table providers  (e.g. in [`LogicalPlan::TableScan`](https://github.com/apache/arrow/blob/437c9173c3e067712eb714c643ca839acc7ed7f6/rust/datafusion/src/logical_plan/plan.rs#L125))
* This change allows the same `TableProvider` instance to be reused easily for different `ExecutionContext`s

# Changes
* Change all uses of `TableProvider` to be wrapped in `Arc` rather than `Box`
