### PR TITLE
ARROW-11693: [C++] Add string length kernel

### DIFF
--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -301,18 +301,14 @@ class TestStringArray : public ::testing::Test {
     auto st2 = ValidateFull(1, {0, 4}, "\xf4\x90\x80\x80");
     // Single UTF8 character straddles two entries
     auto st3 = ValidateFull(2, {0, 1, 2}, "\xc3\xa9");
-    // Null characters in the string
-    auto st4 = ValidateFull(1, {0, 4}, "\0\0\0\0");
     if (T::is_utf8) {
       ASSERT_RAISES(Invalid, st1);
       ASSERT_RAISES(Invalid, st2);
       ASSERT_RAISES(Invalid, st3);
-      ASSERT_RAISES(Invalid, st4);
     } else {
       ASSERT_OK(st1);
       ASSERT_OK(st2);
       ASSERT_OK(st3);
-      ASSERT_OK(st4);
     }
   }
 

--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -301,14 +301,18 @@ class TestStringArray : public ::testing::Test {
     auto st2 = ValidateFull(1, {0, 4}, "\xf4\x90\x80\x80");
     // Single UTF8 character straddles two entries
     auto st3 = ValidateFull(2, {0, 1, 2}, "\xc3\xa9");
+    // Null characters in the string
+    auto st4 = ValidateFull(1, {0, 4}, "\0\0\0\0");
     if (T::is_utf8) {
       ASSERT_RAISES(Invalid, st1);
       ASSERT_RAISES(Invalid, st2);
       ASSERT_RAISES(Invalid, st3);
+      ASSERT_RAISES(Invalid, st4);
     } else {
       ASSERT_OK(st1);
       ASSERT_OK(st2);
       ASSERT_OK(st3);
+      ASSERT_OK(st4);
     }
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -72,7 +72,7 @@ struct Utf8Length {
 
     OutValue length = 0;
     while (strlen > 0) {
-      length += (*str & 0xc0) != 0x80;
+      length += ((*str & 0xc0) != 0x80);
       ++str;
       --strlen;
     }
@@ -1588,7 +1588,7 @@ const FunctionDoc binary_length_doc(
     ("For each string in `strings`, emit the number of bytes.  Null values emit null."),
     {"strings"});
 
-const FunctionDoc utf8_length_doc("Compute utf8 string lengths",
+const FunctionDoc utf8_length_doc("Compute UTF8 string lengths",
                                   ("For each string in `strings`, emit the number of "
                                    "UTF8 characters.  Null values emit null."),
                                   {"strings"});

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -67,7 +67,7 @@ struct BinaryLength {
 struct Utf8Length {
   template <typename OutValue, typename Arg0Value = util::string_view>
   static OutValue Call(KernelContext*, Arg0Value val) {
-    auto str = reinterpret_cast<const uint8_t *>(val.data());
+    auto str = reinterpret_cast<const uint8_t*>(val.data());
     auto strlen = val.size();
 
     OutValue length = 0;
@@ -1619,8 +1619,8 @@ void AddBinaryLength(FunctionRegistry* registry) {
 }
 
 void AddUtf8Length(FunctionRegistry* registry) {
-  auto func = std::make_shared<ScalarFunction>("utf8_length", Arity::Unary(),
-                                               &utf8_length_doc);
+  auto func =
+      std::make_shared<ScalarFunction>("utf8_length", Arity::Unary(), &utf8_length_doc);
 
   ArrayKernelExec exec_offset_32 =
       applicator::ScalarUnaryNotNull<Int32Type, StringType, Utf8Length>::Exec;

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -61,8 +61,8 @@ class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
 TYPED_TEST_SUITE(TestBinaryKernels, BinaryTypes);
 
 TYPED_TEST(TestBinaryKernels, BinaryLength) {
-  this->CheckUnary("binary_length", R"(["aaa", null, "", "b"])", this->offset_type(),
-                   "[3, null, 0, 1]");
+  this->CheckUnary("binary_length", R"(["aaa", null, "áéíóú", "", "b"])",
+                   this->offset_type(), "[3, null, 10, 0, 1]");
 }
 
 template <typename TestType>
@@ -102,6 +102,11 @@ TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
 }
 
 #ifdef ARROW_WITH_UTF8PROC
+
+TYPED_TEST(TestStringKernels, Utf8Length) {
+  this->CheckUnary("utf8_length", R"(["aaa", null, "áéíóú", "", "b"])",
+                   this->offset_type(), "[3, null, 5, 0, 1]");
+}
 
 TYPED_TEST(TestStringKernels, Utf8Upper) {
   this->CheckUnary("utf8_upper", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->type(),

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -101,12 +101,12 @@ TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
                                   CallFunction("utf8_upper", {scalar}, options));
 }
 
-#ifdef ARROW_WITH_UTF8PROC
-
 TYPED_TEST(TestStringKernels, Utf8Length) {
   this->CheckUnary("utf8_length", R"(["aaa", null, "áéíóú", "", "b"])",
                    this->offset_type(), "[3, null, 5, 0, 1]");
 }
+
+#ifdef ARROW_WITH_UTF8PROC
 
 TYPED_TEST(TestStringKernels, Utf8Upper) {
   this->CheckUnary("utf8_upper", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->type(),

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -102,8 +102,8 @@ TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
 }
 
 TYPED_TEST(TestStringKernels, Utf8Length) {
-  this->CheckUnary("utf8_length", R"(["aaa", null, "áéíóú", "", "b"])",
-                   this->offset_type(), "[3, null, 5, 0, 1]");
+  this->CheckUnary("utf8_length", R"(["aaa", null, "áéíóú", "ɑɽⱤoW😀", "áéí 0😀", "", "b"])",
+                   this->offset_type(), "[3, null, 5, 6, 6, 0, 1]");
 }
 
 #ifdef ARROW_WITH_UTF8PROC

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -102,7 +102,8 @@ TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
 }
 
 TYPED_TEST(TestStringKernels, Utf8Length) {
-  this->CheckUnary("utf8_length", R"(["aaa", null, "áéíóú", "ɑɽⱤoW😀", "áéí 0😀", "", "b"])",
+  this->CheckUnary("utf8_length",
+                   R"(["aaa", null, "áéíóú", "ɑɽⱤoW😀", "áéí 0😀", "", "b"])",
                    this->offset_type(), "[3, null, 5, 6, 6, 0, 1]");
 }
 

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -65,7 +65,7 @@ class UTF8Test : public ::testing::Test {
   static std::vector<std::string> invalid_sequences_ascii;
 };
 
-std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f"};
+std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f", std::string("\0", 1)};
 std::vector<std::string> UTF8Test::valid_sequences_2 = {"\xc2\x80", "\xc3\xbf",
                                                         "\xdf\xbf"};
 std::vector<std::string> UTF8Test::valid_sequences_3 = {"\xe0\xa0\x80", "\xe8\x9d\xa5",

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -65,7 +65,8 @@ class UTF8Test : public ::testing::Test {
   static std::vector<std::string> invalid_sequences_ascii;
 };
 
-std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f", std::string("\0", 1)};
+std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f",
+                                                        std::string("\0", 1)};
 std::vector<std::string> UTF8Test::valid_sequences_2 = {"\xc2\x80", "\xc3\xbf",
                                                         "\xdf\xbf"};
 std::vector<std::string> UTF8Test::valid_sequences_3 = {"\xe0\xa0\x80", "\xe8\x9d\xa5",

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -435,9 +435,11 @@ String transforms
 +--------------------------+------------+-------------------------+---------------------+---------+
 | binary_length            | Unary      | Binary- or String-like  | Int32 or Int64      | \(2)    |
 +--------------------------+------------+-------------------------+---------------------+---------+
-| utf8_lower               | Unary      | String-like             | String-like         | \(3)    |
+| utf8_length              | Unary      | String-like             | Int32 or Int64      | \(3)    |
 +--------------------------+------------+-------------------------+---------------------+---------+
-| utf8_upper               | Unary      | String-like             | String-like         | \(3)    |
+| utf8_lower               | Unary      | String-like             | String-like         | \(4)    |
++--------------------------+------------+-------------------------+---------------------+---------+
+| utf8_upper               | Unary      | String-like             | String-like         | \(4)    |
 +--------------------------+------------+-------------------------+---------------------+---------+
 
 
@@ -447,7 +449,10 @@ String transforms
 * \(2) Output is the physical length in bytes of each input element.  Output
   type is Int32 for Binary / String, Int64 for LargeBinary / LargeString.
 
-* \(3) Each UTF8-encoded character in the input is converted to lowercase or
+* \(3) Output is the number of characters (not bytes) of each input element.
+  Output type is Int32 for String, Int64 for LargeString. 
+
+* \(4) Each UTF8-encoded character in the input is converted to lowercase or
   uppercase.
 
 


### PR DESCRIPTION
This PR adds the *utf8_length* compute kernel to the string scalar functions to support calculating the string length (as number of characters) for UTF-8 encoded STRINGs and LARGE STRINGs. The implementation makes use of utf8proc (utf8proc_iterate) to perform the calculation.