### PR TITLE
ARROW-12103: [C++] Correctly handle unaligned access in bit-unpacking code

### DIFF
--- a/cpp/src/arrow/util/bpacking_avx2_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx2_generated.h
@@ -28,10 +28,12 @@
 #include <immintrin.h>
 #endif
 
+#include "arrow/util/ubsan.h"
+
 namespace arrow {
 namespace internal {
 
-inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {
   memset(out, 0x0, 32 * sizeof(*out));
   out += 32;
 
@@ -39,6 +41,7 @@ inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {
 }
 
 inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -47,11 +50,11 @@ inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(7, 6, 5, 4,
-                               3, 2, 1, 0);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                3, 2, 1, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -59,10 +62,10 @@ inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(15, 14, 13, 12,
                                 11, 10, 9, 8);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -70,10 +73,10 @@ inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(23, 22, 21, 20,
                                 19, 18, 17, 16);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -81,10 +84,10 @@ inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(31, 30, 29, 28,
                                 27, 26, 25, 24);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -95,6 +98,7 @@ inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -103,11 +107,11 @@ inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(14, 12, 10, 8,
-                               6, 4, 2, 0);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                6, 4, 2, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -115,10 +119,10 @@ inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(30, 28, 26, 24,
                                 22, 20, 18, 16);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -126,10 +130,10 @@ inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(14, 12, 10, 8,
                                 6, 4, 2, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -137,10 +141,10 @@ inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(30, 28, 26, 24,
                                 22, 20, 18, 16);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -151,6 +155,7 @@ inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -159,11 +164,11 @@ inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(21, 18, 15, 12,
-                               9, 6, 3, 0);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                9, 6, 3, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -171,10 +176,10 @@ inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(13, 10, 7, 4,
                                 1, 0, 27, 24);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[0] >> 30 | in[1] << 2,
-                              in[0], in[0]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -182,10 +187,10 @@ inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(5, 2, 0, 28,
                                 25, 22, 19, 16);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                              in[1] >> 31 | in[2] << 1, in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -193,10 +198,10 @@ inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(29, 26, 23, 20,
                                 17, 14, 11, 8);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -207,6 +212,7 @@ inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xf;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -215,11 +221,11 @@ inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
-                               12, 8, 4, 0);
-  reg_inls = _mm256_set_epi32(in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                12, 8, 4, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -227,10 +233,10 @@ inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
                                 12, 8, 4, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -238,10 +244,10 @@ inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
                                 12, 8, 4, 0);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -249,10 +255,10 @@ inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
                                 12, 8, 4, 0);
-  reg_inls = _mm256_set_epi32(in[3], in[3],
-                              in[3], in[3],
-                              in[3], in[3],
-                              in[3], in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -263,6 +269,7 @@ inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -271,11 +278,11 @@ inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(3, 0, 25, 20,
-                               15, 10, 5, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[0] >> 30 | in[1] << 2,
-                             in[0], in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                15, 10, 5, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -283,10 +290,10 @@ inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(11, 6, 1, 0,
                                 23, 18, 13, 8);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -294,10 +301,10 @@ inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(19, 14, 9, 4,
                                 0, 26, 21, 16);
-  reg_inls = _mm256_set_epi32(in[3], in[3],
-                              in[3], in[3],
-                              in[2] >> 31 | in[3] << 1, in[2],
-                              in[2], in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 31 | SafeLoad(in + 3) << 1, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -305,10 +312,10 @@ inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(27, 22, 17, 12,
                                 7, 2, 0, 24);
-  reg_inls = _mm256_set_epi32(in[4], in[4],
-                              in[4], in[4],
-                              in[4], in[4],
-                              in[3] >> 29 | in[4] << 3, in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 29 | SafeLoad(in + 4) << 3, SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -319,6 +326,7 @@ inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -327,11 +335,11 @@ inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(10, 4, 0, 24,
-                               18, 12, 6, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                             in[0] >> 30 | in[1] << 2, in[0],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                18, 12, 6, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -339,10 +347,10 @@ inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(26, 20, 14, 8,
                                 2, 0, 22, 16);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -350,10 +358,10 @@ inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(10, 4, 0, 24,
                                 18, 12, 6, 0);
-  reg_inls = _mm256_set_epi32(in[4], in[4],
-                              in[3] >> 30 | in[4] << 2, in[3],
-                              in[3], in[3],
-                              in[3], in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -361,10 +369,10 @@ inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(26, 20, 14, 8,
                                 2, 0, 22, 16);
-  reg_inls = _mm256_set_epi32(in[5], in[5],
-                              in[5], in[5],
-                              in[5], in[4] >> 28 | in[5] << 4,
-                              in[4], in[4]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 4));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -375,6 +383,7 @@ inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -383,11 +392,11 @@ inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(17, 10, 3, 0,
-                               21, 14, 7, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                             in[1], in[0] >> 28 | in[1] << 4,
-                             in[0], in[0],
-                             in[0], in[0]);
+                                21, 14, 7, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4,
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -395,10 +404,10 @@ inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(9, 2, 0, 20,
                                 13, 6, 0, 24);
-  reg_inls = _mm256_set_epi32(in[3], in[3],
-                              in[2] >> 27 | in[3] << 5, in[2],
-                              in[2], in[2],
-                              in[1] >> 31 | in[2] << 1, in[1]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 27 | SafeLoad(in + 3) << 5, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -406,10 +415,10 @@ inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(1, 0, 19, 12,
                                 5, 0, 23, 16);
-  reg_inls = _mm256_set_epi32(in[5], in[4] >> 26 | in[5] << 6,
-                              in[4], in[4],
-                              in[4], in[3] >> 30 | in[4] << 2,
-                              in[3], in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -417,10 +426,10 @@ inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(25, 18, 11, 4,
                                 0, 22, 15, 8);
-  reg_inls = _mm256_set_epi32(in[6], in[6],
-                              in[6], in[6],
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[5], in[5]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -431,6 +440,7 @@ inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -439,11 +449,11 @@ inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
-                               24, 16, 8, 0);
-  reg_inls = _mm256_set_epi32(in[1], in[1],
-                             in[1], in[1],
-                             in[0], in[0],
-                             in[0], in[0]);
+                                24, 16, 8, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -451,10 +461,10 @@ inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
                                 24, 16, 8, 0);
-  reg_inls = _mm256_set_epi32(in[3], in[3],
-                              in[3], in[3],
-                              in[2], in[2],
-                              in[2], in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -462,10 +472,10 @@ inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
                                 24, 16, 8, 0);
-  reg_inls = _mm256_set_epi32(in[5], in[5],
-                              in[5], in[5],
-                              in[4], in[4],
-                              in[4], in[4]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -473,10 +483,10 @@ inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
                                 24, 16, 8, 0);
-  reg_inls = _mm256_set_epi32(in[7], in[7],
-                              in[7], in[7],
-                              in[6], in[6],
-                              in[6], in[6]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 6), SafeLoad(in + 6));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -487,6 +497,7 @@ inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -495,11 +506,11 @@ inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out)
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 22, 13, 4,
-                               0, 18, 9, 0);
-  reg_inls = _mm256_set_epi32(in[1] >> 31 | in[2] << 1, in[1],
-                             in[1], in[1],
-                             in[0] >> 27 | in[1] << 5, in[0],
-                             in[0], in[0]);
+                                0, 18, 9, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 27 | SafeLoad(in + 1) << 5, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -507,10 +518,10 @@ inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(7, 0, 21, 12,
                                 3, 0, 17, 8);
-  reg_inls = _mm256_set_epi32(in[4], in[3] >> 30 | in[4] << 2,
-                              in[3], in[3],
-                              in[3], in[2] >> 26 | in[3] << 6,
-                              in[2], in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6,
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -518,10 +529,10 @@ inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(15, 6, 0, 20,
                                 11, 2, 0, 16);
-  reg_inls = _mm256_set_epi32(in[6], in[6],
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[5], in[5],
-                              in[4] >> 25 | in[5] << 7, in[4]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 25 | SafeLoad(in + 5) << 7, SafeLoad(in + 4));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -529,10 +540,10 @@ inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out)
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(23, 14, 5, 0,
                                 19, 10, 1, 0);
-  reg_inls = _mm256_set_epi32(in[8], in[8],
-                              in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[7],
-                              in[7], in[6] >> 24 | in[7] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -543,6 +554,7 @@ inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out)
 }
 
 inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -551,11 +563,11 @@ inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(6, 0, 18, 8,
-                               0, 20, 10, 0);
-  reg_inls = _mm256_set_epi32(in[2], in[1] >> 28 | in[2] << 4,
-                             in[1], in[1],
-                             in[0] >> 30 | in[1] << 2, in[0],
-                             in[0], in[0]);
+                                0, 20, 10, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -563,10 +575,10 @@ inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(22, 12, 2, 0,
                                 14, 4, 0, 16);
-  reg_inls = _mm256_set_epi32(in[4], in[4],
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[3],
-                              in[2] >> 26 | in[3] << 6, in[2]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 2));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -574,10 +586,10 @@ inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(6, 0, 18, 8,
                                 0, 20, 10, 0);
-  reg_inls = _mm256_set_epi32(in[7], in[6] >> 28 | in[7] << 4,
-                              in[6], in[6],
-                              in[5] >> 30 | in[6] << 2, in[5],
-                              in[5], in[5]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7), SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 30 | SafeLoad(in + 6) << 2, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -585,10 +597,10 @@ inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(22, 12, 2, 0,
                                 14, 4, 0, 16);
-  reg_inls = _mm256_set_epi32(in[9], in[9],
-                              in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[8],
-                              in[7] >> 26 | in[8] << 6, in[7]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 9), SafeLoad(in + 9),
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 26 | SafeLoad(in + 8) << 6, SafeLoad(in + 7));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -599,6 +611,7 @@ inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -607,11 +620,11 @@ inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(13, 2, 0, 12,
-                               1, 0, 11, 0);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                             in[1] >> 23 | in[2] << 9, in[1],
-                             in[1], in[0] >> 22 | in[1] << 10,
-                             in[0], in[0]);
+                                1, 0, 11, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 23 | SafeLoad(in + 2) << 9, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 22 | SafeLoad(in + 1) << 10,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -619,10 +632,10 @@ inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(5, 0, 15, 4,
                                 0, 14, 3, 0);
-  reg_inls = _mm256_set_epi32(in[5], in[4] >> 26 | in[5] << 6,
-                              in[4], in[4],
-                              in[3] >> 25 | in[4] << 7, in[3],
-                              in[3], in[2] >> 24 | in[3] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 25 | SafeLoad(in + 4) << 7, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 24 | SafeLoad(in + 3) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -630,10 +643,10 @@ inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 18, 7, 0,
                                 17, 6, 0, 16);
-  reg_inls = _mm256_set_epi32(in[7] >> 29 | in[8] << 3, in[7],
-                              in[7], in[6] >> 28 | in[7] << 4,
-                              in[6], in[6],
-                              in[5] >> 27 | in[6] << 5, in[5]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7) >> 29 | SafeLoad(in + 8) << 3, SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 27 | SafeLoad(in + 6) << 5, SafeLoad(in + 5));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -641,10 +654,10 @@ inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(21, 10, 0, 20,
                                 9, 0, 19, 8);
-  reg_inls = _mm256_set_epi32(in[10], in[10],
-                              in[9] >> 31 | in[10] << 1, in[9],
-                              in[9], in[8] >> 30 | in[9] << 2,
-                              in[8], in[8]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 10), SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 31 | SafeLoad(in + 10) << 1, SafeLoad(in + 9),
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2,
+                              SafeLoad(in + 8), SafeLoad(in + 8));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -655,6 +668,7 @@ inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -663,11 +677,11 @@ inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
-                               4, 0, 12, 0);
-  reg_inls = _mm256_set_epi32(in[2], in[2],
-                             in[1] >> 28 | in[2] << 4, in[1],
-                             in[1], in[0] >> 24 | in[1] << 8,
-                             in[0], in[0]);
+                                4, 0, 12, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 24 | SafeLoad(in + 1) << 8,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -675,10 +689,10 @@ inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
                                 4, 0, 12, 0);
-  reg_inls = _mm256_set_epi32(in[5], in[5],
-                              in[4] >> 28 | in[5] << 4, in[4],
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4, SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -686,10 +700,10 @@ inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
                                 4, 0, 12, 0);
-  reg_inls = _mm256_set_epi32(in[8], in[8],
-                              in[7] >> 28 | in[8] << 4, in[7],
-                              in[7], in[6] >> 24 | in[7] << 8,
-                              in[6], in[6]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4, SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 6), SafeLoad(in + 6));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -697,10 +711,10 @@ inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
                                 4, 0, 12, 0);
-  reg_inls = _mm256_set_epi32(in[11], in[11],
-                              in[10] >> 28 | in[11] << 4, in[10],
-                              in[10], in[9] >> 24 | in[10] << 8,
-                              in[9], in[9]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 11), SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 28 | SafeLoad(in + 11) << 4, SafeLoad(in + 10),
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8,
+                              SafeLoad(in + 9), SafeLoad(in + 9));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -711,6 +725,7 @@ inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -719,11 +734,11 @@ inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 14, 1, 0,
-                               7, 0, 13, 0);
-  reg_inls = _mm256_set_epi32(in[2] >> 27 | in[3] << 5, in[2],
-                             in[2], in[1] >> 20 | in[2] << 12,
-                             in[1], in[0] >> 26 | in[1] << 6,
-                             in[0], in[0]);
+                                7, 0, 13, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 2) >> 27 | SafeLoad(in + 3) << 5, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 20 | SafeLoad(in + 2) << 12,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 26 | SafeLoad(in + 1) << 6,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -731,10 +746,10 @@ inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(3, 0, 9, 0,
                                 15, 2, 0, 8);
-  reg_inls = _mm256_set_epi32(in[6], in[5] >> 22 | in[6] << 10,
-                              in[5], in[4] >> 28 | in[5] << 4,
-                              in[4], in[4],
-                              in[3] >> 21 | in[4] << 11, in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6), SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 21 | SafeLoad(in + 4) << 11, SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -742,10 +757,10 @@ inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(11, 0, 17, 4,
                                 0, 10, 0, 16);
-  reg_inls = _mm256_set_epi32(in[9], in[8] >> 30 | in[9] << 2,
-                              in[8], in[8],
-                              in[7] >> 23 | in[8] << 9, in[7],
-                              in[6] >> 29 | in[7] << 3, in[6]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 9), SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2,
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 23 | SafeLoad(in + 8) << 9, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 29 | SafeLoad(in + 7) << 3, SafeLoad(in + 6));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -753,10 +768,10 @@ inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(19, 6, 0, 12,
                                 0, 18, 5, 0);
-  reg_inls = _mm256_set_epi32(in[12], in[12],
-                              in[11] >> 25 | in[12] << 7, in[11],
-                              in[10] >> 31 | in[11] << 1, in[10],
-                              in[10], in[9] >> 24 | in[10] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 12), SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 25 | SafeLoad(in + 12) << 7, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 31 | SafeLoad(in + 11) << 1, SafeLoad(in + 10),
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -767,6 +782,7 @@ inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -775,11 +791,11 @@ inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(2, 0, 6, 0,
-                               10, 0, 14, 0);
-  reg_inls = _mm256_set_epi32(in[3], in[2] >> 20 | in[3] << 12,
-                             in[2], in[1] >> 24 | in[2] << 8,
-                             in[1], in[0] >> 28 | in[1] << 4,
-                             in[0], in[0]);
+                                10, 0, 14, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 24 | SafeLoad(in + 2) << 8,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -787,10 +803,10 @@ inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(18, 4, 0, 8,
                                 0, 12, 0, 16);
-  reg_inls = _mm256_set_epi32(in[6], in[6],
-                              in[5] >> 22 | in[6] << 10, in[5],
-                              in[4] >> 26 | in[5] << 6, in[4],
-                              in[3] >> 30 | in[4] << 2, in[3]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6, SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -798,10 +814,10 @@ inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(2, 0, 6, 0,
                                 10, 0, 14, 0);
-  reg_inls = _mm256_set_epi32(in[10], in[9] >> 20 | in[10] << 12,
-                              in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[7]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 10), SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12,
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 7));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -809,10 +825,10 @@ inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(18, 4, 0, 8,
                                 0, 12, 0, 16);
-  reg_inls = _mm256_set_epi32(in[13], in[13],
-                              in[12] >> 22 | in[13] << 10, in[12],
-                              in[11] >> 26 | in[12] << 6, in[11],
-                              in[10] >> 30 | in[11] << 2, in[10]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 13), SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 22 | SafeLoad(in + 13) << 10, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 30 | SafeLoad(in + 11) << 2, SafeLoad(in + 10));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -823,6 +839,7 @@ inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -831,11 +848,11 @@ inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(9, 0, 11, 0,
-                               13, 0, 15, 0);
-  reg_inls = _mm256_set_epi32(in[3], in[2] >> 26 | in[3] << 6,
-                             in[2], in[1] >> 28 | in[2] << 4,
-                             in[1], in[0] >> 30 | in[1] << 2,
-                             in[0], in[0]);
+                                13, 0, 15, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -843,10 +860,10 @@ inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(1, 0, 3, 0,
                                 5, 0, 7, 0);
-  reg_inls = _mm256_set_epi32(in[7], in[6] >> 18 | in[7] << 14,
-                              in[6], in[5] >> 20 | in[6] << 12,
-                              in[5], in[4] >> 22 | in[5] << 10,
-                              in[4], in[3] >> 24 | in[4] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7), SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10,
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -854,10 +871,10 @@ inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 10, 0, 12,
                                 0, 14, 0, 16);
-  reg_inls = _mm256_set_epi32(in[10] >> 25 | in[11] << 7, in[10],
-                              in[9] >> 27 | in[10] << 5, in[9],
-                              in[8] >> 29 | in[9] << 3, in[8],
-                              in[7] >> 31 | in[8] << 1, in[7]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 10) >> 25 | SafeLoad(in + 11) << 7, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 27 | SafeLoad(in + 10) << 5, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 29 | SafeLoad(in + 9) << 3, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 31 | SafeLoad(in + 8) << 1, SafeLoad(in + 7));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -865,10 +882,10 @@ inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(17, 2, 0, 4,
                                 0, 6, 0, 8);
-  reg_inls = _mm256_set_epi32(in[14], in[14],
-                              in[13] >> 19 | in[14] << 13, in[13],
-                              in[12] >> 21 | in[13] << 11, in[12],
-                              in[11] >> 23 | in[12] << 9, in[11]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 14), SafeLoad(in + 14),
+                              SafeLoad(in + 13) >> 19 | SafeLoad(in + 14) << 13, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 21 | SafeLoad(in + 13) << 11, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 23 | SafeLoad(in + 12) << 9, SafeLoad(in + 11));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -879,6 +896,7 @@ inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -887,11 +905,11 @@ inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
-                               16, 0, 16, 0);
-  reg_inls = _mm256_set_epi32(in[3], in[3],
-                             in[2], in[2],
-                             in[1], in[1],
-                             in[0], in[0]);
+                                16, 0, 16, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -899,10 +917,10 @@ inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
                                 16, 0, 16, 0);
-  reg_inls = _mm256_set_epi32(in[7], in[7],
-                              in[6], in[6],
-                              in[5], in[5],
-                              in[4], in[4]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4), SafeLoad(in + 4));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -910,10 +928,10 @@ inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
                                 16, 0, 16, 0);
-  reg_inls = _mm256_set_epi32(in[11], in[11],
-                              in[10], in[10],
-                              in[9], in[9],
-                              in[8], in[8]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 11), SafeLoad(in + 11),
+                              SafeLoad(in + 10), SafeLoad(in + 10),
+                              SafeLoad(in + 9), SafeLoad(in + 9),
+                              SafeLoad(in + 8), SafeLoad(in + 8));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -921,10 +939,10 @@ inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
                                 16, 0, 16, 0);
-  reg_inls = _mm256_set_epi32(in[15], in[15],
-                              in[14], in[14],
-                              in[13], in[13],
-                              in[12], in[12]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 15), SafeLoad(in + 15),
+                              SafeLoad(in + 14), SafeLoad(in + 14),
+                              SafeLoad(in + 13), SafeLoad(in + 13),
+                              SafeLoad(in + 12), SafeLoad(in + 12));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -935,6 +953,7 @@ inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -943,11 +962,11 @@ inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 6, 0, 4,
-                               0, 2, 0, 0);
-  reg_inls = _mm256_set_epi32(in[3] >> 23 | in[4] << 9, in[3],
-                             in[2] >> 21 | in[3] << 11, in[2],
-                             in[1] >> 19 | in[2] << 13, in[1],
-                             in[0] >> 17 | in[1] << 15, in[0]);
+                                0, 2, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3) >> 23 | SafeLoad(in + 4) << 9, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 21 | SafeLoad(in + 3) << 11, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 19 | SafeLoad(in + 2) << 13, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 17 | SafeLoad(in + 1) << 15, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -955,10 +974,10 @@ inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 14, 0, 12,
                                 0, 10, 0, 8);
-  reg_inls = _mm256_set_epi32(in[7] >> 31 | in[8] << 1, in[7],
-                              in[6] >> 29 | in[7] << 3, in[6],
-                              in[5] >> 27 | in[6] << 5, in[5],
-                              in[4] >> 25 | in[5] << 7, in[4]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 7) >> 31 | SafeLoad(in + 8) << 1, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 29 | SafeLoad(in + 7) << 3, SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 27 | SafeLoad(in + 6) << 5, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 25 | SafeLoad(in + 5) << 7, SafeLoad(in + 4));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -966,10 +985,10 @@ inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(7, 0, 5, 0,
                                 3, 0, 1, 0);
-  reg_inls = _mm256_set_epi32(in[12], in[11] >> 22 | in[12] << 10,
-                              in[11], in[10] >> 20 | in[11] << 12,
-                              in[10], in[9] >> 18 | in[10] << 14,
-                              in[9], in[8] >> 16 | in[9] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 12), SafeLoad(in + 11) >> 22 | SafeLoad(in + 12) << 10,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 20 | SafeLoad(in + 11) << 12,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 18 | SafeLoad(in + 10) << 14,
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 16 | SafeLoad(in + 9) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -977,10 +996,10 @@ inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(15, 0, 13, 0,
                                 11, 0, 9, 0);
-  reg_inls = _mm256_set_epi32(in[16], in[15] >> 30 | in[16] << 2,
-                              in[15], in[14] >> 28 | in[15] << 4,
-                              in[14], in[13] >> 26 | in[14] << 6,
-                              in[13], in[12] >> 24 | in[13] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 16), SafeLoad(in + 15) >> 30 | SafeLoad(in + 16) << 2,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 28 | SafeLoad(in + 15) << 4,
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 26 | SafeLoad(in + 14) << 6,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 24 | SafeLoad(in + 13) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -991,6 +1010,7 @@ inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -999,11 +1019,11 @@ inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 12, 0, 8,
-                               0, 4, 0, 0);
-  reg_inls = _mm256_set_epi32(in[3] >> 30 | in[4] << 2, in[3],
-                             in[2] >> 26 | in[3] << 6, in[2],
-                             in[1] >> 22 | in[2] << 10, in[1],
-                             in[0] >> 18 | in[1] << 14, in[0]);
+                                0, 4, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 22 | SafeLoad(in + 2) << 10, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 18 | SafeLoad(in + 1) << 14, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1011,10 +1031,10 @@ inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(14, 0, 10, 0,
                                 6, 0, 2, 0);
-  reg_inls = _mm256_set_epi32(in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[6] >> 24 | in[7] << 8,
-                              in[6], in[5] >> 20 | in[6] << 12,
-                              in[5], in[4] >> 16 | in[5] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 16 | SafeLoad(in + 5) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1022,10 +1042,10 @@ inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 12, 0, 8,
                                 0, 4, 0, 0);
-  reg_inls = _mm256_set_epi32(in[12] >> 30 | in[13] << 2, in[12],
-                              in[11] >> 26 | in[12] << 6, in[11],
-                              in[10] >> 22 | in[11] << 10, in[10],
-                              in[9] >> 18 | in[10] << 14, in[9]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 12) >> 30 | SafeLoad(in + 13) << 2, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 22 | SafeLoad(in + 11) << 10, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 18 | SafeLoad(in + 10) << 14, SafeLoad(in + 9));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1033,10 +1053,10 @@ inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(14, 0, 10, 0,
                                 6, 0, 2, 0);
-  reg_inls = _mm256_set_epi32(in[17], in[16] >> 28 | in[17] << 4,
-                              in[16], in[15] >> 24 | in[16] << 8,
-                              in[15], in[14] >> 20 | in[15] << 12,
-                              in[14], in[13] >> 16 | in[14] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 17), SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 20 | SafeLoad(in + 15) << 12,
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1047,6 +1067,7 @@ inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1055,11 +1076,11 @@ inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(5, 0, 0, 12,
-                               0, 6, 0, 0);
-  reg_inls = _mm256_set_epi32(in[4], in[3] >> 18 | in[4] << 14,
-                             in[2] >> 31 | in[3] << 1, in[2],
-                             in[1] >> 25 | in[2] << 7, in[1],
-                             in[0] >> 19 | in[1] << 13, in[0]);
+                                0, 6, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 3) >> 18 | SafeLoad(in + 4) << 14,
+                              SafeLoad(in + 2) >> 31 | SafeLoad(in + 3) << 1, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 25 | SafeLoad(in + 2) << 7, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 19 | SafeLoad(in + 1) << 13, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1067,10 +1088,10 @@ inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 10, 0, 4,
                                 0, 0, 11, 0);
-  reg_inls = _mm256_set_epi32(in[8] >> 29 | in[9] << 3, in[8],
-                              in[7] >> 23 | in[8] << 9, in[7],
-                              in[6] >> 17 | in[7] << 15, in[5] >> 30 | in[6] << 2,
-                              in[5], in[4] >> 24 | in[5] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 8) >> 29 | SafeLoad(in + 9) << 3, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 23 | SafeLoad(in + 8) << 9, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 17 | SafeLoad(in + 7) << 15, SafeLoad(in + 5) >> 30 | SafeLoad(in + 6) << 2,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 24 | SafeLoad(in + 5) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1078,10 +1099,10 @@ inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
                                 9, 0, 3, 0);
-  reg_inls = _mm256_set_epi32(in[13] >> 21 | in[14] << 11, in[13],
-                              in[12] >> 15 | in[13] << 17, in[11] >> 28 | in[12] << 4,
-                              in[11], in[10] >> 22 | in[11] << 10,
-                              in[10], in[9] >> 16 | in[10] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 13) >> 21 | SafeLoad(in + 14) << 11, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 15 | SafeLoad(in + 13) << 17, SafeLoad(in + 11) >> 28 | SafeLoad(in + 12) << 4,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 22 | SafeLoad(in + 11) << 10,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 16 | SafeLoad(in + 10) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1089,10 +1110,10 @@ inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(13, 0, 7, 0,
                                 1, 0, 0, 8);
-  reg_inls = _mm256_set_epi32(in[18], in[17] >> 26 | in[18] << 6,
-                              in[17], in[16] >> 20 | in[17] << 12,
-                              in[16], in[15] >> 14 | in[16] << 18,
-                              in[14] >> 27 | in[15] << 5, in[14]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 18), SafeLoad(in + 17) >> 26 | SafeLoad(in + 18) << 6,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 20 | SafeLoad(in + 17) << 12,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 14 | SafeLoad(in + 16) << 18,
+                              SafeLoad(in + 14) >> 27 | SafeLoad(in + 15) << 5, SafeLoad(in + 14));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1103,6 +1124,7 @@ inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1111,11 +1133,11 @@ inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
-                               0, 8, 0, 0);
-  reg_inls = _mm256_set_epi32(in[4], in[3] >> 24 | in[4] << 8,
-                             in[3], in[2] >> 16 | in[3] << 16,
-                             in[1] >> 28 | in[2] << 4, in[1],
-                             in[0] >> 20 | in[1] << 12, in[0]);
+                                0, 8, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 16 | SafeLoad(in + 3) << 16,
+                              SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 20 | SafeLoad(in + 1) << 12, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1123,10 +1145,10 @@ inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
                                 0, 8, 0, 0);
-  reg_inls = _mm256_set_epi32(in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[7] >> 16 | in[8] << 16,
-                              in[6] >> 28 | in[7] << 4, in[6],
-                              in[5] >> 20 | in[6] << 12, in[5]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16,
+                              SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4, SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12, SafeLoad(in + 5));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1134,10 +1156,10 @@ inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
                                 0, 8, 0, 0);
-  reg_inls = _mm256_set_epi32(in[14], in[13] >> 24 | in[14] << 8,
-                              in[13], in[12] >> 16 | in[13] << 16,
-                              in[11] >> 28 | in[12] << 4, in[11],
-                              in[10] >> 20 | in[11] << 12, in[10]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 14), SafeLoad(in + 13) >> 24 | SafeLoad(in + 14) << 8,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 16 | SafeLoad(in + 13) << 16,
+                              SafeLoad(in + 11) >> 28 | SafeLoad(in + 12) << 4, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 20 | SafeLoad(in + 11) << 12, SafeLoad(in + 10));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1145,10 +1167,10 @@ inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
                                 0, 8, 0, 0);
-  reg_inls = _mm256_set_epi32(in[19], in[18] >> 24 | in[19] << 8,
-                              in[18], in[17] >> 16 | in[18] << 16,
-                              in[16] >> 28 | in[17] << 4, in[16],
-                              in[15] >> 20 | in[16] << 12, in[15]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 19), SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8,
+                              SafeLoad(in + 18), SafeLoad(in + 17) >> 16 | SafeLoad(in + 18) << 16,
+                              SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4, SafeLoad(in + 16),
+                              SafeLoad(in + 15) >> 20 | SafeLoad(in + 16) << 12, SafeLoad(in + 15));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1159,6 +1181,7 @@ inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1167,11 +1190,11 @@ inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 9, 0,
-                               0, 10, 0, 0);
-  reg_inls = _mm256_set_epi32(in[4] >> 19 | in[5] << 13, in[3] >> 30 | in[4] << 2,
-                             in[3], in[2] >> 20 | in[3] << 12,
-                             in[1] >> 31 | in[2] << 1, in[1],
-                             in[0] >> 21 | in[1] << 11, in[0]);
+                                0, 10, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4) >> 19 | SafeLoad(in + 5) << 13, SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12,
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 21 | SafeLoad(in + 1) << 11, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1179,10 +1202,10 @@ inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 6, 0, 0,
                                 7, 0, 0, 8);
-  reg_inls = _mm256_set_epi32(in[9] >> 27 | in[10] << 5, in[9],
-                              in[8] >> 17 | in[9] << 15, in[7] >> 28 | in[8] << 4,
-                              in[7], in[6] >> 18 | in[7] << 14,
-                              in[5] >> 29 | in[6] << 3, in[5]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 9) >> 27 | SafeLoad(in + 10) << 5, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 17 | SafeLoad(in + 9) << 15, SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14,
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1190,10 +1213,10 @@ inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(3, 0, 0, 4,
                                 0, 0, 5, 0);
-  reg_inls = _mm256_set_epi32(in[15], in[14] >> 14 | in[15] << 18,
-                              in[13] >> 25 | in[14] << 7, in[13],
-                              in[12] >> 15 | in[13] << 17, in[11] >> 26 | in[12] << 6,
-                              in[11], in[10] >> 16 | in[11] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 15), SafeLoad(in + 14) >> 14 | SafeLoad(in + 15) << 18,
+                              SafeLoad(in + 13) >> 25 | SafeLoad(in + 14) << 7, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 15 | SafeLoad(in + 13) << 17, SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1201,10 +1224,10 @@ inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(11, 0, 1, 0,
                                 0, 2, 0, 0);
-  reg_inls = _mm256_set_epi32(in[20], in[19] >> 22 | in[20] << 10,
-                              in[19], in[18] >> 12 | in[19] << 20,
-                              in[17] >> 23 | in[18] << 9, in[17],
-                              in[16] >> 13 | in[17] << 19, in[15] >> 24 | in[16] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 20), SafeLoad(in + 19) >> 22 | SafeLoad(in + 20) << 10,
+                              SafeLoad(in + 19), SafeLoad(in + 18) >> 12 | SafeLoad(in + 19) << 20,
+                              SafeLoad(in + 17) >> 23 | SafeLoad(in + 18) << 9, SafeLoad(in + 17),
+                              SafeLoad(in + 16) >> 13 | SafeLoad(in + 17) << 19, SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1215,6 +1238,7 @@ inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1223,11 +1247,11 @@ inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 4, 0, 0,
-                               2, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[4] >> 26 | in[5] << 6, in[4],
-                             in[3] >> 14 | in[4] << 18, in[2] >> 24 | in[3] << 8,
-                             in[2], in[1] >> 12 | in[2] << 20,
-                             in[0] >> 22 | in[1] << 10, in[0]);
+                                2, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6, SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 14 | SafeLoad(in + 4) << 18, SafeLoad(in + 2) >> 24 | SafeLoad(in + 3) << 8,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 12 | SafeLoad(in + 2) << 20,
+                              SafeLoad(in + 0) >> 22 | SafeLoad(in + 1) << 10, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1235,10 +1259,10 @@ inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(10, 0, 0, 8,
                                 0, 0, 6, 0);
-  reg_inls = _mm256_set_epi32(in[10], in[9] >> 20 | in[10] << 12,
-                              in[8] >> 30 | in[9] << 2, in[8],
-                              in[7] >> 18 | in[8] << 14, in[6] >> 28 | in[7] << 4,
-                              in[6], in[5] >> 16 | in[6] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 10), SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12,
+                              SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 18 | SafeLoad(in + 8) << 14, SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 16 | SafeLoad(in + 6) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1246,10 +1270,10 @@ inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 4, 0, 0,
                                 2, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[15] >> 26 | in[16] << 6, in[15],
-                              in[14] >> 14 | in[15] << 18, in[13] >> 24 | in[14] << 8,
-                              in[13], in[12] >> 12 | in[13] << 20,
-                              in[11] >> 22 | in[12] << 10, in[11]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 15) >> 26 | SafeLoad(in + 16) << 6, SafeLoad(in + 15),
+                              SafeLoad(in + 14) >> 14 | SafeLoad(in + 15) << 18, SafeLoad(in + 13) >> 24 | SafeLoad(in + 14) << 8,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 12 | SafeLoad(in + 13) << 20,
+                              SafeLoad(in + 11) >> 22 | SafeLoad(in + 12) << 10, SafeLoad(in + 11));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1257,10 +1281,10 @@ inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(10, 0, 0, 8,
                                 0, 0, 6, 0);
-  reg_inls = _mm256_set_epi32(in[21], in[20] >> 20 | in[21] << 12,
-                              in[19] >> 30 | in[20] << 2, in[19],
-                              in[18] >> 18 | in[19] << 14, in[17] >> 28 | in[18] << 4,
-                              in[17], in[16] >> 16 | in[17] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 21), SafeLoad(in + 20) >> 20 | SafeLoad(in + 21) << 12,
+                              SafeLoad(in + 19) >> 30 | SafeLoad(in + 20) << 2, SafeLoad(in + 19),
+                              SafeLoad(in + 18) >> 18 | SafeLoad(in + 19) << 14, SafeLoad(in + 17) >> 28 | SafeLoad(in + 18) << 4,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 16 | SafeLoad(in + 17) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1271,6 +1295,7 @@ inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1279,11 +1304,11 @@ inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(1, 0, 0, 0,
-                               5, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[5], in[4] >> 10 | in[5] << 22,
-                             in[3] >> 19 | in[4] << 13, in[2] >> 28 | in[3] << 4,
-                             in[2], in[1] >> 14 | in[2] << 18,
-                             in[0] >> 23 | in[1] << 9, in[0]);
+                                5, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 4) >> 10 | SafeLoad(in + 5) << 22,
+                              SafeLoad(in + 3) >> 19 | SafeLoad(in + 4) << 13, SafeLoad(in + 2) >> 28 | SafeLoad(in + 3) << 4,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 14 | SafeLoad(in + 2) << 18,
+                              SafeLoad(in + 0) >> 23 | SafeLoad(in + 1) << 9, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1291,10 +1316,10 @@ inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
                                 0, 6, 0, 0);
-  reg_inls = _mm256_set_epi32(in[10] >> 25 | in[11] << 7, in[10],
-                              in[9] >> 11 | in[10] << 21, in[8] >> 20 | in[9] << 12,
-                              in[7] >> 29 | in[8] << 3, in[7],
-                              in[6] >> 15 | in[7] << 17, in[5] >> 24 | in[6] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 10) >> 25 | SafeLoad(in + 11) << 7, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 11 | SafeLoad(in + 10) << 21, SafeLoad(in + 8) >> 20 | SafeLoad(in + 9) << 12,
+                              SafeLoad(in + 7) >> 29 | SafeLoad(in + 8) << 3, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 15 | SafeLoad(in + 7) << 17, SafeLoad(in + 5) >> 24 | SafeLoad(in + 6) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1302,10 +1327,10 @@ inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 3, 0,
                                 0, 0, 7, 0);
-  reg_inls = _mm256_set_epi32(in[16] >> 17 | in[17] << 15, in[15] >> 26 | in[16] << 6,
-                              in[15], in[14] >> 12 | in[15] << 20,
-                              in[13] >> 21 | in[14] << 11, in[12] >> 30 | in[13] << 2,
-                              in[12], in[11] >> 16 | in[12] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 16) >> 17 | SafeLoad(in + 17) << 15, SafeLoad(in + 15) >> 26 | SafeLoad(in + 16) << 6,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 12 | SafeLoad(in + 15) << 20,
+                              SafeLoad(in + 13) >> 21 | SafeLoad(in + 14) << 11, SafeLoad(in + 12) >> 30 | SafeLoad(in + 13) << 2,
+                              SafeLoad(in + 12), SafeLoad(in + 11) >> 16 | SafeLoad(in + 12) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1313,10 +1338,10 @@ inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(9, 0, 0, 4,
                                 0, 0, 0, 8);
-  reg_inls = _mm256_set_epi32(in[22], in[21] >> 18 | in[22] << 14,
-                              in[20] >> 27 | in[21] << 5, in[20],
-                              in[19] >> 13 | in[20] << 19, in[18] >> 22 | in[19] << 10,
-                              in[17] >> 31 | in[18] << 1, in[17]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 22), SafeLoad(in + 21) >> 18 | SafeLoad(in + 22) << 14,
+                              SafeLoad(in + 20) >> 27 | SafeLoad(in + 21) << 5, SafeLoad(in + 20),
+                              SafeLoad(in + 19) >> 13 | SafeLoad(in + 20) << 19, SafeLoad(in + 18) >> 22 | SafeLoad(in + 19) << 10,
+                              SafeLoad(in + 17) >> 31 | SafeLoad(in + 18) << 1, SafeLoad(in + 17));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1327,6 +1352,7 @@ inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1335,11 +1361,11 @@ inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
-                               8, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[5], in[4] >> 16 | in[5] << 16,
-                             in[3] >> 24 | in[4] << 8, in[3],
-                             in[2], in[1] >> 16 | in[2] << 16,
-                             in[0] >> 24 | in[1] << 8, in[0]);
+                                8, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5), SafeLoad(in + 4) >> 16 | SafeLoad(in + 5) << 16,
+                              SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8, SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 16 | SafeLoad(in + 2) << 16,
+                              SafeLoad(in + 0) >> 24 | SafeLoad(in + 1) << 8, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1347,10 +1373,10 @@ inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
                                 8, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[11], in[10] >> 16 | in[11] << 16,
-                              in[9] >> 24 | in[10] << 8, in[9],
-                              in[8], in[7] >> 16 | in[8] << 16,
-                              in[6] >> 24 | in[7] << 8, in[6]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 11), SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16,
+                              SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8, SafeLoad(in + 9),
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16,
+                              SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8, SafeLoad(in + 6));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1358,10 +1384,10 @@ inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
                                 8, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[17], in[16] >> 16 | in[17] << 16,
-                              in[15] >> 24 | in[16] << 8, in[15],
-                              in[14], in[13] >> 16 | in[14] << 16,
-                              in[12] >> 24 | in[13] << 8, in[12]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 17), SafeLoad(in + 16) >> 16 | SafeLoad(in + 17) << 16,
+                              SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8, SafeLoad(in + 15),
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16,
+                              SafeLoad(in + 12) >> 24 | SafeLoad(in + 13) << 8, SafeLoad(in + 12));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1369,10 +1395,10 @@ inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
                                 8, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[23], in[22] >> 16 | in[23] << 16,
-                              in[21] >> 24 | in[22] << 8, in[21],
-                              in[20], in[19] >> 16 | in[20] << 16,
-                              in[18] >> 24 | in[19] << 8, in[18]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 23), SafeLoad(in + 22) >> 16 | SafeLoad(in + 23) << 16,
+                              SafeLoad(in + 21) >> 24 | SafeLoad(in + 22) << 8, SafeLoad(in + 21),
+                              SafeLoad(in + 20), SafeLoad(in + 19) >> 16 | SafeLoad(in + 20) << 16,
+                              SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8, SafeLoad(in + 18));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1383,6 +1409,7 @@ inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1391,11 +1418,11 @@ inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 4,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[5] >> 15 | in[6] << 17, in[4] >> 22 | in[5] << 10,
-                             in[3] >> 29 | in[4] << 3, in[3],
-                             in[2] >> 11 | in[3] << 21, in[1] >> 18 | in[2] << 14,
-                             in[0] >> 25 | in[1] << 7, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5) >> 15 | SafeLoad(in + 6) << 17, SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10,
+                              SafeLoad(in + 3) >> 29 | SafeLoad(in + 4) << 3, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 11 | SafeLoad(in + 3) << 21, SafeLoad(in + 1) >> 18 | SafeLoad(in + 2) << 14,
+                              SafeLoad(in + 0) >> 25 | SafeLoad(in + 1) << 7, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1403,10 +1430,10 @@ inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 5, 0,
                                 0, 0, 1, 0);
-  reg_inls = _mm256_set_epi32(in[11] >> 23 | in[12] << 9, in[10] >> 30 | in[11] << 2,
-                              in[10], in[9] >> 12 | in[10] << 20,
-                              in[8] >> 19 | in[9] << 13, in[7] >> 26 | in[8] << 6,
-                              in[7], in[6] >> 8 | in[7] << 24);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 11) >> 23 | SafeLoad(in + 12) << 9, SafeLoad(in + 10) >> 30 | SafeLoad(in + 11) << 2,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 12 | SafeLoad(in + 10) << 20,
+                              SafeLoad(in + 8) >> 19 | SafeLoad(in + 9) << 13, SafeLoad(in + 7) >> 26 | SafeLoad(in + 8) << 6,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 8 | SafeLoad(in + 7) << 24);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1414,10 +1441,10 @@ inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 6, 0, 0,
                                 0, 2, 0, 0);
-  reg_inls = _mm256_set_epi32(in[17] >> 31 | in[18] << 1, in[17],
-                              in[16] >> 13 | in[17] << 19, in[15] >> 20 | in[16] << 12,
-                              in[14] >> 27 | in[15] << 5, in[14],
-                              in[13] >> 9 | in[14] << 23, in[12] >> 16 | in[13] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 17) >> 31 | SafeLoad(in + 18) << 1, SafeLoad(in + 17),
+                              SafeLoad(in + 16) >> 13 | SafeLoad(in + 17) << 19, SafeLoad(in + 15) >> 20 | SafeLoad(in + 16) << 12,
+                              SafeLoad(in + 14) >> 27 | SafeLoad(in + 15) << 5, SafeLoad(in + 14),
+                              SafeLoad(in + 13) >> 9 | SafeLoad(in + 14) << 23, SafeLoad(in + 12) >> 16 | SafeLoad(in + 13) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1425,10 +1452,10 @@ inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(7, 0, 0, 0,
                                 3, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[24], in[23] >> 14 | in[24] << 18,
-                              in[22] >> 21 | in[23] << 11, in[21] >> 28 | in[22] << 4,
-                              in[21], in[20] >> 10 | in[21] << 22,
-                              in[19] >> 17 | in[20] << 15, in[18] >> 24 | in[19] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 24), SafeLoad(in + 23) >> 14 | SafeLoad(in + 24) << 18,
+                              SafeLoad(in + 22) >> 21 | SafeLoad(in + 23) << 11, SafeLoad(in + 21) >> 28 | SafeLoad(in + 22) << 4,
+                              SafeLoad(in + 21), SafeLoad(in + 20) >> 10 | SafeLoad(in + 21) << 22,
+                              SafeLoad(in + 19) >> 17 | SafeLoad(in + 20) << 15, SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1439,6 +1466,7 @@ inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1447,11 +1475,11 @@ inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 2, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[5] >> 22 | in[6] << 10, in[4] >> 28 | in[5] << 4,
-                             in[4], in[3] >> 8 | in[4] << 24,
-                             in[2] >> 14 | in[3] << 18, in[1] >> 20 | in[2] << 12,
-                             in[0] >> 26 | in[1] << 6, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10, SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 8 | SafeLoad(in + 4) << 24,
+                              SafeLoad(in + 2) >> 14 | SafeLoad(in + 3) << 18, SafeLoad(in + 1) >> 20 | SafeLoad(in + 2) << 12,
+                              SafeLoad(in + 0) >> 26 | SafeLoad(in + 1) << 6, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1459,10 +1487,10 @@ inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(6, 0, 0, 0,
                                 0, 4, 0, 0);
-  reg_inls = _mm256_set_epi32(in[12], in[11] >> 12 | in[12] << 20,
-                              in[10] >> 18 | in[11] << 14, in[9] >> 24 | in[10] << 8,
-                              in[8] >> 30 | in[9] << 2, in[8],
-                              in[7] >> 10 | in[8] << 22, in[6] >> 16 | in[7] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 12), SafeLoad(in + 11) >> 12 | SafeLoad(in + 12) << 20,
+                              SafeLoad(in + 10) >> 18 | SafeLoad(in + 11) << 14, SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8,
+                              SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 10 | SafeLoad(in + 8) << 22, SafeLoad(in + 6) >> 16 | SafeLoad(in + 7) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1470,10 +1498,10 @@ inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 2, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[18] >> 22 | in[19] << 10, in[17] >> 28 | in[18] << 4,
-                              in[17], in[16] >> 8 | in[17] << 24,
-                              in[15] >> 14 | in[16] << 18, in[14] >> 20 | in[15] << 12,
-                              in[13] >> 26 | in[14] << 6, in[13]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 18) >> 22 | SafeLoad(in + 19) << 10, SafeLoad(in + 17) >> 28 | SafeLoad(in + 18) << 4,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 8 | SafeLoad(in + 17) << 24,
+                              SafeLoad(in + 15) >> 14 | SafeLoad(in + 16) << 18, SafeLoad(in + 14) >> 20 | SafeLoad(in + 15) << 12,
+                              SafeLoad(in + 13) >> 26 | SafeLoad(in + 14) << 6, SafeLoad(in + 13));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1481,10 +1509,10 @@ inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(6, 0, 0, 0,
                                 0, 4, 0, 0);
-  reg_inls = _mm256_set_epi32(in[25], in[24] >> 12 | in[25] << 20,
-                              in[23] >> 18 | in[24] << 14, in[22] >> 24 | in[23] << 8,
-                              in[21] >> 30 | in[22] << 2, in[21],
-                              in[20] >> 10 | in[21] << 22, in[19] >> 16 | in[20] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 25), SafeLoad(in + 24) >> 12 | SafeLoad(in + 25) << 20,
+                              SafeLoad(in + 23) >> 18 | SafeLoad(in + 24) << 14, SafeLoad(in + 22) >> 24 | SafeLoad(in + 23) << 8,
+                              SafeLoad(in + 21) >> 30 | SafeLoad(in + 22) << 2, SafeLoad(in + 21),
+                              SafeLoad(in + 20) >> 10 | SafeLoad(in + 21) << 22, SafeLoad(in + 19) >> 16 | SafeLoad(in + 20) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1495,6 +1523,7 @@ inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1503,11 +1532,11 @@ inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[5] >> 29 | in[6] << 3, in[5],
-                             in[4] >> 7 | in[5] << 25, in[3] >> 12 | in[4] << 20,
-                             in[2] >> 17 | in[3] << 15, in[1] >> 22 | in[2] << 10,
-                             in[0] >> 27 | in[1] << 5, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 7 | SafeLoad(in + 5) << 25, SafeLoad(in + 3) >> 12 | SafeLoad(in + 4) << 20,
+                              SafeLoad(in + 2) >> 17 | SafeLoad(in + 3) << 15, SafeLoad(in + 1) >> 22 | SafeLoad(in + 2) << 10,
+                              SafeLoad(in + 0) >> 27 | SafeLoad(in + 1) << 5, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1515,10 +1544,10 @@ inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 4,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[12] >> 21 | in[13] << 11, in[11] >> 26 | in[12] << 6,
-                              in[10] >> 31 | in[11] << 1, in[10],
-                              in[9] >> 9 | in[10] << 23, in[8] >> 14 | in[9] << 18,
-                              in[7] >> 19 | in[8] << 13, in[6] >> 24 | in[7] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 12) >> 21 | SafeLoad(in + 13) << 11, SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6,
+                              SafeLoad(in + 10) >> 31 | SafeLoad(in + 11) << 1, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 9 | SafeLoad(in + 10) << 23, SafeLoad(in + 8) >> 14 | SafeLoad(in + 9) << 18,
+                              SafeLoad(in + 7) >> 19 | SafeLoad(in + 8) << 13, SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1526,10 +1555,10 @@ inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
                                 1, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[19] >> 13 | in[20] << 19, in[18] >> 18 | in[19] << 14,
-                              in[17] >> 23 | in[18] << 9, in[16] >> 28 | in[17] << 4,
-                              in[16], in[15] >> 6 | in[16] << 26,
-                              in[14] >> 11 | in[15] << 21, in[13] >> 16 | in[14] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 19) >> 13 | SafeLoad(in + 20) << 19, SafeLoad(in + 18) >> 18 | SafeLoad(in + 19) << 14,
+                              SafeLoad(in + 17) >> 23 | SafeLoad(in + 18) << 9, SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 6 | SafeLoad(in + 16) << 26,
+                              SafeLoad(in + 14) >> 11 | SafeLoad(in + 15) << 21, SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1537,10 +1566,10 @@ inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(5, 0, 0, 0,
                                 0, 0, 3, 0);
-  reg_inls = _mm256_set_epi32(in[26], in[25] >> 10 | in[26] << 22,
-                              in[24] >> 15 | in[25] << 17, in[23] >> 20 | in[24] << 12,
-                              in[22] >> 25 | in[23] << 7, in[21] >> 30 | in[22] << 2,
-                              in[21], in[20] >> 8 | in[21] << 24);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 26), SafeLoad(in + 25) >> 10 | SafeLoad(in + 26) << 22,
+                              SafeLoad(in + 24) >> 15 | SafeLoad(in + 25) << 17, SafeLoad(in + 23) >> 20 | SafeLoad(in + 24) << 12,
+                              SafeLoad(in + 22) >> 25 | SafeLoad(in + 23) << 7, SafeLoad(in + 21) >> 30 | SafeLoad(in + 22) << 2,
+                              SafeLoad(in + 21), SafeLoad(in + 20) >> 8 | SafeLoad(in + 21) << 24);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1551,6 +1580,7 @@ inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1559,11 +1589,11 @@ inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[6], in[5] >> 8 | in[6] << 24,
-                             in[4] >> 12 | in[5] << 20, in[3] >> 16 | in[4] << 16,
-                             in[2] >> 20 | in[3] << 12, in[1] >> 24 | in[2] << 8,
-                             in[0] >> 28 | in[1] << 4, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6), SafeLoad(in + 5) >> 8 | SafeLoad(in + 6) << 24,
+                              SafeLoad(in + 4) >> 12 | SafeLoad(in + 5) << 20, SafeLoad(in + 3) >> 16 | SafeLoad(in + 4) << 16,
+                              SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12, SafeLoad(in + 1) >> 24 | SafeLoad(in + 2) << 8,
+                              SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1571,10 +1601,10 @@ inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[13], in[12] >> 8 | in[13] << 24,
-                              in[11] >> 12 | in[12] << 20, in[10] >> 16 | in[11] << 16,
-                              in[9] >> 20 | in[10] << 12, in[8] >> 24 | in[9] << 8,
-                              in[7] >> 28 | in[8] << 4, in[7]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 13), SafeLoad(in + 12) >> 8 | SafeLoad(in + 13) << 24,
+                              SafeLoad(in + 11) >> 12 | SafeLoad(in + 12) << 20, SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16,
+                              SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12, SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4, SafeLoad(in + 7));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1582,10 +1612,10 @@ inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[20], in[19] >> 8 | in[20] << 24,
-                              in[18] >> 12 | in[19] << 20, in[17] >> 16 | in[18] << 16,
-                              in[16] >> 20 | in[17] << 12, in[15] >> 24 | in[16] << 8,
-                              in[14] >> 28 | in[15] << 4, in[14]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 20), SafeLoad(in + 19) >> 8 | SafeLoad(in + 20) << 24,
+                              SafeLoad(in + 18) >> 12 | SafeLoad(in + 19) << 20, SafeLoad(in + 17) >> 16 | SafeLoad(in + 18) << 16,
+                              SafeLoad(in + 16) >> 20 | SafeLoad(in + 17) << 12, SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8,
+                              SafeLoad(in + 14) >> 28 | SafeLoad(in + 15) << 4, SafeLoad(in + 14));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1593,10 +1623,10 @@ inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[27], in[26] >> 8 | in[27] << 24,
-                              in[25] >> 12 | in[26] << 20, in[24] >> 16 | in[25] << 16,
-                              in[23] >> 20 | in[24] << 12, in[22] >> 24 | in[23] << 8,
-                              in[21] >> 28 | in[22] << 4, in[21]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 27), SafeLoad(in + 26) >> 8 | SafeLoad(in + 27) << 24,
+                              SafeLoad(in + 25) >> 12 | SafeLoad(in + 26) << 20, SafeLoad(in + 24) >> 16 | SafeLoad(in + 25) << 16,
+                              SafeLoad(in + 23) >> 20 | SafeLoad(in + 24) << 12, SafeLoad(in + 22) >> 24 | SafeLoad(in + 23) << 8,
+                              SafeLoad(in + 21) >> 28 | SafeLoad(in + 22) << 4, SafeLoad(in + 21));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1607,6 +1637,7 @@ inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1615,11 +1646,11 @@ inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[6] >> 11 | in[7] << 21, in[5] >> 14 | in[6] << 18,
-                             in[4] >> 17 | in[5] << 15, in[3] >> 20 | in[4] << 12,
-                             in[2] >> 23 | in[3] << 9, in[1] >> 26 | in[2] << 6,
-                             in[0] >> 29 | in[1] << 3, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6) >> 11 | SafeLoad(in + 7) << 21, SafeLoad(in + 5) >> 14 | SafeLoad(in + 6) << 18,
+                              SafeLoad(in + 4) >> 17 | SafeLoad(in + 5) << 15, SafeLoad(in + 3) >> 20 | SafeLoad(in + 4) << 12,
+                              SafeLoad(in + 2) >> 23 | SafeLoad(in + 3) << 9, SafeLoad(in + 1) >> 26 | SafeLoad(in + 2) << 6,
+                              SafeLoad(in + 0) >> 29 | SafeLoad(in + 1) << 3, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1627,10 +1658,10 @@ inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
                                 0, 2, 0, 0);
-  reg_inls = _mm256_set_epi32(in[13] >> 19 | in[14] << 13, in[12] >> 22 | in[13] << 10,
-                              in[11] >> 25 | in[12] << 7, in[10] >> 28 | in[11] << 4,
-                              in[9] >> 31 | in[10] << 1, in[9],
-                              in[8] >> 5 | in[9] << 27, in[7] >> 8 | in[8] << 24);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 13) >> 19 | SafeLoad(in + 14) << 13, SafeLoad(in + 12) >> 22 | SafeLoad(in + 13) << 10,
+                              SafeLoad(in + 11) >> 25 | SafeLoad(in + 12) << 7, SafeLoad(in + 10) >> 28 | SafeLoad(in + 11) << 4,
+                              SafeLoad(in + 9) >> 31 | SafeLoad(in + 10) << 1, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 5 | SafeLoad(in + 9) << 27, SafeLoad(in + 7) >> 8 | SafeLoad(in + 8) << 24);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1638,10 +1669,10 @@ inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 1, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[20] >> 27 | in[21] << 5, in[19] >> 30 | in[20] << 2,
-                              in[19], in[18] >> 4 | in[19] << 28,
-                              in[17] >> 7 | in[18] << 25, in[16] >> 10 | in[17] << 22,
-                              in[15] >> 13 | in[16] << 19, in[14] >> 16 | in[15] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 20) >> 27 | SafeLoad(in + 21) << 5, SafeLoad(in + 19) >> 30 | SafeLoad(in + 20) << 2,
+                              SafeLoad(in + 19), SafeLoad(in + 18) >> 4 | SafeLoad(in + 19) << 28,
+                              SafeLoad(in + 17) >> 7 | SafeLoad(in + 18) << 25, SafeLoad(in + 16) >> 10 | SafeLoad(in + 17) << 22,
+                              SafeLoad(in + 15) >> 13 | SafeLoad(in + 16) << 19, SafeLoad(in + 14) >> 16 | SafeLoad(in + 15) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1649,10 +1680,10 @@ inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(3, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[28], in[27] >> 6 | in[28] << 26,
-                              in[26] >> 9 | in[27] << 23, in[25] >> 12 | in[26] << 20,
-                              in[24] >> 15 | in[25] << 17, in[23] >> 18 | in[24] << 14,
-                              in[22] >> 21 | in[23] << 11, in[21] >> 24 | in[22] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 28), SafeLoad(in + 27) >> 6 | SafeLoad(in + 28) << 26,
+                              SafeLoad(in + 26) >> 9 | SafeLoad(in + 27) << 23, SafeLoad(in + 25) >> 12 | SafeLoad(in + 26) << 20,
+                              SafeLoad(in + 24) >> 15 | SafeLoad(in + 25) << 17, SafeLoad(in + 23) >> 18 | SafeLoad(in + 24) << 14,
+                              SafeLoad(in + 22) >> 21 | SafeLoad(in + 23) << 11, SafeLoad(in + 21) >> 24 | SafeLoad(in + 22) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1663,6 +1694,7 @@ inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1671,11 +1703,11 @@ inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[6] >> 18 | in[7] << 14, in[5] >> 20 | in[6] << 12,
-                             in[4] >> 22 | in[5] << 10, in[3] >> 24 | in[4] << 8,
-                             in[2] >> 26 | in[3] << 6, in[1] >> 28 | in[2] << 4,
-                             in[0] >> 30 | in[1] << 2, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14, SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10, SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1683,10 +1715,10 @@ inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(2, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[14], in[13] >> 4 | in[14] << 28,
-                              in[12] >> 6 | in[13] << 26, in[11] >> 8 | in[12] << 24,
-                              in[10] >> 10 | in[11] << 22, in[9] >> 12 | in[10] << 20,
-                              in[8] >> 14 | in[9] << 18, in[7] >> 16 | in[8] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 14), SafeLoad(in + 13) >> 4 | SafeLoad(in + 14) << 28,
+                              SafeLoad(in + 12) >> 6 | SafeLoad(in + 13) << 26, SafeLoad(in + 11) >> 8 | SafeLoad(in + 12) << 24,
+                              SafeLoad(in + 10) >> 10 | SafeLoad(in + 11) << 22, SafeLoad(in + 9) >> 12 | SafeLoad(in + 10) << 20,
+                              SafeLoad(in + 8) >> 14 | SafeLoad(in + 9) << 18, SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1694,10 +1726,10 @@ inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[21] >> 18 | in[22] << 14, in[20] >> 20 | in[21] << 12,
-                              in[19] >> 22 | in[20] << 10, in[18] >> 24 | in[19] << 8,
-                              in[17] >> 26 | in[18] << 6, in[16] >> 28 | in[17] << 4,
-                              in[15] >> 30 | in[16] << 2, in[15]);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 21) >> 18 | SafeLoad(in + 22) << 14, SafeLoad(in + 20) >> 20 | SafeLoad(in + 21) << 12,
+                              SafeLoad(in + 19) >> 22 | SafeLoad(in + 20) << 10, SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8,
+                              SafeLoad(in + 17) >> 26 | SafeLoad(in + 18) << 6, SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 15) >> 30 | SafeLoad(in + 16) << 2, SafeLoad(in + 15));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1705,10 +1737,10 @@ inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(2, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[29], in[28] >> 4 | in[29] << 28,
-                              in[27] >> 6 | in[28] << 26, in[26] >> 8 | in[27] << 24,
-                              in[25] >> 10 | in[26] << 22, in[24] >> 12 | in[25] << 20,
-                              in[23] >> 14 | in[24] << 18, in[22] >> 16 | in[23] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 29), SafeLoad(in + 28) >> 4 | SafeLoad(in + 29) << 28,
+                              SafeLoad(in + 27) >> 6 | SafeLoad(in + 28) << 26, SafeLoad(in + 26) >> 8 | SafeLoad(in + 27) << 24,
+                              SafeLoad(in + 25) >> 10 | SafeLoad(in + 26) << 22, SafeLoad(in + 24) >> 12 | SafeLoad(in + 25) << 20,
+                              SafeLoad(in + 23) >> 14 | SafeLoad(in + 24) << 18, SafeLoad(in + 22) >> 16 | SafeLoad(in + 23) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1719,6 +1751,7 @@ inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out
 }
 
 inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1727,11 +1760,11 @@ inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out
 
   // shift the first 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
-                               0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[6] >> 25 | in[7] << 7, in[5] >> 26 | in[6] << 6,
-                             in[4] >> 27 | in[5] << 5, in[3] >> 28 | in[4] << 4,
-                             in[2] >> 29 | in[3] << 3, in[1] >> 30 | in[2] << 2,
-                             in[0] >> 31 | in[1] << 1, in[0]);
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 6) >> 25 | SafeLoad(in + 7) << 7, SafeLoad(in + 5) >> 26 | SafeLoad(in + 6) << 6,
+                              SafeLoad(in + 4) >> 27 | SafeLoad(in + 5) << 5, SafeLoad(in + 3) >> 28 | SafeLoad(in + 4) << 4,
+                              SafeLoad(in + 2) >> 29 | SafeLoad(in + 3) << 3, SafeLoad(in + 1) >> 30 | SafeLoad(in + 2) << 2,
+                              SafeLoad(in + 0) >> 31 | SafeLoad(in + 1) << 1, SafeLoad(in + 0));
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1739,10 +1772,10 @@ inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out
   // shift the second 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[14] >> 17 | in[15] << 15, in[13] >> 18 | in[14] << 14,
-                              in[12] >> 19 | in[13] << 13, in[11] >> 20 | in[12] << 12,
-                              in[10] >> 21 | in[11] << 11, in[9] >> 22 | in[10] << 10,
-                              in[8] >> 23 | in[9] << 9, in[7] >> 24 | in[8] << 8);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 14) >> 17 | SafeLoad(in + 15) << 15, SafeLoad(in + 13) >> 18 | SafeLoad(in + 14) << 14,
+                              SafeLoad(in + 12) >> 19 | SafeLoad(in + 13) << 13, SafeLoad(in + 11) >> 20 | SafeLoad(in + 12) << 12,
+                              SafeLoad(in + 10) >> 21 | SafeLoad(in + 11) << 11, SafeLoad(in + 9) >> 22 | SafeLoad(in + 10) << 10,
+                              SafeLoad(in + 8) >> 23 | SafeLoad(in + 9) << 9, SafeLoad(in + 7) >> 24 | SafeLoad(in + 8) << 8);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1750,10 +1783,10 @@ inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out
   // shift the third 8 outs
   reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[22] >> 9 | in[23] << 23, in[21] >> 10 | in[22] << 22,
-                              in[20] >> 11 | in[21] << 21, in[19] >> 12 | in[20] << 20,
-                              in[18] >> 13 | in[19] << 19, in[17] >> 14 | in[18] << 18,
-                              in[16] >> 15 | in[17] << 17, in[15] >> 16 | in[16] << 16);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 22) >> 9 | SafeLoad(in + 23) << 23, SafeLoad(in + 21) >> 10 | SafeLoad(in + 22) << 22,
+                              SafeLoad(in + 20) >> 11 | SafeLoad(in + 21) << 21, SafeLoad(in + 19) >> 12 | SafeLoad(in + 20) << 20,
+                              SafeLoad(in + 18) >> 13 | SafeLoad(in + 19) << 19, SafeLoad(in + 17) >> 14 | SafeLoad(in + 18) << 18,
+                              SafeLoad(in + 16) >> 15 | SafeLoad(in + 17) << 17, SafeLoad(in + 15) >> 16 | SafeLoad(in + 16) << 16);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1761,10 +1794,10 @@ inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out
   // shift the last 8 outs
   reg_shifts = _mm256_set_epi32(1, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm256_set_epi32(in[30], in[29] >> 2 | in[30] << 30,
-                              in[28] >> 3 | in[29] << 29, in[27] >> 4 | in[28] << 28,
-                              in[26] >> 5 | in[27] << 27, in[25] >> 6 | in[26] << 26,
-                              in[24] >> 7 | in[25] << 25, in[23] >> 8 | in[24] << 24);
+  reg_inls = _mm256_set_epi32(SafeLoad(in + 30), SafeLoad(in + 29) >> 2 | SafeLoad(in + 30) << 30,
+                              SafeLoad(in + 28) >> 3 | SafeLoad(in + 29) << 29, SafeLoad(in + 27) >> 4 | SafeLoad(in + 28) << 28,
+                              SafeLoad(in + 26) >> 5 | SafeLoad(in + 27) << 27, SafeLoad(in + 25) >> 6 | SafeLoad(in + 26) << 26,
+                              SafeLoad(in + 24) >> 7 | SafeLoad(in + 25) << 25, SafeLoad(in + 23) >> 8 | SafeLoad(in + 24) << 24);
   results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
   out += 8;
@@ -1774,7 +1807,7 @@ inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out
   return in;
 }
 
-inline const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {
   memcpy(out, in, 32 * sizeof(*out));
   in += 32;
   out += 32;

--- a/cpp/src/arrow/util/bpacking_avx512_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx512_generated.h
@@ -28,6 +28,8 @@
 #include <immintrin.h>
 #endif
 
+#include "arrow/util/ubsan.h"
+
 namespace arrow {
 namespace internal {
 
@@ -39,6 +41,7 @@ inline static const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -50,14 +53,14 @@ inline static const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* ou
                                 11, 10, 9, 8,
                                 7, 6, 5, 4,
                                 3, 2, 1, 0);
-  reg_inls = _mm512_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -67,14 +70,14 @@ inline static const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* ou
                                 27, 26, 25, 24,
                                 23, 22, 21, 20,
                                 19, 18, 17, 16);
-  reg_inls = _mm512_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -85,6 +88,7 @@ inline static const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -96,14 +100,14 @@ inline static const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* ou
                                 22, 20, 18, 16,
                                 14, 12, 10, 8,
                                 6, 4, 2, 0);
-  reg_inls = _mm512_set_epi32(in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -113,14 +117,14 @@ inline static const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* ou
                                 22, 20, 18, 16,
                                 14, 12, 10, 8,
                                 6, 4, 2, 0);
-  reg_inls = _mm512_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -131,6 +135,7 @@ inline static const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -142,14 +147,14 @@ inline static const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* ou
                                 1, 0, 27, 24,
                                 21, 18, 15, 12,
                                 9, 6, 3, 0);
-  reg_inls = _mm512_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[0] >> 30 | in[1] << 2,
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -159,14 +164,14 @@ inline static const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* ou
                                 17, 14, 11, 8,
                                 5, 2, 0, 28,
                                 25, 22, 19, 16);
-  reg_inls = _mm512_set_epi32(in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[1] >> 31 | in[2] << 1, in[1],
-                              in[1], in[1],
-                              in[1], in[1]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -177,6 +182,7 @@ inline static const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xf;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -188,14 +194,14 @@ inline static const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* ou
                                 12, 8, 4, 0,
                                 28, 24, 20, 16,
                                 12, 8, 4, 0);
-  reg_inls = _mm512_set_epi32(in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -205,14 +211,14 @@ inline static const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* ou
                                 12, 8, 4, 0,
                                 28, 24, 20, 16,
                                 12, 8, 4, 0);
-  reg_inls = _mm512_set_epi32(in[3], in[3],
-                              in[3], in[3],
-                              in[3], in[3],
-                              in[3], in[3],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[2]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -223,6 +229,7 @@ inline static const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -234,14 +241,14 @@ inline static const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* ou
                                 23, 18, 13, 8,
                                 3, 0, 25, 20,
                                 15, 10, 5, 0);
-  reg_inls = _mm512_set_epi32(in[2], in[2],
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[1], in[0] >> 30 | in[1] << 2,
-                              in[0], in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -251,14 +258,14 @@ inline static const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* ou
                                 7, 2, 0, 24,
                                 19, 14, 9, 4,
                                 0, 26, 21, 16);
-  reg_inls = _mm512_set_epi32(in[4], in[4],
-                              in[4], in[4],
-                              in[4], in[4],
-                              in[3] >> 29 | in[4] << 3, in[3],
-                              in[3], in[3],
-                              in[3], in[3],
-                              in[2] >> 31 | in[3] << 1, in[2],
-                              in[2], in[2]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 29 | SafeLoad(in + 4) << 3, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 31 | SafeLoad(in + 3) << 1, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -269,6 +276,7 @@ inline static const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -280,14 +288,14 @@ inline static const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* ou
                                 2, 0, 22, 16,
                                 10, 4, 0, 24,
                                 18, 12, 6, 0);
-  reg_inls = _mm512_set_epi32(in[2], in[2],
-                              in[2], in[2],
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[0] >> 30 | in[1] << 2, in[0],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -297,14 +305,14 @@ inline static const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* ou
                                 2, 0, 22, 16,
                                 10, 4, 0, 24,
                                 18, 12, 6, 0);
-  reg_inls = _mm512_set_epi32(in[5], in[5],
-                              in[5], in[5],
-                              in[5], in[4] >> 28 | in[5] << 4,
-                              in[4], in[4],
-                              in[4], in[4],
-                              in[3] >> 30 | in[4] << 2, in[3],
-                              in[3], in[3],
-                              in[3], in[3]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -315,6 +323,7 @@ inline static const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -326,14 +335,14 @@ inline static const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* ou
                                 13, 6, 0, 24,
                                 17, 10, 3, 0,
                                 21, 14, 7, 0);
-  reg_inls = _mm512_set_epi32(in[3], in[3],
-                              in[2] >> 27 | in[3] << 5, in[2],
-                              in[2], in[2],
-                              in[1] >> 31 | in[2] << 1, in[1],
-                              in[1], in[1],
-                              in[1], in[0] >> 28 | in[1] << 4,
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 27 | SafeLoad(in + 3) << 5, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4,
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -343,14 +352,14 @@ inline static const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* ou
                                 0, 22, 15, 8,
                                 1, 0, 19, 12,
                                 5, 0, 23, 16);
-  reg_inls = _mm512_set_epi32(in[6], in[6],
-                              in[6], in[6],
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[5], in[5],
-                              in[5], in[4] >> 26 | in[5] << 6,
-                              in[4], in[4],
-                              in[4], in[3] >> 30 | in[4] << 2,
-                              in[3], in[3]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 3));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -361,6 +370,7 @@ inline static const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -372,14 +382,14 @@ inline static const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* ou
                                 24, 16, 8, 0,
                                 24, 16, 8, 0,
                                 24, 16, 8, 0);
-  reg_inls = _mm512_set_epi32(in[3], in[3],
-                              in[3], in[3],
-                              in[2], in[2],
-                              in[2], in[2],
-                              in[1], in[1],
-                              in[1], in[1],
-                              in[0], in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0), SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -389,14 +399,14 @@ inline static const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* ou
                                 24, 16, 8, 0,
                                 24, 16, 8, 0,
                                 24, 16, 8, 0);
-  reg_inls = _mm512_set_epi32(in[7], in[7],
-                              in[7], in[7],
-                              in[6], in[6],
-                              in[6], in[6],
-                              in[5], in[5],
-                              in[5], in[5],
-                              in[4], in[4],
-                              in[4], in[4]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 4));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -407,6 +417,7 @@ inline static const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -418,14 +429,14 @@ inline static const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* ou
                                 3, 0, 17, 8,
                                 0, 22, 13, 4,
                                 0, 18, 9, 0);
-  reg_inls = _mm512_set_epi32(in[4], in[3] >> 30 | in[4] << 2,
-                              in[3], in[3],
-                              in[3], in[2] >> 26 | in[3] << 6,
-                              in[2], in[2],
-                              in[1] >> 31 | in[2] << 1, in[1],
-                              in[1], in[1],
-                              in[0] >> 27 | in[1] << 5, in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 4), SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6,
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 27 | SafeLoad(in + 1) << 5, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -435,14 +446,14 @@ inline static const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* ou
                                 19, 10, 1, 0,
                                 15, 6, 0, 20,
                                 11, 2, 0, 16);
-  reg_inls = _mm512_set_epi32(in[8], in[8],
-                              in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[7],
-                              in[7], in[6] >> 24 | in[7] << 8,
-                              in[6], in[6],
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[5], in[5],
-                              in[4] >> 25 | in[5] << 7, in[4]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 25 | SafeLoad(in + 5) << 7, SafeLoad(in + 4));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -453,6 +464,7 @@ inline static const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* ou
 }
 
 inline static const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -464,14 +476,14 @@ inline static const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* o
                                 14, 4, 0, 16,
                                 6, 0, 18, 8,
                                 0, 20, 10, 0);
-  reg_inls = _mm512_set_epi32(in[4], in[4],
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[3],
-                              in[2] >> 26 | in[3] << 6, in[2],
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[1],
-                              in[0] >> 30 | in[1] << 2, in[0],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -481,14 +493,14 @@ inline static const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* o
                                 14, 4, 0, 16,
                                 6, 0, 18, 8,
                                 0, 20, 10, 0);
-  reg_inls = _mm512_set_epi32(in[9], in[9],
-                              in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[8],
-                              in[7] >> 26 | in[8] << 6, in[7],
-                              in[7], in[6] >> 28 | in[7] << 4,
-                              in[6], in[6],
-                              in[5] >> 30 | in[6] << 2, in[5],
-                              in[5], in[5]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 9), SafeLoad(in + 9),
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 26 | SafeLoad(in + 8) << 6, SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 30 | SafeLoad(in + 6) << 2, SafeLoad(in + 5),
+                              SafeLoad(in + 5), SafeLoad(in + 5));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -499,6 +511,7 @@ inline static const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -510,14 +523,14 @@ inline static const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 14, 3, 0,
                                 13, 2, 0, 12,
                                 1, 0, 11, 0);
-  reg_inls = _mm512_set_epi32(in[5], in[4] >> 26 | in[5] << 6,
-                              in[4], in[4],
-                              in[3] >> 25 | in[4] << 7, in[3],
-                              in[3], in[2] >> 24 | in[3] << 8,
-                              in[2], in[2],
-                              in[1] >> 23 | in[2] << 9, in[1],
-                              in[1], in[0] >> 22 | in[1] << 10,
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 5), SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 25 | SafeLoad(in + 4) << 7, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 24 | SafeLoad(in + 3) << 8,
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 23 | SafeLoad(in + 2) << 9, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 22 | SafeLoad(in + 1) << 10,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -527,14 +540,14 @@ inline static const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* o
                                 9, 0, 19, 8,
                                 0, 18, 7, 0,
                                 17, 6, 0, 16);
-  reg_inls = _mm512_set_epi32(in[10], in[10],
-                              in[9] >> 31 | in[10] << 1, in[9],
-                              in[9], in[8] >> 30 | in[9] << 2,
-                              in[8], in[8],
-                              in[7] >> 29 | in[8] << 3, in[7],
-                              in[7], in[6] >> 28 | in[7] << 4,
-                              in[6], in[6],
-                              in[5] >> 27 | in[6] << 5, in[5]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 10), SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 31 | SafeLoad(in + 10) << 1, SafeLoad(in + 9),
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2,
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 29 | SafeLoad(in + 8) << 3, SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 27 | SafeLoad(in + 6) << 5, SafeLoad(in + 5));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -545,6 +558,7 @@ inline static const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -556,14 +570,14 @@ inline static const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* o
                                 4, 0, 12, 0,
                                 20, 8, 0, 16,
                                 4, 0, 12, 0);
-  reg_inls = _mm512_set_epi32(in[5], in[5],
-                              in[4] >> 28 | in[5] << 4, in[4],
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[3],
-                              in[2], in[2],
-                              in[1] >> 28 | in[2] << 4, in[1],
-                              in[1], in[0] >> 24 | in[1] << 8,
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4, SafeLoad(in + 4),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4, SafeLoad(in + 1),
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 24 | SafeLoad(in + 1) << 8,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -573,14 +587,14 @@ inline static const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* o
                                 4, 0, 12, 0,
                                 20, 8, 0, 16,
                                 4, 0, 12, 0);
-  reg_inls = _mm512_set_epi32(in[11], in[11],
-                              in[10] >> 28 | in[11] << 4, in[10],
-                              in[10], in[9] >> 24 | in[10] << 8,
-                              in[9], in[9],
-                              in[8], in[8],
-                              in[7] >> 28 | in[8] << 4, in[7],
-                              in[7], in[6] >> 24 | in[7] << 8,
-                              in[6], in[6]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 11), SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 28 | SafeLoad(in + 11) << 4, SafeLoad(in + 10),
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8,
+                              SafeLoad(in + 9), SafeLoad(in + 9),
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4, SafeLoad(in + 7),
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 6), SafeLoad(in + 6));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -591,6 +605,7 @@ inline static const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -602,14 +617,14 @@ inline static const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* o
                                 15, 2, 0, 8,
                                 0, 14, 1, 0,
                                 7, 0, 13, 0);
-  reg_inls = _mm512_set_epi32(in[6], in[5] >> 22 | in[6] << 10,
-                              in[5], in[4] >> 28 | in[5] << 4,
-                              in[4], in[4],
-                              in[3] >> 21 | in[4] << 11, in[3],
-                              in[2] >> 27 | in[3] << 5, in[2],
-                              in[2], in[1] >> 20 | in[2] << 12,
-                              in[1], in[0] >> 26 | in[1] << 6,
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 6), SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 21 | SafeLoad(in + 4) << 11, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 27 | SafeLoad(in + 3) << 5, SafeLoad(in + 2),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 20 | SafeLoad(in + 2) << 12,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 26 | SafeLoad(in + 1) << 6,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -619,14 +634,14 @@ inline static const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 18, 5, 0,
                                 11, 0, 17, 4,
                                 0, 10, 0, 16);
-  reg_inls = _mm512_set_epi32(in[12], in[12],
-                              in[11] >> 25 | in[12] << 7, in[11],
-                              in[10] >> 31 | in[11] << 1, in[10],
-                              in[10], in[9] >> 24 | in[10] << 8,
-                              in[9], in[8] >> 30 | in[9] << 2,
-                              in[8], in[8],
-                              in[7] >> 23 | in[8] << 9, in[7],
-                              in[6] >> 29 | in[7] << 3, in[6]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 12), SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 25 | SafeLoad(in + 12) << 7, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 31 | SafeLoad(in + 11) << 1, SafeLoad(in + 10),
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8,
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2,
+                              SafeLoad(in + 8), SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 23 | SafeLoad(in + 8) << 9, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 29 | SafeLoad(in + 7) << 3, SafeLoad(in + 6));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -637,6 +652,7 @@ inline static const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -648,14 +664,14 @@ inline static const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 12, 0, 16,
                                 2, 0, 6, 0,
                                 10, 0, 14, 0);
-  reg_inls = _mm512_set_epi32(in[6], in[6],
-                              in[5] >> 22 | in[6] << 10, in[5],
-                              in[4] >> 26 | in[5] << 6, in[4],
-                              in[3] >> 30 | in[4] << 2, in[3],
-                              in[3], in[2] >> 20 | in[3] << 12,
-                              in[2], in[1] >> 24 | in[2] << 8,
-                              in[1], in[0] >> 28 | in[1] << 4,
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6, SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3),
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 24 | SafeLoad(in + 2) << 8,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -665,14 +681,14 @@ inline static const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 12, 0, 16,
                                 2, 0, 6, 0,
                                 10, 0, 14, 0);
-  reg_inls = _mm512_set_epi32(in[13], in[13],
-                              in[12] >> 22 | in[13] << 10, in[12],
-                              in[11] >> 26 | in[12] << 6, in[11],
-                              in[10] >> 30 | in[11] << 2, in[10],
-                              in[10], in[9] >> 20 | in[10] << 12,
-                              in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[7]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 13), SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 22 | SafeLoad(in + 13) << 10, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 30 | SafeLoad(in + 11) << 2, SafeLoad(in + 10),
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12,
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 7));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -683,6 +699,7 @@ inline static const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -694,14 +711,14 @@ inline static const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* o
                                 5, 0, 7, 0,
                                 9, 0, 11, 0,
                                 13, 0, 15, 0);
-  reg_inls = _mm512_set_epi32(in[7], in[6] >> 18 | in[7] << 14,
-                              in[6], in[5] >> 20 | in[6] << 12,
-                              in[5], in[4] >> 22 | in[5] << 10,
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[2] >> 26 | in[3] << 6,
-                              in[2], in[1] >> 28 | in[2] << 4,
-                              in[1], in[0] >> 30 | in[1] << 2,
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 7), SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10,
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 1), SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2,
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -711,14 +728,14 @@ inline static const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 6, 0, 8,
                                 0, 10, 0, 12,
                                 0, 14, 0, 16);
-  reg_inls = _mm512_set_epi32(in[14], in[14],
-                              in[13] >> 19 | in[14] << 13, in[13],
-                              in[12] >> 21 | in[13] << 11, in[12],
-                              in[11] >> 23 | in[12] << 9, in[11],
-                              in[10] >> 25 | in[11] << 7, in[10],
-                              in[9] >> 27 | in[10] << 5, in[9],
-                              in[8] >> 29 | in[9] << 3, in[8],
-                              in[7] >> 31 | in[8] << 1, in[7]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 14), SafeLoad(in + 14),
+                              SafeLoad(in + 13) >> 19 | SafeLoad(in + 14) << 13, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 21 | SafeLoad(in + 13) << 11, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 23 | SafeLoad(in + 12) << 9, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 25 | SafeLoad(in + 11) << 7, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 27 | SafeLoad(in + 10) << 5, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 29 | SafeLoad(in + 9) << 3, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 31 | SafeLoad(in + 8) << 1, SafeLoad(in + 7));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -729,6 +746,7 @@ inline static const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -740,14 +758,14 @@ inline static const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* o
                                 16, 0, 16, 0,
                                 16, 0, 16, 0,
                                 16, 0, 16, 0);
-  reg_inls = _mm512_set_epi32(in[7], in[7],
-                              in[6], in[6],
-                              in[5], in[5],
-                              in[4], in[4],
-                              in[3], in[3],
-                              in[2], in[2],
-                              in[1], in[1],
-                              in[0], in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 7), SafeLoad(in + 7),
+                              SafeLoad(in + 6), SafeLoad(in + 6),
+                              SafeLoad(in + 5), SafeLoad(in + 5),
+                              SafeLoad(in + 4), SafeLoad(in + 4),
+                              SafeLoad(in + 3), SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 2),
+                              SafeLoad(in + 1), SafeLoad(in + 1),
+                              SafeLoad(in + 0), SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -757,14 +775,14 @@ inline static const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* o
                                 16, 0, 16, 0,
                                 16, 0, 16, 0,
                                 16, 0, 16, 0);
-  reg_inls = _mm512_set_epi32(in[15], in[15],
-                              in[14], in[14],
-                              in[13], in[13],
-                              in[12], in[12],
-                              in[11], in[11],
-                              in[10], in[10],
-                              in[9], in[9],
-                              in[8], in[8]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 15), SafeLoad(in + 15),
+                              SafeLoad(in + 14), SafeLoad(in + 14),
+                              SafeLoad(in + 13), SafeLoad(in + 13),
+                              SafeLoad(in + 12), SafeLoad(in + 12),
+                              SafeLoad(in + 11), SafeLoad(in + 11),
+                              SafeLoad(in + 10), SafeLoad(in + 10),
+                              SafeLoad(in + 9), SafeLoad(in + 9),
+                              SafeLoad(in + 8), SafeLoad(in + 8));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -775,6 +793,7 @@ inline static const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -786,14 +805,14 @@ inline static const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 10, 0, 8,
                                 0, 6, 0, 4,
                                 0, 2, 0, 0);
-  reg_inls = _mm512_set_epi32(in[7] >> 31 | in[8] << 1, in[7],
-                              in[6] >> 29 | in[7] << 3, in[6],
-                              in[5] >> 27 | in[6] << 5, in[5],
-                              in[4] >> 25 | in[5] << 7, in[4],
-                              in[3] >> 23 | in[4] << 9, in[3],
-                              in[2] >> 21 | in[3] << 11, in[2],
-                              in[1] >> 19 | in[2] << 13, in[1],
-                              in[0] >> 17 | in[1] << 15, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 7) >> 31 | SafeLoad(in + 8) << 1, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 29 | SafeLoad(in + 7) << 3, SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 27 | SafeLoad(in + 6) << 5, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 25 | SafeLoad(in + 5) << 7, SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 23 | SafeLoad(in + 4) << 9, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 21 | SafeLoad(in + 3) << 11, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 19 | SafeLoad(in + 2) << 13, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 17 | SafeLoad(in + 1) << 15, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -803,14 +822,14 @@ inline static const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* o
                                 11, 0, 9, 0,
                                 7, 0, 5, 0,
                                 3, 0, 1, 0);
-  reg_inls = _mm512_set_epi32(in[16], in[15] >> 30 | in[16] << 2,
-                              in[15], in[14] >> 28 | in[15] << 4,
-                              in[14], in[13] >> 26 | in[14] << 6,
-                              in[13], in[12] >> 24 | in[13] << 8,
-                              in[12], in[11] >> 22 | in[12] << 10,
-                              in[11], in[10] >> 20 | in[11] << 12,
-                              in[10], in[9] >> 18 | in[10] << 14,
-                              in[9], in[8] >> 16 | in[9] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 16), SafeLoad(in + 15) >> 30 | SafeLoad(in + 16) << 2,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 28 | SafeLoad(in + 15) << 4,
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 26 | SafeLoad(in + 14) << 6,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 24 | SafeLoad(in + 13) << 8,
+                              SafeLoad(in + 12), SafeLoad(in + 11) >> 22 | SafeLoad(in + 12) << 10,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 20 | SafeLoad(in + 11) << 12,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 18 | SafeLoad(in + 10) << 14,
+                              SafeLoad(in + 9), SafeLoad(in + 8) >> 16 | SafeLoad(in + 9) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -821,6 +840,7 @@ inline static const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -832,14 +852,14 @@ inline static const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* o
                                 6, 0, 2, 0,
                                 0, 12, 0, 8,
                                 0, 4, 0, 0);
-  reg_inls = _mm512_set_epi32(in[8], in[7] >> 28 | in[8] << 4,
-                              in[7], in[6] >> 24 | in[7] << 8,
-                              in[6], in[5] >> 20 | in[6] << 12,
-                              in[5], in[4] >> 16 | in[5] << 16,
-                              in[3] >> 30 | in[4] << 2, in[3],
-                              in[2] >> 26 | in[3] << 6, in[2],
-                              in[1] >> 22 | in[2] << 10, in[1],
-                              in[0] >> 18 | in[1] << 14, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 8), SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 16 | SafeLoad(in + 5) << 16,
+                              SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 22 | SafeLoad(in + 2) << 10, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 18 | SafeLoad(in + 1) << 14, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -849,14 +869,14 @@ inline static const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* o
                                 6, 0, 2, 0,
                                 0, 12, 0, 8,
                                 0, 4, 0, 0);
-  reg_inls = _mm512_set_epi32(in[17], in[16] >> 28 | in[17] << 4,
-                              in[16], in[15] >> 24 | in[16] << 8,
-                              in[15], in[14] >> 20 | in[15] << 12,
-                              in[14], in[13] >> 16 | in[14] << 16,
-                              in[12] >> 30 | in[13] << 2, in[12],
-                              in[11] >> 26 | in[12] << 6, in[11],
-                              in[10] >> 22 | in[11] << 10, in[10],
-                              in[9] >> 18 | in[10] << 14, in[9]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 17), SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 20 | SafeLoad(in + 15) << 12,
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16,
+                              SafeLoad(in + 12) >> 30 | SafeLoad(in + 13) << 2, SafeLoad(in + 12),
+                              SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 22 | SafeLoad(in + 11) << 10, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 18 | SafeLoad(in + 10) << 14, SafeLoad(in + 9));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -867,6 +887,7 @@ inline static const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -878,14 +899,14 @@ inline static const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 11, 0,
                                 5, 0, 0, 12,
                                 0, 6, 0, 0);
-  reg_inls = _mm512_set_epi32(in[8] >> 29 | in[9] << 3, in[8],
-                              in[7] >> 23 | in[8] << 9, in[7],
-                              in[6] >> 17 | in[7] << 15, in[5] >> 30 | in[6] << 2,
-                              in[5], in[4] >> 24 | in[5] << 8,
-                              in[4], in[3] >> 18 | in[4] << 14,
-                              in[2] >> 31 | in[3] << 1, in[2],
-                              in[1] >> 25 | in[2] << 7, in[1],
-                              in[0] >> 19 | in[1] << 13, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 8) >> 29 | SafeLoad(in + 9) << 3, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 23 | SafeLoad(in + 8) << 9, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 17 | SafeLoad(in + 7) << 15, SafeLoad(in + 5) >> 30 | SafeLoad(in + 6) << 2,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 24 | SafeLoad(in + 5) << 8,
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 18 | SafeLoad(in + 4) << 14,
+                              SafeLoad(in + 2) >> 31 | SafeLoad(in + 3) << 1, SafeLoad(in + 2),
+                              SafeLoad(in + 1) >> 25 | SafeLoad(in + 2) << 7, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 19 | SafeLoad(in + 1) << 13, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -895,14 +916,14 @@ inline static const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* o
                                 1, 0, 0, 8,
                                 0, 2, 0, 0,
                                 9, 0, 3, 0);
-  reg_inls = _mm512_set_epi32(in[18], in[17] >> 26 | in[18] << 6,
-                              in[17], in[16] >> 20 | in[17] << 12,
-                              in[16], in[15] >> 14 | in[16] << 18,
-                              in[14] >> 27 | in[15] << 5, in[14],
-                              in[13] >> 21 | in[14] << 11, in[13],
-                              in[12] >> 15 | in[13] << 17, in[11] >> 28 | in[12] << 4,
-                              in[11], in[10] >> 22 | in[11] << 10,
-                              in[10], in[9] >> 16 | in[10] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 18), SafeLoad(in + 17) >> 26 | SafeLoad(in + 18) << 6,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 20 | SafeLoad(in + 17) << 12,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 14 | SafeLoad(in + 16) << 18,
+                              SafeLoad(in + 14) >> 27 | SafeLoad(in + 15) << 5, SafeLoad(in + 14),
+                              SafeLoad(in + 13) >> 21 | SafeLoad(in + 14) << 11, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 15 | SafeLoad(in + 13) << 17, SafeLoad(in + 11) >> 28 | SafeLoad(in + 12) << 4,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 22 | SafeLoad(in + 11) << 10,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 16 | SafeLoad(in + 10) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -913,6 +934,7 @@ inline static const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -924,14 +946,14 @@ inline static const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 8, 0, 0,
                                 12, 0, 4, 0,
                                 0, 8, 0, 0);
-  reg_inls = _mm512_set_epi32(in[9], in[8] >> 24 | in[9] << 8,
-                              in[8], in[7] >> 16 | in[8] << 16,
-                              in[6] >> 28 | in[7] << 4, in[6],
-                              in[5] >> 20 | in[6] << 12, in[5],
-                              in[4], in[3] >> 24 | in[4] << 8,
-                              in[3], in[2] >> 16 | in[3] << 16,
-                              in[1] >> 28 | in[2] << 4, in[1],
-                              in[0] >> 20 | in[1] << 12, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 9), SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16,
+                              SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4, SafeLoad(in + 6),
+                              SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12, SafeLoad(in + 5),
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 16 | SafeLoad(in + 3) << 16,
+                              SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 20 | SafeLoad(in + 1) << 12, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -941,14 +963,14 @@ inline static const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 8, 0, 0,
                                 12, 0, 4, 0,
                                 0, 8, 0, 0);
-  reg_inls = _mm512_set_epi32(in[19], in[18] >> 24 | in[19] << 8,
-                              in[18], in[17] >> 16 | in[18] << 16,
-                              in[16] >> 28 | in[17] << 4, in[16],
-                              in[15] >> 20 | in[16] << 12, in[15],
-                              in[14], in[13] >> 24 | in[14] << 8,
-                              in[13], in[12] >> 16 | in[13] << 16,
-                              in[11] >> 28 | in[12] << 4, in[11],
-                              in[10] >> 20 | in[11] << 12, in[10]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 19), SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8,
+                              SafeLoad(in + 18), SafeLoad(in + 17) >> 16 | SafeLoad(in + 18) << 16,
+                              SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4, SafeLoad(in + 16),
+                              SafeLoad(in + 15) >> 20 | SafeLoad(in + 16) << 12, SafeLoad(in + 15),
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 24 | SafeLoad(in + 14) << 8,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 16 | SafeLoad(in + 13) << 16,
+                              SafeLoad(in + 11) >> 28 | SafeLoad(in + 12) << 4, SafeLoad(in + 11),
+                              SafeLoad(in + 10) >> 20 | SafeLoad(in + 11) << 12, SafeLoad(in + 10));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -959,6 +981,7 @@ inline static const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -970,14 +993,14 @@ inline static const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* o
                                 7, 0, 0, 8,
                                 0, 0, 9, 0,
                                 0, 10, 0, 0);
-  reg_inls = _mm512_set_epi32(in[9] >> 27 | in[10] << 5, in[9],
-                              in[8] >> 17 | in[9] << 15, in[7] >> 28 | in[8] << 4,
-                              in[7], in[6] >> 18 | in[7] << 14,
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[4] >> 19 | in[5] << 13, in[3] >> 30 | in[4] << 2,
-                              in[3], in[2] >> 20 | in[3] << 12,
-                              in[1] >> 31 | in[2] << 1, in[1],
-                              in[0] >> 21 | in[1] << 11, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 9) >> 27 | SafeLoad(in + 10) << 5, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 17 | SafeLoad(in + 9) << 15, SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14,
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 19 | SafeLoad(in + 5) << 13, SafeLoad(in + 3) >> 30 | SafeLoad(in + 4) << 2,
+                              SafeLoad(in + 3), SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12,
+                              SafeLoad(in + 1) >> 31 | SafeLoad(in + 2) << 1, SafeLoad(in + 1),
+                              SafeLoad(in + 0) >> 21 | SafeLoad(in + 1) << 11, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -987,14 +1010,14 @@ inline static const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 2, 0, 0,
                                 3, 0, 0, 4,
                                 0, 0, 5, 0);
-  reg_inls = _mm512_set_epi32(in[20], in[19] >> 22 | in[20] << 10,
-                              in[19], in[18] >> 12 | in[19] << 20,
-                              in[17] >> 23 | in[18] << 9, in[17],
-                              in[16] >> 13 | in[17] << 19, in[15] >> 24 | in[16] << 8,
-                              in[15], in[14] >> 14 | in[15] << 18,
-                              in[13] >> 25 | in[14] << 7, in[13],
-                              in[12] >> 15 | in[13] << 17, in[11] >> 26 | in[12] << 6,
-                              in[11], in[10] >> 16 | in[11] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 20), SafeLoad(in + 19) >> 22 | SafeLoad(in + 20) << 10,
+                              SafeLoad(in + 19), SafeLoad(in + 18) >> 12 | SafeLoad(in + 19) << 20,
+                              SafeLoad(in + 17) >> 23 | SafeLoad(in + 18) << 9, SafeLoad(in + 17),
+                              SafeLoad(in + 16) >> 13 | SafeLoad(in + 17) << 19, SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 14 | SafeLoad(in + 15) << 18,
+                              SafeLoad(in + 13) >> 25 | SafeLoad(in + 14) << 7, SafeLoad(in + 13),
+                              SafeLoad(in + 12) >> 15 | SafeLoad(in + 13) << 17, SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6,
+                              SafeLoad(in + 11), SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1005,6 +1028,7 @@ inline static const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1016,14 +1040,14 @@ inline static const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 6, 0,
                                 0, 4, 0, 0,
                                 2, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[10], in[9] >> 20 | in[10] << 12,
-                              in[8] >> 30 | in[9] << 2, in[8],
-                              in[7] >> 18 | in[8] << 14, in[6] >> 28 | in[7] << 4,
-                              in[6], in[5] >> 16 | in[6] << 16,
-                              in[4] >> 26 | in[5] << 6, in[4],
-                              in[3] >> 14 | in[4] << 18, in[2] >> 24 | in[3] << 8,
-                              in[2], in[1] >> 12 | in[2] << 20,
-                              in[0] >> 22 | in[1] << 10, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 10), SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12,
+                              SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 18 | SafeLoad(in + 8) << 14, SafeLoad(in + 6) >> 28 | SafeLoad(in + 7) << 4,
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 16 | SafeLoad(in + 6) << 16,
+                              SafeLoad(in + 4) >> 26 | SafeLoad(in + 5) << 6, SafeLoad(in + 4),
+                              SafeLoad(in + 3) >> 14 | SafeLoad(in + 4) << 18, SafeLoad(in + 2) >> 24 | SafeLoad(in + 3) << 8,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 12 | SafeLoad(in + 2) << 20,
+                              SafeLoad(in + 0) >> 22 | SafeLoad(in + 1) << 10, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1033,14 +1057,14 @@ inline static const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 6, 0,
                                 0, 4, 0, 0,
                                 2, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[21], in[20] >> 20 | in[21] << 12,
-                              in[19] >> 30 | in[20] << 2, in[19],
-                              in[18] >> 18 | in[19] << 14, in[17] >> 28 | in[18] << 4,
-                              in[17], in[16] >> 16 | in[17] << 16,
-                              in[15] >> 26 | in[16] << 6, in[15],
-                              in[14] >> 14 | in[15] << 18, in[13] >> 24 | in[14] << 8,
-                              in[13], in[12] >> 12 | in[13] << 20,
-                              in[11] >> 22 | in[12] << 10, in[11]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 21), SafeLoad(in + 20) >> 20 | SafeLoad(in + 21) << 12,
+                              SafeLoad(in + 19) >> 30 | SafeLoad(in + 20) << 2, SafeLoad(in + 19),
+                              SafeLoad(in + 18) >> 18 | SafeLoad(in + 19) << 14, SafeLoad(in + 17) >> 28 | SafeLoad(in + 18) << 4,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 16 | SafeLoad(in + 17) << 16,
+                              SafeLoad(in + 15) >> 26 | SafeLoad(in + 16) << 6, SafeLoad(in + 15),
+                              SafeLoad(in + 14) >> 14 | SafeLoad(in + 15) << 18, SafeLoad(in + 13) >> 24 | SafeLoad(in + 14) << 8,
+                              SafeLoad(in + 13), SafeLoad(in + 12) >> 12 | SafeLoad(in + 13) << 20,
+                              SafeLoad(in + 11) >> 22 | SafeLoad(in + 12) << 10, SafeLoad(in + 11));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1051,6 +1075,7 @@ inline static const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1062,14 +1087,14 @@ inline static const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 6, 0, 0,
                                 1, 0, 0, 0,
                                 5, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[10] >> 25 | in[11] << 7, in[10],
-                              in[9] >> 11 | in[10] << 21, in[8] >> 20 | in[9] << 12,
-                              in[7] >> 29 | in[8] << 3, in[7],
-                              in[6] >> 15 | in[7] << 17, in[5] >> 24 | in[6] << 8,
-                              in[5], in[4] >> 10 | in[5] << 22,
-                              in[3] >> 19 | in[4] << 13, in[2] >> 28 | in[3] << 4,
-                              in[2], in[1] >> 14 | in[2] << 18,
-                              in[0] >> 23 | in[1] << 9, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 10) >> 25 | SafeLoad(in + 11) << 7, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 11 | SafeLoad(in + 10) << 21, SafeLoad(in + 8) >> 20 | SafeLoad(in + 9) << 12,
+                              SafeLoad(in + 7) >> 29 | SafeLoad(in + 8) << 3, SafeLoad(in + 7),
+                              SafeLoad(in + 6) >> 15 | SafeLoad(in + 7) << 17, SafeLoad(in + 5) >> 24 | SafeLoad(in + 6) << 8,
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 10 | SafeLoad(in + 5) << 22,
+                              SafeLoad(in + 3) >> 19 | SafeLoad(in + 4) << 13, SafeLoad(in + 2) >> 28 | SafeLoad(in + 3) << 4,
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 14 | SafeLoad(in + 2) << 18,
+                              SafeLoad(in + 0) >> 23 | SafeLoad(in + 1) << 9, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1079,14 +1104,14 @@ inline static const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 8,
                                 0, 0, 3, 0,
                                 0, 0, 7, 0);
-  reg_inls = _mm512_set_epi32(in[22], in[21] >> 18 | in[22] << 14,
-                              in[20] >> 27 | in[21] << 5, in[20],
-                              in[19] >> 13 | in[20] << 19, in[18] >> 22 | in[19] << 10,
-                              in[17] >> 31 | in[18] << 1, in[17],
-                              in[16] >> 17 | in[17] << 15, in[15] >> 26 | in[16] << 6,
-                              in[15], in[14] >> 12 | in[15] << 20,
-                              in[13] >> 21 | in[14] << 11, in[12] >> 30 | in[13] << 2,
-                              in[12], in[11] >> 16 | in[12] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 22), SafeLoad(in + 21) >> 18 | SafeLoad(in + 22) << 14,
+                              SafeLoad(in + 20) >> 27 | SafeLoad(in + 21) << 5, SafeLoad(in + 20),
+                              SafeLoad(in + 19) >> 13 | SafeLoad(in + 20) << 19, SafeLoad(in + 18) >> 22 | SafeLoad(in + 19) << 10,
+                              SafeLoad(in + 17) >> 31 | SafeLoad(in + 18) << 1, SafeLoad(in + 17),
+                              SafeLoad(in + 16) >> 17 | SafeLoad(in + 17) << 15, SafeLoad(in + 15) >> 26 | SafeLoad(in + 16) << 6,
+                              SafeLoad(in + 15), SafeLoad(in + 14) >> 12 | SafeLoad(in + 15) << 20,
+                              SafeLoad(in + 13) >> 21 | SafeLoad(in + 14) << 11, SafeLoad(in + 12) >> 30 | SafeLoad(in + 13) << 2,
+                              SafeLoad(in + 12), SafeLoad(in + 11) >> 16 | SafeLoad(in + 12) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1097,6 +1122,7 @@ inline static const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1108,14 +1134,14 @@ inline static const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* o
                                 8, 0, 0, 0,
                                 8, 0, 0, 0,
                                 8, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[11], in[10] >> 16 | in[11] << 16,
-                              in[9] >> 24 | in[10] << 8, in[9],
-                              in[8], in[7] >> 16 | in[8] << 16,
-                              in[6] >> 24 | in[7] << 8, in[6],
-                              in[5], in[4] >> 16 | in[5] << 16,
-                              in[3] >> 24 | in[4] << 8, in[3],
-                              in[2], in[1] >> 16 | in[2] << 16,
-                              in[0] >> 24 | in[1] << 8, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 11), SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16,
+                              SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8, SafeLoad(in + 9),
+                              SafeLoad(in + 8), SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16,
+                              SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8, SafeLoad(in + 6),
+                              SafeLoad(in + 5), SafeLoad(in + 4) >> 16 | SafeLoad(in + 5) << 16,
+                              SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8, SafeLoad(in + 3),
+                              SafeLoad(in + 2), SafeLoad(in + 1) >> 16 | SafeLoad(in + 2) << 16,
+                              SafeLoad(in + 0) >> 24 | SafeLoad(in + 1) << 8, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1125,14 +1151,14 @@ inline static const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* o
                                 8, 0, 0, 0,
                                 8, 0, 0, 0,
                                 8, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[23], in[22] >> 16 | in[23] << 16,
-                              in[21] >> 24 | in[22] << 8, in[21],
-                              in[20], in[19] >> 16 | in[20] << 16,
-                              in[18] >> 24 | in[19] << 8, in[18],
-                              in[17], in[16] >> 16 | in[17] << 16,
-                              in[15] >> 24 | in[16] << 8, in[15],
-                              in[14], in[13] >> 16 | in[14] << 16,
-                              in[12] >> 24 | in[13] << 8, in[12]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 23), SafeLoad(in + 22) >> 16 | SafeLoad(in + 23) << 16,
+                              SafeLoad(in + 21) >> 24 | SafeLoad(in + 22) << 8, SafeLoad(in + 21),
+                              SafeLoad(in + 20), SafeLoad(in + 19) >> 16 | SafeLoad(in + 20) << 16,
+                              SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8, SafeLoad(in + 18),
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 16 | SafeLoad(in + 17) << 16,
+                              SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8, SafeLoad(in + 15),
+                              SafeLoad(in + 14), SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16,
+                              SafeLoad(in + 12) >> 24 | SafeLoad(in + 13) << 8, SafeLoad(in + 12));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1143,6 +1169,7 @@ inline static const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1154,14 +1181,14 @@ inline static const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 1, 0,
                                 0, 0, 0, 4,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[11] >> 23 | in[12] << 9, in[10] >> 30 | in[11] << 2,
-                              in[10], in[9] >> 12 | in[10] << 20,
-                              in[8] >> 19 | in[9] << 13, in[7] >> 26 | in[8] << 6,
-                              in[7], in[6] >> 8 | in[7] << 24,
-                              in[5] >> 15 | in[6] << 17, in[4] >> 22 | in[5] << 10,
-                              in[3] >> 29 | in[4] << 3, in[3],
-                              in[2] >> 11 | in[3] << 21, in[1] >> 18 | in[2] << 14,
-                              in[0] >> 25 | in[1] << 7, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 11) >> 23 | SafeLoad(in + 12) << 9, SafeLoad(in + 10) >> 30 | SafeLoad(in + 11) << 2,
+                              SafeLoad(in + 10), SafeLoad(in + 9) >> 12 | SafeLoad(in + 10) << 20,
+                              SafeLoad(in + 8) >> 19 | SafeLoad(in + 9) << 13, SafeLoad(in + 7) >> 26 | SafeLoad(in + 8) << 6,
+                              SafeLoad(in + 7), SafeLoad(in + 6) >> 8 | SafeLoad(in + 7) << 24,
+                              SafeLoad(in + 5) >> 15 | SafeLoad(in + 6) << 17, SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10,
+                              SafeLoad(in + 3) >> 29 | SafeLoad(in + 4) << 3, SafeLoad(in + 3),
+                              SafeLoad(in + 2) >> 11 | SafeLoad(in + 3) << 21, SafeLoad(in + 1) >> 18 | SafeLoad(in + 2) << 14,
+                              SafeLoad(in + 0) >> 25 | SafeLoad(in + 1) << 7, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1171,14 +1198,14 @@ inline static const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* o
                                 3, 0, 0, 0,
                                 0, 6, 0, 0,
                                 0, 2, 0, 0);
-  reg_inls = _mm512_set_epi32(in[24], in[23] >> 14 | in[24] << 18,
-                              in[22] >> 21 | in[23] << 11, in[21] >> 28 | in[22] << 4,
-                              in[21], in[20] >> 10 | in[21] << 22,
-                              in[19] >> 17 | in[20] << 15, in[18] >> 24 | in[19] << 8,
-                              in[17] >> 31 | in[18] << 1, in[17],
-                              in[16] >> 13 | in[17] << 19, in[15] >> 20 | in[16] << 12,
-                              in[14] >> 27 | in[15] << 5, in[14],
-                              in[13] >> 9 | in[14] << 23, in[12] >> 16 | in[13] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 24), SafeLoad(in + 23) >> 14 | SafeLoad(in + 24) << 18,
+                              SafeLoad(in + 22) >> 21 | SafeLoad(in + 23) << 11, SafeLoad(in + 21) >> 28 | SafeLoad(in + 22) << 4,
+                              SafeLoad(in + 21), SafeLoad(in + 20) >> 10 | SafeLoad(in + 21) << 22,
+                              SafeLoad(in + 19) >> 17 | SafeLoad(in + 20) << 15, SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8,
+                              SafeLoad(in + 17) >> 31 | SafeLoad(in + 18) << 1, SafeLoad(in + 17),
+                              SafeLoad(in + 16) >> 13 | SafeLoad(in + 17) << 19, SafeLoad(in + 15) >> 20 | SafeLoad(in + 16) << 12,
+                              SafeLoad(in + 14) >> 27 | SafeLoad(in + 15) << 5, SafeLoad(in + 14),
+                              SafeLoad(in + 13) >> 9 | SafeLoad(in + 14) << 23, SafeLoad(in + 12) >> 16 | SafeLoad(in + 13) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1189,6 +1216,7 @@ inline static const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1200,14 +1228,14 @@ inline static const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 4, 0, 0,
                                 0, 0, 2, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[12], in[11] >> 12 | in[12] << 20,
-                              in[10] >> 18 | in[11] << 14, in[9] >> 24 | in[10] << 8,
-                              in[8] >> 30 | in[9] << 2, in[8],
-                              in[7] >> 10 | in[8] << 22, in[6] >> 16 | in[7] << 16,
-                              in[5] >> 22 | in[6] << 10, in[4] >> 28 | in[5] << 4,
-                              in[4], in[3] >> 8 | in[4] << 24,
-                              in[2] >> 14 | in[3] << 18, in[1] >> 20 | in[2] << 12,
-                              in[0] >> 26 | in[1] << 6, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 12), SafeLoad(in + 11) >> 12 | SafeLoad(in + 12) << 20,
+                              SafeLoad(in + 10) >> 18 | SafeLoad(in + 11) << 14, SafeLoad(in + 9) >> 24 | SafeLoad(in + 10) << 8,
+                              SafeLoad(in + 8) >> 30 | SafeLoad(in + 9) << 2, SafeLoad(in + 8),
+                              SafeLoad(in + 7) >> 10 | SafeLoad(in + 8) << 22, SafeLoad(in + 6) >> 16 | SafeLoad(in + 7) << 16,
+                              SafeLoad(in + 5) >> 22 | SafeLoad(in + 6) << 10, SafeLoad(in + 4) >> 28 | SafeLoad(in + 5) << 4,
+                              SafeLoad(in + 4), SafeLoad(in + 3) >> 8 | SafeLoad(in + 4) << 24,
+                              SafeLoad(in + 2) >> 14 | SafeLoad(in + 3) << 18, SafeLoad(in + 1) >> 20 | SafeLoad(in + 2) << 12,
+                              SafeLoad(in + 0) >> 26 | SafeLoad(in + 1) << 6, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1217,14 +1245,14 @@ inline static const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 4, 0, 0,
                                 0, 0, 2, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[25], in[24] >> 12 | in[25] << 20,
-                              in[23] >> 18 | in[24] << 14, in[22] >> 24 | in[23] << 8,
-                              in[21] >> 30 | in[22] << 2, in[21],
-                              in[20] >> 10 | in[21] << 22, in[19] >> 16 | in[20] << 16,
-                              in[18] >> 22 | in[19] << 10, in[17] >> 28 | in[18] << 4,
-                              in[17], in[16] >> 8 | in[17] << 24,
-                              in[15] >> 14 | in[16] << 18, in[14] >> 20 | in[15] << 12,
-                              in[13] >> 26 | in[14] << 6, in[13]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 25), SafeLoad(in + 24) >> 12 | SafeLoad(in + 25) << 20,
+                              SafeLoad(in + 23) >> 18 | SafeLoad(in + 24) << 14, SafeLoad(in + 22) >> 24 | SafeLoad(in + 23) << 8,
+                              SafeLoad(in + 21) >> 30 | SafeLoad(in + 22) << 2, SafeLoad(in + 21),
+                              SafeLoad(in + 20) >> 10 | SafeLoad(in + 21) << 22, SafeLoad(in + 19) >> 16 | SafeLoad(in + 20) << 16,
+                              SafeLoad(in + 18) >> 22 | SafeLoad(in + 19) << 10, SafeLoad(in + 17) >> 28 | SafeLoad(in + 18) << 4,
+                              SafeLoad(in + 17), SafeLoad(in + 16) >> 8 | SafeLoad(in + 17) << 24,
+                              SafeLoad(in + 15) >> 14 | SafeLoad(in + 16) << 18, SafeLoad(in + 14) >> 20 | SafeLoad(in + 15) << 12,
+                              SafeLoad(in + 13) >> 26 | SafeLoad(in + 14) << 6, SafeLoad(in + 13));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1235,6 +1263,7 @@ inline static const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1246,14 +1275,14 @@ inline static const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 2, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[12] >> 21 | in[13] << 11, in[11] >> 26 | in[12] << 6,
-                              in[10] >> 31 | in[11] << 1, in[10],
-                              in[9] >> 9 | in[10] << 23, in[8] >> 14 | in[9] << 18,
-                              in[7] >> 19 | in[8] << 13, in[6] >> 24 | in[7] << 8,
-                              in[5] >> 29 | in[6] << 3, in[5],
-                              in[4] >> 7 | in[5] << 25, in[3] >> 12 | in[4] << 20,
-                              in[2] >> 17 | in[3] << 15, in[1] >> 22 | in[2] << 10,
-                              in[0] >> 27 | in[1] << 5, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 12) >> 21 | SafeLoad(in + 13) << 11, SafeLoad(in + 11) >> 26 | SafeLoad(in + 12) << 6,
+                              SafeLoad(in + 10) >> 31 | SafeLoad(in + 11) << 1, SafeLoad(in + 10),
+                              SafeLoad(in + 9) >> 9 | SafeLoad(in + 10) << 23, SafeLoad(in + 8) >> 14 | SafeLoad(in + 9) << 18,
+                              SafeLoad(in + 7) >> 19 | SafeLoad(in + 8) << 13, SafeLoad(in + 6) >> 24 | SafeLoad(in + 7) << 8,
+                              SafeLoad(in + 5) >> 29 | SafeLoad(in + 6) << 3, SafeLoad(in + 5),
+                              SafeLoad(in + 4) >> 7 | SafeLoad(in + 5) << 25, SafeLoad(in + 3) >> 12 | SafeLoad(in + 4) << 20,
+                              SafeLoad(in + 2) >> 17 | SafeLoad(in + 3) << 15, SafeLoad(in + 1) >> 22 | SafeLoad(in + 2) << 10,
+                              SafeLoad(in + 0) >> 27 | SafeLoad(in + 1) << 5, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1263,14 +1292,14 @@ inline static const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 3, 0,
                                 0, 0, 0, 0,
                                 1, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[26], in[25] >> 10 | in[26] << 22,
-                              in[24] >> 15 | in[25] << 17, in[23] >> 20 | in[24] << 12,
-                              in[22] >> 25 | in[23] << 7, in[21] >> 30 | in[22] << 2,
-                              in[21], in[20] >> 8 | in[21] << 24,
-                              in[19] >> 13 | in[20] << 19, in[18] >> 18 | in[19] << 14,
-                              in[17] >> 23 | in[18] << 9, in[16] >> 28 | in[17] << 4,
-                              in[16], in[15] >> 6 | in[16] << 26,
-                              in[14] >> 11 | in[15] << 21, in[13] >> 16 | in[14] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 26), SafeLoad(in + 25) >> 10 | SafeLoad(in + 26) << 22,
+                              SafeLoad(in + 24) >> 15 | SafeLoad(in + 25) << 17, SafeLoad(in + 23) >> 20 | SafeLoad(in + 24) << 12,
+                              SafeLoad(in + 22) >> 25 | SafeLoad(in + 23) << 7, SafeLoad(in + 21) >> 30 | SafeLoad(in + 22) << 2,
+                              SafeLoad(in + 21), SafeLoad(in + 20) >> 8 | SafeLoad(in + 21) << 24,
+                              SafeLoad(in + 19) >> 13 | SafeLoad(in + 20) << 19, SafeLoad(in + 18) >> 18 | SafeLoad(in + 19) << 14,
+                              SafeLoad(in + 17) >> 23 | SafeLoad(in + 18) << 9, SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 16), SafeLoad(in + 15) >> 6 | SafeLoad(in + 16) << 26,
+                              SafeLoad(in + 14) >> 11 | SafeLoad(in + 15) << 21, SafeLoad(in + 13) >> 16 | SafeLoad(in + 14) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1281,6 +1310,7 @@ inline static const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0xfffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1292,14 +1322,14 @@ inline static const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 4, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[13], in[12] >> 8 | in[13] << 24,
-                              in[11] >> 12 | in[12] << 20, in[10] >> 16 | in[11] << 16,
-                              in[9] >> 20 | in[10] << 12, in[8] >> 24 | in[9] << 8,
-                              in[7] >> 28 | in[8] << 4, in[7],
-                              in[6], in[5] >> 8 | in[6] << 24,
-                              in[4] >> 12 | in[5] << 20, in[3] >> 16 | in[4] << 16,
-                              in[2] >> 20 | in[3] << 12, in[1] >> 24 | in[2] << 8,
-                              in[0] >> 28 | in[1] << 4, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 13), SafeLoad(in + 12) >> 8 | SafeLoad(in + 13) << 24,
+                              SafeLoad(in + 11) >> 12 | SafeLoad(in + 12) << 20, SafeLoad(in + 10) >> 16 | SafeLoad(in + 11) << 16,
+                              SafeLoad(in + 9) >> 20 | SafeLoad(in + 10) << 12, SafeLoad(in + 8) >> 24 | SafeLoad(in + 9) << 8,
+                              SafeLoad(in + 7) >> 28 | SafeLoad(in + 8) << 4, SafeLoad(in + 7),
+                              SafeLoad(in + 6), SafeLoad(in + 5) >> 8 | SafeLoad(in + 6) << 24,
+                              SafeLoad(in + 4) >> 12 | SafeLoad(in + 5) << 20, SafeLoad(in + 3) >> 16 | SafeLoad(in + 4) << 16,
+                              SafeLoad(in + 2) >> 20 | SafeLoad(in + 3) << 12, SafeLoad(in + 1) >> 24 | SafeLoad(in + 2) << 8,
+                              SafeLoad(in + 0) >> 28 | SafeLoad(in + 1) << 4, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1309,14 +1339,14 @@ inline static const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 4, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[27], in[26] >> 8 | in[27] << 24,
-                              in[25] >> 12 | in[26] << 20, in[24] >> 16 | in[25] << 16,
-                              in[23] >> 20 | in[24] << 12, in[22] >> 24 | in[23] << 8,
-                              in[21] >> 28 | in[22] << 4, in[21],
-                              in[20], in[19] >> 8 | in[20] << 24,
-                              in[18] >> 12 | in[19] << 20, in[17] >> 16 | in[18] << 16,
-                              in[16] >> 20 | in[17] << 12, in[15] >> 24 | in[16] << 8,
-                              in[14] >> 28 | in[15] << 4, in[14]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 27), SafeLoad(in + 26) >> 8 | SafeLoad(in + 27) << 24,
+                              SafeLoad(in + 25) >> 12 | SafeLoad(in + 26) << 20, SafeLoad(in + 24) >> 16 | SafeLoad(in + 25) << 16,
+                              SafeLoad(in + 23) >> 20 | SafeLoad(in + 24) << 12, SafeLoad(in + 22) >> 24 | SafeLoad(in + 23) << 8,
+                              SafeLoad(in + 21) >> 28 | SafeLoad(in + 22) << 4, SafeLoad(in + 21),
+                              SafeLoad(in + 20), SafeLoad(in + 19) >> 8 | SafeLoad(in + 20) << 24,
+                              SafeLoad(in + 18) >> 12 | SafeLoad(in + 19) << 20, SafeLoad(in + 17) >> 16 | SafeLoad(in + 18) << 16,
+                              SafeLoad(in + 16) >> 20 | SafeLoad(in + 17) << 12, SafeLoad(in + 15) >> 24 | SafeLoad(in + 16) << 8,
+                              SafeLoad(in + 14) >> 28 | SafeLoad(in + 15) << 4, SafeLoad(in + 14));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1327,6 +1357,7 @@ inline static const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x1fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1338,14 +1369,14 @@ inline static const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 2, 0, 0,
                                 0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[13] >> 19 | in[14] << 13, in[12] >> 22 | in[13] << 10,
-                              in[11] >> 25 | in[12] << 7, in[10] >> 28 | in[11] << 4,
-                              in[9] >> 31 | in[10] << 1, in[9],
-                              in[8] >> 5 | in[9] << 27, in[7] >> 8 | in[8] << 24,
-                              in[6] >> 11 | in[7] << 21, in[5] >> 14 | in[6] << 18,
-                              in[4] >> 17 | in[5] << 15, in[3] >> 20 | in[4] << 12,
-                              in[2] >> 23 | in[3] << 9, in[1] >> 26 | in[2] << 6,
-                              in[0] >> 29 | in[1] << 3, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 13) >> 19 | SafeLoad(in + 14) << 13, SafeLoad(in + 12) >> 22 | SafeLoad(in + 13) << 10,
+                              SafeLoad(in + 11) >> 25 | SafeLoad(in + 12) << 7, SafeLoad(in + 10) >> 28 | SafeLoad(in + 11) << 4,
+                              SafeLoad(in + 9) >> 31 | SafeLoad(in + 10) << 1, SafeLoad(in + 9),
+                              SafeLoad(in + 8) >> 5 | SafeLoad(in + 9) << 27, SafeLoad(in + 7) >> 8 | SafeLoad(in + 8) << 24,
+                              SafeLoad(in + 6) >> 11 | SafeLoad(in + 7) << 21, SafeLoad(in + 5) >> 14 | SafeLoad(in + 6) << 18,
+                              SafeLoad(in + 4) >> 17 | SafeLoad(in + 5) << 15, SafeLoad(in + 3) >> 20 | SafeLoad(in + 4) << 12,
+                              SafeLoad(in + 2) >> 23 | SafeLoad(in + 3) << 9, SafeLoad(in + 1) >> 26 | SafeLoad(in + 2) << 6,
+                              SafeLoad(in + 0) >> 29 | SafeLoad(in + 1) << 3, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1355,14 +1386,14 @@ inline static const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 0, 1, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[28], in[27] >> 6 | in[28] << 26,
-                              in[26] >> 9 | in[27] << 23, in[25] >> 12 | in[26] << 20,
-                              in[24] >> 15 | in[25] << 17, in[23] >> 18 | in[24] << 14,
-                              in[22] >> 21 | in[23] << 11, in[21] >> 24 | in[22] << 8,
-                              in[20] >> 27 | in[21] << 5, in[19] >> 30 | in[20] << 2,
-                              in[19], in[18] >> 4 | in[19] << 28,
-                              in[17] >> 7 | in[18] << 25, in[16] >> 10 | in[17] << 22,
-                              in[15] >> 13 | in[16] << 19, in[14] >> 16 | in[15] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 28), SafeLoad(in + 27) >> 6 | SafeLoad(in + 28) << 26,
+                              SafeLoad(in + 26) >> 9 | SafeLoad(in + 27) << 23, SafeLoad(in + 25) >> 12 | SafeLoad(in + 26) << 20,
+                              SafeLoad(in + 24) >> 15 | SafeLoad(in + 25) << 17, SafeLoad(in + 23) >> 18 | SafeLoad(in + 24) << 14,
+                              SafeLoad(in + 22) >> 21 | SafeLoad(in + 23) << 11, SafeLoad(in + 21) >> 24 | SafeLoad(in + 22) << 8,
+                              SafeLoad(in + 20) >> 27 | SafeLoad(in + 21) << 5, SafeLoad(in + 19) >> 30 | SafeLoad(in + 20) << 2,
+                              SafeLoad(in + 19), SafeLoad(in + 18) >> 4 | SafeLoad(in + 19) << 28,
+                              SafeLoad(in + 17) >> 7 | SafeLoad(in + 18) << 25, SafeLoad(in + 16) >> 10 | SafeLoad(in + 17) << 22,
+                              SafeLoad(in + 15) >> 13 | SafeLoad(in + 16) << 19, SafeLoad(in + 14) >> 16 | SafeLoad(in + 15) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1373,6 +1404,7 @@ inline static const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x3fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1384,14 +1416,14 @@ inline static const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[14], in[13] >> 4 | in[14] << 28,
-                              in[12] >> 6 | in[13] << 26, in[11] >> 8 | in[12] << 24,
-                              in[10] >> 10 | in[11] << 22, in[9] >> 12 | in[10] << 20,
-                              in[8] >> 14 | in[9] << 18, in[7] >> 16 | in[8] << 16,
-                              in[6] >> 18 | in[7] << 14, in[5] >> 20 | in[6] << 12,
-                              in[4] >> 22 | in[5] << 10, in[3] >> 24 | in[4] << 8,
-                              in[2] >> 26 | in[3] << 6, in[1] >> 28 | in[2] << 4,
-                              in[0] >> 30 | in[1] << 2, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 14), SafeLoad(in + 13) >> 4 | SafeLoad(in + 14) << 28,
+                              SafeLoad(in + 12) >> 6 | SafeLoad(in + 13) << 26, SafeLoad(in + 11) >> 8 | SafeLoad(in + 12) << 24,
+                              SafeLoad(in + 10) >> 10 | SafeLoad(in + 11) << 22, SafeLoad(in + 9) >> 12 | SafeLoad(in + 10) << 20,
+                              SafeLoad(in + 8) >> 14 | SafeLoad(in + 9) << 18, SafeLoad(in + 7) >> 16 | SafeLoad(in + 8) << 16,
+                              SafeLoad(in + 6) >> 18 | SafeLoad(in + 7) << 14, SafeLoad(in + 5) >> 20 | SafeLoad(in + 6) << 12,
+                              SafeLoad(in + 4) >> 22 | SafeLoad(in + 5) << 10, SafeLoad(in + 3) >> 24 | SafeLoad(in + 4) << 8,
+                              SafeLoad(in + 2) >> 26 | SafeLoad(in + 3) << 6, SafeLoad(in + 1) >> 28 | SafeLoad(in + 2) << 4,
+                              SafeLoad(in + 0) >> 30 | SafeLoad(in + 1) << 2, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1401,14 +1433,14 @@ inline static const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[29], in[28] >> 4 | in[29] << 28,
-                              in[27] >> 6 | in[28] << 26, in[26] >> 8 | in[27] << 24,
-                              in[25] >> 10 | in[26] << 22, in[24] >> 12 | in[25] << 20,
-                              in[23] >> 14 | in[24] << 18, in[22] >> 16 | in[23] << 16,
-                              in[21] >> 18 | in[22] << 14, in[20] >> 20 | in[21] << 12,
-                              in[19] >> 22 | in[20] << 10, in[18] >> 24 | in[19] << 8,
-                              in[17] >> 26 | in[18] << 6, in[16] >> 28 | in[17] << 4,
-                              in[15] >> 30 | in[16] << 2, in[15]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 29), SafeLoad(in + 28) >> 4 | SafeLoad(in + 29) << 28,
+                              SafeLoad(in + 27) >> 6 | SafeLoad(in + 28) << 26, SafeLoad(in + 26) >> 8 | SafeLoad(in + 27) << 24,
+                              SafeLoad(in + 25) >> 10 | SafeLoad(in + 26) << 22, SafeLoad(in + 24) >> 12 | SafeLoad(in + 25) << 20,
+                              SafeLoad(in + 23) >> 14 | SafeLoad(in + 24) << 18, SafeLoad(in + 22) >> 16 | SafeLoad(in + 23) << 16,
+                              SafeLoad(in + 21) >> 18 | SafeLoad(in + 22) << 14, SafeLoad(in + 20) >> 20 | SafeLoad(in + 21) << 12,
+                              SafeLoad(in + 19) >> 22 | SafeLoad(in + 20) << 10, SafeLoad(in + 18) >> 24 | SafeLoad(in + 19) << 8,
+                              SafeLoad(in + 17) >> 26 | SafeLoad(in + 18) << 6, SafeLoad(in + 16) >> 28 | SafeLoad(in + 17) << 4,
+                              SafeLoad(in + 15) >> 30 | SafeLoad(in + 16) << 2, SafeLoad(in + 15));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1419,6 +1451,7 @@ inline static const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* o
 }
 
 inline static const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* out) {
+  using ::arrow::util::SafeLoad;
   uint32_t mask = 0x7fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1430,14 +1463,14 @@ inline static const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[14] >> 17 | in[15] << 15, in[13] >> 18 | in[14] << 14,
-                              in[12] >> 19 | in[13] << 13, in[11] >> 20 | in[12] << 12,
-                              in[10] >> 21 | in[11] << 11, in[9] >> 22 | in[10] << 10,
-                              in[8] >> 23 | in[9] << 9, in[7] >> 24 | in[8] << 8,
-                              in[6] >> 25 | in[7] << 7, in[5] >> 26 | in[6] << 6,
-                              in[4] >> 27 | in[5] << 5, in[3] >> 28 | in[4] << 4,
-                              in[2] >> 29 | in[3] << 3, in[1] >> 30 | in[2] << 2,
-                              in[0] >> 31 | in[1] << 1, in[0]);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 14) >> 17 | SafeLoad(in + 15) << 15, SafeLoad(in + 13) >> 18 | SafeLoad(in + 14) << 14,
+                              SafeLoad(in + 12) >> 19 | SafeLoad(in + 13) << 13, SafeLoad(in + 11) >> 20 | SafeLoad(in + 12) << 12,
+                              SafeLoad(in + 10) >> 21 | SafeLoad(in + 11) << 11, SafeLoad(in + 9) >> 22 | SafeLoad(in + 10) << 10,
+                              SafeLoad(in + 8) >> 23 | SafeLoad(in + 9) << 9, SafeLoad(in + 7) >> 24 | SafeLoad(in + 8) << 8,
+                              SafeLoad(in + 6) >> 25 | SafeLoad(in + 7) << 7, SafeLoad(in + 5) >> 26 | SafeLoad(in + 6) << 6,
+                              SafeLoad(in + 4) >> 27 | SafeLoad(in + 5) << 5, SafeLoad(in + 3) >> 28 | SafeLoad(in + 4) << 4,
+                              SafeLoad(in + 2) >> 29 | SafeLoad(in + 3) << 3, SafeLoad(in + 1) >> 30 | SafeLoad(in + 2) << 2,
+                              SafeLoad(in + 0) >> 31 | SafeLoad(in + 1) << 1, SafeLoad(in + 0));
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;
@@ -1447,14 +1480,14 @@ inline static const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* o
                                 0, 0, 0, 0,
                                 0, 0, 0, 0,
                                 0, 0, 0, 0);
-  reg_inls = _mm512_set_epi32(in[30], in[29] >> 2 | in[30] << 30,
-                              in[28] >> 3 | in[29] << 29, in[27] >> 4 | in[28] << 28,
-                              in[26] >> 5 | in[27] << 27, in[25] >> 6 | in[26] << 26,
-                              in[24] >> 7 | in[25] << 25, in[23] >> 8 | in[24] << 24,
-                              in[22] >> 9 | in[23] << 23, in[21] >> 10 | in[22] << 22,
-                              in[20] >> 11 | in[21] << 21, in[19] >> 12 | in[20] << 20,
-                              in[18] >> 13 | in[19] << 19, in[17] >> 14 | in[18] << 18,
-                              in[16] >> 15 | in[17] << 17, in[15] >> 16 | in[16] << 16);
+  reg_inls = _mm512_set_epi32(SafeLoad(in + 30), SafeLoad(in + 29) >> 2 | SafeLoad(in + 30) << 30,
+                              SafeLoad(in + 28) >> 3 | SafeLoad(in + 29) << 29, SafeLoad(in + 27) >> 4 | SafeLoad(in + 28) << 28,
+                              SafeLoad(in + 26) >> 5 | SafeLoad(in + 27) << 27, SafeLoad(in + 25) >> 6 | SafeLoad(in + 26) << 26,
+                              SafeLoad(in + 24) >> 7 | SafeLoad(in + 25) << 25, SafeLoad(in + 23) >> 8 | SafeLoad(in + 24) << 24,
+                              SafeLoad(in + 22) >> 9 | SafeLoad(in + 23) << 23, SafeLoad(in + 21) >> 10 | SafeLoad(in + 22) << 22,
+                              SafeLoad(in + 20) >> 11 | SafeLoad(in + 21) << 21, SafeLoad(in + 19) >> 12 | SafeLoad(in + 20) << 20,
+                              SafeLoad(in + 18) >> 13 | SafeLoad(in + 19) << 19, SafeLoad(in + 17) >> 14 | SafeLoad(in + 18) << 18,
+                              SafeLoad(in + 16) >> 15 | SafeLoad(in + 17) << 17, SafeLoad(in + 15) >> 16 | SafeLoad(in + 16) << 16);
   results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
   _mm512_storeu_si512(out, results);
   out += 16;


### PR DESCRIPTION
Found by the ubuntu-r-sanitizer job.