### PR TITLE
ARROW-12119: [Rust][DataFusion] Improve performance of to_array_of_size for primitives

### DIFF
--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -114,7 +114,7 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
     }
 
     /// Creates a PrimitiveArray based on a constant value with `count` elements
-    pub fn from_constant(value: T::Native, count: usize) -> Self {
+    pub fn from_value(value: T::Native, count: usize) -> Self {
         // # Safety: length is known
         let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
         let data = ArrayData::new(

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -112,6 +112,21 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         );
         PrimitiveArray::from(data)
     }
+
+    /// Creates a PrimitiveArray based on an iterator of values without nulls
+    pub fn from_constant(value: T::Native, count: usize) -> Self {
+        let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
+        let data = ArrayData::new(
+            T::DATA_TYPE,
+            val_buf.len() / mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
+            None,
+            None,
+            0,
+            vec![val_buf],
+            vec![],
+        );
+        PrimitiveArray::from(data)
+    }
 }
 
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {

--- a/rust/arrow/src/array/array_primitive.rs
+++ b/rust/arrow/src/array/array_primitive.rs
@@ -113,8 +113,9 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         PrimitiveArray::from(data)
     }
 
-    /// Creates a PrimitiveArray based on an iterator of values without nulls
+    /// Creates a PrimitiveArray based on a constant value with `count` elements
     pub fn from_constant(value: T::Native, count: usize) -> Self {
+        // # Safety: length is known
         let val_buf = unsafe { Buffer::from_trusted_len_iter((0..count).map(|_| value)) };
         let data = ArrayData::new(
             T::DATA_TYPE,

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -215,77 +215,73 @@ impl ScalarValue {
             }
             ScalarValue::Float64(e) => match e {
                 Some(value) => {
-                    Arc::new(Float64Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Float64Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Float64, size),
             },
             ScalarValue::Float32(e) => match e {
                 Some(value) => {
-                    Arc::new(Float32Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Float32Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Float32, size),
             },
             ScalarValue::Int8(e) => match e {
                 Some(value) => {
-                    Arc::new(Int8Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Int8Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Int8, size),
             },
             ScalarValue::Int16(e) => match e {
                 Some(value) => {
-                    Arc::new(Int16Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Int16Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Int16, size),
             },
             ScalarValue::Int32(e) => match e {
                 Some(value) => {
-                    Arc::new(Int32Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Int32Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Int32, size),
             },
             ScalarValue::Int64(e) => match e {
                 Some(value) => {
-                    Arc::new(Int64Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Int64Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Int64, size),
             },
             ScalarValue::UInt8(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt8Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(UInt8Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::UInt8, size),
             },
             ScalarValue::UInt16(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt16Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(UInt16Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::UInt16, size),
             },
             ScalarValue::UInt32(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt32Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(UInt32Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::UInt32, size),
             },
             ScalarValue::UInt64(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt64Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(UInt64Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::UInt64, size),
             },
             ScalarValue::TimeMicrosecond(e) => match e {
-                Some(value) => Arc::new(TimestampMicrosecondArray::from_iter_values(
-                    repeat(*value).take(size),
-                )),
+                Some(value) => Arc::new(TimestampMicrosecondArray::from_constant(*value, size)),
                 None => new_null_array(
                     &DataType::Timestamp(TimeUnit::Microsecond, None),
                     size,
                 ),
             },
             ScalarValue::TimeNanosecond(e) => match e {
-                Some(value) => Arc::new(TimestampNanosecondArray::from_iter_values(
-                    repeat(*value).take(size),
-                )),
+                Some(value) => Arc::new(TimestampNanosecondArray::from_constant(*value, size)),
                 None => {
                     new_null_array(&DataType::Timestamp(TimeUnit::Nanosecond, None), size)
                 }
@@ -337,26 +333,22 @@ impl ScalarValue {
             }),
             ScalarValue::Date32(e) => match e {
                 Some(value) => {
-                    Arc::new(Date32Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Date32Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Date32, size),
             },
             ScalarValue::Date64(e) => match e {
                 Some(value) => {
-                    Arc::new(Date64Array::from_iter_values(repeat(*value).take(size)))
+                    Arc::new(Date64Array::from_constant(*value, size))
                 }
                 None => new_null_array(&DataType::Date64, size),
             },
             ScalarValue::IntervalDayTime(e) => match e {
-                Some(value) => Arc::new(IntervalDayTimeArray::from_iter_values(
-                    repeat(*value).take(size),
-                )),
+                Some(value) => Arc::new(IntervalDayTimeArray::from_constant(*value, size)),
                 None => new_null_array(&DataType::Interval(IntervalUnit::DayTime), size),
             },
             ScalarValue::IntervalYearMonth(e) => match e {
-                Some(value) => Arc::new(IntervalYearMonthArray::from_iter_values(
-                    repeat(*value).take(size),
-                )),
+                Some(value) => Arc::new(IntervalYearMonthArray::from_constant(*value, size)),
                 None => {
                     new_null_array(&DataType::Interval(IntervalUnit::YearMonth), size)
                 }

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -215,73 +215,73 @@ impl ScalarValue {
             }
             ScalarValue::Float64(e) => match e {
                 Some(value) => {
-                    Arc::new(Float64Array::from_constant(*value, size))
+                    Arc::new(Float64Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Float64, size),
             },
             ScalarValue::Float32(e) => match e {
                 Some(value) => {
-                    Arc::new(Float32Array::from_constant(*value, size))
+                    Arc::new(Float32Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Float32, size),
             },
             ScalarValue::Int8(e) => match e {
                 Some(value) => {
-                    Arc::new(Int8Array::from_constant(*value, size))
+                    Arc::new(Int8Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Int8, size),
             },
             ScalarValue::Int16(e) => match e {
                 Some(value) => {
-                    Arc::new(Int16Array::from_constant(*value, size))
+                    Arc::new(Int16Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Int16, size),
             },
             ScalarValue::Int32(e) => match e {
                 Some(value) => {
-                    Arc::new(Int32Array::from_constant(*value, size))
+                    Arc::new(Int32Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Int32, size),
             },
             ScalarValue::Int64(e) => match e {
                 Some(value) => {
-                    Arc::new(Int64Array::from_constant(*value, size))
+                    Arc::new(Int64Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Int64, size),
             },
             ScalarValue::UInt8(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt8Array::from_constant(*value, size))
+                    Arc::new(UInt8Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::UInt8, size),
             },
             ScalarValue::UInt16(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt16Array::from_constant(*value, size))
+                    Arc::new(UInt16Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::UInt16, size),
             },
             ScalarValue::UInt32(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt32Array::from_constant(*value, size))
+                    Arc::new(UInt32Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::UInt32, size),
             },
             ScalarValue::UInt64(e) => match e {
                 Some(value) => {
-                    Arc::new(UInt64Array::from_constant(*value, size))
+                    Arc::new(UInt64Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::UInt64, size),
             },
             ScalarValue::TimeMicrosecond(e) => match e {
-                Some(value) => Arc::new(TimestampMicrosecondArray::from_constant(*value, size)),
+                Some(value) => Arc::new(TimestampMicrosecondArray::from_value(*value, size)),
                 None => new_null_array(
                     &DataType::Timestamp(TimeUnit::Microsecond, None),
                     size,
                 ),
             },
             ScalarValue::TimeNanosecond(e) => match e {
-                Some(value) => Arc::new(TimestampNanosecondArray::from_constant(*value, size)),
+                Some(value) => Arc::new(TimestampNanosecondArray::from_value(*value, size)),
                 None => {
                     new_null_array(&DataType::Timestamp(TimeUnit::Nanosecond, None), size)
                 }
@@ -333,22 +333,22 @@ impl ScalarValue {
             }),
             ScalarValue::Date32(e) => match e {
                 Some(value) => {
-                    Arc::new(Date32Array::from_constant(*value, size))
+                    Arc::new(Date32Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Date32, size),
             },
             ScalarValue::Date64(e) => match e {
                 Some(value) => {
-                    Arc::new(Date64Array::from_constant(*value, size))
+                    Arc::new(Date64Array::from_value(*value, size))
                 }
                 None => new_null_array(&DataType::Date64, size),
             },
             ScalarValue::IntervalDayTime(e) => match e {
-                Some(value) => Arc::new(IntervalDayTimeArray::from_constant(*value, size)),
+                Some(value) => Arc::new(IntervalDayTimeArray::from_value(*value, size)),
                 None => new_null_array(&DataType::Interval(IntervalUnit::DayTime), size),
             },
             ScalarValue::IntervalYearMonth(e) => match e {
-                Some(value) => Arc::new(IntervalYearMonthArray::from_constant(*value, size)),
+                Some(value) => Arc::new(IntervalYearMonthArray::from_value(*value, size)),
                 None => {
                     new_null_array(&DataType::Interval(IntervalUnit::YearMonth), size)
                 }

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -214,74 +214,58 @@ impl ScalarValue {
                 Arc::new(BooleanArray::from(vec![*e; size])) as ArrayRef
             }
             ScalarValue::Float64(e) => match e {
-                Some(value) => {
-                    Arc::new(Float64Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Float64Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Float64, size),
             },
             ScalarValue::Float32(e) => match e {
-                Some(value) => {
-                    Arc::new(Float32Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Float32Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Float32, size),
             },
             ScalarValue::Int8(e) => match e {
-                Some(value) => {
-                    Arc::new(Int8Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Int8Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Int8, size),
             },
             ScalarValue::Int16(e) => match e {
-                Some(value) => {
-                    Arc::new(Int16Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Int16Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Int16, size),
             },
             ScalarValue::Int32(e) => match e {
-                Some(value) => {
-                    Arc::new(Int32Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Int32Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Int32, size),
             },
             ScalarValue::Int64(e) => match e {
-                Some(value) => {
-                    Arc::new(Int64Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Int64Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Int64, size),
             },
             ScalarValue::UInt8(e) => match e {
-                Some(value) => {
-                    Arc::new(UInt8Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(UInt8Array::from_value(*value, size)),
                 None => new_null_array(&DataType::UInt8, size),
             },
             ScalarValue::UInt16(e) => match e {
-                Some(value) => {
-                    Arc::new(UInt16Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(UInt16Array::from_value(*value, size)),
                 None => new_null_array(&DataType::UInt16, size),
             },
             ScalarValue::UInt32(e) => match e {
-                Some(value) => {
-                    Arc::new(UInt32Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(UInt32Array::from_value(*value, size)),
                 None => new_null_array(&DataType::UInt32, size),
             },
             ScalarValue::UInt64(e) => match e {
-                Some(value) => {
-                    Arc::new(UInt64Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(UInt64Array::from_value(*value, size)),
                 None => new_null_array(&DataType::UInt64, size),
             },
             ScalarValue::TimeMicrosecond(e) => match e {
-                Some(value) => Arc::new(TimestampMicrosecondArray::from_value(*value, size)),
+                Some(value) => {
+                    Arc::new(TimestampMicrosecondArray::from_value(*value, size))
+                }
                 None => new_null_array(
                     &DataType::Timestamp(TimeUnit::Microsecond, None),
                     size,
                 ),
             },
             ScalarValue::TimeNanosecond(e) => match e {
-                Some(value) => Arc::new(TimestampNanosecondArray::from_value(*value, size)),
+                Some(value) => {
+                    Arc::new(TimestampNanosecondArray::from_value(*value, size))
+                }
                 None => {
                     new_null_array(&DataType::Timestamp(TimeUnit::Nanosecond, None), size)
                 }
@@ -332,15 +316,11 @@ impl ScalarValue {
                 _ => panic!("Unexpected DataType for list"),
             }),
             ScalarValue::Date32(e) => match e {
-                Some(value) => {
-                    Arc::new(Date32Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Date32Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Date32, size),
             },
             ScalarValue::Date64(e) => match e {
-                Some(value) => {
-                    Arc::new(Date64Array::from_value(*value, size))
-                }
+                Some(value) => Arc::new(Date64Array::from_value(*value, size)),
                 None => new_null_array(&DataType::Date64, size),
             },
             ScalarValue::IntervalDayTime(e) => match e {


### PR DESCRIPTION
Utilize `Buffer::from_trusted_len_iter` to speed up `to_array_of_size` for primitive arrays.

This gives about 5-10% improvement on query 6 of TPC-H scale factor 1 (in memory, 16 partitions / threads) `~8.1 ms` vs `~9ms`.