### PR TITLE
ARROW-12093: [R] Throw helpful errors on bad object types in dplyr expressions [WIP]

### DIFF
--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -281,7 +281,7 @@ arrow_eval <- function (expr, mask) {
     invisible(structure(msg, class = "try-error", condition = e))
   })
   # Check that the evaluated expression has one of the expected classes or types
-  if (!class(out) %in% c("array_expression", "Expression", "try-error") &&
+  if (!inherits(out, c("array_expression", "Expression", "try-error")) &&
       !typeof(out) %in% c("logical", "integer", "double", "character", "NULL")) {
     stop(
       "Expression `",

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -314,6 +314,19 @@ test_that("handle bad expressions", {
       NA
     )
   })
+
+  expect_error(
+    tbl %>%
+      Table$create() %>%
+      mutate(q = q), # q is a function
+    "unexpected"
+  )
+  expect_error(
+    tbl %>%
+      Table$create() %>%
+      mutate(int, ge = .GlobalEnv), # .GlobalEnv is an environment
+    "unexpected"
+  )
 })
 
 test_that("print a mutated table", {


### PR DESCRIPTION
This adds some basic validation of the classes and types of the objects returned by `eval_tidy()`