### PR TITLE
ARROW-11717: [Integration] Fix intermittent flight integration failures with rust

### DIFF
--- a/rust/integration-testing/src/flight_server_scenarios.rs
+++ b/rust/integration-testing/src/flight_server_scenarios.rs
@@ -32,8 +32,6 @@ pub async fn listen_on(port: &str) -> Result<SocketAddr> {
 
     let listener = TcpListener::bind(addr).await?;
     let addr = listener.local_addr()?;
-    // NOTE: Log output used in tests
-    println!("Server listening on localhost:{}", addr.port());
 
     Ok(addr)
 }

--- a/rust/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -47,6 +47,9 @@ pub async fn scenario_setup(port: &str) -> Result {
     let svc = FlightServiceServer::new(service);
 
     Server::builder().add_service(svc).serve(addr).await?;
+
+    // NOTE: Log output used in tests to signal server is ready
+    println!("Server listening on localhost:{}", addr.port());
     Ok(())
 }
 

--- a/rust/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -46,10 +46,11 @@ pub async fn scenario_setup(port: &str) -> Result {
     let addr = super::listen_on(port).await?;
     let svc = FlightServiceServer::new(service);
 
-    Server::builder().add_service(svc).serve(addr).await?;
+    let server = Server::builder().add_service(svc).serve(addr);
 
     // NOTE: Log output used in tests to signal server is ready
     println!("Server listening on localhost:{}", addr.port());
+    server.await?;
     Ok(())
 }
 

--- a/rust/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -53,6 +53,9 @@ pub async fn scenario_setup(port: &str) -> Result {
 
     Server::builder().add_service(svc).serve(addr).await?;
 
+    // NOTE: Log output used in tests to signal server is ready
+    println!("Server listening on localhost:{}", addr.port());
+
     Ok(())
 }
 

--- a/rust/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -51,11 +51,11 @@ pub async fn scenario_setup(port: &str) -> Result {
     };
     let svc = FlightServiceServer::new(service);
 
-    Server::builder().add_service(svc).serve(addr).await?;
+    let server = Server::builder().add_service(svc).serve(addr);
 
     // NOTE: Log output used in tests to signal server is ready
     println!("Server listening on localhost:{}", addr.port());
-
+    server.await?;
     Ok(())
 }
 

--- a/rust/integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/middleware.rs
@@ -37,6 +37,9 @@ pub async fn scenario_setup(port: &str) -> Result {
     let addr = super::listen_on(port).await?;
 
     Server::builder().add_service(svc).serve(addr).await?;
+
+    // NOTE: Log output used in tests to signal server is ready
+    println!("Server listening on localhost:{}", addr.port());
     Ok(())
 }
 

--- a/rust/integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/rust/integration-testing/src/flight_server_scenarios/middleware.rs
@@ -36,10 +36,11 @@ pub async fn scenario_setup(port: &str) -> Result {
     let svc = FlightServiceServer::new(service);
     let addr = super::listen_on(port).await?;
 
-    Server::builder().add_service(svc).serve(addr).await?;
+    let server = Server::builder().add_service(svc).serve(addr);
 
     // NOTE: Log output used in tests to signal server is ready
     println!("Server listening on localhost:{}", addr.port());
+    server.await?;
     Ok(())
 }
 


### PR DESCRIPTION
# Background
Thanks to the 🦅 👁️  of @lidavidm https://github.com/apache/arrow/pull/9583#issuecomment-786925049 it appears that the Rust flight integration test prints `"Server listening"` before the server is *actually* read to accept connections. Thus creating a race condition: if the tests try and start faster than the rust server can actually be setup then we see integration test failures as shown in https://issues.apache.org/jira/browse/ARROW-11717:

```
Traceback (most recent call last):
  File "/arrow/dev/archery/archery/integration/runner.py", line 308, in _run_flight_test_case
    consumer.flight_request(port, **client_args)
  File "/arrow/dev/archery/archery/integration/tester_cpp.py", line 116, in flight_request
    run_cmd(cmd)
  File "/arrow/dev/archery/archery/integration/util.py", line 148, in run_cmd
    raise RuntimeError(sio.getvalue())
RuntimeError: Command failed: /build/cpp/debug/flight-test-integration-client -host localhost -port=33569 -scenario auth:basic_proto
With output:
--------------
-- Arrow Fatal Error --
Invalid: Expected UNAUTHENTICATED but got Unavailable
```

# Changes
This PR changes the Rust flight scenario harnesses to print the ready message after the server is *actually* ready.

