### PR TITLE
ARROW-11727: [C++][FlightRPC] Estimate latency quantiles with TDigest

### DIFF
--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -332,6 +332,14 @@ class TDigest::TDigestImpl {
     return Lerp(td[ci_left].mean, td[ci_right].mean, diff);
   }
 
+  double Mean() const {
+    double sum = 0;
+    for (const auto& centroid : tdigests_[current_]) {
+      sum += centroid.mean * centroid.weight;
+    }
+    return total_weight_ == 0 ? NAN : sum / total_weight_;
+  }
+
   double total_weight() const { return total_weight_; }
 
  private:
@@ -387,6 +395,11 @@ void TDigest::Merge(std::vector<TDigest>* tdigests) {
 double TDigest::Quantile(double q) {
   MergeInput();
   return impl_->Quantile(q);
+}
+
+double TDigest::Mean() {
+  MergeInput();
+  return impl_->Mean();
 }
 
 bool TDigest::is_empty() const {

--- a/cpp/src/arrow/util/tdigest.h
+++ b/cpp/src/arrow/util/tdigest.h
@@ -80,6 +80,10 @@ class ARROW_EXPORT TDigest {
   // calculate quantile
   double Quantile(double q);
 
+  double Min() { return Quantile(0); }
+  double Max() { return Quantile(1); }
+  double Mean();
+
   // check if this tdigest contains no valid data points
   bool is_empty() const;
 


### PR DESCRIPTION
Current code uses P-Square algorithm from boost accumulator library to
estimate latency quantiles. P-Square is very bad at estimating skewed
quantiles like 0.99. This patch replaces boost accumulator with our own
TDigest utility, which gives much more accurate estimations.

Evaluate 0.99 latency quantile accuracy of TDigest and Boost.
Exact value is obtained by storing and sorting all data points.

| Exact | TDigest | Boost-P2 |
| ----- | ------- | -------- |
| 86    | 93      | 2130     |
| 175   | 235     | 1526     |
| 151   | 165     | 1926     |
| 147   | 153     | 302      |
| 251   | 313     | 561      |