### PR TITLE
ARROW-11819: [Rust] Add link to the doc

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -21,7 +21,7 @@
 
 [![Coverage Status](https://codecov.io/gh/apache/arrow/rust/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/arrow?branch=master)
 
-Welcome to the implementation of Arrow, the popular in-memory columnar format, in Rust.
+Welcome to the implementation of Arrow, the popular in-memory columnar format, in [Rust](https://www.rust-lang.org/).
 
 This part of the Arrow project is divided in 4 main components:
 


### PR DESCRIPTION
This is a test PR with a minor fix, that has no JIRA issue, that I am using to validate my new fancy script (https://github.com/apache/arrow/pull/9598). However, I think it is a reasonable change on its own