### PR TITLE
ARROW-10953: [R] Validate when creating Table with schema

### DIFF
--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -359,9 +359,21 @@ test_that("table() auto splices (ARROW-5718)", {
 })
 
 test_that("Validation when creating table with schema (ARROW-10953)", {
-  expect_error(Table$create(data.frame(), schema = schema(a = int32())))
-  expect_error(Table$create(data.frame(b = 1), schema = schema(a = int32())))
-  expect_error(Table$create(data.frame(b = 2, c = 3), schema = schema(a = int32())))
+  expect_error(
+    Table$create(data.frame(), schema = schema(a = int32())),
+    "incompatible. schema has 1 fields, and 0 columns are supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    Table$create(data.frame(b = 1), schema = schema(a = int32())),
+    "field at index 1 has name 'a' != 'b'",
+    fixed = TRUE
+  )
+  expect_error(
+    Table$create(data.frame(b = 2, c = 3), schema = schema(a = int32())),
+    "incompatible. schema has 1 fields, and 2 columns are supplied",
+    fixed = TRUE
+  )
 })
 
 test_that("==.Table", {

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -359,9 +359,9 @@ test_that("table() auto splices (ARROW-5718)", {
 })
 
 test_that("Validation when creating table with schema (ARROW-10953)", {
-  tab <- Table$create(data.frame(), schema = schema(a = int32()))
-  skip("This segfaults")
-  expect_identical(dim(as.data.frame(tab)), c(0L, 1L))
+  expect_error(Table$create(data.frame(), schema = schema(a = int32())))
+  expect_error(Table$create(data.frame(b = 1), schema = schema(a = int32())))
+  expect_error(Table$create(data.frame(b = 2, c = 3), schema = schema(a = int32())))
 })
 
 test_that("==.Table", {


### PR DESCRIPTION
This copies the schema checks from `RecordBatch__from_arrays__known_schema` to `CollectTableColumns` to prevent errors when the schema does not match the columns