### PR TITLE
ARROW-12133: [C++][Gandiva] Add option to disable targeting host cpu during llvm ir compilation

### DIFF
--- a/cpp/src/gandiva/configuration.cc
+++ b/cpp/src/gandiva/configuration.cc
@@ -17,17 +17,23 @@
 
 #include "gandiva/configuration.h"
 
+#include "arrow/util/hash_util.h"
+
 namespace gandiva {
 
 const std::shared_ptr<Configuration> ConfigurationBuilder::default_configuration_ =
     InitDefaultConfig();
 
 std::size_t Configuration::Hash() const {
-  return 0;  // dummy for now, no configuration properties yet
+  static constexpr size_t kHashSeed = 0;
+  size_t result = kHashSeed;
+  arrow::internal::hash_combine(result, static_cast<size_t>(optimize_));
+  arrow::internal::hash_combine(result, static_cast<size_t>(target_host_cpu_));
+  return result;
 }
 
 bool Configuration::operator==(const Configuration& other) const {
-  return true;  // always true, no configuration properties yet
+  return optimize_ == other.optimize_ && target_host_cpu_ == other.target_host_cpu_;
 }
 
 bool Configuration::operator!=(const Configuration& other) const {

--- a/cpp/src/gandiva/configuration.h
+++ b/cpp/src/gandiva/configuration.h
@@ -21,7 +21,6 @@
 #include <string>
 
 #include "arrow/status.h"
-
 #include "gandiva/visibility.h"
 
 namespace gandiva {
@@ -35,18 +34,22 @@ class GANDIVA_EXPORT Configuration {
  public:
   friend class ConfigurationBuilder;
 
-  Configuration() : optimize_(true) {}
-  explicit Configuration(bool optimize) : optimize_(optimize) {}
+  Configuration() : optimize_(true), target_host_cpu_(true) {}
+  explicit Configuration(bool optimize) : optimize_(optimize), target_host_cpu_(true) {}
 
   std::size_t Hash() const;
   bool operator==(const Configuration& other) const;
   bool operator!=(const Configuration& other) const;
 
   bool optimize() const { return optimize_; }
+  bool target_host_cpu() const { return target_host_cpu_; }
+
   void set_optimize(bool optimize) { optimize_ = optimize; }
+  void target_host_cpu(bool target_host_cpu) { target_host_cpu_ = target_host_cpu; }
 
  private:
-  bool optimize_;
+  bool optimize_;        /* optimise the generated llvm IR */
+  bool target_host_cpu_; /* set the mcpu flag to host cpu while compiling llvm ir */
 };
 
 /// \brief configuration builder for gandiva

--- a/cpp/src/gandiva/jni/config_builder.cc
+++ b/cpp/src/gandiva/jni/config_builder.cc
@@ -29,26 +29,15 @@ using gandiva::ConfigurationBuilder;
 /*
  * Class:     org_apache_arrow_gandiva_evaluator_ConfigBuilder
  * Method:    buildConfigInstance
- * Signature: ()J
+ * Signature: (ZZ)J
  */
 JNIEXPORT jlong JNICALL
 Java_org_apache_arrow_gandiva_evaluator_ConfigurationBuilder_buildConfigInstance(
-    JNIEnv* env, jobject configuration) {
+    JNIEnv* env, jobject configuration, jboolean optimize, jboolean target_host_cpu) {
   ConfigurationBuilder configuration_builder;
   std::shared_ptr<Configuration> config = configuration_builder.build();
-  return ConfigHolder::MapInsert(config);
-}
-
-/*
- * Class:     org_apache_arrow_gandiva_evaluator_ConfigBuilder
- * Method:    buildConfigInstance
- * Signature: ()J
- */
-JNIEXPORT jlong JNICALL
-Java_org_apache_arrow_gandiva_evaluator_ConfigurationBuilder_buildConfigInstance(
-    JNIEnv* env, jobject configuration, jboolean optimize) {
-  ConfigurationBuilder configuration_builder;
-  std::shared_ptr<Configuration> config = configuration_builder.build(optimize);
+  config->set_optimize(optimize);
+  config->target_host_cpu(target_host_cpu);
   return ConfigHolder::MapInsert(config);
 }
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
@@ -17,17 +17,56 @@
 
 package org.apache.arrow.gandiva.evaluator;
 
+import java.util.Objects;
+
 /**
  * Used to construct gandiva configuration objects.
  */
 public class ConfigurationBuilder {
 
-  public long buildConfigInstance() {
-    return buildConfigInstance(true);
+  public long buildConfigInstance(ConfigOptions configOptions) {
+    return buildConfigInstance(configOptions.optimize, configOptions.targetCPU);
   }
 
-  public native long buildConfigInstance(boolean optimize);
+  private native long buildConfigInstance(boolean optimize, boolean detectHostCPU);
 
   public native void releaseConfigInstance(long configId);
 
+  /**
+   * ConfigOptions contains the configuration parameters to provide to gandiva.
+   */
+  public static class ConfigOptions {
+    private boolean optimize = true;
+    private boolean targetCPU = true;
+
+    public static ConfigOptions getDefault() {
+      return new ConfigOptions();
+    }
+
+    public ConfigOptions() {}
+
+    public ConfigOptions withOptimize(boolean optimize) {
+      this.optimize = optimize;
+      return this;
+    }
+
+    public ConfigOptions withTargetCPU(boolean targetCPU) {
+      this.targetCPU = targetCPU;
+      return this;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(optimize, targetCPU);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof ConfigOptions)) {
+        return false;
+      }
+      return this.optimize == ((ConfigOptions) obj).optimize &&
+              this.targetCPU == ((ConfigOptions) obj).targetCPU;
+    }
+  }
 }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
@@ -74,12 +74,28 @@ public class Filter {
    * @param schema Table schema. The field names in the schema should match the fields used to
    *               create the TreeNodes
    * @param condition condition to be evaluated against data
+   * @param configOptions ConfigOptions parameter
+   * @return A native filter object that can be used to invoke on a RecordBatch
+   */
+  public static Filter make(Schema schema, Condition condition, ConfigurationBuilder.ConfigOptions configOptions)
+          throws GandivaException {
+    return make(schema, condition, JniLoader.getConfiguration(configOptions));
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the condition expression. Invoke
+   * Filter::Evaluate() against a RecordBatch to evaluate the filter on this record batch
+   *
+   * @param schema Table schema. The field names in the schema should match the fields used to
+   *               create the TreeNodes
+   * @param condition condition to be evaluated against data
    * @param optimize Flag to choose if the generated llvm code is to be optimized
    * @return A native filter object that can be used to invoke on a RecordBatch
    */
+  @Deprecated
   public static Filter make(Schema schema, Condition condition, boolean optimize) throws GandivaException {
-    return make(schema, condition, optimize ? JniLoader.getDefaultConfiguration() :
-        JniLoader.getUnoptimizedConfiguration());
+    return make(schema, condition, JniLoader.getConfiguration((new ConfigurationBuilder.ConfigOptions())
+            .withOptimize(optimize)));
   }
 
   /**

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -86,14 +86,32 @@ public class Projector {
    * @param schema Table schema. The field names in the schema should match the fields used
    *               to create the TreeNodes
    * @param exprs  List of expressions to be evaluated against data
+   * @param configOptions ConfigOptions parameter
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs,
+                               ConfigurationBuilder.ConfigOptions configOptions) throws GandivaException {
+    return make(schema, exprs, SelectionVectorType.SV_NONE, JniLoader.getConfiguration(configOptions));
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema Table schema. The field names in the schema should match the fields used
+   *               to create the TreeNodes
+   * @param exprs  List of expressions to be evaluated against data
    * @param optimize Flag to choose if the generated llvm code is to be optimized
    *
    * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
    */
+  @Deprecated
   public static Projector make(Schema schema, List<ExpressionTree> exprs, boolean optimize)
       throws GandivaException {
-    return make(schema, exprs, SelectionVectorType.SV_NONE, optimize ? JniLoader.getDefaultConfiguration() :
-        JniLoader.getUnoptimizedConfiguration());
+    return make(schema, exprs, SelectionVectorType.SV_NONE,
+            JniLoader.getConfiguration((new ConfigurationBuilder.ConfigOptions()).withOptimize(optimize)));
   }
 
   /**
@@ -123,15 +141,34 @@ public class Projector {
    *               to create the TreeNodes
    * @param exprs  List of expressions to be evaluated against data
    * @param selectionVectorType type of selection vector
+   * @param configOptions ConfigOptions parameter
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs, SelectionVectorType selectionVectorType,
+                               ConfigurationBuilder.ConfigOptions configOptions) throws GandivaException {
+    return make(schema, exprs, selectionVectorType, JniLoader.getConfiguration(configOptions));
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema Table schema. The field names in the schema should match the fields used
+   *               to create the TreeNodes
+   * @param exprs  List of expressions to be evaluated against data
+   * @param selectionVectorType type of selection vector
    * @param optimize Flag to choose if the generated llvm code is to be optimized
    *
    * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
    */
+  @Deprecated
   public static Projector make(Schema schema, List<ExpressionTree> exprs,
                                SelectionVectorType selectionVectorType, boolean optimize)
       throws GandivaException {
-    return make(schema, exprs, selectionVectorType, optimize ? JniLoader.getDefaultConfiguration() :
-        JniLoader.getUnoptimizedConfiguration());
+    return make(schema, exprs, selectionVectorType,
+            JniLoader.getConfiguration((new ConfigurationBuilder.ConfigOptions()).withOptimize(optimize)));
   }
 
   /**

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/TestJniLoader.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/TestJniLoader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.gandiva.evaluator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestJniLoader {
+
+  @Test
+  public void testDefaultConfiguration() throws Exception {
+    long configId = JniLoader.getConfiguration(ConfigurationBuilder.ConfigOptions.getDefault());
+    Assert.assertEquals(configId, JniLoader.getDefaultConfiguration());
+    Assert.assertEquals(configId, JniLoader.getConfiguration(ConfigurationBuilder.ConfigOptions.getDefault()));
+
+    long configId2 = JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions().withOptimize(false));
+    long configId3 = JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions().withTargetCPU(false));
+    long configId4 = JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions().withOptimize(false)
+        .withTargetCPU(false));
+
+    Assert.assertTrue(configId != configId2 && configId2 != configId3 && configId3 != configId4);
+
+    Assert.assertEquals(configId2, JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions()
+        .withOptimize(false)));
+    Assert.assertEquals(configId3, JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions()
+        .withTargetCPU(false)));
+    Assert.assertEquals(configId4, JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions()
+        .withOptimize(false).withTargetCPU(false)));
+
+    JniLoader.removeConfiguration(new ConfigurationBuilder.ConfigOptions().withOptimize(false));
+    // configids are monotonically updated. after a config is removed, new one is assigned with higher id
+    Assert.assertNotEquals(configId2, JniLoader.getConfiguration(new ConfigurationBuilder.ConfigOptions()
+        .withOptimize(false)));
+
+    JniLoader.removeConfiguration(new ConfigurationBuilder.ConfigOptions());
+    Assert.assertNotEquals(configId, JniLoader.getConfiguration(ConfigurationBuilder.ConfigOptions.getDefault()));
+  }
+}


### PR DESCRIPTION
Because of the issue mentioned in #9852 , it seems like a good idea to allow a configuration parameter to disable targeting host cpu during jit compilation if there are some unforseen crashes (in case llvm::sys::getHostCPUFeatures has a bug and returns incorrect info)