### PR TITLE
ARROW-12052: [Rust] Add Child Data to Arrow's C FFI implementation.  …

### DIFF
--- a/rust/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/rust/arrow-pyarrow-integration-testing/src/lib.rs
@@ -167,11 +167,22 @@ fn concatenate(array: PyObject, py: Python) -> PyResult<PyObject> {
     to_py(array, py)
 }
 
+/// Converts to rust and back to python
+#[pyfunction]
+fn round_trip(array: PyObject, py: Python) -> PyResult<PyObject> {
+    // import
+    let array = to_rust(array, py)?;
+
+    // export
+    to_py(array, py)
+}
+
 #[pymodule]
 fn arrow_pyarrow_integration_testing(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(double))?;
     m.add_wrapped(wrap_pyfunction!(double_py))?;
     m.add_wrapped(wrap_pyfunction!(substring))?;
     m.add_wrapped(wrap_pyfunction!(concatenate))?;
+    m.add_wrapped(wrap_pyfunction!(round_trip))?;
     Ok(())
 }

--- a/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -78,3 +78,23 @@ class TestCase(unittest.TestCase):
         del expected
         # No leak of C++ memory
         self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
+
+    def test_list_array(self):
+        """
+        Python -> Rust -> Python
+        """
+        old_allocated = pyarrow.total_allocated_bytes()
+        a = pyarrow.array([[1, 2], [1, 2]], pyarrow.list_(pyarrow.int64()))
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+        # list equality does not work, so we check the elements
+        self.assertEqual(a[0][0], b[0][0])
+        self.assertEqual(a[0][1], b[0][1])
+        self.assertEqual(a[1][0], b[1][0])
+        self.assertEqual(a[1][1], b[1][1])
+        del a
+        del b
+        # No leak of C++ memory
+        self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
+
+
+

--- a/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -84,13 +84,11 @@ class TestCase(unittest.TestCase):
         Python -> Rust -> Python
         """
         old_allocated = pyarrow.total_allocated_bytes()
-        a = pyarrow.array([[1, 2], [1, 2]], pyarrow.list_(pyarrow.int64()))
+        a = pyarrow.array([[], None, [1, 2], [4, 5, 6]], pyarrow.list_(pyarrow.int64()))
         b = arrow_pyarrow_integration_testing.round_trip(a)
-        # list equality does not work, so we check the elements
-        self.assertEqual(a[0][0], b[0][0])
-        self.assertEqual(a[0][1], b[0][1])
-        self.assertEqual(a[1][0], b[1][0])
-        self.assertEqual(a[1][1], b[1][1])
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
         del a
         del b
         # No leak of C++ memory

--- a/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/rust/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -89,6 +89,7 @@ class TestCase(unittest.TestCase):
 
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
         del a
         del b
         # No leak of C++ memory

--- a/rust/arrow/src/array/ffi.rs
+++ b/rust/arrow/src/array/ffi.rs
@@ -78,7 +78,7 @@ impl TryFrom<ArrayData> for ffi::ArrowArray {
         let null_buffer = value.null_buffer().cloned();
         let child_data = value
             .child_data()
-            .into_iter()
+            .iter()
             .map(|arr| ArrowArray::try_from((*arr).clone()).expect("infallible"))
             .collect::<Vec<_>>();
 

--- a/rust/arrow/src/datatypes/field.rs
+++ b/rust/arrow/src/datatypes/field.rs
@@ -39,6 +39,12 @@ pub struct Field {
     metadata: Option<BTreeMap<String, String>>,
 }
 
+impl Default for Field {
+    fn default() -> Self {
+        Field::new("", DataType::Null, false)
+    }
+}
+
 impl Field {
     /// Creates a new field
     pub fn new(name: &str, data_type: DataType, nullable: bool) -> Self {

--- a/rust/arrow/src/datatypes/field.rs
+++ b/rust/arrow/src/datatypes/field.rs
@@ -315,8 +315,8 @@ impl Field {
                 };
                 Ok(Field {
                     name,
-                    nullable,
                     data_type,
+                    nullable,
                     dict_id,
                     dict_is_ordered,
                     metadata,

--- a/rust/arrow/src/datatypes/field.rs
+++ b/rust/arrow/src/datatypes/field.rs
@@ -39,12 +39,6 @@ pub struct Field {
     metadata: Option<BTreeMap<String, String>>,
 }
 
-impl Default for Field {
-    fn default() -> Self {
-        Field::new("", DataType::Null, false)
-    }
-}
-
 impl Field {
     /// Creates a new field
     pub fn new(name: &str, data_type: DataType, nullable: bool) -> Self {

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -134,10 +134,11 @@ impl FFI_ArrowSchema {
         // <https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema>
         FFI_ArrowSchema {
             format: CString::new(format).unwrap().into_raw(),
-            // For child data a non null string is expected
-            name: CString::new("").unwrap().into_raw(),
+            // For child data a non null string is expected and is called item
+            name: CString::new("item").unwrap().into_raw(),
             metadata: std::ptr::null_mut(),
-            flags: 0,
+            // default to nullable
+            flags: 2,
             n_children,
             children: children_ptr,
             dictionary: std::ptr::null_mut(),

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -134,7 +134,8 @@ impl FFI_ArrowSchema {
         // <https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema>
         FFI_ArrowSchema {
             format: CString::new(format).unwrap().into_raw(),
-            name: std::ptr::null_mut(),
+            // For child data a non null string is expected
+            name: CString::new("").unwrap().into_raw(),
             metadata: std::ptr::null_mut(),
             flags: 0,
             n_children,

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -542,7 +542,7 @@ impl ArrowArray {
             ffi_arrow_arrays,
         ));
 
-        Ok(ArrowArray { schema, array })
+        Ok(ArrowArray { array, schema })
     }
 
     /// creates a new [ArrowArray] from two pointers. Used to import from the C Data Interface.
@@ -572,7 +572,7 @@ impl ArrowArray {
     pub unsafe fn empty() -> Self {
         let schema = Arc::new(FFI_ArrowSchema::empty());
         let array = Arc::new(FFI_ArrowArray::empty());
-        ArrowArray { schema, array }
+        ArrowArray { array, schema }
     }
 
     /// exports [ArrowArray] to the C Data Interface
@@ -706,7 +706,6 @@ mod tests {
     use crate::datatypes::Field;
     use std::convert::TryFrom;
     use std::iter::FromIterator;
-    use std::sync::Arc;
 
     #[test]
     fn test_round_trip() -> Result<()> {
@@ -799,10 +798,10 @@ mod tests {
             }
         };
 
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
 
         // create an array natively

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -77,6 +77,7 @@ To export an array, create an `ArrowArray` using [ArrowArray::try_new].
 */
 
 use std::{
+    convert::TryFrom,
     ffi::CStr,
     ffi::CString,
     iter,
@@ -90,7 +91,6 @@ use crate::buffer::Buffer;
 use crate::datatypes::{DataType, Field, TimeUnit};
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
-use std::convert::TryFrom;
 
 /// ABI-compatible struct for `ArrowSchema` from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
@@ -210,12 +210,12 @@ fn to_datatype(format: &str, child_type: Option<DataType>) -> Result<DataType> {
         // at that point the child data is not yet known, but it is also not required to determine
         // the buffer length of the list arrays.
         "+l" => DataType::List(Box::new(Field::new(
-            "",
+            "item",
             child_type.unwrap_or(DataType::Null),
             false,
         ))),
         "+L" => DataType::LargeList(Box::new(Field::new(
-            "",
+            "item",
             child_type.unwrap_or(DataType::Null),
             false,
         ))),
@@ -674,6 +674,7 @@ impl ArrowArray {
             .collect()
     }
 
+    /// returns the child data of this array
     pub fn children(&self) -> Result<Vec<ArrayData>> {
         unsafe { create_child_arrays(self.array.clone(), self.schema.clone()) }
     }

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -81,7 +81,8 @@ use std::{
     ffi::CStr,
     ffi::CString,
     iter,
-    mem::size_of,
+    mem::{size_of, ManuallyDrop},
+    os::raw::c_char,
     ptr::{self, NonNull},
     sync::Arc,
 };
@@ -91,8 +92,6 @@ use crate::buffer::Buffer;
 use crate::datatypes::{DataType, Field, TimeUnit};
 use crate::error::{ArrowError, Result};
 use crate::util::bit_util;
-use std::mem::ManuallyDrop;
-use std::os::raw::c_char;
 
 /// ABI-compatible struct for `ArrowSchema` from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -212,12 +212,12 @@ fn to_datatype(format: &str, child_type: Option<DataType>) -> Result<DataType> {
         "+l" => DataType::List(Box::new(Field::new(
             "item",
             child_type.unwrap_or(DataType::Null),
-            false,
+            true,
         ))),
         "+L" => DataType::LargeList(Box::new(Field::new(
             "item",
             child_type.unwrap_or(DataType::Null),
-            false,
+            true,
         ))),
         dt => {
             return Err(ArrowError::CDataInterface(format!(

--- a/rust/arrow/src/ffi.rs
+++ b/rust/arrow/src/ffi.rs
@@ -549,6 +549,7 @@ impl ArrowArray {
     /// creates a new `ArrowArray`. This is used to export to the C Data Interface.
     /// # Safety
     /// See safety of [ArrowArray]
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn try_new(
         data_type: &DataType,
         len: usize,


### PR DESCRIPTION
This PR adds child data to Arrow's C FFI implementation and implements it for `List` and `LargeList` datatypes.