### PR TITLE
ARROW-12037: [Rust] [DataFusion] Support catalogs and schemas for table namespacing

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -157,9 +157,9 @@ async fn benchmark(opt: BenchmarkOpt) -> Result<Vec<arrow::record_batch::RecordB
                 table,
                 start.elapsed().as_millis()
             );
-            ctx.register_table(table, Arc::new(memtable));
+            ctx.register_table(*table, Arc::new(memtable)).unwrap();
         } else {
-            ctx.register_table(table, table_provider);
+            ctx.register_table(*table, table_provider).unwrap();
         }
     }
 
@@ -1614,7 +1614,7 @@ mod tests {
 
             let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
 
-            ctx.register_table(table, Arc::new(provider));
+            ctx.register_table(table, Arc::new(provider)).unwrap();
         }
 
         let plan = create_logical_plan(&mut ctx, n)?;

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -157,9 +157,9 @@ async fn benchmark(opt: BenchmarkOpt) -> Result<Vec<arrow::record_batch::RecordB
                 table,
                 start.elapsed().as_millis()
             );
-            ctx.register_table(*table, Arc::new(memtable)).unwrap();
+            ctx.register_table(*table, Arc::new(memtable))?;
         } else {
-            ctx.register_table(*table, table_provider).unwrap();
+            ctx.register_table(*table, table_provider)?;
         }
     }
 
@@ -1614,7 +1614,7 @@ mod tests {
 
             let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
 
-            ctx.register_table(table, Arc::new(provider)).unwrap();
+            ctx.register_table(table, Arc::new(provider))?;
         }
 
         let plan = create_logical_plan(&mut ctx, n)?;

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -1105,7 +1105,7 @@ fn get_table(
     table: &str,
     table_format: &str,
     max_concurrency: usize,
-) -> Result<Arc<dyn TableProvider + Send + Sync>> {
+) -> Result<Arc<dyn TableProvider>> {
     match table_format {
         // dbgen creates .tbl ('|' delimited) files without header
         "tbl" => {

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -150,7 +150,7 @@ fn create_context(
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, partitions)?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider))?;
 
     Ok(Arc::new(Mutex::new(ctx)))
 }

--- a/rust/datafusion/benches/filter_query_sql.rs
+++ b/rust/datafusion/benches/filter_query_sql.rs
@@ -62,7 +62,7 @@ fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContex
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider))?;
 
     Ok(ctx)
 }

--- a/rust/datafusion/benches/math_query_sql.rs
+++ b/rust/datafusion/benches/math_query_sql.rs
@@ -72,7 +72,7 @@ fn create_context(
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider))?;
 
     Ok(Arc::new(Mutex::new(ctx)))
 }

--- a/rust/datafusion/benches/sort_limit_query_sql.rs
+++ b/rust/datafusion/benches/sort_limit_query_sql.rs
@@ -81,7 +81,8 @@ fn create_context() -> Arc<Mutex<ExecutionContext>> {
         // create local execution context
         let mut ctx = ExecutionContext::new();
         ctx.state.lock().unwrap().config.concurrency = 1;
-        ctx.register_table("aggregate_test_100", Arc::new(mem_table));
+        ctx.register_table("aggregate_test_100", Arc::new(mem_table))
+            .unwrap();
         ctx_holder.lock().unwrap().push(Arc::new(Mutex::new(ctx)))
     });
 

--- a/rust/datafusion/examples/dataframe_in_memory.rs
+++ b/rust/datafusion/examples/dataframe_in_memory.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider)).unwrap();
     let df = ctx.table("t")?;
 
     // construct an expression corresponding to "SELECT a, b FROM t WHERE b = 10" in SQL

--- a/rust/datafusion/examples/dataframe_in_memory.rs
+++ b/rust/datafusion/examples/dataframe_in_memory.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;
-    ctx.register_table("t", Arc::new(provider)).unwrap();
+    ctx.register_table("t", Arc::new(provider))?;
     let df = ctx.table("t")?;
 
     // construct an expression corresponding to "SELECT a, b FROM t WHERE b = 10" in SQL

--- a/rust/datafusion/examples/simple_udaf.rs
+++ b/rust/datafusion/examples/simple_udaf.rs
@@ -48,7 +48,7 @@ fn create_context() -> Result<ExecutionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch1], vec![batch2]])?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider))?;
     Ok(ctx)
 }
 

--- a/rust/datafusion/examples/simple_udf.rs
+++ b/rust/datafusion/examples/simple_udf.rs
@@ -50,7 +50,7 @@ fn create_context() -> Result<ExecutionContext> {
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
     let provider = MemTable::try_new(schema, vec![vec![batch]])?;
-    ctx.register_table("t", Arc::new(provider));
+    ctx.register_table("t", Arc::new(provider))?;
     Ok(ctx)
 }
 

--- a/rust/datafusion/src/catalog/catalog.rs
+++ b/rust/datafusion/src/catalog/catalog.rs
@@ -19,11 +19,16 @@
 //! representing collections of named schemas.
 
 use crate::catalog::schema::SchemaProvider;
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 /// Represents a catalog, comprising a number of named schemas.
 pub trait CatalogProvider: Sync + Send {
+    /// Returns the catalog provider as [`Any`](std::any::Any)
+    /// so that it can be downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
     /// Retrieves the list of available schema names in this catalog.
     fn schema_names(&self) -> Vec<String>;
 
@@ -57,6 +62,10 @@ impl MemoryCatalogProvider {
 }
 
 impl CatalogProvider for MemoryCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn schema_names(&self) -> Vec<String> {
         let schemas = self.schemas.read().unwrap();
         schemas.keys().cloned().collect()

--- a/rust/datafusion/src/catalog/catalog.rs
+++ b/rust/datafusion/src/catalog/catalog.rs
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Describes the interface and built-in implementations of catalogs,
+//! representing collections of named schemas.
+
+use crate::catalog::schema::SchemaProvider;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// Represents a catalog, comprising a number of named schemas.
+pub trait CatalogProvider: Sync + Send {
+    /// Retrieves the list of available schema names in this catalog.
+    fn schema_names(&self) -> Vec<String>;
+
+    /// Retrieves a specific schema from the catalog by name, provided it exists.
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>>;
+}
+
+/// Simple in-memory implementation of a catalog.
+pub struct MemoryCatalogProvider {
+    schemas: RwLock<HashMap<String, Arc<dyn SchemaProvider>>>,
+}
+
+impl MemoryCatalogProvider {
+    /// Instantiates a new MemoryCatalogProvider with an empty collection of schemas.
+    pub fn new() -> Self {
+        Self {
+            schemas: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Adds a new schema to this catalog.
+    /// If a schema of the same name existed before, it is replaced in the catalog and returned.
+    pub fn register_schema(
+        &mut self,
+        name: impl Into<String>,
+        schema: Arc<dyn SchemaProvider>,
+    ) -> Option<Arc<dyn SchemaProvider>> {
+        let mut schemas = self.schemas.write().unwrap();
+        schemas.insert(name.into(), schema)
+    }
+}
+
+impl CatalogProvider for MemoryCatalogProvider {
+    fn schema_names(&self) -> Vec<String> {
+        let schemas = self.schemas.read().unwrap();
+        schemas.keys().cloned().collect()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        let schemas = self.schemas.read().unwrap();
+        schemas.get(name).cloned()
+    }
+}

--- a/rust/datafusion/src/catalog/catalog.rs
+++ b/rust/datafusion/src/catalog/catalog.rs
@@ -52,7 +52,7 @@ impl MemoryCatalogProvider {
     /// Adds a new schema to this catalog.
     /// If a schema of the same name existed before, it is replaced in the catalog and returned.
     pub fn register_schema(
-        &mut self,
+        &self,
         name: impl Into<String>,
         schema: Arc<dyn SchemaProvider>,
     ) -> Option<Arc<dyn SchemaProvider>> {

--- a/rust/datafusion/src/catalog/mod.rs
+++ b/rust/datafusion/src/catalog/mod.rs
@@ -35,12 +35,6 @@ pub struct ResolvedTableReference<'a> {
     pub table: &'a str,
 }
 
-impl<'a> std::fmt::Display for ResolvedTableReference<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.catalog, self.schema, self.table)
-    }
-}
-
 /// Represents a path to a table that may require further resolution
 #[derive(Clone, Copy)]
 pub enum TableReference<'a> {
@@ -103,20 +97,6 @@ impl<'a> TableReference<'a> {
                 schema: default_schema,
                 table,
             },
-        }
-    }
-}
-
-impl<'a> std::fmt::Display for TableReference<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Bare { table } => write!(f, "{}", table),
-            Self::Partial { schema, table } => write!(f, "{}.{}", schema, table),
-            Self::Full {
-                catalog,
-                schema,
-                table,
-            } => write!(f, "{}.{}.{}", catalog, schema, table),
         }
     }
 }

--- a/rust/datafusion/src/catalog/mod.rs
+++ b/rust/datafusion/src/catalog/mod.rs
@@ -20,3 +20,146 @@
 
 pub mod catalog;
 pub mod schema;
+
+use crate::error::DataFusionError;
+use std::convert::TryFrom;
+
+/// Represents a resolved path to a table of the form "catalog.schema.table"
+#[derive(Clone, Copy)]
+pub struct ResolvedTableReference<'a> {
+    /// The catalog (aka database) containing the table
+    pub catalog: &'a str,
+    /// The schema containing the table
+    pub schema: &'a str,
+    /// The table name
+    pub table: &'a str,
+}
+
+impl<'a> std::fmt::Display for ResolvedTableReference<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.catalog, self.schema, self.table)
+    }
+}
+
+/// Represents a path to a table that may require further resolution
+#[derive(Clone, Copy)]
+pub enum TableReference<'a> {
+    /// An unqualified table reference, e.g. "table"
+    Bare {
+        /// The table name
+        table: &'a str,
+    },
+    /// A partially resolved table reference, e.g. "schema.table"
+    Partial {
+        /// The schema containing the table
+        schema: &'a str,
+        /// The table name
+        table: &'a str,
+    },
+    /// A fully resolved table reference, e.g. "catalog.schema.table"
+    Full {
+        /// The catalog (aka database) containing the table
+        catalog: &'a str,
+        /// The schema containing the table
+        schema: &'a str,
+        /// The table name
+        table: &'a str,
+    },
+}
+
+impl<'a> TableReference<'a> {
+    /// Retrieve the actual table name, regardless of qualification
+    pub fn table(&self) -> &str {
+        match self {
+            Self::Full { table, .. }
+            | Self::Partial { table, .. }
+            | Self::Bare { table } => table,
+        }
+    }
+
+    /// Given a default catalog and schema, ensure this table reference is fully resolved
+    pub fn resolve(
+        self,
+        default_catalog: &'a str,
+        default_schema: &'a str,
+    ) -> ResolvedTableReference<'a> {
+        match self {
+            Self::Full {
+                catalog,
+                schema,
+                table,
+            } => ResolvedTableReference {
+                catalog,
+                schema,
+                table,
+            },
+            Self::Partial { schema, table } => ResolvedTableReference {
+                catalog: default_catalog,
+                schema,
+                table,
+            },
+            Self::Bare { table } => ResolvedTableReference {
+                catalog: default_catalog,
+                schema: default_schema,
+                table,
+            },
+        }
+    }
+}
+
+impl<'a> std::fmt::Display for TableReference<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bare { table } => write!(f, "{}", table),
+            Self::Partial { schema, table } => write!(f, "{}.{}", schema, table),
+            Self::Full {
+                catalog,
+                schema,
+                table,
+            } => write!(f, "{}.{}.{}", catalog, schema, table),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for TableReference<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::Bare { table: s }
+    }
+}
+
+impl<'a> From<ResolvedTableReference<'a>> for TableReference<'a> {
+    fn from(resolved: ResolvedTableReference<'a>) -> Self {
+        Self::Full {
+            catalog: resolved.catalog,
+            schema: resolved.schema,
+            table: resolved.table,
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a sqlparser::ast::ObjectName> for TableReference<'a> {
+    type Error = DataFusionError;
+
+    fn try_from(value: &'a sqlparser::ast::ObjectName) -> Result<Self, Self::Error> {
+        let idents = &value.0;
+
+        match idents.len() {
+            1 => Ok(Self::Bare {
+                table: &idents[0].value,
+            }),
+            2 => Ok(Self::Partial {
+                schema: &idents[0].value,
+                table: &idents[1].value,
+            }),
+            3 => Ok(Self::Full {
+                catalog: &idents[0].value,
+                schema: &idents[1].value,
+                table: &idents[2].value,
+            }),
+            _ => Err(DataFusionError::Plan(format!(
+                "invalid table reference: {}",
+                value
+            ))),
+        }
+    }
+}

--- a/rust/datafusion/src/catalog/mod.rs
+++ b/rust/datafusion/src/catalog/mod.rs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module contains interfaces and default implementations
+//! of table namespacing concepts, including catalogs and schemas.
+
+pub mod catalog;
+pub mod schema;

--- a/rust/datafusion/src/catalog/schema.rs
+++ b/rust/datafusion/src/catalog/schema.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Describes the interface and built-in implementations of schemas,
+//! representing collections of named tables.
+
+use crate::datasource::TableProvider;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// Represents a schema, comprising a number of named tables.
+pub trait SchemaProvider: Sync + Send {
+    /// Retrieves the list of available table names in this schema.
+    fn table_names(&self) -> Vec<String>;
+
+    /// Retrieves a specific table from the schema by name, provided it exists.
+    fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>>;
+}
+
+/// Simple in-memory implementation of a schema.
+pub struct MemorySchemaProvider {
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
+}
+
+impl MemorySchemaProvider {
+    /// Instantiates a new MemorySchemaProvider with an empty collection of tables.
+    pub fn new() -> Self {
+        Self {
+            tables: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Adds a new table to this schema.
+    /// If a table of the same name existed before, it is replaced in the schema and returned.
+    pub fn register_table(
+        &self,
+        name: impl Into<String>,
+        table: Arc<dyn TableProvider>,
+    ) -> Option<Arc<dyn TableProvider>> {
+        let mut tables = self.tables.write().unwrap();
+        tables.insert(name.into(), table)
+    }
+
+    /// Removes an existing table from this schema and returns it.
+    /// If no table of that name exists, returns None.
+    pub fn deregister_table(
+        &self,
+        name: impl AsRef<str>,
+    ) -> Option<Arc<dyn TableProvider>> {
+        let mut tables = self.tables.write().unwrap();
+        tables.remove(name.as_ref())
+    }
+}
+
+impl SchemaProvider for MemorySchemaProvider {
+    fn table_names(&self) -> Vec<String> {
+        let tables = self.tables.read().unwrap();
+        tables.keys().cloned().collect()
+    }
+
+    fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        let tables = self.tables.read().unwrap();
+        tables.get(name).cloned()
+    }
+}

--- a/rust/datafusion/src/catalog/schema.rs
+++ b/rust/datafusion/src/catalog/schema.rs
@@ -38,10 +38,11 @@ pub trait SchemaProvider: Sync + Send {
 
     /// If supported by the implementation, adds a new table to this schema.
     /// If a table of the same name existed before, it is replaced in the schema and returned.
+    #[allow(unused_variables)]
     fn register_table(
         &self,
-        _name: String,
-        _table: Arc<dyn TableProvider>,
+        name: String,
+        table: Arc<dyn TableProvider>,
     ) -> Result<Option<Arc<dyn TableProvider>>> {
         Err(DataFusionError::Execution(
             "schema provider does not support registering tables".to_owned(),
@@ -50,7 +51,8 @@ pub trait SchemaProvider: Sync + Send {
 
     /// If supported by the implementation, removes an existing table from this schema and returns it.
     /// If no table of that name exists, returns Ok(None).
-    fn deregister_table(&self, _name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+    #[allow(unused_variables)]
+    fn deregister_table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
         Err(DataFusionError::Execution(
             "schema provider does not support deregistering tables".to_owned(),
         ))

--- a/rust/datafusion/src/catalog/schema.rs
+++ b/rust/datafusion/src/catalog/schema.rs
@@ -20,11 +20,16 @@
 
 use crate::datasource::TableProvider;
 use crate::error::{DataFusionError, Result};
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 /// Represents a schema, comprising a number of named tables.
 pub trait SchemaProvider: Sync + Send {
+    /// Returns the schema provider as [`Any`](std::any::Any)
+    /// so that it can be downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
     /// Retrieves the list of available table names in this schema.
     fn table_names(&self) -> Vec<String>;
 
@@ -67,6 +72,10 @@ impl MemorySchemaProvider {
 }
 
 impl SchemaProvider for MemorySchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn table_names(&self) -> Vec<String> {
         let tables = self.tables.read().unwrap();
         tables.keys().cloned().collect()

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -67,7 +67,7 @@ pub enum TableProviderFilterPushDown {
 }
 
 /// Source table
-pub trait TableProvider {
+pub trait TableProvider: Sync + Send {
     /// Returns the table provider as [`Any`](std::any::Any) so that it can be
     /// downcast to a specific implementation.
     fn as_any(&self) -> &dyn Any;

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -110,7 +110,7 @@ impl MemTable {
 
     /// Create a mem table by reading from another data source
     pub async fn load(
-        t: Arc<dyn TableProvider + Send + Sync>,
+        t: Arc<dyn TableProvider>,
         batch_size: usize,
         output_partitions: Option<usize>,
     ) -> Result<Self> {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -239,7 +239,7 @@ impl ExecutionContext {
     /// Creates a DataFrame for reading a custom TableProvider.
     pub fn read_table(
         &mut self,
-        provider: Arc<dyn TableProvider + Send + Sync>,
+        provider: Arc<dyn TableProvider>,
     ) -> Result<Arc<dyn DataFrame>> {
         let schema = provider.schema();
         let table_scan = LogicalPlan::TableScan {
@@ -288,8 +288,8 @@ impl ExecutionContext {
     pub fn register_table(
         &mut self,
         name: &str,
-        provider: Arc<dyn TableProvider + Send + Sync>,
-    ) -> Option<Arc<dyn TableProvider + Send + Sync>> {
+        provider: Arc<dyn TableProvider>,
+    ) -> Option<Arc<dyn TableProvider>> {
         self.state
             .lock()
             .unwrap()
@@ -300,10 +300,7 @@ impl ExecutionContext {
     /// Deregisters the named table.
     ///
     /// Returns the registered provider, if any
-    pub fn deregister_table(
-        &mut self,
-        name: &str,
-    ) -> Option<Arc<dyn TableProvider + Send + Sync>> {
+    pub fn deregister_table(&mut self, name: &str) -> Option<Arc<dyn TableProvider>> {
         self.state.lock().unwrap().datasources.remove(name)
     }
 
@@ -570,7 +567,7 @@ impl ExecutionConfig {
 #[derive(Clone)]
 pub struct ExecutionContextState {
     /// Data sources that are registered with the context
-    pub datasources: HashMap<String, Arc<dyn TableProvider + Send + Sync>>,
+    pub datasources: HashMap<String, Arc<dyn TableProvider>>,
     /// Scalar functions that are registered with the context
     pub scalar_functions: HashMap<String, Arc<ScalarUDF>>,
     /// Variable provider that are registered with the context
@@ -582,10 +579,7 @@ pub struct ExecutionContextState {
 }
 
 impl ContextProvider for ExecutionContextState {
-    fn get_table_provider(
-        &self,
-        name: &str,
-    ) -> Option<Arc<dyn TableProvider + Send + Sync>> {
+    fn get_table_provider(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
         self.datasources.get(name).map(|ds| Arc::clone(ds))
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -650,7 +650,7 @@ impl ExecutionConfig {
 /// Execution context for registering data sources and executing queries
 #[derive(Clone)]
 pub struct ExecutionContextState {
-    ///
+    /// Collection of catalogs containing schemas and ultimately tables
     pub catalogs: HashMap<String, Arc<dyn CatalogProvider>>,
     /// Scalar functions that are registered with the context
     pub scalar_functions: HashMap<String, Arc<ScalarUDF>>,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -656,7 +656,7 @@ impl ExecutionConfig {
 /// Execution context for registering data sources and executing queries
 #[derive(Clone)]
 pub struct ExecutionContextState {
-    /// Collection of catalogs containing schemas and ultimately tables
+    /// Collection of catalogs containing schemas and ultimately TableProviders
     pub catalogs: HashMap<String, Arc<dyn CatalogProvider>>,
     /// Scalar functions that are registered with the context
     pub scalar_functions: HashMap<String, Arc<ScalarUDF>>,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -835,7 +835,7 @@ mod tests {
         ctx.register_variable(VarType::UserDefined, Arc::new(variable_provider));
 
         let provider = test::create_table_dual();
-        ctx.register_table("dual", provider).unwrap();
+        ctx.register_table("dual", provider)?;
 
         let results =
             plan_and_collect(&mut ctx, "SELECT @@version, @name FROM dual").await?;
@@ -859,10 +859,10 @@ mod tests {
         let mut ctx = create_ctx(&tmp_dir, partition_count)?;
 
         let provider = test::create_table_dual();
-        ctx.register_table("dual", provider).unwrap();
+        ctx.register_table("dual", provider)?;
 
-        assert!(ctx.deregister_table("dual").unwrap().is_some());
-        assert!(ctx.deregister_table("dual").unwrap().is_none());
+        assert!(ctx.deregister_table("dual")?.is_some());
+        assert!(ctx.deregister_table("dual")?.is_none());
 
         Ok(())
     }
@@ -1842,7 +1842,7 @@ mod tests {
         let mut ctx = ExecutionContext::new();
 
         let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
-        ctx.register_table("t", Arc::new(provider)).unwrap();
+        ctx.register_table("t", Arc::new(provider))?;
 
         let myfunc = |args: &[ArrayRef]| {
             let l = &args[0]
@@ -1922,7 +1922,7 @@ mod tests {
             assert_eq!(a.value(i) + b.value(i), sum.value(i));
         }
 
-        ctx.deregister_table("t").unwrap();
+        ctx.deregister_table("t")?;
 
         Ok(())
     }
@@ -1944,7 +1944,7 @@ mod tests {
 
         let provider =
             MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
-        ctx.register_table("t", Arc::new(provider)).unwrap();
+        ctx.register_table("t", Arc::new(provider))?;
 
         let result = plan_and_collect(&mut ctx, "SELECT AVG(a) FROM t").await?;
 
@@ -1981,7 +1981,7 @@ mod tests {
 
         let provider =
             MemTable::try_new(Arc::new(schema), vec![vec![batch1], vec![batch2]])?;
-        ctx.register_table("t", Arc::new(provider)).unwrap();
+        ctx.register_table("t", Arc::new(provider))?;
 
         // define a udaf, using a DataFusion's accumulator
         let my_avg = create_udaf(

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -157,6 +157,7 @@
 extern crate arrow;
 extern crate sqlparser;
 
+pub mod catalog;
 pub mod dataframe;
 pub mod datasource;
 pub mod error;

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -103,7 +103,7 @@ impl LogicalPlanBuilder {
     /// Convert a table provider into a builder with a TableScan
     pub fn scan(
         name: &str,
-        provider: Arc<dyn TableProvider + Send + Sync>,
+        provider: Arc<dyn TableProvider>,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         let schema = provider.schema();

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -134,7 +134,7 @@ pub enum LogicalPlan {
         /// The name of the table
         table_name: String,
         /// The source of the table
-        source: Arc<dyn TableProvider + Send + Sync>,
+        source: Arc<dyn TableProvider>,
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The schema description of the output

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -392,7 +392,6 @@ impl RowGroupPredicateBuilder {
             .collect::<Vec<_>>();
         let stat_schema = Schema::new(stat_fields);
         let execution_context_state = ExecutionContextState {
-            default_schema: None,
             catalogs: HashMap::new(),
             scalar_functions: HashMap::new(),
             var_provider: HashMap::new(),

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -392,7 +392,8 @@ impl RowGroupPredicateBuilder {
             .collect::<Vec<_>>();
         let stat_schema = Schema::new(stat_fields);
         let execution_context_state = ExecutionContextState {
-            datasources: HashMap::new(),
+            default_schema: None,
+            catalogs: HashMap::new(),
             scalar_functions: HashMap::new(),
             var_provider: HashMap::new(),
             aggregate_functions: HashMap::new(),

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -764,7 +764,6 @@ mod tests {
 
     fn make_ctx_state() -> ExecutionContextState {
         ExecutionContextState {
-            default_schema: None,
             catalogs: HashMap::new(),
             scalar_functions: HashMap::new(),
             var_provider: HashMap::new(),

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -764,7 +764,8 @@ mod tests {
 
     fn make_ctx_state() -> ExecutionContextState {
         ExecutionContextState {
-            datasources: HashMap::new(),
+            default_schema: None,
+            catalogs: HashMap::new(),
             scalar_functions: HashMap::new(),
             var_provider: HashMap::new(),
             aggregate_functions: HashMap::new(),

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -58,10 +58,7 @@ use super::utils::{
 /// functions referenced in SQL statements
 pub trait ContextProvider {
     /// Getter for a datasource
-    fn get_table_provider(
-        &self,
-        name: &str,
-    ) -> Option<Arc<dyn TableProvider + Send + Sync>>;
+    fn get_table_provider(&self, name: &str) -> Option<Arc<dyn TableProvider>>;
     /// Getter for a UDF description
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>>;
     /// Getter for a UDAF description
@@ -2493,10 +2490,7 @@ mod tests {
     struct MockContextProvider {}
 
     impl ContextProvider for MockContextProvider {
-        fn get_table_provider(
-            &self,
-            name: &str,
-        ) -> Option<Arc<dyn TableProvider + Send + Sync>> {
+        fn get_table_provider(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
             let schema = match name {
                 "person" => Some(Schema::new(vec![
                     Field::new("id", DataType::UInt32, false),
@@ -2540,7 +2534,7 @@ mod tests {
                 ])),
                 _ => None,
             };
-            schema.map(|s| -> Arc<dyn TableProvider + Send + Sync> {
+            schema.map(|s| -> Arc<dyn TableProvider> {
                 Arc::new(EmptyTable::new(Arc::new(s)))
             })
         }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -2496,8 +2496,7 @@ mod tests {
             &self,
             name: TableReference,
         ) -> Option<Arc<dyn TableProvider>> {
-            let resolved_ref = name.resolve("", "");
-            let schema = match resolved_ref.table {
+            let schema = match name.table() {
                 "person" => Some(Schema::new(vec![
                     Field::new("id", DataType::UInt32, false),
                     Field::new("first_name", DataType::Utf8, false),

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -29,7 +29,7 @@ use std::io::{BufReader, BufWriter};
 use std::sync::Arc;
 use tempfile::TempDir;
 
-pub fn create_table_dual() -> Arc<dyn TableProvider + Send + Sync> {
+pub fn create_table_dual() -> Arc<dyn TableProvider> {
     let dual_schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, false),

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -61,11 +61,11 @@ async fn join() -> Result<()> {
     let table1 = MemTable::try_new(schema1, vec![vec![batch1]])?;
     let table2 = MemTable::try_new(schema2, vec![vec![batch2]])?;
 
-    ctx.register_table("aa", Arc::new(table1));
+    ctx.register_table("aa", Arc::new(table1))?;
 
     let df1 = ctx.table("aa")?;
 
-    ctx.register_table("aaa", Arc::new(table2));
+    ctx.register_table("aaa", Arc::new(table2))?;
 
     let df2 = ctx.table("aaa")?;
 

--- a/rust/datafusion/tests/provider_filter_pushdown.rs
+++ b/rust/datafusion/tests/provider_filter_pushdown.rs
@@ -156,7 +156,7 @@ async fn assert_provider_row_count(value: i64, expected_count: u64) -> Result<()
     let result_col: &UInt64Array = as_primitive_array(results[0].column(0));
     assert_eq!(result_col.value(0), expected_count);
 
-    ctx.register_table("data", Arc::new(provider));
+    ctx.register_table("data", Arc::new(provider))?;
     let sql_results = ctx
         .sql(&format!("select count(*) from data where flag = {}", value))?
         .collect()

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2504,3 +2504,20 @@ async fn inner_join_qualified_names() -> Result<()> {
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn qualified_table_references() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+
+    for table_ref in &[
+        "aggregate_test_100",
+        "public.aggregate_test_100",
+        "datafusion.public.aggregate_test_100",
+    ] {
+        let sql = format!("SELECT COUNT(*) FROM {}", table_ref);
+        let results = execute(&mut ctx, &sql).await;
+        assert_eq!(results, vec![vec!["100"]]);
+    }
+    Ok(())
+}

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1168,7 +1168,7 @@ fn create_case_context() -> Result<ExecutionContext> {
         ]))],
     )?;
     let table = MemTable::try_new(schema, vec![vec![data]])?;
-    ctx.register_table("t1", Arc::new(table));
+    ctx.register_table("t1", Arc::new(table))?;
     Ok(ctx)
 }
 
@@ -1317,7 +1317,7 @@ fn create_join_context(
         ],
     )?;
     let t1_table = MemTable::try_new(t1_schema, vec![vec![t1_data]])?;
-    ctx.register_table("t1", Arc::new(t1_table));
+    ctx.register_table("t1", Arc::new(t1_table))?;
 
     let t2_schema = Arc::new(Schema::new(vec![
         Field::new(column_right, DataType::UInt32, true),
@@ -1336,7 +1336,7 @@ fn create_join_context(
         ],
     )?;
     let t2_table = MemTable::try_new(t2_schema, vec![vec![t2_data]])?;
-    ctx.register_table("t2", Arc::new(t2_table));
+    ctx.register_table("t2", Arc::new(t2_table))?;
 
     Ok(ctx)
 }
@@ -1358,7 +1358,7 @@ fn create_join_context_qualified() -> Result<ExecutionContext> {
         ],
     )?;
     let t1_table = MemTable::try_new(t1_schema, vec![vec![t1_data]])?;
-    ctx.register_table("t1", Arc::new(t1_table));
+    ctx.register_table("t1", Arc::new(t1_table))?;
 
     let t2_schema = Arc::new(Schema::new(vec![
         Field::new("a", DataType::UInt32, true),
@@ -1374,7 +1374,7 @@ fn create_join_context_qualified() -> Result<ExecutionContext> {
         ],
     )?;
     let t2_table = MemTable::try_new(t2_schema, vec![vec![t2_data]])?;
-    ctx.register_table("t2", Arc::new(t2_table));
+    ctx.register_table("t2", Arc::new(t2_table))?;
 
     Ok(ctx)
 }
@@ -1594,7 +1594,7 @@ async fn generic_query_length<T: 'static + Array + From<Vec<&'static str>>>(
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT length(c1) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["0"], vec!["1"], vec!["2"], vec!["3"]];
@@ -1630,7 +1630,7 @@ async fn query_not() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT NOT c1 FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["true"], vec!["NULL"], vec!["false"]];
@@ -1656,7 +1656,7 @@ async fn query_concat() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT concat(c1, '-hi-', cast(c2 as varchar)) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![
@@ -1687,7 +1687,7 @@ async fn query_array() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT array(c1, cast(c2 as varchar)) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![
@@ -1780,7 +1780,7 @@ fn make_timestamp_nano_table() -> Result<Arc<MemTable>> {
 #[tokio::test]
 async fn to_timestamp() -> Result<()> {
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("ts_data", make_timestamp_nano_table()?);
+    ctx.register_table("ts_data", make_timestamp_nano_table()?)?;
 
     let sql = "SELECT COUNT(*) FROM ts_data where ts > to_timestamp('2020-09-08T12:00:00+00:00')";
     let actual = execute(&mut ctx, sql).await;
@@ -1806,7 +1806,7 @@ async fn query_is_null() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT c1 IS NULL FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["false"], vec!["true"], vec!["false"]];
@@ -1830,7 +1830,7 @@ async fn query_is_not_null() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT c1 IS NOT NULL FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["true"], vec!["false"], vec!["true"]];
@@ -1857,7 +1857,7 @@ async fn query_count_distinct() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT COUNT(DISTINCT c1) FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["3".to_string()]];
@@ -1886,7 +1886,7 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     let table = MemTable::try_new(schema, vec![vec![data]])?;
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
 
     // Basic SELECT
     let sql = "SELECT * FROM test";
@@ -1957,7 +1957,7 @@ async fn query_scalar_minus_array() -> Result<()> {
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("test", Arc::new(table));
+    ctx.register_table("test", Arc::new(table))?;
     let sql = "SELECT 4 - c1 FROM test";
     let actual = execute(&mut ctx, sql).await;
     let expected = vec![vec!["4"], vec!["3"], vec!["NULL"], vec!["1"]];
@@ -2036,7 +2036,7 @@ async fn csv_group_by_date() -> Result<()> {
     )?;
     let table = MemTable::try_new(schema, vec![vec![data]])?;
 
-    ctx.register_table("dates", Arc::new(table));
+    ctx.register_table("dates", Arc::new(table))?;
     let sql = "SELECT SUM(cnt) FROM dates GROUP BY date";
     let actual = execute(&mut ctx, sql).await;
     let mut actual: Vec<String> = actual.iter().flatten().cloned().collect();

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2533,6 +2533,7 @@ async fn invalid_qualified_table_references() -> Result<()> {
     for table_ref in &[
         "nonexistentschema.aggregate_test_100",
         "nonexistentcatalog.public.aggregate_test_100",
+        "way.too.many.namespaces.as.ident.prefixes.aggregate_test_100",
     ] {
         let sql = format!("SELECT COUNT(*) FROM {}", table_ref);
         assert!(matches!(ctx.sql(&sql), Err(DataFusionError::Plan(_))));


### PR DESCRIPTION
This is an implementation of catalog and schema providers to support table namespacing (see the [design doc](https://docs.google.com/document/d/1_bCP_tjVRLJyOrMBOezSFNpF0hwPa1ZS_qMWv1uvtS4/edit?usp=sharing)).

I'm creating this draft PR as a supporting implementation for the proposal, to prove out that the work can be done whilst minimising API churn and still allowing for use cases that don't care at all about the notion of catalogs or schemas; in this new setup, the default namespace is `datafusion.public`, which will be created automatically with the default execution context config and allow for table registration.

## Highlights
- Datasource map removed in execution context state, replaced with catalog map
- Execution context allows for registering new catalog providers
- Catalog providers can be queried for their constituent schema providers
- Schema providers can be queried for table providers, similarly to the old datasource map
- Includes basic implementations of `CatalogProvider` and `SchemaProvider` backed by hashmaps
- New `TableReference` enum maps to various ways of referring to a table in sql
  - Bare: `my_table`
  - Partial: `schema.my_table`
  - Full: `catalog.schema.my_table`
- Given a default catalog and schema, `TableReference` instances of any variant can be converted to a `ResolvedTableReference`, which always include all three components