### PR TITLE
ARROW-11501: [C++] endianness check does not work on Solaris

### DIFF
--- a/cpp/src/arrow/util/endian.h
+++ b/cpp/src/arrow/util/endian.h
@@ -22,6 +22,8 @@
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <machine/endian.h>  // IWYU pragma: keep
+#elif defined(sun) || defined(__sun)
+#include <sys/byteorder.h>  // IWYU pragma: keep
 #else
 #include <endian.h>  // IWYU pragma: keep
 #endif

--- a/cpp/src/arrow/vendored/fast_float/README.md
+++ b/cpp/src/arrow/vendored/fast_float/README.md
@@ -5,3 +5,4 @@ See https://github.com/lemire/fast_float
 
 Changes:
 - enclosed in `arrow_vendored` namespace.
+- changeset e0bd5735300e761d8553a24b0525dd1e856fa4ca has been applied (Solaris endian header)

--- a/cpp/src/arrow/vendored/fast_float/float_common.h
+++ b/cpp/src/arrow/vendored/fast_float/float_common.h
@@ -32,6 +32,10 @@
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <machine/endian.h>
+// Start: addition to Arrow for Solaris support
+#elif defined(sun) || defined(__sun)
+#include <sys/byteorder.h>  // IWYU pragma: keep
+// End
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
This includes the change that @kiszk suggested, also applied to the vendored fast_float header as well. That patch has been upstreamed (https://github.com/fastfloat/fast_float/pull/59). I have confirmed that this now compiles on Solaris.