### PR TITLE
ARROW-11653: [Rust][DataFusion] Postgres String Functions: ascii, chr, initcap, repeat, reverse, to_hex

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -57,22 +57,29 @@ DataFusion includes a simple command-line interactive SQL utility. See the [CLI 
 - [x] UDAFs (user-defined aggregate functions)
 - [x] Common math functions
 - String functions
+  - [x] ascii
   - [x] bit_Length
   - [x] btrim
   - [x] char_length
   - [x] character_length
+  - [x] chr
   - [x] concat
   - [x] concat_ws
-  - [x] length
+  - [x] initcap
   - [x] left
+  - [x] length
   - [x] lpad
   - [x] ltrim
   - [x] octet_length
+  - [x] repeat
+  - [x] reverse
   - [x] right
   - [x] rpad
   - [x] rtrim
   - [x] substr
+  - [x] to_hex
   - [x] trim
+
 - Miscellaneous/Boolean functions
   - [x] nullif
 - Common date/time functions

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -1075,18 +1075,23 @@ unary_scalar_expr!(Log2, log2);
 unary_scalar_expr!(Log10, log10);
 
 // string functions
+unary_scalar_expr!(Ascii, ascii);
 unary_scalar_expr!(BitLength, bit_length);
 unary_scalar_expr!(Btrim, btrim);
 unary_scalar_expr!(CharacterLength, character_length);
 unary_scalar_expr!(CharacterLength, length);
+unary_scalar_expr!(Chr, chr);
 unary_scalar_expr!(Concat, concat);
 unary_scalar_expr!(ConcatWithSeparator, concat_ws);
+unary_scalar_expr!(InitCap, initcap);
 unary_scalar_expr!(Left, left);
 unary_scalar_expr!(Lower, lower);
 unary_scalar_expr!(Lpad, lpad);
 unary_scalar_expr!(Ltrim, ltrim);
 unary_scalar_expr!(MD5, md5);
 unary_scalar_expr!(OctetLength, octet_length);
+unary_scalar_expr!(Repeat, repeat);
+unary_scalar_expr!(Reverse, reverse);
 unary_scalar_expr!(Right, right);
 unary_scalar_expr!(Rpad, rpad);
 unary_scalar_expr!(Rtrim, rtrim);
@@ -1095,6 +1100,7 @@ unary_scalar_expr!(SHA256, sha256);
 unary_scalar_expr!(SHA384, sha384);
 unary_scalar_expr!(SHA512, sha512);
 unary_scalar_expr!(Substr, substr);
+unary_scalar_expr!(ToHex, to_hex);
 unary_scalar_expr!(Trim, trim);
 unary_scalar_expr!(Upper, upper);
 

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -33,13 +33,13 @@ pub use builder::LogicalPlanBuilder;
 pub use dfschema::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
 pub use display::display_schema;
 pub use expr::{
-    abs, acos, and, array, asin, atan, avg, binary_expr, bit_length, btrim, case, ceil,
-    character_length, col, combine_filters, concat, concat_ws, cos, count,
+    abs, acos, and, array, ascii, asin, atan, avg, binary_expr, bit_length, btrim, case,
+    ceil, character_length, chr, col, combine_filters, concat, concat_ws, cos, count,
     count_distinct, create_udaf, create_udf, exp, exprlist_to_fields, floor, in_list,
-    left, length, lit, ln, log10, log2, lower, lpad, ltrim, max, md5, min, octet_length,
-    or, right, round, rpad, rtrim, sha224, sha256, sha384, sha512, signum, sin, sqrt,
-    substr, sum, tan, trim, trunc, upper, when, Expr, ExprRewriter, ExpressionVisitor,
-    Literal, Recursion,
+    initcap, left, length, lit, ln, log10, log2, lower, lpad, ltrim, max, md5, min,
+    octet_length, or, repeat, reverse, right, round, rpad, rtrim, sha224, sha256, sha384,
+    sha512, signum, sin, sqrt, substr, sum, tan, to_hex, trim, trunc, upper, when, Expr,
+    ExprRewriter, ExpressionVisitor, Literal, Recursion,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 use arrow::{
     array::{
-        Array, ArrayRef, GenericStringArray, Int64Array, PrimitiveArray, StringArray,
-        StringOffsetSizeTrait,
+        Array, ArrayRef, GenericStringArray, Int32Array, Int64Array, PrimitiveArray,
+        StringArray, StringOffsetSizeTrait,
     },
     datatypes::{ArrowNativeType, ArrowPrimitiveType, DataType},
 };
@@ -136,6 +136,29 @@ macro_rules! downcast_vec {
     }};
 }
 
+/// Returns the numeric code of the first character of the argument.
+/// ascii('x') = 120
+pub fn ascii<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let string_array: &GenericStringArray<T> = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast string to StringArray".to_string())
+        })?;
+
+    let result = string_array
+        .iter()
+        .map(|string| {
+            string.map(|string: &str| {
+                let mut chars = string.chars();
+                chars.next().map_or(0, |v| v as i32)
+            })
+        })
+        .collect::<Int32Array>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
 /// Removes the longest string containing only characters in characters (a space by default) from the start and end of string.
 /// btrim('xyxtrimyyx', 'xyz') = 'trim'
 pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
@@ -144,11 +167,19 @@ pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let string_array: &GenericStringArray<T> = args[0]
                 .as_any()
                 .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "could not cast string to StringArray".to_string(),
+                    )
+                })?;
 
             let result = string_array
                 .iter()
-                .map(|x| x.map(|x: &str| x.trim_start_matches(' ').trim_end_matches(' ')))
+                .map(|string| {
+                    string.map(|string: &str| {
+                        string.trim_start_matches(' ').trim_end_matches(' ')
+                    })
+                })
                 .collect::<GenericStringArray<T>>();
 
             Ok(Arc::new(result) as ArrayRef)
@@ -157,26 +188,34 @@ pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let string_array: &GenericStringArray<T> = args[0]
                 .as_any()
                 .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "could not cast string to StringArray".to_string(),
+                    )
+                })?;
 
             let characters_array: &GenericStringArray<T> = args[1]
                 .as_any()
                 .downcast_ref::<GenericStringArray<T>>()
-                .unwrap();
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "could not cast characters to StringArray".to_string(),
+                    )
+                })?;
 
             let result = string_array
                 .iter()
-                .enumerate()
-                .map(|(i, x)| {
-                    if characters_array.is_null(i) {
-                        None
-                    } else {
-                        x.map(|x: &str| {
-                            let chars: Vec<char> =
-                                characters_array.value(i).chars().collect();
-                            x.trim_start_matches(&chars[..])
-                                .trim_end_matches(&chars[..])
-                        })
+                .zip(characters_array.iter())
+                .map(|(string, characters)| match (string, characters) {
+                    (None, _) => None,
+                    (_, None) => None,
+                    (Some(string), Some(characters)) => {
+                        let chars: Vec<char> = characters.chars().collect();
+                        Some(
+                            string
+                                .trim_start_matches(&chars[..])
+                                .trim_end_matches(&chars[..]),
+                        )
                     }
                 })
                 .collect::<GenericStringArray<T>>();
@@ -184,7 +223,7 @@ pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             Ok(Arc::new(result) as ArrayRef)
         }
         other => Err(DataFusionError::Internal(format!(
-            "btrim was called with {} arguments. It requires at most 2.",
+            "btrim was called with {} arguments. It requires at least 1 and at most 2.",
             other
         ))),
     }
@@ -199,14 +238,54 @@ where
     let string_array: &GenericStringArray<T::Native> = args[0]
         .as_any()
         .downcast_ref::<GenericStringArray<T::Native>>()
-        .unwrap();
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast string to StringArray".to_string())
+        })?;
 
     let result = string_array
         .iter()
-        .map(|x| {
-            x.map(|x: &str| T::Native::from_usize(x.graphemes(true).count()).unwrap())
+        .map(|string| {
+            string.map(|string: &str| {
+                T::Native::from_usize(string.graphemes(true).count()).unwrap()
+            })
         })
         .collect::<PrimitiveArray<T>>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+/// Returns the character with the given code. chr(0) is disallowed because text data types cannot store that character.
+/// chr(65) = 'A'
+pub fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let integer_array: &Int64Array = args[0]
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast integer to Int64Array".to_string())
+        })?;
+
+    // first map is the iterator, second is for the `Option<_>`
+    let result = integer_array
+        .iter()
+        .map(|integer: Option<i64>| {
+            integer
+                .map(|integer| {
+                    if integer == 0 {
+                        Err(DataFusionError::Execution(
+                            "null character not permitted.".to_string(),
+                        ))
+                    } else {
+                        match core::char::from_u32(integer as u32) {
+                            Some(integer) => Ok(integer.to_string()),
+                            None => Err(DataFusionError::Execution(
+                                "requested character too large for encoding.".to_string(),
+                            )),
+                        }
+                    }
+                })
+                .transpose()
+        })
+        .collect::<Result<StringArray>>()?;
 
     Ok(Arc::new(result) as ArrayRef)
 }
@@ -310,6 +389,41 @@ pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
     Ok(Arc::new(result) as ArrayRef)
 }
 
+/// Converts the first letter of each word to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.
+/// initcap('hi THOMAS') = 'Hi Thomas'
+pub fn initcap<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let string_array: &GenericStringArray<T> = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast string to StringArray".to_string())
+        })?;
+
+    // first map is the iterator, second is for the `Option<_>`
+    let result = string_array
+        .iter()
+        .map(|string| {
+            string.map(|string: &str| {
+                let mut char_vector = Vec::<char>::new();
+                let mut previous_character_letter_or_number = false;
+                for c in string.chars() {
+                    if previous_character_letter_or_number {
+                        char_vector.push(c.to_ascii_lowercase());
+                    } else {
+                        char_vector.push(c.to_ascii_uppercase());
+                    }
+                    previous_character_letter_or_number = ('A'..='Z').contains(&c)
+                        || ('a'..='z').contains(&c)
+                        || ('0'..='9').contains(&c);
+                }
+                char_vector.iter().collect::<String>()
+            })
+        })
+        .collect::<GenericStringArray<T>>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
 /// Returns first n characters in the string, or when n is negative, returns all but last |n| characters.
 /// left('abcde', 2) = 'ab'
 pub fn left<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
@@ -363,7 +477,7 @@ pub fn left<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 /// Converts the string to all lower case.
 /// lower('TOM') = 'tom'
 pub fn lower(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    handle(args, |x| x.to_ascii_lowercase(), "lower")
+    handle(args, |string| string.to_ascii_lowercase(), "lower")
 }
 
 /// Extends the string to length length by prepending the characters fill (a space by default). If the string is already longer than length then it is truncated (on the right).
@@ -512,7 +626,7 @@ pub fn ltrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
             let result = string_array
                 .iter()
-                .map(|x| x.map(|x: &str| x.trim_start_matches(' ')))
+                .map(|string| string.map(|string: &str| string.trim_start_matches(' ')))
                 .collect::<GenericStringArray<T>>();
 
             Ok(Arc::new(result) as ArrayRef)
@@ -556,6 +670,56 @@ pub fn ltrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             other
         ))),
     }
+}
+
+/// Repeats string the specified number of times.
+/// repeat('Pg', 4) = 'PgPgPgPg'
+pub fn repeat<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let string_array: &GenericStringArray<T> = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast string to StringArray".to_string())
+        })?;
+
+    let number_array: &Int64Array = args[1]
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast number to Int64Array".to_string())
+        })?;
+
+    let result = string_array
+        .iter()
+        .zip(number_array.iter())
+        .map(|(string, number)| match (string, number) {
+            (None, _) => None,
+            (_, None) => None,
+            (Some(string), Some(number)) => Some(string.repeat(number as usize)),
+        })
+        .collect::<GenericStringArray<T>>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
+/// Reverses the order of the characters in the string.
+/// reverse('abcde') = 'edcba'
+pub fn reverse<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let string_array: &GenericStringArray<T> = args[0]
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("could not cast string to StringArray".to_string())
+        })?;
+
+    let result = string_array
+        .iter()
+        .map(|string| {
+            string.map(|string: &str| string.graphemes(true).rev().collect::<String>())
+        })
+        .collect::<GenericStringArray<T>>();
+
+    Ok(Arc::new(result) as ArrayRef)
 }
 
 /// Returns last n characters in the string, or when n is negative, returns all but first |n| characters.
@@ -907,8 +1071,33 @@ pub fn substr<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 }
 
+/// Converts the number to its equivalent hexadecimal representation.
+/// to_hex(2147483647) = '7fffffff'
+pub fn to_hex<T: ArrowPrimitiveType>(args: &[ArrayRef]) -> Result<ArrayRef>
+where
+    T::Native: StringOffsetSizeTrait,
+{
+    let integer_array: &PrimitiveArray<T> = args[0]
+        .as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .ok_or_else(|| {
+            DataFusionError::Internal(
+                "could not cast integer to PrimitiveArray<T>".to_string(),
+            )
+        })?;
+
+    let result = integer_array
+        .iter()
+        .map(|integer| {
+            integer.map(|integer| format!("{:x}", integer.to_usize().unwrap()))
+        })
+        .collect::<GenericStringArray<i32>>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
 /// Converts the string to all upper case.
 /// upper('tom') = 'TOM'
 pub fn upper(args: &[ColumnarValue]) -> Result<ColumnarValue> {
-    handle(args, |x| x.to_ascii_uppercase(), "upper")
+    handle(args, |string| string.to_ascii_uppercase(), "upper")
 }

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -28,9 +28,9 @@
 pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::logical_plan::{
-    array, avg, bit_length, btrim, character_length, col, concat, concat_ws, count,
-    create_udf, in_list, left, length, lit, lower, lpad, ltrim, max, md5, min,
-    octet_length, right, rpad, rtrim, sha224, sha256, sha384, sha512, substr, sum, trim,
-    upper, JoinType, Partitioning,
+    array, ascii, avg, bit_length, btrim, character_length, chr, col, concat, concat_ws,
+    count, create_udf, in_list, initcap, left, length, lit, lower, lpad, ltrim, max, md5,
+    min, octet_length, repeat, reverse, right, rpad, rtrim, sha224, sha256, sha384,
+    sha512, substr, sum, to_hex, trim, upper, JoinType, Partitioning,
 };
 pub use crate::physical_plan::csv::CsvReadOptions;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2034,6 +2034,9 @@ macro_rules! test_expression {
 
 #[tokio::test]
 async fn test_string_expressions() -> Result<()> {
+    test_expression!("ascii('')", "0");
+    test_expression!("ascii('x')", "120");
+    test_expression!("ascii(NULL)", "NULL");
     test_expression!("bit_length('')", "0");
     test_expression!("bit_length('chars')", "40");
     test_expression!("bit_length('josé')", "40");
@@ -2051,6 +2054,9 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("character_length('chars')", "5");
     test_expression!("character_length('josé')", "4");
     test_expression!("character_length(NULL)", "NULL");
+    test_expression!("chr(CAST(120 AS int))", "x");
+    test_expression!("chr(CAST(128175 AS int))", "💯");
+    test_expression!("chr(CAST(NULL AS int))", "NULL");
     test_expression!("concat('a','b','c')", "abc");
     test_expression!("concat('abcde', 2, NULL, 22)", "abcde222");
     test_expression!("concat(NULL)", "");
@@ -2058,6 +2064,9 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("concat_ws('|','a','b','c')", "a|b|c");
     test_expression!("concat_ws('|',NULL)", "");
     test_expression!("concat_ws(NULL,'a',NULL,'b','c')", "NULL");
+    test_expression!("initcap('')", "");
+    test_expression!("initcap('hi THOMAS')", "Hi Thomas");
+    test_expression!("initcap(NULL)", "NULL");
     test_expression!("left('abcde', -2)", "abc");
     test_expression!("left('abcde', -200)", "");
     test_expression!("left('abcde', 0)", "");
@@ -2088,6 +2097,12 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("octet_length('chars')", "5");
     test_expression!("octet_length('josé')", "5");
     test_expression!("octet_length(NULL)", "NULL");
+    test_expression!("repeat('Pg', 4)", "PgPgPgPg");
+    test_expression!("repeat('Pg', CAST(NULL AS INT))", "NULL");
+    test_expression!("repeat(NULL, 4)", "NULL");
+    test_expression!("reverse('abcde')", "edcba");
+    test_expression!("reverse('loẅks')", "skẅol");
+    test_expression!("reverse(NULL)", "NULL");
     test_expression!("right('abcde', -2)", "cde");
     test_expression!("right('abcde', -200)", "");
     test_expression!("right('abcde', 0)", "");
@@ -2120,6 +2135,9 @@ async fn test_string_expressions() -> Result<()> {
     test_expression!("substr('alphabet', 3, 20)", "phabet");
     test_expression!("substr('alphabet', CAST(NULL AS int), 20)", "NULL");
     test_expression!("substr('alphabet', 3, CAST(NULL AS int))", "NULL");
+    test_expression!("to_hex(2147483647)", "7fffffff");
+    test_expression!("to_hex(9223372036854775807)", "7fffffffffffffff");
+    test_expression!("to_hex(CAST(NULL AS int))", "NULL");
     test_expression!("trim(' tom ')", "tom");
     test_expression!("trim(' tom')", "tom");
     test_expression!("trim('')", "");


### PR DESCRIPTION
@alamb This is the second last of the current string functions but I think there may be one after that with new code.

This implements some of the miscellaneous string functions `ascii`, `chr`, `initcap`, `repeat`, `reverse`, `to_hex`. The next PR will have more useful functions (including regex).

A little bit of tidying for consistency to the other functions was applied.

This PR is a child of #9243 