### PR TITLE
ARROW-11757: [C++][Gandiva] castTIMESTAMP(utf8) function should return rounded milliseconds if input has higher precision than millis

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -21,6 +21,7 @@ extern "C" {
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -672,13 +673,14 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t context, const char* input, gdv_int32 l
   // adjust the milliseconds
   if (sub_seconds_len > 0) {
     if (sub_seconds_len > 3) {
-      const char* msg = "Invalid millis for timestamp value ";
-      set_error_for_date(length, input, msg, context);
-      return 0;
-    }
-    while (sub_seconds_len < 3) {
-      ts_fields[TimeFields::kSubSeconds] *= 10;
-      sub_seconds_len++;
+      double millis =
+          (ts_fields[TimeFields::kSubSeconds] * 1.0) / pow(10, sub_seconds_len - 3);
+      ts_fields[TimeFields::kSubSeconds] = round(millis);
+    } else {
+      while (sub_seconds_len < 3) {
+        ts_fields[TimeFields::kSubSeconds] *= 10;
+        sub_seconds_len++;
+      }
     }
   }
   // handle timezone

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -675,7 +675,7 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t context, const char* input, gdv_int32 l
     if (sub_seconds_len > 3) {
       double millis =
           (ts_fields[TimeFields::kSubSeconds] * 1.0) / pow(10, sub_seconds_len - 3);
-      ts_fields[TimeFields::kSubSeconds] = round(millis);
+      ts_fields[TimeFields::kSubSeconds] = (int)round(millis);
     } else {
       while (sub_seconds_len < 3) {
         ts_fields[TimeFields::kSubSeconds] *= 10;

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -121,15 +121,16 @@ TEST(TestTime, TestCastTimestamp) {
             "Not a valid time for timestamp value 2000-01-01 00:00:100");
   context.Reset();
 
-  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.0001", 24), 0);
-  EXPECT_EQ(context.get_error(),
-            "Invalid millis for timestamp value 2000-01-01 00:00:00.0001");
-  context.Reset();
-
-  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.1000", 24), 0);
-  EXPECT_EQ(context.get_error(),
-            "Invalid millis for timestamp value 2000-01-01 00:00:00.1000");
-  context.Reset();
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.0001", 24),
+            castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00", 19));
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.1000", 24),
+            castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00", 19) + 100);
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.999999999", 29),
+            castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:01", 19));
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.123456", 26),
+            castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00", 19) + 123);
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00.000999", 26),
+            castTIMESTAMP_utf8(context_ptr, "2000-01-01 00:00:00", 19) + 1);
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
For example. castTIMESTAMP("2000-01-01 00:00:00.12345") should return 2000-01-01 00:00:00.123