### PR TITLE
ARROW-10514: [C++][Parquet] Make the column name the same for both output formats of parquet reader

### DIFF
--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -216,7 +216,7 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   for (auto i : selected_columns) {
     const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
     stream << "     { \"Id\": \"" << i << "\","
-	   << " \"Name\": \"" << descr->path()->ToDotString() << "\","
+           << " \"Name\": \"" << descr->path()->ToDotString() << "\","
            << " \"PhysicalType\": \"" << TypeToString(descr->physical_type()) << "\","
            << " \"ConvertedType\": \"" << ConvertedTypeToString(descr->converted_type())
            << "\","

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -215,7 +215,7 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   int c = 0;
   for (auto i : selected_columns) {
     const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
-    stream << "     { \"Id\": \"" << i << "\", \"Name\": \"" << descr->name() << "\","
+    stream << "     { \"Id\": \"" << i << "\", \"Name\": \"" << descr->path()->ToDotString() << "\","
            << " \"PhysicalType\": \"" << TypeToString(descr->physical_type()) << "\","
            << " \"ConvertedType\": \"" << ConvertedTypeToString(descr->converted_type())
            << "\","

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -215,7 +215,8 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   int c = 0;
   for (auto i : selected_columns) {
     const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
-    stream << "     { \"Id\": \"" << i << "\", \"Name\": \"" << descr->path()->ToDotString() << "\","
+    stream << "     { \"Id\": \"" << i << "\","
+	   << " \"Name\": \"" << descr->path()->ToDotString() << "\","
            << " \"PhysicalType\": \"" << TypeToString(descr->physical_type()) << "\","
            << " \"ConvertedType\": \"" << ConvertedTypeToString(descr->converted_type())
            << "\","


### PR DESCRIPTION
In parquet-reader there are two ways to output the schema for a Parquet file: DebugPrint and JSONPrint. When output in JSON format, the Column name is short name instead of full-qualified name. For example, for schema (1), there will be 2 Columns with `"Name": "key"`. That's very confusing.

In this PR we start using full-qualified name for Column in JSONPrint instead of short name, similar to DebugPrint.

(1):
```
required group field_id=0 spark_schema {
  optional group field_id=1 a (Map) {
    repeated group field_id=2 key_value {
      required binary field_id=3 key (String);
      optional group field_id=4 value (Map) {
        repeated group field_id=5 key_value {
          required int32 field_id=6 key;
          required boolean field_id=7 value;
        }
      }
    }
  }
}
```