### PR TITLE
ARROW-12065: [C++][Python] Fix segfault reading JSON file

### DIFF
--- a/cpp/src/arrow/json/CMakeLists.txt
+++ b/cpp/src/arrow/json/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 add_arrow_test(test
                SOURCES
+               chunked_builder_test.cc
                chunker_test.cc
                converter_test.cc
                parser_test.cc

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -48,17 +48,17 @@ namespace {
 
 const DictionaryArray& GetDictionaryArray(const std::shared_ptr<Array>& in) {
   DCHECK_EQ(in->type_id(), Type::DICTIONARY);
-  auto dict_type = static_cast<const DictionaryType*>(in->type().get());
+  auto dict_type = checked_cast<const DictionaryType*>(in->type().get());
   DCHECK_EQ(dict_type->index_type()->id(), Type::INT32);
   DCHECK_EQ(dict_type->value_type()->id(), Type::STRING);
-  return static_cast<const DictionaryArray&>(*in);
+  return checked_cast<const DictionaryArray&>(*in);
 }
 
 template <typename ValidVisitor, typename NullVisitor>
 Status VisitDictionaryEntries(const DictionaryArray& dict_array,
                               ValidVisitor&& visit_valid, NullVisitor&& visit_null) {
-  const StringArray& dict = static_cast<const StringArray&>(*dict_array.dictionary());
-  const Int32Array& indices = static_cast<const Int32Array&>(*dict_array.indices());
+  const StringArray& dict = checked_cast<const StringArray&>(*dict_array.dictionary());
+  const Int32Array& indices = checked_cast<const Int32Array&>(*dict_array.indices());
   for (int64_t i = 0; i < indices.length(); ++i) {
     if (indices.IsValid(i)) {
       RETURN_NOT_OK(visit_valid(dict.GetView(indices.GetView(i))));
@@ -281,8 +281,8 @@ const PromotionGraph* GetPromotionGraph() {
           return timestamp(TimeUnit::SECOND);
 
         case Kind::kArray: {
-          auto type = static_cast<const ListType*>(unexpected_field->type().get());
-          auto value_field = type->value_field();
+          const auto& type = checked_cast<const ListType&>(*unexpected_field->type());
+          auto value_field = type.value_field();
           return list(value_field->WithType(Infer(value_field)));
         }
         case Kind::kObject: {

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -33,6 +33,7 @@
 #include "arrow/buffer_builder.h"
 #include "arrow/type.h"
 #include "arrow/util/bitset_stack.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
 #include "arrow/util/string_view.h"
@@ -431,7 +432,7 @@ class RawBuilderSet {
 
       case Kind::kArray: {
         RETURN_NOT_OK(MakeBuilder<Kind::kArray>(leading_nulls, builder));
-        const auto& list_type = static_cast<const ListType&>(t);
+        const auto& list_type = checked_cast<const ListType&>(t);
 
         BuilderPtr value_builder;
         RETURN_NOT_OK(MakeBuilder(*list_type.value_type(), 0, &value_builder));
@@ -442,7 +443,7 @@ class RawBuilderSet {
       }
       case Kind::kObject: {
         RETURN_NOT_OK(MakeBuilder<Kind::kObject>(leading_nulls, builder));
-        const auto& struct_type = static_cast<const StructType&>(t);
+        const auto& struct_type = checked_cast<const StructType&>(t);
 
         for (const auto& f : struct_type.fields()) {
           BuilderPtr field_builder;

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -28,9 +28,13 @@
 #include "arrow/json/test_common.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/string_view.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace json {
 
 using util::string_view;
@@ -46,7 +50,7 @@ void AssertUnconvertedArraysEqual(const Array& expected, const Array& actual) {
     case Type::DICTIONARY: {
       ASSERT_EQ(expected.type_id(), Type::STRING);
       std::shared_ptr<Array> actual_decoded;
-      ASSERT_OK(DecodeStringDictionary(static_cast<const DictionaryArray&>(actual),
+      ASSERT_OK(DecodeStringDictionary(checked_cast<const DictionaryArray&>(actual),
                                        &actual_decoded));
       return AssertArraysEqual(expected, *actual_decoded);
     }
@@ -59,14 +63,15 @@ void AssertUnconvertedArraysEqual(const Array& expected, const Array& actual) {
       const auto& expected_offsets = expected.data()->buffers[1];
       const auto& actual_offsets = actual.data()->buffers[1];
       AssertBufferEqual(*expected_offsets, *actual_offsets);
-      auto expected_values = static_cast<const ListArray&>(expected).values();
-      auto actual_values = static_cast<const ListArray&>(actual).values();
+      auto expected_values = checked_cast<const ListArray&>(expected).values();
+      auto actual_values = checked_cast<const ListArray&>(actual).values();
       return AssertUnconvertedArraysEqual(*expected_values, *actual_values);
     }
     case Type::STRUCT:
       ASSERT_EQ(expected.type_id(), Type::STRUCT);
-      return AssertUnconvertedStructArraysEqual(static_cast<const StructArray&>(expected),
-                                                static_cast<const StructArray&>(actual));
+      return AssertUnconvertedStructArraysEqual(
+          checked_cast<const StructArray&>(expected),
+          checked_cast<const StructArray&>(actual));
     default:
       FAIL();
   }

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -30,6 +30,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/util/async_generator.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string_view.h"
@@ -40,6 +41,7 @@ namespace arrow {
 
 using util::string_view;
 
+using internal::checked_cast;
 using internal::GetCpuThreadPool;
 using internal::TaskGroup;
 using internal::ThreadPool;
@@ -211,13 +213,13 @@ Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
   builder->Insert(0, field("", type), parsed);
   std::shared_ptr<ChunkedArray> converted_chunked;
   RETURN_NOT_OK(builder->Finish(&converted_chunked));
-  auto converted = static_cast<const StructArray*>(converted_chunked->chunk(0).get());
+  const auto& converted = checked_cast<const StructArray&>(*converted_chunked->chunk(0));
 
-  std::vector<std::shared_ptr<Array>> columns(converted->num_fields());
-  for (int i = 0; i < converted->num_fields(); ++i) {
-    columns[i] = converted->field(i);
+  std::vector<std::shared_ptr<Array>> columns(converted.num_fields());
+  for (int i = 0; i < converted.num_fields(); ++i) {
+    columns[i] = converted.field(i);
   }
-  return RecordBatch::Make(schema(converted->type()->fields()), converted->length(),
+  return RecordBatch::Make(schema(converted.type()->fields()), converted.length(),
                            std::move(columns));
 }
 

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -203,16 +203,6 @@ TEST_P(ReaderTest, MultipleChunks) {
   AssertTablesEqual(*expected_table, *table_);
 }
 
-template <typename T>
-std::string RowsOfOneColumn(string_view name, std::initializer_list<T> values,
-                            decltype(std::to_string(*values.begin()))* = nullptr) {
-  std::stringstream ss;
-  for (auto value : values) {
-    ss << R"({")" << name << R"(":)" << std::to_string(value) << "}\n";
-  }
-  return ss.str();
-}
-
 TEST(ReaderTest, MultipleChunksParallel) {
   int64_t count = 1 << 10;
 


### PR DESCRIPTION
A segfault would occur when a field is inferred as null in a first block and then as list in a second block.

Also re-enable `chunked_builder_test.cc`, which wasn't compiled.