### PR TITLE
ARROW-12013: [C++][FlightRPC] Fix bundled gRPC version probing

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2371,30 +2371,30 @@ macro(build_grpc)
   set(ABSL_LIBRARIES)
 
   # Abseil libraries gRPC depends on
+  # Follows grpc++ package config template for link order of libraries
+  # https://github.com/grpc/grpc/blob/v1.35.0/CMakeLists.txt#L16361
   set(_ABSL_LIBS
-      bad_optional_access
-      base
-      cord
-      graphcycles_internal
-      int128
-      malloc_internal
-      raw_logging_internal
-      spinlock_wait
-      stacktrace
-      status
       statusor
+      status
+      cord
       str_format_internal
+      synchronization
+      graphcycles_internal
+      symbolize
+      demangle_internal
+      stacktrace
+      debugging_internal
+      malloc_internal
+      time
+      time_zone
       strings
       strings_internal
-      symbolize
-      # symbolize depends on debugging_internal
-      debugging_internal
-      # debugging_internal depends on demangle_internal
-      demangle_internal
-      synchronization
       throw_delegate
-      time
-      time_zone)
+      int128
+      base
+      spinlock_wait
+      bad_optional_access
+      raw_logging_internal)
 
   foreach(_ABSL_LIB ${_ABSL_LIBS})
     set(
@@ -2561,7 +2561,7 @@ macro(build_grpc)
     PROPERTIES IMPORTED_LOCATION
                "${GRPC_STATIC_LIBRARY_GRPCPP}"
                INTERFACE_LINK_LIBRARIES
-               "gRPC::grpc;gRPC::gpr;gRPC::upb;gRPC::address_sorting;${ABSL_LIBRARIES}"
+               "gRPC::grpc;gRPC::gpr;gRPC::upb;gRPC::address_sorting;${ABSL_LIBRARIES};Threads::Threads"
                INTERFACE_INCLUDE_DIRECTORIES
                "${GRPC_INCLUDE_DIR}")
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2558,12 +2558,13 @@ macro(build_grpc)
   add_library(gRPC::grpc++ STATIC IMPORTED)
   set_target_properties(
     gRPC::grpc++
-    PROPERTIES IMPORTED_LOCATION
-               "${GRPC_STATIC_LIBRARY_GRPCPP}"
-               INTERFACE_LINK_LIBRARIES
-               "gRPC::grpc;gRPC::gpr;gRPC::upb;gRPC::address_sorting;${ABSL_LIBRARIES};Threads::Threads"
-               INTERFACE_INCLUDE_DIRECTORIES
-               "${GRPC_INCLUDE_DIR}")
+    PROPERTIES
+      IMPORTED_LOCATION
+      "${GRPC_STATIC_LIBRARY_GRPCPP}"
+      INTERFACE_LINK_LIBRARIES
+      "gRPC::grpc;gRPC::gpr;gRPC::upb;gRPC::address_sorting;${ABSL_LIBRARIES};Threads::Threads"
+      INTERFACE_INCLUDE_DIRECTORIES
+      "${GRPC_INCLUDE_DIR}")
 
   add_executable(gRPC::grpc_cpp_plugin IMPORTED)
   set_target_properties(gRPC::grpc_cpp_plugin

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -102,19 +102,24 @@ function(test_grpc_version DST_VAR DETECT_VERSION TEST_FILE)
   endif()
 endfunction()
 
-test_grpc_version(GRPC_VERSION "1.36" "check_tls_opts_136.cc")
-test_grpc_version(GRPC_VERSION "1.34" "check_tls_opts_134.cc")
-test_grpc_version(GRPC_VERSION "1.32" "check_tls_opts_132.cc")
-test_grpc_version(GRPC_VERSION "1.27" "check_tls_opts_127.cc")
-message(
-  STATUS
-    "Found approximate gRPC version: ${GRPC_VERSION} (ARROW_FLIGHT_REQUIRE_TLSCREDENTIALSOPTIONS=${ARROW_FLIGHT_REQUIRE_TLSCREDENTIALSOPTIONS})"
-  )
+if(GRPC_VENDORED)
+  # v1.35.0 -> 1.35
+  string(REGEX MATCH "[0-9]+\\.[0-9]+" GRPC_VERSION "${ARROW_GRPC_BUILD_VERSION}")
+else()
+  test_grpc_version(GRPC_VERSION "1.36" "check_tls_opts_136.cc")
+  test_grpc_version(GRPC_VERSION "1.34" "check_tls_opts_134.cc")
+  test_grpc_version(GRPC_VERSION "1.32" "check_tls_opts_132.cc")
+  test_grpc_version(GRPC_VERSION "1.27" "check_tls_opts_127.cc")
+  message(
+    STATUS
+      "Found approximate gRPC version: ${GRPC_VERSION} (ARROW_FLIGHT_REQUIRE_TLSCREDENTIALSOPTIONS=${ARROW_FLIGHT_REQUIRE_TLSCREDENTIALSOPTIONS})"
+    )
+endif()
 if(GRPC_VERSION EQUAL "1.27")
   add_definitions(-DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc_impl::experimental)
 elseif(GRPC_VERSION EQUAL "1.32")
   add_definitions(-DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc::experimental)
-elseif(GRPC_VERSION EQUAL "1.34")
+elseif(GRPC_VERSION EQUAL "1.34" OR GRPC_VERSION EQUAL "1.35")
   add_definitions(-DGRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS
                   -DGRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS_ROOT_CERTS
                   -DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc::experimental)


### PR DESCRIPTION
Don't probe bundled gRPC version. It's not built when cmake runs, and we know the version.
This patch also tweaks ABSL libraries link order based on gRPC package config file.