### PR TITLE
ARROW-11681: [Rust] Don't unwrap in IPC writers

### DIFF
--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -467,7 +467,7 @@ impl<W: Write> FileWriter<W> {
 impl<W: Write> Drop for FileWriter<W> {
     fn drop(&mut self) {
         if !self.finished {
-            self.finish().unwrap();
+            let _ = self.finish();
         }
     }
 }
@@ -549,7 +549,7 @@ impl<W: Write> StreamWriter<W> {
 impl<W: Write> Drop for StreamWriter<W> {
     fn drop(&mut self) {
         if !self.finished {
-            self.finish().unwrap();
+            let _ = self.finish();
         }
     }
 }


### PR DESCRIPTION
A common reason a writer would be dropping without finishing is because
the underlying stream returned an earlier error. In that case, the
destructor will probably also encounter an error, resulting in a panic.
Instead just ignore the result from finish, mirroring the behavior of
the standard library's BufWriter.