### PR TITLE
ARROW-12116: [Rust] Fix and ignore 1.51 clippy lints

### DIFF
--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -129,6 +129,9 @@
 #![cfg_attr(feature = "avx512", feature(avx512_target_feature))]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
+// upper_case_acronyms lint was introduced in Rust 1.51.
+// It is triggered in the ffi module, and ipc::gen, which we have no control over
+#![allow(clippy::upper_case_acronyms)]
 #![allow(bare_trait_objects)]
 #![warn(missing_debug_implementations)]
 #![deny(clippy::redundant_clone)]

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -129,14 +129,18 @@
 #![cfg_attr(feature = "avx512", feature(avx512_target_feature))]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-// upper_case_acronyms lint was introduced in Rust 1.51.
-// It is triggered in the ffi module, and ipc::gen, which we have no control over
-#![allow(clippy::upper_case_acronyms)]
+#![deny(clippy::redundant_clone)]
+#![allow(
+    // introduced to ignore lint errors when upgrading from 2020-04-22 to 2020-11-14
+    clippy::float_equality_without_abs,
+    clippy::type_complexity,
+    // upper_case_acronyms lint was introduced in Rust 1.51.
+    // It is triggered in the ffi module, and ipc::gen, which we have no control over
+    clippy::upper_case_acronyms,
+    clippy::vec_init_then_push
+)]
 #![allow(bare_trait_objects)]
 #![warn(missing_debug_implementations)]
-#![deny(clippy::redundant_clone)]
-// introduced to ignore lint errors when upgrading from 2020-04-22 to 2020-11-14
-#![allow(clippy::float_equality_without_abs, clippy::type_complexity)]
 
 pub mod alloc;
 mod arch;

--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -93,8 +93,7 @@ fn create_column(field: &str, columns: &[ArrayRef]) -> Result<Table> {
 
     for col in columns {
         for row in 0..col.len() {
-            let mut cells = Vec::new();
-            cells.push(Cell::new(&array_value_to_string(&col, row)?));
+            let cells = vec![Cell::new(&array_value_to_string(&col, row)?)];
             table.add_row(Row::new(cells));
         }
     }

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -18,9 +18,11 @@
 // Clippy lints, some should be disabled incrementally
 #![allow(
     clippy::float_cmp,
+    clippy::from_over_into,
     clippy::module_inception,
     clippy::new_without_default,
-    clippy::type_complexity
+    clippy::type_complexity,
+    clippy::upper_case_acronyms
 )]
 
 //! [DataFusion](https://github.com/apache/arrow/tree/master/rust/datafusion)

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -303,8 +303,8 @@ impl LogicalPlanBuilder {
 
         Ok(Self::from(&LogicalPlan::Aggregate {
             input: Arc::new(self.plan.clone()),
-            group_expr: group_expr,
-            aggr_expr: aggr_expr,
+            group_expr,
+            aggr_expr,
             schema: DFSchemaRef::new(aggr_schema),
         }))
     }

--- a/rust/parquet/src/lib.rs
+++ b/rust/parquet/src/lib.rs
@@ -23,13 +23,16 @@
     clippy::cast_ptr_alignment,
     clippy::float_cmp,
     clippy::float_equality_without_abs,
+    clippy::from_over_into,
     clippy::many_single_char_names,
     clippy::needless_range_loop,
     clippy::new_without_default,
     clippy::or_fun_call,
     clippy::same_item_push,
     clippy::too_many_arguments,
-    clippy::transmute_ptr_to_ptr
+    clippy::transmute_ptr_to_ptr,
+    clippy::upper_case_acronyms,
+    clippy::vec_init_then_push
 )]
 
 #[macro_use]


### PR DESCRIPTION
There's an acronym Rust lint that started failing after 1.51 was announced. The lint is in the `arrow::ffi` and `arrow::ipc::gen` modules, so I'm instead ignoring it and documenting this.