### PR TITLE
ARROW-11740: [C++] posix_memalign not declared in scope on Solaris

### DIFF
--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -24,6 +24,10 @@
 #include <limits>
 #include <memory>
 
+if defined(sun) || defined(__sun)
+#include <stdlib.h>
+#endif
+
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/io_util.h"
@@ -183,8 +187,7 @@ class SystemAllocator {
       return Status::OutOfMemory("malloc of size ", size, " failed");
     }
 #elif defined(sun) || defined(__sun)
-#include <stdlib.h>
-    *out = reinterpret_cast<uint8_t*>(memalign(static_cast<size_t>(size), kAlignment));
+    *out = reinterpret_cast<uint8_t*>(memalign(kAlignment, static_cast<size_t>(size)));
     if (!*out) {
       return Status::OutOfMemory("malloc of size ", size, " failed");
     }

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -182,6 +182,12 @@ class SystemAllocator {
     if (!*out) {
       return Status::OutOfMemory("malloc of size ", size, " failed");
     }
+#elif defined(sun) || defined(__sun)
+#include <stdlib.h>
+    *out = reinterpret_cast<uint8_t*>(memalign(static_cast<size_t>(size), kAlignment));
+    if (!*out) {
+      return Status::OutOfMemory("malloc of size ", size, " failed");
+    }
 #else
     const int result = posix_memalign(reinterpret_cast<void**>(out), kAlignment,
                                       static_cast<size_t>(size));

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -24,7 +24,7 @@
 #include <limits>
 #include <memory>
 
-if defined(sun) || defined(__sun)
+#if defined(sun) || defined(__sun)
 #include <stdlib.h>
 #endif
 


### PR DESCRIPTION
I've confirmed that this compiles on Solaris.