### PR TITLE
ARROW-11642: [C++] Fix preprocessor directive for Windows in JVM detection

### DIFF
--- a/cpp/src/arrow/io/hdfs_internal.cc
+++ b/cpp/src/arrow/io/hdfs_internal.cc
@@ -173,7 +173,7 @@ Result<std::vector<PlatformFilename>> get_potential_libjvm_paths() {
   std::string file_name;
 
 // From heuristics
-#ifdef __WIN32
+#ifdef _WIN32
   ARROW_ASSIGN_OR_RAISE(search_prefixes, MakeFilenameVector({""}));
   ARROW_ASSIGN_OR_RAISE(search_suffixes,
                         MakeFilenameVector({"/jre/bin/server", "/bin/server"}));


### PR DESCRIPTION
Use properly defined WIN32 variable for the preprocessor (as documented in https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160). This currently prevents users (me) from creating a `pyarrow.fs.HadoopFileSystem` using pyarrow 3.0.0 and it renders

```powershell
Python 3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyarrow.fs as fs
>>> file_system = fs.HadoopFileSystem('afdatalaketest')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyarrow\_hdfs.pyx", line 83, in pyarrow._hdfs.HadoopFileSystem.__init__
  File "pyarrow\error.pxi", line 122, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow\error.pxi", line 99, in pyarrow.lib.check_status
OSError: Unable to load libhdfs: The specified module could not be found
```

Changing `__WIN32` for `_WIN32` fixes the issue.