### PR TITLE
ARROW-11965: [R][Docs] Simplify install.packages command in R dev docs

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -144,12 +144,11 @@ checkout:
 ``` shell
 cd ../../r
 
-R --vanilla << EOF
+Rscript -e '
 options(repos = c(REPO_NAME = "https://cloud.r-project.org/"))
 install.packages(c("bit64", "devtools", "roxygen2", "tidyselect", "pkgdown", "covr"))
 devtools::install_dev_deps()
-q()
-EOF
+'
 
 R CMD INSTALL .
 ```

--- a/r/README.md
+++ b/r/README.md
@@ -147,7 +147,7 @@ cd ../../r
 R --vanilla << EOF
 options(repos = c(REPO_NAME = "https://cloud.r-project.org/"))
 install.packages(c("bit64", "devtools", "roxygen2", "tidyselect",
- "pkgdown", "covr") 
+ "pkgdown", "covr"))
 devtools::install_dev_deps()
 q()
 EOF

--- a/r/README.md
+++ b/r/README.md
@@ -145,7 +145,7 @@ checkout:
 cd ../../r
 
 Rscript -e '
-options(repos = c(REPO_NAME = "https://cloud.r-project.org/"))
+options(repos = "https://cloud.r-project.org/")
 install.packages(c("bit64", "devtools", "roxygen2", "tidyselect", "pkgdown", "covr"))
 devtools::install_dev_deps()
 '

--- a/r/README.md
+++ b/r/README.md
@@ -143,7 +143,15 @@ checkout:
 
 ``` shell
 cd ../../r
-R -e 'install.packages(c("devtools", "roxygen2", "pkgdown", "covr")); devtools::install_dev_deps()'
+
+R --vanilla << EOF
+options(repos = c(REPO_NAME = "https://cloud.r-project.org/"))
+install.packages(c("bit64", "devtools", "roxygen2", "tidyselect",
+ "pkgdown", "covr") 
+devtools::install_dev_deps()
+q()
+EOF
+
 R CMD INSTALL .
 ```
 

--- a/r/README.md
+++ b/r/README.md
@@ -146,8 +146,8 @@ cd ../../r
 
 Rscript -e '
 options(repos = "https://cloud.r-project.org/")
-install.packages(c("bit64", "devtools", "roxygen2", "tidyselect", "pkgdown", "covr"))
-devtools::install_dev_deps()
+if (!require("remotes")) install.packages("remotes")
+remotes::install_deps(dependencies = TRUE)
 '
 
 R CMD INSTALL .

--- a/r/README.md
+++ b/r/README.md
@@ -146,8 +146,7 @@ cd ../../r
 
 R --vanilla << EOF
 options(repos = c(REPO_NAME = "https://cloud.r-project.org/"))
-install.packages(c("bit64", "devtools", "roxygen2", "tidyselect",
- "pkgdown", "covr"))
+install.packages(c("bit64", "devtools", "roxygen2", "tidyselect", "pkgdown", "covr"))
 devtools::install_dev_deps()
 q()
 EOF


### PR DESCRIPTION
Hi

I have used the same setup that I used when I worked in finance, this is to call `R  --vanilla` from the terminal, and use the global CRAN  repository, so that this fix applies to Windows/Mac/Linux.

The changes made solve the following problems:
- Packages not installing because the default mirror is not found
- The lack of packages bit64 and tidyselect

Best,
