### PR TITLE
PARQUET-1655: [C++] Fix comparison of Decimal values in statistics

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2697,10 +2697,8 @@ TEST(ArrowReadWrite, DecimalStats) {
   std::shared_ptr<Scalar> expected_min, expected_max;
   ASSERT_OK_AND_ASSIGN(expected_min, array->GetScalar(array->length() - 1));
   ASSERT_OK_AND_ASSIGN(expected_max, array->GetScalar(0));
-  ASSERT_TRUE(expected_min->Equals(*min))
-      << expected_min->ToString() << " != (actual) " << min->ToString();
-  ASSERT_TRUE(expected_max->Equals(*max))
-      << expected_max->ToString() << " != (actual) " << max->ToString();
+  ::arrow::AssertScalarsEqual(*expected_min, *min, /*verbose=*/true);
+  ::arrow::AssertScalarsEqual(*expected_max, *max, /*verbose=*/true);
 }
 
 TEST(ArrowReadWrite, NestedNullableField) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -540,6 +540,23 @@ static std::shared_ptr<GroupNode> MakeSimpleSchema(const DataType& type,
   return std::static_pointer_cast<GroupNode>(node_);
 }
 
+void ReadSingleColumnFileStatistics(std::unique_ptr<FileReader> file_reader,
+                                    std::shared_ptr<Scalar>* min,
+                                    std::shared_ptr<Scalar>* max) {
+  auto metadata = file_reader->parquet_reader()->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  ASSERT_EQ(1, metadata->num_columns());
+
+  auto row_group = metadata->RowGroup(0);
+  ASSERT_EQ(1, row_group->num_columns());
+
+  auto column = row_group->ColumnChunk(0);
+  ASSERT_TRUE(column->is_stats_set());
+  auto statistics = column->statistics();
+
+  ASSERT_OK(StatisticsAsScalars(*statistics, min, max));
+}
+
 // Non-template base class for TestParquetIO, to avoid code duplication
 class ParquetIOTestBase : public ::testing::Test {
  public:
@@ -570,23 +587,6 @@ class ParquetIOTestBase : public ::testing::Test {
     *out = chunked_out->chunk(0);
     ASSERT_NE(nullptr, out->get());
     ASSERT_OK((*out)->ValidateFull());
-  }
-
-  void ReadSingleColumnFileStatistics(std::unique_ptr<FileReader> file_reader,
-                                      std::shared_ptr<Scalar>* min,
-                                      std::shared_ptr<Scalar>* max) {
-    auto metadata = file_reader->parquet_reader()->metadata();
-    ASSERT_EQ(1, metadata->num_row_groups());
-    ASSERT_EQ(1, metadata->num_columns());
-
-    auto row_group = metadata->RowGroup(0);
-    ASSERT_EQ(1, row_group->num_columns());
-
-    auto column = row_group->ColumnChunk(0);
-    ASSERT_TRUE(column->is_stats_set());
-    auto statistics = column->statistics();
-
-    ASSERT_OK(StatisticsAsScalars(*statistics, min, max));
   }
 
   void ReadAndCheckSingleColumnFile(const Array& values) {
@@ -1511,7 +1511,7 @@ class TestPrimitiveParquetIO : public TestParquetIO<TestType> {
     ASSERT_NO_FATAL_FAILURE(MakeTestFile(values, 1, &file_reader));
 
     std::shared_ptr<Scalar> min, max;
-    this->ReadSingleColumnFileStatistics(std::move(file_reader), &min, &max);
+    ReadSingleColumnFileStatistics(std::move(file_reader), &min, &max);
 
     ASSERT_OK_AND_ASSIGN(
         auto value, ::arrow::MakeScalar(::arrow::TypeTraits<TestType>::type_singleton(),
@@ -2671,6 +2671,36 @@ TEST(ArrowReadWrite, Decimal256) {
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
   auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
   CheckSimpleRoundtrip(table, 2, props_store_schema);
+}
+
+TEST(ArrowReadWrite, DecimalStats) {
+  using ::arrow::Decimal128;
+  using ::arrow::field;
+
+  auto type = ::arrow::decimal128(/*precision=*/8, /*scale=*/0);
+
+  const char* json = R"(["255", "128", null, "0", "1", "-127", "-128", "-129", "-255"])";
+  auto array = ::arrow::ArrayFromJSON(type, json);
+  auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, /*row_grop_size=*/100,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  ASSERT_OK_NO_THROW(OpenFile(std::make_shared<BufferReader>(buffer),
+                              ::arrow::default_memory_pool(), &reader));
+
+  std::shared_ptr<Scalar> min, max;
+  ReadSingleColumnFileStatistics(std::move(reader), &min, &max);
+
+  std::shared_ptr<Scalar> expected_min, expected_max;
+  ASSERT_OK_AND_ASSIGN(expected_min, array->GetScalar(array->length() - 1));
+  ASSERT_OK_AND_ASSIGN(expected_max, array->GetScalar(0));
+  ASSERT_TRUE(expected_min->Equals(*min))
+      << expected_min->ToString() << " != (actual) " << min->ToString();
+  ASSERT_TRUE(expected_max->Equals(*max))
+      << expected_max->ToString() << " != (actual) " << max->ToString();
 }
 
 TEST(ArrowReadWrite, NestedNullableField) {

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -63,8 +63,12 @@ using arrow::BooleanArray;
 using arrow::ChunkedArray;
 using arrow::DataType;
 using arrow::Datum;
+using arrow::Decimal128;
 using arrow::Decimal128Array;
+using arrow::Decimal128Type;
+using arrow::Decimal256;
 using arrow::Decimal256Array;
+using arrow::Decimal256Type;
 using arrow::Field;
 using arrow::Int32Array;
 using arrow::ListArray;
@@ -93,6 +97,7 @@ namespace BitUtil = arrow::BitUtil;
 
 namespace parquet {
 namespace arrow {
+namespace {
 
 template <typename ArrowType>
 using ArrayType = typename ::arrow::TypeTraits<ArrowType>::ArrayType;
@@ -188,13 +193,61 @@ static Status FromInt64Statistics(const Int64Statistics& statistics,
   return Status::NotImplemented("Cannot extract statistics for type ");
 }
 
-static inline Status ByteArrayStatisticsAsScalars(const Statistics& statistics,
-                                                  std::shared_ptr<::arrow::Scalar>* min,
-                                                  std::shared_ptr<::arrow::Scalar>* max) {
-  auto logical_type = statistics.descr()->logical_type();
-  auto type = logical_type->type() == LogicalType::Type::STRING ? ::arrow::utf8()
-                                                                : ::arrow::binary();
+template <typename DecimalType>
+Result<std::shared_ptr<::arrow::Scalar>> FromBigEndianString(
+    const std::string& data, std::shared_ptr<DataType> arrow_type) {
+  ARROW_ASSIGN_OR_RAISE(
+      DecimalType decimal,
+      DecimalType::FromBigEndian(reinterpret_cast<const uint8_t*>(data.data()),
+                                 static_cast<int32_t>(data.size())));
+  return ::arrow::MakeScalar(std::move(arrow_type), decimal);
+}
 
+// Extracts Min and Max scalar from bytes like types (i.e. types where
+// decimal is encoded as little endian.
+Status ExtractDecimalMinMaxFromBytesType(const Statistics& statistics,
+                                         const LogicalType& logical_type,
+                                         std::shared_ptr<::arrow::Scalar>* min,
+                                         std::shared_ptr<::arrow::Scalar>* max) {
+  const DecimalLogicalType& decimal_type =
+      checked_cast<const DecimalLogicalType&>(logical_type);
+
+  Result<std::shared_ptr<DataType>> maybe_type =
+      Decimal128Type::Make(decimal_type.precision(), decimal_type.scale());
+  std::shared_ptr<DataType> arrow_type;
+  if (maybe_type.ok()) {
+    arrow_type = maybe_type.ValueOrDie();
+    ARROW_ASSIGN_OR_RAISE(
+        *min, FromBigEndianString<Decimal128>(statistics.EncodeMin(), arrow_type));
+    ARROW_ASSIGN_OR_RAISE(*max, FromBigEndianString<Decimal128>(statistics.EncodeMax(),
+                                                                std::move(arrow_type)));
+    return Status::OK();
+  }
+  // Fallback to see if Decimal256 can represent the type.
+  ARROW_ASSIGN_OR_RAISE(
+      arrow_type, Decimal256Type::Make(decimal_type.precision(), decimal_type.scale()));
+  ARROW_ASSIGN_OR_RAISE(
+      *min, FromBigEndianString<Decimal256>(statistics.EncodeMin(), arrow_type));
+  ARROW_ASSIGN_OR_RAISE(*max, FromBigEndianString<Decimal256>(statistics.EncodeMax(),
+                                                              std::move(arrow_type)));
+
+  return Status::OK();
+}
+
+Status ByteArrayStatisticsAsScalars(const Statistics& statistics,
+                                    std::shared_ptr<::arrow::Scalar>* min,
+                                    std::shared_ptr<::arrow::Scalar>* max) {
+  auto logical_type = statistics.descr()->logical_type();
+  if (logical_type->type() == LogicalType::Type::DECIMAL) {
+    return ExtractDecimalMinMaxFromBytesType(statistics, *logical_type, min, max);
+  }
+  std::shared_ptr<::arrow::DataType> type;
+  if (statistics.descr()->physical_type() == Type::FIXED_LEN_BYTE_ARRAY) {
+    type = ::arrow::fixed_size_binary(statistics.descr()->type_length());
+  } else {
+    type = logical_type->type() == LogicalType::Type::STRING ? ::arrow::utf8()
+                                                             : ::arrow::binary();
+  }
   ARROW_ASSIGN_OR_RAISE(
       *min, ::arrow::MakeScalar(type, Buffer::FromString(statistics.EncodeMin())));
   ARROW_ASSIGN_OR_RAISE(
@@ -202,6 +255,8 @@ static inline Status ByteArrayStatisticsAsScalars(const Statistics& statistics,
 
   return Status::OK();
 }
+
+}  // namespace
 
 Status StatisticsAsScalars(const Statistics& statistics,
                            std::shared_ptr<::arrow::Scalar>* min,
@@ -234,6 +289,7 @@ Status StatisticsAsScalars(const Statistics& statistics,
       return FromInt64Statistics(checked_cast<const Int64Statistics&>(statistics),
                                  *logical_type, min, max);
     case Type::BYTE_ARRAY:
+    case Type::FIXED_LEN_BYTE_ARRAY:
       return ByteArrayStatisticsAsScalars(statistics, min, max);
     default:
       return Status::NotImplemented("Extract statistics unsupported for physical_type ",
@@ -245,6 +301,8 @@ Status StatisticsAsScalars(const Statistics& statistics,
 
 // ----------------------------------------------------------------------
 // Primitive types
+
+namespace {
 
 template <typename ArrowType, typename ParquetType>
 Status TransferInt(RecordReader* reader, MemoryPool* pool,
@@ -583,6 +641,8 @@ Status TransferDecimal(RecordReader* reader, MemoryPool* pool,
   *out = std::make_shared<ChunkedArray>(chunks, type);
   return Status::OK();
 }
+
+}  // namespace
 
 #define TRANSFER_INT32(ENUM, ArrowType)                                              \
   case ::arrow::Type::ENUM: {                                                        \

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -48,6 +48,9 @@ namespace {
 // ----------------------------------------------------------------------
 // Comparator implementations
 
+constexpr int value_length(int value_length, const ByteArray& value) { return value.len; }
+constexpr int value_length(int type_length, const FLBA& value) { return type_length; }
+
 template <typename DType, bool is_signed>
 struct CompareHelper {
   using T = typename DType::c_type;
@@ -133,56 +136,95 @@ struct CompareHelper<Int96Type, is_signed> {
   static T Max(int type_length, const T& a, const T& b) {
     return Compare(0, a, b) ? b : a;
   }
-};  // namespace parquet
+};
 
-template <typename DType, bool is_signed>
-struct ByteLikeCompareHelperBase {
-  using T = ByteArrayType::c_type;
-  using PtrType = typename std::conditional<is_signed, int8_t, uint8_t>::type;
+template <typename T, bool is_signed>
+struct BinaryLikeComparer {};
 
-  static T DefaultMin() { return {}; }
-  static T DefaultMax() { return {}; }
-  static T Coalesce(T val, T fallback) { return val; }
-
-  static inline bool Compare(int type_length, const T& a, const T& b) {
-    const auto* aptr = reinterpret_cast<const PtrType*>(a.ptr);
-    const auto* bptr = reinterpret_cast<const PtrType*>(b.ptr);
-    return std::lexicographical_compare(aptr, aptr + a.len, bptr, bptr + b.len);
+template <typename T>
+struct BinaryLikeComparer<T, /*is_signed=*/false> {
+  static bool Compare(int type_length, const T& a, const T& b) {
+    int a_length = value_length(type_length, a);
+    int b_length = value_length(type_length, b);
+    // Unsigned comparison is used for non-numeric types so straight
+    // lexiographic comparison makes sense. (a.ptr is always unsigned)....
+    return std::lexicographical_compare(a.ptr, a.ptr + a_length, b.ptr, b.ptr + b_length);
   }
+};
 
-  static T Min(int type_length, const T& a, const T& b) {
-    if (a.ptr == nullptr) return b;
-    if (b.ptr == nullptr) return a;
-    return Compare(type_length, a, b) ? a : b;
-  }
+template <typename T>
+struct BinaryLikeComparer<T, /*is_signed=*/true> {
+  static bool Compare(int type_length, const T& a, const T& b) {
+    // Is signed is used for integers encoded as big-endian twos
+    // complement integers. (e.g. decimals).
+    int a_length = value_length(type_length, a);
+    int b_length = value_length(type_length, b);
 
-  static T Max(int type_length, const T& a, const T& b) {
-    if (a.ptr == nullptr) return b;
-    if (b.ptr == nullptr) return a;
-    return Compare(type_length, a, b) ? b : a;
+    // At least of the lengths is zero.
+    if (a_length == 0 || b_length == 0) {
+      return a_length == 0 && b_length > 0;
+    }
+
+    int8_t first_a = *a.ptr;
+    int8_t first_b = *b.ptr;
+    // We can short circuit for different signed numbers or
+    // for equal length bytes arrays that have different first bytes.
+    if ((0x80 & first_a) != (0x80 & first_b) ||
+        (a_length == b_length && first_a != first_b)) {
+      return first_a < first_b;
+    }
+    // When the lengths are unequal and the numbers are of the same
+    // sign we need to extend the digits.
+    const uint8_t* a_start = a.ptr;
+    const uint8_t* b_start = b.ptr;
+    if (a_length != b_length) {
+      const uint8_t* lead_start = nullptr;
+      const uint8_t* lead_end = nullptr;
+      if (a_length > b_length) {
+        int lead_length = a_length - b_length;
+        lead_start = a.ptr;
+        lead_end = a.ptr + lead_length;
+        a_start += lead_length;
+      } else {
+        DCHECK_LT(a_length, b_length);
+        int lead_length = b_length - a_length;
+        lead_start = b.ptr;
+        lead_end = b.ptr + lead_length;
+        b_start += lead_length;
+      }
+      // Compare extra bytes to the sign extension of the first
+      // byte of the other number.
+      uint8_t extension = first_a < 0 ? 0xFF : 0;
+      for (; lead_start != lead_end; lead_start++) {
+        if (*lead_start < extension) {
+          // The first bytes of the long value are less
+          // then the extended short one.  So if a is the long value
+          // we can return true.
+          return a_length > b_length;
+        } else if (*lead_start > extension) {
+          return a_length < b_length;
+        }
+      }
+    } else {
+      a_start++;
+      b_start++;
+    }
+    return std::lexicographical_compare(a_start, a.ptr + a_length, b_start,
+                                        b.ptr + b_length);
   }
 };
 
 template <typename DType, bool is_signed>
 struct BinaryLikeCompareHelperBase {
   using T = typename DType::c_type;
-  using PtrType = typename std::conditional<is_signed, int8_t, uint8_t>::type;
 
   static T DefaultMin() { return {}; }
   static T DefaultMax() { return {}; }
   static T Coalesce(T val, T fallback) { return val; }
 
-  static int value_length(int value_length, const ByteArray& value) { return value.len; }
-
-  static int value_length(int type_length, const FLBA& value) { return type_length; }
-
   static inline bool Compare(int type_length, const T& a, const T& b) {
-    const auto* aptr = reinterpret_cast<const PtrType*>(a.ptr);
-    const auto* bptr = reinterpret_cast<const PtrType*>(b.ptr);
-    return std::lexicographical_compare(aptr, aptr + value_length(type_length, a), bptr,
-                                        bptr + value_length(type_length, b));
+    return BinaryLikeComparer<T, is_signed>::Compare(type_length, a, b);
   }
-
   static T Min(int type_length, const T& a, const T& b) {
     if (a.ptr == nullptr) return b;
     if (b.ptr == nullptr) return a;

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -75,10 +75,9 @@ TEST(Comparison, SignedByteArray) {
       {0x80, 0x80, 0, 0},       {/*0xFF,*/ 0x80, 0, 0},     {/*0xFF,*/ 0xFF, 0x01, 0},
       {/*0xFF,0xFF,*/ 0x80, 0}, {/*0xFF,0xFF,0xFF,*/ 0x80}, {/*0xFF, 0xFF, 0xFF,*/ 0xFF},
       {/*0, 0,*/ 0x01, 0x01},   {/*0,*/ 0x01, 0x01, 0},     {0x01, 0x01, 0, 0}};
-  constexpr uint8_t empty[] = {0};
   std::vector<ByteArray> values_to_compare = {ByteArray()};
   for (const auto& bytes : byte_values) {
-    values_to_compare.emplace_back(ByteArray(bytes.size(), bytes.data()));
+    values_to_compare.emplace_back(ByteArray(static_cast<int>(bytes.size()), bytes.data()));
   }
 
   for (size_t x = 0; x < values_to_compare.size(); x++) {

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -134,10 +134,7 @@ TEST(Comparison, SignedFLBA) {
     EXPECT_FALSE(comparator->Compare(values_to_compare[x], values_to_compare[x])) << x;
     for (size_t y = x + 1; y < values_to_compare.size(); y++) {
       EXPECT_TRUE(comparator->Compare(values_to_compare[x], values_to_compare[y]))
-          << x << " " << y << " "
-          << ::arrow::BitUtil::FromBigEndian(
-                 *reinterpret_cast<int32_t*>(byte_values[x].data()))
-          << " " << *reinterpret_cast<int32_t*>(byte_values[y].data());
+          << x << " " << y;
       EXPECT_FALSE(comparator->Compare(values_to_compare[y], values_to_compare[x]))
           << y << " " << x;
     }

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -139,15 +139,6 @@ TEST(Comparison, SignedFLBA) {
           << y << " " << x;
     }
   }
-
-  constexpr uint8_t bytes1[] = {255, 127, 255};
-  constexpr uint8_t bytes2[] = {255, 255, 255};
-  EXPECT_TRUE(comparator->Compare(FLBA(bytes1), FLBA(bytes2)));
-  EXPECT_FALSE(comparator->Compare(FLBA(bytes2), FLBA(bytes1)));
-  EXPECT_FALSE(comparator->Compare(FLBA(bytes1), FLBA(bytes1)));
-  constexpr uint8_t bytes3[] = {127, 255, 255};
-  EXPECT_TRUE(comparator->Compare(FLBA(bytes2), FLBA(bytes3)));
-  EXPECT_FALSE(comparator->Compare(FLBA(bytes3), FLBA(bytes2)));
 }
 
 TEST(Comparison, UnsignedFLBA) {

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -69,6 +69,10 @@ static FLBA FLBAFromString(const std::string& s) {
 }
 
 TEST(Comparison, SignedByteArray) {
+  // Signed byte array comparison is only used for Decimal comparison. When
+  // decimals are encoded as byte arrays they use twos complement big-endian
+  // encoded values. Comparisons of byte arrays of unequal types need to handle
+  // sign extension.
   auto comparator = MakeComparator<ByteArrayType>(Type::BYTE_ARRAY, SortOrder::SIGNED);
   struct Case {
     std::vector<uint8_t> bytes;

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -77,7 +77,8 @@ TEST(Comparison, SignedByteArray) {
       {/*0, 0,*/ 0x01, 0x01},   {/*0,*/ 0x01, 0x01, 0},     {0x01, 0x01, 0, 0}};
   std::vector<ByteArray> values_to_compare = {ByteArray()};
   for (const auto& bytes : byte_values) {
-    values_to_compare.emplace_back(ByteArray(static_cast<int>(bytes.size()), bytes.data()));
+    values_to_compare.emplace_back(
+        ByteArray(static_cast<int>(bytes.size()), bytes.data()));
   }
 
   for (size_t x = 0; x < values_to_compare.size(); x++) {

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -78,6 +78,8 @@ TEST(Comparison, SignedByteArray) {
     }
   };
 
+  // Test a mix of big-endian comparison values that are both equal and
+  // unequal after sign extension.
   std::vector<Case> cases = {
       {{0x80, 0x80, 0, 0}, 0},           {{/*0xFF,*/ 0x80, 0, 0}, 1},
       {{0xFF, 0x80, 0, 0}, 1},           {{/*0xFF,*/ 0xFF, 0x01, 0}, 2},


### PR DESCRIPTION
The prior logic, I don't think is ever correct for signed
comparison.  Signed comparison of bytes as far as I can
tell from the specification is only used by Decimal
encoded values.  Decimals are always encoded as big-endian
two's complement integers.

The new logic reflects this by doing sign extension when
necessary for comparisons, and only using signed byte comparison
for the very first value when appropriate.

This PR also eliminates what appears to be a some dead code.