### PR TITLE
ARROW-11804: [Developer] Offer to create JIRA issue

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -137,7 +137,6 @@ PR_TITLE_REGEXEN = [(project, re.compile(r'^(' + project + r'-[0-9]+)\b.*$'))
 
 
 def get_jira_id(title):
-    jira_id = None
     for project, regex in PR_TITLE_REGEXEN:
         m = regex.search(title)
         if m:
@@ -275,7 +274,8 @@ class GitHubAPI(object):
 
     def update_pr_title(self, number, title):
         if not self.headers:
-            msg = "Can not update PR {} title to '{}'. ARROW_GITHUB_API_TOKEN environment not set".format(
+            msg = ("Can not update PR {} title to '{}'. " +
+                   "ARROW_GITHUB_API_TOKEN environment not set").format(
                 number, title
             )
             raise Exception(msg)
@@ -283,10 +283,9 @@ class GitHubAPI(object):
         # note need to use the issues URL to update
         url = "%s/issues/%s" % (self.github_api, number)
         data = json.dumps({'title': title})
-        resp = requests.patch(url, data = data, headers=self.headers)
+        resp = requests.patch(url, data=data, headers=self.headers)
         resp.raise_for_status()
         return resp.json()
-
 
 
 class CommandInput(object):
@@ -570,6 +569,7 @@ def get_pr_num():
 
     return input("Which pull request would you like to merge? (e.g. 34): ")
 
+
 _JIRA_COMPONENT_REGEX = re.compile(r'(\[[^\]]*\])+')
 
 # Maps PR title prefixes to JIRA components
@@ -579,6 +579,7 @@ PR_COMPONENTS_TO_JIRA_COMPONENTS = {
     '[C++]': 'C++',
     '[R]': 'R',
 }
+
 
 # Return the best matching JIRA component from a PR title, if any
 # "[Rust] Fix something" --> Rust
@@ -607,7 +608,6 @@ def make_auto_jira(github_api, jira_con, cmd, pr_num):
     if get_jira_id(title)[0]:
         return pr_data
 
-
     print("No JIRA link found for PR", pr_num)
     options = ' or '.join('{0}-XXX'.format(project)
                           for project in SUPPORTED_PROJECTS)
@@ -620,18 +620,20 @@ def make_auto_jira(github_api, jira_con, cmd, pr_num):
     if not component:
         print("  Could not determine component from title")
         print("  Expected '[Component] description', found '{}'".format(title))
-        print("  Known components: {}".format(", ".join(PR_COMPONENTS_TO_JIRA_COMPONENTS)))
+        print("  Known components: {}".format(
+            ", ".join(PR_COMPONENTS_TO_JIRA_COMPONENTS)))
         return pr_data
 
-    components=[{"name": component}]
-    summary="{}".format(title)
+    components = [{"name": component}]
+    summary = "{}".format(title)
 
     print("=== NEW JIRA ===")
     print("Summary\t\t{}".format(summary))
     print("Assignee\tNONE")
     print("Components\t{}".format(component))
     print("Status\t\tNew")
-    description = "Issue automatically created from Pull Request [{}|{}]\n{}".format(
+    description = ("Issue automatically created " +
+                   "from Pull Request [{}|{}]\n{}").format(
         pr_num, html_link, pr_data.get("body")
     )
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -389,7 +389,7 @@ class PullRequest(object):
             had_conflicts = True
 
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                                 '--pretty=format:%an <%ae>']).split("\n")
+                                  '--pretty=format:%an <%ae>']).split("\n")
         distinct_authors = sorted(set(commit_authors),
                                   key=lambda x: commit_authors.count(x),
                                   reverse=True)

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -318,11 +318,19 @@ URL\t\thttps://issues.apache.org/jira/browse/ARROW-1234"""
 
 
 def test_jira_component_name_from_title():
-    assert merge_arrow_pr.jira_component_name_from_title('[Rust] Example PR') == 'Rust'
-    assert merge_arrow_pr.jira_component_name_from_title('[Rust ] Example PR') == None
-    assert merge_arrow_pr.jira_component_name_from_title(' [Rust] Example PR') == 'Rust'
-    assert merge_arrow_pr.jira_component_name_from_title('[Rust][DataFusion] Example PR') == 'Rust - DataFusion'
-    assert merge_arrow_pr.jira_component_name_from_title('[DataFusion][Rust] Example PR') == None
-    assert merge_arrow_pr.jira_component_name_from_title('[Rust][ddFusion] Example PR') ==  None
-    assert merge_arrow_pr.jira_component_name_from_title('[C++] Example PR') == 'C++'
-    assert merge_arrow_pr.jira_component_name_from_title('[R] Example PR') == 'R'
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[Rust] Example PR') == 'Rust'
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[Rust ] Example PR') is None
+    assert merge_arrow_pr.jira_component_name_from_title(
+        ' [Rust] Example PR') == 'Rust'
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[Rust][DataFusion] Example PR') == 'Rust - DataFusion'
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[DataFusion][Rust] Example PR') is None
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[Rust][ddFusion] Example PR') is None
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[C++] Example PR') == 'C++'
+    assert merge_arrow_pr.jira_component_name_from_title(
+        '[R] Example PR') == 'R'

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -315,3 +315,14 @@ Assignee\tFoo Bar
 Components\tC++, Python
 Status\t\tResolved
 URL\t\thttps://issues.apache.org/jira/browse/ARROW-1234"""
+
+
+def test_jira_component_name_from_title():
+    assert merge_arrow_pr.jira_component_name_from_title('[Rust] Example PR') == 'Rust'
+    assert merge_arrow_pr.jira_component_name_from_title('[Rust ] Example PR') == None
+    assert merge_arrow_pr.jira_component_name_from_title(' [Rust] Example PR') == 'Rust'
+    assert merge_arrow_pr.jira_component_name_from_title('[Rust][DataFusion] Example PR') == 'Rust - DataFusion'
+    assert merge_arrow_pr.jira_component_name_from_title('[DataFusion][Rust] Example PR') == None
+    assert merge_arrow_pr.jira_component_name_from_title('[Rust][ddFusion] Example PR') ==  None
+    assert merge_arrow_pr.jira_component_name_from_title('[C++] Example PR') == 'C++'
+    assert merge_arrow_pr.jira_component_name_from_title('[R] Example PR') == 'R'


### PR DESCRIPTION
# Rationale
Currently all contributors are required to make a JIRA account and do some mechanical JIRA creation to create well formed Arrow PRs. This is mindless work and people who are used to it may forget the barrier it imposes on casual contributions and burden on maintainers to keep JIRA synced. 

Here is a good example of such a PR where we almost lost a potential contributor:  https://github.com/apache/arrow/pull/9576#issuecomment-786827957 (and despite @pierwill and I both working for InfluxData I swear I didn't put him up to this :) )

More discussion can be found on this [mailing list thread](https://lists.apache.org/thread.html/rd4533c7f882adbfc51061aceafebe8d84ea194fa5108d6cebc3621e1%40%3Cdev.arrow.apache.org%3E)

# Changes

This PR modifies the `merge_pr.py` to offer to create a JIRA and link it back to github if a pre-existing JIRA can not be found. For the existing workflow where the PR title contains the appropriate JIRA reference, there is no change. With this change, devs / maintainers would only have to ensure the title of PRs started with the correct components, and JIRAs could be automatically created, if they so desire

The script requires `ARROW_GITHUB_API_TOKEN` to have been set to some token that has the ability to update PR descriptions.

# Current behavior
If `merge_pr.py` is invoked on a PR without a JIRA ticket reference the following error occurs

```
(arrow_dev) alamb@MacBook-Pro:~/Software/arrow2/rust$ ../dev/merge_arrow_pr.py 9594
ARROW_HOME = /Users/alamb/Software/arrow2/dev
PROJECT_NAME = arrow
Restoring head pointer to 0f647261
Note: switching to '0f647261'.
...

HEAD is now at 0f6472610 ARROW-11778: [Rust] Cast from LargeUtf8 to Numerical and temporal types
Traceback (most recent call last):
  File "/Users/alamb/Software/arrow2/rust/../dev/merge_arrow_pr.py", line 597, in <module>
    cli()
  File "/Users/alamb/Software/arrow2/rust/../dev/merge_arrow_pr.py", line 566, in cli
    pr = PullRequest(cmd, github_api, PR_REMOTE_NAME, jira_con, pr_num)
  File "/Users/alamb/Software/arrow2/rust/../dev/merge_arrow_pr.py", line 309, in __init__
    self.jira_issue = self._get_jira()
  File "/Users/alamb/Software/arrow2/rust/../dev/merge_arrow_pr.py", line 336, in _get_jira
    self.cmd.fail("PR title should be prefixed by a jira id "
  File "/Users/alamb/Software/arrow2/rust/../dev/merge_arrow_pr.py", line 270, in fail
    raise Exception(msg)
Exception: PR title should be prefixed by a jira id ARROW-XXX or PARQUET-XXX, but found [Rust] Add link to the doc
```

# New Behavior

With the changes in this PR, the maintainer is prompted to optionally create the JIRA ticket:

```
(arrow_dev) alamb@ip-10-0-0-49:~/Software/arrow2$ ./dev/merge_arrow_pr.py 9594
ARROW_HOME = /Users/alamb/Software/arrow2/dev
PROJECT_NAME = arrow
No JIRA link found
  Looked for PR title prefixed by ARROW-XXX or PARQUET-XXX
=== NEW JIRA ===
Summary		[Rust] Add link to the doc
Assignee	NONE
Components	Rust
Status		New

Create JIRA and link to PR? (y/n): y
  Created ARROW-11818

=== Pull Request #9594 ===
title	ARROW-11818: [Rust] Add link to the doc
source	alamb/alamb/test_change
target	master
url	https://api.github.com/repos/apache/arrow/pulls/9594
=== JIRA ARROW-11818 ===
Summary		[Rust] Add link to the doc
Assignee	NOT ASSIGNED!!!
Components	Rust
Status		Open
URL		https://issues.apache.org/jira/browse/ARROW-11818

Proceed with merging pull request #9594? (y/n):
...
```

# Follow on Work

1. If this script is accepted, I would like to file a ticket to  improve the wording of the message left by the JIRA bot [example](https://github.com/apache/arrow/pull/9594#issuecomment-787052762) to make it clear that the creation of a JIRA account + ticket is not required (though perhaps still encouraged for large changes)

2. Add additional mappings from PR description to components (I only added the ones I use and a few others to prove out the idea)
