### PR TITLE
ARROW-11998: [C++] Make it easier to create vectors of move-only data types for tests

### DIFF
--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -126,5 +126,17 @@ class FnOnce<R(A...)> {
   std::unique_ptr<Impl> impl_;
 };
 
+/// A callable object that simply forwards to T's constructor.
+///
+/// This allows passing `Constructor<T>()` as a callable argument for applying
+/// the T constructor without hand-writing a lambda.
+template <typename T>
+struct Constructor {
+  template <typename... Values>
+  T operator()(Values&&... values) {
+    return T(std::forward<Values>(values)...);
+  }
+};
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/stl_util_test.cc
+++ b/cpp/src/arrow/util/stl_util_test.cc
@@ -21,6 +21,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "arrow/result.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/functional.h"
 #include "arrow/util/sort.h"
 #include "arrow/util/string.h"
 #include "arrow/util/vector.h"
@@ -90,6 +93,23 @@ TEST(StlUtilTest, ArgSortPermute) {
   ExpectSortPermutation({c, b, a, d, e, f}, {2, 1, 0, 3, 4, 5}, 5);
   ExpectSortPermutation({b, c, a, f, d, e}, {2, 0, 1, 4, 5, 3}, 2);
   ExpectSortPermutation({b, c, d, e, a, f}, {4, 0, 1, 2, 3, 5}, 2);
+}
+
+TEST(StlUtilTest, MapEmplaceBack) {
+  auto all_good = EmplacedMappedVector<Result<MoveOnlyDataType>>(
+      Constructor<MoveOnlyDataType>(), 1, 2, 3);
+
+  ASSERT_EQ(all_good[0].ValueUnsafe(), 1);
+  ASSERT_EQ(all_good[1].ValueUnsafe(), 2);
+  ASSERT_EQ(all_good[2].ValueUnsafe(), 3);
+  ASSERT_EQ(all_good.size(), 3);
+
+  auto some_bad = EmplacedVector<Result<MoveOnlyDataType>>(
+      MoveOnlyDataType(1), Status::Invalid("XYZ"), Status::IOError("XYZ"));
+
+  ASSERT_EQ(some_bad[0].ValueUnsafe(), 1);
+  ASSERT_TRUE(some_bad[1].status().IsInvalid());
+  ASSERT_TRUE(some_bad[2].status().IsIOError());
 }
 
 }  // namespace internal


### PR DESCRIPTION
Originally envisioned from discussion in ARROW-11883.  I've pulled this into a separate PR.  Once ARROW-11883 has been merged this PR should be updated to remove the TODO before this can be merged.