### PR TITLE
ARROW-11856: [C++] Remove unused reference to RecordBatchStreamWriter

### DIFF
--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -53,7 +53,6 @@ struct IpcWriteOptions;
 class MessageReader;
 
 class RecordBatchStreamReader;
-class RecordBatchStreamWriter;
 class RecordBatchFileReader;
 class RecordBatchWriter;
 


### PR DESCRIPTION
The type RecordBatchStreamWriter was in a type_fwd but never implemented anywhere.  The proper type would be RecordBatchWriter