### PR TITLE
ARROW-11908: [C++] Work around flaky integration by retrying

### DIFF
--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -21,9 +21,11 @@
 // client then requests the data from the server and compares it to
 // the data originally uploaded.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include <gflags/gflags.h>
 
@@ -202,6 +204,19 @@ class IntegrationTestScenario : public flight::Scenario {
 }  // namespace flight
 }  // namespace arrow
 
+constexpr int kRetries = 3;
+
+arrow::Status RunScenario(arrow::flight::Scenario* scenario) {
+  auto options = arrow::flight::FlightClientOptions::Defaults();
+  std::unique_ptr<arrow::flight::FlightClient> client;
+
+  RETURN_NOT_OK(scenario->MakeClient(&options));
+  arrow::flight::Location location;
+  RETURN_NOT_OK(arrow::flight::Location::ForGrpcTcp(FLAGS_host, FLAGS_port, &location));
+  RETURN_NOT_OK(arrow::flight::FlightClient::Connect(location, options, &client));
+  return scenario->RunClient(std::move(client));
+}
+
 int main(int argc, char** argv) {
   arrow::util::ArrowLog::InstallFailureSignalHandler();
 
@@ -214,16 +229,15 @@ int main(int argc, char** argv) {
     scenario = std::make_shared<arrow::flight::IntegrationTestScenario>();
   }
 
-  arrow::flight::FlightClientOptions options =
-      arrow::flight::FlightClientOptions::Defaults();
-  std::unique_ptr<arrow::flight::FlightClient> client;
-
-  ABORT_NOT_OK(scenario->MakeClient(&options));
-
-  arrow::flight::Location location;
-  ABORT_NOT_OK(arrow::flight::Location::ForGrpcTcp(FLAGS_host, FLAGS_port, &location));
-  ABORT_NOT_OK(arrow::flight::FlightClient::Connect(location, options, &client));
-  ABORT_NOT_OK(scenario->RunClient(std::move(client)));
+  // ARROW-11908: retry a few times in case a client is slow to bring up the server
+  auto status = arrow::Status::OK();
+  for (int i = 0; i < kRetries; i++) {
+    status = RunScenario(scenario.get());
+    if (status.ok()) break;
+    // Failed, wait a bit and try again
+    std::this_thread::sleep_for(std::chrono::milliseconds((i + 1) * 500));
+  }
+  ABORT_NOT_OK(status);
 
   arrow::util::ArrowLog::UninstallSignalAction();
   return 0;


### PR DESCRIPTION
In principle I don't like tests which retry until they succeed, but in the meantime, flaky integration tests are making them a bad signal for maintainers. While the Rust side gets sorted out, this should paper over the issues. (It doesn't help that 'connected' in gRPC is (for reasonable reasons) nebulous, such that you don't get an actual connection error until you make a call.)

(The main issue is that it appears Rust's gRPC server returns to application code before it's quite fully listening, so a fast-enough client like C++ might run into a server that's not quite ready yet.)