### PR TITLE
ARROW-11951: [Rust] Remove OffsetSize::prefix

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -183,7 +183,9 @@ impl<'a, T: BinaryOffsetSizeTrait> GenericBinaryArray<T> {
 
 impl<OffsetSize: BinaryOffsetSizeTrait> fmt::Debug for GenericBinaryArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}BinaryArray\n[\n", OffsetSize::prefix())?;
+        let prefix = if OffsetSize::is_large() { "Large" } else { "" };
+
+        write!(f, "{}BinaryArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {
             fmt::Debug::fmt(&array.value(index), f)
         })?;

--- a/rust/arrow/src/array/array_string.rs
+++ b/rust/arrow/src/array/array_string.rs
@@ -268,7 +268,9 @@ impl<'a, T: StringOffsetSizeTrait> GenericStringArray<T> {
 
 impl<OffsetSize: StringOffsetSizeTrait> fmt::Debug for GenericStringArray<OffsetSize> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}StringArray\n[\n", OffsetSize::prefix())?;
+        let prefix = if OffsetSize::is_large() { "Large" } else { "" };
+
+        write!(f, "{}StringArray\n[\n", prefix)?;
         print_long_array(self, f, |array, index, f| {
             fmt::Debug::fmt(&array.value(index), f)
         })?;


### PR DESCRIPTION

# Background:
Left over cleanups suggested by from @sunchao on  https://github.com/apache/arrow/pull/9425

Broken out from https://github.com/apache/arrow/pull/9508

# Rationale:
This function is redundant with `OffsetSize::is_large`
