### PR TITLE
ARROW-11768: [CI][C++] Make s390x job required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,8 @@ jobs:
         JDK: 11
 
   allow_failures:
-    - arch: s390x
+    - name: "Go on s390x"
+    - name: "Java on s390x"
 
 before_install:
   - eval "$(python ci/detect-changes.py)"


### PR DESCRIPTION
We can consider big-endian support in the C++ implementation stable (except for Parquet where it isn't supported).