### PR TITLE
ARROW-11669: [Rust] [DataFusion] Remove concurrency field from GlobalLimitExec and SortExec

### DIFF
--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -44,18 +44,12 @@ pub struct GlobalLimitExec {
     input: Arc<dyn ExecutionPlan>,
     /// Maximum number of rows to return
     limit: usize,
-    /// Number of threads to run parallel LocalLimitExec on
-    concurrency: usize,
 }
 
 impl GlobalLimitExec {
     /// Create a new MergeExec
-    pub fn new(input: Arc<dyn ExecutionPlan>, limit: usize, concurrency: usize) -> Self {
-        GlobalLimitExec {
-            input,
-            limit,
-            concurrency,
-        }
+    pub fn new(input: Arc<dyn ExecutionPlan>, limit: usize) -> Self {
+        GlobalLimitExec { input, limit }
     }
 
     /// Input execution plan
@@ -101,7 +95,6 @@ impl ExecutionPlan for GlobalLimitExec {
             1 => Ok(Arc::new(GlobalLimitExec::new(
                 children[0].clone(),
                 self.limit,
-                self.concurrency,
             ))),
             _ => Err(DataFusionError::Internal(
                 "GlobalLimitExec wrong number of children".to_string(),
@@ -280,7 +273,7 @@ mod tests {
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
 
-        let limit = GlobalLimitExec::new(Arc::new(MergeExec::new(Arc::new(csv))), 7, 2);
+        let limit = GlobalLimitExec::new(Arc::new(MergeExec::new(Arc::new(csv))), 7);
 
         // the result should contain 4 batches (one per input partition)
         let iter = limit.execute(0).await?;

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -318,11 +318,7 @@ impl DefaultPhysicalPlanner {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                Ok(Arc::new(SortExec::try_new(
-                    sort_expr,
-                    input,
-                    ctx_state.config.concurrency,
-                )?))
+                Ok(Arc::new(SortExec::try_new(sort_expr, input)?))
             }
             LogicalPlan::Join {
                 left,
@@ -366,11 +362,7 @@ impl DefaultPhysicalPlanner {
                     Arc::new(LocalLimitExec::new(input, limit))
                 };
 
-                Ok(Arc::new(GlobalLimitExec::new(
-                    input,
-                    limit,
-                    ctx_state.config.concurrency,
-                )))
+                Ok(Arc::new(GlobalLimitExec::new(input, limit)))
             }
             LogicalPlan::CreateExternalTable { .. } => {
                 // There is no default plan for "CREATE EXTERNAL


### PR DESCRIPTION
Remove redundant concurrency field from GlobalLimitExec and SortExec. This was used before we fully moved to Tokio.