### PR TITLE
ARROW-12028 ARROW-11940: [Rust][DataFusion] Add TimestampMillisecond support to GROUP BY/hash aggregates

### DIFF
--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -673,13 +673,11 @@ impl LogicalPlan {
                         partitioning_scheme,
                         ..
                     } => match partitioning_scheme {
-                        Partitioning::RoundRobinBatch(n) => {
-                            write!(
-                                f,
-                                "Repartition: RoundRobinBatch partition_count={}",
-                                n
-                            )
-                        }
+                        Partitioning::RoundRobinBatch(n) => write!(
+                            f,
+                            "Repartition: RoundRobinBatch partition_count={}",
+                            n
+                        ),
                         Partitioning::Hash(expr, n) => {
                             let hash_expr: Vec<String> =
                                 expr.iter().map(|e| format!("{:?}", e)).collect();

--- a/rust/datafusion/src/physical_plan/group_scalar.rs
+++ b/rust/datafusion/src/physical_plan/group_scalar.rs
@@ -65,6 +65,8 @@ impl TryFrom<&ScalarValue> for GroupByScalar {
             ScalarValue::UInt32(Some(v)) => GroupByScalar::UInt32(*v),
             ScalarValue::UInt64(Some(v)) => GroupByScalar::UInt64(*v),
             ScalarValue::TimeMillisecond(Some(v)) => GroupByScalar::TimeMillisecond(*v),
+            ScalarValue::TimeMicrosecond(Some(v)) => GroupByScalar::TimeMicrosecond(*v),
+            ScalarValue::TimeNanosecond(Some(v)) => GroupByScalar::TimeNanosecond(*v),
             ScalarValue::Utf8(Some(v)) => GroupByScalar::Utf8(Box::new(v.clone())),
             ScalarValue::Float32(None)
             | ScalarValue::Float64(None)

--- a/rust/datafusion/src/physical_plan/group_scalar.rs
+++ b/rust/datafusion/src/physical_plan/group_scalar.rs
@@ -38,6 +38,7 @@ pub(crate) enum GroupByScalar {
     Int64(i64),
     Utf8(Box<String>),
     Boolean(bool),
+    TimeMillisecond(i64),
     TimeMicrosecond(i64),
     TimeNanosecond(i64),
     Date32(i32),
@@ -63,6 +64,7 @@ impl TryFrom<&ScalarValue> for GroupByScalar {
             ScalarValue::UInt16(Some(v)) => GroupByScalar::UInt16(*v),
             ScalarValue::UInt32(Some(v)) => GroupByScalar::UInt32(*v),
             ScalarValue::UInt64(Some(v)) => GroupByScalar::UInt64(*v),
+            ScalarValue::TimeMillisecond(Some(v)) => GroupByScalar::TimeMillisecond(*v),
             ScalarValue::Utf8(Some(v)) => GroupByScalar::Utf8(Box::new(v.clone())),
             ScalarValue::Float32(None)
             | ScalarValue::Float64(None)
@@ -106,6 +108,7 @@ impl From<&GroupByScalar> for ScalarValue {
             GroupByScalar::UInt32(v) => ScalarValue::UInt32(Some(*v)),
             GroupByScalar::UInt64(v) => ScalarValue::UInt64(Some(*v)),
             GroupByScalar::Utf8(v) => ScalarValue::Utf8(Some(v.to_string())),
+            GroupByScalar::TimeMillisecond(v) => ScalarValue::TimeMillisecond(Some(*v)),
             GroupByScalar::TimeMicrosecond(v) => ScalarValue::TimeMicrosecond(Some(*v)),
             GroupByScalar::TimeNanosecond(v) => ScalarValue::TimeNanosecond(Some(*v)),
             GroupByScalar::Date32(v) => ScalarValue::Date32(Some(*v)),

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -656,42 +656,20 @@ fn equal_rows(
         .zip(right_arrays)
         .all(|(l, r)| match l.data_type() {
             DataType::Null => true,
-            DataType::Boolean => {
-                equal_rows_elem!(BooleanArray, l, r, left, right)
-            }
-            DataType::Int8 => {
-                equal_rows_elem!(Int8Array, l, r, left, right)
-            }
-            DataType::Int16 => {
-                equal_rows_elem!(Int16Array, l, r, left, right)
-            }
-            DataType::Int32 => {
-                equal_rows_elem!(Int32Array, l, r, left, right)
-            }
-            DataType::Int64 => {
-                equal_rows_elem!(Int64Array, l, r, left, right)
-            }
-            DataType::UInt8 => {
-                equal_rows_elem!(UInt8Array, l, r, left, right)
-            }
-            DataType::UInt16 => {
-                equal_rows_elem!(UInt16Array, l, r, left, right)
-            }
-            DataType::UInt32 => {
-                equal_rows_elem!(UInt32Array, l, r, left, right)
-            }
-            DataType::UInt64 => {
-                equal_rows_elem!(UInt64Array, l, r, left, right)
-            }
+            DataType::Boolean => equal_rows_elem!(BooleanArray, l, r, left, right),
+            DataType::Int8 => equal_rows_elem!(Int8Array, l, r, left, right),
+            DataType::Int16 => equal_rows_elem!(Int16Array, l, r, left, right),
+            DataType::Int32 => equal_rows_elem!(Int32Array, l, r, left, right),
+            DataType::Int64 => equal_rows_elem!(Int64Array, l, r, left, right),
+            DataType::UInt8 => equal_rows_elem!(UInt8Array, l, r, left, right),
+            DataType::UInt16 => equal_rows_elem!(UInt16Array, l, r, left, right),
+            DataType::UInt32 => equal_rows_elem!(UInt32Array, l, r, left, right),
+            DataType::UInt64 => equal_rows_elem!(UInt64Array, l, r, left, right),
             DataType::Timestamp(_, None) => {
                 equal_rows_elem!(Int64Array, l, r, left, right)
             }
-            DataType::Utf8 => {
-                equal_rows_elem!(StringArray, l, r, left, right)
-            }
-            DataType::LargeUtf8 => {
-                equal_rows_elem!(LargeStringArray, l, r, left, right)
-            }
+            DataType::Utf8 => equal_rows_elem!(StringArray, l, r, left, right),
+            DataType::LargeUtf8 => equal_rows_elem!(LargeStringArray, l, r, left, right),
             _ => {
                 // This is internal because we should have caught this before.
                 err = Some(Err(DataFusionError::Internal(

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -19,12 +19,12 @@
 
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
-use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
 use arrow::array::{
-    Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder,
+    ArrayRef, Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder,
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-    UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder, ArrayRef,
+    UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
+use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
 use arrow::{
     array::*,
     datatypes::{ArrowNativeType, Float32Type, TimestampNanosecondType},

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -20,6 +20,11 @@
 use std::{convert::TryFrom, fmt, iter::repeat, sync::Arc};
 
 use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+use arrow::array::{
+    Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder, ArrayRef,
+};
 use arrow::{
     array::*,
     datatypes::{ArrowNativeType, Float32Type, TimestampNanosecondType},
@@ -67,6 +72,8 @@ pub enum ScalarValue {
     Date32(Option<i32>),
     /// Date stored as a signed 64bit int
     Date64(Option<i64>),
+    /// Timestamp Milliseconds
+    TimeMillisecond(Option<i64>),
     /// Timestamp Microseconds
     TimeMicrosecond(Option<i64>),
     /// Timestamp Nanoseconds
@@ -144,6 +151,9 @@ impl ScalarValue {
             ScalarValue::TimeNanosecond(_) => {
                 DataType::Timestamp(TimeUnit::Nanosecond, None)
             }
+            ScalarValue::TimeMillisecond(_) => {
+                DataType::Timestamp(TimeUnit::Millisecond, None)
+            }
             ScalarValue::Float32(_) => DataType::Float32,
             ScalarValue::Float64(_) => DataType::Float64,
             ScalarValue::Utf8(_) => DataType::Utf8,
@@ -177,7 +187,7 @@ impl ScalarValue {
             ScalarValue::Int16(Some(v)) => ScalarValue::Int16(Some(-v)),
             ScalarValue::Int32(Some(v)) => ScalarValue::Int32(Some(-v)),
             ScalarValue::Int64(Some(v)) => ScalarValue::Int64(Some(-v)),
-            _ => panic!("Cannot run arithmetic negate on scala value: {:?}", self),
+            _ => panic!("Cannot run arithmetic negate on scalar value: {:?}", self),
         }
     }
 
@@ -199,6 +209,9 @@ impl ScalarValue {
                 | ScalarValue::Utf8(None)
                 | ScalarValue::LargeUtf8(None)
                 | ScalarValue::List(None, _)
+                | ScalarValue::TimeMillisecond(None)
+                | ScalarValue::TimeMicrosecond(None)
+                | ScalarValue::TimeNanosecond(None)
         )
     }
 
@@ -272,6 +285,15 @@ impl ScalarValue {
                     Arc::new(UInt64Array::from_iter_values(repeat(*value).take(size)))
                 }
                 None => new_null_array(&DataType::UInt64, size),
+            },
+            ScalarValue::TimeMillisecond(e) => match e {
+                Some(value) => Arc::new(TimestampMillisecondArray::from_iter_values(
+                    repeat(*value).take(size),
+                )),
+                None => new_null_array(
+                    &DataType::Timestamp(TimeUnit::Millisecond, None),
+                    size,
+                ),
             },
             ScalarValue::TimeMicrosecond(e) => match e {
                 Some(value) => Arc::new(TimestampMicrosecondArray::from_iter_values(
@@ -599,6 +621,7 @@ impl fmt::Display for ScalarValue {
             ScalarValue::UInt16(e) => format_option!(f, e)?,
             ScalarValue::UInt32(e) => format_option!(f, e)?,
             ScalarValue::UInt64(e) => format_option!(f, e)?,
+            ScalarValue::TimeMillisecond(e) => format_option!(f, e)?,
             ScalarValue::TimeMicrosecond(e) => format_option!(f, e)?,
             ScalarValue::TimeNanosecond(e) => format_option!(f, e)?,
             ScalarValue::Utf8(e) => format_option!(f, e)?,
@@ -659,6 +682,7 @@ impl fmt::Debug for ScalarValue {
             ScalarValue::UInt16(_) => write!(f, "UInt16({})", self),
             ScalarValue::UInt32(_) => write!(f, "UInt32({})", self),
             ScalarValue::UInt64(_) => write!(f, "UInt64({})", self),
+            ScalarValue::TimeMillisecond(_) => write!(f, "TimeMillisecond({})", self),
             ScalarValue::TimeMicrosecond(_) => write!(f, "TimeMicrosecond({})", self),
             ScalarValue::TimeNanosecond(_) => write!(f, "TimeNanosecond({})", self),
             ScalarValue::Utf8(None) => write!(f, "Utf8({})", self),

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2054,10 +2054,14 @@ async fn group_by_timestamp_millis() -> Result<()> {
     let mut ctx = ExecutionContext::new();
 
     let schema = Arc::new(Schema::new(vec![
-        Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
         Field::new("count", DataType::Int32, false),
     ]));
-    let base_dt = Utc.ymd(2018, 7, 1).and_hms(6,0,0);     // 2018-Jul-01 06:00
+    let base_dt = Utc.ymd(2018, 7, 1).and_hms(6, 0, 0); // 2018-Jul-01 06:00
     let hour1 = Duration::hours(1);
     let timestamps = vec![
         base_dt.timestamp_millis(),
@@ -2077,7 +2081,8 @@ async fn group_by_timestamp_millis() -> Result<()> {
     let t1_table = MemTable::try_new(schema, vec![vec![data]])?;
     ctx.register_table("t1", Arc::new(t1_table));
 
-    let sql = "SELECT timestamp, SUM(count) FROM t1 GROUP BY timestamp ORDER BY timestamp ASC";
+    let sql =
+        "SELECT timestamp, SUM(count) FROM t1 GROUP BY timestamp ORDER BY timestamp ASC";
     let actual = execute(&mut ctx, sql).await;
     let actual: Vec<String> = actual.iter().map(|row| row[1].clone()).collect();
     let expected = vec!["80", "130"];

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -18,6 +18,9 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use chrono::prelude::*;
+use chrono::Duration;
+
 extern crate arrow;
 extern crate datafusion;
 
@@ -2042,6 +2045,42 @@ async fn csv_group_by_date() -> Result<()> {
     let mut actual: Vec<String> = actual.iter().flatten().cloned().collect();
     actual.sort();
     let expected = vec!["6", "9"];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
+async fn group_by_timestamp_millis() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+        Field::new("count", DataType::Int32, false),
+    ]));
+    let base_dt = Utc.ymd(2018, 7, 1).and_hms(6,0,0);     // 2018-Jul-01 06:00
+    let hour1 = Duration::hours(1);
+    let timestamps = vec![
+        base_dt.timestamp_millis(),
+        (base_dt + hour1).timestamp_millis(),
+        base_dt.timestamp_millis(),
+        base_dt.timestamp_millis(),
+        (base_dt + hour1).timestamp_millis(),
+        (base_dt + hour1).timestamp_millis(),
+    ];
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(TimestampMillisecondArray::from(timestamps)),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50, 60])),
+        ],
+    )?;
+    let t1_table = MemTable::try_new(schema, vec![vec![data]])?;
+    ctx.register_table("t1", Arc::new(t1_table));
+
+    let sql = "SELECT timestamp, SUM(count) FROM t1 GROUP BY timestamp ORDER BY timestamp ASC";
+    let actual = execute(&mut ctx, sql).await;
+    let actual: Vec<String> = actual.iter().map(|row| row[1].clone()).collect();
+    let expected = vec!["80", "130"];
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
This PR adds support for TimestampMillisecondArray to `Scalar`, `GroupByScalar`, and hash_aggregate / GROUP BYs to Rust DataFusion, thus fixing 12028.   I believe it might also fix 11940, though this needs input from you all.

There are some formatting changes from running `cargo fmt`.