### PR TITLE
ARROW-11872: [C++] Fix Array validation when Array contains non-CPU buffers

### DIFF
--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -180,7 +180,7 @@ struct ValidateArrayImpl {
   bool IsBufferValid(int index) { return IsBufferValid(data, index); }
 
   static bool IsBufferValid(const ArrayData& data, int index) {
-    return data.buffers[index] != nullptr && data.buffers[index]->address();
+    return data.buffers[index] != nullptr && data.buffers[index]->address() != 0;
   }
 
   template <typename BinaryType>

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -180,9 +180,7 @@ struct ValidateArrayImpl {
   bool IsBufferValid(int index) { return IsBufferValid(data, index); }
 
   static bool IsBufferValid(const ArrayData& data, int index) {
-    return data.buffers[index] != nullptr &&
-           (data.buffers[index]->is_cpu() ? data.buffers[index]->data() != nullptr
-                                          : true);
+    return data.buffers[index] != nullptr && data.buffers[index]->address();
   }
 
   template <typename BinaryType>

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -180,7 +180,9 @@ struct ValidateArrayImpl {
   bool IsBufferValid(int index) { return IsBufferValid(data, index); }
 
   static bool IsBufferValid(const ArrayData& data, int index) {
-    return data.buffers[index] != nullptr && data.buffers[index]->data() != nullptr;
+    return data.buffers[index] != nullptr &&
+           (data.buffers[index]->is_cpu() ? data.buffers[index]->data() != nullptr
+                                          : true);
   }
 
   template <typename BinaryType>

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -577,6 +577,8 @@ TEST_F(TestCudaArrowIpc, BasicWriteRead) {
   ASSERT_OK_AND_ASSIGN(device_batch,
                        ReadRecordBatch(batch->schema(), &unused_memo, device_serialized));
 
+  ASSERT_OK(device_batch->Validate());
+
   // Copy data from device, read batch, and compare
   int64_t size = device_serialized->size();
   ASSERT_OK_AND_ASSIGN(auto host_buffer, AllocateBuffer(size, pool_));

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -745,7 +745,8 @@ def test_table_deserialize():
 
 
 def test_create_table_with_device_buffers():
-    # ARROW-11872: make sure that we can create an Arrow Table from GPU-located Arrays without crashing.
+    # ARROW-11872: make sure that we can create an Arrow Table from
+    # GPU-located Arrays without crashing.
     htable = make_table(10)
     # Serialize the host table to bytes
     sink = pa.BufferOutputStream()


### PR DESCRIPTION
Constructing an Arrow Table from Arrays that contains `CudaBuffer` presently fails.

`ValidateArrayImpl::IsBufferValid` is checking the buffers of each Array, but when an Array's buffers aren't on the CPU the `data.buffers[index]->data() != nullptr` check returns false.

Fixes [ARROW-11872](https://issues.apache.org/jira/browse/ARROW-11872).