### PR TITLE
ARROW-10580: [C++] Disallow non-monotonic dense union offsets

### DIFF
--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -527,6 +527,7 @@ struct ValidateArrayFullImpl {
       }
 
       // Check offsets are in bounds
+      std::vector<int64_t> last_child_offsets(256, 0);
       const int32_t* offsets = data.GetValues<int32_t>(2);
       for (int64_t i = 0; i < data.length; ++i) {
         const int32_t code = type_codes[i];
@@ -541,6 +542,11 @@ struct ValidateArrayFullImpl {
                                  "than child length (",
                                  offset, " >= ", child_lengths[code], ")");
         }
+        if (offset < last_child_offsets[code]) {
+          return Status::Invalid("Union value at position ", i,
+                                 " has non-monotonic offset ", offset);
+        }
+        last_child_offsets[code] = offset;
       }
     }
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -854,8 +854,8 @@ def test_union_from_dense():
     int64 = pa.array([1, 2, 3], type='int64')
     types = pa.array([0, 1, 0, 0, 1, 1, 0], type='int8')
     logical_types = pa.array([11, 13, 11, 11, 13, 13, 11], type='int8')
-    value_offsets = pa.array([1, 0, 0, 2, 1, 2, 3], type='int32')
-    py_value = [b'b', 1, b'a', b'c', 2, 3, b'd']
+    value_offsets = pa.array([0, 0, 1, 2, 1, 2, 3], type='int32')
+    py_value = [b'a', 1, b'b', b'c', 2, 3, b'd']
 
     def check_result(result, expected_field_names, expected_type_codes,
                      expected_type_code_values):


### PR DESCRIPTION
The format documentation states that "The respective offsets for each child value array must be in order / increasing."