### PR TITLE
ARROW-11941: [Dev] Don't update Jira if run "DEBUG=1 merge_arrow_pr.py"

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -195,6 +195,10 @@ class JiraIssue(object):
             self.cmd.fail("JIRA issue %s already has status '%s'"
                           % (self.jira_id, cur_status))
 
+        if DEBUG:
+            print("JIRA issue %s untouched" % (self.jira_id))
+            return
+
         resolve = [x for x in self.jira_con.transitions(self.jira_id)
                    if x['name'] == "Resolve Issue"][0]
 


### PR DESCRIPTION
When environment variable DEBUG=1, merge_arrow_pr.py should only try
the merge steps without updating anything. Though PR status is not
changed, Jira issue is updated even if DEBUG=1. This patch fixes it.