### PR TITLE
ARROW-12102: [C++][Gandiva] Implement new cache for Gandiva focused on a build time policy

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -220,6 +220,7 @@ add_gandiva_test(internals-test
                  expression_registry_test.cc
                  selection_vector_test.cc
                  lru_cache_test.cc
+                 lower_value_used_cache_test.cc
                  to_date_holder_test.cc
                  simple_arena_test.cc
                  like_holder_test.cc

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -40,8 +40,6 @@ class BaseCache {
 
   virtual bool contains(const Key& key) = 0;
 
-  virtual void insert(const Key& key, const Value& value) = 0;
-
   virtual void insert(const Key& key, const Value& value, u_long value_to_order) = 0;
 
   virtual arrow::util::optional<Value> get(const Key& key) = 0;

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -32,7 +32,7 @@ class BaseCache {
 
   BaseCache<Key, Value>() = default;
 
-  virtual size_t size() const { return  this->cache_capacity_; }
+  virtual size_t size() const { return this->cache_capacity_; }
 
   virtual size_t capacity() const = 0;
 

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+#include "arrow/util/optional.h"
+
+namespace gandiva {
+
+template <class Key, class Value>
+class BaseCache {
+ public:
+  explicit BaseCache<Key, Value>(size_t capacity) : cache_capacity_(capacity) {};
+
+  BaseCache<Key, Value>() = default;
+
+  size_t size();
+
+  size_t capacity();
+
+  bool empty();
+
+  bool contains(const Key& key);
+
+  void insert(const Key& key, const Value& value);
+
+  void insert(const Key& key, const Value& value, const u_long value_to_order);
+
+  arrow::util::optional<Value> get(const Key& key);
+
+  void clear();
+
+ private:
+  void evict();
+
+ protected:
+  size_t cache_capacity_;
+ };
+}  // namespace gandiva

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -49,7 +49,7 @@ class BaseCache {
   virtual void clear() = 0;
 
  private:
-  virtual void evict() = 0;
+  void evict() {};
 
  protected:
   size_t cache_capacity_{};

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -33,6 +33,8 @@ class BaseCache {
 
   BaseCache<Key, Value>() = default;
 
+  virtual ~BaseCache() = default;
+
   virtual size_t size() const { return this->cache_capacity_; }
 
   virtual size_t capacity() const = 0;

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -28,11 +28,11 @@ namespace gandiva {
 template <class Key, class Value>
 class BaseCache {
  public:
-  explicit BaseCache<Key, Value>(size_t capacity) : cache_capacity_(capacity) {};
+  explicit BaseCache<Key, Value>(size_t capacity) : cache_capacity_(capacity) {}
 
   BaseCache<Key, Value>() = default;
 
-  virtual size_t size() const { return  this->cache_capacity_; };
+  virtual size_t size() const { return  this->cache_capacity_; }
 
   virtual size_t capacity() const = 0;
 
@@ -47,9 +47,9 @@ class BaseCache {
   virtual void clear() = 0;
 
  private:
-  void evict() {};
+  void evict() {}
 
  protected:
   size_t cache_capacity_{};
- };
+};
 }  // namespace gandiva

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -32,26 +32,26 @@ class BaseCache {
 
   BaseCache<Key, Value>() = default;
 
-  size_t size();
+  virtual size_t size() const { return  this->cache_capacity_; };
 
-  size_t capacity();
+  virtual size_t capacity() const = 0;
 
-  bool empty();
+  virtual bool empty() const = 0;
 
-  bool contains(const Key& key);
+  virtual bool contains(const Key& key) = 0;
 
-  void insert(const Key& key, const Value& value);
+  virtual void insert(const Key& key, const Value& value) = 0;
 
-  void insert(const Key& key, const Value& value, const u_long value_to_order);
+  virtual void insert(const Key& key, const Value& value, u_long value_to_order) = 0;
 
-  arrow::util::optional<Value> get(const Key& key);
+  virtual arrow::util::optional<Value> get(const Key& key) = 0;
 
-  void clear();
+  virtual void clear() = 0;
 
  private:
-  void evict();
+  virtual void evict() = 0;
 
  protected:
-  size_t cache_capacity_;
+  size_t cache_capacity_{};
  };
 }  // namespace gandiva

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -40,7 +40,7 @@ class BaseCache {
 
   virtual bool contains(const Key& key) = 0;
 
-  virtual void insert(const Key& key, const Value& value, u_long value_to_order) = 0;
+  virtual void insert(const Key& key, const Value& value, uint64_t value_to_order) = 0;
 
   virtual arrow::util::optional<Value> get(const Key& key) = 0;
 

--- a/cpp/src/gandiva/base_cache.h
+++ b/cpp/src/gandiva/base_cache.h
@@ -24,7 +24,8 @@
 #include "arrow/util/optional.h"
 
 namespace gandiva {
-
+// A base cache class which defines the main methods that should be implemented
+// to expose a different cache with different policies.
 template <class Key, class Value>
 class BaseCache {
  public:

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -20,6 +20,10 @@
 
 namespace gandiva {
 
+// Define the default cache to be used:
+// 0 - Lowest Value Used Cache
+// 1 - LRU cache (Least Recent Used)
+static const int DEFAULT_CACHE_TO_USE = 0;
 static const int DEFAULT_CACHE_SIZE = 500;
 
 int GetCapacity() {
@@ -37,6 +41,22 @@ int GetCapacity() {
   }
   return capacity;
 }
+
+int GetCacheTypeToUse() {
+  int cache_type;
+  const char* env_cache_type = std::getenv("GANDIVA_CACHE_TYPE");
+  if (env_cache_type != nullptr) {
+    cache_type = std::atoi(env_cache_type);
+    if (cache_type > 1) {
+      ARROW_LOG(WARNING) << "Invalid cache type provided. Using default cache type: "
+                         << DEFAULT_CACHE_TO_USE;
+      cache_type = DEFAULT_CACHE_TO_USE;
+    }
+  } else {
+    cache_type = DEFAULT_CACHE_TO_USE;
+  }
+   return cache_type;
+ }
 
 void LogCacheSize(size_t capacity) {
   ARROW_LOG(INFO) << "Creating gandiva cache with capacity: " << capacity;

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -55,8 +55,8 @@ int GetCacheTypeToUse() {
   } else {
     cache_type = DEFAULT_CACHE_TO_USE;
   }
-   return cache_type;
- }
+  return cache_type;
+}
 
 void LogCacheSize(size_t capacity) {
   ARROW_LOG(INFO) << "Creating gandiva cache with capacity: " << capacity;

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -63,6 +63,7 @@ class Cache {
     (*cache_).insert(cache_key, module, value_to_order);
     mtx_.unlock();
   }
+
  private:
   BaseCache<KeyType, ValueType>* cache_;
   std::mutex mtx_;

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -19,6 +19,7 @@
 
 #include <cstdlib>
 #include <mutex>
+#include <memory>
 
 #include "gandiva/lower_value_used_cache.h"
 #include "gandiva/lru_cache.h"
@@ -40,9 +41,9 @@ class Cache {
  public:
   explicit Cache(size_t capacity, int cache_type_to_use) {
     if (cache_type_to_use == 0) {
-      this->cache_ = new LowerValueUsedCache<KeyType, ValueType>(capacity);
+      this->cache_ = std::make_unique<LowerValueUsedCache<KeyType, ValueType>>(capacity);
     } else {
-      this->cache_ = new LruCache<KeyType, ValueType>(capacity);
+      this->cache_ = std::make_unique<LruCache<KeyType, ValueType>>(capacity);
     }
     LogCacheSize(capacity);
   }
@@ -65,7 +66,7 @@ class Cache {
   }
 
  private:
-  BaseCache<KeyType, ValueType>* cache_;
+  std::unique_ptr<BaseCache<KeyType, ValueType>> cache_;
   std::mutex mtx_;
 };
 }  // namespace gandiva

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -40,9 +40,9 @@ class Cache {
  public:
   explicit Cache(size_t capacity, int cache_type_to_use) {
     if (cache_type_to_use == 0) {
-      this->cache_ = LruCache<KeyType, ValueType>(capacity);
+      this->cache_ = new LruCache<KeyType, ValueType>(capacity);
     } else {
-      this->cache_ = LruCache<KeyType, ValueType>(capacity);
+      this->cache_ = new LruCache<KeyType, ValueType>(capacity);
     }
     LogCacheSize(capacity);
   }
@@ -52,19 +52,19 @@ class Cache {
   ValueType GetModule(KeyType cache_key) {
     arrow::util::optional<ValueType> result;
     mtx_.lock();
-    result = cache_.get(cache_key);
+    result = (*cache_).get(cache_key);
     mtx_.unlock();
     return result != arrow::util::nullopt ? *result : nullptr;
   }
 
   void PutModule(KeyType cache_key, ValueType module) {
     mtx_.lock();
-    cache_.insert(cache_key, module, 0);
+    (*cache_).insert(cache_key, module, 0);
     mtx_.unlock();
   }
 
  private:
-  LruCache<KeyType, ValueType> cache_;
+  BaseCache<KeyType, ValueType>* cache_;
   std::mutex mtx_;
 };
 }  // namespace gandiva

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -57,7 +57,7 @@ class Cache {
     return result != arrow::util::nullopt ? *result : nullptr;
   }
 
-  void PutModule(KeyType cache_key, ValueType module, u_long value_to_order) {
+  void PutModule(KeyType cache_key, ValueType module, uint64_t value_to_order) {
     // Define value_to_order if the cache being used considers it, otherwise define 0
     mtx_.lock();
     (*cache_).insert(cache_key, module, value_to_order);

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -40,7 +40,7 @@ class Cache {
  public:
   explicit Cache(size_t capacity, int cache_type_to_use) {
     if (cache_type_to_use == 0) {
-      this->cache_ = new LruCache<KeyType, ValueType>(capacity);
+      this->cache_ = new LowerValueUsedCache<KeyType, ValueType>(capacity);
     } else {
       this->cache_ = new LruCache<KeyType, ValueType>(capacity);
     }
@@ -57,12 +57,12 @@ class Cache {
     return result != arrow::util::nullopt ? *result : nullptr;
   }
 
-  void PutModule(KeyType cache_key, ValueType module) {
+  void PutModule(KeyType cache_key, ValueType module, u_long value_to_order) {
+    // Define value_to_order if the cache being used considers it, otherwise define 0
     mtx_.lock();
-    (*cache_).insert(cache_key, module, 0);
+    (*cache_).insert(cache_key, module, value_to_order);
     mtx_.unlock();
   }
-
  private:
   BaseCache<KeyType, ValueType>* cache_;
   std::mutex mtx_;

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -20,8 +20,8 @@
 #include <cstdlib>
 #include <mutex>
 
-#include "gandiva/lru_cache.h"
 #include "gandiva/lower_value_used_cache.h"
+#include "gandiva/lru_cache.h"
 #include "gandiva/visibility.h"
 
 namespace gandiva {

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <cstdlib>
-#include <mutex>
 #include <memory>
+#include <mutex>
 
 #include "gandiva/lower_value_used_cache.h"
 #include "gandiva/lru_cache.h"

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -124,8 +124,8 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
   ARROW_RETURN_NOT_OK(llvm_gen->Build({condition}, SelectionVector::Mode::MODE_NONE));
   // Stop measuring time and calculate the elapsed time
   auto end = std::chrono::high_resolution_clock::now();
-  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
-      .count();
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
 
   // Instantiate the filter with the completely built llvm generator
   *filter = std::make_shared<Filter>(std::move(llvm_gen), schema, configuration);

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -118,11 +118,17 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
   // Return if the expression is invalid since we will not be able to process further.
   ExprValidator expr_validator(llvm_gen->types(), schema);
   ARROW_RETURN_NOT_OK(expr_validator.Validate(condition));
+
+  // Start measuring build time
+  auto begin = std::chrono::high_resolution_clock::now();
   ARROW_RETURN_NOT_OK(llvm_gen->Build({condition}, SelectionVector::Mode::MODE_NONE));
+  // Stop measuring time and calculate the elapsed time
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
 
   // Instantiate the filter with the completely built llvm generator
   *filter = std::make_shared<Filter>(std::move(llvm_gen), schema, configuration);
-  cache.PutModule(cache_key, *filter);
+  cache.PutModule(cache_key, *filter, elapsed);
 
   return Status::OK();
 }

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -124,7 +124,8 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
   ARROW_RETURN_NOT_OK(llvm_gen->Build({condition}, SelectionVector::Mode::MODE_NONE));
   // Stop measuring time and calculate the elapsed time
   auto end = std::chrono::high_resolution_clock::now();
-  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
+      .count();
 
   // Instantiate the filter with the completely built llvm generator
   *filter = std::make_shared<Filter>(std::move(llvm_gen), schema, configuration);

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -45,6 +45,10 @@ class FilterCacheKey {
 
   bool operator!=(const FilterCacheKey& other) const { return !(*this == other); }
 
+  bool operator<(const FilterCacheKey& other) const {
+    return uniqifier_ < other.uniqifier_;
+  };
+
   SchemaPtr schema() const { return schema_; }
 
   std::string ToString() const;

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -46,7 +46,18 @@ class FilterCacheKey {
   bool operator!=(const FilterCacheKey& other) const { return !(*this == other); }
 
   bool operator<(const FilterCacheKey& other) const {
-    return uniqifier_ < other.uniqifier_;
+    if (hash_code_ < other.hash_code_) {
+      return true;
+    }
+
+    if (expression_as_string_ < other.expression_as_string_) {
+      return true;
+    }
+
+    if (uniqifier_ < other.uniqifier_) {
+      return true;
+    }
+    return false;
   }
 
   SchemaPtr schema() const { return schema_; }

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -47,7 +47,7 @@ class FilterCacheKey {
 
   bool operator<(const FilterCacheKey& other) const {
     return uniqifier_ < other.uniqifier_;
-  };
+  }
 
   SchemaPtr schema() const { return schema_; }
 

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -22,14 +22,14 @@
 #include <utility>
 #include <set>
 
-#include "gandiva/base_cache.h"
 #include "arrow/util/optional.h"
+#include "gandiva/base_cache.h"
 
 // modified cache to support evict policy of lower value used.
 namespace gandiva {
 // a cache which evicts the lower value used item when it is full
 template <class Key, class Value>
-class LowerValueUsedCache : public BaseCache<Key, Value>{
+class LowerValueUsedCache : public BaseCache<Key, Value> {
  public:
   struct hasher {
     template <typename I>
@@ -37,9 +37,8 @@ class LowerValueUsedCache : public BaseCache<Key, Value>{
       return i.Hash();
     }
   };
-  using map_type =
-  std::unordered_map<Key,
-  std::pair<Value, typename std::set<std::pair<u_long, Key>> ::iterator>, hasher>;
+  using map_type =std::unordered_map<
+      Key, std::pair<Value, typename std::set<std::pair<u_long, Key>> ::iterator>, hasher>;
 
   explicit LowerValueUsedCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -29,7 +29,7 @@
 namespace gandiva {
 // a cache which evicts the lower value used item when it is full
 template <class Key, class Value>
-class LowerValueUsedCache : BaseCache<Key, Value>{
+class LowerValueUsedCache : public BaseCache<Key, Value>{
  public:
   struct hasher {
    template <typename I>
@@ -45,15 +45,15 @@ class LowerValueUsedCache : BaseCache<Key, Value>{
 
   LowerValueUsedCache<Key, Value>() : BaseCache<Key, Value>() {};
 
-  size_t size() const { return map_.size(); }
+  size_t size() const override { return map_.size(); }
 
-  size_t capacity() const { return this->cache_capacity_; }
+  size_t capacity() const override { return this->cache_capacity_; }
 
-  bool empty() const { return map_.empty(); }
+  bool empty() const override { return map_.empty(); }
 
-  bool contains(const Key& key) { return map_.find(key) != map_.end(); }
+  bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const u_long value_to_order) {
+  void insert(const Key& key, const Value& value, const u_long value_to_order) override{
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full
@@ -71,7 +71,7 @@ class LowerValueUsedCache : BaseCache<Key, Value>{
     }
   }
 
-  arrow::util::optional<Value> get(const Key& key) {
+  arrow::util::optional<Value> get(const Key& key) override {
     // lookup value in the cache
     typename map_type::iterator value_for_key = map_.find(key);
     if (value_for_key == map_.end()) {
@@ -81,7 +81,7 @@ class LowerValueUsedCache : BaseCache<Key, Value>{
     return value_for_key->second.first;
   }
 
-  void clear() {
+  void clear() override {
     map_.clear();
     lvu_set_.clear();
   }

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -98,6 +98,6 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
 
  private:
   map_type map_;
-  std::set<std::pair<u_long, Key>> lvu_set_;
+  std::set<std::pair<uint64_t, Key>> lvu_set_;
 };
 }  // namespace gandiva

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -37,9 +37,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
       return i.Hash();
     }
   };
-  using map_type = std::unordered_map<
-      Key, std::pair<Value, typename std::set<std::pair<uint64_t, Key>>::iterator>,
-      hasher>;
+  using map_type = std::unordered_map<Key, Value, hasher>;
 
   explicit LowerValueUsedCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 
@@ -68,7 +66,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
 
       // insert the new item
       lvu_set_.insert(std::make_pair(value_to_order, key));
-      map_[key] = std::make_pair(value, lvu_set_.begin());
+      map_[key] = value;
     }
   }
 
@@ -79,7 +77,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
       // value not in cache
       return arrow::util::nullopt;
     }
-    return value_for_key->second.first;
+    return value_for_key->second;
   }
 
   void clear() override {

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -38,7 +38,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
     }
   };
   using map_type =std::unordered_map<
-      Key, std::pair<Value, typename std::set<std::pair<u_long, Key>> ::iterator>, hasher>;
+      Key, std::pair<Value, typename std::set<std::pair<uint64_t, Key>> ::iterator>, hasher>;
 
   explicit LowerValueUsedCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 
@@ -52,7 +52,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const u_long value_to_order) override {
+  void insert(const Key& key, const Value& value, const uint64_t value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full
@@ -89,7 +89,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
   void evict() {
     // evict item from the beginning of the set. This set is ordered from the
     // lower value constant to the higher value.
-    typename std::set<std::pair<u_long, Key>>::iterator i = lvu_set_.begin();
+    typename std::set<std::pair<uint64_t, Key>>::iterator i = lvu_set_.begin();
     map_.erase((*i).second);
     lvu_set_.erase(i);
   }

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <list>
+#include <set>
 #include <unordered_map>
 #include <utility>
-#include <set>
 
 #include "arrow/util/optional.h"
 #include "gandiva/base_cache.h"
@@ -37,8 +37,9 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
       return i.Hash();
     }
   };
-  using map_type =std::unordered_map<
-      Key, std::pair<Value, typename std::set<std::pair<uint64_t, Key>> ::iterator>, hasher>;
+  using map_type = std::unordered_map<
+      Key, std::pair<Value, typename std::set<std::pair<uint64_t, Key>>::iterator>,
+      hasher>;
 
   explicit LowerValueUsedCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 
@@ -52,7 +53,8 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const uint64_t value_to_order) override {
+  void insert(const Key& key, const Value& value,
+              const uint64_t value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <set>
+
+#include "arrow/util/optional.h"
+
+// modified cache to support evict policy of lower value used.
+namespace gandiva {
+// a cache which evicts the lower value used item when it is full
+template <class Key, class Value>
+class LowerValueUsedCache {
+ public:
+  using key_type = Key;
+  using value_type = Value;
+  // try to use set to keep it ordered by the key, so the last position will always
+  // be the higher value.
+  using set_type = std::set<std::pair<u_long, Key>>;
+  struct hasher {
+   template <typename I>
+   std::size_t operator()(const I& i) const {
+     return i.Hash();
+   }
+  };
+  using map_type =
+  std::unordered_map<key_type, std::pair<value_type, typename set_type ::iterator>,
+      hasher>;
+
+  explicit LowerValueUsedCache(size_t capacity) : cache_capacity_(capacity) {}
+
+  ~LowerValueUsedCache() {}
+
+  size_t size() const { return map_.size(); }
+
+  size_t capacity() const { return cache_capacity_; }
+
+  bool empty() const { return map_.empty(); }
+
+  bool contains(const key_type& key) { return map_.find(key) != map_.end(); }
+
+  void insert(const key_type& key, const value_type& value, const u_long value_to_order) {
+    typename map_type::iterator i = map_.find(key);
+    if (i == map_.end()) {
+      // insert item into the cache, but first check if it is full
+      if (size() >= cache_capacity_) {
+        // check if the value should be inserted on cache, otherwise just return
+        if (value_to_order <= lvu_set_.begin()->first) return;
+
+        // cache is full, evict the least recently used item
+        evict();
+      }
+
+      // insert the new item
+      lvu_set_.insert(std::make_pair(value_to_order, key));
+      map_[key] = std::make_pair(value, lvu_set_.begin());
+    }
+  }
+
+  arrow::util::optional<value_type> get(const key_type& key) {
+    // lookup value in the cache
+    typename map_type::iterator value_for_key = map_.find(key);
+    if (value_for_key == map_.end()) {
+      // value not in cache
+      return arrow::util::nullopt;
+    }
+    return value_for_key->second.first;
+  }
+
+  void clear() {
+    map_.clear();
+    lvu_set_.clear();
+  }
+
+ private:
+  void evict() {
+    // evict item from the beginning of the set. This set is ordered from the
+    // lower value constant to the higher value.
+    typename set_type::iterator i = lvu_set_.begin();
+    map_.erase((*i).second);
+    lvu_set_.erase(i);
+  }
+
+ private:
+  map_type map_;
+  set_type lvu_set_;
+  size_t cache_capacity_;
+ };
+}  // namespace gandiva

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <set>
 
-#include "base_cache.h"
+#include "gandiva/base_cache.h"
 #include "arrow/util/optional.h"
 
 // modified cache to support evict policy of lower value used.
@@ -32,18 +32,18 @@ template <class Key, class Value>
 class LowerValueUsedCache : public BaseCache<Key, Value>{
  public:
   struct hasher {
-   template <typename I>
-   std::size_t operator()(const I& i) const {
-     return i.Hash();
-   }
+    template <typename I>
+    std::size_t operator()(const I& i) const {
+      return i.Hash();
+    }
   };
   using map_type =
-  std::unordered_map<Key, std::pair<Value, typename std::set<std::pair<u_long, Key>> ::iterator>,
-      hasher>;
+  std::unordered_map<Key,
+  std::pair<Value, typename std::set<std::pair<u_long, Key>> ::iterator>, hasher>;
 
   explicit LowerValueUsedCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 
-  LowerValueUsedCache<Key, Value>() : BaseCache<Key, Value>() {};
+  LowerValueUsedCache<Key, Value>() : BaseCache<Key, Value>() {}
 
   size_t size() const override { return map_.size(); }
 
@@ -53,7 +53,7 @@ class LowerValueUsedCache : public BaseCache<Key, Value>{
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const u_long value_to_order) override{
+  void insert(const Key& key, const Value& value, const u_long value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full
@@ -98,5 +98,5 @@ class LowerValueUsedCache : public BaseCache<Key, Value>{
  private:
   map_type map_;
   std::set<std::pair<u_long, Key>> lvu_set_;
- };
+};
 }  // namespace gandiva

--- a/cpp/src/gandiva/lower_value_used_cache.h
+++ b/cpp/src/gandiva/lower_value_used_cache.h
@@ -43,6 +43,8 @@ class LowerValueUsedCache : public BaseCache<Key, Value> {
 
   LowerValueUsedCache<Key, Value>() : BaseCache<Key, Value>() {}
 
+  ~LowerValueUsedCache() = default;
+
   size_t size() const override { return map_.size(); }
 
   size_t capacity() const override { return this->cache_capacity_; }

--- a/cpp/src/gandiva/lower_value_used_cache_test.cc
+++ b/cpp/src/gandiva/lower_value_used_cache_test.cc
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gandiva/lower_value_used_cache.h"
+
+#include <map>
+#include <string>
+#include <typeinfo>
+
+#include <gtest/gtest.h>
+
+namespace gandiva {
+
+class TestCacheKey {
+ public:
+  explicit TestCacheKey(int tmp) : tmp_(tmp) {}
+  std::size_t Hash() const { return tmp_; }
+  bool operator==(const TestCacheKey& other) const { return tmp_ == other.tmp_; }
+
+ private:
+  int tmp_;
+};
+
+class TestLowerValueUsedCache : public ::testing::Test {
+ public:
+ TestLowerValueUsedCache() : cache_(2) {}
+
+ protected:
+ LowerValueUsedCache<TestCacheKey, std::string> cache_;
+};
+
+TEST_F(TestLowerValueUsedCache, TestEvict) {
+  cache_.insert(TestCacheKey(1), "bye", 1);
+  cache_.insert(TestCacheKey(2), "bye", 10);
+  cache_.insert(TestCacheKey(1), "bye", 1);
+  cache_.insert(TestCacheKey(3), "bye", 100);
+  // should have evicted key 1
+  ASSERT_EQ(2, cache_.size());
+  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
+}
+
+TEST_F(TestLowerValueUsedCache, TestLruBehavior) {
+  cache_.insert(TestCacheKey(1), "hello");
+  cache_.insert(TestCacheKey(2), "hello");
+  cache_.get(TestCacheKey(1));
+  cache_.insert(TestCacheKey(3), "hello");
+  // should have evicted key 2.
+  ASSERT_EQ(*cache_.get(TestCacheKey(1)), "hello");
+}
+}  // namespace gandiva

--- a/cpp/src/gandiva/lower_value_used_cache_test.cc
+++ b/cpp/src/gandiva/lower_value_used_cache_test.cc
@@ -24,12 +24,12 @@
 
 namespace gandiva {
 
-class TestCacheKey {
+class TestLvuCacheKey {
  public:
-  explicit TestCacheKey(int tmp) : tmp_(tmp) {}
+  explicit TestLvuCacheKey(int tmp) : tmp_(tmp) {}
   std::size_t Hash() const { return tmp_; }
-  bool operator==(const TestCacheKey& other) const { return tmp_ == other.tmp_; }
-  bool operator<(const TestCacheKey& other) const { return tmp_ < other.tmp_; }
+  bool operator==(const TestLvuCacheKey& other) const { return tmp_ == other.tmp_; }
+  bool operator<(const TestLvuCacheKey& other) const { return tmp_ < other.tmp_; }
 
  private:
   int tmp_;
@@ -40,49 +40,49 @@ class TestLowerValueUsedCache : public ::testing::Test {
   TestLowerValueUsedCache() : cache_(2) {}
 
  protected:
-  LowerValueUsedCache<TestCacheKey, std::string> cache_;
+  LowerValueUsedCache<TestLvuCacheKey, std::string> cache_;
 };
 
 TEST_F(TestLowerValueUsedCache, TestEvict) {
-  cache_.insert(TestCacheKey(1), "bye", 1);
-  cache_.insert(TestCacheKey(2), "bye", 10);
-  cache_.insert(TestCacheKey(1), "bye", 1);
-  cache_.insert(TestCacheKey(3), "bye", 20);
-  cache_.insert(TestCacheKey(4), "bye", 100);
-  cache_.insert(TestCacheKey(1), "bye", 1);
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
+  cache_.insert(TestLvuCacheKey(2), "bye", 10);
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
+  cache_.insert(TestLvuCacheKey(3), "bye", 20);
+  cache_.insert(TestLvuCacheKey(4), "bye", 100);
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
   ASSERT_EQ(2, cache_.size());
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
-  ASSERT_EQ(cache_.get(TestCacheKey(2)), arrow::util::nullopt);
-  ASSERT_EQ(cache_.get(TestCacheKey(3)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(4)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(1)), arrow::util::nullopt);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(2)), arrow::util::nullopt);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(3)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(4)), "bye");
 }
 
 TEST_F(TestLowerValueUsedCache, TestLowestValueUsedBehavior) {
   // should insert key 1 and 2
-  cache_.insert(TestCacheKey(1), "bye", 1);
-  cache_.insert(TestCacheKey(2), "bye", 10);
-  cache_.insert(TestCacheKey(1), "bye", 1);
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(2)), "bye");
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
+  cache_.insert(TestLvuCacheKey(2), "bye", 10);
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(1)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(2)), "bye");
 
   // should insert key 3 evicting key 1 (because value to order of key 3 is higher)
-  cache_.insert(TestCacheKey(3), "bye", 20);
-  ASSERT_EQ(cache_.get(TestCacheKey(3)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(2)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
+  cache_.insert(TestLvuCacheKey(3), "bye", 20);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(3)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(2)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(1)), arrow::util::nullopt);
 
   // should insert key 4 evicting key 2 (because value to order of key 4 is higher)
-  cache_.insert(TestCacheKey(4), "bye", 100);
-  ASSERT_EQ(cache_.get(TestCacheKey(3)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(4)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(2)), arrow::util::nullopt);
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
+  cache_.insert(TestLvuCacheKey(4), "bye", 100);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(3)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(4)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(2)), arrow::util::nullopt);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(1)), arrow::util::nullopt);
 
   // should not insert key 1 on cache (because the value to order is lower)
-  cache_.insert(TestCacheKey(1), "bye", 1);
-  ASSERT_EQ(cache_.get(TestCacheKey(3)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(4)), "bye");
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
-  ASSERT_EQ(cache_.get(TestCacheKey(2)), arrow::util::nullopt);
+  cache_.insert(TestLvuCacheKey(1), "bye", 1);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(3)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(4)), "bye");
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(1)), arrow::util::nullopt);
+  ASSERT_EQ(cache_.get(TestLvuCacheKey(2)), arrow::util::nullopt);
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/lower_value_used_cache_test.cc
+++ b/cpp/src/gandiva/lower_value_used_cache_test.cc
@@ -29,9 +29,7 @@ class TestCacheKey {
   explicit TestCacheKey(int tmp) : tmp_(tmp) {}
   std::size_t Hash() const { return tmp_; }
   bool operator==(const TestCacheKey& other) const { return tmp_ == other.tmp_; }
-  bool operator<(const TestCacheKey& other) const {
-    return tmp_ < other.tmp_;
-  }
+  bool operator<(const TestCacheKey& other) const { return tmp_ < other.tmp_; }
 
  private:
   int tmp_;

--- a/cpp/src/gandiva/lower_value_used_cache_test.cc
+++ b/cpp/src/gandiva/lower_value_used_cache_test.cc
@@ -31,7 +31,7 @@ class TestCacheKey {
   bool operator==(const TestCacheKey& other) const { return tmp_ == other.tmp_; }
   bool operator<(const TestCacheKey& other) const {
     return tmp_ < other.tmp_;
-  };
+  }
 
  private:
   int tmp_;
@@ -39,10 +39,10 @@ class TestCacheKey {
 
 class TestLowerValueUsedCache : public ::testing::Test {
  public:
- TestLowerValueUsedCache() : cache_(2) {}
+  TestLowerValueUsedCache() : cache_(2) {}
 
  protected:
- LowerValueUsedCache<TestCacheKey, std::string> cache_;
+  LowerValueUsedCache<TestCacheKey, std::string> cache_;
 };
 
 TEST_F(TestLowerValueUsedCache, TestEvict) {

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -29,7 +29,7 @@
 namespace gandiva {
 // a cache which evicts the least recently used item when it is full
 template <class Key, class Value>
-class LruCache : BaseCache<Key, Value> {
+class LruCache : public BaseCache<Key, Value> {
  public:
   struct hasher {
     template <typename I>
@@ -45,19 +45,19 @@ class LruCache : BaseCache<Key, Value> {
 
   LruCache<Key, Value>() : BaseCache<Key, Value>() {};
 
-  size_t size() const { return map_.size(); }
+  size_t size() const override { return map_.size(); }
 
-  size_t capacity() const { return this->cache_capacity_; }
+  size_t capacity() const override { return this->cache_capacity_; }
 
-  bool empty() const { return map_.empty(); }
+  bool empty() const override { return map_.empty(); }
 
-  bool contains(const Key& key) { return map_.find(key) != map_.end(); }
+  bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value) {
+  void insert(const Key& key, const Value& value) override{
     this->insert(key, value, 0);
   }
 
-  void insert(const Key& key, const Value& value, const u_long /*value_to_order*/) {
+  void insert(const Key& key, const Value& value, const u_long value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full
@@ -72,7 +72,7 @@ class LruCache : BaseCache<Key, Value> {
     }
   }
 
-  arrow::util::optional<Value> get(const Key& key) {
+  arrow::util::optional<Value> get(const Key& key) override {
     // lookup value in the cache
     typename map_type::iterator value_for_key = map_.find(key);
     if (value_for_key == map_.end()) {
@@ -102,7 +102,7 @@ class LruCache : BaseCache<Key, Value> {
     }
   }
 
-  void clear() {
+  void clear() override {
     map_.clear();
     lru_list_.clear();
   }

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -53,7 +53,8 @@ class LruCache : public BaseCache<Key, Value> {
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const uint64_t value_to_order) override {
+  void insert(const Key& key, const Value& value,
+              const uint64_t value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -53,10 +53,6 @@ class LruCache : public BaseCache<Key, Value> {
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value) override{
-    this->insert(key, value, 0);
-  }
-
   void insert(const Key& key, const Value& value, const u_long value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -45,6 +45,8 @@ class LruCache : public BaseCache<Key, Value> {
 
   LruCache<Key, Value>() : BaseCache<Key, Value>() {}
 
+  ~LruCache() = default;
+
   size_t size() const override { return map_.size(); }
 
   size_t capacity() const override { return this->cache_capacity_; }

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -53,7 +53,7 @@ class LruCache : public BaseCache<Key, Value> {
 
   bool contains(const Key& key) override { return map_.find(key) != map_.end(); }
 
-  void insert(const Key& key, const Value& value, const u_long value_to_order) override {
+  void insert(const Key& key, const Value& value, const uint64_t value_to_order) override {
     typename map_type::iterator i = map_.find(key);
     if (i == map_.end()) {
       // insert item into the cache, but first check if it is full

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "base_cache.h"
+#include "gandiva/base_cache.h"
 #include "arrow/util/optional.h"
 
 // modified from boost LRU cache -> the boost cache supported only an
@@ -43,7 +43,7 @@ class LruCache : public BaseCache<Key, Value> {
 
   explicit LruCache(size_t capacity) : BaseCache<Key, Value>(capacity) {}
 
-  LruCache<Key, Value>() : BaseCache<Key, Value>() {};
+  LruCache<Key, Value>() : BaseCache<Key, Value>() {}
 
   size_t size() const override { return map_.size(); }
 

--- a/cpp/src/gandiva/lru_cache.h
+++ b/cpp/src/gandiva/lru_cache.h
@@ -21,8 +21,8 @@
 #include <unordered_map>
 #include <utility>
 
-#include "gandiva/base_cache.h"
 #include "arrow/util/optional.h"
+#include "gandiva/base_cache.h"
 
 // modified from boost LRU cache -> the boost cache supported only an
 // ordered map.

--- a/cpp/src/gandiva/lru_cache_test.cc
+++ b/cpp/src/gandiva/lru_cache_test.cc
@@ -25,11 +25,12 @@
 
 namespace gandiva {
 
-class TestCacheKey {
+class TestLruCacheKey {
  public:
-  explicit TestCacheKey(int tmp) : tmp_(tmp) {}
+  explicit TestLruCacheKey(int tmp) : tmp_(tmp) {}
   std::size_t Hash() const { return tmp_; }
-  bool operator==(const TestCacheKey& other) const { return tmp_ == other.tmp_; }
+  bool operator==(const TestLruCacheKey& other) const { return tmp_ == other.tmp_; }
+  bool operator<(const TestLruCacheKey& other) const { return tmp_ < other.tmp_; }
 
  private:
   int tmp_;
@@ -40,25 +41,25 @@ class TestLruCache : public ::testing::Test {
   TestLruCache() : cache_(2) {}
 
  protected:
-  LruCache<TestCacheKey, std::string> cache_;
+  LruCache<TestLruCacheKey, std::string> cache_;
 };
 
 TEST_F(TestLruCache, TestEvict) {
-  cache_.insert(TestCacheKey(1), "hello", 0);
-  cache_.insert(TestCacheKey(2), "hello", 0);
-  cache_.insert(TestCacheKey(1), "hello", 0);
-  cache_.insert(TestCacheKey(3), "hello", 0);
+  cache_.insert(TestLruCacheKey(1), "hello", 0);
+  cache_.insert(TestLruCacheKey(2), "hello", 0);
+  cache_.insert(TestLruCacheKey(1), "hello", 0);
+  cache_.insert(TestLruCacheKey(3), "hello", 0);
   // should have evicted key 1
   ASSERT_EQ(2, cache_.size());
-  ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
+  ASSERT_EQ(cache_.get(TestLruCacheKey(1)), arrow::util::nullopt);
 }
 
 TEST_F(TestLruCache, TestLruBehavior) {
-  cache_.insert(TestCacheKey(1), "hello", 0);
-  cache_.insert(TestCacheKey(2), "hello", 0);
-  cache_.get(TestCacheKey(1));
-  cache_.insert(TestCacheKey(3), "hello", 0);
+  cache_.insert(TestLruCacheKey(1), "hello", 0);
+  cache_.insert(TestLruCacheKey(2), "hello", 0);
+  cache_.get(TestLruCacheKey(1));
+  cache_.insert(TestLruCacheKey(3), "hello", 0);
   // should have evicted key 2.
-  ASSERT_EQ(*cache_.get(TestCacheKey(1)), "hello");
+  ASSERT_EQ(*cache_.get(TestLruCacheKey(1)), "hello");
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/lru_cache_test.cc
+++ b/cpp/src/gandiva/lru_cache_test.cc
@@ -44,20 +44,20 @@ class TestLruCache : public ::testing::Test {
 };
 
 TEST_F(TestLruCache, TestEvict) {
-  cache_.insert(TestCacheKey(1), "hello");
-  cache_.insert(TestCacheKey(2), "hello");
-  cache_.insert(TestCacheKey(1), "hello");
-  cache_.insert(TestCacheKey(3), "hello");
+  cache_.insert(TestCacheKey(1), "hello", 0);
+  cache_.insert(TestCacheKey(2), "hello", 0);
+  cache_.insert(TestCacheKey(1), "hello", 0);
+  cache_.insert(TestCacheKey(3), "hello", 0);
   // should have evicted key 1
   ASSERT_EQ(2, cache_.size());
   ASSERT_EQ(cache_.get(TestCacheKey(1)), arrow::util::nullopt);
 }
 
 TEST_F(TestLruCache, TestLruBehavior) {
-  cache_.insert(TestCacheKey(1), "hello");
-  cache_.insert(TestCacheKey(2), "hello");
+  cache_.insert(TestCacheKey(1), "hello", 0);
+  cache_.insert(TestCacheKey(2), "hello", 0);
   cache_.get(TestCacheKey(1));
-  cache_.insert(TestCacheKey(3), "hello");
+  cache_.insert(TestCacheKey(3), "hello", 0);
   // should have evicted key 2.
   ASSERT_EQ(*cache_.get(TestCacheKey(1)), "hello");
 }

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -181,8 +181,8 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   ARROW_RETURN_NOT_OK(llvm_gen->Build(exprs, selection_vector_mode));
   // Stop measuring time and calculate the elapsed time
   auto end = std::chrono::high_resolution_clock::now();
-  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
-      .count();
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
 
   // save the output field types. Used for validation at Evaluate() time.
   std::vector<FieldPtr> output_fields;

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -176,7 +176,12 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
     ARROW_RETURN_NOT_OK(expr_validator.Validate(expr));
   }
 
+  // Start measuring build time
+  auto begin = std::chrono::high_resolution_clock::now();
   ARROW_RETURN_NOT_OK(llvm_gen->Build(exprs, selection_vector_mode));
+  // Stop measuring time and calculate the elapsed time
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
 
   // save the output field types. Used for validation at Evaluate() time.
   std::vector<FieldPtr> output_fields;
@@ -188,7 +193,7 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   // Instantiate the projector with the completely built llvm generator
   *projector = std::shared_ptr<Projector>(
       new Projector(std::move(llvm_gen), schema, output_fields, configuration));
-  cache.PutModule(cache_key, *projector);
+  cache.PutModule(cache_key, *projector, elapsed);
 
   return Status::OK();
 }

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -76,7 +76,9 @@ class ProjectorCacheKey {
     }
     return true;
   }
-
+  bool operator<(const ProjectorCacheKey& other) const {
+    return uniqifier_ < other.uniqifier_;
+  };
   bool operator!=(const ProjectorCacheKey& other) const { return !(*this == other); }
 
   SchemaPtr schema() const { return schema_; }

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -77,7 +77,22 @@ class ProjectorCacheKey {
     return true;
   }
   bool operator<(const ProjectorCacheKey& other) const {
-    return uniqifier_ < other.uniqifier_;
+    if (hash_code_ < other.hash_code_) {
+      return true;
+    }
+
+    if (expressions_as_strings_ < other.expressions_as_strings_) {
+      return true;
+    }
+
+    if (mode_ < other.mode_) {
+      return true;
+    }
+
+    if (uniqifier_ < other.uniqifier_) {
+      return true;
+    }
+    return false;
   }
   bool operator!=(const ProjectorCacheKey& other) const { return !(*this == other); }
 

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -78,7 +78,7 @@ class ProjectorCacheKey {
   }
   bool operator<(const ProjectorCacheKey& other) const {
     return uniqifier_ < other.uniqifier_;
-  };
+  }
   bool operator!=(const ProjectorCacheKey& other) const { return !(*this == other); }
 
   SchemaPtr schema() const { return schema_; }
@@ -181,7 +181,8 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   ARROW_RETURN_NOT_OK(llvm_gen->Build(exprs, selection_vector_mode));
   // Stop measuring time and calculate the elapsed time
   auto end = std::chrono::high_resolution_clock::now();
-  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin).count();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
+      .count();
 
   // save the output field types. Used for validation at Evaluate() time.
   std::vector<FieldPtr> output_fields;


### PR DESCRIPTION
Currently gandiva cache is an LRU cache. It would be interesting to change it so that the expressions which take large amount of time to build stay as long as possible in the cache.

So, we need to Implement a new cache for Gandiva focused on this build time policy, and make it configurable so it is possible to define if it will be used the LRU cache or this new one.