### PR TITLE
[MINOR] [Rust] [Parquet] Cleanup clippy.

### DIFF
--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1206,7 +1206,7 @@ impl<'a> TypeVisitor<Option<Box<dyn ArrayReader>>, &'a ArrayReaderBuilderContext
         &mut self,
         cur_type: Arc<Type>,
         context: &'a ArrayReaderBuilderContext,
-    ) -> Result<Option<Box<ArrayReader>>> {
+    ) -> Result<Option<Box<dyn ArrayReader>>> {
         let mut new_context = context.clone();
         new_context.path.append(vec![cur_type.name().to_string()]);
 

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -82,7 +82,7 @@ impl<T: DataType> RecordReader<T> {
     }
 
     /// Set the current page reader.
-    pub fn set_page_reader(&mut self, page_reader: Box<PageReader>) -> Result<()> {
+    pub fn set_page_reader(&mut self, page_reader: Box<dyn PageReader>) -> Result<()> {
         self.column_reader =
             Some(ColumnReaderImpl::new(self.column_desc.clone(), page_reader));
         Ok(())

--- a/rust/parquet/src/column/page.rs
+++ b/rust/parquet/src/column/page.rs
@@ -219,7 +219,7 @@ pub trait PageWriter {
 }
 
 /// An iterator over pages of some specific column in a parquet file.
-pub trait PageIterator: Iterator<Item = Result<Box<PageReader>>> {
+pub trait PageIterator: Iterator<Item = Result<Box<dyn PageReader>>> {
     /// Get schema of parquet file.
     fn schema(&mut self) -> Result<SchemaDescPtr>;
 

--- a/rust/parquet/src/column/reader.rs
+++ b/rust/parquet/src/column/reader.rs
@@ -49,7 +49,7 @@ pub enum ColumnReader {
 /// column reader will read from pages in `col_page_reader`.
 pub fn get_column_reader(
     col_descr: ColumnDescPtr,
-    col_page_reader: Box<PageReader>,
+    col_page_reader: Box<dyn PageReader>,
 ) -> ColumnReader {
     match col_descr.physical_type() {
         Type::BOOLEAN => ColumnReader::BoolColumnReader(ColumnReaderImpl::new(
@@ -106,7 +106,7 @@ pub struct ColumnReaderImpl<T: DataType> {
     descr: ColumnDescPtr,
     def_level_decoder: Option<LevelDecoder>,
     rep_level_decoder: Option<LevelDecoder>,
-    page_reader: Box<PageReader>,
+    page_reader: Box<dyn PageReader>,
     current_encoding: Option<Encoding>,
 
     // The total number of values stored in the data page.
@@ -117,12 +117,12 @@ pub struct ColumnReaderImpl<T: DataType> {
     num_decoded_values: u32,
 
     // Cache of decoders for existing encodings
-    decoders: HashMap<Encoding, Box<Decoder<T>>>,
+    decoders: HashMap<Encoding, Box<dyn Decoder<T>>>,
 }
 
 impl<T: DataType> ColumnReaderImpl<T> {
     /// Creates new column reader based on column descriptor and page reader.
-    pub fn new(descr: ColumnDescPtr, page_reader: Box<PageReader>) -> Self {
+    pub fn new(descr: ColumnDescPtr, page_reader: Box<dyn PageReader>) -> Self {
         Self {
             descr,
             def_level_decoder: None,

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -78,7 +78,7 @@ macro_rules! gen_stats_section {
 pub fn get_column_writer(
     descr: ColumnDescPtr,
     props: WriterPropertiesPtr,
-    page_writer: Box<PageWriter>,
+    page_writer: Box<dyn PageWriter>,
 ) -> ColumnWriter {
     match descr.physical_type() {
         Type::BOOLEAN => ColumnWriter::BoolColumnWriter(ColumnWriterImpl::new(
@@ -166,12 +166,12 @@ pub struct ColumnWriterImpl<T: DataType> {
     // Column writer properties
     descr: ColumnDescPtr,
     props: WriterPropertiesPtr,
-    page_writer: Box<PageWriter>,
+    page_writer: Box<dyn PageWriter>,
     has_dictionary: bool,
     dict_encoder: Option<DictEncoder<T>>,
-    encoder: Box<Encoder<T>>,
+    encoder: Box<dyn Encoder<T>>,
     codec: Compression,
-    compressor: Option<Box<Codec>>,
+    compressor: Option<Box<dyn Codec>>,
     // Metrics per page
     num_buffered_values: u32,
     num_buffered_encoded_values: u32,
@@ -203,7 +203,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
     pub fn new(
         descr: ColumnDescPtr,
         props: WriterPropertiesPtr,
-        page_writer: Box<PageWriter>,
+        page_writer: Box<dyn PageWriter>,
     ) -> Self {
         let codec = props.compression(descr.path());
         let compressor = create_codec(codec).unwrap();
@@ -879,7 +879,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
 
     /// Returns reference to the underlying page writer.
     /// This method is intended to use in tests only.
-    fn get_page_writer_ref(&self) -> &Box<PageWriter> {
+    fn get_page_writer_ref(&self) -> &Box<dyn PageWriter> {
         &self.page_writer
     }
 
@@ -1842,7 +1842,7 @@ mod tests {
 
     /// Returns column writer.
     fn get_test_column_writer<T: DataType>(
-        page_writer: Box<PageWriter>,
+        page_writer: Box<dyn PageWriter>,
         max_def_level: i16,
         max_rep_level: i16,
         props: WriterPropertiesPtr,
@@ -1854,7 +1854,7 @@ mod tests {
 
     /// Returns column reader.
     fn get_test_column_reader<T: DataType>(
-        page_reader: Box<PageReader>,
+        page_reader: Box<dyn PageReader>,
         max_def_level: i16,
         max_rep_level: i16,
     ) -> ColumnReaderImpl<T> {
@@ -1879,7 +1879,7 @@ mod tests {
     }
 
     /// Returns page writer that collects pages without serializing them.
-    fn get_test_page_writer() -> Box<PageWriter> {
+    fn get_test_page_writer() -> Box<dyn PageWriter> {
         Box::new(TestPageWriter {})
     }
 

--- a/rust/parquet/src/compression.rs
+++ b/rust/parquet/src/compression.rs
@@ -60,7 +60,7 @@ pub trait Codec {
 /// Given the compression type `codec`, returns a codec used to compress and decompress
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
-pub fn create_codec(codec: CodecType) -> Result<Option<Box<Codec>>> {
+pub fn create_codec(codec: CodecType) -> Result<Option<Box<dyn Codec>>> {
     match codec {
         #[cfg(any(feature = "brotli", test))]
         CodecType::BROTLI => Ok(Some(Box::new(BrotliCodec::new()))),

--- a/rust/parquet/src/encodings/decoding.rs
+++ b/rust/parquet/src/encodings/decoding.rs
@@ -108,8 +108,8 @@ pub trait Decoder<T: DataType> {
 pub fn get_decoder<T: DataType>(
     descr: ColumnDescPtr,
     encoding: Encoding,
-) -> Result<Box<Decoder<T>>> {
-    let decoder: Box<Decoder<T>> = match encoding {
+) -> Result<Box<dyn Decoder<T>>> {
+    let decoder: Box<dyn Decoder<T>> = match encoding {
         Encoding::PLAIN => Box::new(PlainDecoder::new(descr.type_length())),
         Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => {
             return Err(general_err!(
@@ -231,7 +231,7 @@ impl<T: DataType> DictDecoder<T> {
     }
 
     /// Decodes and sets values for dictionary using `decoder` decoder.
-    pub fn set_dict(&mut self, mut decoder: Box<Decoder<T>>) -> Result<()> {
+    pub fn set_dict(&mut self, mut decoder: Box<dyn Decoder<T>>) -> Result<()> {
         let num_values = decoder.values_left();
         self.dictionary.resize(num_values, T::T::default());
         let _ = decoder.get(&mut self.dictionary)?;

--- a/rust/parquet/src/encodings/encoding.rs
+++ b/rust/parquet/src/encodings/encoding.rs
@@ -77,8 +77,8 @@ pub fn get_encoder<T: DataType>(
     desc: ColumnDescPtr,
     encoding: Encoding,
     mem_tracker: MemTrackerPtr,
-) -> Result<Box<Encoder<T>>> {
-    let encoder: Box<Encoder<T>> = match encoding {
+) -> Result<Box<dyn Encoder<T>>> {
+    let encoder: Box<dyn Encoder<T>> = match encoding {
         Encoding::PLAIN => Box::new(PlainEncoder::new(desc, mem_tracker, vec![])),
         Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => {
             return Err(general_err!(
@@ -1261,8 +1261,8 @@ mod tests {
     }
 
     fn put_and_get<T: DataType>(
-        encoder: &mut Box<Encoder<T>>,
-        decoder: &mut Box<Decoder<T>>,
+        encoder: &mut Box<dyn Encoder<T>>,
+        decoder: &mut Box<dyn Decoder<T>>,
         input: &[T::T],
         output: &mut [T::T],
     ) -> Result<usize> {
@@ -1305,13 +1305,19 @@ mod tests {
         ))
     }
 
-    fn create_test_encoder<T: DataType>(type_len: i32, enc: Encoding) -> Box<Encoder<T>> {
+    fn create_test_encoder<T: DataType>(
+        type_len: i32,
+        enc: Encoding,
+    ) -> Box<dyn Encoder<T>> {
         let desc = create_test_col_desc_ptr(type_len, T::get_physical_type());
         let mem_tracker = Arc::new(MemTracker::new());
         get_encoder(desc, enc, mem_tracker).unwrap()
     }
 
-    fn create_test_decoder<T: DataType>(type_len: i32, enc: Encoding) -> Box<Decoder<T>> {
+    fn create_test_decoder<T: DataType>(
+        type_len: i32,
+        enc: Encoding,
+    ) -> Box<dyn Decoder<T>> {
         let desc = create_test_col_desc_ptr(type_len, T::get_physical_type());
         get_decoder(desc, enc).unwrap()
     }

--- a/rust/parquet/src/errors.rs
+++ b/rust/parquet/src/errors.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for ParquetError {
 }
 
 impl std::error::Error for ParquetError {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn ::std::error::Error> {
         None
     }
 }

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -66,11 +66,14 @@ pub trait FileWriter {
     /// There is no limit on a number of row groups in a file; however, row groups have
     /// to be written sequentially. Every time the next row group is requested, the
     /// previous row group must be finalised and closed using `close_row_group` method.
-    fn next_row_group(&mut self) -> Result<Box<RowGroupWriter>>;
+    fn next_row_group(&mut self) -> Result<Box<dyn RowGroupWriter>>;
 
     /// Finalises and closes row group that was created using `next_row_group` method.
     /// After calling this method, the next row group is available for writes.
-    fn close_row_group(&mut self, row_group_writer: Box<RowGroupWriter>) -> Result<()>;
+    fn close_row_group(
+        &mut self,
+        row_group_writer: Box<dyn RowGroupWriter>,
+    ) -> Result<()>;
 
     /// Closes and finalises file writer.
     ///
@@ -165,7 +168,7 @@ impl<W: ParquetWriter> SerializedFileWriter<W> {
     /// Finalises active row group writer, otherwise no-op.
     fn finalise_row_group_writer(
         &mut self,
-        mut row_group_writer: Box<RowGroupWriter>,
+        mut row_group_writer: Box<dyn RowGroupWriter>,
     ) -> Result<()> {
         let row_group_metadata = row_group_writer.close()?;
         self.total_num_rows += row_group_metadata.num_rows();
@@ -229,7 +232,7 @@ impl<W: ParquetWriter> SerializedFileWriter<W> {
 
 impl<W: 'static + ParquetWriter> FileWriter for SerializedFileWriter<W> {
     #[inline]
-    fn next_row_group(&mut self) -> Result<Box<RowGroupWriter>> {
+    fn next_row_group(&mut self) -> Result<Box<dyn RowGroupWriter>> {
         self.assert_closed()?;
         self.assert_previous_writer_closed()?;
         let row_group_writer = SerializedRowGroupWriter::new(
@@ -242,7 +245,10 @@ impl<W: 'static + ParquetWriter> FileWriter for SerializedFileWriter<W> {
     }
 
     #[inline]
-    fn close_row_group(&mut self, row_group_writer: Box<RowGroupWriter>) -> Result<()> {
+    fn close_row_group(
+        &mut self,
+        row_group_writer: Box<dyn RowGroupWriter>,
+    ) -> Result<()> {
         self.assert_closed()?;
         let res = self.finalise_row_group_writer(row_group_writer);
         self.previous_writer_closed = res.is_ok();
@@ -993,7 +999,7 @@ mod tests {
     }
 
     /// Helper function to compress a slice
-    fn compress_helper(compressor: Option<&mut Box<Codec>>, data: &[u8]) -> Vec<u8> {
+    fn compress_helper(compressor: Option<&mut Box<dyn Codec>>, data: &[u8]) -> Vec<u8> {
         let mut output_buf = vec![];
         if let Some(cmpr) = compressor {
             cmpr.compress(data, &mut output_buf).unwrap();

--- a/rust/parquet/src/lib.rs
+++ b/rust/parquet/src/lib.rs
@@ -18,7 +18,6 @@
 #![allow(incomplete_features)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-#![allow(bare_trait_objects)]
 #![allow(
     clippy::approx_constant,
     clippy::borrowed_box,

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -134,7 +134,7 @@ pub trait RowAccessor {
 
 /// Trait for formating fields within a Row.
 pub trait RowFormatter {
-    fn fmt(&self, i: usize) -> &fmt::Display;
+    fn fmt(&self, i: usize) -> &dyn fmt::Display;
 }
 
 /// Macro to generate type-safe get_xxx methods for primitive types,
@@ -173,7 +173,7 @@ macro_rules! row_complex_accessor {
 
 impl RowFormatter for Row {
     /// Get Display reference for a given field.
-    fn fmt(&self, i: usize) -> &fmt::Display {
+    fn fmt(&self, i: usize) -> &dyn fmt::Display {
         &self.fields[i].1
     }
 }
@@ -387,8 +387,8 @@ pub fn make_map(entries: Vec<(Field, Field)>) -> Map {
 
 /// Trait for type-safe access of an index for a `Map`
 pub trait MapAccessor {
-    fn get_keys<'a>(&'a self) -> Box<ListAccessor + 'a>;
-    fn get_values<'a>(&'a self) -> Box<ListAccessor + 'a>;
+    fn get_keys<'a>(&'a self) -> Box<dyn ListAccessor + 'a>;
+    fn get_values<'a>(&'a self) -> Box<dyn ListAccessor + 'a>;
 }
 
 struct MapList<'a> {
@@ -453,14 +453,14 @@ impl<'a> ListAccessor for MapList<'a> {
 }
 
 impl MapAccessor for Map {
-    fn get_keys<'a>(&'a self) -> Box<ListAccessor + 'a> {
+    fn get_keys<'a>(&'a self) -> Box<dyn ListAccessor + 'a> {
         let map_list = MapList {
             elements: self.entries.iter().map(|v| &v.0).collect(),
         };
         Box::new(map_list)
     }
 
-    fn get_values<'a>(&'a self) -> Box<ListAccessor + 'a> {
+    fn get_values<'a>(&'a self) -> Box<dyn ListAccessor + 'a> {
         let map_list = MapList {
             elements: self.entries.iter().map(|v| &v.1).collect(),
         };

--- a/rust/parquet/src/record/reader.rs
+++ b/rust/parquet/src/record/reader.rs
@@ -58,7 +58,7 @@ impl TreeBuilder {
     pub fn build(
         &self,
         descr: SchemaDescPtr,
-        row_group_reader: &RowGroupReader,
+        row_group_reader: &dyn RowGroupReader,
     ) -> Reader {
         // Prepare lookup table of column path -> original column index
         // This allows to prune columns and map schema leaf nodes to the column readers
@@ -96,7 +96,7 @@ impl TreeBuilder {
     pub fn as_iter(
         &self,
         descr: SchemaDescPtr,
-        row_group_reader: &RowGroupReader,
+        row_group_reader: &dyn RowGroupReader,
     ) -> ReaderIter {
         let num_records = row_group_reader.metadata().num_rows() as usize;
         ReaderIter::new(self.build(descr, row_group_reader), num_records)
@@ -110,7 +110,7 @@ impl TreeBuilder {
         mut curr_def_level: i16,
         mut curr_rep_level: i16,
         paths: &HashMap<ColumnPath, usize>,
-        row_group_reader: &RowGroupReader,
+        row_group_reader: &dyn RowGroupReader,
     ) -> Reader {
         assert!(field.get_basic_info().has_repetition());
         // Update current definition and repetition levels for this type
@@ -615,12 +615,12 @@ impl fmt::Display for Reader {
 /// The enum Either with variants That represet a reference and a box of
 /// [`FileReader`](crate::file::reader::FileReader).
 enum Either<'a> {
-    Left(&'a FileReader),
-    Right(Box<FileReader>),
+    Left(&'a dyn FileReader),
+    Right(Box<dyn FileReader>),
 }
 
 impl<'a> Either<'a> {
-    fn reader(&self) -> &FileReader {
+    fn reader(&self) -> &dyn FileReader {
         match *self {
             Either::Left(r) => r,
             Either::Right(ref r) => &**r,
@@ -665,7 +665,7 @@ impl<'a> RowIter<'a> {
 
     /// Creates iterator of [`Row`](crate::record::Row)s for all row groups in a
     /// file.
-    pub fn from_file(proj: Option<Type>, reader: &'a FileReader) -> Result<Self> {
+    pub fn from_file(proj: Option<Type>, reader: &'a dyn FileReader) -> Result<Self> {
         let either = Either::Left(reader);
         let descr = Self::get_proj_descr(
             proj,
@@ -678,7 +678,7 @@ impl<'a> RowIter<'a> {
     /// Creates iterator of [`Row`](crate::record::Row)s for a specific row group.
     pub fn from_row_group(
         proj: Option<Type>,
-        reader: &'a RowGroupReader,
+        reader: &'a dyn RowGroupReader,
     ) -> Result<Self> {
         let descr = Self::get_proj_descr(proj, reader.metadata().schema_descr_ptr())?;
         let tree_builder = Self::tree_builder();
@@ -691,7 +691,7 @@ impl<'a> RowIter<'a> {
 
     /// Creates a iterator of [`Row`](crate::record::Row)s from a
     /// [`FileReader`](crate::file::reader::FileReader) using the full file schema.
-    pub fn from_file_into(reader: Box<FileReader>) -> Self {
+    pub fn from_file_into(reader: Box<dyn FileReader>) -> Self {
         let either = Either::Right(reader);
         let descr = either
             .reader()

--- a/rust/parquet/src/record/record_writer.rs
+++ b/rust/parquet/src/record/record_writer.rs
@@ -21,6 +21,6 @@ use super::super::file::writer::RowGroupWriter;
 pub trait RecordWriter<T> {
     fn write_to_row_group(
         &self,
-        row_group_writer: &mut Box<RowGroupWriter>,
+        row_group_writer: &mut Box<dyn RowGroupWriter>,
     ) -> Result<(), ParquetError>;
 }

--- a/rust/parquet/src/schema/printer.rs
+++ b/rust/parquet/src/schema/printer.rs
@@ -54,7 +54,7 @@ use crate::schema::types::Type;
 /// Prints Parquet metadata [`ParquetMetaData`](crate::file::metadata::ParquetMetaData)
 /// information.
 #[allow(unused_must_use)]
-pub fn print_parquet_metadata(out: &mut io::Write, metadata: &ParquetMetaData) {
+pub fn print_parquet_metadata(out: &mut dyn io::Write, metadata: &ParquetMetaData) {
     print_file_metadata(out, &metadata.file_metadata());
     writeln!(out);
     writeln!(out);
@@ -71,7 +71,7 @@ pub fn print_parquet_metadata(out: &mut io::Write, metadata: &ParquetMetaData) {
 /// Prints file metadata [`FileMetaData`](crate::file::metadata::FileMetaData)
 /// information.
 #[allow(unused_must_use)]
-pub fn print_file_metadata(out: &mut io::Write, file_metadata: &FileMetaData) {
+pub fn print_file_metadata(out: &mut dyn io::Write, file_metadata: &FileMetaData) {
     writeln!(out, "version: {}", file_metadata.version());
     writeln!(out, "num of rows: {}", file_metadata.num_rows());
     if let Some(created_by) = file_metadata.created_by().as_ref() {
@@ -94,7 +94,7 @@ pub fn print_file_metadata(out: &mut io::Write, file_metadata: &FileMetaData) {
 
 /// Prints Parquet [`Type`](crate::schema::types::Type) information.
 #[allow(unused_must_use)]
-pub fn print_schema(out: &mut io::Write, tp: &Type) {
+pub fn print_schema(out: &mut dyn io::Write, tp: &Type) {
     // TODO: better if we can pass fmt::Write to Printer.
     // But how can we make it to accept both io::Write & fmt::Write?
     let mut s = String::new();
@@ -106,7 +106,7 @@ pub fn print_schema(out: &mut io::Write, tp: &Type) {
 }
 
 #[allow(unused_must_use)]
-fn print_row_group_metadata(out: &mut io::Write, rg_metadata: &RowGroupMetaData) {
+fn print_row_group_metadata(out: &mut dyn io::Write, rg_metadata: &RowGroupMetaData) {
     writeln!(out, "total byte size: {}", rg_metadata.total_byte_size());
     writeln!(out, "num of rows: {}", rg_metadata.num_rows());
     writeln!(out);
@@ -121,7 +121,10 @@ fn print_row_group_metadata(out: &mut io::Write, rg_metadata: &RowGroupMetaData)
 }
 
 #[allow(unused_must_use)]
-fn print_column_chunk_metadata(out: &mut io::Write, cc_metadata: &ColumnChunkMetaData) {
+fn print_column_chunk_metadata(
+    out: &mut dyn io::Write,
+    cc_metadata: &ColumnChunkMetaData,
+) {
     writeln!(out, "column type: {}", cc_metadata.column_type());
     writeln!(out, "column path: {}", cc_metadata.column_path());
     let encoding_strs: Vec<_> = cc_metadata
@@ -167,7 +170,7 @@ fn print_column_chunk_metadata(out: &mut io::Write, cc_metadata: &ColumnChunkMet
 }
 
 #[allow(unused_must_use)]
-fn print_dashes(out: &mut io::Write, num: i32) {
+fn print_dashes(out: &mut dyn io::Write, num: i32) {
     for _ in 0..num {
         write!(out, "-");
     }
@@ -178,13 +181,13 @@ const INDENT_WIDTH: i32 = 2;
 
 /// Struct for printing Parquet message type.
 struct Printer<'a> {
-    output: &'a mut fmt::Write,
+    output: &'a mut dyn fmt::Write,
     indent: i32,
 }
 
 #[allow(unused_must_use)]
 impl<'a> Printer<'a> {
-    fn new(output: &'a mut fmt::Write) -> Self {
+    fn new(output: &'a mut dyn fmt::Write) -> Self {
         Printer { output, indent: 0 }
     }
 

--- a/rust/parquet/src/util/test_common/page_util.rs
+++ b/rust/parquet/src/util/test_common/page_util.rs
@@ -119,7 +119,7 @@ impl DataPageBuilder for DataPageBuilderImpl {
             values.len()
         );
         self.encoding = Some(encoding);
-        let mut encoder: Box<Encoder<T>> =
+        let mut encoder: Box<dyn Encoder<T>> =
             get_encoder::<T>(self.desc.clone(), encoding, self.mem_tracker.clone())
                 .expect("get_encoder() should be OK");
         encoder.put(values).expect("put() should be OK");


### PR DESCRIPTION
This removes one of the clippy ignores by making trait objects explicit on the parquet crate.