### PR TITLE
ARROW-12039: [Nightly][Gandiva] Fix gandiva-jar-ubuntu nightly build failure

### DIFF
--- a/dev/tasks/gandiva-jars/github.linux.yml
+++ b/dev/tasks/gandiva-jars/github.linux.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   package:
     name: Package Gandiva
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout Arrow
         run: |


### PR DESCRIPTION
After ubuntu-latest tag moved from ubuntu-18.04 to ubuntu-20.04, the java build started failing with ```Error:  Failed to execute goal on project arrow-orc: Could not resolve dependencies for project org.apache.arrow.orc:arrow-orc:jar:4.0.0-SNAPSHOT: Could not find artifact jdk.tools:jdk.tools:jar:1.6 at specified path /usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/../lib/tools.jar -> [Help 1]``` which seems to due to some jdk related issue and not related to gandiva. So pinning the version to 18.04