### PR TITLE
ARROW-12012: [Java][JDBC] Fix BinaryConsumer reallocation

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
@@ -26,8 +26,6 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.VarBinaryVector;
 
-import io.netty.util.internal.PlatformDependent;
-
 /**
  * Consumer which consume binary type values from {@link ResultSet}.
  * Write the data to {@link org.apache.arrow.vector.VarBinaryVector}.

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
@@ -1,0 +1,23 @@
+package org.apache.arrow.adapter.jdbc.consumer;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
+import org.junit.Before;
+
+
+public abstract class AbstractConsumerTest {
+
+    protected BufferAllocator allocator;
+
+    @Before
+    public void setUp() {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+    }
+
+    @After
+    public void tearDown() {
+        allocator.close();
+    }
+
+}

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.arrow.adapter.jdbc.consumer;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -5,19 +22,18 @@ import org.apache.arrow.memory.RootAllocator;
 import org.junit.After;
 import org.junit.Before;
 
-
 public abstract class AbstractConsumerTest {
 
-    protected BufferAllocator allocator;
+  protected BufferAllocator allocator;
 
-    @Before
-    public void setUp() {
-        allocator = new RootAllocator(Long.MAX_VALUE);
-    }
+  @Before
+  public void setUp() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
 
-    @After
-    public void tearDown() {
-        allocator.close();
-    }
+  @After
+  public void tearDown() {
+    allocator.close();
+  }
 
 }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
@@ -1,99 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.arrow.adapter.jdbc.consumer;
 
-import org.apache.arrow.vector.BaseValueVector;
-import org.apache.arrow.vector.VarBinaryVector;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.*;
+import org.apache.arrow.vector.BaseValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.junit.Test;
 
 public class BinaryConsumerTest extends AbstractConsumerTest {
 
-    private static final int INITIAL_VALUE_ALLOCATION = BaseValueVector.INITIAL_VALUE_ALLOCATION;
-    private static final int DEFAULT_RECORD_BYTE_COUNT = 8;
+  private static final int INITIAL_VALUE_ALLOCATION = BaseValueVector.INITIAL_VALUE_ALLOCATION;
+  private static final int DEFAULT_RECORD_BYTE_COUNT = 8;
 
-    protected void assertConsume(boolean nullable, Consumer<BinaryConsumer> dataConsumer, byte[][] expect){
-        try(final VarBinaryVector vector = new VarBinaryVector("binary", allocator)) {
-            BinaryConsumer consumer = BinaryConsumer.createConsumer(vector, 0, nullable);
-            dataConsumer.accept(consumer);
-            assertEquals(expect.length - 1, vector.getLastSet());
-            for (int i = 0; i < expect.length; i++) {
-                byte[] value = expect[i];
-                if (value == null) {
-                    assertTrue(vector.isNull(i));
-                } else {
-                    assertArrayEquals(expect[i], vector.get(i));
-                }
-            }
+  protected void assertConsume(boolean nullable, Consumer<BinaryConsumer> dataConsumer, byte[][] expect) {
+    try (final VarBinaryVector vector = new VarBinaryVector("binary", allocator)) {
+      BinaryConsumer consumer = BinaryConsumer.createConsumer(vector, 0, nullable);
+      dataConsumer.accept(consumer);
+      assertEquals(expect.length - 1, vector.getLastSet());
+      for (int i = 0; i < expect.length; i++) {
+        byte[] value = expect[i];
+        if (value == null) {
+          assertTrue(vector.isNull(i));
+        } else {
+          assertArrayEquals(expect[i], vector.get(i));
         }
+      }
     }
+  }
 
-    private byte[] createBytes(int length) {
-        byte[] bytes = new byte[length];
-        for(int i=0;i<length;i++) {
-            bytes[i] = (byte) (i % 1024);
+  private byte[] createBytes(int length) {
+    byte[] bytes = new byte[length];
+    for (int i = 0; i < length; i++) {
+      bytes[i] = (byte) (i % 1024);
+    }
+    return bytes;
+  }
+
+
+  public void testConsumeInputStream(byte[][] values, boolean nullable) throws IOException {
+    assertConsume(nullable, binaryConsumer -> {
+      for (byte[] value : values) {
+        try {
+          binaryConsumer.consume(new ByteArrayInputStream(value));
+        } catch (IOException e) {
+          e.printStackTrace();
         }
-        return bytes;
+        binaryConsumer.moveWriterPosition();
+      }
+    }, values);
+  }
+
+  @Test
+  public void testConsumeInputStream() throws IOException {
+    testConsumeInputStream(new byte[][]{
+        createBytes(DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(DEFAULT_RECORD_BYTE_COUNT),
+        createBytes(DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(DEFAULT_RECORD_BYTE_COUNT * 2),
+        createBytes(DEFAULT_RECORD_BYTE_COUNT),
+        createBytes(DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT * 10),
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT),
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    testConsumeInputStream(new byte[][]{
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT),
+        createBytes(DEFAULT_RECORD_BYTE_COUNT),
+        createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
+    }, false);
+
+    byte[][] testRecords = new byte[INITIAL_VALUE_ALLOCATION * 2][];
+    for (int i = 0; i < testRecords.length; i++) {
+      testRecords[i] = createBytes(DEFAULT_RECORD_BYTE_COUNT);
     }
-
-
-    public void testConsumeInputStream(byte[][] values, boolean nullable) throws IOException {
-        assertConsume(nullable, binaryConsumer -> {
-            for (byte[] value : values) {
-                try {
-                    binaryConsumer.consume(new ByteArrayInputStream(value));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-                binaryConsumer.moveWriterPosition();
-            }
-        }, values);
-    }
-
-    @Test
-    public void testConsumeInputStream() throws IOException {
-        testConsumeInputStream(new byte[][]{
-                createBytes(DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(DEFAULT_RECORD_BYTE_COUNT),
-                createBytes(DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(DEFAULT_RECORD_BYTE_COUNT * 2),
-                createBytes(DEFAULT_RECORD_BYTE_COUNT),
-                createBytes(DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT * 10),
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT),
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        testConsumeInputStream(new byte[][]{
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT),
-                createBytes(DEFAULT_RECORD_BYTE_COUNT),
-                createBytes(INITIAL_VALUE_ALLOCATION * DEFAULT_RECORD_BYTE_COUNT)
-        }, false);
-
-        byte[][] testRecords = new byte[INITIAL_VALUE_ALLOCATION * 2][];
-        for (int i=0;i<testRecords.length;i++) {
-            testRecords[i] = createBytes(DEFAULT_RECORD_BYTE_COUNT);
-        }
-        testConsumeInputStream(testRecords, false);
-    }
+    testConsumeInputStream(testRecords, false);
+  }
 
 }


### PR DESCRIPTION
[ARROW-12012](https://issues.apache.org/jira/browse/ARROW-12012)
An exception will be thrown when BinaryConsumer consumes a large amount or a lot of data.