### PR TITLE
ARROW-11992: [Rust][Parquet] Add upgrade notes on 4.0 rename of LogicalType

### DIFF
--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -48,8 +48,8 @@ See [crate documentation](https://docs.rs/crate/parquet/4.0.0-SNAPSHOT) on avail
 
 ## Upgrading from versions prior to 4.0
 
-*Upgrade Note*: If you used version 3.0 or previous of this crate, you
-likely need to change your code to refer to [`ConvertedType`] rather
+If you are upgrading from version 3.0 or previous of this crate, you
+likely need to change your code to use [`ConvertedType`] rather
 than [`LogicalType`]. Version 4.0 introduces an *entirely new* struct
 called `LogicalType` to align with the standard, and `LogicalType` was
 was renamed to `ConvertedType`.

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -46,6 +46,15 @@ while let Some(record) = iter.next() {
 ```
 See [crate documentation](https://docs.rs/crate/parquet/4.0.0-SNAPSHOT) on available API.
 
+## Upgrading from versions prior to 4.0
+
+*Upgrade Note*: If you used version 3.0 or previous of this crate, you
+likely need to change your code to refer to [`ConvertedType`] rather
+than [`LogicalType`]. Version 4.0 introduces an *entirely new* struct
+called `LogicalType` to align with the standard, and `LogicalType` was
+was renamed to `ConvertedType`.
+
+
 ## Supported Parquet Version
 - Parquet-format 2.4.0
 
@@ -84,7 +93,7 @@ Run `cargo test` for unit tests. To also run tests related to the binaries, use 
 ## Binaries
 The following binaries are provided (use `cargo install --features cli` to install them):
 - **parquet-schema** for printing Parquet file schema and metadata.
-`Usage: parquet-schema <file-path>`, where `file-path` is the path to a Parquet file. Use `-v/--verbose` flag 
+`Usage: parquet-schema <file-path>`, where `file-path` is the path to a Parquet file. Use `-v/--verbose` flag
 to print full metadata or schema only (when not specified only schema will be printed).
 
 - **parquet-read** for reading records from a Parquet file.
@@ -93,8 +102,8 @@ and `num-records` is the number of records to read from a file (when not specifi
 be printed). Use `-j/--json` to print records in JSON lines format.
 
 - **parquet-rowcount** for reporting the number of records in one or more Parquet files.
-`Usage: parquet-rowcount <file-paths>...`, where `<file-paths>...` is a space separated list of one or more 
-files to read. 
+`Usage: parquet-rowcount <file-paths>...`, where `<file-paths>...` is a space separated list of one or more
+files to read.
 
 If you see `Library not loaded` error, please make sure `LD_LIBRARY_PATH` is set properly:
 ```

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -49,10 +49,11 @@ See [crate documentation](https://docs.rs/crate/parquet/4.0.0-SNAPSHOT) on avail
 ## Upgrading from versions prior to 4.0
 
 If you are upgrading from version 3.0 or previous of this crate, you
-likely need to change your code to use [`ConvertedType`] rather
-than [`LogicalType`]. Version 4.0 introduces an *entirely new* struct
-called `LogicalType` to align with the standard, and `LogicalType` was
-was renamed to `ConvertedType`.
+likely need to change your code to use [`ConvertedType`] rather than
+[`LogicalType`]. Version 4.0 introduces an *entirely new* struct
+called `LogicalType` to align with the `LogicalType` introduced in
+Parquet Format 2.4.0. The type previously called `LogicalType` was was
+renamed to `ConvertedType`.
 
 
 ## Supported Parquet Version

--- a/rust/parquet/src/basic.rs
+++ b/rust/parquet/src/basic.rs
@@ -59,6 +59,8 @@ pub enum Type {
 /// Common types (converted types) used by frameworks when using Parquet.
 /// This helps map between types in those frameworks to the base types in Parquet.
 /// This is only metadata and not needed to read or write the data.
+///
+/// *Upgrade Note*: This struct was renamed from `LogicalType` in version 4.0.0.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ConvertedType {
     NONE,
@@ -156,6 +158,12 @@ pub enum ConvertedType {
 // Mirrors `parquet::LogicalType`
 
 /// Logical types used by version 2 of the Parquet format.
+///
+/// *Upgrade Note*: This is an *entirely new* struct as of version
+/// 4.0.0. The struct previously known as `LogicalType` was renamed to
+/// `ConvertedType`. If you used version 3.0 or previous of this
+/// crate, you should likely change your code to refer to
+/// [`ConvertedType`] rather than [`LogicalType`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalType {
     STRING(StringType),

--- a/rust/parquet/src/basic.rs
+++ b/rust/parquet/src/basic.rs
@@ -160,10 +160,8 @@ pub enum ConvertedType {
 /// Logical types used by version 2 of the Parquet format.
 ///
 /// *Upgrade Note*: This is an *entirely new* struct as of version
-/// 4.0.0. The struct previously known as `LogicalType` was renamed to
-/// `ConvertedType`. If you used version 3.0 or previous of this
-/// crate, you should likely change your code to refer to
-/// [`ConvertedType`] rather than [`LogicalType`].
+/// 4.0.0. The struct previously named `LogicalType` was renamed to
+/// [`ConvertedType`]. Please see the README.md for more details.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogicalType {
     STRING(StringType),


### PR DESCRIPTION
# Rationale
While updating arrow deps in https://github.com/influxdata/influxdb_iox/pull/1003, I got (very) confused for a while with the parquet upgrade as `LogicalType` was renamed to `ConvertedType` but then a new type called `LogicalType` was added in https://github.com/apache/arrow/pull/9592.

# Changes
Add some comments to try and help future users save some time during upgrade
