### PR TITLE
ARROW-11959: [Rust][DataFusion] Fix log line

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -356,7 +356,7 @@ impl ExecutionContext {
         for optimizer in optimizers {
             new_plan = optimizer.optimize(&new_plan)?;
         }
-        debug!("Optimized logical plan:\n {:?}", plan);
+        debug!("Optimized logical plan:\n {:?}", new_plan);
         Ok(new_plan)
     }
 


### PR DESCRIPTION
Just a small fix to fix a debug line. It was printing the unoptimized plan instead of the optimized plan.