### PR TITLE
ARROW-12076: [Rust] Fix build

### DIFF
--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -59,7 +59,7 @@ macro_rules! compare_op {
             vec![Buffer::from(buffer)],
             vec![],
         );
-        Ok(BooleanArray::from(Arc::new(data)))
+        Ok(BooleanArray::from(data))
     }};
 }
 
@@ -135,7 +135,7 @@ macro_rules! compare_op_scalar {
             vec![Buffer::from(buffer)],
             vec![],
         );
-        Ok(BooleanArray::from(Arc::new(data)))
+        Ok(BooleanArray::from(data))
     }};
 }
 


### PR DESCRIPTION
There was a logical conflict between https://github.com/apache/arrow/commit/eebf64b00e3a26f61c4bebec7241a0b24d27ec67 which removed the Arc in `ArrayData` and  https://github.com/apache/arrow/commit/8dd6abbb72b6b8958f3b2f35512bdadcaf43066f which optimized the compute kernels.

FYI @Dandandan  and @nevi-me 