### PR TITLE
ARROW-11927: [Rust][DataFusion] Support Limit push down optimization

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -121,6 +121,7 @@ impl TableProvider for CsvFile {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         _filters: &[Expr],
+        _limit: Option<usize>
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CsvExec::try_new(
             &self.path,

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -121,7 +121,7 @@ impl TableProvider for CsvFile {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         _filters: &[Expr],
-        _limit: Option<usize>
+        _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CsvExec::try_new(
             &self.path,

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -121,7 +121,7 @@ impl TableProvider for CsvFile {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         _filters: &[Expr],
-        _limit: Option<usize>,
+        limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CsvExec::try_new(
             &self.path,
@@ -132,6 +132,7 @@ impl TableProvider for CsvFile {
                 .file_extension(self.file_extension.as_str()),
             projection.clone(),
             batch_size,
+            limit,
         )?))
     }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -131,7 +131,9 @@ impl TableProvider for CsvFile {
                 .delimiter(self.delimiter)
                 .file_extension(self.file_extension.as_str()),
             projection.clone(),
-            batch_size,
+            limit
+                .map(|l| std::cmp::min(l, batch_size))
+                .unwrap_or(batch_size),
             limit,
         )?))
     }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -81,6 +81,10 @@ pub trait TableProvider {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
+        // limit can be used to reduce the amount scanned
+        // from the datasource as a performance optimization.
+        // If set, it contains the amount of rows needed by the `LogicalPlan`,
+        // The datasource should return *at least* this number of rows if available.
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -81,6 +81,7 @@ pub trait TableProvider {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
+        limit: Option<usize>
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     /// Returns the table Statistics

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -81,7 +81,7 @@ pub trait TableProvider {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 
     /// Returns the table Statistics

--- a/rust/datafusion/src/datasource/empty.rs
+++ b/rust/datafusion/src/datasource/empty.rs
@@ -54,6 +54,7 @@ impl TableProvider for EmptyTable {
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
+        _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // even though there is no data, projections apply
         let projection = match projection.clone() {

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -115,7 +115,7 @@ impl MemTable {
         output_partitions: Option<usize>,
     ) -> Result<Self> {
         let schema = t.schema();
-        let exec = t.scan(&None, batch_size, &[])?;
+        let exec = t.scan(&None, batch_size, &[], None)?;
         let partition_count = exec.output_partitioning().partition_count();
 
         let tasks = (0..partition_count)
@@ -177,6 +177,7 @@ impl TableProvider for MemTable {
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
+        _limit: Option<usize>
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let columns: Vec<usize> = match projection {
             Some(p) => p.clone(),
@@ -278,7 +279,7 @@ mod tests {
         );
 
         // scan with projection
-        let exec = provider.scan(&Some(vec![2, 1]), 1024, &[])?;
+        let exec = provider.scan(&Some(vec![2, 1]), 1024, &[], None)?;
         let mut it = exec.execute(0).await?;
         let batch2 = it.next().await.unwrap()?;
         assert_eq!(2, batch2.schema().fields().len());
@@ -308,7 +309,7 @@ mod tests {
 
         let provider = MemTable::try_new(schema, vec![vec![batch]])?;
 
-        let exec = provider.scan(&None, 1024, &[])?;
+        let exec = provider.scan(&None, 1024, &[], None)?;
         let mut it = exec.execute(0).await?;
         let batch1 = it.next().await.unwrap()?;
         assert_eq!(3, batch1.schema().fields().len());
@@ -338,7 +339,7 @@ mod tests {
 
         let projection: Vec<usize> = vec![0, 4];
 
-        match provider.scan(&Some(projection), 1024, &[]) {
+        match provider.scan(&Some(projection), 1024, &[], None) {
             Err(DataFusionError::Internal(e)) => {
                 assert_eq!("\"Projection index out of range\"", format!("{:?}", e))
             }
@@ -459,7 +460,7 @@ mod tests {
         let provider =
             MemTable::try_new(Arc::new(merged_schema), vec![vec![batch1, batch2]])?;
 
-        let exec = provider.scan(&None, 1024, &[])?;
+        let exec = provider.scan(&None, 1024, &[], None)?;
         let mut it = exec.execute(0).await?;
         let batch1 = it.next().await.unwrap()?;
         assert_eq!(3, batch1.schema().fields().len());

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -177,7 +177,7 @@ impl TableProvider for MemTable {
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
-        _limit: Option<usize>
+        _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let columns: Vec<usize> = match projection {
             Some(p) => p.clone(),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -90,7 +90,9 @@ impl TableProvider for ParquetTable {
             &self.path,
             projection.clone(),
             predicate,
-            batch_size,
+            limit
+                .map(|l|std::cmp::min(l, batch_size))
+                .unwrap_or(batch_size),
             self.max_concurrency,
             limit,
         )?))

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -83,6 +83,7 @@ impl TableProvider for ParquetTable {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
+        _limit: Option<usize>
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let predicate = combine_filters(filters);
         Ok(Arc::new(ParquetExec::try_from_path(
@@ -113,7 +114,7 @@ mod tests {
     async fn read_small_batches() -> Result<()> {
         let table = load_table("alltypes_plain.parquet")?;
         let projection = None;
-        let exec = table.scan(&projection, 2, &[])?;
+        let exec = table.scan(&projection, 2, &[], None)?;
         let stream = exec.execute(0).await?;
 
         let count = stream
@@ -337,7 +338,7 @@ mod tests {
         table: Arc<dyn TableProvider>,
         projection: &Option<Vec<usize>>,
     ) -> Result<RecordBatch> {
-        let exec = table.scan(projection, 1024, &[])?;
+        let exec = table.scan(projection, 1024, &[], None)?;
         let mut it = exec.execute(0).await?;
         it.next()
             .await

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -83,7 +83,7 @@ impl TableProvider for ParquetTable {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
-        _limit: Option<usize>
+        _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let predicate = combine_filters(filters);
         Ok(Arc::new(ParquetExec::try_from_path(

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -91,7 +91,7 @@ impl TableProvider for ParquetTable {
             projection.clone(),
             predicate,
             limit
-                .map(|l|std::cmp::min(l, batch_size))
+                .map(|l| std::cmp::min(l, batch_size))
                 .unwrap_or(batch_size),
             self.max_concurrency,
             limit,

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -43,7 +43,7 @@ pub struct ParquetTable {
 impl ParquetTable {
     /// Attempt to initialize a new `ParquetTable` from a file path.
     pub fn try_new(path: &str, max_concurrency: usize) -> Result<Self> {
-        let parquet_exec = ParquetExec::try_from_path(path, None, None, 0, 1)?;
+        let parquet_exec = ParquetExec::try_from_path(path, None, None, 0, 1, None)?;
         let schema = parquet_exec.schema();
         Ok(Self {
             path: path.to_string(),
@@ -83,7 +83,7 @@ impl TableProvider for ParquetTable {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
         filters: &[Expr],
-        _limit: Option<usize>,
+        limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let predicate = combine_filters(filters);
         Ok(Arc::new(ParquetExec::try_from_path(
@@ -92,6 +92,7 @@ impl TableProvider for ParquetTable {
             predicate,
             batch_size,
             self.max_concurrency,
+            limit,
         )?))
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -42,6 +42,7 @@ use crate::logical_plan::{
 };
 use crate::optimizer::constant_folding::ConstantFolding;
 use crate::optimizer::filter_push_down::FilterPushDown;
+use crate::optimizer::limit_push_down::LimitPushDown;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
 use crate::physical_plan::csv::CsvReadOptions;
@@ -521,6 +522,7 @@ impl ExecutionConfig {
                 Arc::new(ProjectionPushDown::new()),
                 Arc::new(FilterPushDown::new()),
                 Arc::new(HashBuildProbeOrder::new()),
+                Arc::new(LimitPushDown::new()),
             ],
             query_planner: Arc::new(DefaultQueryPlanner {}),
         }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -244,6 +244,7 @@ impl ExecutionContext {
             projected_schema: schema.to_dfschema_ref()?,
             projection: None,
             filters: vec![],
+            limit: None,
         };
         Ok(Arc::new(DataFrameImpl::new(
             self.state.clone(),
@@ -316,6 +317,7 @@ impl ExecutionContext {
                     projected_schema: schema.to_dfschema_ref()?,
                     projection: None,
                     filters: vec![],
+                    limit: None,
                 };
                 Ok(Arc::new(DataFrameImpl::new(
                     self.state.clone(),

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -120,6 +120,7 @@ impl LogicalPlanBuilder {
             projected_schema,
             projection,
             filters: vec![],
+            limit: None,
         };
 
         Ok(Self::from(&table_scan))

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -586,6 +586,7 @@ impl LogicalPlan {
                         ref table_name,
                         ref projection,
                         ref filters,
+                        ref limit,
                         ..
                     } => {
                         let sep = " ".repeat(min(1, table_name.len()));
@@ -597,6 +598,10 @@ impl LogicalPlan {
 
                         if !filters.is_empty() {
                             write!(f, ", filters={:?}", filters)?;
+                        }
+
+                        if let Some(n) = limit {
+                            write!(f, ", limit={}", n)?;
                         }
 
                         Ok(())

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -133,7 +133,7 @@ pub enum LogicalPlan {
         /// Optional expressions to be used as filters by the table provider
         filters: Vec<Expr>,
         /// Optional limit to skip reading
-        limit: Option<usize>
+        limit: Option<usize>,
     },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -132,6 +132,8 @@ pub enum LogicalPlan {
         projected_schema: DFSchemaRef,
         /// Optional expressions to be used as filters by the table provider
         filters: Vec<Expr>,
+        /// Optional limit to skip reading
+        limit: Option<usize>
     },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -346,7 +346,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             filters,
             projection,
             table_name,
-            limit
+            limit,
         } => {
             let mut used_columns = HashSet::new();
             let mut new_filters = filters.clone();
@@ -377,7 +377,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                     projected_schema: projected_schema.clone(),
                     table_name: table_name.clone(),
                     filters: new_filters,
-                    limit: *limit
+                    limit: *limit,
                 },
             )
         }
@@ -942,7 +942,7 @@ mod tests {
             _: &Option<Vec<usize>>,
             _: usize,
             _: &[Expr],
-            _: Option<usize>
+            _: Option<usize>,
         ) -> Result<Arc<dyn ExecutionPlan>> {
             unimplemented!()
         }

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -346,6 +346,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
             filters,
             projection,
             table_name,
+            limit
         } => {
             let mut used_columns = HashSet::new();
             let mut new_filters = filters.clone();
@@ -376,6 +377,7 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                     projected_schema: projected_schema.clone(),
                     table_name: table_name.clone(),
                     filters: new_filters,
+                    limit: *limit
                 },
             )
         }
@@ -940,6 +942,7 @@ mod tests {
             _: &Option<Vec<usize>>,
             _: usize,
             _: &[Expr],
+            _: Option<usize>
         ) -> Result<Arc<dyn ExecutionPlan>> {
             unimplemented!()
         }
@@ -974,6 +977,7 @@ mod tests {
             )?),
             projection: None,
             source: Arc::new(test_provider),
+            limit: None,
         };
 
         LogicalPlanBuilder::from(&table_scan)

--- a/rust/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/rust/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -204,6 +204,7 @@ mod tests {
             _projection: &Option<Vec<usize>>,
             _batch_size: usize,
             _filters: &[Expr],
+            _limit: Option<usize>,
         ) -> Result<std::sync::Arc<dyn crate::physical_plan::ExecutionPlan>> {
             unimplemented!()
         }
@@ -233,6 +234,7 @@ mod tests {
             source: Arc::new(TestTableProvider { num_rows: 1000 }),
             projected_schema: Arc::new(DFSchema::empty()),
             filters: vec![],
+            limit: None,
         };
 
         let lp_right = LogicalPlan::TableScan {
@@ -241,6 +243,7 @@ mod tests {
             source: Arc::new(TestTableProvider { num_rows: 100 }),
             projected_schema: Arc::new(DFSchema::empty()),
             filters: vec![],
+            limit: None,
         };
 
         assert!(should_swap_join_order(&lp_left, &lp_right));

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 //! Optimizer rule to push down LIMIT in the query plan
+use std::sync::Arc;
+
 use super::utils;
 use crate::error::Result;
 use crate::logical_plan::LogicalPlan;
@@ -23,10 +25,53 @@ use crate::optimizer::optimizer::OptimizerRule;
 
 /// Optimization rule that tries pushes down LIMIT n
 /// where applicable to reduce the scanned or necessary in outer join
-pub struct LimitPushdown {}
+pub struct LimitPushDown {}
 
-fn limit_push_down(n: Option<usize>, plan: &LogicalPlan) -> Result<LogicalPlan> {
+impl LimitPushDown {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+fn limit_push_down(
+    upper_limit: Option<usize>,
+    plan: &LogicalPlan,
+) -> Result<LogicalPlan> {
     match plan {
+        LogicalPlan::Limit { n, input } => {
+            println!("limit");
+            return Ok(LogicalPlan::Limit {
+                n: *n,
+                // push down limit to plan (minimum of upper limit and current limit)
+                input: Arc::new(limit_push_down(
+                    upper_limit.map(|x| std::cmp::min(x, *n)).or(Some(*n)),
+                    input.as_ref(),
+                )?),
+            });
+        }
+        LogicalPlan::TableScan {
+            table_name,
+            source,
+            projection,
+            filters,
+            limit,
+            projected_schema,
+        } => {
+            if let Some(n) = upper_limit {
+                return Ok(LogicalPlan::TableScan {
+                    table_name: table_name.clone(),
+                    source: source.clone(),
+                    projection: projection.clone(),
+                    filters: filters.clone(),
+                    limit: limit.map(|x| std::cmp::min(x, n)).or(Some(n)),
+                    projected_schema: projected_schema.clone(),
+                });
+            } else {
+                return Ok(plan.clone());
+            }
+        }
+
         _ => {
             let expr = plan.expressions();
 
@@ -42,12 +87,43 @@ fn limit_push_down(n: Option<usize>, plan: &LogicalPlan) -> Result<LogicalPlan> 
     }
 }
 
-impl OptimizerRule for LimitPushdown {
+impl OptimizerRule for LimitPushDown {
     fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
         limit_push_down(None, plan)
     }
 
     fn name(&self) -> &str {
         "limit_push_down"
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        logical_plan::{LogicalPlan, LogicalPlanBuilder},
+        test::*,
+    };
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = LimitPushDown::new();
+        let optimized_plan = rule.optimize(plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    #[test]
+    fn limit_pushdown_table_provider() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(&table_scan).limit(1000)?.build()?;
+
+        // Pushes the limit down to table provider
+        // TableScan returns at least the limit nr. of rows (if it has rows)
+        let expected = "Limit: 1000\
+        \n  TableScan: test projection=None, limit=1000";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
     }
 }

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -39,17 +39,14 @@ fn limit_push_down(
     plan: &LogicalPlan,
 ) -> Result<LogicalPlan> {
     match plan {
-        LogicalPlan::Limit { n, input } => {
-            println!("limit");
-            return Ok(LogicalPlan::Limit {
-                n: *n,
-                // push down limit to plan (minimum of upper limit and current limit)
-                input: Arc::new(limit_push_down(
-                    upper_limit.map(|x| std::cmp::min(x, *n)).or(Some(*n)),
-                    input.as_ref(),
-                )?),
-            });
-        }
+        LogicalPlan::Limit { n, input } => Ok(LogicalPlan::Limit {
+            n: *n,
+            // push down limit to plan (minimum of upper limit and current limit)
+            input: Arc::new(limit_push_down(
+                upper_limit.map(|x| std::cmp::min(x, *n)).or(Some(*n)),
+                input.as_ref(),
+            )?),
+        }),
         LogicalPlan::TableScan {
             table_name,
             source,

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Optimizer rule to push down LIMIT in the query plan
 use super::utils;
 use crate::error::Result;
 use crate::logical_plan::LogicalPlan;
@@ -26,7 +27,7 @@ pub struct LimitPushdown {}
 
 fn limit_push_down(n: Option<usize>, plan: &LogicalPlan) -> Result<LogicalPlan> {
     match plan {
-        expr => {
+        _ => {
             let expr = plan.expressions();
 
             // apply the optimization to all inputs of the plan

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -65,7 +65,7 @@ fn limit_push_down(
                     projected_schema: projected_schema.clone(),
                 })
             } else {
-                limit_push_down(None, plan)
+                Ok(plan.clone())
             }
         }
         LogicalPlan::Projection {

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::utils;
+use crate::error::Result;
+use crate::logical_plan::LogicalPlan;
+use crate::optimizer::optimizer::OptimizerRule;
+
+/// Optimization rule that tries pushes down LIMIT n
+/// where applicable to reduce the scanned or necessary in outer join
+pub struct LimitPushdown {}
+
+fn limit_push_down(n: Option<usize>, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    match plan {
+        expr => {
+            let expr = plan.expressions();
+
+            // apply the optimization to all inputs of the plan
+            let inputs = plan.inputs();
+            let new_inputs = inputs
+                .iter()
+                .map(|plan| limit_push_down(None, plan))
+                .collect::<Result<Vec<_>>>()?;
+
+            utils::from_plan(plan, &expr, &new_inputs)
+        }
+    }
+}
+
+impl OptimizerRule for LimitPushdown {
+    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+        limit_push_down(None, plan)
+    }
+
+    fn name(&self) -> &str {
+        "limit_push_down"
+    }
+}

--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -21,8 +21,8 @@
 pub mod constant_folding;
 pub mod filter_push_down;
 pub mod hash_build_probe_order;
+pub mod limit_push_down;
 pub mod optimizer;
 pub mod projection_push_down;
-pub mod limit_push_down;
 
 pub mod utils;

--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -23,4 +23,6 @@ pub mod filter_push_down;
 pub mod hash_build_probe_order;
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod limit_push_down;
+
 pub mod utils;

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -244,6 +244,7 @@ fn optimize_plan(
             source,
             projection,
             filters,
+            limit,
             ..
         } => {
             let (projection, projected_schema) = get_projected_schema(
@@ -260,6 +261,7 @@ fn optimize_plan(
                 projection: Some(projection),
                 projected_schema,
                 filters: filters.clone(),
+                limit: *limit,
             })
         }
         LogicalPlan::Explain {

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -127,6 +127,8 @@ pub struct CsvExec {
     projected_schema: SchemaRef,
     /// Batch size
     batch_size: usize,
+    /// Limit in nr. of rows
+    limit: Option<usize>,
 }
 
 impl CsvExec {
@@ -136,6 +138,7 @@ impl CsvExec {
         options: CsvReadOptions,
         projection: Option<Vec<usize>>,
         batch_size: usize,
+        limit: Option<usize>,
     ) -> Result<Self> {
         let file_extension = String::from(options.file_extension);
 
@@ -169,6 +172,7 @@ impl CsvExec {
             projection,
             projected_schema: Arc::new(projected_schema),
             batch_size,
+            limit,
         })
     }
 
@@ -210,6 +214,11 @@ impl CsvExec {
     /// Batch size
     pub fn batch_size(&self) -> usize {
         self.batch_size
+    }
+
+    /// Limit
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
     }
 
     /// Infer schema for given CSV dataset
@@ -270,6 +279,7 @@ impl ExecutionPlan for CsvExec {
             self.delimiter,
             &self.projection,
             self.batch_size,
+            self.limit,
         )?))
     }
 }
@@ -289,15 +299,19 @@ impl CsvStream {
         delimiter: Option<u8>,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
+        limit: Option<usize>,
     ) -> Result<Self> {
         let file = File::open(filename)?;
+
+        let bounds = limit.map(|x| (0, x));
+
         let reader = csv::Reader::new(
             file,
             schema,
             has_header,
             delimiter,
             batch_size,
-            None,
+            bounds,
             projection.clone(),
         );
 
@@ -340,6 +354,7 @@ mod tests {
             CsvReadOptions::new().schema(&schema),
             Some(vec![0, 2, 4]),
             1024,
+            None,
         )?;
         assert_eq!(13, csv.schema.fields().len());
         assert_eq!(3, csv.projected_schema.fields().len());
@@ -362,8 +377,13 @@ mod tests {
         let testdata = arrow::util::test_util::arrow_test_data();
         let filename = "aggregate_test_100.csv";
         let path = format!("{}/csv/{}", testdata, filename);
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
         assert_eq!(13, csv.schema.fields().len());
         assert_eq!(13, csv.projected_schema.fields().len());
         assert_eq!(13, csv.file_schema().fields().len());

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -302,8 +302,8 @@ impl CsvStream {
         limit: Option<usize>,
     ) -> Result<Self> {
         let file = File::open(filename)?;
-
-        let bounds = limit.map(|x| (0, x));
+        let start_line = if has_header { 1 } else { 0 };
+        let bounds = limit.map(|x| (start_line, x + start_line));
 
         let reader = csv::Reader::new(
             file,

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -303,7 +303,7 @@ impl CsvStream {
     ) -> Result<Self> {
         let file = File::open(filename)?;
         let start_line = if has_header { 1 } else { 0 };
-        let bounds = limit.map(|x| (start_line, x + start_line));
+        let bounds = limit.map(|x| (0, x + start_line));
 
         let reader = csv::Reader::new(
             file,

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -199,8 +199,13 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024, None)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
 
         let predicate: Arc<dyn PhysicalExpr> = binary(
             binary(

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -200,7 +200,7 @@ mod tests {
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
         let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024, None)?;
 
         let predicate: Arc<dyn PhysicalExpr> = binary(
             binary(

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -267,8 +267,13 @@ mod tests {
         let path =
             test::create_partitioned_csv("aggregate_test_100.csv", num_partitions)?;
 
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024, None)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
 
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -268,7 +268,7 @@ mod tests {
             test::create_partitioned_csv("aggregate_test_100.csv", num_partitions)?;
 
         let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024, None)?;
 
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);

--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -195,8 +195,13 @@ mod tests {
         let path =
             test::create_partitioned_csv("aggregate_test_100.csv", num_partitions)?;
 
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
 
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -914,7 +914,7 @@ fn read_files(
                     //println!("ParquetExec got new batch from {}", filename);
                     total_rows += batch.num_rows();
                     send_result(&response_tx, Ok(batch))?;
-                    if limit.map(|l| total_rows > l).unwrap_or(false) {
+                    if limit.map(|l| total_rows >= l).unwrap_or(false) {
                         break 'outer;
                     }
                 }

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -176,8 +176,9 @@ impl DefaultPhysicalPlanner {
                 source,
                 projection,
                 filters,
+                limit,
                 ..
-            } => source.scan(projection, batch_size, filters),
+            } => source.scan(projection, batch_size, filters, *limit),
             LogicalPlan::Aggregate {
                 input,
                 group_expr,

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -197,8 +197,13 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
 
         // pick column c1 and name it column c1 in the output schema
         let projection =

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -271,8 +271,13 @@ mod tests {
         let schema = test::aggr_test_schema();
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
-        let csv =
-            CsvExec::try_new(&path, CsvReadOptions::new().schema(&schema), None, 1024)?;
+        let csv = CsvExec::try_new(
+            &path,
+            CsvReadOptions::new().schema(&schema),
+            None,
+            1024,
+            None,
+        )?;
 
         let sort_exec = Arc::new(SortExec::try_new(
             vec![

--- a/rust/datafusion/tests/custom_sources.rs
+++ b/rust/datafusion/tests/custom_sources.rs
@@ -144,7 +144,7 @@ impl TableProvider for CustomTableProvider {
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
-        _limit: Option<usize>
+        _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CustomExecutionPlan {
             projection: projection.clone(),

--- a/rust/datafusion/tests/custom_sources.rs
+++ b/rust/datafusion/tests/custom_sources.rs
@@ -144,6 +144,7 @@ impl TableProvider for CustomTableProvider {
         projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
+        _limit: Option<usize>
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(CustomExecutionPlan {
             projection: projection.clone(),

--- a/rust/datafusion/tests/provider_filter_pushdown.rs
+++ b/rust/datafusion/tests/provider_filter_pushdown.rs
@@ -106,6 +106,7 @@ impl TableProvider for CustomProvider {
         _: &Option<Vec<usize>>,
         _: usize,
         filters: &[Expr],
+        _: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match &filters[0] {
             Expr::BinaryExpr { right, .. } => {


### PR DESCRIPTION
This PR adds limit push down support.

* Supports push down through projection, other limits and table providers.
* Adds CSV and Parquet support for limit addition to table provider

The idea is to push the limit all the way down to table providers if possible, so when we have a query with a limit, it can be pushed down ( through SELECT, LIMIT, OUTER JOIN and UNION, but we don't support the last two in DataFusion yet) we can skip scanning data after processing at least n rows, or save some processing higher up in the plan. 

Example usage, after this change returns results instantly vs > 1 second without the rule on SF=1:
```
CREATE EXTERNAL TABLE lineitems STORED AS PARQUET LOCATION '/mnt/parquet/lineitem';
SELECT * FROM lineitems LIMIT 1;
```

