### PR TITLE
ARROW-12015: [Rust] Fix Clippy

### DIFF
--- a/rust/arrow/src/array/array_binary.rs
+++ b/rust/arrow/src/array/array_binary.rs
@@ -418,10 +418,9 @@ impl FixedSizeBinaryArray {
                             slice.len()
                         )));
                     }
-                } else {
-                    size = Some(slice.len());
-                    buffer.extend_zeros(slice.len() * prepend);
                 }
+                size = Some(slice.len());
+                buffer.extend_zeros(slice.len() * prepend);
                 bit_util::set_bit(null_buf.as_slice_mut(), len);
                 buffer.extend_from_slice(slice);
             } else if let Some(size) = size {


### PR DESCRIPTION
Master has some lint failures: 
https://github.com/apache/arrow/pull/9749/checks?check_run_id=2144048180

```
error: this `else { if .. }` block can be collapsed
   --> arrow/src/array/array_binary.rs:427:20
    |
427 |               } else {
    |  ____________________^
428 | |                 if let Some(size) = size {
429 | |                     buffer.extend_zeros(size);
430 | |                 } else {
431 | |                     prepend += 1;
432 | |                 }
433 | |             }
    | |_____________^
    |
    = note: `-D clippy::collapsible-if` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: collapse nested if block
    |
427 |             } else if let Some(size) = size {
428 |                 buffer.extend_zeros(size);
429 |             } else {
430 |                 prepend += 1;
431 |             }
    |
```
Intrpduced in https://github.com/apache/arrow/pull/9647 / https://github.com/apache/arrow/commit/775a714006e2dbe0ed15cb83deb69c2c2ce1e77c (though I had problems reproducing this locally)