### PR TITLE
ARROW-11964: [Rust][DataFusion] Extend constant folding and parquet filtering support

### DIFF
--- a/rust/datafusion/src/optimizer/constant_folding.rs
+++ b/rust/datafusion/src/optimizer/constant_folding.rs
@@ -297,7 +297,7 @@ impl<'a> ExprRewriter for ConstantRewriter<'a> {
                     let res = cast(&lit.to_array(), &data_type)?;
                     Expr::Literal(ScalarValue::try_from_array(&res, 0)?)
                 }
-                expr => expr.clone(),
+                expr => expr,
             },
             expr => {
                 // no rewrite possible


### PR DESCRIPTION
This PR enables to use some more constant folding and adds support for `Between` in parquet filtering.

Additionally, it adds some more debug logging.

Before:

```
[2021-03-14T17:23:20Z DEBUG datafusion::execution::context] Optimized logical plan:
     Projection: #SUM(l_extendedprice Multiply l_discount) AS revenue
      Aggregate: groupBy=[[]], aggr=[[SUM(#l_extendedprice Multiply #l_discount)]]
        Filter: #l_shipdate GtEq CAST(Utf8("1994-01-01") AS Date32) And #l_shipdate Lt CAST(Utf8("1995-01-01") AS Date32) And #l_discount BETWEEN Float64(0.06) Minus Float64(0.01) AND Float64(0.06) Plus Float64(0.01) And #l_quantity Lt Int64(24)
          TableScan: lineitem projection=Some([4, 5, 6, 10]), filters=[#l_shipdate GtEq CAST(Utf8("1994-01-01") AS Date32), #l_shipdate Lt CAST(Utf8("1995-01-01") AS Date32), #l_discount BETWEEN Float64(0.06) Minus Float64(0.01) AND Float64(0.06) Plus Float64(0.01), #l_quantity Lt Int64(24)]
```

After:
```
[2021-03-14T17:23:20Z DEBUG datafusion::execution::context] Optimized logical plan:
     Projection: #SUM(l_extendedprice Multiply l_discount) AS revenue
      Aggregate: groupBy=[[]], aggr=[[SUM(#l_extendedprice Multiply #l_discount)]]
        Filter: #l_shipdate GtEq Date32("8766") And #l_shipdate Lt Date32("9131") And #l_discount BETWEEN Float64(0.049999999999999996) AND Float64(0.06999999999999999) And #l_quantity Lt Int64(24)
          TableScan: lineitem projection=Some([4, 5, 6, 10]), filters=[#l_shipdate GtEq Date32("8766"), #l_shipdate Lt Date32("9131"), #l_discount BETWEEN Float64(0.049999999999999996) AND Float64(0.06999999999999999), #l_quantity Lt Int64(24)]
```

Todo: address/fix some tests