### PR TITLE
ARROW-11516: [R] Allow all C++ compute functions to be called by name in dplyr

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -45,6 +45,10 @@
     s3_register("reticulate::r_to_py", cl)
   }
 
+  # Create these once, at package build time
+  dplyr_functions$dataset <- build_function_list(build_dataset_expression)
+  dplyr_functions$array <- build_function_list(build_array_expression)
+
   invisible()
 }
 

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -282,16 +282,14 @@ arrow_eval <- function (expr, mask) {
 build_function_list <- function(FUN) {
   wrapper <- function(operator) {
     force(operator)
-    function(e1, e2) FUN(operator, e1, e2)
+    function(...) FUN(operator, ...)
   }
+  all_arrow_funs <- list_compute_functions()
 
   c(
+    # Include mappings from R function name spellings
     lapply(set_names(names(.array_function_map)), wrapper),
-    # TODO: lapply also for the arrow spellings?
-    # See list_compute_functions()
-    # (would want to do these first, and then modifyList with the R ones
-    # in case of name collision)
-    # Would need to generalize FUN to accept ... args
+    # Plus some special handling where it's not 1:1
     str_trim = function(string, side = c("both", "left", "right")) {
       side <- match.arg(side)
       switch(
@@ -300,20 +298,29 @@ build_function_list <- function(FUN) {
         right = FUN("utf8_rtrim_whitespace", string),
         both = FUN("utf8_trim_whitespace", string)
       )
-    }
+    },
+    # Now also include all available Arrow Compute functions,
+    # namespaced as arrow_fun
+    set_names(
+      lapply(all_arrow_funs, wrapper),
+      paste0("arrow_", all_arrow_funs)
+    )
   )
 }
 
-# Create these once, at package build time
-dataset_function_list <- build_function_list(build_dataset_expression)
-array_function_list <- build_function_list(build_array_expression)
+# We'll populate these at package load time.
+dplyr_functions <- NULL
+init_env <- function () {
+  dplyr_functions <<- new.env(hash = TRUE)
+}
+init_env()
 
 # Create a data mask for evaluating a dplyr expression
 arrow_mask <- function(.data) {
   if (query_on_dataset(.data)) {
-    f_env <- new_environment(dataset_function_list)
+    f_env <- new_environment(dplyr_functions$dataset)
   } else {
-    f_env <- new_environment(array_function_list)
+    f_env <- new_environment(dplyr_functions$array)
   }
 
   # Add functions that need to error hard and clear.

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -33,9 +33,10 @@ array_expression <- function(FUN,
 
 #' @export
 Ops.ArrowDatum <- function(e1, e2) {
-  if (.Generic %in% names(.array_function_map)) {
-    expr <- build_array_expression(.Generic, e1, e2)
-    eval_array_expression(expr)
+  if (.Generic == "!") {
+    eval_array_expression(build_array_expression(.Generic, e1))
+  } else if (.Generic %in% names(.array_function_map)) {
+    eval_array_expression(build_array_expression(.Generic, e1, e2))
   } else {
     stop(paste0("Unsupported operation on `", class(e1)[1L], "` : "), .Generic, call. = FALSE)
   }
@@ -50,38 +51,34 @@ Ops.array_expression <- function(e1, e2) {
   }
 }
 
-build_array_expression <- function(.Generic, e1, e2, ...) {
-  if (.Generic %in% names(.unary_function_map) || nargs() == 2L) {
-    expr <- array_expression(.unary_function_map[[.Generic]] %||% .Generic, e1)
-  } else {
-    e1 <- .wrap_arrow(e1, .Generic)
-    e2 <- .wrap_arrow(e2, .Generic)
+build_array_expression <- function(FUN,
+                                   ...,
+                                   args = list(...),
+                                   options = empty_named_list()) {
+  args <- lapply(args, .wrap_arrow, FUN)
 
-    # In Arrow, "divide" is one function, which does integer division on
-    # integer inputs and floating-point division on floats
-    if (.Generic == "/") {
-      # TODO: omg so many ways it's wrong to assume these types
-      e1 <- cast_array_expression(e1, float64())
-      e2 <- cast_array_expression(e2, float64())
-    } else if (.Generic == "%/%") {
-      # In R, integer division works like floor(float division)
-      out <- build_array_expression("/", e1, e2)
-      return(cast_array_expression(out, int32(), allow_float_truncate = TRUE))
-    } else if (.Generic == "%%") {
-      # {e1 - e2 * ( e1 %/% e2 )}
-      # ^^^ form doesn't work because Ops.Array evaluates eagerly,
-      # but we can build that up
-      quotient <- build_array_expression("%/%", e1, e2)
-      base <- build_array_expression("*", quotient, e2)
-      # this cast is to ensure that the result of this and e1 are the same
-      # (autocasting only applies to scalars)
-      base <- cast_array_expression(base, e1$type)
-      return(build_array_expression("-", e1, base))
-    }
-
-    expr <- array_expression(.binary_function_map[[.Generic]] %||% .Generic, e1, e2, ...)
+  # In Arrow, "divide" is one function, which does integer division on
+  # integer inputs and floating-point division on floats
+  if (FUN == "/") {
+    # TODO: omg so many ways it's wrong to assume these types
+    args <- lapply(args, cast_array_expression, float64())
+  } else if (FUN == "%/%") {
+    # In R, integer division works like floor(float division)
+    out <- build_array_expression("/", args = args, options = options)
+    return(cast_array_expression(out, int32(), allow_float_truncate = TRUE))
+  } else if (FUN == "%%") {
+    # {e1 - e2 * ( e1 %/% e2 )}
+    # ^^^ form doesn't work because Ops.Array evaluates eagerly,
+    # but we can build that up
+    quotient <- build_array_expression("%/%", args = args)
+    base <- build_array_expression("*", quotient, args[[2]])
+    # this cast is to ensure that the result of this and e1 are the same
+    # (autocasting only applies to scalars)
+    base <- cast_array_expression(base, args[[1]]$type)
+    return(build_array_expression("-", args[[1]], base))
   }
-  expr
+
+  array_expression(.array_function_map[[FUN]] %||% FUN, args = args, options = options)
 }
 
 cast_array_expression <- function(x, to_type, safe = TRUE, ...) {
@@ -269,40 +266,40 @@ Expression$scalar <- function(x) {
   dataset___expr__scalar(Scalar$create(x))
 }
 
-build_dataset_expression <- function(.Generic, e1, e2, ...) {
-  if (.Generic %in% names(.unary_function_map) || nargs() == 2L) {
-    expr <- Expression$create(.unary_function_map[[.Generic]] %||% .Generic, e1)
-  } else if (.Generic == "%in%") {
+build_dataset_expression <- function(FUN,
+                                     ...,
+                                     args = list(...),
+                                     options = empty_named_list()) {
+  if (FUN == "%in%") {
     # Special-case %in%, which is different from the Array function name
-    expr <- Expression$create("is_in", e1,
+    expr <- Expression$create("is_in", args[[1]],
       options = list(
-        value_set = Array$create(e2),
+        value_set = Array$create(args[[2]]),
         skip_nulls = TRUE
       )
     )
   } else {
-    if (!inherits(e1, "Expression")) {
-      e1 <- Expression$scalar(e1)
-    }
-    if (!inherits(e2, "Expression")) {
-      e2 <- Expression$scalar(e2)
-    }
+    args <- lapply(args, function(x) {
+      if (!inherits(x, "Expression")) {
+        x <- Expression$scalar(x)
+      }
+      x
+    })
 
     # In Arrow, "divide" is one function, which does integer division on
     # integer inputs and floating-point division on floats
-    if (.Generic == "/") {
+    if (FUN == "/") {
       # TODO: omg so many ways it's wrong to assume these types
-      e1 <- e1$cast(float64())
-      e2 <- e2$cast(float64())
-    } else if (.Generic == "%/%") {
+      args <- lapply(args, function(x) x$cast(float64()))
+    } else if (FUN == "%/%") {
       # In R, integer division works like floor(float division)
-      out <- build_dataset_expression("/", e1, e2)
+      out <- build_dataset_expression("/", args = args)
       return(out$cast(int32(), allow_float_truncate = TRUE))
-    } else if (.Generic == "%%") {
-      return(e1 - e2 * ( e1 %/% e2 ))
+    } else if (FUN == "%%") {
+      return(args[[1]] - args[[2]] * ( args[[1]] %/% args[[2]] ))
     }
 
-    expr <- Expression$create(.binary_function_map[[.Generic]] %||% .Generic, e1, e2, ...)
+    expr <- Expression$create(.array_function_map[[FUN]] %||% FUN, args = args, options = options)
   }
   expr
 }

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -556,7 +556,10 @@ test_that("filter() with arrow compute functions by name", {
       select(part, lgl) %>%
       filter(arrow_is_valid(lgl), arrow_equal(part, 1)) %>%
       collect(),
-    tibble(part = 1L, lgl = df1$lgl[!is.na(df1$lgl)])
+    ds %>%
+       select(part, lgl) %>%
+       filter(!is.na(lgl), part == 1L) %>%
+       collect()
   )
 })
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -548,6 +548,18 @@ test_that("filter() with strings", {
   )
 })
 
+test_that("filter() with arrow compute functions by name", {
+  skip_if_not_available("parquet")
+  ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
+  expect_equivalent(
+    ds %>%
+      select(part, lgl) %>%
+      filter(arrow_is_valid(lgl), arrow_equal(part, 1)) %>%
+      collect(),
+    tibble(part = 1L, lgl = df1$lgl[!is.na(df1$lgl)])
+  )
+})
+
 test_that("filter() with .data", {
   skip_if_not_available("parquet")
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -250,6 +250,30 @@ test_that("Filtering with a function that doesn't have an Array/expr method stil
   )
 })
 
+test_that("Calling Arrow compute functions 'directly'", {
+  expect_equal(
+    tbl %>%
+      record_batch() %>%
+      filter(arrow_add(dbl, 1) > 3L) %>%
+      select(string = chr, int, dbl) %>%
+      collect(),
+    tbl %>%
+      filter(dbl + 1 > 3L) %>%
+      select(string = chr, int, dbl)
+  )
+
+  expect_dplyr_equal(
+    tbl %>%
+      record_batch() %>%
+      filter(arrow_greater(arrow_add(dbl, 1), 3L)) %>%
+      select(string = chr, int, dbl) %>%
+      collect(),
+    tbl %>%
+      filter(dbl + 1 > 3L) %>%
+      select(string = chr, int, dbl)
+  )
+})
+
 test_that("filter() with .data pronoun", {
   expect_dplyr_equal(
     input %>%

--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -21,7 +21,7 @@ test_that("install_pyarrow", {
   skip_on_cran()
   skip_if_not_dev_mode()
   # Python problems on Apple M1 still
-  skip_if(grepl("arm-apple", R.Version()$platform))
+  skip_if(grepl("arm-apple|aarch64.*darwin", R.Version()$platform))
   skip_if_not_installed("reticulate")
   venv <- try(reticulate::virtualenv_create("arrow-test"))
   # Bail out if virtualenv isn't available


### PR DESCRIPTION
This PR adds bindings in the dplyr data mask for all functions (currently there are 98) in the arrow compute module, namespaced with an `arrow_` prefix. In order to do this, most of the changes here are a refactor of the expression-building code to take a variable number of arguments. That way, we can support a range of unary/binary/varargs compute kernels without having to declare up front which are which.

In many cases, the newly exposed compute kernels don't take additional options, so they will just work. For those that do, we'll likely need to add some special C++ bindings to pass those through, unless we can come up with a clever solution in the compute module to facilitate that. Either way, this is left to a followup.