### PR TITLE
ARROW-11637: [CI][Conda] Update nightly clean target platforms and packages list

### DIFF
--- a/dev/tasks/conda-recipes/clean.py
+++ b/dev/tasks/conda-recipes/clean.py
@@ -9,8 +9,23 @@ import sys
 
 
 VERSIONS_TO_KEEP = 5
-PLATFORMS = ["linux-64", "osx-64", "win-64"]
-PACKAGES = ["pyarrow", "arrow-cpp"]
+PACKAGES = [
+    "arrow-cpp",
+    "arrow-cpp-proc",
+    "parquet-cpp",
+    "pyarrow",
+    "pyarrow-tests",
+    "r-arrow",
+]
+PLATFORMS = [
+    "linux-64",
+    "linux-aarch64",
+    "osx-64",
+    "win-64",
+]
+EXCLUDED_PATTERNS = [
+    ["r-arrow", "linux-aarch64"],
+]
 
 
 def packages_to_delete(package_name: str, platform: str) -> List[str]:
@@ -52,8 +67,10 @@ def packages_to_delete(package_name: str, platform: str) -> List[str]:
 
 if __name__ == "__main__":
     to_delete = []
-    for platform in PLATFORMS:
-        for package in PACKAGES:
+    for package in PACKAGES:
+        for platform in PLATFORMS:
+            if [package, platform] in EXCLUDED_PATTERNS:
+                continue
             to_delete += packages_to_delete(package, platform)
 
     for name in to_delete:


### PR DESCRIPTION
We need to remove old packages from nightly to avoid storage full.