### PR TITLE
ARROW-11668: [C++] Sporadic UBSAN error in FutureStessTest.TryAddCallback

### DIFF
--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -182,7 +182,7 @@ class ReadaheadGenerator {
  public:
   ReadaheadGenerator(AsyncGenerator<T> source_generator, int max_readahead)
       : source_generator_(std::move(source_generator)), max_readahead_(max_readahead) {
-    auto finished = std::make_shared<std::atomic<bool>>();
+    auto finished = std::make_shared<std::atomic<bool>>(false);
     mark_finished_if_done_ = [finished](const Result<T>& next_result) {
       if (!next_result.ok()) {
         finished->store(true);

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -513,7 +513,7 @@ TEST(FutureStessTest, TryAddCallback) {
   for (unsigned int n = 0; n < 1; n++) {
     auto fut = Future<>::Make();
     std::atomic<unsigned int> callbacks_added(0);
-    std::atomic<bool> finished;
+    std::atomic<bool> finished(false);
     std::mutex mutex;
     std::condition_variable cv;
     std::thread::id callback_adder_thread_id;


### PR DESCRIPTION
The UBSAN test was periodically failing because an uninitialized std::atomic<bool> could have any value.  I did a review of std::atomic<bool> and found at least one other place where I had made this incorrect assumption.  Both are fixed here.