### PR TITLE
ARROW-12019: [Rust] [Parquet] Update README for 2.6.0 support

### DIFF
--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -57,7 +57,7 @@ This crate used `parquet::basic::LogicalType` to map to the `ConvertedType`, but
 
 The `ConvertedType` is deprecated in the format, but is still written
 to preserve backward compatibility.
-It is preferred that `LogicalType` is used, as it suports nanosecond
+It is preferred that `LogicalType` is used, as it supports nanosecond
 precision timestamps without using the deprecated `Int96` Parquet type.
 
 ## Supported Parquet Version

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -50,14 +50,18 @@ See [crate documentation](https://docs.rs/crate/parquet/4.0.0-SNAPSHOT) on avail
 
 If you are upgrading from version 3.0 or previous of this crate, you
 likely need to change your code to use [`ConvertedType`] rather than
-[`LogicalType`]. Version 4.0 introduces an *entirely new* struct
-called `LogicalType` to align with the `LogicalType` introduced in
-Parquet Format 2.4.0. The type previously called `LogicalType` was was
-renamed to `ConvertedType`.
+[`LogicalType`] to preserve existing behaviour in your code.
 
+Version 2.4.0 of the Parquet format introduced a `LogicalType` to replace the existing `ConvertedType`.
+This crate used `parquet::basic::LogicalType` to map to the `ConvertedType`, but this has been renamed to `parquet::basic::ConvertedType` from version 4.0 of this crate.
+
+The `ConvertedType` is deprecated in the format, but is still written
+to preserve backward compatibility.
+It is preferred that `LogicalType` is used, as it suports nanosecond
+precision timestamps without using the deprecated `Int96` Parquet type.
 
 ## Supported Parquet Version
-- Parquet-format 2.4.0
+- Parquet-format 2.6.0
 
 To update Parquet format to a newer version, check if [parquet-format](https://github.com/sunchao/parquet-format-rs)
 version is available. Then simply update version of `parquet-format` crate in Cargo.toml.
@@ -73,9 +77,9 @@ version is available. Then simply update version of `parquet-format` crate in Ca
 - [X] Write support
   - [X] Primitive column value writers
   - [ ] Row record writer
-  - [ ] Arrow record writer
+  - [X] Arrow record writer
 - [ ] Predicate pushdown
-- [ ] Parquet format 2.5 support
+- [X] Parquet format 2.6.0 support
 
 ## Requirements
 

--- a/rust/parquet/src/basic.rs
+++ b/rust/parquet/src/basic.rs
@@ -60,7 +60,8 @@ pub enum Type {
 /// This helps map between types in those frameworks to the base types in Parquet.
 /// This is only metadata and not needed to read or write the data.
 ///
-/// *Upgrade Note*: This struct was renamed from `LogicalType` in version 4.0.0.
+/// This struct was renamed from `LogicalType` in version 4.0.0.
+/// If targeting Parquet format 2.4.0 or above, please use [LogicalType] instead.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ConvertedType {
     NONE,
@@ -157,9 +158,9 @@ pub enum ConvertedType {
 // ----------------------------------------------------------------------
 // Mirrors `parquet::LogicalType`
 
-/// Logical types used by version 2 of the Parquet format.
+/// Logical types used by version 2.4.0+ of the Parquet format.
 ///
-/// *Upgrade Note*: This is an *entirely new* struct as of version
+/// This is an *entirely new* struct as of version
 /// 4.0.0. The struct previously named `LogicalType` was renamed to
 /// [`ConvertedType`]. Please see the README.md for more details.
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Updates the README for 2.6.0 support, and updates the notes about ConvertedType & LogicalType