### PR TITLE
ARROW-11942: [C++] If tasks are submitted quickly the thread pool may fail to spin up new threads

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -721,7 +721,7 @@ ExtensionTypeGuard::~ExtensionTypeGuard() {
 
 class GatingTask::Impl {
  public:
-  Impl(double timeout_seconds)
+  explicit Impl(double timeout_seconds)
       : timeout_seconds_(timeout_seconds), status_(), unlocked_(false) {}
 
   ~Impl() {
@@ -790,10 +790,7 @@ class GatingTask::Impl {
   std::condition_variable finished_cv_;
 };
 
-GatingTask::GatingTask(double timeout_seconds)
-    : impl_(new Impl(timeout_seconds)){
-
-      };
+GatingTask::GatingTask(double timeout_seconds) : impl_(new Impl(timeout_seconds)) {}
 
 std::function<void()> GatingTask::Task() { return impl_->Task(); }
 Status GatingTask::Unlock() { return impl_->Unlock(); }

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -26,12 +26,14 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <locale>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -715,6 +717,90 @@ ExtensionTypeGuard::~ExtensionTypeGuard() {
   if (!extension_name_.empty()) {
     ARROW_CHECK_OK(UnregisterExtensionType(extension_name_));
   }
+}
+
+class GatingTask::Impl {
+ public:
+  Impl(double timeout_seconds)
+      : timeout_seconds_(timeout_seconds), status_(), unlocked_(false) {}
+
+  ~Impl() {
+    std::unique_lock<std::mutex> lk(mx_);
+    if (!finished_cv_.wait_for(
+            lk, std::chrono::nanoseconds(static_cast<int64_t>(timeout_seconds_ * 1e9)),
+            [this] { return num_finished_ == num_launched_; })) {
+      ADD_FAILURE()
+          << "A GatingTask instance was destroyed but the underlying tasks did not "
+             "finish running"
+          << std::endl;
+    }
+  }
+
+  std::function<void()> Task() {
+    num_launched_++;
+    return [this] {
+      std::unique_lock<std::mutex> lk(mx_);
+      num_running_++;
+      lk.unlock();
+      running_cv_.notify_all();
+      lk.lock();
+      if (!unlocked_cv_.wait_for(
+              lk, std::chrono::nanoseconds(static_cast<int64_t>(timeout_seconds_ * 1e9)),
+              [this] { return unlocked_; })) {
+        status_ &=
+            Status::Invalid("Timed out (" + std::to_string(timeout_seconds_) + "," +
+                            std::to_string(unlocked_) +
+                            " seconds) waiting for the gating task to be unlocked");
+      }
+      num_finished_++;
+      lk.unlock();
+      finished_cv_.notify_all();
+    };
+  }
+
+  Status WaitForRunning(int count) {
+    std::unique_lock<std::mutex> lk(mx_);
+    if (running_cv_.wait_for(
+            lk, std::chrono::nanoseconds(static_cast<int64_t>(timeout_seconds_ * 1e9)),
+            [this, count] { return num_running_ >= count; })) {
+      return Status::OK();
+    }
+    return Status::Invalid("Timed out waiting for tasks to launch");
+  }
+
+  Status Unlock() {
+    {
+      std::lock_guard<std::mutex> lk(mx_);
+      unlocked_ = true;
+    }
+    unlocked_cv_.notify_all();
+    return status_;
+  }
+
+ private:
+  double timeout_seconds_;
+  Status status_;
+  bool unlocked_;
+  int num_launched_ = 0;
+  int num_running_ = 0;
+  int num_finished_ = 0;
+  std::mutex mx_;
+  std::condition_variable running_cv_;
+  std::condition_variable unlocked_cv_;
+  std::condition_variable finished_cv_;
+};
+
+GatingTask::GatingTask(double timeout_seconds)
+    : impl_(new Impl(timeout_seconds)){
+
+      };
+
+std::function<void()> GatingTask::Task() { return impl_->Task(); }
+Status GatingTask::Unlock() { return impl_->Unlock(); }
+Status GatingTask::WaitForRunning(int count) { return impl_->WaitForRunning(count); }
+GatingTask::~GatingTask() {}
+std::shared_ptr<GatingTask> GatingTask::Make(double timeout_seconds) {
+  return std::make_shared<GatingTask>(timeout_seconds);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -588,7 +588,7 @@ struct MoveOnlyDataType {
 };
 
 // A task that blocks until unlocked.  Useful for timing tests.
-class GatingTask {
+class ARROW_TESTING_EXPORT GatingTask {
  public:
   explicit GatingTask(double timeout_seconds = 10);
   /// \brief During destruction we wait for all pending tasks to finish

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -587,6 +587,32 @@ struct MoveOnlyDataType {
   int moves = 0;
 };
 
+// A task that blocks until unlocked.  Useful for timing tests.
+class GatingTask {
+ public:
+  explicit GatingTask(double timeout_seconds = 10);
+  /// \brief During destruction we wait for all pending tasks to finish
+  ~GatingTask();
+
+  /// \brief Creates a new waiting task (presumably to spawn on a thread).  It will return
+  /// invalid if the timeout arrived before the unlock.  The task will not complete until
+  /// unlocked or timed out
+  ///
+  /// Note: The GatingTask must outlive any Task instances
+  std::function<void()> Task();
+  /// \brief Waits until at least count tasks are running.
+  Status WaitForRunning(int count);
+  /// \brief Unlocks all waiting tasks.  Returns an invalid status if any waiting task has
+  /// timed out
+  Status Unlock();
+
+  static std::shared_ptr<GatingTask> Make(double timeout_seconds = 10);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
 }  // namespace arrow
 
 namespace nonstd {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -62,8 +62,8 @@ struct ThreadPool::State {
   // Desired number of threads
   int desired_capacity_ = 0;
 
-  // Number of threads ready to execute a task immediately
-  int ready_count_ = 0;
+  // Total number of tasks that are either queued or running
+  int tasks_queued_or_running_ = 0;
 
   // Are we shutting down?
   bool please_shutdown_ = false;
@@ -85,7 +85,6 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
     return state->workers_.size() > static_cast<size_t>(state->desired_capacity_);
   };
 
-  ++state->ready_count_;
   while (true) {
     // By the time this thread is started, some tasks may have been pushed
     // or shutdown could even have been requested.  So we only wait on the
@@ -98,8 +97,8 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
       if (should_secede()) {
         break;
       }
-      --state->ready_count_;
-      DCHECK_GE(state->ready_count_, 0);
+
+      DCHECK_GE(state->tasks_queued_or_running_, 0);
       {
         Task task = std::move(state->pending_tasks_.front());
         state->pending_tasks_.pop_front();
@@ -115,7 +114,7 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
         ARROW_UNUSED(std::move(task));  // release resources before waiting for lock
         lock.lock();
       }
-      ++state->ready_count_;
+      state->tasks_queued_or_running_--;
     }
     // Now either the queue is empty *or* a quick shutdown was requested
     if (state->please_shutdown_ || should_secede()) {
@@ -124,8 +123,7 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
     // Wait for next wakeup
     state->cv_.wait(lock);
   }
-  --state->ready_count_;
-  DCHECK_GE(state->ready_count_, 0);
+  DCHECK_GE(state->tasks_queued_or_running_, 0);
 
   // We're done.  Move our thread object to the trashcan of finished
   // workers.  This has two motivations:
@@ -238,7 +236,6 @@ Status ThreadPool::Shutdown(bool wait) {
     state_->pending_tasks_.clear();
   }
   CollectFinishedWorkersUnlocked();
-  DCHECK_EQ(state_->ready_count_, 0);
   return Status::OK();
 }
 
@@ -269,10 +266,10 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken sto
       return Status::Invalid("operation forbidden during or after shutdown");
     }
     CollectFinishedWorkersUnlocked();
-    if (state_->desired_capacity_ > static_cast<int>(state_->workers_.size()) &&
-        state_->ready_count_ == 0) {
-      // Pool capacity is not full and no workers are ready to execute the task,
-      // spawn one more thread.
+    state_->tasks_queued_or_running_++;
+    if (state_->workers_.size() < state_->tasks_queued_or_running_ &&
+        state_->desired_capacity_ > static_cast<int>(state_->workers_.size())) {
+      // We can still spin up more workers so spin up a new worker
       LaunchWorkersUnlocked(/*threads=*/1);
     }
     state_->pending_tasks_.push_back(

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -267,7 +267,7 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken sto
     }
     CollectFinishedWorkersUnlocked();
     state_->tasks_queued_or_running_++;
-    if (state_->workers_.size() < state_->tasks_queued_or_running_ &&
+    if (static_cast<int>(state_->workers_.size()) < state_->tasks_queued_or_running_ &&
         state_->desired_capacity_ > static_cast<int>(state_->workers_.size())) {
       // We can still spin up more workers so spin up a new worker
       LaunchWorkersUnlocked(/*threads=*/1);

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -291,13 +291,20 @@ TEST_F(TestThreadPool, SetCapacity) {
   ASSERT_EQ(pool->GetCapacity(), 3);
   ASSERT_EQ(pool->GetActualCapacity(), 0);
 
-  ASSERT_OK(pool->Spawn(std::bind(SleepFor, /*seconds=*/0.1)));
-  ASSERT_EQ(pool->GetActualCapacity(), 1);
+  auto gating_task = GatingTask::Make();
 
+  ASSERT_OK(pool->Spawn(gating_task->Task()));
+  gating_task->WaitForRunning(1);
+  ASSERT_EQ(pool->GetActualCapacity(), 1);
+  gating_task->Unlock();
+
+  gating_task = GatingTask::Make();
   // Spawn more tasks than the pool capacity
   for (int i = 0; i < 6; ++i) {
-    ASSERT_OK(pool->Spawn(std::bind(SleepFor, /*seconds=*/0.1)));
+    ASSERT_OK(pool->Spawn(gating_task->Task()));
   }
+  gating_task->WaitForRunning(3);
+  SleepFor(0.001);  // Sleep a bit just to make sure it isn't making any threads
   ASSERT_EQ(pool->GetActualCapacity(), 3);  // maxxed out
 
   // The tasks have not finished yet, increasing the desired capacity
@@ -309,20 +316,25 @@ TEST_F(TestThreadPool, SetCapacity) {
   // Thread reaping is eager (but asynchronous)
   ASSERT_OK(pool->SetCapacity(2));
   ASSERT_EQ(pool->GetCapacity(), 2);
+
   // Wait for workers to wake up and secede
+  gating_task->Unlock();
   BusyWait(0.5, [&] { return pool->GetActualCapacity() == 2; });
   ASSERT_EQ(pool->GetActualCapacity(), 2);
 
   // Downsize while tasks are pending
   ASSERT_OK(pool->SetCapacity(5));
   ASSERT_EQ(pool->GetCapacity(), 5);
+  gating_task = GatingTask::Make();
   for (int i = 0; i < 10; ++i) {
-    ASSERT_OK(pool->Spawn(std::bind(SleepFor, /*seconds=*/0.1)));
+    ASSERT_OK(pool->Spawn(gating_task->Task()));
   }
+  ASSERT_OK(gating_task->WaitForRunning(5));
   ASSERT_EQ(pool->GetActualCapacity(), 5);
 
   ASSERT_OK(pool->SetCapacity(2));
   ASSERT_EQ(pool->GetCapacity(), 2);
+  ASSERT_OK(gating_task->Unlock());
   BusyWait(0.5, [&] { return pool->GetActualCapacity() == 2; });
   ASSERT_EQ(pool->GetActualCapacity(), 2);
 

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -294,16 +294,16 @@ TEST_F(TestThreadPool, SetCapacity) {
   auto gating_task = GatingTask::Make();
 
   ASSERT_OK(pool->Spawn(gating_task->Task()));
-  gating_task->WaitForRunning(1);
+  ASSERT_OK(gating_task->WaitForRunning(1));
   ASSERT_EQ(pool->GetActualCapacity(), 1);
-  gating_task->Unlock();
+  ASSERT_OK(gating_task->Unlock());
 
   gating_task = GatingTask::Make();
   // Spawn more tasks than the pool capacity
   for (int i = 0; i < 6; ++i) {
     ASSERT_OK(pool->Spawn(gating_task->Task()));
   }
-  gating_task->WaitForRunning(3);
+  ASSERT_OK(gating_task->WaitForRunning(3));
   SleepFor(0.001);  // Sleep a bit just to make sure it isn't making any threads
   ASSERT_EQ(pool->GetActualCapacity(), 3);  // maxxed out
 
@@ -318,7 +318,7 @@ TEST_F(TestThreadPool, SetCapacity) {
   ASSERT_EQ(pool->GetCapacity(), 2);
 
   // Wait for workers to wake up and secede
-  gating_task->Unlock();
+  ASSERT_OK(gating_task->Unlock());
   BusyWait(0.5, [&] { return pool->GetActualCapacity() == 2; });
   ASSERT_EQ(pool->GetActualCapacity(), 2);
 


### PR DESCRIPTION
Probably only really affects unit tests.  Consider an idle thread pool with 1 thread (ready_count_ == 1).  If `Spawn` is called very quickly it may look like `ready_count_` is still greater than 0 (because `ready_count_` doesn't necessarily decrement by the time `Spawn` returns) and so it will not spin up new threads.

Also, added a `GatingTask` utility which can be used to reduce the sleeps in a test and make them more reliable.