### PR TITLE
ARROW-11667: [Rust] Add documentation for utf8 comparison kernels

### DIFF
--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines basic comparison kernels for `PrimitiveArrays`.
+//! Defines basic comparison kernels for [`PrimitiveArray`]s.
 //!
 //! These kernels can leverage SIMD if available on your system.  Currently no runtime
 //! detection is provided, you should enable the specific SIMD intrinsics using
@@ -113,7 +113,7 @@ where
     compare_op_scalar!(left, right, op)
 }
 
-/// Perform SQL `left LIKE right` operation on `StringArray` / `LargeStringArray`.
+/// Perform SQL `left LIKE right` operation on [`StringArray`] / [`LargeStringArray`].
 ///
 /// There are two wildcards supported with the LIKE operator:
 ///
@@ -183,8 +183,8 @@ fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
 }
 
-/// Perform SQL `left LIKE right` operation on `StringArray` /
-/// `LargeStringArray` and a scalar.
+/// Perform SQL `left LIKE right` operation on [`StringArray`] /
+/// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`like_utf8`] for more details.
 pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
@@ -249,8 +249,8 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
-/// Perform SQL `left NOT LIKE right` operation on `StringArray` /
-/// `LargeStringArray`.
+/// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
+/// [`LargeStringArray`].
 ///
 /// See the documentation on [`like_utf8`] for more details.
 pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
@@ -301,8 +301,8 @@ pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
-/// Perform SQL `left NOT LIKE right` operation on `StringArray` /
-/// `LargeStringArray` and a scalar.
+/// Perform SQL `left NOT LIKE right` operation on [`StringArray`] /
+/// [`LargeStringArray`] and a scalar.
 ///
 /// See the documentation on [`like_utf8`] for more details.
 pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
@@ -354,7 +354,7 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
-/// Perform `left == right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left == right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -362,7 +362,7 @@ pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a == b)
 }
 
-/// Perform `left == right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left == right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -370,7 +370,7 @@ pub fn eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a == b)
 }
 
-/// Perform `left != right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left != right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -378,7 +378,7 @@ pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a != b)
 }
 
-/// Perform `left != right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left != right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -386,7 +386,7 @@ pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a != b)
 }
 
-/// Perform `left < right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left < right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -394,7 +394,7 @@ pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a < b)
 }
 
-/// Perform `left < right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left < right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -402,7 +402,7 @@ pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a < b)
 }
 
-/// Perform `left <= right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left <= right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -410,7 +410,7 @@ pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a <= b)
 }
 
-/// Perform `left <= right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left <= right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -418,7 +418,7 @@ pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a <= b)
 }
 
-/// Perform `left > right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left > right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -426,7 +426,7 @@ pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a > b)
 }
 
-/// Perform `left > right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left > right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -434,7 +434,7 @@ pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a > b)
 }
 
-/// Perform `left >= right` operation on `StringArray` / `LargeStringArray`.
+/// Perform `left >= right` operation on [`StringArray`] / [`LargeStringArray`].
 pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -442,7 +442,7 @@ pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a >= b)
 }
 
-/// Perform `left >= right` operation on `StringArray` / `LargeStringArray` and a scalar.
+/// Perform `left >= right` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
 pub fn gt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -85,6 +85,8 @@ macro_rules! compare_op_scalar {
     }};
 }
 
+/// Evaluate `op(left, right)` for `PrimitiveArray`s using a specified
+/// comparison function.
 pub fn no_simd_compare_op<T, F>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
@@ -97,6 +99,8 @@ where
     compare_op!(left, right, op)
 }
 
+/// Evaluate `op(left, right)` for `PrimitiveArray` and scalar using
+/// a specified comparison function.
 pub fn no_simd_compare_op_scalar<T, F>(
     left: &PrimitiveArray<T>,
     right: T::Native,
@@ -109,6 +113,24 @@ where
     compare_op_scalar!(left, right, op)
 }
 
+/// Perform SQL `left LIKE right` operation on `StringArray` / `LargeStringArray`.
+///
+/// There are two wildcards supported with the LIKE operator:
+///
+/// 1. `%` - The percent sign represents zero, one, or multiple characters
+/// 2. `_` - The underscore represents a single character
+///
+/// For example:
+/// ```
+/// use arrow::array::{StringArray, BooleanArray};
+/// use arrow::compute::like_utf8;
+///
+/// let strings = StringArray::from(vec!["Arrow", "Arrow", "Arrow", "Ar"]);
+/// let patterns = StringArray::from(vec!["A%", "B%", "A.", "A."]);
+///
+/// let result = like_utf8(&strings, &patterns).unwrap();
+/// assert_eq!(result, BooleanArray::from(vec![true, false, false, true]));
+/// ```
 pub fn like_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -161,6 +183,10 @@ fn is_like_pattern(c: char) -> bool {
     c == '%' || c == '_'
 }
 
+/// Perform SQL `left LIKE right` operation on `StringArray` /
+/// `LargeStringArray` and a scalar.
+///
+/// See the documentation on [`like_utf8`] for more details.
 pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -223,6 +249,10 @@ pub fn like_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
+/// Perform SQL `left NOT LIKE right` operation on `StringArray` /
+/// `LargeStringArray`.
+///
+/// See the documentation on [`like_utf8`] for more details.
 pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -271,6 +301,10 @@ pub fn nlike_utf8<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
+/// Perform SQL `left NOT LIKE right` operation on `StringArray` /
+/// `LargeStringArray` and a scalar.
+///
+/// See the documentation on [`like_utf8`] for more details.
 pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -320,6 +354,7 @@ pub fn nlike_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
+/// Perform `left == right` operation on `StringArray` / `LargeStringArray`.
 pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -327,6 +362,7 @@ pub fn eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a == b)
 }
 
+/// Perform `left == right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -334,6 +370,7 @@ pub fn eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a == b)
 }
 
+/// Perform `left != right` operation on `StringArray` / `LargeStringArray`.
 pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -341,6 +378,7 @@ pub fn neq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a != b)
 }
 
+/// Perform `left != right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -348,6 +386,7 @@ pub fn neq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a != b)
 }
 
+/// Perform `left < right` operation on `StringArray` / `LargeStringArray`.
 pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -355,6 +394,7 @@ pub fn lt_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a < b)
 }
 
+/// Perform `left < right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -362,6 +402,7 @@ pub fn lt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a < b)
 }
 
+/// Perform `left <= right` operation on `StringArray` / `LargeStringArray`.
 pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -369,6 +410,7 @@ pub fn lt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a <= b)
 }
 
+/// Perform `left <= right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -376,6 +418,7 @@ pub fn lt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a <= b)
 }
 
+/// Perform `left > right` operation on `StringArray` / `LargeStringArray`.
 pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -383,6 +426,7 @@ pub fn gt_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a > b)
 }
 
+/// Perform `left > right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,
@@ -390,6 +434,7 @@ pub fn gt_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     compare_op_scalar!(left, right, |a, b| a > b)
 }
 
+/// Perform `left >= right` operation on `StringArray` / `LargeStringArray`.
 pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -397,6 +442,7 @@ pub fn gt_eq_utf8<OffsetSize: StringOffsetSizeTrait>(
     compare_op!(left, right, |a, b| a >= b)
 }
 
+/// Perform `left >= right` operation on `StringArray` / `LargeStringArray` and a scalar.
 pub fn gt_eq_utf8_scalar<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &str,

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -85,7 +85,7 @@ macro_rules! compare_op_scalar {
     }};
 }
 
-/// Evaluate `op(left, right)` for `PrimitiveArray`s using a specified
+/// Evaluate `op(left, right)` for [`PrimitiveArray`]s using a specified
 /// comparison function.
 pub fn no_simd_compare_op<T, F>(
     left: &PrimitiveArray<T>,
@@ -99,7 +99,7 @@ where
     compare_op!(left, right, op)
 }
 
-/// Evaluate `op(left, right)` for `PrimitiveArray` and scalar using
+/// Evaluate `op(left, right)` for [`PrimitiveArray`] and scalar using
 /// a specified comparison function.
 pub fn no_simd_compare_op_scalar<T, F>(
     left: &PrimitiveArray<T>,
@@ -769,7 +769,7 @@ where
     return compare_op_scalar!(left, right, |a, b| a >= b);
 }
 
-/// Checks if a `GenericListArray` contains a value in the `PrimitiveArray`
+/// Checks if a [`GenericListArray`] contains a value in the [`PrimitiveArray`]
 pub fn contains<T, OffsetSize>(
     left: &PrimitiveArray<T>,
     right: &GenericListArray<OffsetSize>,
@@ -825,7 +825,7 @@ where
     Ok(BooleanArray::from(Arc::new(data)))
 }
 
-/// Checks if a `GenericListArray` contains a value in the `GenericStringArray`
+/// Checks if a [`GenericListArray`] contains a value in the [`GenericStringArray`]
 pub fn contains_utf8<OffsetSize>(
     left: &GenericStringArray<OffsetSize>,
     right: &ListArray,


### PR DESCRIPTION
ARROW-11667: [Rust] Add documentation for utf8 comparison kernels

When looking at the docs for https://docs.rs/arrow/3.0.0/arrow/compute/kernels/comparison/index.html I noticed there were several kernels without documentation, so I added some.
