### PR TITLE
ARROW-12136: [Rust][DataFusion] Reduce default batch_size to 8192

### DIFF
--- a/rust/benchmarks/src/bin/nyctaxi.rs
+++ b/rust/benchmarks/src/bin/nyctaxi.rs
@@ -51,7 +51,7 @@ struct Opt {
     concurrency: usize,
 
     /// Batch size when reading CSV or Parquet files
-    #[structopt(short = "s", long = "batch-size", default_value = "4096")]
+    #[structopt(short = "s", long = "batch-size", default_value = "8192")]
     batch_size: usize,
 
     /// Path to data files

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -63,7 +63,7 @@ struct BenchmarkOpt {
     concurrency: usize,
 
     /// Batch size when reading CSV or Parquet files
-    #[structopt(short = "s", long = "batch-size", default_value = "32768")]
+    #[structopt(short = "s", long = "batch-size", default_value = "8192")]
     batch_size: usize,
 
     /// Path to data files
@@ -106,7 +106,7 @@ struct ConvertOpt {
     partitions: usize,
 
     /// Batch size when reading CSV or Parquet files
-    #[structopt(short = "s", long = "batch-size", default_value = "4096")]
+    #[structopt(short = "s", long = "batch-size", default_value = "8192")]
     batch_size: usize,
 }
 
@@ -1658,7 +1658,7 @@ mod tests {
                 debug: false,
                 iterations: 1,
                 concurrency: 2,
-                batch_size: 4096,
+                batch_size: 8192,
                 path: PathBuf::from(path.to_string()),
                 file_format: "tbl".to_string(),
                 mem_table: false,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -586,7 +586,7 @@ impl ExecutionConfig {
     pub fn new() -> Self {
         Self {
             concurrency: num_cpus::get(),
-            batch_size: 32768,
+            batch_size: 8048,
             optimizers: vec![
                 Arc::new(ConstantFolding::new()),
                 Arc::new(ProjectionPushDown::new()),

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -586,7 +586,7 @@ impl ExecutionConfig {
     pub fn new() -> Self {
         Self {
             concurrency: num_cpus::get(),
-            batch_size: 8048,
+            batch_size: 8192,
             optimizers: vec![
                 Arc::new(ConstantFolding::new()),
                 Arc::new(ProjectionPushDown::new()),


### PR DESCRIPTION
I did some comparisons with different batch sized with TCP-H on SF=1 in memory / 16 partitions. We chose a higher batch_size earlier as DF had some problems with smaller batch sizes (in hash join, but also because it missed the CoalesceBatches node).
Smaller batch sizes have some performance benefit: more (possible) parallelism for smaller tables, batches are available sooner (think e.g. of `CoalesceBatches` with highly selective filter) and therefore more parallelism, etc.
Also, memory usage can be reduced.

Currently it seems a value around 8000 is the sweet spot for SF=1, only query 1 is faster with a slightly smaller batch size.

![image](https://user-images.githubusercontent.com/163737/112861775-669d5780-90b5-11eb-82e8-26c846d87075.png)
