### PR TITLE
ARROW-11845: [Rust] Implement to_isize() for ArrowNativeTypes

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -88,6 +88,12 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         // Soundness
         // pointer alignment & location is ensured by RawPtrBox
         // buffer bounds/offset is ensured by the value_offset invariants
+
+        // Safety of `to_isize().unwrap()`
+        // `start` and `end` are &OffsetSize, which is a generic type that implements the
+        // OffsetSizeTrait. Currently, only i32 and i64 implement OffsetSizeTrait,
+        // both of which should cleanly cast to isize on an architecture that supports
+        // 32/64-bit offsets
         std::slice::from_raw_parts(
             self.value_data.as_ptr().offset(start.to_isize().unwrap()),
             (end - start).to_usize().unwrap(),
@@ -104,6 +110,12 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         // Soundness
         // pointer alignment & location is ensured by RawPtrBox
         // buffer bounds/offset is ensured by the value_offset invariants
+
+        // Safety of `to_isize().unwrap()`
+        // `start` and `end` are &OffsetSize, which is a generic type that implements the
+        // OffsetSizeTrait. Currently, only i32 and i64 implement OffsetSizeTrait,
+        // both of which should cleanly cast to isize on an architecture that supports
+        // 32/64-bit offsets
         unsafe {
             std::slice::from_raw_parts(
                 self.value_data.as_ptr().offset(start.to_isize().unwrap()),

--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -89,7 +89,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         // pointer alignment & location is ensured by RawPtrBox
         // buffer bounds/offset is ensured by the value_offset invariants
         std::slice::from_raw_parts(
-            self.value_data.as_ptr().offset(start.to_isize()),
+            self.value_data.as_ptr().offset(start.to_isize().unwrap()),
             (end - start).to_usize().unwrap(),
         )
     }
@@ -106,7 +106,7 @@ impl<OffsetSize: BinaryOffsetSizeTrait> GenericBinaryArray<OffsetSize> {
         // buffer bounds/offset is ensured by the value_offset invariants
         unsafe {
             std::slice::from_raw_parts(
-                self.value_data.as_ptr().offset(start.to_isize()),
+                self.value_data.as_ptr().offset(start.to_isize().unwrap()),
                 (*end - *start).to_usize().unwrap(),
             )
         }

--- a/rust/arrow/src/array/array_list.rs
+++ b/rust/arrow/src/array/array_list.rs
@@ -34,8 +34,6 @@ pub trait OffsetSizeTrait: ArrowNativeType + Num + Ord + std::ops::AddAssign {
     fn is_large() -> bool;
 
     fn prefix() -> &'static str;
-
-    fn to_isize(&self) -> isize;
 }
 
 impl OffsetSizeTrait for i32 {
@@ -47,10 +45,6 @@ impl OffsetSizeTrait for i32 {
     fn prefix() -> &'static str {
         ""
     }
-
-    fn to_isize(&self) -> isize {
-        num::ToPrimitive::to_isize(self).unwrap()
-    }
 }
 
 impl OffsetSizeTrait for i64 {
@@ -61,10 +55,6 @@ impl OffsetSizeTrait for i64 {
 
     fn prefix() -> &'static str {
         "Large"
-    }
-
-    fn to_isize(&self) -> isize {
-        num::ToPrimitive::to_isize(self).unwrap()
     }
 }
 

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -88,7 +88,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         // buffer bounds/offset is ensured by the value_offset invariants
         // ISSUE: utf-8 well formedness is not checked
         let slice = std::slice::from_raw_parts(
-            self.value_data.as_ptr().offset(start.to_isize()),
+            self.value_data.as_ptr().offset(start.to_isize().unwrap()),
             (*end - *start).to_usize().unwrap(),
         );
         std::str::from_utf8_unchecked(slice)
@@ -107,7 +107,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         // ISSUE: utf-8 well formedness is not checked
         unsafe {
             let slice = std::slice::from_raw_parts(
-                self.value_data.as_ptr().offset(start.to_isize()),
+                self.value_data.as_ptr().offset(start.to_isize().unwrap()),
                 (*end - *start).to_usize().unwrap(),
             );
             std::str::from_utf8_unchecked(slice)

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -87,6 +87,12 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         // pointer alignment & location is ensured by RawPtrBox
         // buffer bounds/offset is ensured by the value_offset invariants
         // ISSUE: utf-8 well formedness is not checked
+
+        // Safety of `to_isize().unwrap()`
+        // `start` and `end` are &OffsetSize, which is a generic type that implements the
+        // OffsetSizeTrait. Currently, only i32 and i64 implement OffsetSizeTrait,
+        // both of which should cleanly cast to isize on an architecture that supports
+        // 32/64-bit offsets
         let slice = std::slice::from_raw_parts(
             self.value_data.as_ptr().offset(start.to_isize().unwrap()),
             (*end - *start).to_usize().unwrap(),
@@ -106,6 +112,11 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         // buffer bounds/offset is ensured by the value_offset invariants
         // ISSUE: utf-8 well formedness is not checked
         unsafe {
+            // Safety of `to_isize().unwrap()`
+            // `start` and `end` are &OffsetSize, which is a generic type that implements the
+            // OffsetSizeTrait. Currently, only i32 and i64 implement OffsetSizeTrait,
+            // both of which should cleanly cast to isize on an architecture that supports
+            // 32/64-bit offsets
             let slice = std::slice::from_raw_parts(
                 self.value_data.as_ptr().offset(start.to_isize().unwrap()),
                 (*end - *start).to_usize().unwrap(),

--- a/rust/arrow/src/datatypes/native.rs
+++ b/rust/arrow/src/datatypes/native.rs
@@ -50,6 +50,12 @@ pub trait ArrowNativeType:
         None
     }
 
+    /// Convert native type to isize.
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        None
+    }
+
     /// Convert native type from i32.
     #[inline]
     fn from_i32(_: i32) -> Option<Self> {
@@ -107,6 +113,11 @@ impl ArrowNativeType for i8 {
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
+    }
 }
 
 impl JsonSerializable for i16 {
@@ -125,6 +136,11 @@ impl ArrowNativeType for i16 {
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
+    }
 }
 
 impl JsonSerializable for i32 {
@@ -142,6 +158,11 @@ impl ArrowNativeType for i32 {
     #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
+    }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
     }
 
     /// Convert native type from i32.
@@ -168,6 +189,11 @@ impl ArrowNativeType for i64 {
         num::ToPrimitive::to_usize(self)
     }
 
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
+    }
+
     /// Convert native type from i64.
     #[inline]
     fn from_i64(val: i64) -> Option<Self> {
@@ -191,6 +217,11 @@ impl ArrowNativeType for u8 {
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
+    }
 }
 
 impl JsonSerializable for u16 {
@@ -208,6 +239,11 @@ impl ArrowNativeType for u16 {
     #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
+    }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
     }
 }
 
@@ -227,6 +263,11 @@ impl ArrowNativeType for u32 {
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
     }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
+    }
 }
 
 impl JsonSerializable for u64 {
@@ -244,6 +285,11 @@ impl ArrowNativeType for u64 {
     #[inline]
     fn to_usize(&self) -> Option<usize> {
         num::ToPrimitive::to_usize(self)
+    }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        num::ToPrimitive::to_isize(self)
     }
 }
 


### PR DESCRIPTION
Corrects an issue with the Debug implementation for ArrowNativeTypes
(like Date32Array) that panic for negative values due to a .to_usize()
call. This may impact the handling of Time32/Time64 since as_time()
contains an explicit cast to u32.

This was accomplished by adding `.to_isize()` to the `ArrowNativeType`
trait and implementing it for all types that implement `ArrowNativeType`.
This also meant removing the `.to_isize()` function from the 
`OffsetSizeTrait` trait since it was redudant. Since code that relied on
`OffsetSizeTrait::to_isize()` were expecting an `isize` and not `Option<isize>`,
I added `unwrap()` calls. This is potentially not the right approach, normally
I'd want to properly handle any `Err` that resulted, but the code was
already relying on `unwrap()` and I wanted to keep my scope narrow.

The result of this change is that negative values are allowed (and 
printable through `Debug`) for Date32, Date64, Timestamp32, and
Timestamp64 typed Arrays. Time32/Time64 still accept negative values
when building and panic on printing, but now the error comes from 
chrono not converting negative values to 'time' format. If negative values
are not valid for Time32/Time64 Arrays, it may be necessary to add some
checking/error handling to the `.append_*()` functions to prevent adding
negative values in the first place.