### PR TITLE
ARROW-11775: [Rust][DataFusion] Feature Flags for Dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,6 +113,7 @@ jobs:
           cargo test
           # test datafusion examples
           cd datafusion
+          cargo test --no-default-features --features cli
           cargo run --example csv_sql
           cargo run --example parquet_sql
           cd ..

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -40,9 +40,10 @@ name = "datafusion-cli"
 path = "src/bin/main.rs"
 
 [features]
-default = ["cli"]
+default = ["cli", "crypto-functions"]
 cli = ["rustyline"]
 simd = ["arrow/simd"]
+crypto-functions = ["md-5", "sha2"]
 
 [dependencies]
 ahash = "0.7"
@@ -61,8 +62,8 @@ futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 log = "^0.4"
-md-5 = "^0.9.1"
-sha2 = "^0.9.1"
+md-5 = { version = "^0.9.1", optional = true }
+sha2 = { version = "^0.9.1", optional = true }
 ordered-float = "2.0"
 unicode-segmentation = "^1.7.1"
 

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -40,10 +40,10 @@ name = "datafusion-cli"
 path = "src/bin/main.rs"
 
 [features]
-default = ["cli", "crypto-functions"]
+default = ["cli", "crypto_expressions"]
 cli = ["rustyline"]
 simd = ["arrow/simd"]
-crypto-functions = ["md-5", "sha2"]
+crypto_expressions = ["md-5", "sha2"]
 
 [dependencies]
 ahash = "0.7"

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -16,10 +16,11 @@
 // under the License.
 
 //! Crypto expressions
-
 use std::sync::Arc;
 
+#[cfg(feature = "crypto-functions")]
 use md5::Md5;
+#[cfg(feature = "crypto-functions")]
 use sha2::{
     digest::Output as SHA2DigestOutput, Digest as SHA2Digest, Sha224, Sha256, Sha384,
     Sha512,
@@ -37,6 +38,7 @@ use arrow::{
 use super::{string_expressions::unary_string_function, ColumnarValue};
 
 /// Computes the md5 of a string.
+#[cfg(feature = "crypto-functions")]
 fn md5_process(input: &str) -> String {
     let mut digest = Md5::default();
     digest.update(&input);
@@ -51,6 +53,7 @@ fn md5_process(input: &str) -> String {
 }
 
 // It's not possible to return &[u8], because trait in trait without short lifetime
+#[cfg(feature = "crypto-functions")]
 fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
     let mut digest = D::default();
     digest.update(&input);
@@ -62,6 +65,7 @@ fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
 /// This function errors when:
 /// * the number of arguments is not 1
 /// * the first argument is not castable to a `GenericStringArray`
+#[cfg(feature = "crypto-functions")]
 fn unary_binary_function<T, R, F>(
     args: &[&dyn Array],
     op: F,
@@ -91,6 +95,7 @@ where
     Ok(array.iter().map(|x| x.map(|x| op(x))).collect())
 }
 
+#[cfg(feature = "crypto-functions")]
 fn handle<F, R>(args: &[ColumnarValue], op: F, name: &str) -> Result<ColumnarValue>
 where
     R: AsRef<[u8]>,
@@ -138,6 +143,7 @@ where
     }
 }
 
+#[cfg(feature = "crypto-functions")]
 fn md5_array<T: StringOffsetSizeTrait>(
     args: &[&dyn Array],
 ) -> Result<GenericStringArray<i32>> {
@@ -145,6 +151,7 @@ fn md5_array<T: StringOffsetSizeTrait>(
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+#[cfg(feature = "crypto-functions")]
 pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     match &args[0] {
         ColumnarValue::Array(a) => match a.data_type() {
@@ -179,21 +186,60 @@ pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+#[cfg(feature = "crypto-functions")]
 pub fn sha224(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha224>, "ssh224")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+#[cfg(feature = "crypto-functions")]
 pub fn sha256(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha256>, "sha256")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+#[cfg(feature = "crypto-functions")]
 pub fn sha384(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha384>, "sha384")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
+#[cfg(feature = "crypto-functions")]
 pub fn sha512(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha512>, "sha512")
+}
+
+#[cfg(not(feature = "crypto-functions"))]
+pub fn md5(_: &[ColumnarValue]) -> Result<ColumnarValue> {
+    Err(DataFusionError::Internal(
+        "requires compilation with feature flag: crypto-functions".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "crypto-functions"))]
+pub fn sha224(_: &[ColumnarValue]) -> Result<ColumnarValue> {
+    Err(DataFusionError::Internal(
+        "requires compilation with feature flag: crypto-functions".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "crypto-functions"))]
+pub fn sha256(_: &[ColumnarValue]) -> Result<ColumnarValue> {
+    Err(DataFusionError::Internal(
+        "requires compilation with feature flag: crypto-functions".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "crypto-functions"))]
+pub fn sha384(_: &[ColumnarValue]) -> Result<ColumnarValue> {
+    Err(DataFusionError::Internal(
+        "requires compilation with feature flag: crypto-functions".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "crypto-functions"))]
+pub fn sha512(_: &[ColumnarValue]) -> Result<ColumnarValue> {
+    Err(DataFusionError::Internal(
+        "requires compilation with feature flag: crypto-functions".to_string(),
+    ))
 }

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -18,9 +18,7 @@
 //! Crypto expressions
 use std::sync::Arc;
 
-#[cfg(feature = "crypto-functions")]
 use md5::Md5;
-#[cfg(feature = "crypto-functions")]
 use sha2::{
     digest::Output as SHA2DigestOutput, Digest as SHA2Digest, Sha224, Sha256, Sha384,
     Sha512,
@@ -38,7 +36,6 @@ use arrow::{
 use super::{string_expressions::unary_string_function, ColumnarValue};
 
 /// Computes the md5 of a string.
-#[cfg(feature = "crypto-functions")]
 fn md5_process(input: &str) -> String {
     let mut digest = Md5::default();
     digest.update(&input);
@@ -53,7 +50,6 @@ fn md5_process(input: &str) -> String {
 }
 
 // It's not possible to return &[u8], because trait in trait without short lifetime
-#[cfg(feature = "crypto-functions")]
 fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
     let mut digest = D::default();
     digest.update(&input);
@@ -65,7 +61,6 @@ fn sha_process<D: SHA2Digest + Default>(input: &str) -> SHA2DigestOutput<D> {
 /// This function errors when:
 /// * the number of arguments is not 1
 /// * the first argument is not castable to a `GenericStringArray`
-#[cfg(feature = "crypto-functions")]
 fn unary_binary_function<T, R, F>(
     args: &[&dyn Array],
     op: F,
@@ -95,7 +90,6 @@ where
     Ok(array.iter().map(|x| x.map(|x| op(x))).collect())
 }
 
-#[cfg(feature = "crypto-functions")]
 fn handle<F, R>(args: &[ColumnarValue], op: F, name: &str) -> Result<ColumnarValue>
 where
     R: AsRef<[u8]>,
@@ -143,7 +137,6 @@ where
     }
 }
 
-#[cfg(feature = "crypto-functions")]
 fn md5_array<T: StringOffsetSizeTrait>(
     args: &[&dyn Array],
 ) -> Result<GenericStringArray<i32>> {
@@ -151,7 +144,6 @@ fn md5_array<T: StringOffsetSizeTrait>(
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-#[cfg(feature = "crypto-functions")]
 pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     match &args[0] {
         ColumnarValue::Array(a) => match a.data_type() {
@@ -186,60 +178,21 @@ pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-#[cfg(feature = "crypto-functions")]
 pub fn sha224(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha224>, "ssh224")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-#[cfg(feature = "crypto-functions")]
 pub fn sha256(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha256>, "sha256")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-#[cfg(feature = "crypto-functions")]
 pub fn sha384(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha384>, "sha384")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-#[cfg(feature = "crypto-functions")]
 pub fn sha512(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha512>, "sha512")
-}
-
-#[cfg(not(feature = "crypto-functions"))]
-pub fn md5(_: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::Internal(
-        "requires compilation with feature flag: crypto-functions".to_string(),
-    ))
-}
-
-#[cfg(not(feature = "crypto-functions"))]
-pub fn sha224(_: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::Internal(
-        "requires compilation with feature flag: crypto-functions".to_string(),
-    ))
-}
-
-#[cfg(not(feature = "crypto-functions"))]
-pub fn sha256(_: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::Internal(
-        "requires compilation with feature flag: crypto-functions".to_string(),
-    ))
-}
-
-#[cfg(not(feature = "crypto-functions"))]
-pub fn sha384(_: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::Internal(
-        "requires compilation with feature flag: crypto-functions".to_string(),
-    ))
-}
-
-#[cfg(not(feature = "crypto-functions"))]
-pub fn sha512(_: &[ColumnarValue]) -> Result<ColumnarValue> {
-    Err(DataFusionError::Internal(
-        "requires compilation with feature flag: crypto-functions".to_string(),
-    ))
 }

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -1462,6 +1462,72 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "crypto-functions"), ignore)]
+    fn test_functions_crypto_functions_feature_flag_on() -> Result<()> {
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some("34b7da764b21d298ef307d04d8152dc5")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some("d41d8cd98f00b204e9800998ecf8427e")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg_attr(feature = "crypto-functions", ignore)]
+    fn test_functions_crypto_functions_feature_flag_off() -> Result<()> {
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "requires compilation with feature flag: crypto-functions".to_string()
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Err(DataFusionError::Internal(
+                "requires compilation with feature flag: crypto-functions".to_string()
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(None))],
+            Err(DataFusionError::Internal(
+                "requires compilation with feature flag: crypto-functions".to_string()
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_concat_error() -> Result<()> {
         let result = return_type(&BuiltinScalarFunction::Concat, &[]);
         if result.is_ok() {

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -34,7 +34,6 @@ use super::{
     ColumnarValue, PhysicalExpr,
 };
 use crate::physical_plan::array_expressions;
-use crate::physical_plan::crypto_expressions;
 use crate::physical_plan::datetime_expressions;
 use crate::physical_plan::expressions::{nullif_func, SUPPORTED_NULLIF_TYPES};
 use crate::physical_plan::math_expressions;
@@ -447,6 +446,26 @@ pub fn return_type(
     }
 }
 
+#[cfg(feature = "crypto_expressions")]
+macro_rules! invoke_if_crypto_expressions_feature_flag {
+    ($FUNC:ident, $NAME:expr) => {{
+        use crate::physical_plan::crypto_expressions;
+        crypto_expressions::$FUNC
+    }};
+}
+
+#[cfg(not(feature = "crypto_expressions"))]
+macro_rules! invoke_if_crypto_expressions_feature_flag {
+    ($FUNC:ident, $NAME:expr) => {
+        |_: &[ColumnarValue]| -> Result<ColumnarValue> {
+            Err(DataFusionError::Internal(format!(
+                "function {} requires compilation with feature flag: crypto_expressions.",
+                $NAME
+            )))
+        }
+    };
+}
+
 /// Create a physical (function) expression.
 /// This function errors when `args`' can't be coerced to a valid argument type of the function.
 pub fn create_physical_expr(
@@ -531,7 +550,9 @@ pub fn create_physical_expr(
                 other,
             ))),
         },
-        BuiltinScalarFunction::MD5 => crypto_expressions::md5,
+        BuiltinScalarFunction::MD5 => {
+            invoke_if_crypto_expressions_feature_flag!(md5, "md5")
+        }
         BuiltinScalarFunction::NullIf => nullif_func,
         BuiltinScalarFunction::OctetLength => |args| match &args[0] {
             ColumnarValue::Array(v) => Ok(ColumnarValue::Array(length(v.as_ref())?)),
@@ -557,10 +578,18 @@ pub fn create_physical_expr(
                 other,
             ))),
         },
-        BuiltinScalarFunction::SHA224 => crypto_expressions::sha224,
-        BuiltinScalarFunction::SHA256 => crypto_expressions::sha256,
-        BuiltinScalarFunction::SHA384 => crypto_expressions::sha384,
-        BuiltinScalarFunction::SHA512 => crypto_expressions::sha512,
+        BuiltinScalarFunction::SHA224 => {
+            invoke_if_crypto_expressions_feature_flag!(sha224, "sha224")
+        }
+        BuiltinScalarFunction::SHA256 => {
+            invoke_if_crypto_expressions_feature_flag!(sha256, "sha256")
+        }
+        BuiltinScalarFunction::SHA384 => {
+            invoke_if_crypto_expressions_feature_flag!(sha384, "sha384")
+        }
+        BuiltinScalarFunction::SHA512 => {
+            invoke_if_crypto_expressions_feature_flag!(sha512, "sha512")
+        }
         BuiltinScalarFunction::Substr => |args| match args[0].data_type() {
             DataType::Utf8 => {
                 make_scalar_function(string_expressions::substr::<i32>)(args)
@@ -825,8 +854,8 @@ mod tests {
     };
     use arrow::{
         array::{
-            Array, ArrayRef, FixedSizeListArray, Float64Array, Int32Array, StringArray,
-            UInt32Array, UInt64Array,
+            Array, ArrayRef, BinaryArray, FixedSizeListArray, Float64Array, Int32Array,
+            StringArray, UInt32Array, UInt64Array,
         },
         datatypes::Field,
         record_batch::RecordBatch,
@@ -1184,6 +1213,44 @@ mod tests {
             Utf8,
             StringArray
         );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some("34b7da764b21d298ef307d04d8152dc5")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some("d41d8cd98f00b204e9800998ecf8427e")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &str,
+            Utf8,
+            StringArray
+        );
+        #[cfg(not(feature = "crypto_expressions"))]
+        test_function!(
+            MD5,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "function md5 requires compilation with feature flag: crypto_expressions.".to_string()
+            )),
+            &str,
+            Utf8,
+            StringArray
+        );
         test_function!(
             OctetLength,
             &[lit(ScalarValue::Utf8(Some("chars".to_string())))],
@@ -1215,6 +1282,200 @@ mod tests {
             i32,
             Int32,
             Int32Array
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA224,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some(&[
+                11u8, 246u8, 203u8, 98u8, 100u8, 156u8, 66u8, 169u8, 174u8, 56u8, 118u8,
+                171u8, 111u8, 109u8, 146u8, 173u8, 54u8, 203u8, 84u8, 20u8, 228u8, 149u8,
+                248u8, 135u8, 50u8, 146u8, 190u8, 77u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA224,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some(&[
+                209u8, 74u8, 2u8, 140u8, 42u8, 58u8, 43u8, 201u8, 71u8, 97u8, 2u8, 187u8,
+                40u8, 130u8, 52u8, 196u8, 21u8, 162u8, 176u8, 31u8, 130u8, 142u8, 166u8,
+                42u8, 197u8, 179u8, 228u8, 47u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA224,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(not(feature = "crypto_expressions"))]
+        test_function!(
+            SHA224,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "function sha224 requires compilation with feature flag: crypto_expressions.".to_string()
+            )),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA256,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some(&[
+                225u8, 96u8, 143u8, 117u8, 197u8, 215u8, 129u8, 63u8, 61u8, 64u8, 49u8,
+                203u8, 48u8, 191u8, 183u8, 134u8, 80u8, 125u8, 152u8, 19u8, 117u8, 56u8,
+                255u8, 142u8, 18u8, 138u8, 111u8, 247u8, 78u8, 132u8, 230u8, 67u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA256,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some(&[
+                227u8, 176u8, 196u8, 66u8, 152u8, 252u8, 28u8, 20u8, 154u8, 251u8, 244u8,
+                200u8, 153u8, 111u8, 185u8, 36u8, 39u8, 174u8, 65u8, 228u8, 100u8, 155u8,
+                147u8, 76u8, 164u8, 149u8, 153u8, 27u8, 120u8, 82u8, 184u8, 85u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA256,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(not(feature = "crypto_expressions"))]
+        test_function!(
+            SHA256,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "function sha256 requires compilation with feature flag: crypto_expressions.".to_string()
+            )),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA384,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some(&[
+                9u8, 111u8, 91u8, 104u8, 170u8, 119u8, 132u8, 142u8, 79u8, 223u8, 92u8,
+                28u8, 11u8, 53u8, 13u8, 226u8, 219u8, 250u8, 214u8, 15u8, 253u8, 124u8,
+                37u8, 217u8, 234u8, 7u8, 198u8, 193u8, 155u8, 138u8, 77u8, 85u8, 169u8,
+                24u8, 126u8, 177u8, 23u8, 197u8, 87u8, 136u8, 63u8, 88u8, 193u8, 109u8,
+                250u8, 195u8, 227u8, 67u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA384,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some(&[
+                56u8, 176u8, 96u8, 167u8, 81u8, 172u8, 150u8, 56u8, 76u8, 217u8, 50u8,
+                126u8, 177u8, 177u8, 227u8, 106u8, 33u8, 253u8, 183u8, 17u8, 20u8, 190u8,
+                7u8, 67u8, 76u8, 12u8, 199u8, 191u8, 99u8, 246u8, 225u8, 218u8, 39u8,
+                78u8, 222u8, 191u8, 231u8, 111u8, 101u8, 251u8, 213u8, 26u8, 210u8,
+                241u8, 72u8, 152u8, 185u8, 91u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA384,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(not(feature = "crypto_expressions"))]
+        test_function!(
+            SHA384,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "function sha384 requires compilation with feature flag: crypto_expressions.".to_string()
+            )),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA512,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Ok(Some(&[
+                110u8, 27u8, 155u8, 63u8, 232u8, 64u8, 104u8, 14u8, 55u8, 5u8, 31u8,
+                122u8, 213u8, 233u8, 89u8, 214u8, 243u8, 154u8, 208u8, 248u8, 136u8,
+                93u8, 133u8, 81u8, 102u8, 245u8, 92u8, 101u8, 148u8, 105u8, 211u8, 200u8,
+                183u8, 129u8, 24u8, 196u8, 74u8, 42u8, 73u8, 199u8, 45u8, 219u8, 72u8,
+                28u8, 214u8, 216u8, 115u8, 16u8, 52u8, 225u8, 28u8, 192u8, 48u8, 7u8,
+                11u8, 168u8, 67u8, 169u8, 11u8, 52u8, 149u8, 203u8, 141u8, 62u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA512,
+            &[lit(ScalarValue::Utf8(Some("".to_string())))],
+            Ok(Some(&[
+                207u8, 131u8, 225u8, 53u8, 126u8, 239u8, 184u8, 189u8, 241u8, 84u8, 40u8,
+                80u8, 214u8, 109u8, 128u8, 7u8, 214u8, 32u8, 228u8, 5u8, 11u8, 87u8,
+                21u8, 220u8, 131u8, 244u8, 169u8, 33u8, 211u8, 108u8, 233u8, 206u8, 71u8,
+                208u8, 209u8, 60u8, 93u8, 133u8, 242u8, 176u8, 255u8, 131u8, 24u8, 210u8,
+                135u8, 126u8, 236u8, 47u8, 99u8, 185u8, 49u8, 189u8, 71u8, 65u8, 122u8,
+                129u8, 165u8, 56u8, 50u8, 122u8, 249u8, 39u8, 218u8, 62u8
+            ])),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(feature = "crypto_expressions")]
+        test_function!(
+            SHA512,
+            &[lit(ScalarValue::Utf8(None))],
+            Ok(None),
+            &[u8],
+            Binary,
+            BinaryArray
+        );
+        #[cfg(not(feature = "crypto_expressions"))]
+        test_function!(
+            SHA512,
+            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
+            Err(DataFusionError::Internal(
+                "function sha512 requires compilation with feature flag: crypto_expressions.".to_string()
+            )),
+            &[u8],
+            Binary,
+            BinaryArray
         );
         test_function!(
             Substr,
@@ -1454,72 +1715,6 @@ mod tests {
             Trim,
             &[lit(ScalarValue::Utf8(None))],
             Ok(None),
-            &str,
-            Utf8,
-            StringArray
-        );
-        Ok(())
-    }
-
-    #[test]
-    #[cfg_attr(not(feature = "crypto-functions"), ignore)]
-    fn test_functions_crypto_functions_feature_flag_on() -> Result<()> {
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
-            Ok(Some("34b7da764b21d298ef307d04d8152dc5")),
-            &str,
-            Utf8,
-            StringArray
-        );
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(Some("".to_string())))],
-            Ok(Some("d41d8cd98f00b204e9800998ecf8427e")),
-            &str,
-            Utf8,
-            StringArray
-        );
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(None))],
-            Ok(None),
-            &str,
-            Utf8,
-            StringArray
-        );
-        Ok(())
-    }
-
-    #[test]
-    #[cfg_attr(feature = "crypto-functions", ignore)]
-    fn test_functions_crypto_functions_feature_flag_off() -> Result<()> {
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(Some("tom".to_string())))],
-            Err(DataFusionError::Internal(
-                "requires compilation with feature flag: crypto-functions".to_string()
-            )),
-            &str,
-            Utf8,
-            StringArray
-        );
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(Some("".to_string())))],
-            Err(DataFusionError::Internal(
-                "requires compilation with feature flag: crypto-functions".to_string()
-            )),
-            &str,
-            Utf8,
-            StringArray
-        );
-        test_function!(
-            MD5,
-            &[lit(ScalarValue::Utf8(None))],
-            Err(DataFusionError::Internal(
-                "requires compilation with feature flag: crypto-functions".to_string()
-            )),
             &str,
             Utf8,
             StringArray

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -277,6 +277,7 @@ pub mod aggregates;
 pub mod array_expressions;
 pub mod coalesce_batches;
 pub mod common;
+#[cfg(feature = "crypto_expressions")]
 pub mod crypto_expressions;
 pub mod csv;
 pub mod datetime_expressions;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2219,6 +2219,7 @@ async fn test_interval_expressions() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "crypto-functions"), ignore)]
 async fn test_crypto_expressions() -> Result<()> {
     test_expression!("md5('tom')", "34b7da764b21d298ef307d04d8152dc5");
     test_expression!("md5('')", "d41d8cd98f00b204e9800998ecf8427e");
@@ -2249,6 +2250,7 @@ async fn test_crypto_expressions() -> Result<()> {
     test_expression!("sha512(NULL)", "NULL");
     Ok(())
 }
+
 #[tokio::test]
 async fn test_extract_date_part() -> Result<()> {
     test_expression!("date_part('hour', CAST('2020-01-01' AS DATE))", "0");

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2219,7 +2219,7 @@ async fn test_interval_expressions() -> Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "crypto-functions"), ignore)]
+#[cfg_attr(not(feature = "crypto_expressions"), ignore)]
 async fn test_crypto_expressions() -> Result<()> {
     test_expression!("md5('tom')", "34b7da764b21d298ef307d04d8152dc5");
     test_expression!("md5('')", "d41d8cd98f00b204e9800998ecf8427e");


### PR DESCRIPTION
@alamb @andygrove @nevi-me 

Based on the Rust Arrow sync call we discussed setting feature flags to allow use of DataFusion without having to pull in unnecessary dependencies.

Here is an example applied to the crypto functions. It:

- puts the crypto functions behind a feature flag called `crypto-functions` with the required dependencies tagged.
- adds the `crypto-functions` to the `default` feature flag meaning it will be included in the default build.
- adds tests for both states of the feature flag. Note that the cargo behavior of specifying conditions in the rust test framework is inverted (at least in my mind) so that you can only specify `ignore` not `include` rules. Practically this means to run the test with the feature flag you do: `#[cfg_attr(not(feature = "crypto-functions"), ignore)]` which is not ideal but functional.
- currently I am throwing `Err(DataFusionError::Internal("requires compilation with feature flag: crypto-functions".to_string()))` errors which I think is a better user experience than `panic` based macros but this could easily be changed to `unimplemented!` with a similar message.
- unfortunately we will probably need to execute `cargo test --no-default-features --features cli` AND `cargo test` in CICD to ensure the proper coverage (`--features cli` is required to compile).

Thoughts?