### PR TITLE
ARROW-11692: [Rust][DataFusion] Improve OptimizerRule comments

### DIFF
--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -20,11 +20,14 @@
 use crate::error::Result;
 use crate::logical_plan::LogicalPlan;
 
-/// An optimizer rules performs a transformation on a logical plan to produce an optimized
-/// logical plan.
+
+/// `OptimizerRule` transforms one ['LogicalPlan'] into another which
+/// computes the same results, but in a potentially more efficient
+/// way.
 pub trait OptimizerRule {
-    /// Perform optimizations on the plan
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan>;
-    /// Produce a human readable name for this optimizer rule
+    /// Rewrite `plan` to an optimized form
+    fn optimize(&self, plan: LogicalPlan) -> Result<LogicalPlan>;
+
+    /// A human readable name for this optimizer rule
     fn name(&self) -> &str;
 }

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -26,7 +26,7 @@ use crate::logical_plan::LogicalPlan;
 /// way.
 pub trait OptimizerRule {
     /// Rewrite `plan` to an optimized form
-    fn optimize(&self, plan: LogicalPlan) -> Result<LogicalPlan>;
+    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan>;
 
     /// A human readable name for this optimizer rule
     fn name(&self) -> &str;

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -20,7 +20,6 @@
 use crate::error::Result;
 use crate::logical_plan::LogicalPlan;
 
-
 /// `OptimizerRule` transforms one ['LogicalPlan'] into another which
 /// computes the same results, but in a potentially more efficient
 /// way.


### PR DESCRIPTION
I am messing around with `OptimizerRule` for some experiments, and found myself clarifying the comments each time... So I figured I would at least get the doc changes queued for inclusion 