### PR TITLE
ARROW-11497: [Python] Provide parquet enable compliant nested type flag for python binding

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1215,6 +1215,9 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
                 self._properties["allow_truncated_timestamps"]
             ),
             writer_engine_version="V2",
+            use_compliant_nested_type=(
+                self._properties["use_compliant_nested_type"]
+            )
         )
 
     cdef void init(self, const shared_ptr[CFileWriteOptions]& sp):
@@ -1232,6 +1235,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             use_deprecated_int96_timestamps=False,
             coerce_timestamps=None,
             allow_truncated_timestamps=False,
+            use_compliant_nested_type=False,
         )
         self._set_properties()
         self._set_arrow_properties()

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -382,6 +382,8 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* allow_truncated_timestamps()
             Builder* disallow_truncated_timestamps()
             Builder* store_schema()
+            Builder* enable_compliant_nested_types()
+            Builder* disable_compliant_nested_types()
             Builder* set_engine_version(ArrowWriterEngineVersion version)
             shared_ptr[ArrowWriterProperties] build()
         c_bool support_deprecated_int96_timestamps()
@@ -501,7 +503,8 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
     use_deprecated_int96_timestamps=*,
     coerce_timestamps=*,
     allow_truncated_timestamps=*,
-    writer_engine_version=*) except *
+    writer_engine_version=*,
+    use_compliant_nested_type=*) except *
 
 cdef class ParquetSchema(_Weakrefable):
     cdef:

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1265,7 +1265,8 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
         use_deprecated_int96_timestamps=False,
         coerce_timestamps=None,
         allow_truncated_timestamps=False,
-        writer_engine_version=None) except *:
+        writer_engine_version=None,
+        use_compliant_nested_type=False) except *:
     """Arrow writer properties"""
     cdef:
         shared_ptr[ArrowWriterProperties] arrow_properties
@@ -1299,6 +1300,13 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
     else:
         arrow_props.disallow_truncated_timestamps()
 
+    # use_compliant_nested_type
+
+    if use_compliant_nested_type:
+        arrow_props.enable_compliant_nested_types()
+    else:
+        arrow_props.disable_compliant_nested_types()
+
     # writer_engine_version
 
     if writer_engine_version == "V1":
@@ -1328,6 +1336,7 @@ cdef class ParquetWriter(_Weakrefable):
         object compression
         object compression_level
         object data_page_version
+        object use_compliant_nested_type
         object version
         object write_statistics
         object writer_engine_version
@@ -1345,7 +1354,8 @@ cdef class ParquetWriter(_Weakrefable):
                   compression_level=None,
                   use_byte_stream_split=False,
                   writer_engine_version=None,
-                  data_page_version=None):
+                  data_page_version=None,
+                  use_compliant_nested_type=False):
         cdef:
             shared_ptr[WriterProperties] properties
             shared_ptr[ArrowWriterProperties] arrow_properties
@@ -1377,7 +1387,8 @@ cdef class ParquetWriter(_Weakrefable):
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,
             coerce_timestamps=coerce_timestamps,
             allow_truncated_timestamps=allow_truncated_timestamps,
-            writer_engine_version=writer_engine_version
+            writer_engine_version=writer_engine_version,
+            use_compliant_nested_type=use_compliant_nested_type
         )
 
         pool = maybe_unbox_memory_pool(memory_pool)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -541,6 +541,8 @@ data_page_version : {"1.0", "2.0"}, default "1.0"
     The serialized Parquet data page format version to write, defaults to
     1.0. This does not impact the file schema logical types and Arrow to
     Parquet type casting behavior; for that use the "version" option.
+use_compliant_nested_type : bool, default False
+    Write compliant Parquet nested type, defaults to disable.
 """
 
 
@@ -572,6 +574,7 @@ schema : arrow Schema
                  use_byte_stream_split=False,
                  writer_engine_version=None,
                  data_page_version='1.0',
+                 use_compliant_nested_type=False,
                  **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
@@ -622,6 +625,7 @@ schema : arrow Schema
             use_byte_stream_split=use_byte_stream_split,
             writer_engine_version=engine_version,
             data_page_version=data_page_version,
+            use_compliant_nested_type=use_compliant_nested_type,
             **options)
         self.is_open = True
 
@@ -1775,6 +1779,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 compression_level=None,
                 use_byte_stream_split=False,
                 data_page_version='1.0',
+                use_compliant_nested_type=False,
                 **kwargs):
     row_group_size = kwargs.pop('chunk_size', row_group_size)
     use_int96 = use_deprecated_int96_timestamps
@@ -1794,6 +1799,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 compression_level=compression_level,
                 use_byte_stream_split=use_byte_stream_split,
                 data_page_version=data_page_version,
+                use_compliant_nested_type=use_compliant_nested_type,
                 **kwargs) as writer:
             writer.write_table(table, row_group_size=row_group_size)
     except Exception:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -541,8 +541,31 @@ data_page_version : {"1.0", "2.0"}, default "1.0"
     The serialized Parquet data page format version to write, defaults to
     1.0. This does not impact the file schema logical types and Arrow to
     Parquet type casting behavior; for that use the "version" option.
-use_compliant_nested_type : bool, default False
-    Write compliant Parquet nested type, defaults to disable.
+use_compliant_nested_type: bool, default False
+    Whether to write compliant Parquet nested type (lists) as defined
+    `here <https://github.com/apache/parquet-format/blob/master/
+    LogicalTypes.md#nested-types>`_, defaults to ``False``.
+    For ``use_compliant_nested_type=True``, this will write into a list
+    with 3-level structure where the middle level, named ``list``,
+    is a repeated group with a single field named ``element``
+    ::
+      <list-repetition> group <name> (LIST) {
+        repeated group list {
+          <element-repetition> <element-type> element;
+        }
+      }
+
+    For ``use_compliant_nested_type=False``, this will also write into a list
+    with 3-level structure, where the name of the single field of the middle
+    level ``list`` is taken from the element name for nested columns in Arrow,
+    which defaults to ``item``
+    ::
+      <list-repetition> group <name> (LIST) {
+        repeated group list {
+          <element-repetition> <element-type> item;
+       }
+      }
+
 """
 
 

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -58,7 +58,7 @@ def test_write_compliant_nested_type_enable(tempdir,
                                             use_legacy_dataset, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
-    # verify that we can read/write with new flag
+    # verify that we can read/write pandas df with new flag
     _roundtrip_pandas_dataframe(df,
                                 write_kwargs={
                                     'use_compliant_nested_type': True},
@@ -91,10 +91,8 @@ def test_write_compliant_nested_type_disable(tempdir,
                                              use_legacy_dataset, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
-    # verify that we can read/write with new flag disable (default behaviour)
-    _roundtrip_pandas_dataframe(df,
-                                write_kwargs={
-                                    'use_compliant_nested_type': False},
+    # verify that we can read/write with new flag disabled (default behaviour)
+    _roundtrip_pandas_dataframe(df, write_kwargs={},
                                 use_legacy_dataset=use_legacy_dataset)
 
     # Write to a parquet file while disabling compliant nested type

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -22,7 +22,8 @@ from pyarrow.tests.parquet.common import parametrize_legacy_dataset
 
 try:
     import pyarrow.parquet as pq
-    from pyarrow.tests.parquet.common import _read_table, _write_table, _check_roundtrip
+    from pyarrow.tests.parquet.common import (_read_table,
+                                              _check_roundtrip)
 except ImportError:
     pq = None
 
@@ -41,27 +42,34 @@ _test_data_simple = [
 ]
 
 _test_data_complex = [
-    {'name': 'list1', 'items': [{'name': 'elem1', 'value': '1'}, {'name': 'elem2', 'value': '2'}]},
+    {'name': 'list1', 'items': [
+        {'name': 'elem1', 'value': '1'}, {'name': 'elem2', 'value': '2'}]},
     {'name': 'list2', 'items': [{'name': 'elem1', 'value': '0'}]},
 ]
 
-parametrize_test_data = pytest.mark.parametrize("test_data", [_test_data_simple, _test_data_complex])
+parametrize_test_data = pytest.mark.parametrize(
+    "test_data", [_test_data_simple, _test_data_complex])
 
 
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 @parametrize_test_data
-def test_write_compliant_nested_type_enable(tempdir, use_legacy_dataset, test_data):
+def test_write_compliant_nested_type_enable(tempdir,
+                                            use_legacy_dataset, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
     # verify that we can read/write with new flag
-    _roundtrip_pandas_dataframe(df, write_kwargs={'use_compliant_nested_type': True},
+    _roundtrip_pandas_dataframe(df,
+                                write_kwargs={
+                                    'use_compliant_nested_type': True},
                                 use_legacy_dataset=use_legacy_dataset)
 
     # Write to a parquet file with compliant nested type
     table = pa.Table.from_pandas(df, preserve_index=False)
     path = str(tempdir / 'data.parquet')
-    with pq.ParquetWriter(path, table.schema, use_compliant_nested_type=True, version='2.0') as writer:
+    with pq.ParquetWriter(path, table.schema,
+                          use_compliant_nested_type=True,
+                          version='2.0') as writer:
         writer.write_table(table)
     # Read back as a table
     new_table = _read_table(path)
@@ -71,17 +79,22 @@ def test_write_compliant_nested_type_enable(tempdir, use_legacy_dataset, test_da
     assert new_table.schema.types[1].value_field.name == 'element'
 
     # Verify that the new table can be read/written correctly
-    _check_roundtrip(new_table, use_legacy_dataset=use_legacy_dataset, use_compliant_nested_type=True)
+    _check_roundtrip(new_table,
+                     use_legacy_dataset=use_legacy_dataset,
+                     use_compliant_nested_type=True)
 
 
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 @parametrize_test_data
-def test_write_compliant_nested_type_disable(tempdir, use_legacy_dataset, test_data):
+def test_write_compliant_nested_type_disable(tempdir,
+                                             use_legacy_dataset, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
     # verify that we can read/write with new flag disable (default behaviour)
-    _roundtrip_pandas_dataframe(df, write_kwargs={'use_compliant_nested_type': False},
+    _roundtrip_pandas_dataframe(df,
+                                write_kwargs={
+                                    'use_compliant_nested_type': False},
                                 use_legacy_dataset=use_legacy_dataset)
 
     # Write to a parquet file while disabling compliant nested type
@@ -97,4 +110,6 @@ def test_write_compliant_nested_type_disable(tempdir, use_legacy_dataset, test_d
     assert new_table.schema.types[1].value_field.name == 'item'
 
     # Verify that the new table can be read/written correctly
-    _check_roundtrip(new_table, use_legacy_dataset=use_legacy_dataset, use_compliant_nested_type=False)
+    _check_roundtrip(new_table,
+                     use_legacy_dataset=use_legacy_dataset,
+                     use_compliant_nested_type=False)

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import pyarrow as pa
+from pyarrow.tests.parquet.common import parametrize_legacy_dataset
+
+try:
+    import pyarrow.parquet as pq
+    from pyarrow.tests.parquet.common import _read_table, _write_table, _check_roundtrip
+except ImportError:
+    pq = None
+
+try:
+    import pandas as pd
+    import pandas.testing as tm
+
+    from pyarrow.tests.parquet.common import _roundtrip_pandas_dataframe
+except ImportError:
+    pd = tm = None
+
+# Tests for ARROW-11497
+_test_data_simple = [
+    {'name': 'list1', 'items': [1, 2]},
+    {'name': 'list2', 'items': [0]},
+]
+
+_test_data_complex = [
+    {'name': 'list1', 'items': [{'name': 'elem1', 'value': '1'}, {'name': 'elem2', 'value': '2'}]},
+    {'name': 'list2', 'items': [{'name': 'elem1', 'value': '0'}]},
+]
+
+parametrize_test_data = pytest.mark.parametrize("test_data", [_test_data_simple, _test_data_complex])
+
+
+@pytest.mark.pandas
+@parametrize_legacy_dataset
+@parametrize_test_data
+def test_write_compliant_nested_type_enable(tempdir, use_legacy_dataset, test_data):
+    # prepare dataframe for testing
+    df = pd.DataFrame(data=test_data)
+    # verify that we can read/write with new flag
+    _roundtrip_pandas_dataframe(df, write_kwargs={'use_compliant_nested_type': True},
+                                use_legacy_dataset=use_legacy_dataset)
+
+    # Write to a parquet file with compliant nested type
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    path = str(tempdir / 'data.parquet')
+    with pq.ParquetWriter(path, table.schema, use_compliant_nested_type=True, version='2.0') as writer:
+        writer.write_table(table)
+    # Read back as a table
+    new_table = _read_table(path)
+    # Validate that "items" columns compliant to Parquet nested format
+    # Should be like this: list<element: struct<name: string, value: string>>
+    assert isinstance(new_table.schema.types[1], pa.ListType)
+    assert new_table.schema.types[1].value_field.name == 'element'
+
+    # Verify that the new table can be read/written correctly
+    _check_roundtrip(new_table, use_legacy_dataset=use_legacy_dataset, use_compliant_nested_type=True)
+
+
+@pytest.mark.pandas
+@parametrize_legacy_dataset
+@parametrize_test_data
+def test_write_compliant_nested_type_disable(tempdir, use_legacy_dataset, test_data):
+    # prepare dataframe for testing
+    df = pd.DataFrame(data=test_data)
+    # verify that we can read/write with new flag disable (default behaviour)
+    _roundtrip_pandas_dataframe(df, write_kwargs={'use_compliant_nested_type': False},
+                                use_legacy_dataset=use_legacy_dataset)
+
+    # Write to a parquet file while disabling compliant nested type
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    path = str(tempdir / 'data.parquet')
+    with pq.ParquetWriter(path, table.schema, version='2.0') as writer:
+        writer.write_table(table)
+    new_table = _read_table(path)
+
+    # Validate that "items" columns is not compliant to Parquet nested format
+    # Should be like this: list<item: struct<name: string, value: string>>
+    assert isinstance(new_table.schema.types[1], pa.ListType)
+    assert new_table.schema.types[1].value_field.name == 'item'
+
+    # Verify that the new table can be read/written correctly
+    _check_roundtrip(new_table, use_legacy_dataset=use_legacy_dataset, use_compliant_nested_type=False)

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -37,14 +37,14 @@ except ImportError:
 
 # Tests for ARROW-11497
 _test_data_simple = [
-    {'name': 'list1', 'items': [1, 2]},
-    {'name': 'list2', 'items': [0]},
+    {'items': [1, 2]},
+    {'items': [0]},
 ]
 
 _test_data_complex = [
-    {'name': 'list1', 'items': [
-        {'name': 'elem1', 'value': '1'}, {'name': 'elem2', 'value': '2'}]},
-    {'name': 'list2', 'items': [{'name': 'elem1', 'value': '0'}]},
+    {'items': [{'name': 'elem1', 'value': '1'},
+               {'name': 'elem2', 'value': '2'}]},
+    {'items': [{'name': 'elem1', 'value': '0'}]},
 ]
 
 parametrize_test_data = pytest.mark.parametrize(
@@ -75,8 +75,8 @@ def test_write_compliant_nested_type_enable(tempdir,
     new_table = _read_table(path)
     # Validate that "items" columns compliant to Parquet nested format
     # Should be like this: list<element: struct<name: string, value: string>>
-    assert isinstance(new_table.schema.types[1], pa.ListType)
-    assert new_table.schema.types[1].value_field.name == 'element'
+    assert isinstance(new_table.schema.types[0], pa.ListType)
+    assert new_table.schema.types[0].value_field.name == 'element'
 
     # Verify that the new table can be read/written correctly
     _check_roundtrip(new_table,
@@ -106,8 +106,8 @@ def test_write_compliant_nested_type_disable(tempdir,
 
     # Validate that "items" columns is not compliant to Parquet nested format
     # Should be like this: list<item: struct<name: string, value: string>>
-    assert isinstance(new_table.schema.types[1], pa.ListType)
-    assert new_table.schema.types[1].value_field.name == 'item'
+    assert isinstance(new_table.schema.types[0], pa.ListType)
+    assert new_table.schema.types[0].value_field.name == 'item'
 
     # Verify that the new table can be read/written correctly
     _check_roundtrip(new_table,


### PR DESCRIPTION
Hi,

I am making a PR following the discussion in [ARROW-11497](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-11497)

This is my first PR to this project, please let me know if I'm missing something, I will try to address all problem as much as I can.

Cheers,
Truc