### PR TITLE
ARROW-12094: [C++][R] Fix re2 building on clang/libc++

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -620,8 +620,12 @@ endif()
 # ----------------------------------------------------------------------
 # ExternalProject options
 
-set(EP_CXX_FLAGS "${CMAKE_CXX_COMPILER_ARG1} ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}}")
-set(EP_C_FLAGS "${CMAKE_C_COMPILER_ARG1} ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}}")
+set(
+  EP_CXX_FLAGS
+  "${CMAKE_CXX_COMPILER_ARG1} ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}}"
+  )
+set(EP_C_FLAGS
+    "${CMAKE_C_COMPILER_ARG1} ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}}")
 
 if(NOT MSVC_TOOLCHAIN)
   # Set -fPIC on all external projects

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -620,8 +620,8 @@ endif()
 # ----------------------------------------------------------------------
 # ExternalProject options
 
-set(EP_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}}")
-set(EP_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}}")
+set(EP_CXX_FLAGS "${CMAKE_CXX_COMPILER_ARG1} ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}}")
+set(EP_C_FLAGS "${CMAKE_C_COMPILER_ARG1} ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}}")
 
 if(NOT MSVC_TOOLCHAIN)
   # Set -fPIC on all external projects

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -117,11 +117,14 @@ arrow_info <- function() {
   if (out$libarrow) {
     pool <- default_memory_pool()
     runtimeinfo <- runtime_info()
+    compute_funcs <- list_compute_functions()
     out <- c(out, list(
       capabilities = c(
         dataset = arrow_with_dataset(),
         parquet = arrow_with_parquet(),
         s3 = arrow_with_s3(),
+        utf8proc = "utf8_upper" %in% compute_funcs,
+        re2 = "replace_substring_regex" %in% compute_funcs,
         vapply(tolower(names(CompressionType)[-1]), codec_is_available, logical(1))
       ),
       memory_pool = list(

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -15,25 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+build_features <- arrow_info()$capabilities
+
 skip_if_not_available <- function(feature) {
-  if (feature == "dataset") {
-    skip_if_not(arrow_with_dataset())
-  } else if (feature == "parquet") {
-    skip_if_not(arrow_with_parquet())
-  } else if (feature %in% c("string", "utf8proc")) {
-    skip_if_not(
-      "utf8_upper" %in% list_compute_functions(),
-      "Arrow C++ library not built with utf8proc dependency"
-    )
-  } else if (feature %in% c("regex", "re2")) {
-    skip_if_not(
-      "replace_substring_regex" %in% list_compute_functions(),
-      "Arrow C++ library not built with re2 dependency"
-    )
-  } else if (feature == "s3") {
-    skip_if_not(arrow_with_s3())
-  } else if (!codec_is_available(feature)) {
-    skip(paste("Arrow C++ not built with support for", feature))
+  if (!isTRUE(build_features[feature])) {
+    skip(paste("Arrow C++ not built with", feature))
   }
 }
 

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -15,11 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-build_features <- arrow_info()$capabilities
+build_features <- c(
+  arrow_info()$capabilities,
+  # Special handling for "uncompressed", for tests that iterate over compressions
+  uncompressed = TRUE
+)
 
 skip_if_not_available <- function(feature) {
-  # Special handling for "uncompressed", for test that iterate over compressions
-  if (!(feature %in% "uncompressed") && !isTRUE(build_features[feature])) {
+  yes <- feature %in% names(build_features) && build_features[feature]
+  if (!yes) {
     skip(paste("Arrow C++ not built with", feature))
   }
 }

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -18,7 +18,8 @@
 build_features <- arrow_info()$capabilities
 
 skip_if_not_available <- function(feature) {
-  if (!isTRUE(build_features[feature])) {
+  # Special handling for "uncompressed", for test that iterate over compressions
+  if (!(feature %in% "uncompressed") && !isTRUE(build_features[feature])) {
     skip(paste("Arrow C++ not built with", feature))
   }
 }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -331,6 +331,12 @@ build_libarrow <- function(src_dir, dst_dir) {
     # but `ar` fails to build libarrow_bundled_dependencies, so turn them off
     # so that there are no bundled deps
     env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF ARROW_PARQUET=OFF ARROW_DATASET=OFF ARROW_WITH_RE2=OFF ARROW_WITH_UTF8PROC=OFF EXTRA_CMAKE_FLAGS=-DARROW_SIMD_LEVEL=NONE")
+  } else if grepl("libc++", env_var_list["CXX"], fixed = TRUE) {
+    # ARROW-12094: re2 seems to fail on the rhub/fedora-clang-devel build,
+    # which among other features uses libc++
+    # See ci/scripts/r_docker_configure.sh for config and references.
+    # Here, we'll just turn off re2 as a workaround
+    env_vars <- paste(env_vars, "ARROW_WITH_RE2=OFF")
   }
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
   status <- system(

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -331,12 +331,6 @@ build_libarrow <- function(src_dir, dst_dir) {
     # but `ar` fails to build libarrow_bundled_dependencies, so turn them off
     # so that there are no bundled deps
     env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF ARROW_PARQUET=OFF ARROW_DATASET=OFF ARROW_WITH_RE2=OFF ARROW_WITH_UTF8PROC=OFF EXTRA_CMAKE_FLAGS=-DARROW_SIMD_LEVEL=NONE")
-  } else if (grepl("libc++", env_var_list["CXX"], fixed = TRUE)) {
-    # ARROW-12094: re2 seems to fail on the rhub/fedora-clang-devel build,
-    # which among other features uses libc++
-    # See ci/scripts/r_docker_configure.sh for config and references.
-    # Here, we'll just turn off re2 as a workaround
-    env_vars <- paste(env_vars, "ARROW_WITH_RE2=OFF")
   }
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
   status <- system(

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -331,7 +331,7 @@ build_libarrow <- function(src_dir, dst_dir) {
     # but `ar` fails to build libarrow_bundled_dependencies, so turn them off
     # so that there are no bundled deps
     env_vars <- paste(env_vars, "ARROW_JEMALLOC=OFF ARROW_PARQUET=OFF ARROW_DATASET=OFF ARROW_WITH_RE2=OFF ARROW_WITH_UTF8PROC=OFF EXTRA_CMAKE_FLAGS=-DARROW_SIMD_LEVEL=NONE")
-  } else if grepl("libc++", env_var_list["CXX"], fixed = TRUE) {
+  } else if (grepl("libc++", env_var_list["CXX"], fixed = TRUE)) {
     # ARROW-12094: re2 seems to fail on the rhub/fedora-clang-devel build,
     # which among other features uses libc++
     # See ci/scripts/r_docker_configure.sh for config and references.


### PR DESCRIPTION
Also includes a followup to ARROW-11736 to add the utf8proc/re2 features to arrow_info() and use that in skip_if_not_available().