### PR TITLE
ARROW-11733: [Rust][DataFusion] Implement hash partitioning

### DIFF
--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -699,7 +699,10 @@ macro_rules! hash_array {
 }
 
 /// Creates hash values for every element in the row based on the values in the columns
-pub fn create_hashes(arrays: &[ArrayRef], random_state: &RandomState) -> Result<Vec<u64>> {
+pub fn create_hashes(
+    arrays: &[ArrayRef],
+    random_state: &RandomState,
+) -> Result<Vec<u64>> {
     let rows = arrays[0].len();
     let mut hashes = vec![0; rows];
 

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -699,7 +699,7 @@ macro_rules! hash_array {
 }
 
 /// Creates hash values for every element in the row based on the values in the columns
-fn create_hashes(arrays: &[ArrayRef], random_state: &RandomState) -> Result<Vec<u64>> {
+pub fn create_hashes(arrays: &[ArrayRef], random_state: &RandomState) -> Result<Vec<u64>> {
     let rows = arrays[0].len();
     let mut hashes = vec![0; rows];
 

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -180,7 +180,7 @@ impl ExecutionPlan for RepartitionExec {
                                         columns,
                                     );
                                     let tx = &mut channels[num_output_partition].0;
-                                    tx.send(Some(input_batch)).map_err(|e| {
+                                    tx.send(Some(output_batch)).map_err(|e| {
                                         DataFusionError::Execution(e.to_string())
                                     })?;
                                 }

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -162,7 +162,7 @@ impl ExecutionPlan for RepartitionExec {
                                     let indices =
                                         indices[num_output_partition].clone().into();
                                     // Produce batches based on indices
-                                    let columns = batch
+                                    let columns = input_batch
                                         .columns()
                                         .iter()
                                         .map(|c| {

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -366,6 +366,7 @@ mod tests {
 
         let total_rows: usize = output_partitions.iter().map(|x| x.len()).sum();
 
+        assert_eq!(8, output_partitions.len());
         assert_eq!(total_rows, 8 * 50 * 3);
 
         Ok(())

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -351,7 +351,6 @@ mod tests {
         let partition = create_vec_batches(&schema, 50);
         let partitions = vec![partition.clone(), partition.clone(), partition.clone()];
 
-        // repartition from 3 input to 5 output
         let output_partitions = repartition(
             &schema,
             partitions,

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -158,9 +158,10 @@ impl ExecutionPlan for RepartitionExec {
                                         [(*hash % num_output_partitions as u64) as usize]
                                         .push(index as u64)
                                 }
-                                for num_output_partition in 0..num_output_partitions {
-                                    let indices =
-                                        indices[num_output_partition].clone().into();
+                                for (num_output_partition, partition_indices) in
+                                    indices.into_iter().enumerate()
+                                {
+                                    let indices = partition_indices.into();
                                     // Produce batches based on indices
                                     let columns = input_batch
                                         .columns()


### PR DESCRIPTION
This PR implements a first version of hash repartition.
This can used to (further) parallelize hash joins / aggregates or to implement distributed algorithms like `ShuffleHashJoin`(https://github.com/ballista-compute/ballista/issues/595 )

I didn't yet optimize for speed, as I think it makes sense to implement it and look for improvements later.

FYI @andygrove 
