### PR TITLE
ARROW-11746: [Developer][Archery] Fix prefer real time check

### DIFF
--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -104,7 +104,7 @@ class GoogleBenchmarkObservation:
     @property
     def is_realtime(self):
         """ Indicate if the preferred value is realtime instead of cputime. """
-        return self.name.find("/realtime") != -1
+        return self.name.find("/real_time") != -1
 
     @property
     def name(self):

--- a/dev/archery/tests/test_benchmarks.py
+++ b/dev/archery/tests/test_benchmarks.py
@@ -58,6 +58,61 @@ def test_benchmark_median():
         pass
 
 
+def assert_benchmark(name, google_result, archery_result):
+    observation = GoogleBenchmarkObservation(**google_result)
+    benchmark = GoogleBenchmark(name, [observation])
+    result = json.dumps(benchmark, cls=JsonEncoder)
+    assert json.loads(result) == archery_result
+
+
+def test_prefer_real_time():
+    name = "AllocateDeallocate<Jemalloc>/size:1048576/real_time"
+    google_result = {
+        "cpu_time": 1778.6004847419827,
+        "iterations": 352765,
+        "name": name,
+        "real_time": 1835.3137357788837,
+        "repetition_index": 0,
+        "repetitions": 0,
+        "run_name": "AllocateDeallocate<Jemalloc>/size:1048576/real_time",
+        "run_type": "iteration",
+        "threads": 1,
+        "time_unit": "ns",
+    }
+    archery_result = {
+        "name": name,
+        "unit": "ns",
+        "less_is_better": True,
+        "values": [1835.3137357788837],
+    }
+    assert name.endswith("/real_time")
+    assert_benchmark(name, google_result, archery_result)
+
+
+def test_prefer_cpu_time():
+    name = "AllocateDeallocate<Jemalloc>/size:1048576"
+    google_result = {
+        "cpu_time": 1778.6004847419827,
+        "iterations": 352765,
+        "name": name,
+        "real_time": 1835.3137357788837,
+        "repetition_index": 0,
+        "repetitions": 0,
+        "run_name": "AllocateDeallocate<Jemalloc>/size:1048576",
+        "run_type": "iteration",
+        "threads": 1,
+        "time_unit": "ns",
+    }
+    archery_result = {
+        "name": name,
+        "unit": "ns",
+        "less_is_better": True,
+        "values": [1778.6004847419827],
+    }
+    assert not name.endswith("/real_time")
+    assert_benchmark(name, google_result, archery_result)
+
+
 def test_omits_aggregates():
     name = "AllocateDeallocate<Jemalloc>/size:1048576/real_time"
     google_aggregate = {
@@ -88,7 +143,7 @@ def test_omits_aggregates():
         "name": name,
         "unit": "ns",
         "less_is_better": True,
-        "values": [1778.6004847419827],
+        "values": [1835.3137357788837],
     }
     assert google_aggregate["run_type"] == "aggregate"
     assert google_result["run_type"] == "iteration"


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/ARROW-11746

Google Benchmark adds `/real_time` to the end of the benchmark name to indicate if the `real_time` observation should be preferred over the `cpu_time` observation.

https://github.com/google/benchmark/blob/af72911f2fe6b8114564614d2db17a449f8c4af0/src/benchmark_register.cc#L222

Example: `AllocateDeallocate<Jemalloc>/size:1048576/real_time`

Archery is looking for `"/realtime"`, not `"/real_time"` though.

```
 @property
 def is_realtime(self):
     """ Indicate if the preferred value is realtime instead of cputime. """
     return self.name.find("/realtime") != -1
```