### PR TITLE
ARROW-11833: [C++]  Fix missing architecture flag for vendored fast_float

### DIFF
--- a/cpp/src/arrow/vendored/fast_float/float_common.h
+++ b/cpp/src/arrow/vendored/fast_float/float_common.h
@@ -13,7 +13,8 @@
        || defined(__amd64) || defined(__aarch64__) || defined(_M_ARM64) \
        || defined(__MINGW64__)                                          \
        || defined(__s390x__)                                            \
-       || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)))
+       || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) defined(__PPC64LE__)) \
+       || defined(__EMSCRIPTEN__))
 #define FASTFLOAT_64BIT
 #else
 #error Unknown platform

--- a/cpp/src/arrow/vendored/fast_float/float_common.h
+++ b/cpp/src/arrow/vendored/fast_float/float_common.h
@@ -13,7 +13,7 @@
        || defined(__amd64) || defined(__aarch64__) || defined(_M_ARM64) \
        || defined(__MINGW64__)                                          \
        || defined(__s390x__)                                            \
-       || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) defined(__PPC64LE__)) \
+       || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) \
        || defined(__EMSCRIPTEN__))
 #define FASTFLOAT_64BIT
 #else


### PR DESCRIPTION
Please don't merge until upstream https://github.com/fastfloat/fast_float/pull/63