### PR TITLE
ARROW-11650: [Rust][DataFusion] Add Postgres License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2193,3 +2193,34 @@ The files in cpp/src/arrow/vendored/fast_float/ contain code from
 https://github.com/lemire/fast_float
 
 which is made available under the Apache License 2.0.
+--------------------------------------------------------------------------------
+
+DataFusion aims to support the PostgreSQL compatibility. To achieve compatibility
+parts of the DataFusion code base may have reproduced code and documentation from the
+PostgreSQL project and are subject to the following license.
+
+  PostgreSQL Database Management System
+  (formerly known as Postgres, then as Postgres95)
+
+  Portions Copyright © 1996-2021, The PostgreSQL Global Development Group
+
+  Portions Copyright © 1994, The Regents of the University of California
+
+  Permission to use, copy, modify, and distribute this software and its
+  documentation for any purpose, without fee, and without a written
+  agreement is hereby granted, provided that the above copyright notice
+  and this paragraph and the following two paragraphs appear in all
+  copies.
+
+  IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+  FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+  INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+  DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF
+  THE POSSIBILITY OF SUCH DAMAGE.
+
+  THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+  AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+  ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS
+  TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+  MODIFICATIONS.


### PR DESCRIPTION
DataFusion aims to support the PostgreSQL compatibility. To achieve compatibility parts of the DataFusion code base may have reproduced code and documentation from the PostgreSQL project and needs the license to reflect this.