### PR TITLE
ARROW-11734: [C++] vendored safe-math.h does not compile on Solaris

### DIFF
--- a/cpp/src/arrow/vendored/portable-snippets/safe-math.h
+++ b/cpp/src/arrow/vendored/portable-snippets/safe-math.h
@@ -58,7 +58,8 @@
 #  define PSNIP_SAFE__FUNCTION PSNIP_SAFE__COMPILER_ATTRIBUTES static PSNIP_SAFE__INLINE
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+// !defined(__cplusplus) added for Solaris support
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define psnip_safe_bool _Bool
 #else
 #  define psnip_safe_bool int


### PR DESCRIPTION
This change fixes the issue, though I don't know enough about what is going on here to fix it properly. Maybe something similar to https://github.com/Cyan4973/xxHash/pull/498 is better (and could be upstreamed)?