### PR TITLE
ARROW-11722: [Rust] Improve error message in FFI cast.

### DIFF
--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -193,11 +193,11 @@ fn to_datatype(format: &str) -> Result<DataType> {
         "ttm" => DataType::Time32(TimeUnit::Millisecond),
         "ttu" => DataType::Time64(TimeUnit::Microsecond),
         "ttn" => DataType::Time64(TimeUnit::Nanosecond),
-        _ => {
-            return Err(ArrowError::CDataInterface(
-                "The datatype \"{}\" is still not supported in Rust implementation"
-                    .to_string(),
-            ))
+        dt => {
+            return Err(ArrowError::CDataInterface(format!(
+                "The datatype \"{}\" is still not supported in Rust implementation",
+                dt
+            )))
         }
     })
 }

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -195,7 +195,7 @@ fn to_datatype(format: &str) -> Result<DataType> {
         "ttn" => DataType::Time64(TimeUnit::Nanosecond),
         dt => {
             return Err(ArrowError::CDataInterface(format!(
-                "The datatype \"{}\" is still not supported in Rust implementation",
+                "The datatype \"{}\" is not supported in the Rust implementation",
                 dt
             )))
         }


### PR DESCRIPTION
While trying to cast from pyarrow to rust I encountered the following error message: `CDataInterface("The datatype \"{}\" is still not supported in Rust implementation")`, which is not very informative. 

This PR is very small and prints the datatype format passed to the function in the error message.