### PR TITLE
ARROW-11723: [Rust][DataFusion] Change SQL parser to use PostgreSQL dialect

### DIFF
--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -21,7 +21,7 @@
 
 use sqlparser::{
     ast::{ColumnDef, ColumnOptionDef, Statement as SQLStatement, TableConstraint},
-    dialect::{keywords::Keyword, Dialect, GenericDialect},
+    dialect::{keywords::Keyword, Dialect, PostgreSqlDialect},
     parser::{Parser, ParserError},
     tokenizer::{Token, Tokenizer},
 };
@@ -78,7 +78,7 @@ pub struct DFParser<'a> {
 impl<'a> DFParser<'a> {
     /// Parse the specified tokens
     pub fn new(sql: &str) -> Result<Self, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::new_with_dialect(sql, dialect)
     }
 
@@ -97,7 +97,7 @@ impl<'a> DFParser<'a> {
 
     /// Parse a SQL statement and produce a set of statements with dialect
     pub fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
-        let dialect = &GenericDialect {};
+        let dialect = &PostgreSqlDialect {};
         DFParser::parse_sql_with_dialect(sql, dialect)
     }
 


### PR DESCRIPTION
As suggested by @andygrove we should use the PostgreSQL dialect now (by default), now that we decided o be PostgreSQL-compatible.

Currently this makes the `VarProvider` fail (introduced here: https://github.com/apache/arrow/pull/8135), which depends on identifiers starting with `@`, and which is not supported in PostgreSQL. I am wondering if we should remove this feature or make it work in another way?