### PR TITLE
ARROW-12041: [C++][Python] Fix type property of tensor and sparse tensor IPC messages

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -268,6 +268,10 @@ std::string FormatMessageType(MessageType type) {
       return "record batch";
     case MessageType::DICTIONARY_BATCH:
       return "dictionary";
+    case MessageType::TENSOR:
+      return "tensor";
+    case MessageType::SPARSE_TENSOR:
+      return "sparse tensor";
     default:
       break;
   }


### PR DESCRIPTION
Currently `pyarrow.ipc.Message.type` returns `'unknown'` for tensor and sparse tensor IPC messages. This PR fixes this.