### PR TITLE
ARROW-11659: [R] Preserve group_by .drop argument

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -30,7 +30,8 @@
     "dplyr::",
     c(
       "select", "filter", "collect", "summarise", "group_by", "groups",
-      "group_vars", "ungroup", "mutate", "transmute", "arrange", "rename", "pull"
+      "group_vars", "group_by_drop_default", "ungroup", "mutate", "transmute",
+      "arrange", "rename", "pull"
     )
   )
   for (cl in c("Dataset", "ArrowTabular", "arrow_dplyr_query")) {

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -42,7 +42,10 @@ arrow_dplyr_query <- function(.data) {
       filtered_rows = TRUE,
       # group_by_vars is a character vector of columns (as renamed)
       # in the data. They will be kept when data is pulled into R.
-      group_by_vars = character()
+      group_by_vars = character(),
+      # drop_empty_groups is a logical value indicating whether to drop
+      # groups formed by factor levels that don't appear in the data
+      drop_empty_groups = TRUE
     ),
     class = "arrow_dplyr_query"
   )
@@ -424,11 +427,16 @@ restore_dplyr_features <- function(df, query) {
   if (grouped) {
     # Preserve groupings, if present
     if (is.data.frame(df)) {
-      df <- dplyr::grouped_df(df, dplyr::group_vars(query))
+      df <- dplyr::grouped_df(
+          df,
+          dplyr::group_vars(query),
+          drop = group_by_drop_default(query)
+        )
     } else {
       # This is a Table, via collect(as_data_frame = FALSE)
       df <- arrow_dplyr_query(df)
       df$group_by_vars <- query$group_by_vars
+      df$drop_empty_groups <- query$drop_empty_groups
     }
   }
   df
@@ -463,10 +471,7 @@ group_by.arrow_dplyr_query <- function(.data,
                                        ...,
                                        .add = FALSE,
                                        add = .add,
-                                       .drop = TRUE) {
-  if (!isTRUE(.drop)) {
-    stop(".drop argument not supported for Arrow objects", call. = FALSE)
-  }
+                                       .drop = group_by_drop_default(.data)) {
   .data <- arrow_dplyr_query(.data)
   # ... can contain expressions (i.e. can add (or rename?) columns)
   # Check for those (they show up as named expressions)
@@ -485,6 +490,7 @@ group_by.arrow_dplyr_query <- function(.data,
     gv <- dplyr::group_by_prepare(.data, ..., add = add)$group_names
   }
   .data$group_by_vars <- gv
+  .data$drop_empty_groups <- .drop
   .data
 }
 group_by.Dataset <- group_by.ArrowTabular <- group_by.arrow_dplyr_query
@@ -495,8 +501,14 @@ groups.Dataset <- groups.ArrowTabular <- function(x) NULL
 group_vars.arrow_dplyr_query <- function(x) x$group_by_vars
 group_vars.Dataset <- group_vars.ArrowTabular <- function(x) NULL
 
+group_by_drop_default.arrow_dplyr_query <-
+  function(.tbl) .tbl$drop_empty_groups %||% TRUE
+group_by_drop_default.Dataset <- group_by_drop_default.ArrowTabular <-
+  function(.tbl) TRUE
+
 ungroup.arrow_dplyr_query <- function(x, ...) {
   x$group_by_vars <- character()
+  x$drop_empty_groups <- TRUE
   x
 }
 ungroup.Dataset <- ungroup.ArrowTabular <- force

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -429,10 +429,10 @@ restore_dplyr_features <- function(df, query) {
     # Preserve groupings, if present
     if (is.data.frame(df)) {
       df <- dplyr::grouped_df(
-          df,
-          dplyr::group_vars(query),
-          drop = group_by_drop_default(query)
-        )
+        df,
+        dplyr::group_vars(query),
+        drop = group_by_drop_default(query)
+      )
     } else {
       # This is a Table, via collect(as_data_frame = FALSE)
       df <- arrow_dplyr_query(df)

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -44,8 +44,9 @@ arrow_dplyr_query <- function(.data) {
       # in the data. They will be kept when data is pulled into R.
       group_by_vars = character(),
       # drop_empty_groups is a logical value indicating whether to drop
-      # groups formed by factor levels that don't appear in the data
-      drop_empty_groups = TRUE
+      # groups formed by factor levels that don't appear in the data. It
+      # should be non-null only when the data is grouped.
+      drop_empty_groups = NULL
     ),
     class = "arrow_dplyr_query"
   )
@@ -490,7 +491,7 @@ group_by.arrow_dplyr_query <- function(.data,
     gv <- dplyr::group_by_prepare(.data, ..., add = add)$group_names
   }
   .data$group_by_vars <- gv
-  .data$drop_empty_groups <- ifelse(length(gv), .drop, TRUE)
+  .data$drop_empty_groups <- ifelse(length(gv), .drop, group_by_drop_default(.data))
   .data
 }
 group_by.Dataset <- group_by.ArrowTabular <- group_by.arrow_dplyr_query
@@ -501,6 +502,8 @@ groups.Dataset <- groups.ArrowTabular <- function(x) NULL
 group_vars.arrow_dplyr_query <- function(x) x$group_by_vars
 group_vars.Dataset <- group_vars.ArrowTabular <- function(x) NULL
 
+# the logical literal in the two functions below controls the default value of
+# the .drop argument to group_by()
 group_by_drop_default.arrow_dplyr_query <-
   function(.tbl) .tbl$drop_empty_groups %||% TRUE
 group_by_drop_default.Dataset <- group_by_drop_default.ArrowTabular <-
@@ -508,7 +511,7 @@ group_by_drop_default.Dataset <- group_by_drop_default.ArrowTabular <-
 
 ungroup.arrow_dplyr_query <- function(x, ...) {
   x$group_by_vars <- character()
-  x$drop_empty_groups <- TRUE
+  x$drop_empty_groups <- NULL
   x
 }
 ungroup.Dataset <- ungroup.ArrowTabular <- force

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -490,7 +490,7 @@ group_by.arrow_dplyr_query <- function(.data,
     gv <- dplyr::group_by_prepare(.data, ..., add = add)$group_names
   }
   .data$group_by_vars <- gv
-  .data$drop_empty_groups <- .drop
+  .data$drop_empty_groups <- ifelse(length(gv), .drop, TRUE)
   .data
 }
 group_by.Dataset <- group_by.ArrowTabular <- group_by.arrow_dplyr_query

--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -121,3 +121,15 @@ make_string_of_size <- function(size = 1) {
 
 example_with_extra_metadata <- example_with_metadata
 attributes(example_with_extra_metadata$b) <- list(lots = rep(make_string_of_size(1), 100))
+
+example_with_logical_factors <- tibble::tibble(
+  starting_a_fight = factor(c(FALSE, TRUE, TRUE, TRUE)),
+  consoling_a_child = factor(c(TRUE, FALSE, TRUE, TRUE)),
+  petting_a_dog = factor(c(TRUE, TRUE, FALSE, TRUE)),
+  saying = c(
+    "shhhhh, it's ok",
+    "you wanna go outside?",
+    "you want your mommy?",
+    "hey buddy"
+  )
+)

--- a/r/tests/testthat/test-dplyr.R
+++ b/r/tests/testthat/test-dplyr.R
@@ -195,21 +195,62 @@ test_that("group_by then rename", {
 })
 
 test_that("group_by with .drop", {
-  expect_identical(
-    Table$create(tbl) %>% 
-      group_by(chr, .drop = TRUE) %>%
-      group_vars(), 
-    "chr"
+  test_groups <- c("starting_a_fight", "consoling_a_child", "petting_a_dog")
+  expect_dplyr_equal(
+    input %>%
+      group_by(!!!syms(test_groups), .drop = TRUE) %>%
+      collect(),
+    example_with_logical_factors
   )
   expect_dplyr_equal(
     input %>%
-      group_by(chr, .drop = TRUE) %>%
+      group_by(!!!syms(test_groups), .drop = FALSE) %>%
       collect(),
-    tbl
+    example_with_logical_factors
   )
-  expect_error(
-    Table$create(tbl) %>% group_by(chr, .drop = FALSE),
-    "not supported"
+  expect_equal(
+    example_with_logical_factors %>%
+      group_by(!!!syms(test_groups), .drop = TRUE) %>%
+      collect() %>%
+      n_groups(),
+    4L
+  )
+  expect_equal(
+    example_with_logical_factors %>%
+      group_by(!!!syms(test_groups), .drop = FALSE) %>%
+      collect() %>%
+      n_groups(),
+    8L
+  )
+  expect_equal(
+    example_with_logical_factors %>%
+      group_by(!!!syms(test_groups), .drop = FALSE) %>%
+      group_by_drop_default(),
+    FALSE
+  )
+  expect_equal(
+    example_with_logical_factors %>%
+      group_by(!!!syms(test_groups), .drop = TRUE) %>%
+      group_by_drop_default(),
+    TRUE
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by_drop_default(),
+    example_with_logical_factors
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(!!!syms(test_groups)) %>%
+      group_by_drop_default(),
+    example_with_logical_factors
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(!!!syms(test_groups), .drop = FALSE) %>%
+      ungroup() %>%
+      group_by_drop_default(),
+    example_with_logical_factors
   )
 })
 

--- a/r/tests/testthat/test-dplyr.R
+++ b/r/tests/testthat/test-dplyr.R
@@ -236,6 +236,12 @@ test_that("group_by with .drop", {
   )
   expect_dplyr_equal(
     input %>%
+      group_by(.drop = FALSE) %>% # no group by vars
+      group_by_drop_default(),
+    example_with_logical_factors
+  )
+  expect_dplyr_equal(
+    input %>%
       group_by_drop_default(),
     example_with_logical_factors
   )


### PR DESCRIPTION
This preserves the `.drop` argument in the method for `dplyr::group_by()` and implements a method for `dplyr::group_by_drop_default()` which returns `TRUE` except on `arrow_dplyr_query` objects that were previously obtained by `group_by(.drop = FALSE)`.