### PR TITLE
ARROW-8631: [C++][Python][Dataset] Add ReadOptions to CsvFileFormat, expose options to python

### DIFF
--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -187,7 +187,7 @@ inline bool operator==(const SubtreeImpl::Encoded& l, const SubtreeImpl::Encoded
 
 template <typename T>
 arrow::Result<std::shared_ptr<T>> DowncastFragmentScanOptions(
-    const std::shared_ptr<ScanOptions>& scan_options, const std::string& type_name) {
+    ScanOptions* scan_options, const std::string& type_name) {
   if (!scan_options) return nullptr;
   if (!scan_options->fragment_scan_options) return nullptr;
   const auto actual_type_name = scan_options->fragment_scan_options->type_name();

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -185,17 +185,26 @@ inline bool operator==(const SubtreeImpl::Encoded& l, const SubtreeImpl::Encoded
          l.partition_expression == r.partition_expression;
 }
 
+/// Get fragment scan options of the expected type.
+/// \return Fragment scan options if provided on the scan options, else the default
+///     options if set, else a default-constructed value. If options are provided
+///     but of the wrong type, an error is returned.
 template <typename T>
-arrow::Result<std::shared_ptr<T>> DowncastFragmentScanOptions(
-    ScanOptions* scan_options, const std::string& type_name) {
-  if (!scan_options) return nullptr;
-  if (!scan_options->fragment_scan_options) return nullptr;
-  const auto actual_type_name = scan_options->fragment_scan_options->type_name();
-  if (actual_type_name != type_name) {
-    return Status::Invalid("FragmentScanOptions of type ", actual_type_name,
+arrow::Result<std::shared_ptr<T>> GetFragmentScanOptions(
+    const std::string& type_name, ScanOptions* scan_options,
+    const std::shared_ptr<FragmentScanOptions>& default_options) {
+  auto source = default_options;
+  if (scan_options && scan_options->fragment_scan_options) {
+    source = scan_options->fragment_scan_options;
+  }
+  if (!source) {
+    return std::make_shared<T>();
+  }
+  if (source->type_name() != type_name) {
+    return Status::Invalid("FragmentScanOptions of type ", source->type_name(),
                            " were provided for scanning a fragment of type ", type_name);
   }
-  return internal::checked_pointer_cast<T>(scan_options->fragment_scan_options);
+  return internal::checked_pointer_cast<T>(source);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -186,11 +186,15 @@ inline bool operator==(const SubtreeImpl::Encoded& l, const SubtreeImpl::Encoded
 }
 
 template <typename T>
-std::shared_ptr<T> DowncastFragmentScanOptions(
+arrow::Result<std::shared_ptr<T>> DowncastFragmentScanOptions(
     const std::shared_ptr<ScanOptions>& scan_options, const std::string& type_name) {
   if (!scan_options) return nullptr;
   if (!scan_options->fragment_scan_options) return nullptr;
-  if (scan_options->fragment_scan_options->type_name() != type_name) return nullptr;
+  const auto actual_type_name = scan_options->fragment_scan_options->type_name();
+  if (actual_type_name != type_name) {
+    return Status::Invalid("FragmentScanOptions of type ", actual_type_name,
+                           " were provided for scanning a fragment of type ", type_name);
+  }
   return internal::checked_pointer_cast<T>(scan_options->fragment_scan_options);
 }
 

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -185,5 +185,14 @@ inline bool operator==(const SubtreeImpl::Encoded& l, const SubtreeImpl::Encoded
          l.partition_expression == r.partition_expression;
 }
 
+template <typename T>
+std::shared_ptr<T> DowncastFragmentScanOptions(
+    const std::shared_ptr<ScanOptions>& scan_options, const std::string& type_name) {
+  if (!scan_options) return nullptr;
+  if (!scan_options->fragment_scan_options) return nullptr;
+  if (scan_options->fragment_scan_options->type_name() != type_name) return nullptr;
+  return internal::checked_pointer_cast<T>(scan_options->fragment_scan_options);
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -124,6 +124,11 @@ class ARROW_DS_EXPORT FileSource {
 /// \brief Base class for file format implementation
 class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileFormat> {
  public:
+  /// Options affecting how this format is scanned.
+  ///
+  /// The options here can be overridden at scan time.
+  std::shared_ptr<FragmentScanOptions> default_fragment_scan_options;
+
   virtual ~FileFormat() = default;
 
   /// \brief The name identifying the kind of file format

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -79,13 +79,14 @@ Result<std::unordered_set<std::string>> GetColumnNames(
 static inline Result<csv::ConvertOptions> GetConvertOptions(
     const CsvFileFormat& format, const std::shared_ptr<ScanOptions>& scan_options,
     const util::string_view first_block, MemoryPool* pool) {
-  ARROW_ASSIGN_OR_RAISE(auto column_names,
-                        GetColumnNames(format.parse_options, first_block, pool));
-
-  auto convert_options = csv::ConvertOptions::Defaults();
   ARROW_ASSIGN_OR_RAISE(
-      auto csv_scan_options,
-      DowncastFragmentScanOptions<CsvFragmentScanOptions>(scan_options, kCsvTypeName));
+      auto column_names,
+      GetColumnNames(format.reader_options.parse_options, first_block, pool));
+
+  auto convert_options = format.reader_options.convert_options;
+  ARROW_ASSIGN_OR_RAISE(auto csv_scan_options,
+                        DowncastFragmentScanOptions<CsvFragmentScanOptions>(
+                            scan_options.get(), kCsvTypeName));
   if (csv_scan_options) {
     convert_options = csv_scan_options->convert_options;
   }
@@ -106,15 +107,15 @@ static inline Result<csv::ReadOptions> GetReadOptions(
   // contention when ScanTasks are also executed in multiple threads, so we disable it
   // here.
   read_options.use_threads = false;
-  read_options.skip_rows = format.skip_rows;
-  read_options.column_names = format.column_names;
-  read_options.autogenerate_column_names = format.autogenerate_column_names;
-  ARROW_ASSIGN_OR_RAISE(
-      auto csv_scan_options,
-      DowncastFragmentScanOptions<CsvFragmentScanOptions>(scan_options, kCsvTypeName));
-  if (csv_scan_options) {
-    read_options.block_size = csv_scan_options->block_size;
-  }
+  read_options.skip_rows = format.reader_options.skip_rows;
+  read_options.column_names = format.reader_options.column_names;
+  read_options.autogenerate_column_names =
+      format.reader_options.autogenerate_column_names;
+  ARROW_ASSIGN_OR_RAISE(auto csv_scan_options,
+                        DowncastFragmentScanOptions<CsvFragmentScanOptions>(
+                            scan_options.get(), kCsvTypeName));
+  read_options.block_size =
+      csv_scan_options ? csv_scan_options->block_size : format.reader_options.block_size;
   return read_options;
 }
 
@@ -131,7 +132,7 @@ static inline Result<std::shared_ptr<csv::StreamingReader>> OpenReader(
                                              default_memory_pool(), std::move(input)));
   ARROW_ASSIGN_OR_RAISE(first_block, input->Peek(reader_options.block_size));
 
-  const auto& parse_options = format.parse_options;
+  const auto& parse_options = format.reader_options.parse_options;
   auto convert_options = csv::ConvertOptions::Defaults();
   if (scan_options != nullptr) {
     ARROW_ASSIGN_OR_RAISE(convert_options,
@@ -173,17 +174,47 @@ class CsvScanTask : public ScanTask {
 bool CsvFileFormat::Equals(const FileFormat& format) const {
   if (type_name() != format.type_name()) return false;
 
-  const auto& other_parse_options =
-      checked_cast<const CsvFileFormat&>(format).parse_options;
+  const auto other_format = checked_cast<const CsvFileFormat&>(format);
+  const auto& other_convert_options = other_format.reader_options.convert_options;
+  const auto& other_parse_options = other_format.reader_options.parse_options;
 
-  return parse_options.delimiter == other_parse_options.delimiter &&
-         parse_options.quoting == other_parse_options.quoting &&
-         parse_options.quote_char == other_parse_options.quote_char &&
-         parse_options.double_quote == other_parse_options.double_quote &&
-         parse_options.escaping == other_parse_options.escaping &&
-         parse_options.escape_char == other_parse_options.escape_char &&
-         parse_options.newlines_in_values == other_parse_options.newlines_in_values &&
-         parse_options.ignore_empty_lines == other_parse_options.ignore_empty_lines;
+  return reader_options.convert_options.check_utf8 == other_convert_options.check_utf8 &&
+         reader_options.convert_options.column_types ==
+             other_convert_options.column_types &&
+         reader_options.convert_options.null_values ==
+             other_convert_options.null_values &&
+         reader_options.convert_options.true_values ==
+             other_convert_options.true_values &&
+         reader_options.convert_options.false_values ==
+             other_convert_options.false_values &&
+         reader_options.convert_options.strings_can_be_null ==
+             other_convert_options.strings_can_be_null &&
+         reader_options.convert_options.auto_dict_encode ==
+             other_convert_options.auto_dict_encode &&
+         reader_options.convert_options.auto_dict_max_cardinality ==
+             other_convert_options.auto_dict_max_cardinality &&
+         reader_options.convert_options.include_columns ==
+             other_convert_options.include_columns &&
+         reader_options.convert_options.include_missing_columns ==
+             other_convert_options.include_missing_columns &&
+         // N.B. values are not comparable
+         reader_options.convert_options.timestamp_parsers.size() ==
+             other_convert_options.timestamp_parsers.size() &&
+         reader_options.block_size == other_format.reader_options.block_size &&
+         reader_options.parse_options.delimiter == other_parse_options.delimiter &&
+         reader_options.parse_options.quoting == other_parse_options.quoting &&
+         reader_options.parse_options.quote_char == other_parse_options.quote_char &&
+         reader_options.parse_options.double_quote == other_parse_options.double_quote &&
+         reader_options.parse_options.escaping == other_parse_options.escaping &&
+         reader_options.parse_options.escape_char == other_parse_options.escape_char &&
+         reader_options.parse_options.newlines_in_values ==
+             other_parse_options.newlines_in_values &&
+         reader_options.parse_options.ignore_empty_lines ==
+             other_parse_options.ignore_empty_lines &&
+         reader_options.skip_rows == other_format.reader_options.skip_rows &&
+         reader_options.column_names == other_format.reader_options.column_names &&
+         reader_options.autogenerate_column_names ==
+             other_format.reader_options.autogenerate_column_names;
 }
 
 Result<bool> CsvFileFormat::IsSupported(const FileSource& source) const {

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -38,6 +38,11 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
   /// Options affecting the parsing of CSV files
   csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
+  /// Options affecting how CSV files are read.
+  ///
+  /// Note use_threads is ignored (it is always considered false) and block_size
+  /// should be set on CsvFragmentScanOptions.
+  csv::ReadOptions read_options = csv::ReadOptions::Defaults();
 
   std::string type_name() const override { return kCsvTypeName; }
 
@@ -67,6 +72,9 @@ class ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
   std::string type_name() const override { return kCsvTypeName; }
 
   csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
+
+  /// Block size for reading (arrow::csv::ReadOptions::block_size)
+  int32_t block_size = 1 << 20;  // 1 MB
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -33,35 +33,11 @@ namespace dataset {
 
 constexpr char kCsvTypeName[] = "csv";
 
-/// \brief Per-scan options for CSV fragments
-struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
-  std::string type_name() const override { return kCsvTypeName; }
-
-  /// CSV conversion options
-  csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
-
-  /// Block size for reading (see arrow::csv::ReadOptions::block_size)
-  int32_t block_size = 1 << 20;  // 1 MB
-};
-
 /// \brief A FileFormat implementation that reads from and writes to Csv files
 class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
-  /// \brief Dataset-wide options for CSV. For convenience (both for users, and
-  /// for authors of language bindings), these include fields for per-scan
-  /// options, however, if per-scan options are provided, then those fields will
-  /// be overridden.
-  struct ReaderOptions : CsvFragmentScanOptions {
-    /// Options affecting the parsing of CSV files
-    csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
-    /// Number of header rows to skip (see arrow::csv::ReadOptions::skip_rows)
-    int32_t skip_rows = 0;
-    /// Column names for the target table (see arrow::csv::ReadOptions::column_names)
-    std::vector<std::string> column_names;
-    /// Whether to generate column names or assume a header row (see
-    /// arrow::csv::ReadOptions::autogenerate_column_names)
-    bool autogenerate_column_names = false;
-  } reader_options;
+  /// Options affecting the parsing of CSV files
+  csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
 
   std::string type_name() const override { return kCsvTypeName; }
 
@@ -84,6 +60,19 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   }
 
   std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override { return NULLPTR; }
+};
+
+/// \brief Per-scan options for CSV fragments
+struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
+  std::string type_name() const override { return kCsvTypeName; }
+
+  /// CSV conversion options
+  csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
+
+  /// CSV reading options
+  ///
+  /// Note that use_threads is always ignored.
+  csv::ReadOptions read_options = csv::ReadOptions::Defaults();
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -33,18 +33,35 @@ namespace dataset {
 
 constexpr char kCsvTypeName[] = "csv";
 
+/// \brief Per-scan options for CSV fragments
+struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
+  std::string type_name() const override { return kCsvTypeName; }
+
+  /// CSV conversion options
+  csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
+
+  /// Block size for reading (see arrow::csv::ReadOptions::block_size)
+  int32_t block_size = 1 << 20;  // 1 MB
+};
+
 /// \brief A FileFormat implementation that reads from and writes to Csv files
 class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
-  /// Options affecting the parsing of CSV files
-  csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
-  /// Number of header rows to skip (see arrow::csv::ReadOptions::skip_rows)
-  int32_t skip_rows = 0;
-  /// Column names for the target table (see arrow::csv::ReadOptions::column_names)
-  std::vector<std::string> column_names;
-  /// Whether to generate column names or assume a header row (see
-  /// arrow::csv::ReadOptions::autogenerate_column_names)
-  bool autogenerate_column_names = false;
+  /// \brief Dataset-wide options for CSV. For convenience (both for users, and
+  /// for authors of language bindings), these include fields for per-scan
+  /// options, however, if per-scan options are provided, then those fields will
+  /// be overridden.
+  struct ReaderOptions : CsvFragmentScanOptions {
+    /// Options affecting the parsing of CSV files
+    csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
+    /// Number of header rows to skip (see arrow::csv::ReadOptions::skip_rows)
+    int32_t skip_rows = 0;
+    /// Column names for the target table (see arrow::csv::ReadOptions::column_names)
+    std::vector<std::string> column_names;
+    /// Whether to generate column names or assume a header row (see
+    /// arrow::csv::ReadOptions::autogenerate_column_names)
+    bool autogenerate_column_names = false;
+  } reader_options;
 
   std::string type_name() const override { return kCsvTypeName; }
 
@@ -67,16 +84,6 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   }
 
   std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override { return NULLPTR; }
-};
-
-class ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
- public:
-  std::string type_name() const override { return kCsvTypeName; }
-
-  csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
-
-  /// Block size for reading (see arrow::csv::ReadOptions::block_size)
-  int32_t block_size = 1 << 20;  // 1 MB
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -38,11 +38,13 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
   /// Options affecting the parsing of CSV files
   csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
-  /// Options affecting how CSV files are read.
-  ///
-  /// Note use_threads is ignored (it is always considered false) and block_size
-  /// should be set on CsvFragmentScanOptions.
-  csv::ReadOptions read_options = csv::ReadOptions::Defaults();
+  /// Number of header rows to skip (see arrow::csv::ReadOptions::skip_rows)
+  int32_t skip_rows = 0;
+  /// Column names for the target table (see arrow::csv::ReadOptions::column_names)
+  std::vector<std::string> column_names;
+  /// Whether to generate column names or assume a header row (see
+  /// arrow::csv::ReadOptions::autogenerate_column_names)
+  bool autogenerate_column_names = false;
 
   std::string type_name() const override { return kCsvTypeName; }
 
@@ -73,7 +75,7 @@ class ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
 
   csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
 
-  /// Block size for reading (arrow::csv::ReadOptions::block_size)
+  /// Block size for reading (see arrow::csv::ReadOptions::block_size)
   int32_t block_size = 1 << 20;  // 1 MB
 };
 

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -93,6 +93,27 @@ class TestCsvFileFormat : public testing::TestWithParam<Compression::type> {
   std::shared_ptr<ScanOptions> opts_ = std::make_shared<ScanOptions>();
 };
 
+TEST_P(TestCsvFileFormat, Equality) {
+  CsvFileFormat options1;
+  CsvFileFormat options2;
+  options2.reader_options.skip_rows = 3;
+  CsvFileFormat options3;
+  options3.reader_options.parse_options.delimiter = '\t';
+  CsvFileFormat options4;
+  options4.reader_options.block_size = 1 << 30;
+
+  ASSERT_TRUE(options1.Equals(options1));
+  ASSERT_TRUE(options2.Equals(options2));
+  ASSERT_TRUE(options3.Equals(options3));
+  ASSERT_TRUE(options4.Equals(options4));
+  ASSERT_FALSE(options1.Equals(options2));
+  ASSERT_FALSE(options1.Equals(options3));
+  ASSERT_FALSE(options1.Equals(options4));
+  ASSERT_FALSE(options2.Equals(options3));
+  ASSERT_FALSE(options2.Equals(options4));
+  ASSERT_FALSE(options3.Equals(options4));
+}
+
 TEST_P(TestCsvFileFormat, ScanRecordBatchReader) {
   auto source = GetFileSource(R"(f64
 1.0
@@ -142,7 +163,7 @@ MYNULL
 N/A
 bar)");
   SetSchema({field("str", utf8())});
-  format_->skip_rows = 1;
+  format_->reader_options.skip_rows = 1;
   ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
   auto fragment_scan_options = std::make_shared<CsvFragmentScanOptions>();
   fragment_scan_options->block_size = 1 << 22;

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -142,7 +142,7 @@ MYNULL
 N/A
 bar)");
   SetSchema({field("str", utf8())});
-  format_->read_options.skip_rows = 1;
+  format_->skip_rows = 1;
   ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
   auto fragment_scan_options = std::make_shared<CsvFragmentScanOptions>();
   fragment_scan_options->block_size = 1 << 22;

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -149,6 +149,12 @@ Status ScannerBuilder::Pool(MemoryPool* pool) {
   return Status::OK();
 }
 
+Status ScannerBuilder::FragmentScanOptions(
+    std::shared_ptr<dataset::FragmentScanOptions> fragment_scan_options) {
+  scan_options_->fragment_scan_options = std::move(fragment_scan_options);
+  return Status::OK();
+}
+
 Result<std::shared_ptr<Scanner>> ScannerBuilder::Finish() {
   if (!scan_options_->projection.IsBound()) {
     RETURN_NOT_OK(Project(scan_options_->dataset_schema->field_names()));

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -240,6 +240,9 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \brief Set the pool from which materialized and scanned arrays will be allocated.
   Status Pool(MemoryPool* pool);
 
+  /// \brief Set fragment-specific scan options.
+  Status FragmentScanOptions(std::shared_ptr<FragmentScanOptions> fragment_scan_options);
+
   /// \brief Return the constructed now-immutable Scanner object
   Result<std::shared_ptr<Scanner>> Finish();
 

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -46,6 +46,8 @@ class Fragment;
 using FragmentIterator = Iterator<std::shared_ptr<Fragment>>;
 using FragmentVector = std::vector<std::shared_ptr<Fragment>>;
 
+class FragmentScanOptions;
+
 class FileSource;
 class FileFormat;
 class FileFragment;
@@ -58,6 +60,7 @@ struct FileSystemDatasetWriteOptions;
 class InMemoryDataset;
 
 class CsvFileFormat;
+class CsvFragmentScanOptions;
 
 class IpcFileFormat;
 class IpcFileWriter;

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -60,7 +60,7 @@ struct FileSystemDatasetWriteOptions;
 class InMemoryDataset;
 
 class CsvFileFormat;
-class CsvFragmentScanOptions;
+struct CsvFragmentScanOptions;
 
 class IpcFileFormat;
 class IpcFileWriter;

--- a/python/pyarrow/_csv.pxd
+++ b/python/pyarrow/_csv.pxd
@@ -21,9 +21,26 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport _Weakrefable
 
 
+cdef class ConvertOptions(_Weakrefable):
+    cdef:
+        CCSVConvertOptions options
+
+    @staticmethod
+    cdef ConvertOptions wrap(CCSVConvertOptions options)
+
+
 cdef class ParseOptions(_Weakrefable):
     cdef:
         CCSVParseOptions options
 
     @staticmethod
     cdef ParseOptions wrap(CCSVParseOptions options)
+
+
+cdef class ReadOptions(_Weakrefable):
+    cdef:
+        CCSVReadOptions options
+        public object encoding
+
+    @staticmethod
+    cdef ReadOptions wrap(CCSVReadOptions options)

--- a/python/pyarrow/_csv.pxd
+++ b/python/pyarrow/_csv.pxd
@@ -35,3 +35,12 @@ cdef class ParseOptions(_Weakrefable):
 
     @staticmethod
     cdef ParseOptions wrap(CCSVParseOptions options)
+
+
+cdef class ReadOptions(_Weakrefable):
+    cdef:
+        CCSVReadOptions options
+        public object encoding
+
+    @staticmethod
+    cdef ReadOptions wrap(CCSVReadOptions options)

--- a/python/pyarrow/_csv.pxd
+++ b/python/pyarrow/_csv.pxd
@@ -35,12 +35,3 @@ cdef class ParseOptions(_Weakrefable):
 
     @staticmethod
     cdef ParseOptions wrap(CCSVParseOptions options)
-
-
-cdef class ReadOptions(_Weakrefable):
-    cdef:
-        CCSVReadOptions options
-        public object encoding
-
-    @staticmethod
-    cdef ReadOptions wrap(CCSVReadOptions options)

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -73,6 +73,10 @@ cdef class ReadOptions(_Weakrefable):
         The character encoding of the CSV data.  Columns that cannot
         decode using this encoding can still be read as Binary.
     """
+    cdef:
+        CCSVReadOptions options
+        public object encoding
+
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
@@ -156,13 +160,6 @@ cdef class ReadOptions(_Weakrefable):
     @autogenerate_column_names.setter
     def autogenerate_column_names(self, value):
         self.options.autogenerate_column_names = value
-
-    @staticmethod
-    cdef ReadOptions wrap(CCSVReadOptions options):
-        out = ReadOptions()
-        out.options = options
-        out.encoding = 'utf8'
-        return out
 
 
 cdef class ParseOptions(_Weakrefable):
@@ -608,6 +605,36 @@ cdef class ConvertOptions(_Weakrefable):
         out = ConvertOptions()
         out.options = options
         return out
+
+    def equals(self, ConvertOptions other):
+        return (
+            self.check_utf8 == other.check_utf8 and
+            self.column_types == other.column_types and
+            self.null_values == other.null_values and
+            self.true_values == other.true_values and
+            self.false_values == other.false_values and
+            self.timestamp_parsers == other.timestamp_parsers and
+            self.strings_can_be_null == other.strings_can_be_null and
+            self.auto_dict_encode == other.auto_dict_encode and
+            self.auto_dict_max_cardinality ==
+            other.auto_dict_max_cardinality and
+            self.include_columns == other.include_columns and
+            self.include_missing_columns == other.include_missing_columns
+        )
+
+    def __getstate__(self):
+        return (self.check_utf8, self.column_types, self.null_values,
+                self.true_values, self.false_values, self.timestamp_parsers,
+                self.strings_can_be_null, self.auto_dict_encode,
+                self.auto_dict_max_cardinality, self.include_columns,
+                self.include_missing_columns)
+
+    def __setstate__(self, state):
+        (self.check_utf8, self.column_types, self.null_values,
+         self.true_values, self.false_values, self.timestamp_parsers,
+         self.strings_can_be_null, self.auto_dict_encode,
+         self.auto_dict_max_cardinality, self.include_columns,
+         self.include_missing_columns) = state
 
 
 cdef _get_reader(input_file, ReadOptions read_options,

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -73,9 +73,6 @@ cdef class ReadOptions(_Weakrefable):
         The character encoding of the CSV data.  Columns that cannot
         decode using this encoding can still be read as Binary.
     """
-    cdef:
-        CCSVReadOptions options
-        public object encoding
 
     # Avoid mistakingly creating attributes
     __slots__ = ()
@@ -160,6 +157,40 @@ cdef class ReadOptions(_Weakrefable):
     @autogenerate_column_names.setter
     def autogenerate_column_names(self, value):
         self.options.autogenerate_column_names = value
+
+    def equals(self, ReadOptions other):
+        return (
+            self.use_threads == other.use_threads and
+            self.block_size == other.block_size and
+            self.skip_rows == other.skip_rows and
+            self.column_names == other.column_names and
+            self.autogenerate_column_names ==
+            other.autogenerate_column_names and
+            self.encoding == other.encoding
+        )
+
+    @staticmethod
+    cdef ReadOptions wrap(CCSVReadOptions options):
+        out = ReadOptions()
+        out.options = options
+        out.encoding = 'utf8'  # No way to know this
+        return out
+
+    def __getstate__(self):
+        return (self.use_threads, self.block_size, self.skip_rows,
+                self.column_names, self.autogenerate_column_names,
+                self.encoding)
+
+    def __setstate__(self, state):
+        (self.use_threads, self.block_size, self.skip_rows,
+         self.column_names, self.autogenerate_column_names,
+         self.encoding) = state
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except TypeError:
+            return False
 
 
 cdef class ParseOptions(_Weakrefable):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -73,10 +73,6 @@ cdef class ReadOptions(_Weakrefable):
         The character encoding of the CSV data.  Columns that cannot
         decode using this encoding can still be read as Binary.
     """
-    cdef:
-        CCSVReadOptions options
-        public object encoding
-
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
@@ -160,6 +156,13 @@ cdef class ReadOptions(_Weakrefable):
     @autogenerate_column_names.setter
     def autogenerate_column_names(self, value):
         self.options.autogenerate_column_names = value
+
+    @staticmethod
+    cdef ReadOptions wrap(CCSVReadOptions options):
+        out = ReadOptions()
+        out.options = options
+        out.encoding = 'utf8'
+        return out
 
 
 cdef class ParseOptions(_Weakrefable):
@@ -391,9 +394,6 @@ cdef class ConvertOptions(_Weakrefable):
         `column_types`, or null by default).
         This option is ignored if `include_columns` is empty.
     """
-    cdef:
-        CCSVConvertOptions options
-
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
@@ -602,6 +602,12 @@ cdef class ConvertOptions(_Weakrefable):
                 raise TypeError("Expected list of str or ISO8601 objects")
 
         self.options.timestamp_parsers = move(c_parsers)
+
+    @staticmethod
+    cdef ConvertOptions wrap(CCSVConvertOptions options):
+        out = ConvertOptions()
+        out.options = options
+        return out
 
 
 cdef _get_reader(input_file, ReadOptions read_options,

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -320,6 +320,12 @@ cdef class ParseOptions(_Weakrefable):
          self.escape_char, self.newlines_in_values,
          self.ignore_empty_lines) = state
 
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except TypeError:
+            return False
+
 
 cdef class _ISO8601(_Weakrefable):
     """
@@ -635,6 +641,12 @@ cdef class ConvertOptions(_Weakrefable):
          self.strings_can_be_null, self.auto_dict_encode,
          self.auto_dict_max_cardinality, self.include_columns,
          self.include_missing_columns) = state
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except TypeError:
+            return False
 
 
 cdef _get_reader(input_file, ReadOptions read_options,

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -22,6 +22,7 @@ from pyarrow.util import _stringify_path, _is_path_like
 
 from pyarrow._dataset import (  # noqa
     CsvFileFormat,
+    CsvFragmentScanOptions,
     Expression,
     Dataset,
     DatasetFactory,

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -253,17 +253,22 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             CFileFormat):
         pass
 
-    cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
-            CFileFormat):
+    cdef cppclass CCsvFragmentScanOptions \
+            "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):
+        CCSVConvertOptions convert_options
+        int32_t block_size
+
+    cdef cppclass CCsvFileFormatReaderOptions \
+            "arrow::dataset::ParquetFileFormat::ReaderOptions"(
+                CCsvFragmentScanOptions):
         CCSVParseOptions parse_options
         int32_t skip_rows
         vector[c_string] column_names
         c_bool autogenerate_column_names
 
-    cdef cppclass CCsvFragmentScanOptions \
-            "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):
-        CCSVConvertOptions convert_options
-        int32_t block_size
+    cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
+            CFileFormat):
+        CCsvFileFormatReaderOptions reader_options
 
     cdef cppclass CPartitioning "arrow::dataset::Partitioning":
         c_string type_name() const

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -256,7 +256,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
             CFileFormat):
         CCSVParseOptions parse_options
-        CCSVReadOptions read_options
+        int32_t skip_rows
+        vector[c_string] column_names
+        c_bool autogenerate_column_names
 
     cdef cppclass CCsvFragmentScanOptions \
             "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -60,7 +60,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
 
     cdef cppclass CFragmentScanOptions "arrow::dataset::FragmentScanOptions":
-        pass
+        c_string type_name() const
 
     ctypedef CIterator[shared_ptr[CScanTask]] CScanTaskIterator \
         "arrow::dataset::ScanTaskIterator"
@@ -169,6 +169,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         c_string type_name() const
 
     cdef cppclass CFileFormat "arrow::dataset::FileFormat":
+        shared_ptr[CFragmentScanOptions] default_fragment_scan_options
         c_string type_name() const
         CResult[shared_ptr[CSchema]] Inspect(const CFileSource&) const
         CResult[shared_ptr[CFileFragment]] MakeFragment(
@@ -253,22 +254,14 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             CFileFormat):
         pass
 
+    cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
+            CFileFormat):
+        CCSVParseOptions parse_options
+
     cdef cppclass CCsvFragmentScanOptions \
             "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):
         CCSVConvertOptions convert_options
-        int32_t block_size
-
-    cdef cppclass CCsvFileFormatReaderOptions \
-            "arrow::dataset::ParquetFileFormat::ReaderOptions"(
-                CCsvFragmentScanOptions):
-        CCSVParseOptions parse_options
-        int32_t skip_rows
-        vector[c_string] column_names
-        c_bool autogenerate_column_names
-
-    cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
-            CFileFormat):
-        CCsvFileFormatReaderOptions reader_options
+        CCSVReadOptions read_options
 
     cdef cppclass CPartitioning "arrow::dataset::Partitioning":
         c_string type_name() const

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -59,6 +59,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
 
+    cdef cppclass CFragmentScanOptions "arrow::dataset::FragmentScanOptions":
+        pass
+
     ctypedef CIterator[shared_ptr[CScanTask]] CScanTaskIterator \
         "arrow::dataset::ScanTaskIterator"
 
@@ -101,6 +104,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CStatus UseThreads(c_bool use_threads)
         CStatus Pool(CMemoryPool* pool)
         CStatus BatchSize(int64_t batch_size)
+        CStatus FragmentScanOptions(
+            shared_ptr[CFragmentScanOptions] fragment_scan_options)
         CResult[shared_ptr[CScanner]] Finish()
         shared_ptr[CSchema] schema() const
 
@@ -251,6 +256,12 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
             CFileFormat):
         CCSVParseOptions parse_options
+        CCSVReadOptions read_options
+
+    cdef cppclass CCsvFragmentScanOptions \
+            "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):
+        CCSVConvertOptions convert_options
+        int32_t block_size
 
     cdef cppclass CPartitioning "arrow::dataset::Partitioning":
         c_string type_name() const

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -428,8 +428,8 @@ dataset___IpcFileFormat__Make <- function(){
     .Call(`_arrow_dataset___IpcFileFormat__Make`)
 }
 
-dataset___CsvFileFormat__Make <- function(parse_options, skip_rows, column_names, autogenerate_column_names){
-    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options, skip_rows, column_names, autogenerate_column_names)
+dataset___CsvFileFormat__Make <- function(parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size){
+    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size)
 }
 
 dataset___FragmentScanOptions__type_name <- function(fragment_scan_options){

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -428,8 +428,16 @@ dataset___IpcFileFormat__Make <- function(){
     .Call(`_arrow_dataset___IpcFileFormat__Make`)
 }
 
-dataset___CsvFileFormat__Make <- function(parse_options){
-    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options)
+dataset___CsvFileFormat__Make <- function(parse_options, skip_rows, column_names, autogenerate_column_names){
+    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options, skip_rows, column_names, autogenerate_column_names)
+}
+
+dataset___FragmentScanOptions__type_name <- function(fragment_scan_options){
+    .Call(`_arrow_dataset___FragmentScanOptions__type_name`, fragment_scan_options)
+}
+
+dataset___CsvFragmentScanOptions__Make <- function(convert_options, block_size){
+    .Call(`_arrow_dataset___CsvFragmentScanOptions__Make`, convert_options, block_size)
 }
 
 dataset___DirectoryPartitioning <- function(schm){
@@ -466,6 +474,10 @@ dataset___ScannerBuilder__UseThreads <- function(sb, threads){
 
 dataset___ScannerBuilder__BatchSize <- function(sb, batch_size){
     invisible(.Call(`_arrow_dataset___ScannerBuilder__BatchSize`, sb, batch_size))
+}
+
+dataset___ScannerBuilder__FragmentScanOptions <- function(sb, options){
+    invisible(.Call(`_arrow_dataset___ScannerBuilder__FragmentScanOptions`, sb, options))
 }
 
 dataset___ScannerBuilder__schema <- function(sb){

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -428,16 +428,16 @@ dataset___IpcFileFormat__Make <- function(){
     .Call(`_arrow_dataset___IpcFileFormat__Make`)
 }
 
-dataset___CsvFileFormat__Make <- function(parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size){
-    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size)
+dataset___CsvFileFormat__Make <- function(parse_options, convert_options, read_options){
+    .Call(`_arrow_dataset___CsvFileFormat__Make`, parse_options, convert_options, read_options)
 }
 
 dataset___FragmentScanOptions__type_name <- function(fragment_scan_options){
     .Call(`_arrow_dataset___FragmentScanOptions__type_name`, fragment_scan_options)
 }
 
-dataset___CsvFragmentScanOptions__Make <- function(convert_options, block_size){
-    .Call(`_arrow_dataset___CsvFragmentScanOptions__Make`, convert_options, block_size)
+dataset___CsvFragmentScanOptions__Make <- function(convert_options, read_options){
+    .Call(`_arrow_dataset___CsvFragmentScanOptions__Make`, convert_options, read_options)
 }
 
 dataset___DirectoryPartitioning <- function(schm){

--- a/r/R/dataset-scan.R
+++ b/r/R/dataset-scan.R
@@ -67,6 +67,7 @@ Scanner$create <- function(dataset,
                            filter = TRUE,
                            use_threads = option_use_threads(),
                            batch_size = NULL,
+                           fragment_scan_options = NULL,
                            ...) {
   if (inherits(dataset, "arrow_dplyr_query")) {
     if (inherits(dataset$.data, "ArrowTabular")) {
@@ -78,6 +79,8 @@ Scanner$create <- function(dataset,
       dataset$selected_columns,
       dataset$filtered_rows,
       use_threads,
+      batch_size,
+      fragment_scan_options,
       ...
     ))
   }
@@ -98,6 +101,9 @@ Scanner$create <- function(dataset,
   }
   if (is_integerish(batch_size)) {
     scanner_builder$BatchSize(batch_size)
+  }
+  if (!is.null(fragment_scan_options)) {
+    scanner_builder$FragmentScanOptions(fragment_scan_options)
   }
   scanner_builder$Finish()
 }
@@ -183,6 +189,10 @@ ScannerBuilder <- R6Class("ScannerBuilder", inherit = ArrowObject,
     },
     BatchSize = function(batch_size) {
       dataset___ScannerBuilder__BatchSize(self, batch_size)
+      self
+    },
+    FragmentScanOptions = function(options) {
+      dataset___ScannerBuilder__FragmentScanOptions(self, options)
       self
     },
     Finish = function() dataset___ScannerBuilder__Finish(self)

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1105,16 +1105,50 @@ extern "C" SEXP _arrow_dataset___IpcFileFormat__Make(){
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options);
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp){
+std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows, cpp11::strings column_names, bool autogenerate_column_names);
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::csv::ParseOptions>&>::type parse_options(parse_options_sexp);
-	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options));
+	arrow::r::Input<int32_t>::type skip_rows(skip_rows_sexp);
+	arrow::r::Input<cpp11::strings>::type column_names(column_names_sexp);
+	arrow::r::Input<bool>::type autogenerate_column_names(autogenerate_column_names_sexp);
+	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options, skip_rows, column_names, autogenerate_column_names));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp){
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp){
 	Rf_error("Cannot call dataset___CsvFileFormat__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// dataset.cpp
+#if defined(ARROW_R_WITH_DATASET)
+std::string dataset___FragmentScanOptions__type_name(const std::shared_ptr<ds::FragmentScanOptions>& fragment_scan_options);
+extern "C" SEXP _arrow_dataset___FragmentScanOptions__type_name(SEXP fragment_scan_options_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<ds::FragmentScanOptions>&>::type fragment_scan_options(fragment_scan_options_sexp);
+	return cpp11::as_sexp(dataset___FragmentScanOptions__type_name(fragment_scan_options));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_dataset___FragmentScanOptions__type_name(SEXP fragment_scan_options_sexp){
+	Rf_error("Cannot call dataset___FragmentScanOptions__type_name(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// dataset.cpp
+#if defined(ARROW_R_WITH_DATASET)
+std::shared_ptr<ds::CsvFragmentScanOptions> dataset___CsvFragmentScanOptions__Make(const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, int32_t block_size);
+extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP block_size_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::csv::ConvertOptions>&>::type convert_options(convert_options_sexp);
+	arrow::r::Input<int32_t>::type block_size(block_size_sexp);
+	return cpp11::as_sexp(dataset___CsvFragmentScanOptions__Make(convert_options, block_size));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP block_size_sexp){
+	Rf_error("Cannot call dataset___CsvFragmentScanOptions__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
@@ -1262,6 +1296,23 @@ END_CPP11
 #else
 extern "C" SEXP _arrow_dataset___ScannerBuilder__BatchSize(SEXP sb_sexp, SEXP batch_size_sexp){
 	Rf_error("Cannot call dataset___ScannerBuilder__BatchSize(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// dataset.cpp
+#if defined(ARROW_R_WITH_DATASET)
+void dataset___ScannerBuilder__FragmentScanOptions(const std::shared_ptr<ds::ScannerBuilder>& sb, const std::shared_ptr<ds::FragmentScanOptions>& options);
+extern "C" SEXP _arrow_dataset___ScannerBuilder__FragmentScanOptions(SEXP sb_sexp, SEXP options_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<ds::ScannerBuilder>&>::type sb(sb_sexp);
+	arrow::r::Input<const std::shared_ptr<ds::FragmentScanOptions>&>::type options(options_sexp);
+	dataset___ScannerBuilder__FragmentScanOptions(sb, options);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_dataset___ScannerBuilder__FragmentScanOptions(SEXP sb_sexp, SEXP options_sexp){
+	Rf_error("Cannot call dataset___ScannerBuilder__FragmentScanOptions(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
@@ -4222,7 +4273,9 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___IpcFileWriteOptions__update2", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update2, 4}, 
 		{ "_arrow_dataset___IpcFileWriteOptions__update1", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update1, 3}, 
 		{ "_arrow_dataset___IpcFileFormat__Make", (DL_FUNC) &_arrow_dataset___IpcFileFormat__Make, 0}, 
-		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 1}, 
+		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 4}, 
+		{ "_arrow_dataset___FragmentScanOptions__type_name", (DL_FUNC) &_arrow_dataset___FragmentScanOptions__type_name, 1}, 
+		{ "_arrow_dataset___CsvFragmentScanOptions__Make", (DL_FUNC) &_arrow_dataset___CsvFragmentScanOptions__Make, 2}, 
 		{ "_arrow_dataset___DirectoryPartitioning", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning, 1}, 
 		{ "_arrow_dataset___DirectoryPartitioning__MakeFactory", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning__MakeFactory, 1}, 
 		{ "_arrow_dataset___HivePartitioning", (DL_FUNC) &_arrow_dataset___HivePartitioning, 2}, 
@@ -4232,6 +4285,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___ScannerBuilder__Filter", (DL_FUNC) &_arrow_dataset___ScannerBuilder__Filter, 2}, 
 		{ "_arrow_dataset___ScannerBuilder__UseThreads", (DL_FUNC) &_arrow_dataset___ScannerBuilder__UseThreads, 2}, 
 		{ "_arrow_dataset___ScannerBuilder__BatchSize", (DL_FUNC) &_arrow_dataset___ScannerBuilder__BatchSize, 2}, 
+		{ "_arrow_dataset___ScannerBuilder__FragmentScanOptions", (DL_FUNC) &_arrow_dataset___ScannerBuilder__FragmentScanOptions, 2}, 
 		{ "_arrow_dataset___ScannerBuilder__schema", (DL_FUNC) &_arrow_dataset___ScannerBuilder__schema, 1}, 
 		{ "_arrow_dataset___ScannerBuilder__Finish", (DL_FUNC) &_arrow_dataset___ScannerBuilder__Finish, 1}, 
 		{ "_arrow_dataset___Scanner__ToTable", (DL_FUNC) &_arrow_dataset___Scanner__ToTable, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1105,20 +1105,17 @@ extern "C" SEXP _arrow_dataset___IpcFileFormat__Make(){
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows, cpp11::strings column_names, bool autogenerate_column_names, const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, int32_t block_size);
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp, SEXP convert_options_sexp, SEXP block_size_sexp){
+std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, const std::shared_ptr<arrow::csv::ReadOptions>& read_options);
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP convert_options_sexp, SEXP read_options_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::csv::ParseOptions>&>::type parse_options(parse_options_sexp);
-	arrow::r::Input<int32_t>::type skip_rows(skip_rows_sexp);
-	arrow::r::Input<cpp11::strings>::type column_names(column_names_sexp);
-	arrow::r::Input<bool>::type autogenerate_column_names(autogenerate_column_names_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::csv::ConvertOptions>&>::type convert_options(convert_options_sexp);
-	arrow::r::Input<int32_t>::type block_size(block_size_sexp);
-	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size));
+	arrow::r::Input<const std::shared_ptr<arrow::csv::ReadOptions>&>::type read_options(read_options_sexp);
+	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options, convert_options, read_options));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp, SEXP convert_options_sexp, SEXP block_size_sexp){
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP convert_options_sexp, SEXP read_options_sexp){
 	Rf_error("Cannot call dataset___CsvFileFormat__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -1140,16 +1137,16 @@ extern "C" SEXP _arrow_dataset___FragmentScanOptions__type_name(SEXP fragment_sc
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::CsvFragmentScanOptions> dataset___CsvFragmentScanOptions__Make(const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, int32_t block_size);
-extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP block_size_sexp){
+std::shared_ptr<ds::CsvFragmentScanOptions> dataset___CsvFragmentScanOptions__Make(const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, const std::shared_ptr<arrow::csv::ReadOptions>& read_options);
+extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP read_options_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::csv::ConvertOptions>&>::type convert_options(convert_options_sexp);
-	arrow::r::Input<int32_t>::type block_size(block_size_sexp);
-	return cpp11::as_sexp(dataset___CsvFragmentScanOptions__Make(convert_options, block_size));
+	arrow::r::Input<const std::shared_ptr<arrow::csv::ReadOptions>&>::type read_options(read_options_sexp);
+	return cpp11::as_sexp(dataset___CsvFragmentScanOptions__Make(convert_options, read_options));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP block_size_sexp){
+extern "C" SEXP _arrow_dataset___CsvFragmentScanOptions__Make(SEXP convert_options_sexp, SEXP read_options_sexp){
 	Rf_error("Cannot call dataset___CsvFragmentScanOptions__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -4275,7 +4272,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___IpcFileWriteOptions__update2", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update2, 4}, 
 		{ "_arrow_dataset___IpcFileWriteOptions__update1", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update1, 3}, 
 		{ "_arrow_dataset___IpcFileFormat__Make", (DL_FUNC) &_arrow_dataset___IpcFileFormat__Make, 0}, 
-		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 6}, 
+		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 3}, 
 		{ "_arrow_dataset___FragmentScanOptions__type_name", (DL_FUNC) &_arrow_dataset___FragmentScanOptions__type_name, 1}, 
 		{ "_arrow_dataset___CsvFragmentScanOptions__Make", (DL_FUNC) &_arrow_dataset___CsvFragmentScanOptions__Make, 2}, 
 		{ "_arrow_dataset___DirectoryPartitioning", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1105,18 +1105,20 @@ extern "C" SEXP _arrow_dataset___IpcFileFormat__Make(){
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows, cpp11::strings column_names, bool autogenerate_column_names);
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp){
+std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows, cpp11::strings column_names, bool autogenerate_column_names, const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options, int32_t block_size);
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp, SEXP convert_options_sexp, SEXP block_size_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::csv::ParseOptions>&>::type parse_options(parse_options_sexp);
 	arrow::r::Input<int32_t>::type skip_rows(skip_rows_sexp);
 	arrow::r::Input<cpp11::strings>::type column_names(column_names_sexp);
 	arrow::r::Input<bool>::type autogenerate_column_names(autogenerate_column_names_sexp);
-	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options, skip_rows, column_names, autogenerate_column_names));
+	arrow::r::Input<const std::shared_ptr<arrow::csv::ConvertOptions>&>::type convert_options(convert_options_sexp);
+	arrow::r::Input<int32_t>::type block_size(block_size_sexp);
+	return cpp11::as_sexp(dataset___CsvFileFormat__Make(parse_options, skip_rows, column_names, autogenerate_column_names, convert_options, block_size));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp){
+extern "C" SEXP _arrow_dataset___CsvFileFormat__Make(SEXP parse_options_sexp, SEXP skip_rows_sexp, SEXP column_names_sexp, SEXP autogenerate_column_names_sexp, SEXP convert_options_sexp, SEXP block_size_sexp){
 	Rf_error("Cannot call dataset___CsvFileFormat__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -4273,7 +4275,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___IpcFileWriteOptions__update2", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update2, 4}, 
 		{ "_arrow_dataset___IpcFileWriteOptions__update1", (DL_FUNC) &_arrow_dataset___IpcFileWriteOptions__update1, 3}, 
 		{ "_arrow_dataset___IpcFileFormat__Make", (DL_FUNC) &_arrow_dataset___IpcFileFormat__Make, 0}, 
-		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 4}, 
+		{ "_arrow_dataset___CsvFileFormat__Make", (DL_FUNC) &_arrow_dataset___CsvFileFormat__Make, 6}, 
 		{ "_arrow_dataset___FragmentScanOptions__type_name", (DL_FUNC) &_arrow_dataset___FragmentScanOptions__type_name, 1}, 
 		{ "_arrow_dataset___CsvFragmentScanOptions__Make", (DL_FUNC) &_arrow_dataset___CsvFragmentScanOptions__Make, 2}, 
 		{ "_arrow_dataset___DirectoryPartitioning", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning, 1}, 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -272,18 +272,15 @@ std::shared_ptr<ds::IpcFileFormat> dataset___IpcFileFormat__Make() {
 
 // [[dataset::export]]
 std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(
-    const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows,
-    cpp11::strings column_names, bool autogenerate_column_names,
+    const std::shared_ptr<arrow::csv::ParseOptions>& parse_options,
     const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options,
-    int32_t block_size) {
+    const std::shared_ptr<arrow::csv::ReadOptions>& read_options) {
   auto format = std::make_shared<ds::CsvFileFormat>();
-  format->reader_options.parse_options = *parse_options;
-  format->reader_options.skip_rows = skip_rows;
-  format->reader_options.column_names =
-      cpp11::as_cpp<std::vector<std::string>>(column_names);
-  format->reader_options.autogenerate_column_names = autogenerate_column_names;
-  format->reader_options.convert_options = *convert_options;
-  format->reader_options.block_size = block_size;
+  format->parse_options = *parse_options;
+  auto scan_options = std::make_shared<ds::CsvFragmentScanOptions>();
+  if (convert_options) scan_options->convert_options = *convert_options;
+  if (read_options) scan_options->read_options = *read_options;
+  format->default_fragment_scan_options = std::move(scan_options);
   return format;
 }
 
@@ -298,10 +295,10 @@ std::string dataset___FragmentScanOptions__type_name(
 // [[dataset::export]]
 std::shared_ptr<ds::CsvFragmentScanOptions> dataset___CsvFragmentScanOptions__Make(
     const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options,
-    int32_t block_size) {
+    const std::shared_ptr<arrow::csv::ReadOptions>& read_options) {
   auto options = std::make_shared<ds::CsvFragmentScanOptions>();
   options->convert_options = *convert_options;
-  options->block_size = block_size;
+  options->read_options = *read_options;
   return options;
 }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -273,12 +273,17 @@ std::shared_ptr<ds::IpcFileFormat> dataset___IpcFileFormat__Make() {
 // [[dataset::export]]
 std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(
     const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows,
-    cpp11::strings column_names, bool autogenerate_column_names) {
+    cpp11::strings column_names, bool autogenerate_column_names,
+    const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options,
+    int32_t block_size) {
   auto format = std::make_shared<ds::CsvFileFormat>();
-  format->parse_options = *parse_options;
-  format->skip_rows = skip_rows;
-  format->column_names = cpp11::as_cpp<std::vector<std::string>>(column_names);
-  format->autogenerate_column_names = autogenerate_column_names;
+  format->reader_options.parse_options = *parse_options;
+  format->reader_options.skip_rows = skip_rows;
+  format->reader_options.column_names =
+      cpp11::as_cpp<std::vector<std::string>>(column_names);
+  format->reader_options.autogenerate_column_names = autogenerate_column_names;
+  format->reader_options.convert_options = *convert_options;
+  format->reader_options.block_size = block_size;
   return format;
 }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -272,10 +272,32 @@ std::shared_ptr<ds::IpcFileFormat> dataset___IpcFileFormat__Make() {
 
 // [[dataset::export]]
 std::shared_ptr<ds::CsvFileFormat> dataset___CsvFileFormat__Make(
-    const std::shared_ptr<arrow::csv::ParseOptions>& parse_options) {
+    const std::shared_ptr<arrow::csv::ParseOptions>& parse_options, int32_t skip_rows,
+    cpp11::strings column_names, bool autogenerate_column_names) {
   auto format = std::make_shared<ds::CsvFileFormat>();
   format->parse_options = *parse_options;
+  format->skip_rows = skip_rows;
+  format->column_names = cpp11::as_cpp<std::vector<std::string>>(column_names);
+  format->autogenerate_column_names = autogenerate_column_names;
   return format;
+}
+
+// FragmentScanOptions, CsvFragmentScanOptions
+
+// [[dataset::export]]
+std::string dataset___FragmentScanOptions__type_name(
+    const std::shared_ptr<ds::FragmentScanOptions>& fragment_scan_options) {
+  return fragment_scan_options->type_name();
+}
+
+// [[dataset::export]]
+std::shared_ptr<ds::CsvFragmentScanOptions> dataset___CsvFragmentScanOptions__Make(
+    const std::shared_ptr<arrow::csv::ConvertOptions>& convert_options,
+    int32_t block_size) {
+  auto options = std::make_shared<ds::CsvFragmentScanOptions>();
+  options->convert_options = *convert_options;
+  options->block_size = block_size;
+  return options;
 }
 
 // DirectoryPartitioning, HivePartitioning
@@ -344,6 +366,13 @@ void dataset___ScannerBuilder__UseThreads(const std::shared_ptr<ds::ScannerBuild
 void dataset___ScannerBuilder__BatchSize(const std::shared_ptr<ds::ScannerBuilder>& sb,
                                          int64_t batch_size) {
   StopIfNotOk(sb->BatchSize(batch_size));
+}
+
+// [[dataset::export]]
+void dataset___ScannerBuilder__FragmentScanOptions(
+    const std::shared_ptr<ds::ScannerBuilder>& sb,
+    const std::shared_ptr<ds::FragmentScanOptions>& options) {
+  StopIfNotOk(sb->FragmentScanOptions(options));
 }
 
 // [[dataset::export]]

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -316,6 +316,22 @@ test_that("CSV scan options", {
 
   tab <- sb$Finish()$ToTable()
   expect_equivalent(as.data.frame(tab), tibble(chr = c("foo", NA)))
+
+  # Set default convert options in CsvFileFormat
+  csv_format <- CsvFileFormat$create(null_values = c("mynull"),
+                                     strings_can_be_null = TRUE)
+  ds <- open_dataset(dst_dir, format = csv_format)
+  expect_equivalent(ds %>% collect(), tibble(chr = c("foo", NA)))
+
+  # Set both parse and convert options
+  df <- tibble(chr = c("foo", "mynull"), chr2 = c("bar", "baz"))
+  write.table(df, dst_file, row.names = FALSE, quote = FALSE, sep = "\t")
+  ds <- open_dataset(dst_dir, format = "csv",
+                     delimiter="\t",
+                     null_values = c("mynull"),
+                     strings_can_be_null = TRUE)
+  expect_equivalent(ds %>% collect(), tibble(chr = c("foo", NA),
+                                             chr2 = c("bar", "baz")))
 })
 
 test_that("compressed CSV dataset", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -374,10 +374,7 @@ test_that("CSV dataset options", {
       select(string = chr)
   )
 
-  format <- FileFormat$create("csv", column_names = c("foo"))
-  ds <- open_dataset(dst_dir, format = format)
-  expect_is(ds$format, "CsvFileFormat")
-  expect_is(ds$filesystem, "LocalFileSystem")
+  ds <- open_dataset(dst_dir, format = "csv", column_names = c("foo"))
 
   expect_equivalent(
     ds %>%


### PR DESCRIPTION
This adds ReadOptions to CsvFileFormat and exposes ReadOptions, ConvertOptions, and CsvFragmentScanOptions to Python.

ReadOptions was added to CsvFileFormat as its options can affect the discovered schema. For the block size, which does not need to be global, a field was added to CsvFragmentScanOptions.