### PR TITLE
ARROW-11725: [Rust][DataFusion] Make use of the new divide_scalar kernel in arrow

### DIFF
--- a/rust/datafusion/src/physical_plan/expressions/binary.rs
+++ b/rust/datafusion/src/physical_plan/expressions/binary.rs
@@ -167,7 +167,7 @@ macro_rules! binary_string_array_op_scalar {
         let result: Result<Arc<dyn Array>> = match $LEFT.data_type() {
             DataType::Utf8 => compute_utf8_op_scalar!($LEFT, $RIGHT, $OP, StringArray),
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for scalar operation on string array",
                 other
             ))),
         };
@@ -180,7 +180,7 @@ macro_rules! binary_string_array_op {
         match $LEFT.data_type() {
             DataType::Utf8 => compute_utf8_op!($LEFT, $RIGHT, $OP, StringArray),
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for binary operation on string arrays",
                 other
             ))),
         }
@@ -204,7 +204,7 @@ macro_rules! binary_primitive_array_op {
             DataType::Float32 => compute_op!($LEFT, $RIGHT, $OP, Float32Array),
             DataType::Float64 => compute_op!($LEFT, $RIGHT, $OP, Float64Array),
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for binary operation on primitive arrays",
                 other
             ))),
         }
@@ -228,7 +228,7 @@ macro_rules! binary_primitive_array_op_scalar {
             DataType::Float32 => compute_op_scalar!($LEFT, $RIGHT, $OP, Float32Array),
             DataType::Float64 => compute_op_scalar!($LEFT, $RIGHT, $OP, Float64Array),
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for scalar operation on primitive array",
                 other
             ))),
         };
@@ -260,7 +260,7 @@ macro_rules! binary_array_op_scalar {
                 compute_op_scalar!($LEFT, $RIGHT, $OP, Date32Array)
             }
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for scalar operation on dyn array",
                 other
             ))),
         };
@@ -295,7 +295,7 @@ macro_rules! binary_array_op {
                 compute_op!($LEFT, $RIGHT, $OP, Date64Array)
             }
             other => Err(DataFusionError::Internal(format!(
-                "Unsupported data type {:?}",
+                "Data type {:?} not supported for binary operation on dyn arrays",
                 other
             ))),
         }


### PR DESCRIPTION
This is a small PR to make DataFusion use the just-merged `divide_scalar` arrow kernel (#9454).

Performance-wise: 
* on the `arrow` side, this specialized kernel is ~40-50% faster than the standard `divide`, mostly due to not having to check for divide-by-zero on every row; 
* on the `datafusion` side, it can now skip the `scalar.to_array_of_size(num_rows)` allocation, which should be a decent win for operations on large arrays. 

The eventual goal is to have `op_scalar` variants for every arithmetic operation — `divide` will show the biggest performance gains but all variants should save DataFusion a (possibly expensive) allocation.