### PR TITLE
ARROW-11975: [CI][GLib] Remove needless libgccjit

### DIFF
--- a/ci/scripts/msys2_system_clean.sh
+++ b/ci/scripts/msys2_system_clean.sh
@@ -29,4 +29,5 @@ pacman \
   ${MINGW_PACKAGE_PREFIX}-gcc-ada \
   ${MINGW_PACKAGE_PREFIX}-gcc-fortran \
   ${MINGW_PACKAGE_PREFIX}-gcc-libgfortran \
-  ${MINGW_PACKAGE_PREFIX}-gcc-objc
+  ${MINGW_PACKAGE_PREFIX}-gcc-objc \
+  ${MINGW_PACKAGE_PREFIX}-libgccjit


### PR DESCRIPTION
It blocks gcc update.