### PR TITLE
ARROW-11718: [Rust] Don't write IPC footers on drop

### DIFF
--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -78,6 +78,8 @@ fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()>
         writer.write(&b)?;
     }
 
+    writer.finish()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
As discussed in #9520, these destructors shouldn't be there at all.