### PR TITLE
ARROW-11914: [R] [CI] r-sanitizer nightly is broken

### DIFF
--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -27,7 +27,7 @@ pushd ${source_dir}/tests
 
 export TEST_R_WITH_ARROW=TRUE
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=/arrow/r/tools/ubsan.supp"
-${R_BIN} < testthat.R > testthat.out 2>&1 || cat testthat.out; exit 1
+${R_BIN} < testthat.R > testthat.out 2>&1 || { cat testthat.out; exit 1; }
 
 cat testthat.out
 if grep -q "runtime error" testthat.out; then

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -27,7 +27,7 @@ pushd ${source_dir}/tests
 
 export TEST_R_WITH_ARROW=TRUE
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=/arrow/r/tools/ubsan.supp"
-${R_BIN} < testthat.R > testthat.out 2>&1
+${R_BIN} < testthat.R > testthat.out 2>&1 || cat testthat.out; exit 1
 
 cat testthat.out
 if grep -q "runtime error" testthat.out; then

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -778,7 +778,7 @@ class RDictionaryConverter<ValueType, enable_if_has_string_view<ValueType>>
           arrow::dictionary(result_type->index_type(), result_type->value_type(), true);
     }
 
-    return result;
+    return std::make_shared<DictionaryArray>(result->data());
   }
 };
 


### PR DESCRIPTION
This resolves the sanitizer error (thank you @lidavidm for the c++ solution!). I also added a step to print `testthat.out` if `RDsan` fails which we weren't doing before. Hopefully that helps diagnose these a bit easier in the future.