### PR TITLE
ARROW-11745: [C++] Add helper to generate random record batches by schema

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -147,14 +147,14 @@ class MinioFixture : public benchmark::Fixture {
   /// Appends integer columns to the beginning (to act as indices).
   Status MakeParquetObject(const std::string& path, int num_columns, int num_rows) {
     std::vector<std::shared_ptr<ChunkedArray>> columns;
-    FieldVector fields{field("timestamp", int64(), /*nullable=*/true,
-                                      key_value_metadata({{"min", "0"},
-                                                          {"max", "10000000000"},
-                                                          {"null_probability", "0"}})),
-                       ::arrow::field("val", int32(), /*nullable=*/true,
-                                      key_value_metadata({{"min", "0"},
-                                                          {"max", "1000000000"},
-                                                          {"null_probability", "0"}}))};
+    FieldVector fields{
+        field("timestamp", int64(), /*nullable=*/true,
+              key_value_metadata(
+                  {{"min", "0"}, {"max", "10000000000"}, {"null_probability", "0"}})),
+        ::arrow::field(
+            "val", int32(), /*nullable=*/true,
+            key_value_metadata(
+                {{"min", "0"}, {"max", "1000000000"}, {"null_probability", "0"}}))};
     for (int i = 0; i < num_columns; i++) {
       std::stringstream ss;
       ss << "col" << i;

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -36,6 +36,7 @@
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/range.h"
 
 #include "parquet/arrow/reader.h"
@@ -146,32 +147,25 @@ class MinioFixture : public benchmark::Fixture {
   /// Appends integer columns to the beginning (to act as indices).
   Status MakeParquetObject(const std::string& path, int num_columns, int num_rows) {
     std::vector<std::shared_ptr<ChunkedArray>> columns;
-    std::vector<std::shared_ptr<Field>> fields;
-
-    {
-      arrow::random::RandomArrayGenerator generator(0);
-      std::shared_ptr<Array> values = generator.Int64(num_rows, 0, 1e10, 0);
-      columns.push_back(std::make_shared<ChunkedArray>(values));
-      fields.push_back(::arrow::field("timestamp", values->type()));
-    }
-    {
-      arrow::random::RandomArrayGenerator generator(1);
-      std::shared_ptr<Array> values = generator.Int32(num_rows, 0, 1e9, 0);
-      columns.push_back(std::make_shared<ChunkedArray>(values));
-      fields.push_back(::arrow::field("val", values->type()));
-    }
-
+    FieldVector fields{::arrow::field("timestamp", int64(), /*nullable=*/true,
+                                      key_value_metadata({{"min", "0"},
+                                                          {"max", "10000000000"},
+                                                          {"null_probability", "0"}})),
+                       ::arrow::field("val", int32(), /*nullable=*/true,
+                                      key_value_metadata({{"min", "0"},
+                                                          {"max", "1000000000"},
+                                                          {"null_probability", "0"}}))};
     for (int i = 0; i < num_columns; i++) {
-      arrow::random::RandomArrayGenerator generator(i);
-      std::shared_ptr<Array> values = generator.Float64(num_rows, -1.e10, 1e10, 0);
       std::stringstream ss;
       ss << "col" << i;
-      columns.push_back(std::make_shared<ChunkedArray>(values));
-      fields.push_back(::arrow::field(ss.str(), values->type()));
+      fields.push_back(::arrow::field(
+          ss.str(), float64(), /*nullable=*/true,
+          key_value_metadata(
+              {{"min", "-1.e10"}, {"max", "1e10"}, {"null_probability", "0"}})));
     }
-    auto schema = std::make_shared<::arrow::Schema>(fields);
-
-    std::shared_ptr<Table> table = Table::Make(schema, columns);
+    auto batch = random::Generate(fields, num_rows, 0);
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> table,
+                          Table::FromRecordBatches({batch}));
 
     std::shared_ptr<io::OutputStream> sink;
     ARROW_ASSIGN_OR_RAISE(sink, fs_->OpenOutputStream(path));

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -147,7 +147,7 @@ class MinioFixture : public benchmark::Fixture {
   /// Appends integer columns to the beginning (to act as indices).
   Status MakeParquetObject(const std::string& path, int num_columns, int num_rows) {
     std::vector<std::shared_ptr<ChunkedArray>> columns;
-    FieldVector fields{::arrow::field("timestamp", int64(), /*nullable=*/true,
+    FieldVector fields{field("timestamp", int64(), /*nullable=*/true,
                                       key_value_metadata({{"min", "0"},
                                                           {"max", "10000000000"},
                                                           {"null_probability", "0"}})),

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -151,17 +151,16 @@ class MinioFixture : public benchmark::Fixture {
         field("timestamp", int64(), /*nullable=*/true,
               key_value_metadata(
                   {{"min", "0"}, {"max", "10000000000"}, {"null_probability", "0"}})),
-        ::arrow::field(
-            "val", int32(), /*nullable=*/true,
-            key_value_metadata(
-                {{"min", "0"}, {"max", "1000000000"}, {"null_probability", "0"}}))};
+        field("val", int32(), /*nullable=*/true,
+              key_value_metadata(
+                  {{"min", "0"}, {"max", "1000000000"}, {"null_probability", "0"}}))};
     for (int i = 0; i < num_columns; i++) {
       std::stringstream ss;
       ss << "col" << i;
-      fields.push_back(::arrow::field(
-          ss.str(), float64(), /*nullable=*/true,
-          key_value_metadata(
-              {{"min", "-1.e10"}, {"max", "1e10"}, {"null_probability", "0"}})));
+      fields.push_back(
+          field(ss.str(), float64(), /*nullable=*/true,
+                key_value_metadata(
+                    {{"min", "-1.e10"}, {"max", "1e10"}, {"null_probability", "0"}})));
     }
     auto batch = random::GenerateBatch(fields, num_rows, 0);
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> table,

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -163,7 +163,7 @@ class MinioFixture : public benchmark::Fixture {
           key_value_metadata(
               {{"min", "-1.e10"}, {"max", "1e10"}, {"null_probability", "0"}})));
     }
-    auto batch = random::Generate(fields, num_rows, 0);
+    auto batch = random::GenerateBatch(fields, num_rows, 0);
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> table,
                           Table::FromRecordBatches({batch}));
 

--- a/cpp/src/arrow/testing/CMakeLists.txt
+++ b/cpp/src/arrow/testing/CMakeLists.txt
@@ -17,6 +17,10 @@
 
 arrow_install_all_headers("arrow/testing")
 
+if(ARROW_BUILD_TESTS)
+  add_arrow_test(random_test)
+endif()
+
 # json_integration_test is two things at the same time:
 # - an executable that can be called to answer integration test requests
 # - a self-(unit)test for the C++ side of integration testing

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -451,6 +451,7 @@ std::shared_ptr<Array> OffsetsFromLengthsArray(OffsetArrayType* lengths,
       DCHECK_GE(*length, 0);
     } else {
       data[index] = data[index - 1];
+      null_count++;
     }
     index++;
   }

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -620,7 +620,7 @@ Result<std::shared_ptr<Array>> GenerateArray(const Field& field, int64_t length,
     const ARROW_TYPE::c_type max_value = GetMetadata<ARROW_TYPE>(                       \
         field.metadata().get(), "max", std::numeric_limits<ARROW_TYPE::c_type>::max()); \
     const double nan_probability =                                                      \
-        GetMetadata<DoubleType>(field.metadata().get(), "nan_probability", 10);         \
+        GetMetadata<DoubleType>(field.metadata().get(), "nan_probability", 0);          \
     return generator->GENERATOR_FUNC(length, min_value, max_value, null_probability,    \
                                      nan_probability);                                  \
   }
@@ -689,8 +689,8 @@ Result<std::shared_ptr<Array>> GenerateArray(const Field& field, int64_t length,
       GENERATE_INTEGRAL_CASE_VIEW(Int64Type, DayTimeIntervalType);
 
     case Type::type::LIST: {
-      const int32_t values_length =
-          GetMetadata<Int32Type>(field.metadata().get(), "values", length);
+      const int32_t values_length = GetMetadata<Int32Type>(
+          field.metadata().get(), "values", static_cast<int32_t>(length));
       const bool force_empty_nulls =
           GetMetadata<BooleanType>(field.metadata().get(), "force_empty_nulls", false);
       auto values = GenerateArray(
@@ -744,8 +744,8 @@ Result<std::shared_ptr<Array>> GenerateArray(const Field& field, int64_t length,
     }
 
     case Type::type::MAP: {
-      const int32_t values_length =
-          GetMetadata<Int32Type>(field.metadata().get(), "values", length);
+      const int32_t values_length = GetMetadata<Int32Type>(
+          field.metadata().get(), "values", static_cast<int32_t>(length));
       const bool force_empty_nulls =
           GetMetadata<BooleanType>(field.metadata().get(), "force_empty_nulls", false);
       auto map_type = internal::checked_pointer_cast<MapType>(field.type());

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -364,8 +364,9 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
 
 /// Generate a record batch with random data of the specified length.
 ///
-/// Generation options are read from key-value metadata for each field
-/// (including nested fields).
+/// Generation options are read from key-value metadata for each field. Options
+/// are applied recursively, e.g. for list(field(int8())), metadata of the child
+/// field will be used when generating child values.
 ///
 /// The following options are supported:
 ///
@@ -375,13 +376,36 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
 ///
 /// For all numeric types T:
 /// - min (T::c_type): the minimum value to generate (inclusive), default
-/// std::numeric_limits<T::c_type>::min()
+///   std::numeric_limits<T::c_type>::min()
 /// - max (T::c_type): the maximum value to generate (inclusive), default
-/// std::numeric_limits<T::c_type>::max() Note this means that, for example, min/max are
-/// int16_t values for HalfFloatType.
+///   std::numeric_limits<T::c_type>::max()
+/// Note this means that, for example, min/max are int16_t values for HalfFloatType.
 ///
 /// For floating point types T for which is_physical_floating_type<T>:
-/// - nan_probability (double): range [0.0, 1.0]
+/// - nan_probability (double): range [0.0, 1.0] the probability of a NaN value.
+///
+/// For BooleanType:
+/// - true_probability (double): range [0.0, 1.0] the probability of a true.
+///
+/// For DictionaryType:
+/// - values (int32_t): the size of the dictionary.
+/// Other properties are passed to the generator for the dictionary indices. However, min
+/// and max cannot be specified. Note it is not possible to otherwise customize the
+/// generation of dictionary values.
+///
+/// For list, string, and binary types T, including their large variants:
+/// - min_length (T::offset_type): the minimum length of the child to generate,
+///   default 0
+/// - max_length (T::offset_type): the minimum length of the child to generate,
+///   default 1024
+///
+/// For string and binary types T (not including their large variants):
+/// - unique (int32_t): if positive, this many distinct values will be generated
+///   and all array values will be one of these values, default -1
+///
+/// For MapType:
+/// - values (int32_t): the number of key-value pairs to generate, which will be
+///   partitioned among the array values.
 ARROW_TESTING_EXPORT
 std::shared_ptr<arrow::RecordBatch> GenerateBatch(const FieldVector& fields, int64_t size,
                                                   SeedType seed);

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -249,6 +249,10 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
                                  double null_probability = 0,
                                  bool force_empty_nulls = false);
 
+  std::shared_ptr<Array> LargeOffsets(int64_t size, int64_t first_offset,
+                                      int64_t last_offset, double null_probability = 0,
+                                      bool force_empty_nulls = false);
+
   /// \brief Generate a random StringArray
   ///
   /// \param[in] size the size of the array to generate
@@ -357,6 +361,10 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   std::uniform_int_distribution<SeedType> seed_distribution_;
   std::default_random_engine seed_rng_;
 };
+
+ARROW_TESTING_EXPORT
+std::shared_ptr<arrow::RecordBatch> Generate(const FieldVector& fields, int64_t size,
+                                             SeedType seed);
 
 }  // namespace random
 

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -363,7 +363,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
 };
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<arrow::RecordBatch> Generate(const FieldVector& fields, int64_t size,
+std::shared_ptr<arrow::RecordBatch> GenerateBatch(const FieldVector& fields, int64_t size,
                                              SeedType seed);
 
 }  // namespace random

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -362,9 +362,34 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   std::default_random_engine seed_rng_;
 };
 
+/// Generate a record batch with random data of the specified length.
+///
+/// Generation options are read from key-value metadata for each field
+/// (including nested fields).
+///
+/// The following options are supported:
+///
+/// For all types except NullType:
+/// - null_probability (double): range [0.0, 1.0] the probability of a null value.
+/// Default/value is 0.0 if the field is marked non-nullable, else it is 0.01
+///
+/// For all numeric types T:
+/// - min (T::c_type): the minimum value to generate (inclusive), default
+/// std::numeric_limits<T::c_type>::min()
+/// - max (T::c_type): the maximum value to generate (inclusive), default
+/// std::numeric_limits<T::c_type>::max() Note this means that, for example, min/max are
+/// int16_t values for HalfFloatType.
+///
+/// For floating point types T for which is_physical_floating_type<T>:
+/// - nan_probability (double): range [0.0, 1.0]
 ARROW_TESTING_EXPORT
 std::shared_ptr<arrow::RecordBatch> GenerateBatch(const FieldVector& fields, int64_t size,
-                                             SeedType seed);
+                                                  SeedType seed);
+
+/// Generate an array with random data. See GenerateBatch for usage info.
+ARROW_TESTING_EXPORT
+std::shared_ptr<arrow::Array> GenerateArray(const Field& field, int64_t size,
+                                            SeedType seed);
 
 }  // namespace random
 

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -355,6 +355,57 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   std::shared_ptr<Array> ArrayOf(std::shared_ptr<DataType> type, int64_t size,
                                  double null_probability);
 
+  /// \brief Generate an array with random data based on the given field. See BatchOf
+  /// for usage info.
+  std::shared_ptr<Array> ArrayOf(const Field& field, int64_t size);
+
+  /// \brief Generate a record batch with random data of the specified length.
+  ///
+  /// Generation options are read from key-value metadata for each field, and may be
+  /// specified at any nesting level. For example, generation options for the child
+  /// values of a list array can be specified by constructing the list type with
+  /// list(field("item", int8(), options_metadata))
+  ///
+  /// The following options are supported:
+  ///
+  /// For all types except NullType:
+  /// - null_probability (double): range [0.0, 1.0] the probability of a null value.
+  /// Default/value is 0.0 if the field is marked non-nullable, else it is 0.01
+  ///
+  /// For all numeric types T:
+  /// - min (T::c_type): the minimum value to generate (inclusive), default
+  ///   std::numeric_limits<T::c_type>::min()
+  /// - max (T::c_type): the maximum value to generate (inclusive), default
+  ///   std::numeric_limits<T::c_type>::max()
+  /// Note this means that, for example, min/max are int16_t values for HalfFloatType.
+  ///
+  /// For floating point types T for which is_physical_floating_type<T>:
+  /// - nan_probability (double): range [0.0, 1.0] the probability of a NaN value.
+  ///
+  /// For BooleanType:
+  /// - true_probability (double): range [0.0, 1.0] the probability of a true.
+  ///
+  /// For DictionaryType:
+  /// - values (int32_t): the size of the dictionary.
+  /// Other properties are passed to the generator for the dictionary indices. However,
+  /// min and max cannot be specified. Note it is not possible to otherwise customize
+  /// the generation of dictionary values.
+  ///
+  /// For list, string, and binary types T, including their large variants:
+  /// - min_length (T::offset_type): the minimum length of the child to generate,
+  ///   default 0
+  /// - max_length (T::offset_type): the minimum length of the child to generate,
+  ///   default 1024
+  ///
+  /// For string and binary types T (not including their large variants):
+  /// - unique (int32_t): if positive, this many distinct values will be generated
+  ///   and all array values will be one of these values, default -1
+  ///
+  /// For MapType:
+  /// - values (int32_t): the number of key-value pairs to generate, which will be
+  ///   partitioned among the array values.
+  std::shared_ptr<arrow::RecordBatch> BatchOf(const FieldVector& fields, int64_t size);
+
   SeedType seed() { return seed_distribution_(seed_rng_); }
 
  private:
@@ -362,56 +413,12 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   std::default_random_engine seed_rng_;
 };
 
-/// Generate a record batch with random data of the specified length.
-///
-/// Generation options are read from key-value metadata for each field, and may be
-/// specified at any nesting level. For example, generation options for the child values
-/// of a list array can be specified by constructing the list type with
-/// list(field("item", int8(), options_metadata))
-///
-/// The following options are supported:
-///
-/// For all types except NullType:
-/// - null_probability (double): range [0.0, 1.0] the probability of a null value.
-/// Default/value is 0.0 if the field is marked non-nullable, else it is 0.01
-///
-/// For all numeric types T:
-/// - min (T::c_type): the minimum value to generate (inclusive), default
-///   std::numeric_limits<T::c_type>::min()
-/// - max (T::c_type): the maximum value to generate (inclusive), default
-///   std::numeric_limits<T::c_type>::max()
-/// Note this means that, for example, min/max are int16_t values for HalfFloatType.
-///
-/// For floating point types T for which is_physical_floating_type<T>:
-/// - nan_probability (double): range [0.0, 1.0] the probability of a NaN value.
-///
-/// For BooleanType:
-/// - true_probability (double): range [0.0, 1.0] the probability of a true.
-///
-/// For DictionaryType:
-/// - values (int32_t): the size of the dictionary.
-/// Other properties are passed to the generator for the dictionary indices. However, min
-/// and max cannot be specified. Note it is not possible to otherwise customize the
-/// generation of dictionary values.
-///
-/// For list, string, and binary types T, including their large variants:
-/// - min_length (T::offset_type): the minimum length of the child to generate,
-///   default 0
-/// - max_length (T::offset_type): the minimum length of the child to generate,
-///   default 1024
-///
-/// For string and binary types T (not including their large variants):
-/// - unique (int32_t): if positive, this many distinct values will be generated
-///   and all array values will be one of these values, default -1
-///
-/// For MapType:
-/// - values (int32_t): the number of key-value pairs to generate, which will be
-///   partitioned among the array values.
+/// Generate an array with random data. See RandomArrayGenerator::BatchOf.
 ARROW_TESTING_EXPORT
 std::shared_ptr<arrow::RecordBatch> GenerateBatch(const FieldVector& fields, int64_t size,
                                                   SeedType seed);
 
-/// Generate an array with random data. See GenerateBatch for usage info.
+/// Generate an array with random data. See RandomArrayGenerator::BatchOf.
 ARROW_TESTING_EXPORT
 std::shared_ptr<arrow::Array> GenerateArray(const Field& field, int64_t size,
                                             SeedType seed);

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -364,9 +364,10 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
 
 /// Generate a record batch with random data of the specified length.
 ///
-/// Generation options are read from key-value metadata for each field. Options
-/// are applied recursively, e.g. for list(field(int8())), metadata of the child
-/// field will be used when generating child values.
+/// Generation options are read from key-value metadata for each field, and may be
+/// specified at any nesting level. For example, generation options for the child values
+/// of a list array can be specified by constructing the list type with
+/// list(field("item", int8(), options_metadata))
 ///
 /// The following options are supported:
 ///

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -44,7 +44,15 @@ class RandomNumericArrayTest : public ::testing::Test {
 
 TEST_P(RandomArrayTest, GenerateArray) {
   auto field = GetField();
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto array = GenerateArray(*field, 128, 0xDEADBEEF);
+  AssertTypeEqual(field->type(), array->type());
+  ASSERT_EQ(128, array->length());
+  ASSERT_OK(array->ValidateFull());
+}
+
+TEST_P(RandomArrayTest, GenerateBatch) {
+  auto field = GetField();
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = batch->column(0);
   ASSERT_EQ(128, array->length());
@@ -57,7 +65,7 @@ TEST_P(RandomArrayTest, GenerateArrayWithZeroNullProbability) {
   if (field->type()->id() == Type::type::NA) {
     GTEST_SKIP() << "Cannot generate non-null null arrays";
   }
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = batch->column(0);
   ASSERT_OK(array->ValidateFull());
@@ -69,13 +77,12 @@ TEST_P(RandomArrayTest, GenerateNonNullableArray) {
   if (field->type()->id() == Type::type::NA) {
     GTEST_SKIP() << "Cannot generate non-null null arrays";
   }
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = batch->column(0);
   ASSERT_OK(array->ValidateFull());
   ASSERT_EQ(0, array->null_count());
 }
-
 
 auto values = ::testing::Values(
     field("null", null()), field("bool", boolean()), field("uint8", uint8()),
@@ -137,20 +144,20 @@ TYPED_TEST_SUITE(RandomNumericArrayTest, NumericTypes);
 TYPED_TEST(RandomNumericArrayTest, GenerateMinMax) {
   auto field = this->GetField()->WithMetadata(
       key_value_metadata({{"min", "0"}, {"max", "127"}, {"nan_probability", "0.0"}}));
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = this->Downcast(batch->column(0));
   for (auto slot : *array) {
     if (!slot.has_value()) continue;
-    ASSERT_GE(slot, 0);
-    ASSERT_LE(slot, 127);
+    ASSERT_GE(slot, typename TypeParam::c_type(0));
+    ASSERT_LE(slot, typename TypeParam::c_type(127));
   }
 }
 
 TEST(TypeSpecificTests, FloatNan) {
   auto field = arrow::field("float32", float32())
                    ->WithMetadata(key_value_metadata({{"nan_probability", "1.0"}}));
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = internal::checked_pointer_cast<NumericArray<FloatType>>(batch->column(0));
   auto it = array->begin();
@@ -165,10 +172,9 @@ TEST(TypeSpecificTests, FloatNan) {
 TEST(TypeSpecificTests, RepeatedStrings) {
   auto field =
       arrow::field("string", utf8())->WithMetadata(key_value_metadata({{"unique", "1"}}));
-  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  auto batch = GenerateBatch({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = internal::checked_pointer_cast<StringArray>(batch->column(0));
-  auto it = array->begin();
   util::string_view singular_value = array->GetView(0);
   for (auto slot : *array) {
     if (!slot.has_value()) continue;

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -141,16 +141,16 @@ using NumericTypes =
 TYPED_TEST_SUITE(RandomNumericArrayTest, NumericTypes);
 
 TYPED_TEST(RandomNumericArrayTest, GenerateMinMax) {
-  auto field =
-      this->GetField()->WithMetadata(key_value_metadata({{"min", "0"}, {"max", "127"}}));
+  auto field = this->GetField()->WithMetadata(
+      key_value_metadata({{"min", "0"}, {"max", "127"}, {"nan_probability", "0.0"}}));
   auto batch = Generate({field}, 128, 0xDEADBEEF);
   AssertSchemaEqual(schema({field}), batch->schema());
   auto array = this->Downcast(batch->column(0));
   auto it = array->begin();
   while (it != array->end()) {
-    if ((*it).has_value() && !std::isnan(**it)) {
-      ASSERT_GE(**it, 0);
-      ASSERT_LE(**it, 128);
+    if ((*it).has_value()) {
+      ASSERT_GE(**it, typename TypeParam::c_type(0));
+      ASSERT_LE(**it, typename TypeParam::c_type(127));
     }
     it++;
   }

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/array.h"
+#include "arrow/record_batch.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
+
+namespace arrow {
+namespace random {
+
+class RandomArrayTest : public ::testing::TestWithParam<std::shared_ptr<Field>> {
+ protected:
+  std::shared_ptr<Field> GetField() { return GetParam(); }
+};
+
+template <typename T>
+class RandomNumericArrayTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<Field> GetField() { return field("field0", std::make_shared<T>()); }
+
+  std::shared_ptr<NumericArray<T>> Downcast(std::shared_ptr<Array> array) {
+    return internal::checked_pointer_cast<NumericArray<T>>(array);
+  }
+};
+
+TEST_P(RandomArrayTest, GenerateArray) {
+  auto field = GetField();
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = batch->column(0);
+  ASSERT_EQ(128, array->length());
+  ASSERT_OK(array->ValidateFull());
+}
+
+TEST_P(RandomArrayTest, GenerateNonNullArray) {
+  auto field =
+      GetField()->WithMetadata(key_value_metadata({{"null_probability", "0.0"}}));
+  if (field->type()->id() == Type::type::NA) {
+    GTEST_SKIP() << "Cannot generate non-null null arrays";
+  }
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = batch->column(0);
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(0, array->null_count());
+}
+
+TEST_P(RandomArrayTest, GenerateNonNullableArray) {
+  auto field = GetField()->WithNullable(false);
+  if (field->type()->id() == Type::type::NA) {
+    GTEST_SKIP() << "Cannot generate non-null null arrays";
+  }
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = batch->column(0);
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(0, array->null_count());
+}
+
+struct FieldParamName {
+  template <class ParamType>
+  std::string operator()(const ::testing::TestParamInfo<ParamType>& info) const {
+    return std::to_string(info.index) + info.param->name();
+  }
+};
+
+auto values = ::testing::Values(
+    field("null", null()), field("bool", boolean()), field("uint8", uint8()),
+    field("int8", int8()), field("uint16", uint16()), field("int16", int16()),
+    field("uint32", uint32()), field("int32", int32()), field("uint64", uint64()),
+    field("int64", int64()), field("float16", float16()), field("float32", float32()),
+    field("float64", float64()), field("string", utf8()), field("binary", binary()),
+    field("fixed_size_binary", fixed_size_binary(8)),
+    field("decimal128", decimal128(8, 3)), field("decimal256", decimal256(16, 4)),
+    field("date32", date32()), field("date64", date64()),
+    field("timestampns", timestamp(TimeUnit::NANO)),
+    field("timestamps", timestamp(TimeUnit::SECOND, "America/Phoenix")),
+    field("time32ms", time32(TimeUnit::MILLI)), field("time64ns", time64(TimeUnit::NANO)),
+    field("time32s", time32(TimeUnit::SECOND)),
+    field("time64us", time64(TimeUnit::MICRO)), field("month_interval", month_interval()),
+    field("daytime_interval", day_time_interval()), field("listint8", list(int8())),
+    field("listlistint8", list(list(int8()))),
+    field("listint8emptynulls", list(int8()), true,
+          key_value_metadata({{"force_empty_nulls", "true"}})),
+    field("listint81024values", list(int8()), true,
+          key_value_metadata({{"values", "1024"}})),
+    field("structints", struct_({
+                            field("int8", int8()),
+                            field("int16", int16()),
+                            field("int32", int32()),
+                        })),
+    field("structnested", struct_({
+                              field("string", utf8()),
+                              field("list", list(int64())),
+                              field("timestamp", timestamp(TimeUnit::MILLI)),
+                          })),
+    field("sparseunion", sparse_union({
+                             field("int8", int8()),
+                             field("int16", int16()),
+                             field("int32", int32()),
+                         })),
+    field("denseunion", dense_union({
+                            field("int8", int8()),
+                            field("int16", int16()),
+                            field("int32", int32()),
+                        })),
+    field("dictionary", dictionary(int8(), utf8())), field("map", map(int8(), utf8())),
+    field("fixedsizelist", fixed_size_list(int8(), 4)),
+    field("durationns", duration(TimeUnit::NANO)), field("largestring", large_utf8()),
+    field("largebinary", large_binary()),
+    field("largelistlistint8", large_list(list(int8()))));
+
+INSTANTIATE_TEST_SUITE_P(
+    TestRandomArrayGeneration, RandomArrayTest, values,
+    [](const ::testing::TestParamInfo<RandomArrayTest::ParamType>& info) {
+      return std::to_string(info.index) + info.param->name();
+    });
+
+using NumericTypes =
+    ::testing::Types<UInt8Type, Int8Type, UInt16Type, Int16Type, UInt32Type, Int32Type,
+                     HalfFloatType, FloatType, DoubleType>;
+TYPED_TEST_SUITE(RandomNumericArrayTest, NumericTypes);
+
+TYPED_TEST(RandomNumericArrayTest, GenerateMinMax) {
+  auto field =
+      this->GetField()->WithMetadata(key_value_metadata({{"min", "0"}, {"max", "127"}}));
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = this->Downcast(batch->column(0));
+  auto it = array->begin();
+  while (it != array->end()) {
+    if ((*it).has_value() && !std::isnan(**it)) {
+      ASSERT_GE(**it, 0);
+      ASSERT_LE(**it, 128);
+    }
+    it++;
+  }
+}
+
+TEST(TypeSpecificTests, FloatNan) {
+  auto field = arrow::field("float32", float32())
+                   ->WithMetadata(key_value_metadata({{"nan_probability", "1.0"}}));
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = internal::checked_pointer_cast<NumericArray<FloatType>>(batch->column(0));
+  auto it = array->begin();
+  while (it != array->end()) {
+    if ((*it).has_value()) {
+      ASSERT_TRUE(std::isnan(**it));
+    }
+    it++;
+  }
+}
+
+TEST(TypeSpecificTests, RepeatedStrings) {
+  auto field =
+      arrow::field("string", utf8())->WithMetadata(key_value_metadata({{"unique", "1"}}));
+  auto batch = Generate({field}, 128, 0xDEADBEEF);
+  AssertSchemaEqual(schema({field}), batch->schema());
+  auto array = internal::checked_pointer_cast<StringArray>(batch->column(0));
+  auto it = array->begin();
+  util::optional<util::string_view> singular_value;
+  while (it != array->end()) {
+    if ((*it).has_value()) {
+      if (!singular_value.has_value()) {
+        singular_value = *it;
+      } else {
+        ASSERT_EQ(*singular_value, **it);
+      }
+    }
+    it++;
+  }
+}
+
+}  // namespace random
+}  // namespace arrow

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -169,8 +169,8 @@ TYPED_TEST(RandomNumericArrayTest, GenerateMinMax) {
 
 // Test all the supported options
 TEST(TypeSpecificTests, BoolTrueProbability) {
-  auto field = arrow::field("bool", boolean())
-                   ->WithMetadata(key_value_metadata({{"true_probability", "1.0"}}));
+  auto field =
+      arrow::field("bool", boolean(), key_value_metadata({{"true_probability", "1.0"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<BooleanArray>(base_array);
@@ -181,8 +181,8 @@ TEST(TypeSpecificTests, BoolTrueProbability) {
 }
 
 TEST(TypeSpecificTests, DictionaryValues) {
-  auto field = arrow::field("dictionary", dictionary(int8(), utf8()))
-                   ->WithMetadata(key_value_metadata({{"values", "16"}}));
+  auto field = arrow::field("dictionary", dictionary(int8(), utf8()),
+                            key_value_metadata({{"values", "16"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<DictionaryArray>(base_array);
@@ -191,8 +191,8 @@ TEST(TypeSpecificTests, DictionaryValues) {
 }
 
 TEST(TypeSpecificTests, Float32Nan) {
-  auto field = arrow::field("float32", float32())
-                   ->WithMetadata(key_value_metadata({{"nan_probability", "1.0"}}));
+  auto field = arrow::field("float32", float32(),
+                            key_value_metadata({{"nan_probability", "1.0"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<NumericArray<FloatType>>(base_array);
@@ -203,8 +203,8 @@ TEST(TypeSpecificTests, Float32Nan) {
 }
 
 TEST(TypeSpecificTests, Float64Nan) {
-  auto field = arrow::field("float64", float64())
-                   ->WithMetadata(key_value_metadata({{"nan_probability", "1.0"}}));
+  auto field = arrow::field("float64", float64(),
+                            key_value_metadata({{"nan_probability", "1.0"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<NumericArray<DoubleType>>(base_array);
@@ -216,9 +216,9 @@ TEST(TypeSpecificTests, Float64Nan) {
 
 TEST(TypeSpecificTests, ListLengths) {
   {
-    auto field = arrow::field("list", list(int8()))
-                     ->WithMetadata(
-                         key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
+    auto field =
+        arrow::field("list", list(int8()),
+                     key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<ListArray>(base_array);
@@ -230,9 +230,9 @@ TEST(TypeSpecificTests, ListLengths) {
     }
   }
   {
-    auto field = arrow::field("list", large_list(int8()))
-                     ->WithMetadata(key_value_metadata(
-                         {{"min_length", "10"}, {"max_length", "10"}}));
+    auto field =
+        arrow::field("list", large_list(int8()),
+                     key_value_metadata({{"min_length", "10"}, {"max_length", "10"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<LargeListArray>(base_array);
@@ -246,8 +246,8 @@ TEST(TypeSpecificTests, ListLengths) {
 }
 
 TEST(TypeSpecificTests, MapValues) {
-  auto field = arrow::field("map", map(int8(), int8()))
-                   ->WithMetadata(key_value_metadata({{"values", "4"}}));
+  auto field =
+      arrow::field("map", map(int8(), int8()), key_value_metadata({{"values", "4"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<MapArray>(base_array);
@@ -257,8 +257,7 @@ TEST(TypeSpecificTests, MapValues) {
 }
 
 TEST(TypeSpecificTests, RepeatedStrings) {
-  auto field =
-      arrow::field("string", utf8())->WithMetadata(key_value_metadata({{"unique", "1"}}));
+  auto field = arrow::field("string", utf8(), key_value_metadata({{"unique", "1"}}));
   auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
   AssertTypeEqual(field->type(), base_array->type());
   auto array = internal::checked_pointer_cast<StringArray>(base_array);
@@ -273,9 +272,8 @@ TEST(TypeSpecificTests, RepeatedStrings) {
 
 TEST(TypeSpecificTests, StringLengths) {
   {
-    auto field = arrow::field("list", utf8())
-                     ->WithMetadata(
-                         key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
+    auto field = arrow::field(
+        "list", utf8(), key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<StringArray>(base_array);
@@ -287,9 +285,8 @@ TEST(TypeSpecificTests, StringLengths) {
     }
   }
   {
-    auto field = arrow::field("list", binary())
-                     ->WithMetadata(
-                         key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
+    auto field = arrow::field(
+        "list", binary(), key_value_metadata({{"min_length", "1"}, {"max_length", "1"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<BinaryArray>(base_array);
@@ -301,9 +298,9 @@ TEST(TypeSpecificTests, StringLengths) {
     }
   }
   {
-    auto field = arrow::field("list", large_utf8())
-                     ->WithMetadata(key_value_metadata(
-                         {{"min_length", "10"}, {"max_length", "10"}}));
+    auto field =
+        arrow::field("list", large_utf8(),
+                     key_value_metadata({{"min_length", "10"}, {"max_length", "10"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<LargeStringArray>(base_array);
@@ -315,9 +312,9 @@ TEST(TypeSpecificTests, StringLengths) {
     }
   }
   {
-    auto field = arrow::field("list", large_binary())
-                     ->WithMetadata(key_value_metadata(
-                         {{"min_length", "10"}, {"max_length", "10"}}));
+    auto field =
+        arrow::field("list", large_binary(),
+                     key_value_metadata({{"min_length", "10"}, {"max_length", "10"}}));
     auto base_array = GenerateArray(*field, kExpectedLength, 0xDEADBEEF);
     AssertTypeEqual(field->type(), base_array->type());
     auto array = internal::checked_pointer_cast<LargeBinaryArray>(base_array);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2233,6 +2233,12 @@ std::shared_ptr<Field> field(std::string name, std::shared_ptr<DataType> type,
                                  std::move(metadata));
 }
 
+std::shared_ptr<Field> field(std::string name, std::shared_ptr<DataType> type,
+                             std::shared_ptr<const KeyValueMetadata> metadata) {
+  return std::make_shared<Field>(std::move(name), std::move(type), /*nullable=*/true,
+                                 std::move(metadata));
+}
+
 std::shared_ptr<DataType> decimal(int32_t precision, int32_t scale) {
   return precision <= Decimal128Type::kMaxPrecision ? decimal128(precision, scale)
                                                     : decimal256(precision, scale);

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -629,6 +629,17 @@ std::shared_ptr<Field> ARROW_EXPORT
 field(std::string name, std::shared_ptr<DataType> type, bool nullable = true,
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
+/// \brief Create a Field instance with metadata
+///
+/// The field will be assumed to be nullable.
+///
+/// \param name the field name
+/// \param type the field value type
+/// \param metadata any custom key-value metadata
+std::shared_ptr<Field> ARROW_EXPORT
+field(std::string name, std::shared_ptr<DataType> type,
+      std::shared_ptr<const KeyValueMetadata> metadata);
+
 /// \brief Create a Schema instance
 ///
 /// \param fields the schema's fields


### PR DESCRIPTION
This adds a vaguely Hypothesis-esque helper to generate a random record batch from a list of fields, whose metadata is inspected and used to set generation parameters (e.g. min/max value).