### PR TITLE
ARROW-7364: [Rust][DataFusion] Add cast options to cast kernel and TRY_CAST to DataFusion

### DIFF
--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -48,6 +48,15 @@ use crate::{array::*, compute::take};
 use crate::{buffer::Buffer, util::serialization::lexical_to_string};
 use num::{NumCast, ToPrimitive};
 
+/// CastOptions provides a way to override the default cast behaviors
+#[derive(Debug)]
+pub struct CastOptions {
+    /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
+    pub safe: bool,
+}
+
+pub const DEFAULT_CAST_OPTIONS: CastOptions = CastOptions { safe: true };
+
 /// Return true if a value of type `from_type` can be cast into a
 /// value of `to_type`. Note that such as cast may be lossy.
 ///
@@ -254,6 +263,35 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
 /// * Utf8 to boolean
 /// * Interval and duration
 pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
+    cast_with_options(array, to_type, &DEFAULT_CAST_OPTIONS)
+}
+
+/// Cast `array` to the provided data type and return a new Array with
+/// type `to_type`, if possible. It accepts `CastOptions` to allow consumers
+/// to configure cast behavior.
+///
+/// Behavior:
+/// * Boolean to Utf8: `true` => '1', `false` => `0`
+/// * Utf8 to numeric: strings that can't be parsed to numbers return null, float strings
+///   in integer casts return null
+/// * Numeric to boolean: 0 returns `false`, any other value returns `true`
+/// * List to List: the underlying data type is cast
+/// * Primitive to List: a list array with 1 value per slot is created
+/// * Date32 and Date64: precision lost when going to higher interval
+/// * Time32 and Time64: precision lost when going to higher interval
+/// * Timestamp and Date{32|64}: precision lost when going to higher interval
+/// * Temporal to/from backing primitive: zero-copy with data type change
+///
+/// Unsupported Casts
+/// * To or from `StructArray`
+/// * List to primitive
+/// * Utf8 to boolean
+/// * Interval and duration
+pub fn cast_with_options(
+    array: &ArrayRef,
+    to_type: &DataType,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef> {
     use DataType::*;
     let from_type = array.data_type();
 
@@ -262,61 +300,91 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         return Ok(array.clone());
     }
     match (from_type, to_type) {
-        (Struct(_), _) => Err(ArrowError::ComputeError(
+        (Struct(_), _) => Err(ArrowError::CastError(
             "Cannot cast from struct to other types".to_string(),
         )),
-        (_, Struct(_)) => Err(ArrowError::ComputeError(
+        (_, Struct(_)) => Err(ArrowError::CastError(
             "Cannot cast to struct from other types".to_string(),
         )),
-        (List(_), List(ref to)) => cast_list_inner::<i32>(array, to, to_type),
-        (LargeList(_), LargeList(ref to)) => cast_list_inner::<i64>(array, to, to_type),
+        (List(_), List(ref to)) => {
+            cast_list_inner::<i32>(array, to, to_type, cast_options)
+        }
+        (LargeList(_), LargeList(ref to)) => {
+            cast_list_inner::<i64>(array, to, to_type, cast_options)
+        }
         (List(list_from), LargeList(list_to)) => {
             if list_to.data_type() != list_from.data_type() {
-                Err(ArrowError::ComputeError(
+                Err(ArrowError::CastError(
                     "cannot cast list to large-list with different child data".into(),
                 ))
             } else {
-                cast_list_container::<i32, i64>(&**array)
+                cast_list_container::<i32, i64>(&**array, cast_options)
             }
         }
         (LargeList(list_from), List(list_to)) => {
             if list_to.data_type() != list_from.data_type() {
-                Err(ArrowError::ComputeError(
+                Err(ArrowError::CastError(
                     "cannot cast large-list to list with different child data".into(),
                 ))
             } else {
-                cast_list_container::<i64, i32>(&**array)
+                cast_list_container::<i64, i32>(&**array, cast_options)
             }
         }
-        (List(_), _) => Err(ArrowError::ComputeError(
+        (List(_), _) => Err(ArrowError::CastError(
             "Cannot cast list to non-list data types".to_string(),
         )),
-        (_, List(ref to)) => cast_primitive_to_list::<i32>(array, to, to_type),
-        (_, LargeList(ref to)) => cast_primitive_to_list::<i64>(array, to, to_type),
+        (_, List(ref to)) => {
+            cast_primitive_to_list::<i32>(array, to, to_type, cast_options)
+        }
+        (_, LargeList(ref to)) => {
+            cast_primitive_to_list::<i64>(array, to, to_type, cast_options)
+        }
         (Dictionary(index_type, _), _) => match **index_type {
-            DataType::Int8 => dictionary_cast::<Int8Type>(array, to_type),
-            DataType::Int16 => dictionary_cast::<Int16Type>(array, to_type),
-            DataType::Int32 => dictionary_cast::<Int32Type>(array, to_type),
-            DataType::Int64 => dictionary_cast::<Int64Type>(array, to_type),
-            DataType::UInt8 => dictionary_cast::<UInt8Type>(array, to_type),
-            DataType::UInt16 => dictionary_cast::<UInt16Type>(array, to_type),
-            DataType::UInt32 => dictionary_cast::<UInt32Type>(array, to_type),
-            DataType::UInt64 => dictionary_cast::<UInt64Type>(array, to_type),
-            _ => Err(ArrowError::ComputeError(format!(
+            DataType::Int8 => dictionary_cast::<Int8Type>(array, to_type, cast_options),
+            DataType::Int16 => dictionary_cast::<Int16Type>(array, to_type, cast_options),
+            DataType::Int32 => dictionary_cast::<Int32Type>(array, to_type, cast_options),
+            DataType::Int64 => dictionary_cast::<Int64Type>(array, to_type, cast_options),
+            DataType::UInt8 => dictionary_cast::<UInt8Type>(array, to_type, cast_options),
+            DataType::UInt16 => {
+                dictionary_cast::<UInt16Type>(array, to_type, cast_options)
+            }
+            DataType::UInt32 => {
+                dictionary_cast::<UInt32Type>(array, to_type, cast_options)
+            }
+            DataType::UInt64 => {
+                dictionary_cast::<UInt64Type>(array, to_type, cast_options)
+            }
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from dictionary type {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
         },
         (_, Dictionary(index_type, value_type)) => match **index_type {
-            DataType::Int8 => cast_to_dictionary::<Int8Type>(array, value_type),
-            DataType::Int16 => cast_to_dictionary::<Int16Type>(array, value_type),
-            DataType::Int32 => cast_to_dictionary::<Int32Type>(array, value_type),
-            DataType::Int64 => cast_to_dictionary::<Int64Type>(array, value_type),
-            DataType::UInt8 => cast_to_dictionary::<UInt8Type>(array, value_type),
-            DataType::UInt16 => cast_to_dictionary::<UInt16Type>(array, value_type),
-            DataType::UInt32 => cast_to_dictionary::<UInt32Type>(array, value_type),
-            DataType::UInt64 => cast_to_dictionary::<UInt64Type>(array, value_type),
-            _ => Err(ArrowError::ComputeError(format!(
+            DataType::Int8 => {
+                cast_to_dictionary::<Int8Type>(array, value_type, cast_options)
+            }
+            DataType::Int16 => {
+                cast_to_dictionary::<Int16Type>(array, value_type, cast_options)
+            }
+            DataType::Int32 => {
+                cast_to_dictionary::<Int32Type>(array, value_type, cast_options)
+            }
+            DataType::Int64 => {
+                cast_to_dictionary::<Int64Type>(array, value_type, cast_options)
+            }
+            DataType::UInt8 => {
+                cast_to_dictionary::<UInt8Type>(array, value_type, cast_options)
+            }
+            DataType::UInt16 => {
+                cast_to_dictionary::<UInt16Type>(array, value_type, cast_options)
+            }
+            DataType::UInt32 => {
+                cast_to_dictionary::<UInt32Type>(array, value_type, cast_options)
+            }
+            DataType::UInt64 => {
+                cast_to_dictionary::<UInt64Type>(array, value_type, cast_options)
+            }
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from type {:?} to dictionary type {:?} not supported",
                 from_type, to_type,
             ))),
@@ -332,26 +400,26 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             Int64 => cast_numeric_to_bool::<Int64Type>(array),
             Float32 => cast_numeric_to_bool::<Float32Type>(array),
             Float64 => cast_numeric_to_bool::<Float64Type>(array),
-            Utf8 => Err(ArrowError::ComputeError(format!(
+            Utf8 => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
         },
         (Boolean, _) => match to_type {
-            UInt8 => cast_bool_to_numeric::<UInt8Type>(array),
-            UInt16 => cast_bool_to_numeric::<UInt16Type>(array),
-            UInt32 => cast_bool_to_numeric::<UInt32Type>(array),
-            UInt64 => cast_bool_to_numeric::<UInt64Type>(array),
-            Int8 => cast_bool_to_numeric::<Int8Type>(array),
-            Int16 => cast_bool_to_numeric::<Int16Type>(array),
-            Int32 => cast_bool_to_numeric::<Int32Type>(array),
-            Int64 => cast_bool_to_numeric::<Int64Type>(array),
-            Float32 => cast_bool_to_numeric::<Float32Type>(array),
-            Float64 => cast_bool_to_numeric::<Float64Type>(array),
+            UInt8 => cast_bool_to_numeric::<UInt8Type>(array, cast_options),
+            UInt16 => cast_bool_to_numeric::<UInt16Type>(array, cast_options),
+            UInt32 => cast_bool_to_numeric::<UInt32Type>(array, cast_options),
+            UInt64 => cast_bool_to_numeric::<UInt64Type>(array, cast_options),
+            Int8 => cast_bool_to_numeric::<Int8Type>(array, cast_options),
+            Int16 => cast_bool_to_numeric::<Int16Type>(array, cast_options),
+            Int32 => cast_bool_to_numeric::<Int32Type>(array, cast_options),
+            Int64 => cast_bool_to_numeric::<Int64Type>(array, cast_options),
+            Float32 => cast_bool_to_numeric::<Float32Type>(array, cast_options),
+            Float64 => cast_bool_to_numeric::<Float64Type>(array, cast_options),
             Utf8 => {
                 let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
                 Ok(Arc::new(
@@ -361,29 +429,29 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                         .collect::<StringArray>(),
                 ))
             }
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
         },
         (Utf8, _) => match to_type {
             LargeUtf8 => cast_str_container::<i32, i64>(&**array),
-            UInt8 => cast_string_to_numeric::<UInt8Type, i32>(array),
-            UInt16 => cast_string_to_numeric::<UInt16Type, i32>(array),
-            UInt32 => cast_string_to_numeric::<UInt32Type, i32>(array),
-            UInt64 => cast_string_to_numeric::<UInt64Type, i32>(array),
-            Int8 => cast_string_to_numeric::<Int8Type, i32>(array),
-            Int16 => cast_string_to_numeric::<Int16Type, i32>(array),
-            Int32 => cast_string_to_numeric::<Int32Type, i32>(array),
-            Int64 => cast_string_to_numeric::<Int64Type, i32>(array),
-            Float32 => cast_string_to_numeric::<Float32Type, i32>(array),
-            Float64 => cast_string_to_numeric::<Float64Type, i32>(array),
-            Date32 => cast_string_to_date32::<i32>(&**array),
-            Date64 => cast_string_to_date64::<i32>(&**array),
+            UInt8 => cast_string_to_numeric::<UInt8Type, i32>(array, cast_options),
+            UInt16 => cast_string_to_numeric::<UInt16Type, i32>(array, cast_options),
+            UInt32 => cast_string_to_numeric::<UInt32Type, i32>(array, cast_options),
+            UInt64 => cast_string_to_numeric::<UInt64Type, i32>(array, cast_options),
+            Int8 => cast_string_to_numeric::<Int8Type, i32>(array, cast_options),
+            Int16 => cast_string_to_numeric::<Int16Type, i32>(array, cast_options),
+            Int32 => cast_string_to_numeric::<Int32Type, i32>(array, cast_options),
+            Int64 => cast_string_to_numeric::<Int64Type, i32>(array, cast_options),
+            Float32 => cast_string_to_numeric::<Float32Type, i32>(array, cast_options),
+            Float64 => cast_string_to_numeric::<Float64Type, i32>(array, cast_options),
+            Date32 => cast_string_to_date32::<i32>(&**array, cast_options),
+            Date64 => cast_string_to_date64::<i32>(&**array, cast_options),
             Timestamp(TimeUnit::Nanosecond, None) => {
-                cast_string_to_timestamp_ns::<i32>(&**array)
+                cast_string_to_timestamp_ns::<i32>(&**array, cast_options)
             }
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -405,13 +473,26 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                 Ok(Arc::new(
                     array
                         .iter()
-                        .map(|maybe_value| {
-                            maybe_value.and_then(|value| str::from_utf8(value).ok())
+                        .map(|maybe_value| match maybe_value {
+                            Some(value) => {
+                                let result = str::from_utf8(value);
+                                if cast_options.safe {
+                                    Ok(result.ok())
+                                } else {
+                                    Some(result.map_err(|_| {
+                                        ArrowError::CastError(
+                                            "Cannot cast binary to string".to_string(),
+                                        )
+                                    }))
+                                    .transpose()
+                                }
+                            }
+                            None => Ok(None),
                         })
-                        .collect::<StringArray>(),
+                        .collect::<Result<StringArray>>()?,
                 ))
             }
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -432,34 +513,47 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                 Ok(Arc::new(
                     array
                         .iter()
-                        .map(|maybe_value| {
-                            maybe_value.and_then(|value| str::from_utf8(value).ok())
+                        .map(|maybe_value| match maybe_value {
+                            Some(value) => {
+                                let result = str::from_utf8(value);
+                                if cast_options.safe {
+                                    Ok(result.ok())
+                                } else {
+                                    Some(result.map_err(|_| {
+                                        ArrowError::CastError(
+                                            "Cannot cast binary to string".to_string(),
+                                        )
+                                    }))
+                                    .transpose()
+                                }
+                            }
+                            None => Ok(None),
                         })
-                        .collect::<LargeStringArray>(),
+                        .collect::<Result<LargeStringArray>>()?,
                 ))
             }
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
         },
         (LargeUtf8, _) => match to_type {
-            UInt8 => cast_string_to_numeric::<UInt8Type, i64>(array),
-            UInt16 => cast_string_to_numeric::<UInt16Type, i64>(array),
-            UInt32 => cast_string_to_numeric::<UInt32Type, i64>(array),
-            UInt64 => cast_string_to_numeric::<UInt64Type, i64>(array),
-            Int8 => cast_string_to_numeric::<Int8Type, i64>(array),
-            Int16 => cast_string_to_numeric::<Int16Type, i64>(array),
-            Int32 => cast_string_to_numeric::<Int32Type, i64>(array),
-            Int64 => cast_string_to_numeric::<Int64Type, i64>(array),
-            Float32 => cast_string_to_numeric::<Float32Type, i64>(array),
-            Float64 => cast_string_to_numeric::<Float64Type, i64>(array),
-            Date32 => cast_string_to_date32::<i64>(&**array),
-            Date64 => cast_string_to_date64::<i64>(&**array),
+            UInt8 => cast_string_to_numeric::<UInt8Type, i64>(array, cast_options),
+            UInt16 => cast_string_to_numeric::<UInt16Type, i64>(array, cast_options),
+            UInt32 => cast_string_to_numeric::<UInt32Type, i64>(array, cast_options),
+            UInt64 => cast_string_to_numeric::<UInt64Type, i64>(array, cast_options),
+            Int8 => cast_string_to_numeric::<Int8Type, i64>(array, cast_options),
+            Int16 => cast_string_to_numeric::<Int16Type, i64>(array, cast_options),
+            Int32 => cast_string_to_numeric::<Int32Type, i64>(array, cast_options),
+            Int64 => cast_string_to_numeric::<Int64Type, i64>(array, cast_options),
+            Float32 => cast_string_to_numeric::<Float32Type, i64>(array, cast_options),
+            Float64 => cast_string_to_numeric::<Float64Type, i64>(array, cast_options),
+            Date32 => cast_string_to_date32::<i64>(&**array, cast_options),
+            Date64 => cast_string_to_date64::<i64>(&**array, cast_options),
             Timestamp(TimeUnit::Nanosecond, None) => {
-                cast_string_to_timestamp_ns::<i64>(&**array)
+                cast_string_to_timestamp_ns::<i64>(&**array, cast_options)
             }
-            _ => Err(ArrowError::ComputeError(format!(
+            _ => Err(ArrowError::CastError(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -569,7 +663,11 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
 
         // temporal casts
         (Int32, Date32) => cast_array_data::<Date32Type>(array, to_type.clone()),
-        (Int32, Date64) => cast(&cast(array, &DataType::Date32)?, &DataType::Date64),
+        (Int32, Date64) => cast_with_options(
+            &cast_with_options(array, &DataType::Date32, &cast_options)?,
+            &DataType::Date64,
+            &cast_options,
+        ),
         (Int32, Time32(TimeUnit::Second)) => {
             cast_array_data::<Time32SecondType>(array, to_type.clone())
         }
@@ -578,10 +676,18 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         }
         // No support for microsecond/nanosecond with i32
         (Date32, Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
-        (Date32, Int64) => cast(&cast(array, &DataType::Int32)?, &DataType::Int64),
+        (Date32, Int64) => cast_with_options(
+            &cast_with_options(array, &DataType::Int32, cast_options)?,
+            &DataType::Int64,
+            &cast_options,
+        ),
         (Time32(_), Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
         (Int64, Date64) => cast_array_data::<Date64Type>(array, to_type.clone()),
-        (Int64, Date32) => cast(&cast(array, &DataType::Int32)?, &DataType::Date32),
+        (Int64, Date32) => cast_with_options(
+            &cast_with_options(array, &DataType::Int32, &cast_options)?,
+            &DataType::Date32,
+            &cast_options,
+        ),
         // No support for second/milliseconds with i64
         (Int64, Time64(TimeUnit::Microsecond)) => {
             cast_array_data::<Time64MicrosecondType>(array, to_type.clone())
@@ -591,7 +697,11 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         }
 
         (Date64, Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
-        (Date64, Int32) => cast(&cast(array, &DataType::Int64)?, &DataType::Int32),
+        (Date64, Int32) => cast_with_options(
+            &cast_with_options(array, &DataType::Int64, &cast_options)?,
+            &DataType::Int32,
+            &cast_options,
+        ),
         (Time64(_), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
         (Date32, Date64) => {
             let date_array = array.as_any().downcast_ref::<Date32Array>().unwrap();
@@ -811,7 +921,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         // null to primitive/flat types
         (Null, Int32) => Ok(Arc::new(Int32Array::from(vec![None; array.len()]))),
 
-        (_, _) => Err(ArrowError::ComputeError(format!(
+        (_, _) => Err(ArrowError::CastError(format!(
             "Casting from {:?} to {:?} not supported",
             from_type, to_type,
         ))),
@@ -928,6 +1038,7 @@ where
 #[allow(clippy::unnecessary_wraps)]
 fn cast_string_to_numeric<T, Offset: StringOffsetSizeTrait>(
     from: &ArrayRef,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef>
 where
     T: ArrowNumericType,
@@ -937,34 +1048,52 @@ where
         from.as_any()
             .downcast_ref::<GenericStringArray<Offset>>()
             .unwrap(),
-    )))
+        cast_options,
+    )?))
 }
 
 fn string_to_numeric_cast<T, Offset: StringOffsetSizeTrait>(
     from: &GenericStringArray<Offset>,
-) -> PrimitiveArray<T>
+    cast_options: &CastOptions,
+) -> Result<PrimitiveArray<T>>
 where
     T: ArrowNumericType,
     <T as ArrowPrimitiveType>::Native: lexical_core::FromLexical,
 {
-    let iter = (0..from.len()).map(|i| {
-        if from.is_null(i) {
-            None
-        } else {
-            lexical_core::parse(from.value(i).as_bytes()).ok()
-        }
-    });
+    let vec = (0..from.len())
+        .map(|i| {
+            if from.is_null(i) {
+                Ok(None)
+            } else {
+                let string = from.value(i);
+                let result = lexical_core::parse(string.as_bytes());
+                if cast_options.safe {
+                    Ok(result.ok())
+                } else {
+                    Some(result.map_err(|_| {
+                        ArrowError::CastError(format!(
+                            "Cannot cast string '{}' to value of {} type",
+                            string,
+                            std::any::type_name::<T>()
+                        ))
+                    }))
+                    .transpose()
+                }
+            }
+        })
+        .collect::<Result<Vec<Option<_>>>>()?;
     // Benefit:
     //     20% performance improvement
     // Soundness:
     //     The iterator is trustedLen because it comes from an `StringArray`.
-    unsafe { PrimitiveArray::<T>::from_trusted_len_iter(iter) }
+    Ok(unsafe { PrimitiveArray::<T>::from_trusted_len_iter(vec.iter()) })
 }
 
 /// Casts generic string arrays to Date32Array
 #[allow(clippy::unnecessary_wraps)]
 fn cast_string_to_date32<Offset: StringOffsetSizeTrait>(
     array: &dyn Array,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     use chrono::Datelike;
     let string_array = array
@@ -972,23 +1101,37 @@ fn cast_string_to_date32<Offset: StringOffsetSizeTrait>(
         .downcast_ref::<GenericStringArray<Offset>>()
         .unwrap();
 
-    let iter = (0..string_array.len()).map(|i| {
-        if string_array.is_null(i) {
-            None
-        } else {
-            string_array
-                .value(i)
-                .parse::<chrono::NaiveDate>()
-                .map(|date| date.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
-                .ok()
-        }
-    });
+    let vec = (0..string_array.len())
+        .map(|i| {
+            if string_array.is_null(i) {
+                Ok(None)
+            } else {
+                let string = string_array
+                .value(i);
+
+                let result = string
+                    .parse::<chrono::NaiveDate>()
+                    .map(|date| date.num_days_from_ce() - EPOCH_DAYS_FROM_CE);
+
+                if cast_options.safe {
+                    Ok(result.ok())
+                } else {
+                    Some(result.map_err(|_| {
+                        ArrowError::CastError(
+                            format!("Cannot cast string '{}' to value of arrow::datatypes::types::Date32Type type", string),
+                        )
+                    }))
+                    .transpose()
+                }
+            }
+        })
+        .collect::<Result<Vec<Option<i32>>>>()?;
 
     // Benefit:
     //     20% performance improvement
     // Soundness:
     //     The iterator is trustedLen because it comes from an `StringArray`.
-    let array = unsafe { Date32Array::from_trusted_len_iter(iter) };
+    let array = unsafe { Date32Array::from_trusted_len_iter(vec.iter()) };
     Ok(Arc::new(array) as ArrayRef)
 }
 
@@ -996,29 +1139,44 @@ fn cast_string_to_date32<Offset: StringOffsetSizeTrait>(
 #[allow(clippy::unnecessary_wraps)]
 fn cast_string_to_date64<Offset: StringOffsetSizeTrait>(
     array: &dyn Array,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     let string_array = array
         .as_any()
         .downcast_ref::<GenericStringArray<Offset>>()
         .unwrap();
 
-    let iter = (0..string_array.len()).map(|i| {
-        if string_array.is_null(i) {
-            None
-        } else {
-            string_array
-                .value(i)
-                .parse::<chrono::NaiveDateTime>()
-                .map(|datetime| datetime.timestamp_millis())
-                .ok()
-        }
-    });
+    let vec = (0..string_array.len())
+        .map(|i| {
+            if string_array.is_null(i) {
+                Ok(None)
+            } else {
+                let string = string_array
+                .value(i);
+
+                let result = string
+                    .parse::<chrono::NaiveDateTime>()
+                    .map(|datetime| datetime.timestamp_millis());
+
+                if cast_options.safe {
+                    Ok(result.ok())
+                } else {
+                    Some(result.map_err(|_| {
+                        ArrowError::CastError(
+                            format!("Cannot cast string '{}' to value of arrow::datatypes::types::Date64Type type", string),
+                        )
+                    }))
+                    .transpose()
+                }
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>>>()?;
 
     // Benefit:
     //     20% performance improvement
     // Soundness:
     //     The iterator is trustedLen because it comes from an `StringArray`.
-    let array = unsafe { Date64Array::from_trusted_len_iter(iter) };
+    let array = unsafe { Date64Array::from_trusted_len_iter(vec.iter()) };
     Ok(Arc::new(array) as ArrayRef)
 }
 
@@ -1026,25 +1184,33 @@ fn cast_string_to_date64<Offset: StringOffsetSizeTrait>(
 #[allow(clippy::unnecessary_wraps)]
 fn cast_string_to_timestamp_ns<Offset: StringOffsetSizeTrait>(
     array: &dyn Array,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     let string_array = array
         .as_any()
         .downcast_ref::<GenericStringArray<Offset>>()
         .unwrap();
 
-    let iter = (0..string_array.len()).map(|i| {
-        if string_array.is_null(i) {
-            None
-        } else {
-            string_to_timestamp_nanos(string_array.value(i)).ok()
-        }
-    });
+    let vec = (0..string_array.len())
+        .map(|i| {
+            if string_array.is_null(i) {
+                Ok(None)
+            } else {
+                let result = string_to_timestamp_nanos(string_array.value(i));
+                if cast_options.safe {
+                    Ok(result.ok())
+                } else {
+                    Some(result).transpose()
+                }
+            }
+        })
+        .collect::<Result<Vec<Option<i64>>>>()?;
 
     // Benefit:
     //     20% performance improvement
     // Soundness:
     //     The iterator is trustedLen because it comes from an `StringArray`.
-    let array = unsafe { TimestampNanosecondArray::from_trusted_len_iter(iter) };
+    let array = unsafe { TimestampNanosecondArray::from_trusted_len_iter(vec.iter()) };
     Ok(Arc::new(array) as ArrayRef)
 }
 
@@ -1086,17 +1252,24 @@ where
 ///
 /// `false` returns 0 while `true` returns 1
 #[allow(clippy::unnecessary_wraps)]
-fn cast_bool_to_numeric<TO>(from: &ArrayRef) -> Result<ArrayRef>
+fn cast_bool_to_numeric<TO>(
+    from: &ArrayRef,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef>
 where
     TO: ArrowNumericType,
     TO::Native: num::cast::NumCast,
 {
     Ok(Arc::new(bool_to_numeric_cast::<TO>(
         from.as_any().downcast_ref::<BooleanArray>().unwrap(),
+        cast_options,
     )))
 }
 
-fn bool_to_numeric_cast<T>(from: &BooleanArray) -> PrimitiveArray<T>
+fn bool_to_numeric_cast<T>(
+    from: &BooleanArray,
+    _cast_options: &CastOptions,
+) -> PrimitiveArray<T>
 where
     T: ArrowNumericType,
     T::Native: num::NumCast,
@@ -1125,6 +1298,7 @@ where
 fn dictionary_cast<K: ArrowDictionaryKeyType>(
     array: &ArrayRef,
     to_type: &DataType,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     use DataType::*;
 
@@ -1141,8 +1315,9 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
 
             let keys_array: ArrayRef = Arc::new(dict_array.keys_array());
             let values_array: ArrayRef = dict_array.values();
-            let cast_keys = cast(&keys_array, to_index_type)?;
-            let cast_values = cast(&values_array, to_value_type)?;
+            let cast_keys = cast_with_options(&keys_array, to_index_type, &cast_options)?;
+            let cast_values =
+                cast_with_options(&values_array, to_value_type, &cast_options)?;
 
             // Failure to cast keys (because they don't fit in the
             // target type) results in NULL values;
@@ -1181,7 +1356,7 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
                 UInt32 => Arc::new(DictionaryArray::<UInt32Type>::from(data)),
                 UInt64 => Arc::new(DictionaryArray::<UInt64Type>::from(data)),
                 _ => {
-                    return Err(ArrowError::ComputeError(format!(
+                    return Err(ArrowError::CastError(format!(
                         "Unsupported type {:?} for dictionary index",
                         to_index_type
                     )))
@@ -1190,12 +1365,16 @@ fn dictionary_cast<K: ArrowDictionaryKeyType>(
 
             Ok(new_array)
         }
-        _ => unpack_dictionary::<K>(array, to_type),
+        _ => unpack_dictionary::<K>(array, to_type, cast_options),
     }
 }
 
 // Unpack a dictionary where the keys are of type <K> into a flattened array of type to_type
-fn unpack_dictionary<K>(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef>
+fn unpack_dictionary<K>(
+    array: &ArrayRef,
+    to_type: &DataType,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef>
 where
     K: ArrowDictionaryKeyType,
 {
@@ -1210,11 +1389,12 @@ where
 
     // attempt to cast the dict values to the target type
     // use the take kernel to expand out the dictionary
-    let cast_dict_values = cast(&dict_array.values(), to_type)?;
+    let cast_dict_values =
+        cast_with_options(&dict_array.values(), to_type, cast_options)?;
 
     // Note take requires first casting the indices to u32
     let keys_array: ArrayRef = Arc::new(dict_array.keys_array());
-    let indicies = cast(&keys_array, &DataType::UInt32)?;
+    let indicies = cast_with_options(&keys_array, &DataType::UInt32, cast_options)?;
     let u32_indicies =
         indicies
             .as_any()
@@ -1235,21 +1415,54 @@ where
 fn cast_to_dictionary<K: ArrowDictionaryKeyType>(
     array: &ArrayRef,
     dict_value_type: &DataType,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     use DataType::*;
 
     match *dict_value_type {
-        Int8 => pack_numeric_to_dictionary::<K, Int8Type>(array, dict_value_type),
-        Int16 => pack_numeric_to_dictionary::<K, Int16Type>(array, dict_value_type),
-        Int32 => pack_numeric_to_dictionary::<K, Int32Type>(array, dict_value_type),
-        Int64 => pack_numeric_to_dictionary::<K, Int64Type>(array, dict_value_type),
-        UInt8 => pack_numeric_to_dictionary::<K, UInt8Type>(array, dict_value_type),
-        UInt16 => pack_numeric_to_dictionary::<K, UInt16Type>(array, dict_value_type),
-        UInt32 => pack_numeric_to_dictionary::<K, UInt32Type>(array, dict_value_type),
-        UInt64 => pack_numeric_to_dictionary::<K, UInt64Type>(array, dict_value_type),
-        Utf8 => pack_string_to_dictionary::<K>(array),
-        _ => Err(ArrowError::ComputeError(format!(
-            "Internal Error: Unsupported output type for dictionary packing: {:?}",
+        Int8 => pack_numeric_to_dictionary::<K, Int8Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        Int16 => pack_numeric_to_dictionary::<K, Int16Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        Int32 => pack_numeric_to_dictionary::<K, Int32Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        Int64 => pack_numeric_to_dictionary::<K, Int64Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        UInt8 => pack_numeric_to_dictionary::<K, UInt8Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        UInt16 => pack_numeric_to_dictionary::<K, UInt16Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        UInt32 => pack_numeric_to_dictionary::<K, UInt32Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        UInt64 => pack_numeric_to_dictionary::<K, UInt64Type>(
+            array,
+            dict_value_type,
+            cast_options,
+        ),
+        Utf8 => pack_string_to_dictionary::<K>(array, cast_options),
+        _ => Err(ArrowError::CastError(format!(
+            "Unsupported output type for dictionary packing: {:?}",
             dict_value_type
         ))),
     }
@@ -1260,13 +1473,14 @@ fn cast_to_dictionary<K: ArrowDictionaryKeyType>(
 fn pack_numeric_to_dictionary<K, V>(
     array: &ArrayRef,
     dict_value_type: &DataType,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef>
 where
     K: ArrowDictionaryKeyType,
     V: ArrowNumericType,
 {
     // attempt to cast the source array values to the target value type (the dictionary values type)
-    let cast_values = cast(array, &dict_value_type)?;
+    let cast_values = cast_with_options(array, &dict_value_type, cast_options)?;
     let values = cast_values
         .as_any()
         .downcast_ref::<PrimitiveArray<V>>()
@@ -1289,11 +1503,14 @@ where
 
 // Packs the data as a StringDictionaryArray, if possible, with the
 // key types of K
-fn pack_string_to_dictionary<K>(array: &ArrayRef) -> Result<ArrayRef>
+fn pack_string_to_dictionary<K>(
+    array: &ArrayRef,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef>
 where
     K: ArrowDictionaryKeyType,
 {
-    let cast_values = cast(array, &DataType::Utf8)?;
+    let cast_values = cast_with_options(array, &DataType::Utf8, cast_options)?;
     let values = cast_values.as_any().downcast_ref::<StringArray>().unwrap();
 
     let keys_builder = PrimitiveBuilder::<K>::new(values.len());
@@ -1316,9 +1533,10 @@ fn cast_primitive_to_list<OffsetSize: OffsetSizeTrait + NumCast>(
     array: &ArrayRef,
     to: &Field,
     to_type: &DataType,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     // cast primitive to list's primitive
-    let cast_array = cast(array, to.data_type())?;
+    let cast_array = cast_with_options(array, to.data_type(), cast_options)?;
     // create offsets, where if array.len() = 2, we have [0,1,2]
     // Safety:
     // Length of range can be trusted.
@@ -1353,10 +1571,11 @@ fn cast_list_inner<OffsetSize: OffsetSizeTrait>(
     array: &Arc<dyn Array>,
     to: &Field,
     to_type: &DataType,
+    cast_options: &CastOptions,
 ) -> Result<ArrayRef> {
     let data = array.data_ref();
     let underlying_array = make_array(data.child_data()[0].clone());
-    let cast_array = cast(&underlying_array, to.data_type())?;
+    let cast_array = cast_with_options(&underlying_array, to.data_type(), cast_options)?;
     let array_data = ArrayData::new(
         to_type.clone(),
         array.len(),
@@ -1426,6 +1645,7 @@ where
 /// This function can leave the value data intact and only has to cast the offset dtypes.
 fn cast_list_container<OffsetSizeFrom, OffsetSizeTo>(
     array: &dyn Array,
+    _cast_options: &CastOptions,
 ) -> Result<ArrayRef>
 where
     OffsetSizeFrom: OffsetSizeTrait + ToPrimitive,
@@ -1644,7 +1864,23 @@ mod tests {
         assert_eq!(6, c.value(1));
         assert_eq!(false, c.is_valid(2));
         assert_eq!(8, c.value(3));
-        assert_eq!(false, c.is_valid(2));
+        assert_eq!(false, c.is_valid(4));
+    }
+
+    #[test]
+    fn test_cast_with_options_utf8_to_i32() {
+        let a = StringArray::from(vec!["5", "6", "seven", "8", "9.1"]);
+        let array = Arc::new(a) as ArrayRef;
+        let result =
+            cast_with_options(&array, &DataType::Int32, &CastOptions { safe: false });
+        match result {
+            Ok(_) => panic!("expected error"),
+            Err(e) => {
+                assert!(e.to_string().contains(
+                    "Cast error: Cannot cast string 'seven' to value of arrow::datatypes::types::Int32Type type"
+                ))
+            }
+        }
     }
 
     #[test]
@@ -3245,13 +3481,13 @@ mod tests {
                 // check for mismatch
                 match (cast_result, reported_cast_ability) {
                     (Ok(_), false) => {
-                        panic!("Was able to cast array from {:?} to {:?} but can_cast_types reported false",
-                               array.data_type(), to_type)
+                        panic!("Was able to cast array {:?} from {:?} to {:?} but can_cast_types reported false",
+                               array, array.data_type(), to_type)
                     }
                     (Err(e), true) => {
-                        panic!("Was not able to cast array from {:?} to {:?} but can_cast_types reported true. \
+                        panic!("Was not able to cast array {:?} from {:?} to {:?} but can_cast_types reported true. \
                                 Error was {:?}",
-                               array.data_type(), to_type, e)
+                               array, array.data_type(), to_type, e)
                     }
                     // otherwise it was a match
                     _ => {}

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -52,7 +52,7 @@ ahash = "0.7"
 hashbrown = "0.11"
 arrow = { path = "../arrow", version = "4.0.0-SNAPSHOT", features = ["prettyprint"] }
 parquet = { path = "../parquet", version = "4.0.0-SNAPSHOT", features = ["arrow"] }
-sqlparser = "0.8.0"
+sqlparser = "0.9.0"
 clap = "2.33"
 rustyline = {version = "7.0", optional = true}
 paste = "^1.0"

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -160,6 +160,8 @@ DataFusion also includes a simple command-line interactive SQL utility. See the 
 - [x] Limit
 - [x] Aggregate
 - [x] Common math functions
+- [x] cast
+- [x] try_cast
 - Postgres compatible String functions
   - [x] ascii
   - [x] bit_length

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -73,6 +73,7 @@ impl ExpressionVisitor for ColumnNameVisitor<'_> {
             Expr::Between { .. } => {}
             Expr::Case { .. } => {}
             Expr::Cast { .. } => {}
+            Expr::TryCast { .. } => {}
             Expr::Sort { .. } => {}
             Expr::ScalarFunction { .. } => {}
             Expr::ScalarUDF { .. } => {}
@@ -261,6 +262,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<Expr>> {
             Ok(expr_list)
         }
         Expr::Cast { expr, .. } => Ok(vec![expr.as_ref().to_owned()]),
+        Expr::TryCast { expr, .. } => Ok(vec![expr.as_ref().to_owned()]),
         Expr::Column(_) => Ok(vec![]),
         Expr::Alias(expr, ..) => Ok(vec![expr.as_ref().to_owned()]),
         Expr::Literal(_) => Ok(vec![]),
@@ -354,6 +356,10 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
             })
         }
         Expr::Cast { data_type, .. } => Ok(Expr::Cast {
+            expr: Box::new(expressions[0].clone()),
+            data_type: data_type.clone(),
+        }),
+        Expr::TryCast { data_type, .. } => Ok(Expr::TryCast {
             expr: Box::new(expressions[0].clone()),
             data_type: data_type.clone(),
         }),

--- a/rust/datafusion/src/physical_plan/expressions/binary.rs
+++ b/rust/datafusion/src/physical_plan/expressions/binary.rs
@@ -39,7 +39,7 @@ use arrow::record_batch::RecordBatch;
 
 use crate::error::{DataFusionError, Result};
 use crate::logical_plan::Operator;
-use crate::physical_plan::expressions::cast;
+use crate::physical_plan::expressions::try_cast;
 use crate::physical_plan::{ColumnarValue, PhysicalExpr};
 use crate::scalar::ScalarValue;
 
@@ -547,8 +547,8 @@ fn binary_cast(
     let cast_type = common_binary_type(lhs_type, op, rhs_type)?;
 
     Ok((
-        cast(lhs, input_schema, cast_type.clone())?,
-        cast(rhs, input_schema, cast_type)?,
+        try_cast(lhs, input_schema, cast_type.clone())?,
+        try_cast(rhs, input_schema, cast_type)?,
     ))
 }
 

--- a/rust/datafusion/src/physical_plan/expressions/mod.rs
+++ b/rust/datafusion/src/physical_plan/expressions/mod.rs
@@ -42,11 +42,12 @@ mod negative;
 mod not;
 mod nullif;
 mod sum;
+mod try_cast;
 
 pub use average::{avg_return_type, Avg, AvgAccumulator};
 pub use binary::{binary, binary_operator_data_type, BinaryExpr};
 pub use case::{case, CaseExpr};
-pub use cast::{cast, CastExpr};
+pub use cast::{cast, cast_with_options, CastExpr};
 pub use column::{col, Column};
 pub use count::Count;
 pub use in_list::{in_list, InListExpr};
@@ -58,6 +59,7 @@ pub use negative::{negative, NegativeExpr};
 pub use not::{not, NotExpr};
 pub use nullif::{nullif_func, SUPPORTED_NULLIF_TYPES};
 pub use sum::{sum_return_type, Sum};
+pub use try_cast::{try_cast, TryCastExpr};
 /// returns the name of the state
 pub fn format_state_name(name: &str, state_name: &str) -> String {
     format!("{}[{}]", name, state_name)

--- a/rust/datafusion/src/physical_plan/expressions/try_cast.rs
+++ b/rust/datafusion/src/physical_plan/expressions/try_cast.rs
@@ -25,37 +25,23 @@ use crate::physical_plan::PhysicalExpr;
 use crate::scalar::ScalarValue;
 use arrow::compute;
 use arrow::compute::kernels;
-use arrow::compute::CastOptions;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use compute::can_cast_types;
 
-/// provide Datafusion default cast options
-pub const DEFAULT_DATAFUSION_CAST_OPTIONS: CastOptions = CastOptions { safe: false };
-
-/// CAST expression casts an expression to a specific data type and returns a runtime error on invalid cast
+/// TRY_CAST expression casts an expression to a specific data type and retuns NULL on invalid cast
 #[derive(Debug)]
-pub struct CastExpr {
+pub struct TryCastExpr {
     /// The expression to cast
     expr: Arc<dyn PhysicalExpr>,
     /// The data type to cast to
     cast_type: DataType,
-    /// Cast options
-    cast_options: CastOptions,
 }
 
-impl CastExpr {
+impl TryCastExpr {
     /// Create a new CastExpr
-    pub fn new(
-        expr: Arc<dyn PhysicalExpr>,
-        cast_type: DataType,
-        cast_options: CastOptions,
-    ) -> Self {
-        Self {
-            expr,
-            cast_type,
-            cast_options,
-        }
+    pub fn new(expr: Arc<dyn PhysicalExpr>, cast_type: DataType) -> Self {
+        Self { expr, cast_type }
     }
 
     /// The expression to cast
@@ -69,13 +55,13 @@ impl CastExpr {
     }
 }
 
-impl fmt::Display for CastExpr {
+impl fmt::Display for TryCastExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CAST({} AS {:?})", self.expr, self.cast_type)
     }
 }
 
-impl PhysicalExpr for CastExpr {
+impl PhysicalExpr for TryCastExpr {
     /// Return a reference to Any that can be used for downcasting
     fn as_any(&self) -> &dyn Any {
         self
@@ -85,27 +71,20 @@ impl PhysicalExpr for CastExpr {
         Ok(self.cast_type.clone())
     }
 
-    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
-        self.expr.nullable(input_schema)
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        Ok(true)
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
         let value = self.expr.evaluate(batch)?;
         match value {
-            ColumnarValue::Array(array) => {
-                Ok(ColumnarValue::Array(kernels::cast::cast_with_options(
-                    &array,
-                    &self.cast_type,
-                    &self.cast_options,
-                )?))
-            }
+            ColumnarValue::Array(array) => Ok(ColumnarValue::Array(kernels::cast::cast(
+                &array,
+                &self.cast_type,
+            )?)),
             ColumnarValue::Scalar(scalar) => {
                 let scalar_array = scalar.to_array();
-                let cast_array = kernels::cast::cast_with_options(
-                    &scalar_array,
-                    &self.cast_type,
-                    &self.cast_options,
-                )?;
+                let cast_array = kernels::cast::cast(&scalar_array, &self.cast_type)?;
                 let cast_scalar = ScalarValue::try_from_array(&cast_array, 0)?;
                 Ok(ColumnarValue::Scalar(cast_scalar))
             }
@@ -117,40 +96,22 @@ impl PhysicalExpr for CastExpr {
 /// `cast_type`, if any casting is needed.
 ///
 /// Note that such casts may lose type information
-pub fn cast_with_options(
+pub fn try_cast(
     expr: Arc<dyn PhysicalExpr>,
     input_schema: &Schema,
     cast_type: DataType,
-    cast_options: CastOptions,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let expr_type = expr.data_type(input_schema)?;
     if expr_type == cast_type {
         Ok(expr.clone())
     } else if can_cast_types(&expr_type, &cast_type) {
-        Ok(Arc::new(CastExpr::new(expr, cast_type, cast_options)))
+        Ok(Arc::new(TryCastExpr::new(expr, cast_type)))
     } else {
         Err(DataFusionError::Internal(format!(
             "Unsupported CAST from {:?} to {:?}",
             expr_type, cast_type
         )))
     }
-}
-
-/// Return a PhysicalExpression representing `expr` casted to
-/// `cast_type`, if any casting is needed.
-///
-/// Note that such casts may lose type information
-pub fn cast(
-    expr: Arc<dyn PhysicalExpr>,
-    input_schema: &Schema,
-    cast_type: DataType,
-) -> Result<Arc<dyn PhysicalExpr>> {
-    cast_with_options(
-        expr,
-        input_schema,
-        cast_type,
-        DEFAULT_DATAFUSION_CAST_OPTIONS,
-    )
 }
 
 #[cfg(test)]
@@ -171,14 +132,14 @@ mod tests {
     // 4. verify that the resulting expression is of type B
     // 5. verify that the resulting values are downcastable and correct
     macro_rules! generic_test_cast {
-        ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr, $CAST_OPTIONS:expr) => {{
+        ($A_ARRAY:ident, $A_TYPE:expr, $A_VEC:expr, $TYPEARRAY:ident, $TYPE:expr, $VEC:expr) => {{
             let schema = Schema::new(vec![Field::new("a", $A_TYPE, false)]);
             let a = $A_ARRAY::from($A_VEC);
             let batch =
                 RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
             // verify that we can construct the expression
-            let expression = cast_with_options(col("a"), &schema, $TYPE, $CAST_OPTIONS)?;
+            let expression = try_cast(col("a"), &schema, $TYPE)?;
 
             // verify that its display is correct
             assert_eq!(format!("CAST(a AS {:?})", $TYPE), format!("{}", expression));
@@ -225,8 +186,7 @@ mod tests {
                 Some(3_u32),
                 Some(4_u32),
                 Some(5_u32)
-            ],
-            DEFAULT_DATAFUSION_CAST_OPTIONS
+            ]
         );
         Ok(())
     }
@@ -239,8 +199,20 @@ mod tests {
             vec![1, 2, 3, 4, 5],
             StringArray,
             DataType::Utf8,
-            vec![Some("1"), Some("2"), Some("3"), Some("4"), Some("5")],
-            DEFAULT_DATAFUSION_CAST_OPTIONS
+            vec![Some("1"), Some("2"), Some("3"), Some("4"), Some("5")]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_try_cast_utf8_i32() -> Result<()> {
+        generic_test_cast!(
+            StringArray,
+            DataType::Utf8,
+            vec!["a", "2", "3", "b", "5"],
+            Int32Array,
+            DataType::Int32,
+            vec![None, Some(2), Some(3), None, Some(5)]
         );
         Ok(())
     }
@@ -259,8 +231,7 @@ mod tests {
             original.clone(),
             TimestampNanosecondArray,
             DataType::Timestamp(TimeUnit::Nanosecond, None),
-            expected,
-            DEFAULT_DATAFUSION_CAST_OPTIONS
+            expected
         );
         Ok(())
     }
@@ -270,32 +241,7 @@ mod tests {
         // Ensure a useful error happens at plan time if invalid casts are used
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
-        let result = cast(col("a"), &schema, DataType::LargeBinary);
+        let result = try_cast(col("a"), &schema, DataType::LargeBinary);
         result.expect_err("expected Invalid CAST");
-    }
-
-    #[test]
-    fn invalid_cast_with_options_error() -> Result<()> {
-        // Ensure a useful error happens at plan time if invalid casts are used
-        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
-        let a = StringArray::from(vec!["9.1"]);
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
-        let expression = cast_with_options(
-            col("a"),
-            &schema,
-            DataType::Int32,
-            DEFAULT_DATAFUSION_CAST_OPTIONS,
-        )?;
-        let result = expression.evaluate(&batch);
-
-        match result {
-            Ok(_) => panic!("expected error"),
-            Err(e) => {
-                assert!(e.to_string().contains(
-                    "Cast error: Cannot cast string '9.1' to value of arrow::datatypes::types::Int32Type type"
-                ))
-            }
-        }
-        Ok(())
     }
 }

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -35,7 +35,7 @@ use arrow::datatypes::{DataType, Schema, TimeUnit};
 
 use super::{functions::Signature, PhysicalExpr};
 use crate::error::{DataFusionError, Result};
-use crate::physical_plan::expressions::cast;
+use crate::physical_plan::expressions::try_cast;
 
 /// Returns `expressions` coerced to types compatible with
 /// `signature`, if possible.
@@ -56,7 +56,7 @@ pub fn coerce(
     expressions
         .iter()
         .enumerate()
-        .map(|(i, expr)| cast(expr.clone(), &schema, new_types[i].clone()))
+        .map(|(i, expr)| try_cast(expr.clone(), &schema, new_types[i].clone()))
         .collect::<Result<Vec<_>>>()
 }
 
@@ -260,7 +260,7 @@ mod tests {
         let expressions = |t: Vec<DataType>, schema| -> Result<Vec<_>> {
             t.iter()
                 .enumerate()
-                .map(|(i, t)| cast(col(&format!("c{}", i)), &schema, t.clone()))
+                .map(|(i, t)| try_cast(col(&format!("c{}", i)), &schema, t.clone()))
                 .collect::<Result<Vec<_>>>()
         };
 

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -919,6 +919,14 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 data_type: convert_data_type(data_type)?,
             }),
 
+            SQLExpr::TryCast {
+                ref expr,
+                ref data_type,
+            } => Ok(Expr::TryCast {
+                expr: Box::new(self.sql_expr_to_logical_expr(&expr)?),
+                data_type: convert_data_type(data_type)?,
+            }),
+
             SQLExpr::TypedString {
                 ref data_type,
                 ref value,

--- a/rust/datafusion/src/sql/utils.rs
+++ b/rust/datafusion/src/sql/utils.rs
@@ -319,6 +319,13 @@ where
                 expr: Box::new(clone_with_replacement(&**nested_expr, replacement_fn)?),
                 data_type: data_type.clone(),
             }),
+            Expr::TryCast {
+                expr: nested_expr,
+                data_type,
+            } => Ok(Expr::TryCast {
+                expr: Box::new(clone_with_replacement(&**nested_expr, replacement_fn)?),
+                data_type: data_type.clone(),
+            }),
             Expr::Sort {
                 expr: nested_expr,
                 asc,
@@ -328,7 +335,6 @@ where
                 asc: *asc,
                 nulls_first: *nulls_first,
             }),
-
             Expr::Column(_) | Expr::Literal(_) | Expr::ScalarVariable(_) => {
                 Ok(expr.clone())
             }


### PR DESCRIPTION
@andygrove @alamb @nevi-me 

This is my WIP implementation of adding `CastOptions` to the Rust Kernel and changing the default `CastOptions` for DataFusion to be `safe = false`.

From here we have two options:
1. use some sort of feature flag (like Spark) to set the default (see `spark.sql.ansi.enabled` [here](https://spark.apache.org/docs/latest/configuration.html#runtime-sql-configuration)).
2. add a `safe_cast` `expr` to do the same operation but override the default.

Thoughts?