### PR TITLE
ARROW-11896: [Rust] Disable Debug symbols on CI test builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,8 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          # do not produce debug symbols to keep memory usage down
+          export RUSTFLAGS="-C debuginfo=0"
           cd rust
           cargo build
 
@@ -164,6 +166,8 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          # do not produce debug symbols to keep memory usage down
+          export RUSTFLAGS="-C debuginfo=0"
           cd rust/arrow
           cargo test --features "simd"
 
@@ -390,5 +394,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          # do not produce debug symbols to keep memory usage down
+          export RUSTFLAGS="-C debuginfo=0"
           cd rust/arrow
           cargo build --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,6 +108,8 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          # do not produce debug symbols to keep memory usage down
+          export RUSTFLAGS="-C debuginfo=0"
           cd rust
           # run tests on all workspace members with default feature list
           cargo test


### PR DESCRIPTION
The theory is that the inclusion of debug symbols is increasing the memory requirements of compiling the test binaries which is causing the tests to hit the CI builder's memory limits (and being OOM killed). 

Changes:
Since the debug symbols aren't used for tests, run the CI tests without them to save memory

In theory this might also make the builds faster as well

@nevi-me  and I theorize (without proof) that some new release of a dependency pushed the memory usage over the github builder limit which is why we started seeing this all of a sudden on master without any obvious corresponding code change