### PR TITLE
ARROW-11825: [Rust][DataFusion] Add mimalloc as option to benchmarks

### DIFF
--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -38,4 +38,5 @@ structopt = { version = "0.3", default-features = false }
 tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread"] }
 futures = "0.3"
 env_logger = "^0.8"
+mimalloc = { version = "0.1", optional = true, default-features = false }
 snmalloc-rs = {version = "0.2", optional = true, features= ["cache-friendly"] }

--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -53,10 +53,10 @@ The benchmark can then be run (assuming the data created from `dbgen` is in `/mn
 cargo run --release --bin tpch -- benchmark --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
 ```
 
-You can enable the features `simd` (to use SIMD instructions) and/or `snmalloc` (to use the snmalloc allocator) as features by passing them in as `--features`:
+You can enable the features `simd` (to use SIMD instructions) and/or `mimalloc` or `snmalloc` (to use either the mimalloc or snmalloc allocator) as features by passing them in as `--features`:
 
 ```
-cargo run --release --features "simd snmalloc" --bin tpch -- benchmark --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
+cargo run --release --features "simd mimalloc" --bin tpch -- benchmark --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
 ```
 
 The benchmark program also supports CSV and Parquet input file formats and a utility is provided to convert from `tbl`

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -40,6 +40,10 @@ use structopt::StructOpt;
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Debug, StructOpt)]
 struct BenchmarkOpt {
     /// Query number


### PR DESCRIPTION
Allows to compare both allocators in the benchmarks.
Looks like there is no clear faster overall allocator, both are faster on some TCP-H queries.