### PR TITLE
ARROW-11742: [Rust][DataFusion] Add Expr::is_null and Expr::is_not_nu…

### DIFF
--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -443,11 +443,13 @@ impl Expr {
     }
 
     /// Return `IsNull(Box(self))
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_null(self) -> Expr {
         Expr::IsNull(Box::new(self))
     }
 
     /// Return `IsNotNull(Box(self))
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_not_null(self) -> Expr {
         Expr::IsNotNull(Box::new(self))
     }

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -442,6 +442,16 @@ impl Expr {
         }
     }
 
+    /// Return `IsNull(Box(self))
+    pub fn is_null(self) -> Expr {
+        Expr::IsNull(Box::new(self))
+    }
+
+    /// Return `IsNotNull(Box(self))
+    pub fn is_not_null(self) -> Expr {
+        Expr::IsNotNull(Box::new(self))
+    }
+
     /// Create a sort expression from an existing expression.
     ///
     /// ```

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -1398,6 +1398,14 @@ mod tests {
         )
     }
 
+    #[test]
+    fn filter_is_null_and_is_not_null() {
+        let col_null = Expr::Column("col1".to_string());
+        let col_not_null = Expr::Column("col2".to_string());
+        assert_eq!(format!("{:?}", col_null.is_null()), "#col1 IS NULL");
+        assert_eq!(format!("{:?}", col_not_null.is_not_null()), "#col2 IS NOT NULL");
+    }
+
     #[derive(Default)]
     struct RecordingRewriter {
         v: Vec<String>,

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -1403,7 +1403,10 @@ mod tests {
         let col_null = Expr::Column("col1".to_string());
         let col_not_null = Expr::Column("col2".to_string());
         assert_eq!(format!("{:?}", col_null.is_null()), "#col1 IS NULL");
-        assert_eq!(format!("{:?}", col_not_null.is_not_null()), "#col2 IS NOT NULL");
+        assert_eq!(
+            format!("{:?}", col_not_null.is_not_null()),
+            "#col2 IS NOT NULL"
+        );
     }
 
     #[derive(Default)]


### PR DESCRIPTION
Implement is_null and is_not_null for DataFusion logical_plan's Expr specified in[ ARROW-11742](https://issues.apache.org/jira/browse/ARROW-11742)