### PR TITLE
ARROW-11495: [Rust][Datafusion] Better numerical_coercion

### DIFF
--- a/rust/datafusion/src/physical_plan/expressions/binary.rs
+++ b/rust/datafusion/src/physical_plan/expressions/binary.rs
@@ -43,7 +43,9 @@ use crate::physical_plan::expressions::cast;
 use crate::physical_plan::{ColumnarValue, PhysicalExpr};
 use crate::scalar::ScalarValue;
 
-use super::coercion::{eq_coercion, order_coercion, string_coercion, numerical_arithmetic_coercion};
+use super::coercion::{
+    eq_coercion, numerical_arithmetic_coercion, order_coercion, string_coercion,
+};
 
 /// Binary expression
 #[derive(Debug)]

--- a/rust/datafusion/src/physical_plan/expressions/binary.rs
+++ b/rust/datafusion/src/physical_plan/expressions/binary.rs
@@ -43,7 +43,7 @@ use crate::physical_plan::expressions::cast;
 use crate::physical_plan::{ColumnarValue, PhysicalExpr};
 use crate::scalar::ScalarValue;
 
-use super::coercion::{eq_coercion, numerical_coercion, order_coercion, string_coercion};
+use super::coercion::{eq_coercion, order_coercion, string_coercion, numerical_arithmetic_coercion};
 
 /// Binary expression
 #[derive(Debug)]
@@ -342,7 +342,7 @@ fn common_binary_type(
         // for math expressions, the final value of the coercion is also the return type
         // because coercion favours higher information types
         Operator::Plus | Operator::Minus | Operator::Divide | Operator::Multiply => {
-            numerical_coercion(lhs_type, rhs_type)
+            numerical_arithmetic_coercion(&op, lhs_type, rhs_type)
         }
         Operator::Modulus => {
             return Err(DataFusionError::NotImplemented(
@@ -700,9 +700,9 @@ mod tests {
             DataType::UInt32,
             vec![1u32, 2u32],
             Operator::Plus,
-            Int32Array,
-            DataType::Int32,
-            vec![2i32, 4i32]
+            Int64Array,
+            DataType::Int64,
+            vec![2i64, 4i64]
         );
         test_coercion!(
             Int32Array,
@@ -712,9 +712,9 @@ mod tests {
             DataType::UInt16,
             vec![1u16],
             Operator::Plus,
-            Int32Array,
-            DataType::Int32,
-            vec![2i32]
+            Int64Array,
+            DataType::Int64,
+            vec![2i64]
         );
         test_coercion!(
             Float32Array,
@@ -724,9 +724,9 @@ mod tests {
             DataType::UInt16,
             vec![1u16],
             Operator::Plus,
-            Float32Array,
-            DataType::Float32,
-            vec![2f32]
+            Float64Array,
+            DataType::Float64,
+            vec![2f64]
         );
         test_coercion!(
             Float32Array,
@@ -736,9 +736,9 @@ mod tests {
             DataType::UInt16,
             vec![1u16],
             Operator::Multiply,
-            Float32Array,
-            DataType::Float32,
-            vec![2f32]
+            Float64Array,
+            DataType::Float64,
+            vec![2f64]
         );
         test_coercion!(
             StringArray,

--- a/rust/datafusion/src/physical_plan/expressions/coercion.rs
+++ b/rust/datafusion/src/physical_plan/expressions/coercion.rs
@@ -17,9 +17,9 @@
 
 //! Coercion rules used to coerce types to match existing expressions' implementations
 
+use crate::logical_plan::Operator;
 use arrow::datatypes::DataType;
 use std::cmp;
-use crate::logical_plan::Operator;
 
 /// Determine if a DataType is signed numeric or not
 pub fn is_signed_numeric(dt: &DataType) -> bool {
@@ -108,7 +108,6 @@ pub fn construct_numeric_type(
     }
 }
 
-
 /// Coercion rules for dictionary values (aka the type of the  dictionary itself)
 fn dictionary_value_coercion(
     lhs_type: &DataType,
@@ -188,9 +187,7 @@ pub fn numerical_arithmetic_coercion(
         Operator::Plus | Operator::Multiply => {
             construct_numeric_type(has_signed, has_float, next_size(max_size))
         }
-        Operator::Minus => {
-            construct_numeric_type(true, has_float, next_size(max_size))
-        }
+        Operator::Minus => construct_numeric_type(true, has_float, next_size(max_size)),
         Operator::Divide => Some(DataType::Float64),
         Operator::Modulus => {
             // https://github.com/ClickHouse/ClickHouse/blob/master/src/Functions/DivisionUtils.h#L113-L117
@@ -205,7 +202,7 @@ pub fn numerical_arithmetic_coercion(
                 Some(type0)
             }
         }
-        _ => None
+        _ => None,
     }
 }
 
@@ -273,10 +270,11 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<Da
         },
     );
 
-    let should_double = (has_float && has_integer && max_size_of_integer >= max_size_of_float)
-        || (has_signed
-        && has_unsigned
-        && max_size_of_unsigned_integer >= max_size_of_signed_integer);
+    let should_double =
+        (has_float && has_integer && max_size_of_integer >= max_size_of_float)
+            || (has_signed
+                && has_unsigned
+                && max_size_of_unsigned_integer >= max_size_of_signed_integer);
 
     construct_numeric_type(
         has_signed,

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -660,16 +660,16 @@ async fn csv_query_nullif_divide_by_0() -> Result<()> {
     let actual = execute(&mut ctx, sql).await;
     let actual = &actual[80..90]; // We just want to compare rows 80-89
     let expected = vec![
-        vec!["258"],
-        vec!["664"],
+        vec!["258.280701754386"],
+        vec!["664.3827160493827"],
         vec!["NULL"],
-        vec!["22"],
-        vec!["164"],
-        vec!["448"],
-        vec!["365"],
-        vec!["1640"],
-        vec!["671"],
-        vec!["203"],
+        vec!["22.405405405405407"],
+        vec!["164.17961165048544"],
+        vec!["448.593984962406"],
+        vec!["365.0120481927711"],
+        vec!["1640.388888888889"],
+        vec!["671.5232558139535"],
+        vec!["203.7246376811594"],
     ];
     assert_eq!(expected, actual);
     Ok(())
@@ -1911,7 +1911,7 @@ async fn query_without_from() -> Result<()> {
 
     let sql = "SELECT 1+2, 3/4, cos(0)";
     let actual = execute(&mut ctx, sql).await;
-    let expected = vec![vec!["3", "0", "1"]];
+    let expected = vec![vec!["3", "0.75", "1"]];
     assert_eq!(expected, actual);
 
     Ok(())


### PR DESCRIPTION
We should consider number overflow in arithmetic operator functions.

```
UIn8 + UIn8 should be UInt16, but now it's UInt8
UInt16 * UInt16 should be UInt32, but now it's UInt16

The least supertype of UInt8 and Int8 should be Int16
```

Refer:  https://github.com/ClickHouse/ClickHouse/blob/bd81f43ecb/src/DataTypes/NumberTraits.h