### PR TITLE
ARROW-12031: [C++][CSV] infer CSV timestamps columns with fractional seconds

### DIFF
--- a/cpp/src/arrow/csv/column_builder_test.cc
+++ b/cpp/src/arrow/csv/column_builder_test.cc
@@ -422,6 +422,37 @@ TEST_F(InferringColumnBuilderTest, MultipleChunkTimestamp) {
   CheckInferred(tg, {{""}, {"1970-01-01"}, {"2018-11-13 17:11:10"}}, options, expected);
 }
 
+TEST_F(InferringColumnBuilderTest, SingleChunkTimestampNS) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(
+      timestamp(TimeUnit::NANO), {{false, true, true, true, true}},
+      {{0, 0, 1542129070123000000, 1542129070123456000, 1542129070123456789}}, &expected);
+  CheckInferred(tg,
+                {{"", "1970-01-01", "2018-11-13 17:11:10.123",
+                  "2018-11-13 17:11:10.123456", "2018-11-13 17:11:10.123456789"}},
+                options, expected);
+}
+
+TEST_F(InferringColumnBuilderTest, MultipleChunkTimestampNS) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(
+      timestamp(TimeUnit::NANO), {{false}, {true}, {true, true, true}},
+      {{0}, {0}, {1542129070123000000, 1542129070123456000, 1542129070123456789}},
+      &expected);
+  CheckInferred(tg,
+                {{""},
+                 {"1970-01-01"},
+                 {"2018-11-13 17:11:10.123", "2018-11-13 17:11:10.123456",
+                  "2018-11-13 17:11:10.123456789"}},
+                options, expected);
+}
+
 TEST_F(InferringColumnBuilderTest, SingleChunkString) {
   auto options = ConvertOptions::Defaults();
   auto tg = TaskGroup::MakeSerial();

--- a/cpp/src/arrow/csv/inference_internal.h
+++ b/cpp/src/arrow/csv/inference_internal.h
@@ -33,6 +33,7 @@ enum class InferKind {
   Real,
   Date,
   Timestamp,
+  TimestampNS,
   TextDict,
   BinaryDict,
   Text,
@@ -61,6 +62,8 @@ class InferStatus {
       case InferKind::Date:
         return SetKind(InferKind::Timestamp);
       case InferKind::Timestamp:
+        return SetKind(InferKind::TimestampNS);
+      case InferKind::TimestampNS:
         return SetKind(InferKind::Real);
       case InferKind::Real:
         if (options_.auto_dict_encode) {
@@ -112,8 +115,9 @@ class InferStatus {
       case InferKind::Date:
         return make_converter(date32());
       case InferKind::Timestamp:
-        // We don't support parsing second fractions for now
         return make_converter(timestamp(TimeUnit::SECOND));
+      case InferKind::TimestampNS:
+        return make_converter(timestamp(TimeUnit::NANO));
       case InferKind::Real:
         return make_converter(float64());
       case InferKind::Text:

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -112,6 +112,7 @@ column.  Type inference considers the following data types, in order:
 * Boolean
 * Date32
 * Timestamp (with seconds unit)
+* Timestamp (with nanoseconds unit)
 * Float64
 * Dictionary<String> (if :member:`ConvertOptions::auto_dict_encode` is true)
 * Dictionary<Binary> (if :member:`ConvertOptions::auto_dict_encode` is true)

--- a/docs/source/python/csv.rst
+++ b/docs/source/python/csv.rst
@@ -29,7 +29,7 @@ The features currently offered are the following:
   such as ``my_data.csv.gz``)
 * fetching column names from the first row in the CSV file
 * column-wise type inference and conversion to one of ``null``, ``int64``,
-  ``float64``, ``date32``, ``timestamp[s]``, ``string`` or ``binary`` data
+  ``float64``, ``date32``, ``timestamp[s]``, ``timestamp[ns]``, ``string`` or ``binary`` data
 * opportunistic dictionary encoding of ``string`` and ``binary`` columns
   (disabled by default)
 * detecting various spellings of null values such as ``NaN`` or ``#N/A``

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -509,14 +509,19 @@ class BaseTestCSVRead:
 
     def test_simple_timestamps(self):
         # Infer a timestamp column
-        rows = b"a,b\n1970,1970-01-01 00:00:00\n1989,1989-07-14 01:00:00\n"
+        rows = (b"a,b,c\n"
+                b"1970,1970-01-01 00:00:00,1970-01-01 00:00:00.123\n"
+                b"1989,1989-07-14 01:00:00,1989-07-14 01:00:00.123456\n")
         table = self.read_bytes(rows)
         schema = pa.schema([('a', pa.int64()),
-                            ('b', pa.timestamp('s'))])
+                            ('b', pa.timestamp('s')),
+                            ('c', pa.timestamp('ns'))])
         assert table.schema == schema
         assert table.to_pydict() == {
             'a': [1970, 1989],
             'b': [datetime(1970, 1, 1), datetime(1989, 7, 14, 1)],
+            'c': [datetime(1970, 1, 1, 0, 0, 0, 123000),
+                  datetime(1989, 7, 14, 1, 0, 0, 123456)],
         }
 
     def test_timestamp_parsers(self):


### PR DESCRIPTION
- implement support for inferring CSV timestamps columns with fractional seconds
- use timestamp[ns] parser which also covers [ms] and [us] to
  avoid testing 2 additional timestamp types