### PR TITLE
ARROW-12048: [Rust][DataFusion] Support Common Table Expressions

### DIFF
--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -412,7 +412,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         LogicalPlanBuilder::scan(&table_name, provider, None)?.build()
                     }
                     (_, None) => Err(DataFusionError::Plan(format!(
-                        "no provider found for table {}",
+                        "Table or CTE with name '{}' not found",
                         name
                     ))),
                 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 use arrow::datatypes::*;
+use hashbrown::HashMap;
 
 use crate::prelude::JoinType;
 use sqlparser::ast::{
@@ -114,7 +115,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         alias: Option<String>,
     ) -> Result<LogicalPlan> {
         let set_expr = &query.body;
-        let plan = self.set_expr_to_plan(set_expr, alias)?;
+        let ctes: HashMap<String, Query> = query
+            .clone()
+            .with
+            .map(|x| {
+                x.cte_tables
+                    .iter()
+                    .map(|cte| (cte.alias.name.value.clone(), cte.query.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let plan = self.set_expr_to_plan(set_expr, alias, &ctes)?;
 
         let plan = self.order_by(&plan, &query.order_by)?;
 
@@ -125,9 +136,10 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         set_expr: &SetExpr,
         alias: Option<String>,
+        ctes: &HashMap<String, Query>,
     ) -> Result<LogicalPlan> {
         match set_expr {
-            SetExpr::Select(s) => self.select_to_plan(s.as_ref()),
+            SetExpr::Select(s) => self.select_to_plan(s.as_ref(), ctes),
             SetExpr::SetOperation {
                 op,
                 left,
@@ -135,8 +147,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 all,
             } => match (op, all) {
                 (SetOperator::Union, true) => {
-                    let left_plan = self.set_expr_to_plan(left.as_ref(), None)?;
-                    let right_plan = self.set_expr_to_plan(right.as_ref(), None)?;
+                    let left_plan = self.set_expr_to_plan(left.as_ref(), None, ctes)?;
+                    let right_plan = self.set_expr_to_plan(right.as_ref(), None, ctes)?;
                     let inputs = vec![left_plan, right_plan]
                         .into_iter()
                         .flat_map(|p| match p {
@@ -280,24 +292,32 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn plan_from_tables(&self, from: &[TableWithJoins]) -> Result<Vec<LogicalPlan>> {
+    fn plan_from_tables(
+        &self,
+        from: &[TableWithJoins],
+        ctes: &HashMap<String, Query>,
+    ) -> Result<Vec<LogicalPlan>> {
         match from.len() {
             0 => Ok(vec![LogicalPlanBuilder::empty(true).build()?]),
             _ => from
                 .iter()
-                .map(|t| self.plan_table_with_joins(t))
+                .map(|t| self.plan_table_with_joins(t, ctes))
                 .collect::<Result<Vec<_>>>(),
         }
     }
 
-    fn plan_table_with_joins(&self, t: &TableWithJoins) -> Result<LogicalPlan> {
-        let left = self.create_relation(&t.relation)?;
+    fn plan_table_with_joins(
+        &self,
+        t: &TableWithJoins,
+        ctes: &HashMap<String, Query>,
+    ) -> Result<LogicalPlan> {
+        let left = self.create_relation(&t.relation, ctes)?;
         match t.joins.len() {
             0 => Ok(left),
             n => {
-                let mut left = self.parse_relation_join(&left, &t.joins[0])?;
+                let mut left = self.parse_relation_join(&left, &t.joins[0], ctes)?;
                 for i in 1..n {
-                    left = self.parse_relation_join(&left, &t.joins[i])?;
+                    left = self.parse_relation_join(&left, &t.joins[i], ctes)?;
                 }
                 Ok(left)
             }
@@ -308,8 +328,9 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         &self,
         left: &LogicalPlan,
         join: &Join,
+        ctes: &HashMap<String, Query>,
     ) -> Result<LogicalPlan> {
-        let right = self.create_relation(&join.relation)?;
+        let right = self.create_relation(&join.relation, ctes)?;
         match &join.join_operator {
             JoinOperator::LeftOuter(constraint) => {
                 self.parse_join(left, &right, constraint, JoinType::Left)
@@ -372,15 +393,24 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn create_relation(&self, relation: &TableFactor) -> Result<LogicalPlan> {
+    fn create_relation(
+        &self,
+        relation: &TableFactor,
+        ctes: &HashMap<String, Query>,
+    ) -> Result<LogicalPlan> {
         match relation {
-            TableFactor::Table { name, .. } => {
+            TableFactor::Table { name, alias, .. } => {
                 let table_name = name.to_string();
-                match self.schema_provider.get_table_provider(&table_name) {
-                    Some(provider) => {
+                let cte = ctes.get(&table_name);
+                match (cte, self.schema_provider.get_table_provider(&table_name)) {
+                    (Some(cte_query), _) => self.query_to_plan_with_alias(
+                        cte_query,
+                        alias.as_ref().map(|a| a.name.value.to_string()),
+                    ),
+                    (_, Some(provider)) => {
                         LogicalPlanBuilder::scan(&table_name, provider, None)?.build()
                     }
-                    None => Err(DataFusionError::Plan(format!(
+                    (_, None) => Err(DataFusionError::Plan(format!(
                         "no provider found for table {}",
                         name
                     ))),
@@ -393,7 +423,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 alias.as_ref().map(|a| a.name.value.to_string()),
             ),
             TableFactor::NestedJoin(table_with_joins) => {
-                self.plan_table_with_joins(table_with_joins)
+                self.plan_table_with_joins(table_with_joins, ctes)
             }
             // @todo Support TableFactory::TableFunction?
             _ => Err(DataFusionError::NotImplemented(format!(
@@ -404,8 +434,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
     }
 
     /// Generate a logic plan from an SQL select
-    fn select_to_plan(&self, select: &Select) -> Result<LogicalPlan> {
-        let plans = self.plan_from_tables(&select.from)?;
+    fn select_to_plan(
+        &self,
+        select: &Select,
+        ctes: &HashMap<String, Query>,
+    ) -> Result<LogicalPlan> {
+        let plans = self.plan_from_tables(&select.from, ctes)?;
 
         let plan = match &select.selection {
             Some(predicate_expr) => {

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -123,7 +123,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 let logical_plan = self.query_to_plan_with_alias(
                     &cte.query,
                     Some(cte.alias.name.value.clone()),
-                    ctes,
+                    &mut ctes.clone(),
                 )?;
                 ctes.insert(cte.alias.name.value.clone(), logical_plan);
             }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -118,8 +118,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let ctes: HashMap<String, Query> = query
             .clone()
             .with
-            .map(|x| {
-                x.cte_tables
+            .map(|with| {
+                with.cte_tables
                     .iter()
                     .map(|cte| (cte.alias.name.value.clone(), cte.query.clone()))
                     .collect()

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1941,6 +1941,26 @@ async fn query_without_from() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_cte() -> Result<()> {
+    // Test for SELECT <expression> without FROM.
+    // Should evaluate expressions in project position.
+    let mut ctx = ExecutionContext::new();
+
+    let sql = "WITH t AS (SELECT 1) SELECT * FROM t";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["1"]];
+    assert_eq!(expected, actual);
+
+    let sql = "WITH t AS (SELECT 1 AS a), u AS (SELECT 2 AS a) SELECT * FROM t UNION ALL SELECT * FROM u";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["1"], vec!["2"]];
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+
+#[tokio::test]
 async fn query_scalar_minus_array() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Int32, true)]));
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1992,6 +1992,12 @@ async fn query_cte_incorrect() -> Result<()> {
     assert!(plan.is_err());
     assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'u\' not found");
 
+    // wrapping should hide u
+    let sql = "WITH t AS (WITH u as (SELECT 1) SELECT 1) SELECT * from u";
+    let plan = ctx.create_logical_plan(&sql);
+    assert!(plan.is_err());
+    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'u\' not found");
+    
     Ok(())
 }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1959,7 +1959,6 @@ async fn query_cte() -> Result<()> {
     Ok(())
 }
 
-
 #[tokio::test]
 async fn query_scalar_minus_array() -> Result<()> {
     let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Int32, true)]));

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1981,11 +1981,13 @@ async fn query_cte_incorrect() -> Result<()> {
     let sql = "WITH t AS (SELECT * FROM t) SELECT * from u";
     let plan = ctx.create_logical_plan(&sql);
     assert!(plan.is_err());
+    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'t\' not found");
 
     // forward referencing
     let sql = "WITH t AS (SELECT * FROM u), u AS (SELECT 1) SELECT * from u";
     let plan = ctx.create_logical_plan(&sql);
     assert!(plan.is_err());
+    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'u\' not found");
 
     Ok(())
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1956,6 +1956,11 @@ async fn query_cte() -> Result<()> {
     let expected = vec![vec!["1"], vec!["2"]];
     assert_eq!(expected, actual);
 
+    let sql = "WITH t AS (SELECT 1 AS id1), u AS (SELECT 1 AS id2, 5 as x) SELECT x FROM t JOIN u ON (id1 = id2)";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["5"]];
+    assert_eq!(expected, actual);
+
     Ok(())
 }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1984,20 +1984,29 @@ async fn query_cte_incorrect() -> Result<()> {
     let sql = "WITH t AS (SELECT * FROM t) SELECT * from u";
     let plan = ctx.create_logical_plan(&sql);
     assert!(plan.is_err());
-    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'t\' not found");
+    assert_eq!(
+        format!("{}", plan.unwrap_err()),
+        "Error during planning: Table or CTE with name \'t\' not found"
+    );
 
     // forward referencing
     let sql = "WITH t AS (SELECT * FROM u), u AS (SELECT 1) SELECT * from u";
     let plan = ctx.create_logical_plan(&sql);
     assert!(plan.is_err());
-    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'u\' not found");
+    assert_eq!(
+        format!("{}", plan.unwrap_err()),
+        "Error during planning: Table or CTE with name \'u\' not found"
+    );
 
     // wrapping should hide u
     let sql = "WITH t AS (WITH u as (SELECT 1) SELECT 1) SELECT * from u";
     let plan = ctx.create_logical_plan(&sql);
     assert!(plan.is_err());
-    assert_eq!(format!("{}", plan.unwrap_err()),  "Error during planning: Table or CTE with name \'u\' not found");
-    
+    assert_eq!(
+        format!("{}", plan.unwrap_err()),
+        "Error during planning: Table or CTE with name \'u\' not found"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
This adds support for CTE syntax:

```sql
WITH 
   name AS (SELECT ...)
   [, name2 AS (SELECT ...)]
SELECT ...
FROM ...
```

Before this PR, the CTE syntax was ignored.

This PR supports CTEs referening a previous CTE within the same query (but no forward references)