### PR TITLE
ARROW-11758: [C++][Compute] Improve summation kernel percision

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -99,37 +99,11 @@ std::unique_ptr<KernelState> CountInit(KernelContext*, const KernelInitArgs& arg
 // ----------------------------------------------------------------------
 // Sum implementation
 
-// Round size optimized based on data type and compiler
-template <typename T>
-struct RoundSizeDefault {
-  static constexpr int64_t size = 16;
-};
-
-// Round size set to 32 for float/int32_t/uint32_t
-template <>
-struct RoundSizeDefault<float> {
-  static constexpr int64_t size = 32;
-};
-
-template <>
-struct RoundSizeDefault<int32_t> {
-  static constexpr int64_t size = 32;
-};
-
-template <>
-struct RoundSizeDefault<uint32_t> {
-  static constexpr int64_t size = 32;
-};
+template <typename ArrowType>
+struct SumImplDefault : public SumImpl<ArrowType, SimdLevel::NONE> {};
 
 template <typename ArrowType>
-struct SumImplDefault
-    : public SumImpl<RoundSizeDefault<typename TypeTraits<ArrowType>::CType>::size,
-                     ArrowType, SimdLevel::NONE> {};
-
-template <typename ArrowType>
-struct MeanImplDefault
-    : public MeanImpl<RoundSizeDefault<typename TypeTraits<ArrowType>::CType>::size,
-                      ArrowType, SimdLevel::NONE> {};
+struct MeanImplDefault : public MeanImpl<ArrowType, SimdLevel::NONE> {};
 
 std::unique_ptr<KernelState> SumInit(KernelContext* ctx, const KernelInitArgs& args) {
   SumLikeInit<SumImplDefault> visitor(ctx, *args.inputs[0].type);

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_avx2.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_avx2.cc
@@ -24,37 +24,11 @@ namespace aggregate {
 // ----------------------------------------------------------------------
 // Sum implementation
 
-// Round size optimized based on data type and compiler
-template <typename T>
-struct RoundSizeAvx2 {
-  static constexpr int64_t size = 32;
-};
-
-// Round size set to 64 for float/int32_t/uint32_t
-template <>
-struct RoundSizeAvx2<float> {
-  static constexpr int64_t size = 64;
-};
-
-template <>
-struct RoundSizeAvx2<int32_t> {
-  static constexpr int64_t size = 64;
-};
-
-template <>
-struct RoundSizeAvx2<uint32_t> {
-  static constexpr int64_t size = 64;
-};
+template <typename ArrowType>
+struct SumImplAvx2 : public SumImpl<ArrowType, SimdLevel::AVX2> {};
 
 template <typename ArrowType>
-struct SumImplAvx2
-    : public SumImpl<RoundSizeAvx2<typename TypeTraits<ArrowType>::CType>::size,
-                     ArrowType, SimdLevel::AVX2> {};
-
-template <typename ArrowType>
-struct MeanImplAvx2
-    : public MeanImpl<RoundSizeAvx2<typename TypeTraits<ArrowType>::CType>::size,
-                      ArrowType, SimdLevel::AVX2> {};
+struct MeanImplAvx2 : public MeanImpl<ArrowType, SimdLevel::AVX2> {};
 
 std::unique_ptr<KernelState> SumInitAvx2(KernelContext* ctx, const KernelInitArgs& args) {
   SumLikeInit<SumImplAvx2> visitor(ctx, *args.inputs[0].type);

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_avx512.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_avx512.cc
@@ -24,37 +24,11 @@ namespace aggregate {
 // ----------------------------------------------------------------------
 // Sum implementation
 
-// Round size optimized based on data type and compiler
-template <typename T>
-struct RoundSizeAvx512 {
-  static constexpr int64_t size = 32;
-};
-
-// Round size set to 64 for float/int32_t/uint32_t
-template <>
-struct RoundSizeAvx512<float> {
-  static constexpr int64_t size = 64;
-};
-
-template <>
-struct RoundSizeAvx512<int32_t> {
-  static constexpr int64_t size = 64;
-};
-
-template <>
-struct RoundSizeAvx512<uint32_t> {
-  static constexpr int64_t size = 64;
-};
+template <typename ArrowType>
+struct SumImplAvx512 : public SumImpl<ArrowType, SimdLevel::AVX512> {};
 
 template <typename ArrowType>
-struct SumImplAvx512
-    : public SumImpl<RoundSizeAvx512<typename TypeTraits<ArrowType>::CType>::size,
-                     ArrowType, SimdLevel::AVX512> {};
-
-template <typename ArrowType>
-struct MeanImplAvx512
-    : public MeanImpl<RoundSizeAvx512<typename TypeTraits<ArrowType>::CType>::size,
-                      ArrowType, SimdLevel::AVX512> {};
+struct MeanImplAvx512 : public MeanImpl<ArrowType, SimdLevel::AVX512> {};
 
 std::unique_ptr<KernelState> SumInitAvx512(KernelContext* ctx,
                                            const KernelInitArgs& args) {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -51,229 +51,49 @@ void AddMinMaxAvx512AggKernels(ScalarAggregateFunction* func);
 // ----------------------------------------------------------------------
 // Sum implementation
 
-template <int64_t kRoundSize, typename ArrowType, SimdLevel::type SimdLevel>
-struct SumState {
-  using SumType = typename FindAccumulatorType<ArrowType>::Type;
-  using ThisType = SumState<kRoundSize, ArrowType, SimdLevel>;
-  using T = typename TypeTraits<ArrowType>::CType;
-  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
-
-  ThisType operator+(const ThisType& rhs) const {
-    return ThisType(this->count + rhs.count, this->sum + rhs.sum);
-  }
-
-  ThisType& operator+=(const ThisType& rhs) {
-    this->count += rhs.count;
-    this->sum += rhs.sum;
-
-    return *this;
-  }
-
- public:
-  void Consume(const Array& input) {
-    const ArrayType& array = static_cast<const ArrayType&>(input);
-    if (input.null_count() == 0) {
-      (*this) += ConsumeNoNulls(array);
-    } else {
-      (*this) += ConsumeWithNulls(array);
-    }
-  }
-
-  size_t count = 0;
-  typename SumType::c_type sum = 0;
-
- private:
-  template <int64_t kNoNullsRoundSize>
-  ThisType ConsumeNoNulls(const T* values, const int64_t length) const {
-    ThisType local;
-    const int64_t length_rounded = BitUtil::RoundDown(length, kNoNullsRoundSize);
-    typename SumType::c_type sum_rounded[kNoNullsRoundSize] = {0};
-
-    // Unroll the loop to add the results in parallel
-    for (int64_t i = 0; i < length_rounded; i += kNoNullsRoundSize) {
-      for (int64_t k = 0; k < kNoNullsRoundSize; k++) {
-        sum_rounded[k] += values[i + k];
-      }
-    }
-    for (int64_t k = 0; k < kNoNullsRoundSize; k++) {
-      local.sum += sum_rounded[k];
-    }
-
-    // The trailing part
-    for (int64_t i = length_rounded; i < length; ++i) {
-      local.sum += values[i];
-    }
-
-    local.count = length;
-    return local;
-  }
-
-  ThisType ConsumeNoNulls(const ArrayType& array) const {
-    const auto values = array.raw_values();
-    const int64_t length = array.length();
-
-    return ConsumeNoNulls<kRoundSize>(values, length);
-  }
-
-  // While this is not branchless, gcc needs this to be in a different function
-  // for it to generate cmov which tends to be slightly faster than
-  // multiplication but safe for handling NaN with doubles.
-  inline T MaskedValue(bool valid, T value) const { return valid ? value : 0; }
-
-  inline ThisType UnrolledSum(uint8_t bits, const T* values) const {
-    ThisType local;
-
-    if (bits < 0xFF) {
-      // Some nulls
-      for (size_t i = 0; i < 8; i++) {
-        local.sum += MaskedValue(bits & (1U << i), values[i]);
-      }
-      local.count += BitUtil::kBytePopcount[bits];
-    } else {
-      // No nulls
-      for (size_t i = 0; i < 8; i++) {
-        local.sum += values[i];
-      }
-      local.count += 8;
-    }
-
-    return local;
-  }
-
-  ThisType ConsumeWithNulls(const ArrayType& array) const {
-    ThisType local;
-    const T* values = array.raw_values();
-    const int64_t length = array.length();
-    int64_t offset = array.offset();
-    const uint8_t* bitmap = array.null_bitmap_data();
-    int64_t idx = 0;
-
-    const auto p = arrow::internal::BitmapWordAlign<1>(bitmap, offset, length);
-    // First handle the leading bits
-    const int64_t leading_bits = p.leading_bits;
-    while (idx < leading_bits) {
-      if (BitUtil::GetBit(bitmap, offset)) {
-        local.sum += values[idx];
-        local.count++;
-      }
-      idx++;
-      offset++;
-    }
-
-    // The aligned parts scanned with BitBlockCounter
-    constexpr int64_t kBatchSize = arrow::internal::BitBlockCounter::kWordBits;
-    arrow::internal::BitBlockCounter data_counter(bitmap, offset, length - leading_bits);
-    auto current_block = data_counter.NextWord();
-    while (idx < length) {
-      if (current_block.AllSet()) {  // All true values
-        int run_length = 0;
-        // Scan forward until a block that has some false values (or the end)
-        while (current_block.length > 0 && current_block.AllSet()) {
-          run_length += current_block.length;
-          current_block = data_counter.NextWord();
-        }
-        // Aggregate the no nulls parts
-        if (run_length >= kRoundSize * 8) {
-          local += ConsumeNoNulls<kRoundSize>(&values[idx], run_length);
-        } else {
-          local += ConsumeNoNulls<8>(&values[idx], run_length);
-        }
-        idx += run_length;
-        offset += run_length;
-        // The current_block already computed, advance to next loop
-        continue;
-      } else if (!current_block.NoneSet()) {  // Some values are null
-        const int64_t idx_byte = BitUtil::BytesForBits(offset);
-        const uint8_t* aligned_bitmap = &bitmap[idx_byte];
-        const T* aligned_values = &values[idx];
-
-        if (kBatchSize == current_block.length) {
-          for (int64_t i = 0; i < kBatchSize / 8; i++) {
-            local += UnrolledSum(aligned_bitmap[i], &aligned_values[i * 8]);
-          }
-        } else {  // The end part
-          for (int64_t i = 0; i < current_block.length; i++) {
-            if (BitUtil::GetBit(bitmap, offset)) {
-              local.sum += values[idx];
-              local.count++;
-            }
-            idx++;
-            offset++;
-          }
-        }
-
-        idx += current_block.length;
-        offset += current_block.length;
-      } else {  // All null values
-        idx += current_block.length;
-        offset += current_block.length;
-      }
-      current_block = data_counter.NextWord();
-    }
-
-    return local;
-  }
-};
-
-template <int64_t kRoundSize, SimdLevel::type SimdLevel>
-struct SumState<kRoundSize, BooleanType, SimdLevel> {
-  using SumType = typename FindAccumulatorType<BooleanType>::Type;
-  using ThisType = SumState<kRoundSize, BooleanType, SimdLevel>;
-
-  ThisType& operator+=(const ThisType& rhs) {
-    this->count += rhs.count;
-    this->sum += rhs.sum;
-    return *this;
-  }
-
- public:
-  void Consume(const Array& input) {
-    const BooleanArray& array = static_cast<const BooleanArray&>(input);
-    count += array.length() - array.null_count();
-    sum += array.true_count();
-  }
-
-  size_t count = 0;
-  typename SumType::c_type sum = 0;
-};
-
-template <uint64_t kRoundSize, typename ArrowType, SimdLevel::type SimdLevel>
+template <typename ArrowType, SimdLevel::type SimdLevel>
 struct SumImpl : public ScalarAggregator {
-  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
-  using ThisType = SumImpl<kRoundSize, ArrowType, SimdLevel>;
+  using ThisType = SumImpl<ArrowType, SimdLevel>;
+  using CType = typename ArrowType::c_type;
   using SumType = typename FindAccumulatorType<ArrowType>::Type;
   using OutputType = typename TypeTraits<SumType>::ScalarType;
 
   void Consume(KernelContext*, const ExecBatch& batch) override {
-    this->state.Consume(ArrayType(batch[0].array()));
+    const auto& data = batch[0].array();
+    this->count = data->length - data->GetNullCount();
+    if (is_boolean_type<ArrowType>::value) {
+      this->sum = BooleanArray(data).true_count();
+    } else {
+      this->sum =
+          arrow::compute::detail::SumArray<CType, typename SumType::c_type>(*data);
+    }
   }
 
   void MergeFrom(KernelContext*, KernelState&& src) override {
     const auto& other = checked_cast<const ThisType&>(src);
-    this->state += other.state;
+    this->count += other.count;
+    this->sum += other.sum;
   }
 
   void Finalize(KernelContext*, Datum* out) override {
-    if (state.count == 0) {
+    if (this->count == 0) {
       out->value = std::make_shared<OutputType>();
     } else {
-      out->value = MakeScalar(state.sum);
+      out->value = MakeScalar(this->sum);
     }
   }
 
-  SumState<kRoundSize, ArrowType, SimdLevel> state;
+  size_t count = 0;
+  typename SumType::c_type sum = 0;
 };
 
-template <int64_t kRoundSize, typename ArrowType, SimdLevel::type SimdLevel>
-struct MeanImpl : public SumImpl<kRoundSize, ArrowType, SimdLevel> {
+template <typename ArrowType, SimdLevel::type SimdLevel>
+struct MeanImpl : public SumImpl<ArrowType, SimdLevel> {
   void Finalize(KernelContext*, Datum* out) override {
-    const bool is_valid = this->state.count > 0;
-    const double divisor = static_cast<double>(is_valid ? this->state.count : 1UL);
-    const double mean = static_cast<double>(this->state.sum) / divisor;
-
-    if (!is_valid) {
+    if (this->count == 0) {
       out->value = std::make_shared<DoubleScalar>();
     } else {
+      const double mean = static_cast<double>(this->sum) / this->count;
       out->value = std::make_shared<DoubleScalar>(mean);
     }
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -62,7 +62,7 @@ struct SumImpl : public ScalarAggregator {
     const auto& data = batch[0].array();
     this->count = data->length - data->GetNullCount();
     if (is_boolean_type<ArrowType>::value) {
-      this->sum = BooleanArray(data).true_count();
+      this->sum = static_cast<typename SumType::c_type>(BooleanArray(data).true_count());
     } else {
       this->sum =
           arrow::compute::detail::SumArray<CType, typename SumType::c_type>(*data);

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -19,6 +19,8 @@
 
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit_run_reader.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace compute {
@@ -56,6 +58,110 @@ struct ScalarAggregator : public KernelState {
 void AddAggKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                   ScalarAggregateFunction* func,
                   SimdLevel::type simd_level = SimdLevel::NONE);
+
+namespace detail {
+
+using arrow::internal::VisitSetBitRunsVoid;
+
+// non-recursive pairwise summation for floating points
+// https://en.wikipedia.org/wiki/Pairwise_summation
+template <typename ValueType, typename SumType, typename ValueFunc>
+enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
+    const ArrayData& data, ValueFunc&& func) {
+  const int64_t data_size = data.length - data.GetNullCount();
+  if (data_size == 0) {
+    return 0;
+  }
+
+  // number of inputs to accumulate before merging with another block
+  constexpr int kBlockSize = 16;  // same as numpy
+  // levels (tree depth) = ceil(log2(len)) + 1, a bit larger than necessary
+  const int levels = BitUtil::Log2(static_cast<uint64_t>(data_size)) + 1;
+  // temporary summation per level
+  std::vector<SumType> sum(levels);
+  // whether two summations are ready and should be reduced to upper level
+  // one bit for each level, bit0 -> level0, ...
+  uint64_t mask = 0;
+  // level of root node holding the final summation
+  int root_level = 0;
+
+  // reduce summation of one block (may be smaller than kBlockSize) from leaf node
+  // continue reducing to upper level if two summations are ready for non-leaf node
+  auto reduce = [&](SumType block_sum) {
+    int cur_level = 0;
+    uint64_t cur_level_mask = 1ULL;
+    sum[cur_level] += block_sum;
+    mask ^= cur_level_mask;
+    while ((mask & cur_level_mask) == 0) {
+      block_sum = sum[cur_level];
+      sum[cur_level] = 0;
+      ++cur_level;
+      DCHECK_LT(cur_level, levels);
+      cur_level_mask <<= 1;
+      sum[cur_level] += block_sum;
+      mask ^= cur_level_mask;
+    }
+    root_level = std::max(root_level, cur_level);
+  };
+
+  const ValueType* values = data.GetValues<ValueType>(1);
+  VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
+                      [&](int64_t pos, int64_t len) {
+                        const ValueType* v = &values[pos];
+                        // unsigned division by constant is cheaper than signed one
+                        const uint64_t blocks = static_cast<uint64_t>(len) / kBlockSize;
+                        const uint64_t remains = static_cast<uint64_t>(len) % kBlockSize;
+
+                        for (uint64_t i = 0; i < blocks; ++i) {
+                          SumType block_sum = 0;
+                          for (int j = 0; j < kBlockSize; ++j) {
+                            block_sum += func(v[j]);
+                          }
+                          reduce(block_sum);
+                          v += kBlockSize;
+                        }
+
+                        if (remains > 0) {
+                          SumType block_sum = 0;
+                          for (uint64_t i = 0; i < remains; ++i) {
+                            block_sum += func(v[i]);
+                          }
+                          reduce(block_sum);
+                        }
+                      });
+
+  // reduce intermediate summations from all non-leaf nodes
+  for (int i = 1; i <= root_level; ++i) {
+    sum[i] += sum[i - 1];
+  }
+
+  return sum[root_level];
+}
+
+// naive summation for integers
+// TODO(yibo): much worse performance than BitBlockCounter,
+//             why compiler failed to vectorize the trivial loop?
+template <typename ValueType, typename SumType, typename ValueFunc>
+enable_if_t<!std::is_floating_point<SumType>::value, SumType> SumArray(
+    const ArrayData& data, ValueFunc&& func) {
+  SumType sum = 0;
+  const ValueType* values = data.GetValues<ValueType>(1);
+  VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
+                      [&](int64_t pos, int64_t len) {
+                        for (int64_t i = 0; i < len; ++i) {
+                          sum += func(values[pos + i]);
+                        }
+                      });
+  return sum;
+}
+
+template <typename ValueType, typename SumType>
+SumType SumArray(const ArrayData& data) {
+  return SumArray<ValueType, SumType>(
+      data, [](ValueType v) { return static_cast<SumType>(v); });
+}
+
+}  // namespace detail
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -139,8 +139,6 @@ enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
 }
 
 // naive summation for integers
-// TODO(yibo): much worse performance than BitBlockCounter,
-//             why compiler failed to vectorize the trivial loop?
 template <typename ValueType, typename SumType, typename ValueFunc>
 enable_if_t<!std::is_floating_point<SumType>::value, SumType> SumArray(
     const ArrayData& data, ValueFunc&& func) {

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -32,96 +32,6 @@ namespace {
 using arrow::internal::int128_t;
 using arrow::internal::VisitSetBitRunsVoid;
 
-// non-recursive pairwise summation for floating points
-// https://en.wikipedia.org/wiki/Pairwise_summation
-template <typename ValueType, typename SumType, typename ValueFunc>
-enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
-    const ArrayData& data, ValueFunc&& func) {
-  const int64_t data_size = data.length - data.GetNullCount();
-  if (data_size == 0) {
-    return 0;
-  }
-
-  // number of inputs to accumulate before merging with another block
-  constexpr int kBlockSize = 16;  // same as numpy
-  // levels (tree depth) = ceil(log2(len)) + 1, a bit larger than necessary
-  const int levels = BitUtil::Log2(static_cast<uint64_t>(data_size)) + 1;
-  // temporary summation per level
-  std::vector<SumType> sum(levels);
-  // whether two summations are ready and should be reduced to upper level
-  // one bit for each level, bit0 -> level0, ...
-  uint64_t mask = 0;
-  // level of root node holding the final summation
-  int root_level = 0;
-
-  // reduce summation of one block (may be smaller than kBlockSize) from leaf node
-  // continue reducing to upper level if two summations are ready for non-leaf node
-  auto reduce = [&](SumType block_sum) {
-    int cur_level = 0;
-    uint64_t cur_level_mask = 1ULL;
-    sum[cur_level] += block_sum;
-    mask ^= cur_level_mask;
-    while ((mask & cur_level_mask) == 0) {
-      block_sum = sum[cur_level];
-      sum[cur_level] = 0;
-      ++cur_level;
-      DCHECK_LT(cur_level, levels);
-      cur_level_mask <<= 1;
-      sum[cur_level] += block_sum;
-      mask ^= cur_level_mask;
-    }
-    root_level = std::max(root_level, cur_level);
-  };
-
-  const ValueType* values = data.GetValues<ValueType>(1);
-  VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
-                      [&](int64_t pos, int64_t len) {
-                        const ValueType* v = &values[pos];
-                        // unsigned division by constant is cheaper than signed one
-                        const uint64_t blocks = static_cast<uint64_t>(len) / kBlockSize;
-                        const uint64_t remains = static_cast<uint64_t>(len) % kBlockSize;
-
-                        for (uint64_t i = 0; i < blocks; ++i) {
-                          SumType block_sum = 0;
-                          for (int j = 0; j < kBlockSize; ++j) {
-                            block_sum += func(v[j]);
-                          }
-                          reduce(block_sum);
-                          v += kBlockSize;
-                        }
-
-                        if (remains > 0) {
-                          SumType block_sum = 0;
-                          for (uint64_t i = 0; i < remains; ++i) {
-                            block_sum += func(v[i]);
-                          }
-                          reduce(block_sum);
-                        }
-                      });
-
-  // reduce intermediate summations from all non-leaf nodes
-  for (int i = 1; i <= root_level; ++i) {
-    sum[i] += sum[i - 1];
-  }
-
-  return sum[root_level];
-}
-
-// naive summation is faster for integrals
-template <typename ValueType, typename SumType, typename ValueFunc>
-enable_if_t<!std::is_floating_point<SumType>::value, SumType> SumArray(
-    const ArrayData& data, ValueFunc&& func) {
-  SumType sum = 0;
-  const ValueType* values = data.GetValues<ValueType>(1);
-  VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
-                      [&](int64_t pos, int64_t len) {
-                        for (int64_t i = 0; i < len; ++i) {
-                          sum += func(values[pos + i]);
-                        }
-                      });
-  return sum;
-}
-
 template <typename ArrowType>
 struct VarStdState {
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
@@ -140,14 +50,14 @@ struct VarStdState {
 
     using SumType =
         typename std::conditional<is_floating_type<T>::value, double, int128_t>::type;
-    SumType sum = SumArray<CType, SumType>(
-        *array.data(), [](CType value) { return static_cast<SumType>(value); });
+    SumType sum = arrow::compute::detail::SumArray<CType, SumType>(*array.data());
 
     const double mean = static_cast<double>(sum) / count;
-    const double m2 = SumArray<CType, double>(*array.data(), [mean](CType value) {
-      const double v = static_cast<double>(value);
-      return (v - mean) * (v - mean);
-    });
+    const double m2 = arrow::compute::detail::SumArray<CType, double>(
+        *array.data(), [mean](CType value) {
+          const double v = static_cast<double>(value);
+          return (v - mean) * (v - mean);
+        });
 
     this->count = count;
     this->mean = mean;

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -195,8 +195,36 @@ class BaseSetBitRunReader {
   /// \param[in] bitmap source data
   /// \param[in] start_offset bit offset into the source data
   /// \param[in] length number of bits to copy
-  inline BaseSetBitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t length);
+  ARROW_NOINLINE
+  BaseSetBitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
+      : bitmap_(bitmap),
+        length_(length),
+        remaining_(length_),
+        current_word_(0),
+        current_num_bits_(0) {
+    if (Reverse) {
+      bitmap_ += (start_offset + length) / 8;
+      const int8_t end_bit_offset = static_cast<int8_t>((start_offset + length) % 8);
+      if (length > 0 && end_bit_offset) {
+        // Get LSBs from last byte
+        ++bitmap_;
+        current_num_bits_ =
+            std::min(static_cast<int32_t>(length), static_cast<int32_t>(end_bit_offset));
+        current_word_ = LoadPartialWord(8 - end_bit_offset, current_num_bits_);
+      }
+    } else {
+      bitmap_ += start_offset / 8;
+      const int8_t bit_offset = static_cast<int8_t>(start_offset % 8);
+      if (length > 0 && bit_offset) {
+        // Get MSBs from first byte
+        current_num_bits_ =
+            std::min(static_cast<int32_t>(length), static_cast<int32_t>(8 - bit_offset));
+        current_word_ = LoadPartialWord(bit_offset, current_num_bits_);
+      }
+    }
+  }
 
+  ARROW_NOINLINE
   SetBitRun NextRun() {
     int64_t pos = 0;
     int64_t len = 0;
@@ -424,48 +452,15 @@ inline uint64_t BaseSetBitRunReader<true>::ConsumeBits(uint64_t word, int32_t nu
   return word << num_bits;
 }
 
-template <>
-inline BaseSetBitRunReader<false>::BaseSetBitRunReader(const uint8_t* bitmap,
-                                                       int64_t start_offset,
-                                                       int64_t length)
-    : bitmap_(bitmap + start_offset / 8), length_(length), remaining_(length_) {
-  const int8_t bit_offset = static_cast<int8_t>(start_offset % 8);
-  if (length > 0 && bit_offset) {
-    // Get MSBs from first byte
-    current_num_bits_ =
-        std::min(static_cast<int32_t>(length), static_cast<int32_t>(8 - bit_offset));
-    current_word_ = LoadPartialWord(bit_offset, current_num_bits_);
-  } else {
-    current_num_bits_ = 0;
-    current_word_ = 0;
-  }
-}
-
-template <>
-inline BaseSetBitRunReader<true>::BaseSetBitRunReader(const uint8_t* bitmap,
-                                                      int64_t start_offset,
-                                                      int64_t length)
-    : bitmap_(bitmap + (start_offset + length) / 8),
-      length_(length),
-      remaining_(length_) {
-  const int8_t end_bit_offset = static_cast<int8_t>((start_offset + length) % 8);
-  if (length > 0 && end_bit_offset) {
-    // Get LSBs from last byte
-    ++bitmap_;
-    current_num_bits_ =
-        std::min(static_cast<int32_t>(length), static_cast<int32_t>(end_bit_offset));
-    current_word_ = LoadPartialWord(8 - end_bit_offset, current_num_bits_);
-  } else {
-    current_num_bits_ = 0;
-    current_word_ = 0;
-  }
-}
-
 using SetBitRunReader = BaseSetBitRunReader</*Reverse=*/false>;
 using ReverseSetBitRunReader = BaseSetBitRunReader</*Reverse=*/true>;
 
 // Functional-style bit run visitors.
 
+// XXX: Try to make this function small so the compiler can inline and optimize
+// the `visit` function, which is normally a hot loop with vectorizable code.
+// - don't inline SetBitRunReader constructor, it doesn't hurt performance
+// - un-inline NextRun hurts 'many null' cases a bit, but improves normal cases
 template <typename Visit>
 Status VisitSetBitRuns(const uint8_t* bitmap, int64_t offset, int64_t length,
                        Visit&& visit) {


### PR DESCRIPTION
Leverage pairwise sum to reduce round-off error from O(n) to O(logn).

**NOTE:** This patch hurts sum kernel performance for floating points
significantly. I don't worry too much as perf is on par with Numpy.

For floating point, up to 75% drop is observed. This is because old code
manually unrolls loops which greatly improves performance. But this is
something should be avoided. Due to precision limitation, basic math
rules doesn't apply to floating points. E.g., `(a+b)+c != a+(b+c)`. Test
shows SSE4 and AVX2 summation kernels may give different results (both
wrong), simply because they use different unroll steps. [1]
I guess this is also the reason why compiler only unroll loops for
integers, but not floating points.

[1] https://issues.apache.org/jira/browse/ARROW-11758