### PR TITLE
ARROW-11887: [C++] Add asynchronous read to streaming CSV reader

### DIFF
--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -199,6 +199,19 @@ class SerialBlockReader : public BlockReader {
     return MakeTransformedIterator(std::move(buffer_iterator), block_reader_fn);
   }
 
+  static AsyncGenerator<CSVBlock> MakeAsyncIterator(
+      AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
+      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer) {
+    auto block_reader =
+        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer);
+    // Wrap shared pointer in callable
+    Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
+        [block_reader](std::shared_ptr<Buffer> next) {
+          return (*block_reader)(std::move(next));
+        };
+    return MakeAsyncGenerator(std::move(buffer_generator), block_reader_fn);
+  }
+
   Result<TransformFlow<CSVBlock>> operator()(std::shared_ptr<Buffer> next_buffer) {
     if (buffer_ == nullptr) {
       return TransformFinish();
@@ -304,15 +317,14 @@ class ThreadedBlockReader : public BlockReader {
 
 class ReaderMixin {
  public:
-  ReaderMixin(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  ReaderMixin(io::IOContext io_context, std::shared_ptr<io::InputStream> input,
               const ReadOptions& read_options, const ParseOptions& parse_options,
-              const ConvertOptions& convert_options, StopToken stop_token)
-      : pool_(pool),
+              const ConvertOptions& convert_options)
+      : io_context_(std::move(io_context)),
         read_options_(read_options),
         parse_options_(parse_options),
         convert_options_(convert_options),
-        input_(std::move(input)),
-        stop_token_(std::move(stop_token)) {}
+        input_(std::move(input)) {}
 
  protected:
   // Read header and column names from buffer, create column builders
@@ -336,7 +348,7 @@ class ReaderMixin {
 
     if (read_options_.column_names.empty()) {
       // Parse one row (either to read column names or to know the number of columns)
-      BlockParser parser(pool_, parse_options_, num_csv_cols_, 1);
+      BlockParser parser(io_context_.pool(), parse_options_, num_csv_cols_, 1);
       uint32_t parsed_size = 0;
       RETURN_NOT_OK(parser.Parse(
           util::string_view(reinterpret_cast<const char*>(data), data_end - data),
@@ -454,8 +466,8 @@ class ReaderMixin {
                             const std::shared_ptr<Buffer>& block, int64_t block_index,
                             bool is_final) {
     static constexpr int32_t max_num_rows = std::numeric_limits<int32_t>::max();
-    auto parser =
-        std::make_shared<BlockParser>(pool_, parse_options_, num_csv_cols_, max_num_rows);
+    auto parser = std::make_shared<BlockParser>(io_context_.pool(), parse_options_,
+                                                num_csv_cols_, max_num_rows);
 
     std::shared_ptr<Buffer> straddling;
     std::vector<util::string_view> views;
@@ -465,8 +477,8 @@ class ReaderMixin {
       } else if (completion->size() == 0) {
         straddling = partial;
       } else {
-        ARROW_ASSIGN_OR_RAISE(straddling,
-                              ConcatenateBuffers({partial, completion}, pool_));
+        ARROW_ASSIGN_OR_RAISE(
+            straddling, ConcatenateBuffers({partial, completion}, io_context_.pool()));
       }
       views = {util::string_view(*straddling), util::string_view(*block)};
     } else {
@@ -481,7 +493,7 @@ class ReaderMixin {
     return ParseResult{std::move(parser), static_cast<int64_t>(parsed_size)};
   }
 
-  MemoryPool* pool_;
+  io::IOContext io_context_;
   ReadOptions read_options_;
   ParseOptions parse_options_;
   ConvertOptions convert_options_;
@@ -494,7 +506,6 @@ class ReaderMixin {
 
   std::shared_ptr<io::InputStream> input_;
   std::shared_ptr<internal::TaskGroup> task_group_;
-  StopToken stop_token_;
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -516,16 +527,16 @@ class BaseTableReader : public ReaderMixin, public csv::TableReader {
     for (const auto& column : conversion_schema_.columns) {
       std::shared_ptr<ColumnBuilder> builder;
       if (column.is_missing) {
-        ARROW_ASSIGN_OR_RAISE(builder,
-                              ColumnBuilder::MakeNull(pool_, column.type, task_group_));
+        ARROW_ASSIGN_OR_RAISE(builder, ColumnBuilder::MakeNull(io_context_.pool(),
+                                                               column.type, task_group_));
       } else if (column.type != nullptr) {
-        ARROW_ASSIGN_OR_RAISE(builder,
-                              ColumnBuilder::Make(pool_, column.type, column.index,
-                                                  convert_options_, task_group_));
-      } else {
         ARROW_ASSIGN_OR_RAISE(
-            builder,
-            ColumnBuilder::Make(pool_, column.index, convert_options_, task_group_));
+            builder, ColumnBuilder::Make(io_context_.pool(), column.type, column.index,
+                                         convert_options_, task_group_));
+      } else {
+        ARROW_ASSIGN_OR_RAISE(builder,
+                              ColumnBuilder::Make(io_context_.pool(), column.index,
+                                                  convert_options_, task_group_));
       }
       column_builders_.push_back(std::move(builder));
     }
@@ -574,37 +585,41 @@ class BaseTableReader : public ReaderMixin, public csv::TableReader {
 
 class BaseStreamingReader : public ReaderMixin, public csv::StreamingReader {
  public:
-  using ReaderMixin::ReaderMixin;
+  BaseStreamingReader(io::IOContext io_context, Executor* cpu_executor,
+                      std::shared_ptr<io::InputStream> input,
+                      const ReadOptions& read_options, const ParseOptions& parse_options,
+                      const ConvertOptions& convert_options)
+      : ReaderMixin(io_context, std::move(input), read_options, parse_options,
+                    convert_options),
+        cpu_executor_(cpu_executor) {}
 
-  virtual Status Init() = 0;
+  virtual Future<std::shared_ptr<csv::StreamingReader>> Init() = 0;
 
   std::shared_ptr<Schema> schema() const override { return schema_; }
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
-    do {
-      RETURN_NOT_OK(ReadNext().Value(batch));
-    } while (*batch != nullptr && (*batch)->num_rows() == 0);
+    auto next_fut = ReadNextAsync();
+    auto next_result = next_fut.result();
+    ARROW_ASSIGN_OR_RAISE(*batch, next_result);
     return Status::OK();
   }
 
  protected:
-  virtual Result<std::shared_ptr<RecordBatch>> ReadNext() = 0;
-
   // Make column decoders from conversion schema
   Status MakeColumnDecoders() {
     for (const auto& column : conversion_schema_.columns) {
       std::shared_ptr<ColumnDecoder> decoder;
       if (column.is_missing) {
-        ARROW_ASSIGN_OR_RAISE(decoder,
-                              ColumnDecoder::MakeNull(pool_, column.type, task_group_));
+        ARROW_ASSIGN_OR_RAISE(decoder, ColumnDecoder::MakeNull(io_context_.pool(),
+                                                               column.type, task_group_));
       } else if (column.type != nullptr) {
-        ARROW_ASSIGN_OR_RAISE(decoder,
-                              ColumnDecoder::Make(pool_, column.type, column.index,
-                                                  convert_options_, task_group_));
-      } else {
         ARROW_ASSIGN_OR_RAISE(
-            decoder,
-            ColumnDecoder::Make(pool_, column.index, convert_options_, task_group_));
+            decoder, ColumnDecoder::Make(io_context_.pool(), column.type, column.index,
+                                         convert_options_, task_group_));
+      } else {
+        ARROW_ASSIGN_OR_RAISE(decoder,
+                              ColumnDecoder::Make(io_context_.pool(), column.index,
+                                                  convert_options_, task_group_));
       }
       column_decoders_.push_back(std::move(decoder));
     }
@@ -672,101 +687,142 @@ class BaseStreamingReader : public ReaderMixin, public csv::StreamingReader {
   std::vector<std::shared_ptr<ColumnDecoder>> column_decoders_;
   std::shared_ptr<Schema> schema_;
   std::shared_ptr<RecordBatch> pending_batch_;
-  Iterator<std::shared_ptr<Buffer>> buffer_iterator_;
+  AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator_;
+  Executor* cpu_executor_;
   bool eof_ = false;
 };
 
 /////////////////////////////////////////////////////////////////////////
 // Serial StreamingReader implementation
 
-class SerialStreamingReader : public BaseStreamingReader {
+class SerialStreamingReader : public BaseStreamingReader,
+                              public std::enable_shared_from_this<SerialStreamingReader> {
  public:
   using BaseStreamingReader::BaseStreamingReader;
 
-  Status Init() override {
+  Future<std::shared_ptr<csv::StreamingReader>> Init() override {
     ARROW_ASSIGN_OR_RAISE(auto istream_it,
                           io::MakeInputStreamIterator(input_, read_options_.block_size));
 
-    // Since we're converting serially, no need to readahead more than one block
-    int32_t block_queue_size = 1;
-    ARROW_ASSIGN_OR_RAISE(auto rh_it,
-                          MakeReadaheadIterator(std::move(istream_it), block_queue_size));
-    buffer_iterator_ = CSVBufferIterator::Make(std::move(rh_it));
-    task_group_ = internal::TaskGroup::MakeSerial(stop_token_);
+    ARROW_ASSIGN_OR_RAISE(auto bg_it, MakeBackgroundGenerator(std::move(istream_it),
+                                                              io_context_.executor()));
 
+    auto rh_it = MakeSerialReadaheadGenerator(std::move(bg_it), 8);
+
+    auto transferred_it = MakeTransferredGenerator(rh_it, cpu_executor_);
+
+    buffer_generator_ = CSVBufferIterator::MakeAsync(std::move(transferred_it));
+    task_group_ = internal::TaskGroup::MakeSerial(io_context_.stop_token());
+
+    auto self = shared_from_this();
     // Read schema from first batch
-    ARROW_ASSIGN_OR_RAISE(pending_batch_, ReadNext());
-    DCHECK_NE(schema_, nullptr);
-    return Status::OK();
+    return ReadNextAsync().Then([self](const std::shared_ptr<RecordBatch>& first_batch)
+                                    -> Result<std::shared_ptr<csv::StreamingReader>> {
+      self->pending_batch_ = first_batch;
+      DCHECK_NE(self->schema_, nullptr);
+      return self;
+    });
   }
 
- protected:
-  Result<std::shared_ptr<RecordBatch>> ReadNext() override {
-    if (eof_) {
-      return nullptr;
-    }
-    if (stop_token_.IsStopRequested()) {
-      eof_ = true;
-      return stop_token_.Poll();
-    }
-    if (!block_iterator_) {
-      Status st = SetupReader();
-      if (!st.ok()) {
-        // Can't setup reader => bail out
-        eof_ = true;
-        return st;
-      }
-    }
-    auto batch = std::move(pending_batch_);
-    if (batch != nullptr) {
-      return batch;
-    }
-
-    if (!source_eof_) {
-      ARROW_ASSIGN_OR_RAISE(auto maybe_block, block_iterator_.Next());
-      if (!IsIterationEnd(maybe_block)) {
-        last_block_index_ = maybe_block.block_index;
-        auto maybe_parsed = ParseAndInsert(maybe_block.partial, maybe_block.completion,
-                                           maybe_block.buffer, maybe_block.block_index,
-                                           maybe_block.is_final);
-        if (!maybe_parsed.ok()) {
-          // Parse error => bail out
-          eof_ = true;
-          return maybe_parsed.status();
-        }
-        RETURN_NOT_OK(maybe_block.consume_bytes(*maybe_parsed));
-      } else {
-        source_eof_ = true;
-        for (auto& decoder : column_decoders_) {
-          decoder->SetEOF(last_block_index_ + 1);
-        }
-      }
-    }
-
+  Result<std::shared_ptr<RecordBatch>> DecodeBatchAndUpdateSchema() {
     auto maybe_batch = DecodeNextBatch();
     if (schema_ == nullptr && maybe_batch.ok()) {
       schema_ = (*maybe_batch)->schema();
     }
     return maybe_batch;
+  }
+
+  Future<std::shared_ptr<RecordBatch>> DoReadNext(
+      std::shared_ptr<SerialStreamingReader> self) {
+    auto batch = std::move(pending_batch_);
+    if (batch != nullptr) {
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
+    }
+
+    if (!source_eof_) {
+      return block_generator_()
+          .Then([self](const CSVBlock& maybe_block) -> Status {
+            if (!IsIterationEnd(maybe_block)) {
+              self->last_block_index_ = maybe_block.block_index;
+              auto maybe_parsed = self->ParseAndInsert(
+                  maybe_block.partial, maybe_block.completion, maybe_block.buffer,
+                  maybe_block.block_index, maybe_block.is_final);
+              if (!maybe_parsed.ok()) {
+                // Parse error => bail out
+                self->eof_ = true;
+                return maybe_parsed.status();
+              }
+              RETURN_NOT_OK(maybe_block.consume_bytes(*maybe_parsed));
+            } else {
+              self->source_eof_ = true;
+              for (auto& decoder : self->column_decoders_) {
+                decoder->SetEOF(self->last_block_index_ + 1);
+              }
+            }
+            return Status::OK();
+          })
+          .Then([self](const ::arrow::detail::Empty& st)
+                    -> Result<std::shared_ptr<RecordBatch>> {
+            return self->DecodeBatchAndUpdateSchema();
+          });
+    }
+    return Future<std::shared_ptr<RecordBatch>>::MakeFinished(
+        DecodeBatchAndUpdateSchema());
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextSkippingEmpty(
+      std::shared_ptr<SerialStreamingReader> self) {
+    return DoReadNext(self).Then([self](const std::shared_ptr<RecordBatch>& batch) {
+      if (batch != nullptr && batch->num_rows() == 0) {
+        return self->ReadNextSkippingEmpty(self);
+      }
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
+    });
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextAsync() override {
+    if (eof_) {
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(nullptr);
+    }
+    if (io_context_.stop_token().IsStopRequested()) {
+      eof_ = true;
+      return io_context_.stop_token().Poll();
+    }
+    auto self = shared_from_this();
+    if (!block_generator_) {
+      return SetupReader(self).Then([self](const Result<::arrow::detail::Empty>& res)
+                                        -> Future<std::shared_ptr<RecordBatch>> {
+        if (!res.ok()) {
+          self->eof_ = true;
+          return res.status();
+        }
+        return self->ReadNextSkippingEmpty(self);
+      });
+    } else {
+      return self->ReadNextSkippingEmpty(self);
+    }
   };
 
-  Status SetupReader() {
-    ARROW_ASSIGN_OR_RAISE(auto first_buffer, buffer_iterator_.Next());
-    if (first_buffer == nullptr) {
-      return Status::Invalid("Empty CSV file");
-    }
-    RETURN_NOT_OK(ProcessHeader(first_buffer, &first_buffer));
-    RETURN_NOT_OK(MakeColumnDecoders());
+ protected:
+  Future<> SetupReader(std::shared_ptr<SerialStreamingReader> self) {
+    return buffer_generator_().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
+      if (first_buffer == nullptr) {
+        return Status::Invalid("Empty CSV file");
+      }
+      auto own_first_buffer = first_buffer;
+      RETURN_NOT_OK(self->ProcessHeader(own_first_buffer, &own_first_buffer));
+      RETURN_NOT_OK(self->MakeColumnDecoders());
 
-    block_iterator_ = SerialBlockReader::MakeIterator(std::move(buffer_iterator_),
-                                                      MakeChunker(parse_options_),
-                                                      std::move(first_buffer));
-    return Status::OK();
+      self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
+          std::move(self->buffer_generator_), MakeChunker(self->parse_options_),
+          std::move(own_first_buffer));
+      return Status::OK();
+    });
   }
 
   bool source_eof_ = false;
   int64_t last_block_index_ = 0;
-  Iterator<CSVBlock> block_iterator_;
+  AsyncGenerator<CSVBlock> block_generator_;
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -789,7 +845,7 @@ class SerialTableReader : public BaseTableReader {
   }
 
   Result<std::shared_ptr<Table>> Read() override {
-    task_group_ = internal::TaskGroup::MakeSerial(stop_token_);
+    task_group_ = internal::TaskGroup::MakeSerial(io_context_.stop_token());
 
     // First block
     ARROW_ASSIGN_OR_RAISE(auto first_buffer, buffer_iterator_.Next());
@@ -803,7 +859,7 @@ class SerialTableReader : public BaseTableReader {
                                                           MakeChunker(parse_options_),
                                                           std::move(first_buffer));
     while (true) {
-      RETURN_NOT_OK(stop_token_.Poll());
+      RETURN_NOT_OK(io_context_.stop_token().Poll());
 
       ARROW_ASSIGN_OR_RAISE(auto maybe_block, block_iterator.Next());
       if (IsIterationEnd(maybe_block)) {
@@ -831,15 +887,14 @@ class AsyncThreadedTableReader
  public:
   using BaseTableReader::BaseTableReader;
 
-  AsyncThreadedTableReader(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  AsyncThreadedTableReader(io::IOContext io_context,
+                           std::shared_ptr<io::InputStream> input,
                            const ReadOptions& read_options,
                            const ParseOptions& parse_options,
-                           const ConvertOptions& convert_options, StopToken stop_token,
-                           Executor* cpu_executor, Executor* io_executor)
-      : BaseTableReader(pool, input, read_options, parse_options, convert_options,
-                        std::move(stop_token)),
-        cpu_executor_(cpu_executor),
-        io_executor_(io_executor) {}
+                           const ConvertOptions& convert_options, Executor* cpu_executor)
+      : BaseTableReader(std::move(io_context), input, read_options, parse_options,
+                        convert_options),
+        cpu_executor_(cpu_executor) {}
 
   ~AsyncThreadedTableReader() override {
     if (task_group_) {
@@ -853,8 +908,8 @@ class AsyncThreadedTableReader
     ARROW_ASSIGN_OR_RAISE(auto istream_it,
                           io::MakeInputStreamIterator(input_, read_options_.block_size));
 
-    ARROW_ASSIGN_OR_RAISE(auto bg_it,
-                          MakeBackgroundGenerator(std::move(istream_it), io_executor_));
+    ARROW_ASSIGN_OR_RAISE(auto bg_it, MakeBackgroundGenerator(std::move(istream_it),
+                                                              io_context_.executor()));
 
     auto transferred_it = MakeTransferredGenerator(bg_it, cpu_executor_);
 
@@ -868,7 +923,8 @@ class AsyncThreadedTableReader
   Result<std::shared_ptr<Table>> Read() override { return ReadAsync().result(); }
 
   Future<std::shared_ptr<Table>> ReadAsync() override {
-    task_group_ = internal::TaskGroup::MakeThreaded(cpu_executor_, stop_token_);
+    task_group_ =
+        internal::TaskGroup::MakeThreaded(cpu_executor_, io_context_.stop_token());
 
     auto self = shared_from_this();
     return ProcessFirstBuffer().Then([self](std::shared_ptr<Buffer> first_buffer) {
@@ -925,7 +981,6 @@ class AsyncThreadedTableReader
   }
 
   Executor* cpu_executor_;
-  Executor* io_executor_;
   AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator_;
 };
 
@@ -936,29 +991,25 @@ Result<std::shared_ptr<TableReader>> MakeTableReader(
   std::shared_ptr<BaseTableReader> reader;
   if (read_options.use_threads) {
     auto cpu_executor = internal::GetCpuThreadPool();
-    auto io_executor = io_context.executor();
     reader = std::make_shared<AsyncThreadedTableReader>(
-        pool, input, read_options, parse_options, convert_options,
-        io_context.stop_token(), cpu_executor, io_executor);
+        io_context, input, read_options, parse_options, convert_options, cpu_executor);
   } else {
-    reader =
-        std::make_shared<SerialTableReader>(pool, input, read_options, parse_options,
-                                            convert_options, io_context.stop_token());
+    reader = std::make_shared<SerialTableReader>(io_context, input, read_options,
+                                                 parse_options, convert_options);
   }
   RETURN_NOT_OK(reader->Init());
   return reader;
 }
 
-Result<std::shared_ptr<StreamingReader>> MakeStreamingReader(
+Future<std::shared_ptr<StreamingReader>> MakeStreamingReader(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
+  auto cpu_executor = internal::GetCpuThreadPool();
   std::shared_ptr<BaseStreamingReader> reader;
-  reader = std::make_shared<SerialStreamingReader>(io_context.pool(), input, read_options,
-                                                   parse_options, convert_options,
-                                                   io_context.stop_token());
-  RETURN_NOT_OK(reader->Init());
-  return reader;
+  reader = std::make_shared<SerialStreamingReader>(
+      io_context, cpu_executor, input, read_options, parse_options, convert_options);
+  return reader->Init();
 }
 
 }  // namespace
@@ -986,11 +1037,26 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     MemoryPool* pool, std::shared_ptr<io::InputStream> input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
-  return MakeStreamingReader(io::IOContext(pool), std::move(input), read_options,
-                             parse_options, convert_options);
+  auto io_context = io::IOContext(pool);
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), read_options,
+                                        parse_options, convert_options);
+  auto reader_result = reader_fut.result();
+  ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
+  return reader;
 }
 
 Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
+    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    const ReadOptions& read_options, const ParseOptions& parse_options,
+    const ConvertOptions& convert_options) {
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), read_options,
+                                        parse_options, convert_options);
+  auto reader_result = reader_fut.result();
+  ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
+  return reader;
+}
+
+Future<std::shared_ptr<StreamingReader>> StreamingReader::MakeAsync(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
@@ -999,4 +1065,5 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
 }
 
 }  // namespace csv
+
 }  // namespace arrow

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -65,16 +65,24 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
 
   /// Create a StreamingReader instance
   ///
-  /// Currently, the StreamingReader is always single-threaded (parallel
-  /// readahead is not supported).
+  /// This involves some I/O as the first batch must be loaded during the creation process
+  /// so it is returned as a future
+  ///
+  /// Currently, the StreamingReader is not async-reentrant and does not do any fan-out
+  /// parsing (see ARROW-11889)
+  static Future<std::shared_ptr<StreamingReader>> MakeAsync(
+      io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+      const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+
   static Result<std::shared_ptr<StreamingReader>> Make(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,
       const ReadOptions&, const ParseOptions&, const ConvertOptions&);
 
   ARROW_DEPRECATED("Use IOContext-based overload")
   static Result<std::shared_ptr<StreamingReader>> Make(
-      MemoryPool* pool, std::shared_ptr<io::InputStream> input, const ReadOptions&,
-      const ParseOptions&, const ConvertOptions&);
+      MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+      const ReadOptions& read_options, const ParseOptions& parse_options,
+      const ConvertOptions& convert_options);
 };
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -32,11 +32,39 @@
 #include "arrow/table.h"
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/future.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {
+
+using RecordBatchGenerator = AsyncGenerator<std::shared_ptr<RecordBatch>>;
+
 namespace csv {
+
+// Allows the streaming reader to be used in tests that expect a table reader
+class StreamingReaderAsTableReader : public TableReader {
+ public:
+  explicit StreamingReaderAsTableReader(std::shared_ptr<StreamingReader> reader)
+      : reader_(std::move(reader)) {}
+  virtual ~StreamingReaderAsTableReader() = default;
+  virtual Result<std::shared_ptr<Table>> Read() {
+    auto table_fut = ReadAsync();
+    auto table_res = table_fut.result();
+    ARROW_ASSIGN_OR_RAISE(auto table, table_res);
+    return table;
+  }
+  virtual Future<std::shared_ptr<Table>> ReadAsync() {
+    auto reader = reader_;
+    RecordBatchGenerator rb_generator = [reader]() { return reader->ReadNextAsync(); };
+    return CollectAsyncGenerator(rb_generator).Then([](const RecordBatchVector& rbs) {
+      return Table::FromRecordBatches(rbs);
+    });
+  }
+
+ private:
+  std::shared_ptr<StreamingReader> reader_;
+};
 
 using TableReaderFactory =
     std::function<Result<std::shared_ptr<TableReader>>(std::shared_ptr<io::InputStream>)>;
@@ -149,6 +177,33 @@ TEST(AsyncReaderTests, StressInvalid) {
 TEST(AsyncReaderTests, NestedParallelism) {
   ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
   ASSERT_OK_AND_ASSIGN(auto table_factory, MakeAsyncFactory(thread_pool));
+  TestNestedParallelism(thread_pool, table_factory);
+}
+
+Result<TableReaderFactory> MakeStreamingFactory() {
+  return [](std::shared_ptr<io::InputStream> input_stream)
+             -> Result<std::shared_ptr<TableReader>> {
+    auto read_options = ReadOptions::Defaults();
+    read_options.block_size = 1 << 10;
+    ARROW_ASSIGN_OR_RAISE(
+        auto streaming_reader,
+        StreamingReader::Make(io::default_io_context(), input_stream, read_options,
+                              ParseOptions::Defaults(), ConvertOptions::Defaults()));
+    return std::make_shared<StreamingReaderAsTableReader>(std::move(streaming_reader));
+  };
+}
+
+TEST(StreamingReaderTests, Stress) {
+  ASSERT_OK_AND_ASSIGN(auto table_factory, MakeStreamingFactory());
+  StressTableReader(table_factory);
+}
+TEST(StreamingReaderTests, StressInvalid) {
+  ASSERT_OK_AND_ASSIGN(auto table_factory, MakeStreamingFactory());
+  StressInvalidTableReader(table_factory);
+}
+TEST(StreamingReaderTests, NestedParallelism) {
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto table_factory, MakeStreamingFactory());
   TestNestedParallelism(thread_pool, table_factory);
 }
 

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -280,7 +280,7 @@ AsyncGenerator<V> MakeMappedGenerator(AsyncGenerator<T> source_generator,
   return MappingGenerator<T, V>(std::move(source_generator), std::move(map));
 }
 
-/// \see MakeAsyncGenerator
+/// \see MakeTransformedGenerator
 template <typename T, typename V>
 class TransformingGenerator {
   // The transforming generator state will be referenced as an async generator but will
@@ -382,8 +382,8 @@ class TransformingGenerator {
 ///
 /// This generator may queue up to 1 instance of T
 template <typename T, typename V>
-AsyncGenerator<V> MakeAsyncGenerator(AsyncGenerator<T> generator,
-                                     Transformer<T, V> transformer) {
+AsyncGenerator<V> MakeTransformedGenerator(AsyncGenerator<T> generator,
+                                           Transformer<T, V> transformer) {
   return TransformingGenerator<T, V>(generator, transformer);
 }
 

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -496,7 +496,7 @@ TEST(TestAsyncUtil, SynchronousFinish) {
     return Future<TestInt>::MakeFinished(IterationTraits<TestInt>::End());
   };
   Transformer<TestInt, TestStr> skip_all = [](TestInt value) { return TransformSkip(); };
-  auto transformed = MakeAsyncGenerator(generator, skip_all);
+  auto transformed = MakeTransformedGenerator(generator, skip_all);
   auto future = CollectAsyncGenerator(transformed);
   ASSERT_FINISHES_OK_AND_ASSIGN(auto actual, future);
   ASSERT_EQ(std::vector<TestStr>(), actual);
@@ -561,7 +561,7 @@ TEST(TestAsyncUtil, StackOverflow) {
   };
   Transformer<TestInt, TestStr> discard =
       [](TestInt next) -> Result<TransformFlow<TestStr>> { return TransformSkip(); };
-  auto transformed = MakeAsyncGenerator(generator, discard);
+  auto transformed = MakeTransformedGenerator(generator, discard);
   auto collected_future = CollectAsyncGenerator(transformed);
   ASSERT_FINISHES_OK_AND_ASSIGN(auto collected, collected_future);
   ASSERT_EQ(0, collected.size());
@@ -796,7 +796,7 @@ TEST(TestAsyncUtil, ReadaheadFailed) {
 TEST(TestAsyncIteratorTransform, SkipSome) {
   auto original = AsyncVectorIt<TestInt>({1, 2, 3});
   auto filter = MakeFilter([](TestInt& t) { return t.value != 2; });
-  auto filtered = MakeAsyncGenerator(std::move(original), filter);
+  auto filtered = MakeTransformedGenerator(std::move(original), filter);
   AssertAsyncGeneratorMatch({"1", "3"}, std::move(filtered));
 }
 

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -39,6 +39,8 @@ using internal::checked_cast;
 // should ideally not limit scalability.
 static std::mutex global_waiter_mutex;
 
+const double FutureWaiter::kInfinity = HUGE_VAL;
+
 class FutureWaiterImpl : public FutureWaiter {
  public:
   FutureWaiterImpl(Kind kind, std::vector<FutureImpl*> futures)

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -176,7 +176,9 @@ class ARROW_EXPORT FutureWaiter {
  public:
   enum Kind : int8_t { ANY, ALL, ALL_OR_FIRST_FAILED, ITERATE };
 
-  static constexpr double kInfinity = HUGE_VAL;
+  // HUGE_VAL isn't constexpr on Windows
+  // https://social.msdn.microsoft.com/Forums/vstudio/en-US/47e8b9ff-b205-4189-968e-ee3bc3e2719f/constexpr-compile-error?forum=vclanguage
+  static const double kInfinity;
 
   static std::unique_ptr<FutureWaiter> Make(Kind kind, std::vector<FutureImpl*> futures);
 


### PR DESCRIPTION
This moves the read to the IO context and runs continuations on the CPU thread pool.  It does not add any parallelism.  The resulting reader is not reentrant or async-reentrant and it does not do any fan-out parallelism for converting/etc.  That follow-up can be addressed in ARROW-11889.

This is needed by ARROW-7001 to enable nested parallelism in the datasets API.