### PR TITLE
ARROW-11997: [Python] concat_tables crashes python interpreter

### DIFF
--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# cython: profile=False
-# distutils: language = c++
+# cython: profile = False
 # cython: embedsignature = True
+# cython: nonecheck = True
+# distutils: language = c++
 
 import datetime
 import decimal as _pydecimal

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -207,13 +207,13 @@ cdef class ChunkedArray(_PandasConvertible):
         -------
         are_equal : bool
         """
+        if other is None:
+            return False
+
         cdef:
             CChunkedArray* this_arr = self.chunked_array
             CChunkedArray* other_arr = other.chunked_array
             c_bool result
-
-        if other is None:
-            return False
 
         with nogil:
             result = this_arr.Equals(deref(other_arr))
@@ -1432,13 +1432,13 @@ cdef class Table(_PandasConvertible):
         -------
         are_equal : bool
         """
+        if other is None:
+            return False
+
         cdef:
             CTable* this_table = self.table
             CTable* other_table = other.table
             c_bool result
-
-        if other is None:
-            return False
 
         with nogil:
             result = this_table.Equals(deref(other_table), check_metadata)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2225,6 +2225,8 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
             CConcatenateTablesOptions.Defaults())
 
     for table in tables:
+        if table is None:
+            raise TypeError("Unable to concatenate table. Table is None.")
         c_tables.push_back(table.sp_table)
 
     with nogil:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2225,8 +2225,6 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
             CConcatenateTablesOptions.Defaults())
 
     for table in tables:
-        if table is None:
-            raise TypeError("Unable to concatenate table. Table is None.")
         c_tables.push_back(table.sp_table)
 
     with nogil:

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -353,6 +353,7 @@ def test_filters_cutoff_exclusive_datetime(tempdir, use_legacy_dataset):
 
 
 @pytest.mark.pandas
+@pytest.mark.dataset
 def test_filters_inclusive_datetime(tempdir):
     # ARROW-11480
     path = tempdir / 'timestamps.parquet'

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -272,8 +272,7 @@ def test_chunked_array_equals():
     ne([c, a], [a, c])
 
     # ARROW-4822
-    with pytest.raises(AttributeError):
-        pa.chunked_array([], type=pa.int32()).equals(None)
+    assert not pa.chunked_array([], type=pa.int32()).equals(None)
 
 
 @pytest.mark.parametrize(
@@ -715,12 +714,10 @@ def test_table_column_sets_private_name():
 
 def test_table_equals():
     table = pa.Table.from_arrays([], names=[])
-
     assert table.equals(table)
 
     # ARROW-4822
-    with pytest.raises(AttributeError):
-        table.equals(None)
+    assert not table.equals(None)
 
     other = pa.Table.from_arrays([], names=[], metadata={'key': 'value'})
     assert not table.equals(other, check_metadata=True)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -271,7 +271,9 @@ def test_chunked_array_equals():
     eq([a, c], [d])
     ne([c, a], [a, c])
 
-    assert not pa.chunked_array([], type=pa.int32()).equals(None)
+    # ARROW-4822
+    with pytest.raises(AttributeError):
+        pa.chunked_array([], type=pa.int32()).equals(None)
 
 
 @pytest.mark.parametrize(
@@ -715,8 +717,10 @@ def test_table_equals():
     table = pa.Table.from_arrays([], names=[])
 
     assert table.equals(table)
+
     # ARROW-4822
-    assert not table.equals(None)
+    with pytest.raises(AttributeError):
+        table.equals(None)
 
     other = pa.Table.from_arrays([], names=[], metadata={'key': 'value'})
     assert not table.equals(other, check_metadata=True)
@@ -1135,7 +1139,8 @@ def test_concat_tables():
 
 
 def test_concat_tables_none_table():
-    with pytest.raises(TypeError):
+    # ARROW-11997
+    with pytest.raises(AttributeError):
         pa.concat_tables([None])
 
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1134,6 +1134,11 @@ def test_concat_tables():
     assert result.equals(expected)
 
 
+def test_concat_tables_none_table():
+    with pytest.raises(TypeError):
+        pa.concat_tables([None])
+
+
 @pytest.mark.pandas
 def test_concat_tables_with_different_schema_metadata():
     import pandas as pd


### PR DESCRIPTION
Before:

```
>>> import pyarrow
>>> pyarrow.concat_tables([None])
Bus error: 10
Python quit unexpectedly
```

After:

```
>>> import pyarrow
>>> pyarrow.concat_tables([None])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyarrow/table.pxi", line 2228, in pyarrow.lib.concat_tables
    c_tables.push_back(table.sp_table)
AttributeError: 'NoneType' object has no attribute 'sp_table
```