### PR TITLE
ARROW-11996: [R] Make r/configure run successfully on Solaris

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -149,7 +149,7 @@ else
       fi
 
       ${R_HOME}/bin/Rscript tools/nixlibs.R $VERSION
-      PKG_CFLAGS="-I$(pwd)/libarrow/arrow-${VERSION}/include $PKG_CFLAGS"
+      PKG_CFLAGS="-I`pwd`/libarrow/arrow-${VERSION}/include $PKG_CFLAGS"
 
       LIB_DIR="libarrow/arrow-${VERSION}/lib"
       if [ -d "$LIB_DIR" ]; then
@@ -162,8 +162,8 @@ else
         #
         # TODO: what about non-bundled deps?
         BUNDLED_LIBS=`cd $LIB_DIR && ls *.a`
-        BUNDLED_LIBS=`echo $BUNDLED_LIBS | sed -E "s/lib(.*)\.a/-l\1/" | sed -e "s/\\.a lib/ -l/g"`
-        PKG_DIRS="-L$(pwd)/$LIB_DIR"
+        BUNDLED_LIBS=`echo "$BUNDLED_LIBS" | sed -e "s/\\.a lib/ -l/g" | sed -e "s/\\.a$//" | sed -e "s/^lib/-l/" | tr '\n' ' ' | sed -e "s/ $//"`
+        PKG_DIRS="-L`pwd`/$LIB_DIR"
 
         # When using brew's openssl it is not bundled and it is not on the system
         # search path  and so we must add the lib path to BUNDLED_LIBS if we are

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -324,7 +324,13 @@ build_libarrow <- function(src_dir, dst_dir) {
   env_vars <- with_mimalloc(env_vars)
   if (tolower(Sys.info()[["sysname"]]) %in% "sunos") {
     # jemalloc doesn't seem to build on Solaris
-    env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF")
+    # nor does thrift, so turn off parquet,
+    # and arrowExports.cpp requires parquet for dataset (ARROW-11994), so turn that off
+    # xsimd doesn't compile, so set SIMD level to NONE to skip it
+    # re2 and utf8proc do compile,
+    # but `ar` fails to build libarrow_bundled_dependencies, so turn them off
+    # so that there are no bundled deps
+    env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF ARROW_PARQUET=OFF ARROW_DATASET=OFF ARROW_WITH_RE2=OFF ARROW_WITH_UTF8PROC=OFF EXTRA_CMAKE_FLAGS=-DARROW_SIMD_LEVEL=NONE")
   }
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
   status <- system(


### PR DESCRIPTION
Actually turning off utf8proc and re2 will be done in ARROW-11736, which should be the last remaining issue for building (a minimal build) on Solaris.