### PR TITLE
ARROW-11881: [Rust][DataFusion] Fix clippy lint

### DIFF
--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -121,7 +121,7 @@ impl ExecutionPlan for MergeExec {
 
                 // spawn independent tasks whose resulting streams (of batches)
                 // are sent to the channel for consumption.
-                for part_i in (0..input_partitions) {
+                for part_i in 0..input_partitions {
                     let input = self.input.clone();
                     let mut sender = sender.clone();
                     tokio::spawn(async move {


### PR DESCRIPTION
ARROW-11881: [Rust][DataFusion] Fix clippy lint

A linter error has appeared on master somehow:

```
error: unnecessary parentheses around `for` iterator expression
   --> datafusion/src/physical_plan/merge.rs:124:31
    |
124 |                 for part_i in (0..input_partitions) {
    |                               ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `-D unused-parens` implied by `-D warnings`
```


Seen on at least https://github.com/apache/arrow/pull/9612 and https://github.com/apache/arrow/pull/9639:

https://github.com/apache/arrow/pull/9612/checks?check_run_id=2042047472

https://github.com/apache/arrow/pull/9639/checks?check_run_id=2042649120
