### PR TITLE
ARROW-11855: [C++][Python] Memory leak in to_pandas when converting chunked struct array

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -657,7 +657,7 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
   // Use it to cache the struct type and number of fields for all chunks
   int32_t num_fields = arr->num_fields();
   auto array_type = arr->type();
-  std::vector<OwnedRef> fields_data(num_fields);
+  std::vector<OwnedRef> fields_data(num_fields * data.num_chunks());
   OwnedRef dict_item;
 
   // See notes in MakeInnerOptions.
@@ -666,12 +666,14 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
   options.timestamp_as_object = true;
 
   for (int c = 0; c < data.num_chunks(); c++) {
+    auto fields_data_offset = c * num_fields;
     auto arr = checked_cast<const StructArray*>(data.chunk(c).get());
     // Convert the struct arrays first
     for (int32_t i = 0; i < num_fields; i++) {
       const auto field = arr->field(static_cast<int>(i));
-      RETURN_NOT_OK(ConvertArrayToPandas(options, field, nullptr, fields_data[i].ref()));
-      DCHECK(PyArray_Check(fields_data[i].obj()));
+      RETURN_NOT_OK(ConvertArrayToPandas(options, field, nullptr,
+                                         fields_data[i + fields_data_offset].ref()));
+      DCHECK(PyArray_Check(fields_data[i + fields_data_offset].obj()));
     }
 
     // Construct a dictionary for each row
@@ -689,7 +691,8 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
           auto name = array_type->field(static_cast<int>(field_idx))->name();
           if (!arr->field(static_cast<int>(field_idx))->IsNull(i)) {
             // Value exists in child array, obtain it
-            auto array = reinterpret_cast<PyArrayObject*>(fields_data[field_idx].obj());
+            auto array = reinterpret_cast<PyArrayObject*>(
+                fields_data[field_idx + fields_data_offset].obj());
             auto ptr = reinterpret_cast<const char*>(PyArray_GETPTR1(array, i));
             field_value.reset(PyArray_GETITEM(array, ptr));
             RETURN_IF_PYERROR();

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2275,14 +2275,15 @@ class TestConvertStructTypes:
     def test_to_pandas_multiple_chunks(self):
         # ARROW-11855
         bytes_start = pa.total_allocated_bytes()
-        ints = pa.array([1], type=pa.int64())
-        arr1 = pa.StructArray.from_arrays([ints], ['ints'])
-        arr2 = pa.StructArray.from_arrays([ints], ['ints'])
+        ints1 = pa.array([1], type=pa.int64())
+        ints2 = pa.array([2], type=pa.int64())
+        arr1 = pa.StructArray.from_arrays([ints1], ['ints'])
+        arr2 = pa.StructArray.from_arrays([ints2], ['ints'])
         arr = pa.chunked_array([arr1, arr2])
 
         expected = pd.Series([
             {'ints': 1},
-            {'ints': 1}
+            {'ints': 2}
         ])
 
         series = pd.Series(arr.to_pandas())
@@ -2292,7 +2293,9 @@ class TestConvertStructTypes:
         del arr
         del arr1
         del arr2
-        del ints
+        del ints1
+        del ints2
+        gc.collect()
         bytes_end = pa.total_allocated_bytes()
         assert bytes_end == bytes_start
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2274,6 +2274,7 @@ class TestConvertStructTypes:
 
     def test_to_pandas_multiple_chunks(self):
         # ARROW-11855
+        gc.collect()
         bytes_start = pa.total_allocated_bytes()
         ints1 = pa.array([1], type=pa.int64())
         ints2 = pa.array([2], type=pa.int64())
@@ -2295,7 +2296,6 @@ class TestConvertStructTypes:
         del arr2
         del ints1
         del ints2
-        gc.collect()
         bytes_end = pa.total_allocated_bytes()
         assert bytes_end == bytes_start
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2272,6 +2272,30 @@ class TestConvertStructTypes:
         series = pd.Series(arr.to_pandas())
         tm.assert_series_equal(series, expected)
 
+    def test_to_pandas_multiple_chunks(self):
+        # ARROW-11855
+        bytes_start = pa.total_allocated_bytes()
+        ints = pa.array([1], type=pa.int64())
+        arr1 = pa.StructArray.from_arrays([ints], ['ints'])
+        arr2 = pa.StructArray.from_arrays([ints], ['ints'])
+        arr = pa.chunked_array([arr1, arr2])
+
+        expected = pd.Series([
+            {'ints': 1},
+            {'ints': 1}
+        ])
+
+        series = pd.Series(arr.to_pandas())
+        tm.assert_series_equal(series, expected)
+
+        del series
+        del arr
+        del arr1
+        del arr2
+        del ints
+        bytes_end = pa.total_allocated_bytes()
+        assert bytes_end == bytes_start
+
     def test_from_numpy(self):
         dt = np.dtype([('x', np.int32),
                        (('y_title', 'y'), np.bool_)])


### PR DESCRIPTION
When converting a struct with chunks to python the ownership of the arrow arrays was not being properly tracked and the deletion of the resulting pandas dataframe would leave some buffers behind.  I believe it was something like this (pseudo-code)...

```
array_tracker** refs[num_fields];
for chunk in chunks:
  *refs[chunk.index] = convert(...)
  for row in rows:
    row.owns.append(refs[chunk.index])
```