### PR TITLE
ARROW-11802: [Rust][DataFusion] Remove use of crossbeam channels to avoid potential deadlocks

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -52,7 +52,6 @@ parquet = { path = "../parquet", version = "4.0.0-SNAPSHOT", features = ["arrow"
 sqlparser = "0.8.0"
 clap = "2.33"
 rustyline = {version = "7.0", optional = true}
-crossbeam = "0.8"
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -60,6 +60,7 @@ async-trait = "0.1.41"
 futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tokio-stream = "0.1"
 log = "^0.4"
 md-5 = "^0.9.1"
 sha2 = "^0.9.1"

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -287,7 +287,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn one_to_many_round_robin() -> Result<()> {
         // define input partitions
         let schema = test_schema();
@@ -307,7 +307,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn many_to_one_round_robin() -> Result<()> {
         // define input partitions
         let schema = test_schema();
@@ -324,7 +324,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn many_to_many_round_robin() -> Result<()> {
         // define input partitions
         let schema = test_schema();
@@ -345,7 +345,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn many_to_many_hash_partition() -> Result<()> {
         // define input partitions
         let schema = test_schema();
@@ -416,7 +416,7 @@ mod tests {
         Ok(output_partitions)
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn many_to_many_round_robin_within_tokio_task() -> Result<()> {
         let join_handle: JoinHandle<Result<Vec<Vec<RecordBatch>>>> =
             tokio::spawn(async move {

--- a/rust/datafusion/src/physical_plan/repartition.rs
+++ b/rust/datafusion/src/physical_plan/repartition.rs
@@ -206,7 +206,6 @@ impl ExecutionPlan for RepartitionExec {
                     }
                     Ok(())
                 });
-                tokio::task::yield_now().await;
             }
         }
 


### PR DESCRIPTION
# Rationale

As spotted / articulated by @edrevo https://github.com/apache/arrow/pull/9523#issuecomment-786911328, the intermixing of `crossbeam` channels (not designed for `async` and can block task threads) and `async` code such as DataFusion can lead to deadlock.

At least one of the crossbeam uses predates DataFusion being async (e.g. the one in the parquet reader). The use of crossbeam in the repartition operator in #8982 may have resulted from the re-use of the same pattern.

# Changes

1. Removes the use of crossbeam channels from DataFusion (in `RepartitionExec` and `ParquetExec`) and replace with tokio channels (which are designed for single threaded code).
2. Removes `crossbeam` dependency entirely
3. Removes use of `multi_thread`ed executor in tests (e.g. `#[tokio::test(flavor = "multi_thread")]`) which can mask hangs

# Kudos / Thanks

This PR incorporates the work of @seddonm1 from https://github.com/apache/arrow/pull/9603 and @edrevo in  https://github.com/edrevo/arrow/tree/remove-crossbeam (namely 97c256c4f76b8185311f36a7b27e317588904a3a). A big thanks to both of them for their help in this endeavor. 

