### PR TITLE
ARROW-11730: [C++] Add implicit convenience constructors for constructing Future from Status/Result

### DIFF
--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -493,9 +493,15 @@ class ARROW_MUST_USE_TYPE Future {
     });
   }
 
+  /// \brief Implicit constructor to create a finished future from a value
+  Future(ValueType val) : Future() {  // NOLINT runtime/explicit
+    impl_ = FutureImpl::MakeFinished(FutureState::SUCCESS);
+    SetResult(std::move(val));
+  }
+
   /// \brief Implicit constructor to create a future from a Result, enabling use
   ///     of macros like ARROW_ASSIGN_OR_RAISE.
-  Future(Result<ValueType> res) : Future() {  // NOLINT(runtime/explicit)
+  Future(Result<ValueType> res) : Future() {  // NOLINT runtime/explicit
     if (ARROW_PREDICT_TRUE(res.ok())) {
       impl_ = FutureImpl::MakeFinished(FutureState::SUCCESS);
     } else {
@@ -506,7 +512,7 @@ class ARROW_MUST_USE_TYPE Future {
 
   /// \brief Implicit constructor to create a future from a Status, enabling use
   ///     of macros like ARROW_RETURN_NOT_OK.
-  Future(Status s)  // NOLINT(runtime/explicit)
+  Future(Status s)  // NOLINT runtime/explicit
       : Future(Result<ValueType>(std::move(s))) {}
 
  protected:

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -493,6 +493,22 @@ class ARROW_MUST_USE_TYPE Future {
     });
   }
 
+  /// \brief Implicit constructor to create a future from a Result, enabling use
+  ///     of macros like ARROW_ASSIGN_OR_RAISE.
+  Future(Result<ValueType> res) : Future() {  // NOLINT(runtime/explicit)
+    if (ARROW_PREDICT_TRUE(res.ok())) {
+      impl_ = FutureImpl::MakeFinished(FutureState::SUCCESS);
+    } else {
+      impl_ = FutureImpl::MakeFinished(FutureState::FAILURE);
+    }
+    SetResult(std::move(res));
+  }
+
+  /// \brief Implicit constructor to create a future from a Status, enabling use
+  ///     of macros like ARROW_RETURN_NOT_OK.
+  Future(Status s)  // NOLINT(runtime/explicit)
+      : Future(Result<ValueType>(std::move(s))) {}
+
  protected:
   template <typename OnComplete>
   struct Callback {

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -392,6 +392,30 @@ TEST(FutureSyncTest, GetStatusFuture) {
   }
 }
 
+// Ensure the implicit convenience constructors behave as desired.
+TEST(FutureSyncTest, ImplicitConstructors) {
+  {
+    auto fut = ([]() -> Future<MoveOnlyDataType> {
+      return arrow::Status::Invalid("Invalid");
+    })();
+    AssertFailed(fut);
+    ASSERT_RAISES(Invalid, fut.result());
+  }
+  {
+    auto fut = ([]() -> Future<MoveOnlyDataType> {
+      return arrow::Result<MoveOnlyDataType>(arrow::Status::Invalid("Invalid"));
+    })();
+    AssertFailed(fut);
+    ASSERT_RAISES(Invalid, fut.result());
+  }
+  {
+    auto fut = ([]() -> Future<MoveOnlyDataType> {
+      return arrow::Result<MoveOnlyDataType>(MoveOnlyDataType(42));
+    })();
+    AssertSuccessful(fut);
+  }
+}
+
 TEST(FutureRefTest, ChainRemoved) {
   // Creating a future chain should not prevent the futures from being deleted if the
   // entire chain is deleted

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -409,6 +409,10 @@ TEST(FutureSyncTest, ImplicitConstructors) {
     ASSERT_RAISES(Invalid, fut.result());
   }
   {
+    auto fut = ([]() -> Future<MoveOnlyDataType> { return MoveOnlyDataType(42); })();
+    AssertSuccessful(fut);
+  }
+  {
     auto fut = ([]() -> Future<MoveOnlyDataType> {
       return arrow::Result<MoveOnlyDataType>(MoveOnlyDataType(42));
     })();


### PR DESCRIPTION
This enables use of macros like ARROW_RETURN_NOT_OK and ARROW_ASSIGN_OR_RAISE.