### PR TITLE
ARROW-11708: [Rust] fix Rust 2021 linting warnings

### DIFF
--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -2046,7 +2046,9 @@ mod tests {
         let read = batch.column(0);
         assert!(
             expected.data_ref() == read.data_ref(),
-            format!("{:?} != {:?}", expected.data(), read.data())
+            "{:?} != {:?}",
+            expected.data(),
+            read.data(),
         );
     }
 

--- a/rust/arrow/src/json/writer.rs
+++ b/rust/arrow/src/json/writer.rs
@@ -156,10 +156,10 @@ pub fn array_to_json_array(array: &ArrayRef) -> Vec<Value> {
             jsonmaps.into_iter().map(Value::Object).collect()
         }
         _ => {
-            panic!(format!(
+            panic!(
                 "Unsupported datatype for array conversion: {:#?}",
                 array.data_type()
-            ));
+            );
         }
     }
 }
@@ -281,7 +281,7 @@ fn set_column_for_json_rows(
                 });
         }
         _ => {
-            panic!(format!("Unsupported datatype: {:#?}", array.data_type()));
+            panic!("Unsupported datatype: {:#?}", array.data_type());
         }
     }
 }

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -278,12 +278,13 @@ impl From<&StructArray> for RecordBatch {
     }
 }
 
-impl Into<StructArray> for RecordBatch {
-    fn into(self) -> StructArray {
-        self.schema
+impl From<RecordBatch> for StructArray {
+    fn from(batch: RecordBatch) -> Self {
+        batch
+            .schema
             .fields
             .iter()
-            .zip(self.columns.iter())
+            .zip(batch.columns.iter())
             .map(|t| (t.0.clone(), t.1.clone()))
             .collect::<Vec<(Field, ArrayRef)>>()
             .into()

--- a/rust/arrow/src/util/test_util.rs
+++ b/rust/arrow/src/util/test_util.rs
@@ -78,7 +78,7 @@ pub fn get_temp_file(file_name: &str, content: &[u8]) -> fs::File {
 pub fn arrow_test_data() -> String {
     match get_data_dir("ARROW_TEST_DATA", "../../testing/data") {
         Ok(pb) => pb.display().to_string(),
-        Err(err) => panic!(format!("failed to get arrow data dir: {}", err)),
+        Err(err) => panic!("failed to get arrow data dir: {}", err),
     }
 }
 
@@ -103,7 +103,7 @@ pub fn parquet_test_data() -> String {
         "../../cpp/submodules/parquet-testing/data",
     ) {
         Ok(pb) => pb.display().to_string(),
-        Err(err) => panic!(format!("failed to get parquet data dir: {}", err)),
+        Err(err) => panic!("failed to get parquet data dir: {}", err),
     }
 }
 

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -855,7 +855,7 @@ mod tests {
                 "Expression {:?} expected to error due to impossible coercion",
                 case
             );
-            assert!(logical_plan.is_err(), message);
+            assert!(logical_plan.is_err(), "{}", message);
         }
         Ok(())
     }

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         "JSON_TO_ARROW" => json_to_arrow(json_file, arrow_file, verbose),
         "ARROW_TO_JSON" => arrow_to_json(arrow_file, json_file, verbose),
         "VALIDATE" => validate(arrow_file, json_file, verbose),
-        _ => panic!(format!("mode {} not supported", mode)),
+        _ => panic!("mode {} not supported", mode),
     }
 }
 


### PR DESCRIPTION
Sample warning:

```
warning: panic message is not a string literal                                                                                                                                                                                 
    --> arrow/src/json/reader.rs:2049:13                                                                                                                                                                                       
     |                                                                                                                                                                                                                         
2049 |             format!("{:?} != {:?}", expected.data(), read.data())                                                                                                                                                       
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                       
     |                                                                                                                                                                                                                         
     = note: `#[warn(non_fmt_panic)]` on by default                                                                                                                                                                            
     = note: this is no longer accepted in Rust 2021 
```