### PR TITLE
ARROW-12006: [Java] Fix checkstyle config to work on Windows

### DIFF
--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -48,7 +48,9 @@
       <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
 
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Google style modules -->
 


### PR DESCRIPTION
On Windows checkstyle will fail if you preserve LF endings but this change looks for LF explicitly.