### PR TITLE
ARROW-11630: [Rust] Introduce limit option for sort kernel

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -52,7 +52,6 @@ hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
 partial_sort = "0.1.1"
-pdqsort = "1.0.3"
 
 [features]
 default = []

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,7 +51,7 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
-partial_sort = "0.1.1"
+partial_sort = "0.1.2"
 
 [features]
 default = []

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,6 +51,8 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
+partial_sort = "0.1.1"
+pdqsort = "1.0.3"
 
 [features]
 default = []

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,7 +51,6 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
-partial_sort = "0.1.2"
 
 [features]
 default = []

--- a/rust/arrow/benches/sort_kernel.rs
+++ b/rust/arrow/benches/sort_kernel.rs
@@ -33,7 +33,7 @@ fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
     Arc::new(array)
 }
 
-fn bench_sort(arr_a: &ArrayRef, array_b: &ArrayRef) {
+fn bench_sort(arr_a: &ArrayRef, array_b: &ArrayRef, limit: Option<usize>) {
     let columns = vec![
         SortColumn {
             values: arr_a.clone(),
@@ -45,29 +45,58 @@ fn bench_sort(arr_a: &ArrayRef, array_b: &ArrayRef) {
         },
     ];
 
-    criterion::black_box(lexsort(&columns, None).unwrap());
+    criterion::black_box(lexsort(&columns, limit).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_array(2u64.pow(10) as usize, false);
     let arr_b = create_array(2u64.pow(10) as usize, false);
 
-    c.bench_function("sort 2^10", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+    c.bench_function("sort 2^10", |b| b.iter(|| bench_sort(&arr_a, &arr_b, None)));
 
     let arr_a = create_array(2u64.pow(12) as usize, false);
     let arr_b = create_array(2u64.pow(12) as usize, false);
 
-    c.bench_function("sort 2^12", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+    c.bench_function("sort 2^12", |b| b.iter(|| bench_sort(&arr_a, &arr_b, None)));
 
     let arr_a = create_array(2u64.pow(10) as usize, true);
     let arr_b = create_array(2u64.pow(10) as usize, true);
 
-    c.bench_function("sort nulls 2^10", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+    c.bench_function("sort nulls 2^10", |b| {
+        b.iter(|| bench_sort(&arr_a, &arr_b, None))
+    });
 
     let arr_a = create_array(2u64.pow(12) as usize, true);
     let arr_b = create_array(2u64.pow(12) as usize, true);
 
-    c.bench_function("sort nulls 2^12", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+    c.bench_function("sort nulls 2^12", |b| {
+        b.iter(|| bench_sort(&arr_a, &arr_b, None))
+    });
+
+    /// with limit
+    {
+        let arr_a = create_array(2u64.pow(12) as usize, false);
+        let arr_b = create_array(2u64.pow(12) as usize, false);
+        c.bench_function("sort 2^12 limit 10", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(10)))
+        });
+
+        let arr_a = create_array(2u64.pow(12) as usize, false);
+        let arr_b = create_array(2u64.pow(12) as usize, false);
+        c.bench_function("sort 2^12 limit 100", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(100)))
+        });
+
+        let arr_a = create_array(2u64.pow(12) as usize, true);
+        let arr_b = create_array(2u64.pow(12) as usize, true);
+
+        c.bench_function("sort nulls 2^12 limit 10", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(10)))
+        });
+        c.bench_function("sort nulls 2^12 limit 100", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(10)))
+        });
+    }
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/benches/sort_kernel.rs
+++ b/rust/arrow/benches/sort_kernel.rs
@@ -45,7 +45,7 @@ fn bench_sort(arr_a: &ArrayRef, array_b: &ArrayRef) {
         },
     ];
 
-    criterion::black_box(lexsort(&columns).unwrap());
+    criterion::black_box(lexsort(&columns, None).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/rust/arrow/benches/sort_kernel.rs
+++ b/rust/arrow/benches/sort_kernel.rs
@@ -73,7 +73,7 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_sort(&arr_a, &arr_b, None))
     });
 
-    /// with limit
+    // with limit
     {
         let arr_a = create_array(2u64.pow(12) as usize, false);
         let arr_b = create_array(2u64.pow(12) as usize, false);
@@ -87,6 +87,12 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| bench_sort(&arr_a, &arr_b, Some(100)))
         });
 
+        let arr_a = create_array(2u64.pow(12) as usize, false);
+        let arr_b = create_array(2u64.pow(12) as usize, false);
+        c.bench_function("sort 2^12 limit 1000", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(1000)))
+        });
+
         let arr_a = create_array(2u64.pow(12) as usize, true);
         let arr_b = create_array(2u64.pow(12) as usize, true);
 
@@ -94,7 +100,10 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| bench_sort(&arr_a, &arr_b, Some(10)))
         });
         c.bench_function("sort nulls 2^12 limit 100", |b| {
-            b.iter(|| bench_sort(&arr_a, &arr_b, Some(10)))
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(100)))
+        });
+        c.bench_function("sort nulls 2^12 limit 1000", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(1000)))
         });
     }
 }

--- a/rust/arrow/benches/sort_kernel.rs
+++ b/rust/arrow/benches/sort_kernel.rs
@@ -93,6 +93,12 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| bench_sort(&arr_a, &arr_b, Some(1000)))
         });
 
+        let arr_a = create_array(2u64.pow(12) as usize, false);
+        let arr_b = create_array(2u64.pow(12) as usize, false);
+        c.bench_function("sort 2^12 limit 2^12", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(2u64.pow(12) as usize)))
+        });
+
         let arr_a = create_array(2u64.pow(12) as usize, true);
         let arr_b = create_array(2u64.pow(12) as usize, true);
 
@@ -104,6 +110,9 @@ fn add_benchmark(c: &mut Criterion) {
         });
         c.bench_function("sort nulls 2^12 limit 1000", |b| {
             b.iter(|| bench_sort(&arr_a, &arr_b, Some(1000)))
+        });
+        c.bench_function("sort nulls 2^12 limit 2^12", |b| {
+            b.iter(|| bench_sort(&arr_a, &arr_b, Some(2u64.pow(12) as usize)))
         });
     }
 }

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -2312,7 +2312,7 @@ mod tests {
             "a", "cat", "mat", "on", "sat", "the", "xxx", "xxxx", "fdadfdsf",
         ];
         let mut d = before.clone();
-        d.sort();
+        d.sort_unstable();
 
         for last in 0..before.len() {
             before.partial_sort(last, |a, b| a.cmp(b));
@@ -2327,7 +2327,7 @@ mod tests {
         let mut before: Vec<u32> = (0..size).map(|_| rng.gen::<u32>()).collect();
         let mut d = before.clone();
         let last = (rng.next_u32() % size) as usize;
-        d.sort();
+        d.sort_unstable();
 
         before.partial_sort(last, |a, b| a.cmp(b));
         assert_eq!(&d[0..last], &before[0..last]);

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -41,6 +41,7 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
 }
 
 /// Sort the `ArrayRef` partially.
+/// It's unstable_sort, may not preserve the order of equal elements
 /// Return an sorted `ArrayRef`, discarding the data after limit.
 pub fn sort_limit(
     values: &ArrayRef,
@@ -830,6 +831,7 @@ pub fn lexsort_to_indices(
     ))
 }
 
+/// It's unstable_sort, may not preserve the order of equal elements
 pub fn partial_sort<T, F>(v: &mut [T], limit: usize, mut is_less: F)
 where
     F: FnMut(&T, &T) -> Ordering,

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -653,7 +653,7 @@ where
         _ => {}
     }
 
-    /// we are not using partial_sort here, because array is ArrayRef. Something is not working good in that.
+    // we are not using partial_sort here, because array is ArrayRef. Something is not working good in that.
     if !descending {
         valids.sort_by(|a, b| cmp_array(a.1.as_ref(), b.1.as_ref()));
     } else {

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -646,11 +646,8 @@ where
     let mut len = values.len();
     let descending = options.descending;
 
-    match limit {
-        Some(limit) => {
-            len = limit.min(len);
-        }
-        _ => {}
+    if let Some(size) = limit {
+        len = size.min(len);
     }
 
     // we are not using partial_sort here, because array is ArrayRef. Something is not working good in that.

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -1471,8 +1471,19 @@ mod tests {
                 descending: false,
                 nulls_first: true,
             }),
-            Some(4),
-            vec![Some(1.0), Some(f64::NAN), Some(f64::NAN), Some(f64::NAN)],
+            Some(2),
+            vec![Some(1.0), Some(f64::NAN)],
+        );
+
+        // limit with actual value
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(2.0), Some(4.0), Some(3.0), Some(1.0)],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+            Some(3),
+            vec![Some(1.0), Some(2.0), Some(3.0)],
         );
     }
 

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -156,12 +156,14 @@ fn sort_batches(
     )?;
 
     // sort combined record batch
+    // TODO: pushup the limit expression to sort
     let indices = lexsort_to_indices(
         &expr
             .iter()
             .map(|e| e.evaluate_to_sort_column(&combined_batch))
             .collect::<Result<Vec<SortColumn>>>()
             .map_err(DataFusionError::into_arrow_external_error)?,
+        None,
     )?;
 
     // reorder all rows based on sorted indices


### PR DESCRIPTION
- Introduce `limit: Option<usize>` for sort functions, then we can use [partial_sort](https://crates.io/crates/partial_sort) to achieve better performance in queries with limit & sort. Datafusion can use it later if it can push up the limit to the sort plan (currently use None as default). 