### PR TITLE
ARROW-12107: [Rust][DataFusion] Support `SELECT * from information_schema.columns`

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -245,11 +245,17 @@ This library currently supports many SQL constructs, including
 * `GROUP BY` together with one of the following aggregations: `MIN`, `MAX`, `COUNT`, `SUM`, `AVG`
 * `ORDER BY` together with an expression and optional `ASC` or `DESC` and also optional `NULLS FIRST` or `NULLS LAST`
 
+
 ## Supported Functions
 
 DataFusion strives to implement a subset of the [PostgreSQL SQL dialect](https://www.postgresql.org/docs/current/functions.html) where possible. We explicitly choose a single dialect to maximize interoperability with other tools and allow reuse of the PostgreSQL documents and tutorials as much as possible.
 
 Currently, only a subset of the PosgreSQL dialect is implemented, and we will document any deviations.
+
+## Information Schema
+
+DataFusion supports the `TABLES` and `COLUMNS` views of the ISO SQL `information_schema` schema to list tables and columns respectively. More information can be found in the [Postgres docs](https://www.postgresql.org/docs/13/infoschema-schema.html)).
+
 
 ## Supported Data Types
 

--- a/rust/datafusion/src/catalog/information_schema.rs
+++ b/rust/datafusion/src/catalog/information_schema.rs
@@ -22,7 +22,7 @@
 use std::{any, sync::Arc};
 
 use arrow::{
-    array::StringBuilder,
+    array::{StringBuilder, UInt64Builder},
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
@@ -36,6 +36,7 @@ use super::{
 
 const INFORMATION_SCHEMA: &str = "information_schema";
 const TABLES: &str = "tables";
+const COLUMNS: &str = "columns";
 
 /// Wraps another [`CatalogProvider`] and adds a "information_schema"
 /// schema that can introspect on tables in the catalog_list
@@ -91,43 +92,82 @@ struct InformationSchemaProvider {
     catalog_list: Arc<dyn CatalogList>,
 }
 
+impl InformationSchemaProvider {
+    /// Construct the `information_schema.tables` virtual table
+    fn make_tables(&self) -> Arc<dyn TableProvider> {
+        // create a mem table with the names of tables
+        let mut builder = InformationSchemaTablesBuilder::new();
+
+        for catalog_name in self.catalog_list.catalog_names() {
+            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+
+            for schema_name in catalog.schema_names() {
+                if schema_name != INFORMATION_SCHEMA {
+                    let schema = catalog.schema(&schema_name).unwrap();
+                    for table_name in schema.table_names() {
+                        builder.add_base_table(&catalog_name, &schema_name, table_name)
+                    }
+                }
+            }
+
+            // Add a final list for the information schema tables themselves
+            builder.add_system_table(&catalog_name, INFORMATION_SCHEMA, TABLES);
+            builder.add_system_table(&catalog_name, INFORMATION_SCHEMA, COLUMNS);
+        }
+
+        let mem_table = builder.build();
+
+        Arc::new(mem_table)
+    }
+
+    /// Construct the `information_schema.columns` virtual table
+    fn make_columns(&self) -> Arc<dyn TableProvider> {
+        let mut builder = InformationSchemaColumnsBuilder::new();
+
+        for catalog_name in self.catalog_list.catalog_names() {
+            let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
+
+            for schema_name in catalog.schema_names() {
+                if schema_name != INFORMATION_SCHEMA {
+                    let schema = catalog.schema(&schema_name).unwrap();
+                    for table_name in schema.table_names() {
+                        let table = schema.table(&table_name).unwrap();
+                        for (i, field) in table.schema().fields().iter().enumerate() {
+                            builder.add_column(
+                                &catalog_name,
+                                &schema_name,
+                                &table_name,
+                                field.name(),
+                                i,
+                                field.is_nullable(),
+                                field.data_type(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        let mem_table = builder.build();
+
+        Arc::new(mem_table)
+    }
+}
+
 impl SchemaProvider for InformationSchemaProvider {
     fn as_any(&self) -> &(dyn any::Any + 'static) {
         self
     }
 
     fn table_names(&self) -> Vec<String> {
-        vec![TABLES.to_string()]
+        vec![TABLES.to_string(), COLUMNS.to_string()]
     }
 
     fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
         if name.eq_ignore_ascii_case("tables") {
-            // create a mem table with the names of tables
-            let mut builder = InformationSchemaTablesBuilder::new();
-
-            for catalog_name in self.catalog_list.catalog_names() {
-                let catalog = self.catalog_list.catalog(&catalog_name).unwrap();
-
-                for schema_name in catalog.schema_names() {
-                    if schema_name != INFORMATION_SCHEMA {
-                        let schema = catalog.schema(&schema_name).unwrap();
-                        for table_name in schema.table_names() {
-                            builder.add_base_table(
-                                &catalog_name,
-                                &schema_name,
-                                table_name,
-                            )
-                        }
-                    }
-                }
-
-                // Add a final list for the information schema tables themselves
-                builder.add_system_table(&catalog_name, INFORMATION_SCHEMA, TABLES);
-            }
-
-            let mem_table = builder.build();
-
-            Some(Arc::new(mem_table))
+            Some(self.make_tables())
+        } else if name.eq_ignore_ascii_case("columns") {
+            Some(self.make_columns())
         } else {
             None
         }
@@ -135,7 +175,8 @@ impl SchemaProvider for InformationSchemaProvider {
 }
 
 /// Builds the `information_schema.TABLE` table row by row
-
+///
+/// Columns are based on https://www.postgresql.org/docs/current/infoschema-columns.html
 struct InformationSchemaTablesBuilder {
     catalog_names: StringBuilder,
     schema_names: StringBuilder,
@@ -214,6 +255,229 @@ impl InformationSchemaTablesBuilder {
                 Arc::new(schema_names.finish()),
                 Arc::new(table_names.finish()),
                 Arc::new(table_types.finish()),
+            ],
+        )
+        .unwrap();
+
+        MemTable::try_new(schema, vec![vec![batch]]).unwrap()
+    }
+}
+
+/// Builds the `information_schema.COLUMNS` table row by row
+///
+/// Columns are based on https://www.postgresql.org/docs/current/infoschema-columns.html
+struct InformationSchemaColumnsBuilder {
+    catalog_names: StringBuilder,
+    schema_names: StringBuilder,
+    table_names: StringBuilder,
+    column_names: StringBuilder,
+    ordinal_positions: UInt64Builder,
+    column_defaults: StringBuilder,
+    is_nullables: StringBuilder,
+    data_types: StringBuilder,
+    character_maximum_lengths: UInt64Builder,
+    character_octet_lengths: UInt64Builder,
+    numeric_precisions: UInt64Builder,
+    numeric_precision_radixes: UInt64Builder,
+    numeric_scales: UInt64Builder,
+    datetime_precisions: UInt64Builder,
+    interval_types: StringBuilder,
+}
+
+impl InformationSchemaColumnsBuilder {
+    fn new() -> Self {
+        // StringBuilder requires providing an initial capacity, so
+        // pick 10 here arbitrarily as this is not performance
+        // critical code and the number of tables is unavailable here.
+        let default_capacity = 10;
+        Self {
+            catalog_names: StringBuilder::new(default_capacity),
+            schema_names: StringBuilder::new(default_capacity),
+            table_names: StringBuilder::new(default_capacity),
+            column_names: StringBuilder::new(default_capacity),
+            ordinal_positions: UInt64Builder::new(default_capacity),
+            column_defaults: StringBuilder::new(default_capacity),
+            is_nullables: StringBuilder::new(default_capacity),
+            data_types: StringBuilder::new(default_capacity),
+            character_maximum_lengths: UInt64Builder::new(default_capacity),
+            character_octet_lengths: UInt64Builder::new(default_capacity),
+            numeric_precisions: UInt64Builder::new(default_capacity),
+            numeric_precision_radixes: UInt64Builder::new(default_capacity),
+            numeric_scales: UInt64Builder::new(default_capacity),
+            datetime_precisions: UInt64Builder::new(default_capacity),
+            interval_types: StringBuilder::new(default_capacity),
+        }
+    }
+
+    fn add_column(
+        &mut self,
+        catalog_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+        table_name: impl AsRef<str>,
+        column_name: impl AsRef<str>,
+        column_position: usize,
+        is_nullable: bool,
+        data_type: &DataType,
+    ) {
+        use DataType::*;
+
+        // Note: append_value is actually infallable.
+        self.catalog_names
+            .append_value(catalog_name.as_ref())
+            .unwrap();
+        self.schema_names
+            .append_value(schema_name.as_ref())
+            .unwrap();
+        self.table_names.append_value(table_name.as_ref()).unwrap();
+
+        self.column_names
+            .append_value(column_name.as_ref())
+            .unwrap();
+
+        self.ordinal_positions
+            .append_value(column_position as u64)
+            .unwrap();
+
+        // DataFusion does not support column default values, so null
+        self.column_defaults.append_null().unwrap();
+
+        // "YES if the column is possibly nullable, NO if it is known not nullable. "
+        let nullable_str = if is_nullable { "YES" } else { "NO" };
+        self.is_nullables.append_value(nullable_str).unwrap();
+
+        // "System supplied type" --> Use debug format of the datatype
+        self.data_types
+            .append_value(format!("{:?}", data_type))
+            .unwrap();
+
+        // "If data_type identifies a character or bit string type, the
+        // declared maximum length; null for all other data types or
+        // if no maximum length was declared."
+        //
+        // Arrow has no equivalent of VARCHAR(20), so we leave this as Null
+        let max_chars = None;
+        self.character_maximum_lengths
+            .append_option(max_chars)
+            .unwrap();
+
+        // "Maximum length, in bytes, for binary data, character data,
+        // or text and image data."
+        let char_len: Option<u64> = match data_type {
+            Utf8 | Binary => Some(i32::MAX as u64),
+            LargeBinary | LargeUtf8 => Some(i64::MAX as u64),
+            _ => None,
+        };
+        self.character_octet_lengths
+            .append_option(char_len)
+            .unwrap();
+
+        // numeric_precision: "If data_type identifies a numeric type, this column
+        // contains the (declared or implicit) precision of the type
+        // for this column. The precision indicates the number of
+        // significant digits. It can be expressed in decimal (base
+        // 10) or binary (base 2) terms, as specified in the column
+        // numeric_precision_radix. For all other data types, this
+        // column is null."
+        //
+        // numeric_radix: If data_type identifies a numeric type, this
+        // column indicates in which base the values in the columns
+        // numeric_precision and numeric_scale are expressed. The
+        // value is either 2 or 10. For all other data types, this
+        // column is null.
+        //
+        // numeric_scale: If data_type identifies an exact numeric
+        // type, this column contains the (declared or implicit) scale
+        // of the type for this column. The scale indicates the number
+        // of significant digits to the right of the decimal point. It
+        // can be expressed in decimal (base 10) or binary (base 2)
+        // terms, as specified in the column
+        // numeric_precision_radix. For all other data types, this
+        // column is null.
+        let (numeric_precision, numeric_radix, numeric_scale) = match data_type {
+            Int8 | UInt8 => (Some(8), Some(2), None),
+            Int16 | UInt16 => (Some(16), Some(2), None),
+            Int32 | UInt32 => (Some(32), Some(2), None),
+            // From max value of 65504 as explained on
+            // https://en.wikipedia.org/wiki/Half-precision_floating-point_format#Exponent_encoding
+            Float16 => (Some(15), Some(2), None),
+            // Numbers from postgres `real` type
+            Float32 => (Some(24), Some(2), None),
+            // Numbers from postgres `double` type
+            Float64 => (Some(24), Some(2), None),
+            Decimal(precision, scale) => {
+                (Some(*precision as u64), Some(10), Some(*scale as u64))
+            }
+            _ => (None, None, None),
+        };
+
+        self.numeric_precisions
+            .append_option(numeric_precision)
+            .unwrap();
+        self.numeric_precision_radixes
+            .append_option(numeric_radix)
+            .unwrap();
+        self.numeric_scales.append_option(numeric_scale).unwrap();
+
+        self.datetime_precisions.append_option(None).unwrap();
+        self.interval_types.append_null().unwrap();
+    }
+
+    fn build(self) -> MemTable {
+        let schema = Schema::new(vec![
+            Field::new("table_catalog", DataType::Utf8, false),
+            Field::new("table_schema", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("column_name", DataType::Utf8, false),
+            Field::new("ordinal_position", DataType::UInt64, false),
+            Field::new("column_default", DataType::Utf8, false),
+            Field::new("is_nullable", DataType::Utf8, false),
+            Field::new("data_type", DataType::Utf8, false),
+            Field::new("character_maximum_length", DataType::UInt64, false),
+            Field::new("character_octet_length", DataType::UInt64, false),
+            Field::new("numeric_precision", DataType::UInt64, false),
+            Field::new("numeric_precision_radix", DataType::UInt64, false),
+            Field::new("numeric_scale", DataType::UInt64, false),
+            Field::new("datetime_precision", DataType::UInt64, false),
+            Field::new("interval_type", DataType::Utf8, false),
+        ]);
+
+        let Self {
+            mut catalog_names,
+            mut schema_names,
+            mut table_names,
+            mut column_names,
+            mut ordinal_positions,
+            mut column_defaults,
+            mut is_nullables,
+            mut data_types,
+            mut character_maximum_lengths,
+            mut character_octet_lengths,
+            mut numeric_precisions,
+            mut numeric_precision_radixes,
+            mut numeric_scales,
+            mut datetime_precisions,
+            mut interval_types,
+        } = self;
+
+        let schema = Arc::new(schema);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(catalog_names.finish()),
+                Arc::new(schema_names.finish()),
+                Arc::new(table_names.finish()),
+                Arc::new(column_names.finish()),
+                Arc::new(ordinal_positions.finish()),
+                Arc::new(column_defaults.finish()),
+                Arc::new(is_nullables.finish()),
+                Arc::new(data_types.finish()),
+                Arc::new(character_maximum_lengths.finish()),
+                Arc::new(character_octet_lengths.finish()),
+                Arc::new(numeric_precisions.finish()),
+                Arc::new(numeric_precision_radixes.finish()),
+                Arc::new(numeric_scales.finish()),
+                Arc::new(datetime_precisions.finish()),
+                Arc::new(interval_types.finish()),
             ],
         )
         .unwrap();

--- a/rust/datafusion/src/catalog/information_schema.rs
+++ b/rust/datafusion/src/catalog/information_schema.rs
@@ -309,6 +309,7 @@ impl InformationSchemaColumnsBuilder {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_column(
         &mut self,
         catalog_name: impl AsRef<str>,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -2241,6 +2241,7 @@ mod tests {
             "+---------------+--------------------+------------+------------+",
             "| table_catalog | table_schema       | table_name | table_type |",
             "+---------------+--------------------+------------+------------+",
+            "| datafusion    | information_schema | columns    | VIEW       |",
             "| datafusion    | information_schema | tables     | VIEW       |",
             "| datafusion    | public             | t          | BASE TABLE |",
             "+---------------+--------------------+------------+------------+",

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -795,7 +795,9 @@ mod tests {
         physical_plan::expressions::AvgAccumulator,
     };
     use arrow::array::{
-        Array, ArrayRef, DictionaryArray, Float64Array, Int32Array, Int64Array,
+        Array, ArrayRef, BinaryArray, DictionaryArray, Float64Array, Int32Array,
+        Int64Array, LargeBinaryArray, LargeStringArray, StringArray,
+        TimestampNanosecondArray,
     };
     use arrow::compute::add;
     use arrow::datatypes::*;
@@ -2108,10 +2110,11 @@ mod tests {
             "+---------------+--------------------+------------+------------+",
             "| table_catalog | table_schema       | table_name | table_type |",
             "+---------------+--------------------+------------+------------+",
+            "| datafusion    | information_schema | columns    | VIEW       |",
             "| datafusion    | information_schema | tables     | VIEW       |",
             "+---------------+--------------------+------------+------------+",
         ];
-        assert_batches_eq!(expected, &result);
+        assert_batches_sorted_eq!(expected, &result);
     }
 
     #[tokio::test]
@@ -2134,6 +2137,7 @@ mod tests {
             "| table_catalog | table_schema       | table_name | table_type |",
             "+---------------+--------------------+------------+------------+",
             "| datafusion    | information_schema | tables     | VIEW       |",
+            "| datafusion    | information_schema | columns    | VIEW       |",
             "| datafusion    | public             | t          | BASE TABLE |",
             "+---------------+--------------------+------------+------------+",
         ];
@@ -2152,6 +2156,7 @@ mod tests {
             "+---------------+--------------------+------------+------------+",
             "| table_catalog | table_schema       | table_name | table_type |",
             "+---------------+--------------------+------------+------------+",
+            "| datafusion    | information_schema | columns    | VIEW       |",
             "| datafusion    | information_schema | tables     | VIEW       |",
             "| datafusion    | public             | t          | BASE TABLE |",
             "| datafusion    | public             | t2         | BASE TABLE |",
@@ -2193,10 +2198,13 @@ mod tests {
             "+------------------+--------------------+------------+------------+",
             "| table_catalog    | table_schema       | table_name | table_type |",
             "+------------------+--------------------+------------+------------+",
+            "| datafusion       | information_schema | columns    | VIEW       |",
             "| datafusion       | information_schema | tables     | VIEW       |",
+            "| my_catalog       | information_schema | columns    | VIEW       |",
             "| my_catalog       | information_schema | tables     | VIEW       |",
             "| my_catalog       | my_schema          | t1         | BASE TABLE |",
             "| my_catalog       | my_schema          | t2         | BASE TABLE |",
+            "| my_other_catalog | information_schema | columns    | VIEW       |",
             "| my_other_catalog | information_schema | tables     | VIEW       |",
             "| my_other_catalog | my_other_schema    | t3         | BASE TABLE |",
             "+------------------+--------------------+------------+------------+",
@@ -2253,6 +2261,94 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "This feature is not implemented: SHOW SOMETHING_UNKNOWN not implemented. Supported syntax: SHOW <TABLES>");
+    }
+
+    #[tokio::test]
+    async fn information_schema_columns_not_exist_by_default() {
+        let mut ctx = ExecutionContext::new();
+
+        let err = plan_and_collect(&mut ctx, "SELECT * from information_schema.columns")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Error during planning: Table or CTE with name 'information_schema.columns' not found"
+        );
+    }
+
+    fn table_with_many_types() -> Arc<dyn TableProvider> {
+        let schema = Schema::new(vec![
+            Field::new("int32_col", DataType::Int32, false),
+            Field::new("float64_col", DataType::Float64, true),
+            Field::new("utf8_col", DataType::Utf8, true),
+            Field::new("large_utf8_col", DataType::LargeUtf8, false),
+            Field::new("binary_col", DataType::Binary, false),
+            Field::new("large_binary_col", DataType::LargeBinary, false),
+            Field::new(
+                "timestamp_nanos",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(Float64Array::from(vec![1.0])),
+                Arc::new(StringArray::from(vec![Some("foo")])),
+                Arc::new(LargeStringArray::from(vec![Some("bar")])),
+                Arc::new(BinaryArray::from(vec![b"foo" as &[u8]])),
+                Arc::new(LargeBinaryArray::from(vec![b"foo" as &[u8]])),
+                Arc::new(TimestampNanosecondArray::from_opt_vec(
+                    vec![Some(123)],
+                    None,
+                )),
+            ],
+        )
+        .unwrap();
+        let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]]).unwrap();
+        Arc::new(provider)
+    }
+
+    #[tokio::test]
+    async fn information_schema_columns() {
+        let mut ctx = ExecutionContext::with_config(
+            ExecutionConfig::new().with_information_schema(true),
+        );
+        let catalog = MemoryCatalogProvider::new();
+        let schema = MemorySchemaProvider::new();
+
+        schema
+            .register_table("t1".to_owned(), table_with_sequence(1, 1).unwrap())
+            .unwrap();
+
+        schema
+            .register_table("t2".to_owned(), table_with_many_types())
+            .unwrap();
+        catalog.register_schema("my_schema", Arc::new(schema));
+        ctx.register_catalog("my_catalog", Arc::new(catalog));
+
+        let result =
+            plan_and_collect(&mut ctx, "SELECT * from information_schema.columns")
+                .await
+                .unwrap();
+
+        let expected = vec![
+    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+    "| table_catalog | table_schema | table_name | column_name      | ordinal_position | column_default | is_nullable | data_type                   | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
+    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+    "| my_catalog    | my_schema    | t1         | i                | 0                |                | YES         | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | binary_col       | 4                |                | NO          | Binary                      |                          | 2147483647             |                   |                         |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | float64_col      | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | int32_col        | 0                |                | NO          | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | large_binary_col | 5                |                | NO          | LargeBinary                 |                          | 9223372036854775807    |                   |                         |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | large_utf8_col   | 3                |                | NO          | LargeUtf8                   |                          | 9223372036854775807    |                   |                         |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | timestamp_nanos  | 6                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+    "| my_catalog    | my_schema    | t2         | utf8_col         | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+        ];
+        assert_batches_sorted_eq!(expected, &result);
     }
 
     #[tokio::test]

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2149,7 +2149,7 @@ async fn group_by_timestamp_millis() -> Result<()> {
         ],
     )?;
     let t1_table = MemTable::try_new(schema, vec![vec![data]])?;
-    ctx.register_table("t1", Arc::new(t1_table));
+    ctx.register_table("t1", Arc::new(t1_table)).unwrap();
 
     let sql =
         "SELECT timestamp, SUM(count) FROM t1 GROUP BY timestamp ORDER BY timestamp ASC";

--- a/rust/parquet/benches/arrow_writer.rs
+++ b/rust/parquet/benches/arrow_writer.rs
@@ -143,7 +143,8 @@ fn write_batch(batch: &RecordBatch) -> Result<()> {
     let mut writer = ArrowWriter::try_new(cursor, batch.schema(), None)?;
 
     writer.write(&batch)?;
-    writer.close()
+    writer.close()?;
+    Ok(())
 }
 
 fn bench_primitive_writer(c: &mut Criterion) {


### PR DESCRIPTION
Builds on the code in #9818 

# Rationale

Provide schema metadata access (so a user can see what columns exist and their type).

See the doc for background: https://docs.google.com/document/d/12cpZUSNPqVH9Z0BBx6O8REu7TFqL-NPPAYCUPpDls1k/edit#

I plan to add support for `SHOW COLUMNS` possibly as a follow on PR (though I have found out that `SHOW COLUMNS` and `SHOW TABLES` are not supported by either MySQL or by Postgres 🤔 )

# Changes
I chose to add the first 15 columns from `information_schema.columns` You can see the full list in Postgres [here](https://www.postgresql.org/docs/9.5/infoschema-columns.html) and SQL Server [here](https://docs.microsoft.com/en-us/sql/relational-databases/system-information-schema-views/columns-transact-sql?view=sql-server-ver15). 

There are a bunch more columns that say "Applies to features not available in PostgreSQL" and that don't apply to DataFusion either-- since my usecase is to get the basic schema information out I chose not to add a bunch of columns that are always null at this time.

I feel the use of column builders here is somewhat awkward (as it requires many calls to `unwrap`). I am thinking of a follow on PR to refactor this code to use `Vec<String>` and `Vec<u64>` and then create `StringArray` and `UInt64Array` directly from them but for now I just want the functionality


# Example use

Setup:
```
echo "1,Foo,44.9" > /tmp/table.csv
echo "2,Bar,22.1" >> /tmp/table.csv
cargo run --bin datafusion-cli
```


Then run :

```
> CREATE EXTERNAL TABLE t(a int, b varchar, c float)
STORED AS CSV
LOCATION '/tmp/table.csv';
0 rows in set. Query took 0 seconds.

>   select table_name, column_name, ordinal_position, is_nullable, data_type from information_schema.columns;
+------------+-------------+------------------+-------------+-----------+
| table_name | column_name | ordinal_position | is_nullable | data_type |
+------------+-------------+------------------+-------------+-----------+
| t          | a           | 0                | NO          | Int32     |
| t          | b           | 1                | NO          | Utf8      |
| t          | c           | 2                | NO          | Float32   |
+------------+-------------+------------------+-------------+-----------+
3 row in set. Query took 0 seconds.
```



