### PR TITLE
ARROW-12131: [CI][GLib] Ensure upgrading MSYS2

### DIFF
--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -61,6 +61,7 @@ esac
 pacman \
   --needed \
   --noconfirm \
+  --refresh \
   --sync \
   "${packages[@]}"
 


### PR DESCRIPTION
We need to refresh package database for ucrt64 repository after system upgrade.

See also: https://github.com/msys2/setup-msys2/issues/119