### PR TITLE
ARROW-11880: [R] Handle empty or NULL transmute() args properly

### DIFF
--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -508,16 +508,18 @@ mutate.arrow_dplyr_query <- function(.data,
                                      .after = NULL) {
   call <- match.call()
   exprs <- quos(...)
-  if (length(exprs) == 0) {
+
+  .keep <- match.arg(.keep)
+  .before <- enquo(.before)
+  .after <- enquo(.after)
+
+  if (.keep %in% c("all", "unused") && length(exprs) == 0) {
     # Nothing to do
     return(.data)
   }
 
   .data <- arrow_dplyr_query(.data)
 
-  .keep <- match.arg(.keep)
-  .before <- enquo(.before)
-  .after <- enquo(.after)
   # Restrict the cases we support for now
   if (!quo_is_null(.before) || !quo_is_null(.after)) {
     # TODO(ARROW-11701)

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -846,6 +846,38 @@ test_that("mutate() with NULL inputs", {
   )
 })
 
+test_that("empty mutate()", {
+  expect_equal(
+    ds %>%
+      mutate() %>%
+      collect(),
+    ds %>%
+      collect()
+  )
+})
+
+test_that("transmute() with NULL inputs", {
+  expect_equal(
+    ds %>%
+      transmute(int = NULL) %>%
+      collect(),
+    ds %>%
+      select() %>%
+      collect()
+  )
+})
+
+test_that("empty transmute()", {
+  expect_equal(
+    ds %>%
+      transmute() %>%
+      collect(),
+    ds %>%
+      select() %>%
+      collect()
+  )
+})
+
 test_that("filter scalar validation doesn't crash (ARROW-7772)", {
   expect_error(
     ds %>%

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -43,12 +43,48 @@ test_that("basic mutate", {
   )
 })
 
+test_that("mutate() with NULL inputs", {
+  expect_dplyr_equal(
+    input %>%
+      mutate(int = NULL) %>%
+      collect(),
+    tbl
+  )
+})
+
+test_that("empty mutate()", {
+  expect_dplyr_equal(
+    input %>%
+      mutate() %>%
+      collect(),
+    tbl
+  )
+})
+
 test_that("transmute", {
   expect_dplyr_equal(
     input %>%
       select(int, chr) %>%
       filter(int > 5) %>%
       transmute(int = int + 6L) %>%
+      collect(),
+    tbl
+  )
+})
+
+test_that("transmute() with NULL inputs", {
+  expect_dplyr_equal(
+    input %>%
+      transmute(int = NULL) %>%
+      collect(),
+    tbl
+  )
+})
+
+test_that("empty transmute()", {
+  expect_dplyr_equal(
+    input %>%
+      transmute() %>%
       collect(),
     tbl
   )


### PR DESCRIPTION
Previously `transmute()` with no arguments returned `.data`. With the changes here, it now returns zero columns of `.data` for consistency with dplyr.  