### PR TITLE
ARROW-11979: Combine limit into SortOptions - REQUEST FOR COMMENT

### DIFF
--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -310,6 +310,7 @@ impl DefaultPhysicalPlanner {
                             SortOptions {
                                 descending: !*asc,
                                 nulls_first: *nulls_first,
+                                ..Default::default()
                             },
                             ctx_state,
                         ),

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -363,6 +363,7 @@ mod tests {
                     options: SortOptions {
                         descending: true,
                         nulls_first: true,
+                        ..Default::default()
                     },
                 },
                 PhysicalSortExpr {
@@ -370,6 +371,7 @@ mod tests {
                     options: SortOptions {
                         descending: false,
                         nulls_first: false,
+                        ..Default::default()
                     },
                 },
             ],


### PR DESCRIPTION

The `sort_limit` kernel was added by @sundy-li in https://github.com/apache/arrow/pull/9602

While writing some doc examples in https://github.com/apache/arrow/pull/9721, it occured to me we could potentially simplify the API so I figured I would offer a proposed PR for comment

# Rationale

Since we already have a `SortOptions` structure that controls sorting options, we could also add the `limit` to that structure rather than adding a new `sort_limit` function and still avoid changing the API

# Changes

Move the `limit` option to `SortOptions`
