### PR TITLE
ARROW-11676: [Format] Introduce Complex IntervalUnit

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -246,7 +246,7 @@ table Timestamp {
   timezone: string;
 }
 
-enum IntervalUnit: short { YEAR_MONTH, DAY_TIME}
+enum IntervalUnit: short { YEAR_MONTH, DAY_TIME, COMPLEX }
 // A "calendar" interval which models types that don't necessarily
 // have a precise duration without the context of a base timestamp (e.g.
 // days can differ in length during day light savings time transitions).
@@ -254,6 +254,9 @@ enum IntervalUnit: short { YEAR_MONTH, DAY_TIME}
 //   4-byte integers.
 // DAY_TIME - Indicates the number of elapsed days and milliseconds,
 //   stored as 2 contiguous 32-bit integers (8-bytes in total).  Support
+//   of this IntervalUnit is not required for full arrow compatibility.
+// COMPLEX - Indicates the number of elapsed whole months, days and milliseconds,
+//   stored as 3 contiguous 32-bit integers (12-bytes in total).  Support
 //   of this IntervalUnit is not required for full arrow compatibility.
 table Interval {
   unit: IntervalUnit;


### PR DESCRIPTION
This commit introduces a new type for IntervalUnit to support complex intervals which allows storing months, days, and milliseconds as different parts which are important to support complex intervals without recasting parts.
