### PR TITLE
ARROW-11687: [Rust][DataFusion] RepartitionExec Hanging

### DIFF
--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -125,7 +125,7 @@ impl ExecutionPlan for RepartitionExec {
                 let input = self.input.clone();
                 let mut channels = channels.clone();
                 let partitioning = self.partitioning.clone();
-                let _: JoinHandle<Result<()>> = tokio::spawn(async move {
+                let join_handle: JoinHandle<Result<()>> = tokio::spawn(async move {
                     let mut stream = input.execute(i).await?;
                     let mut counter = 0;
                     while let Some(result) = stream.next().await {
@@ -157,6 +157,7 @@ impl ExecutionPlan for RepartitionExec {
                     }
                     Ok(())
                 });
+                join_handle.await.map(|_| ()).map_err(|e| DataFusionError::Execution(e.to_string()))?;
             }
         }
 

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -157,7 +157,10 @@ impl ExecutionPlan for RepartitionExec {
                     }
                     Ok(())
                 });
-                join_handle.await.map(|_| ()).map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                join_handle
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             }
         }
 


### PR DESCRIPTION
@andygrove 

I found an interesting defect where the final partition of the `RepartitionExec::execute` thread spawner was consistently not being spawned via `tokio::spawn`. This meant that `RepartitionStream::poll_next` was sitting waiting forever for data that never arrived. I am unable to reproduce via DataFusion tests.

It looks like a race condition where the `JoinHandle` was not being `await`ed and something strange going on with the internals of tokio like lazy evaluation?

This PR fixes the problem.