### PR TITLE
ARROW-11988: [C++][Gandiva] Implements last_day function

### DIFF
--- a/cpp/src/gandiva/function_registry_common.h
+++ b/cpp/src/gandiva/function_registry_common.h
@@ -165,6 +165,15 @@ typedef std::unordered_map<const FunctionSignature*, const NativeFunction*, KeyH
   NativeFunction(#NAME, std::vector<std::string> ALIASES, DataTypeVector{TYPE()}, \
                  TYPE(), kResultNullIfNull, ARROW_STRINGIFY(NAME##_##TYPE))
 
+// Last day functions (used with data/time types) that :
+// - NULL handling is of type NULL_IF_NULL
+//
+// The pre-compiled fn name includes the base name & input type name. eg. last_day_from_date64
+#define LAST_DAY_SAFE_NULL_IF_NULL(NAME, ALIASES, TYPE)                            \
+  NativeFunction(#NAME, std::vector<std::string> ALIASES, DataTypeVector{TYPE()}, \
+                 date64(), kResultNullIfNull, ARROW_STRINGIFY(NAME##_from_##TYPE))
+
+
 // Hash32 functions that :
 // - NULL handling is of type NULL_NEVER
 //

--- a/cpp/src/gandiva/function_registry_common.h
+++ b/cpp/src/gandiva/function_registry_common.h
@@ -174,7 +174,6 @@ typedef std::unordered_map<const FunctionSignature*, const NativeFunction*, KeyH
   NativeFunction(#NAME, std::vector<std::string> ALIASES, DataTypeVector{TYPE()}, \
                  date64(), kResultNullIfNull, ARROW_STRINGIFY(NAME##_from_##TYPE))
 
-
 // Hash32 functions that :
 // - NULL handling is of type NULL_NEVER
 //

--- a/cpp/src/gandiva/function_registry_common.h
+++ b/cpp/src/gandiva/function_registry_common.h
@@ -168,8 +168,9 @@ typedef std::unordered_map<const FunctionSignature*, const NativeFunction*, KeyH
 // Last day functions (used with data/time types) that :
 // - NULL handling is of type NULL_IF_NULL
 //
-// The pre-compiled fn name includes the base name & input type name. eg. last_day_from_date64
-#define LAST_DAY_SAFE_NULL_IF_NULL(NAME, ALIASES, TYPE)                            \
+// The pre-compiled fn name includes the base name & input type name. eg:
+// - last_day_from_date64
+#define LAST_DAY_SAFE_NULL_IF_NULL(NAME, ALIASES, TYPE)                           \
   NativeFunction(#NAME, std::vector<std::string> ALIASES, DataTypeVector{TYPE()}, \
                  date64(), kResultNullIfNull, ARROW_STRINGIFY(NAME##_from_##TYPE))
 

--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -83,8 +83,7 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
       NativeFunction("extractDay", {}, DataTypeVector{day_time_interval()}, int64(),
                      kResultNullIfNull, "extractDay_daytimeinterval"),
 
-      DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {})
-  };
+      DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {})};
 
   return date_time_fn_registry_;
 }

--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -82,6 +82,8 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
 
       NativeFunction("extractDay", {}, DataTypeVector{day_time_interval()}, int64(),
                      kResultNullIfNull, "extractDay_daytimeinterval"),
+
+      DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {})
   };
 
   return date_time_fn_registry_;

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -451,18 +451,19 @@ EXTRACT_HOUR_TIME(time32)
 DATE_TRUNC_FUNCTIONS(date64)
 DATE_TRUNC_FUNCTIONS(timestamp)
 
-#define LAST_DAY_FUNC(TYPE)                                                                                    \
-  FORCE_INLINE                                                                                                 \
-  gdv_date64 last_day_from_##TYPE(gdv_date64 millis) {                                                         \
-    EpochTimePoint received_day(millis);                                                                       \
-    const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();                                     \
-                                                                                                               \
-    int received_day_in_month = day_without_hours_and_sec.TmMday();                                            \
-    const auto &first_day_in_month = day_without_hours_and_sec.AddDays(1 - received_day_in_month);             \
-                                                                                                               \
-    const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1);                                  \
-                                                                                                               \
-    return month_last_day.MillisSinceEpoch();                                                                  \
+#define LAST_DAY_FUNC(TYPE)                                                   \
+  FORCE_INLINE                                                                \
+  gdv_date64 last_day_from_##TYPE(gdv_date64 millis) {                        \
+    EpochTimePoint received_day(millis);                                      \
+    const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();    \
+                                                                              \
+    int received_day_in_month = day_without_hours_and_sec.TmMday();           \
+    const auto &first_day_in_month =                                          \
+    day_without_hours_and_sec.AddDays(1 - received_day_in_month);             \
+                                                                              \
+    const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1); \
+                                                                              \
+    return month_last_day.MillisSinceEpoch();                                 \
   }
 
 DATE_TYPES(LAST_DAY_FUNC)

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -451,22 +451,21 @@ EXTRACT_HOUR_TIME(time32)
 DATE_TRUNC_FUNCTIONS(date64)
 DATE_TRUNC_FUNCTIONS(timestamp)
 
-FORCE_INLINE
-gdv_date64 last_day_from_timestamp(gdv_date64 millis, gdv_boolean valid) {
-  if(!valid) {
-    return 0;
+#define LAST_DAY_FUNC(TYPE)                                                                                    \
+  FORCE_INLINE                                                                                                 \
+  gdv_date64 last_day_from_##TYPE(gdv_date64 millis) {                                                         \
+  EpochTimePoint received_day(millis);                                                                         \
+    const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();                                     \
+                                                                                                               \
+    int received_day_in_month = day_without_hours_and_sec.TmMday();                                            \
+    const auto &first_day_in_month = day_without_hours_and_sec.AddDays(1 - received_day_in_month);             \
+                                                                                                               \
+    const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1);                                  \
+                                                                                                               \
+    return month_last_day.MillisSinceEpoch();                                                                  \
   }
 
-  EpochTimePoint received_day(millis);
-  const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();
-
-  int received_day_in_month = day_without_hours_and_sec.TmMday();
-  const auto &first_day_in_month = day_without_hours_and_sec.AddDays(1 - received_day_in_month);
-
-  const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1);
-
-  return month_last_day.MillisSinceEpoch();
-}
+DATE_TYPES(LAST_DAY_FUNC)
 
 FORCE_INLINE
 gdv_date64 castDATE_int64(gdv_int64 in) { return in; }

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -452,6 +452,23 @@ DATE_TRUNC_FUNCTIONS(date64)
 DATE_TRUNC_FUNCTIONS(timestamp)
 
 FORCE_INLINE
+gdv_date64 last_day_from_timestamp(gdv_date64 millis, gdv_boolean valid) {
+  if(!valid) {
+    return 0;
+  }
+
+  EpochTimePoint received_day(millis);
+  const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();
+
+  int received_day_in_month = day_without_hours_and_sec.TmMday();
+  const auto &first_day_in_month = day_without_hours_and_sec.AddDays(1 - received_day_in_month);
+
+  const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1);
+
+  return month_last_day.MillisSinceEpoch();
+}
+
+FORCE_INLINE
 gdv_date64 castDATE_int64(gdv_int64 in) { return in; }
 
 FORCE_INLINE

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -454,7 +454,7 @@ DATE_TRUNC_FUNCTIONS(timestamp)
 #define LAST_DAY_FUNC(TYPE)                                                                                    \
   FORCE_INLINE                                                                                                 \
   gdv_date64 last_day_from_##TYPE(gdv_date64 millis) {                                                         \
-  EpochTimePoint received_day(millis);                                                                         \
+    EpochTimePoint received_day(millis);                                                                       \
     const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();                                     \
                                                                                                                \
     int received_day_in_month = day_without_hours_and_sec.TmMday();                                            \

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -455,13 +455,13 @@ DATE_TRUNC_FUNCTIONS(timestamp)
   FORCE_INLINE                                                                \
   gdv_date64 last_day_from_##TYPE(gdv_date64 millis) {                        \
     EpochTimePoint received_day(millis);                                      \
-    const auto &day_without_hours_and_sec = received_day.ClearTimeOfDay();    \
+    const auto& day_without_hours_and_sec = received_day.ClearTimeOfDay();    \
                                                                               \
     int received_day_in_month = day_without_hours_and_sec.TmMday();           \
-    const auto &first_day_in_month =                                          \
-    day_without_hours_and_sec.AddDays(1 - received_day_in_month);             \
+    const auto& first_day_in_month =                                          \
+        day_without_hours_and_sec.AddDays(1 - received_day_in_month);         \
                                                                               \
-    const auto &month_last_day = first_day_in_month.AddMonths(1).AddDays(-1); \
+    const auto& month_last_day = first_day_in_month.AddMonths(1).AddDays(-1); \
                                                                               \
     return month_last_day.MillisSinceEpoch();                                 \
   }

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -699,4 +699,29 @@ TEST(TestTime, TestCastTimestampToDate) {
   EXPECT_EQ(StringToTimestamp("2000-05-01 00:00:00"), out);
 }
 
+TEST(TestTime, TestLastDay) {
+  // leap year test
+  gdv_timestamp ts = StringToTimestamp("2016-02-11 03:20:34");
+  auto out = last_day_from_timestamp(ts);
+  EXPECT_EQ(StringToTimestamp("2016-02-29 00:00:00"), out);
+
+  ts = StringToTimestamp("2016-02-29 23:59:59");
+  out = last_day_from_timestamp(ts);
+  EXPECT_EQ(StringToTimestamp("2016-02-29 00:00:00"), out);
+
+  ts = StringToTimestamp("2016-01-30 23:59:00");
+  out = last_day_from_timestamp(ts);
+  EXPECT_EQ(StringToTimestamp("2016-01-31 00:00:00"), out);
+
+  // normal year
+  ts = StringToTimestamp("2017-02-03 23:59:59");
+  out = last_day_from_timestamp(ts);
+  EXPECT_EQ(StringToTimestamp("2017-02-28 00:00:00"), out);
+
+  // december
+  ts = StringToTimestamp("2015-12-03 03:12:59");
+  out = last_day_from_timestamp(ts);
+  EXPECT_EQ(StringToTimestamp("2015-12-31 00:00:00"), out);
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -201,6 +201,7 @@ gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);
 const char* castVARCHAR_timestamp_int64(int64_t, gdv_timestamp, gdv_int64, gdv_int32*);
+gdv_date64 last_day_from_timestamp(gdv_date64 millis, gdv_boolean valid);
 
 gdv_int64 truncate_int64_int32(gdv_int64 in, gdv_int32 out_scale);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -201,7 +201,7 @@ gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);
 const char* castVARCHAR_timestamp_int64(int64_t, gdv_timestamp, gdv_int64, gdv_int32*);
-gdv_date64 last_day_from_timestamp(gdv_date64 millis, gdv_boolean valid);
+gdv_date64 last_day_from_timestamp(gdv_date64 millis);
 
 gdv_int64 truncate_int64_int32(gdv_int64 in, gdv_int32 out_scale);
 

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -537,4 +537,57 @@ TEST_F(TestProjector, TestMonthsBetween) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_output, outputs.at(0));
 }
 
+TEST_F(TestProjector, TestLastDay) {
+  auto f0 = field("f0", arrow::date64());
+  auto f1 = field("f1", arrow::date64());
+  auto schema = arrow::schema({f0, f1});
+
+  // output fields
+  auto output = field("out", arrow::float64());
+
+  auto months_between_expr =
+      TreeExprBuilder::MakeExpression("months_between", {f0, f1}, output);
+
+  std::shared_ptr<Projector> projector;
+  auto status =
+      Projector::Make(schema, {months_between_expr}, TestConfiguration(), &projector);
+  std::cout << status.message();
+  ASSERT_TRUE(status.ok());
+
+  time_t epoch = Epoch();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto validity = {true, true, true, true};
+  std::vector<int64_t> f0_data = {MillisSince(epoch, 1995, 3, 2, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1995, 2, 2, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1995, 3, 31, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1996, 3, 31, 0, 0, 0, 0)};
+
+  auto array0 =
+      MakeArrowTypeArray<arrow::Date64Type, int64_t>(date64(), f0_data, validity);
+
+  std::vector<int64_t> f1_data = {MillisSince(epoch, 1995, 2, 2, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1995, 3, 2, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1995, 2, 28, 0, 0, 0, 0),
+                                  MillisSince(epoch, 1996, 2, 29, 0, 0, 0, 0)};
+
+  auto array1 =
+      MakeArrowTypeArray<arrow::Date64Type, int64_t>(date64(), f1_data, validity);
+
+  // expected output
+  auto exp_output = MakeArrowArrayFloat64({1.0, -1.0, 1.0, 1.0}, validity);
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok());
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_output, outputs.at(0));
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -39,7 +39,7 @@ class TestProjector : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool *pool_;
+  arrow::MemoryPool* pool_;
 };
 
 time_t Epoch() {
@@ -371,7 +371,7 @@ TEST_F(TestProjector, TestTimestampDiff) {
       TreeExprBuilder::MakeExpression("timestampdiffYear", {f0, f1}, diff_seconds);
 
   std::shared_ptr<Projector> projector;
-  auto exprs = {diff_secs_expr, diff_mins_expr, diff_hours_expr, diff_days_expr,
+  auto exprs = {diff_secs_expr,  diff_mins_expr,   diff_hours_expr,    diff_days_expr,
                 diff_weeks_expr, diff_months_expr, diff_quarters_expr, diff_years_expr};
   auto status = Projector::Make(schema, exprs, TestConfiguration(), &projector);
   ASSERT_TRUE(status.ok());
@@ -383,14 +383,14 @@ TEST_F(TestProjector, TestTimestampDiff) {
   // 2017-03-30T22:50:59.050
   auto end_millis = MillisSince(epoch, 2017, 3, 30, 22, 50, 59, 50);
   std::vector<int64_t> f0_data = {start_millis, end_millis,
-      // 2015-09-10T20:49:42.999
+                                  // 2015-09-10T20:49:42.999
                                   start_millis + 999,
-      // 2015-09-10T20:49:42.999
+                                  // 2015-09-10T20:49:42.999
                                   MillisSince(epoch, 2015, 9, 10, 20, 49, 42, 999)};
   std::vector<int64_t> f1_data = {end_millis, start_millis,
-      // 2015-09-10T20:49:42.999
+                                  // 2015-09-10T20:49:42.999
                                   start_millis + 999,
-      // 2015-09-9T21:49:42.999 (23 hours behind)
+                                  // 2015-09-9T21:49:42.999 (23 hours behind)
                                   MillisSince(epoch, 2015, 9, 9, 21, 49, 42, 999)};
 
   int64_t num_records = f0_data.size();
@@ -544,12 +544,10 @@ TEST_F(TestProjector, TestLastDay) {
   // output fields
   auto output = field("out", arrow::date64());
 
-  auto last_day_expr =
-      TreeExprBuilder::MakeExpression("last_day", {f0}, output);
+  auto last_day_expr = TreeExprBuilder::MakeExpression("last_day", {f0}, output);
 
   std::shared_ptr<Projector> projector;
-  auto status =
-      Projector::Make(schema, {last_day_expr}, TestConfiguration(), &projector);
+  auto status = Projector::Make(schema, {last_day_expr}, TestConfiguration(), &projector);
   std::cout << status.message();
   ASSERT_TRUE(status.ok());
 
@@ -573,7 +571,6 @@ TEST_F(TestProjector, TestLastDay) {
                                          MillisSince(epoch, 2016, 1, 31, 0, 0, 0, 0),
                                          MillisSince(epoch, 2017, 2, 28, 0, 0, 0, 0),
                                          MillisSince(epoch, 2015, 12, 31, 0, 0, 0, 0)};
-
 
   // expected output
   auto exp_output = MakeArrowArrayDate64(f0_output_data, validity);


### PR DESCRIPTION
Implements the `last_day` function inside the Gandiva. The function gets a timestamp and returns the date of the last day of the month defined in timestamp.

JIRA issue: https://issues.apache.org/jira/browse/ARROW-11988