### PR TITLE
ARROW-11779: [Rust] make alloc module public

### DIFF
--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -135,7 +135,7 @@
 // introduced to ignore lint errors when upgrading from 2020-04-22 to 2020-11-14
 #![allow(clippy::float_equality_without_abs, clippy::type_complexity)]
 
-mod alloc;
+pub mod alloc;
 mod arch;
 pub mod array;
 pub mod bitmap;


### PR DESCRIPTION
Polars uses the `arrow::memory` module. With the backwards incompatible change of #9495, the API is refactored to `arrow::alloc`.

By making `alloc` public, users can shift to the new changes. 