### PR TITLE
ARROW-11724: [C++] Resolve namespace collisions with protobuf 3.15

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -58,11 +58,11 @@
 #include "arrow/flight/serialization_internal.h"
 #include "arrow/flight/types.h"
 
-namespace pb = arrow::flight::protocol;
-
 namespace arrow {
 
 namespace flight {
+
+namespace pb = arrow::flight::protocol;
 
 const char* kWriteSizeDetailTypeId = "flight::FlightWriteSizeStatusDetail";
 

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -51,10 +51,10 @@
 #include "arrow/flight/middleware_internal.h"
 #include "arrow/flight/test_util.h"
 
-namespace pb = arrow::flight::protocol;
-
 namespace arrow {
 namespace flight {
+
+namespace pb = arrow::flight::protocol;
 
 const char kValidUsername[] = "flight_username";
 const char kValidPassword[] = "flight_password";

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -53,13 +53,13 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
 
-namespace pb = arrow::flight::protocol;
-
 static constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
 
 namespace arrow {
 namespace flight {
 namespace internal {
+
+namespace pb = arrow::flight::protocol;
 
 using arrow::ipc::IpcPayload;
 

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -60,10 +60,10 @@ using ServerContext = grpc::ServerContext;
 template <typename T>
 using ServerWriter = grpc::ServerWriter<T>;
 
-namespace pb = arrow::flight::protocol;
-
 namespace arrow {
 namespace flight {
+
+namespace pb = arrow::flight::protocol;
 
 // Macro that runs interceptors before returning the given status
 #define RETURN_WITH_MIDDLEWARE(CONTEXT, STATUS) \


### PR DESCRIPTION
Renames our alias to `afpb` to not clash with `protobuf`'s definition.

Original error:

```
../src/arrow/flight/server.cc:63:11: error: redefinition of 'pb' as an alias for a different namespace
namespace pb = arrow::flight::protocol;
          ^
/Users/uwe/mambaforge/conda-bld/arrow-cpp-ext_1613940663852/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/include/google/protobuf/port.h:44:11: note: previously defined as an alias for 'protobuf_future_namespace_placeholder'
namespace pb = ::protobuf_future_namespace_placeholder;
          ^
1 error generated.
```