### PR TITLE
ARROW-11822: [Rust][Datafusion] Support case sensitive comparisons for functions and aggregates

### DIFF
--- a/rust/datafusion/src/physical_plan/aggregates.rs
+++ b/rust/datafusion/src/physical_plan/aggregates.rs
@@ -72,12 +72,12 @@ impl fmt::Display for AggregateFunction {
 impl FromStr for AggregateFunction {
     type Err = DataFusionError;
     fn from_str(name: &str) -> Result<AggregateFunction> {
-        Ok(match &*name.to_uppercase() {
-            "MIN" => AggregateFunction::Min,
-            "MAX" => AggregateFunction::Max,
-            "COUNT" => AggregateFunction::Count,
-            "AVG" => AggregateFunction::Avg,
-            "SUM" => AggregateFunction::Sum,
+        Ok(match name {
+            "min" => AggregateFunction::Min,
+            "max" => AggregateFunction::Max,
+            "count" => AggregateFunction::Count,
+            "avg" => AggregateFunction::Avg,
+            "sum" => AggregateFunction::Sum,
             _ => {
                 return Err(DataFusionError::Plan(format!(
                     "There is no built-in function named {}",


### PR DESCRIPTION
Broken out from https://github.com/apache/arrow/pull/9600 by @wqc200. Note this does not contain the part of #9600 that controls the output display of functions.

# Rationale

Aggregate functions are checked using case insensitive comparison (e.g. `select MAX(x)` and `select max(x)` both work - the code is [here](https://github.com/apache/arrow/blob/356c300c5ee1e2b23a83652514af11e3a731d596/rust/datafusion/src/physical_plan/aggregates.rs#L75)

However, scalar functions, user defined aggregates, and user defined functions, are checked using case sensitive comparisons (e.g. `select sqrt(x)` works while `select SQRT` does not. Postgres always uses case insensitive comparison:

```
alamb=# select sqrt(x) from foo;
 sqrt
------
(0 rows)

alamb=# select SQRT(x) from foo;
 sqrt
------
(0 rows)
```

# Changes

Always use case insensitive comparisons for unquoted identifier comparison, both for consistency within DataFusion as well as consistency with Postgres (and the SQL standard)

Adds tests that demonstrate the behavior

# Notes

This PR changes how user defined functions are resolved in SQL queries. If a user registers two functions with names
`"my_sqrt"` and `"MY_SQRT"` previously they could both be called
individually. After this PR `my_sqrt` will be called unless the user
specifically put `"SQRT"` (in quotes) in their query.
