### PR TITLE
ARROW-12146: [C++][Gandiva] Implement CONVERT_FROM(expression, replacement char) function

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -204,7 +204,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_fromUTF8", {"convert_fromutf8"},
+      NativeFunction("convert_replaceUTF8", {"convert_replaceutf8"},
                      DataTypeVector{binary(), utf8()}, utf8(), kResultNullIfNull,
                      "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -204,8 +204,9 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary(), utf8()},
-                     utf8(), kResultNullIfNull, "convert_replace_invalid_fromUTF8_binary",
+      NativeFunction("convert_fromUTF8", {"convert_fromutf8"},
+                     DataTypeVector{binary(), utf8()}, utf8(), kResultNullIfNull,
+                     "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -204,6 +204,10 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary(), utf8()},
+                     utf8(), kResultNullIfNull, "convert_replace_invalid_fromUTF8_binary",
+                     NativeFunction::kNeedsContext),
+
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},
                      int32(), kResultNullIfNull, "locate_utf8_utf8_int32",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1250,6 +1250,7 @@ FORCE_INLINE
 const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context, const char* text_in,
                                                     gdv_int32 text_len,
                                                     const char* char_to_replace,
+                                                    gdv_int32 /*char_to_replace_len*/,
                                                     gdv_int32* out_len) {
   *out_len = text_len;
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1249,7 +1249,12 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 FORCE_INLINE
 const char* convert_replace_invalid_fromUTF8_binary(
     gdv_int64 context, const char* text_in, gdv_int32 text_len,
-    const char* char_to_replace, gdv_int32 /*char_to_replace_len*/, gdv_int32* out_len) {
+    const char* char_to_replace, gdv_int32 char_to_replace_len, gdv_int32* out_len) {
+  if (char_to_replace_len > 1) {
+    gdv_fn_context_set_error_msg(context, "Replacement of multiple bytes not supported");
+    *out_len = 0;
+    return "";
+  }
   // actually the convert_replace function replaces the invalid bytes with a single byte
   // so the output length will be the same as the input length
   *out_len = text_len;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1258,9 +1258,11 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 }
 
 FORCE_INLINE
-const char* convert_replace_invalid_fromUTF8_binary(
-    int64_t context, const char* text_in, int32_t text_len,
-    const char* char_to_replace, int32_t char_to_replace_len, int32_t* out_len) {
+const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char* text_in,
+                                                    int32_t text_len,
+                                                    const char* char_to_replace,
+                                                    int32_t char_to_replace_len,
+                                                    int32_t* out_len) {
   if (char_to_replace_len > 1) {
     gdv_fn_context_set_error_msg(context, "Replacement of multiple bytes not supported");
     *out_len = 0;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1249,8 +1249,10 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 FORCE_INLINE
 const char* convert_replace_invalid_fromUTF8_binary(
     gdv_int64 context, const char* text_in, gdv_int32 text_len,
-    const char* char_to_replace, gdv_int32 char_to_replace_len, gdv_int32* out_len) {
-  *out_len = text_len * char_to_replace_len;
+    const char* char_to_replace, gdv_int32 /*char_to_replace_len*/, gdv_int32* out_len) {
+  // actually the convert_replace function replaces the invalid bytes with a single byte
+  // so the output length will be the same as the input length
+  *out_len = text_len;
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
@@ -1264,8 +1266,8 @@ const char* convert_replace_invalid_fromUTF8_binary(
   for (int text_index = 0; text_index < text_len; text_index += char_len) {
     char_len = utf8_char_length(text_in[text_index]);
     if (char_len == 0 || text_index + char_len > text_len) {
-      memcpy(ret + out_byte_counter, char_to_replace, char_to_replace_len);
-      out_byte_counter += char_to_replace_len;
+      memcpy(ret + out_byte_counter, char_to_replace, 1);
+      out_byte_counter += 1;
       // define char_len = 1 to increase text_index by 1 (as ASCII char fits in 1 byte)
       char_len = 1;
     } else {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1271,8 +1271,8 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
     *out_len = 0;
     return "";
   }
-  // actually the convert_replace function replaces the invalid bytes with a single byte
-  // so the output length will be the same as the input length
+  // actually the convert_replace function replaces invalid chars with an ASCII
+  // character so the output length will be the same as the input length
   *out_len = text_len;
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
@@ -1294,7 +1294,7 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
       char_len = 1;
       // first copy the valid bytes until now and then replace the invalid character
       memcpy(ret + out_byte_counter, text_in + out_byte_counter, valid_bytes_to_cpy);
-      memcpy(ret + out_byte_counter + valid_bytes_to_cpy, char_to_replace, char_len);
+      ret[out_byte_counter + valid_bytes_to_cpy] = char_to_replace[0];
       out_byte_counter += valid_bytes_to_cpy + char_len;
       valid_bytes_to_cpy = 0;
       continue;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1247,7 +1247,8 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 }
 
 FORCE_INLINE
-const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context, const char* text_in,
+const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context,
+                                                    const char* text_in,
                                                     gdv_int32 text_len,
                                                     const char* char_to_replace,
                                                     gdv_int32 /*char_to_replace_len*/,

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1263,7 +1263,10 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
                                                     const char* char_to_replace,
                                                     int32_t char_to_replace_len,
                                                     int32_t* out_len) {
-  if (char_to_replace_len > 1) {
+  if (char_to_replace_len == 0) {
+    *out_len = text_len;
+    return text_in;
+  } else if (char_to_replace_len != 1) {
     gdv_fn_context_set_error_msg(context, "Replacement of multiple bytes not supported");
     *out_len = 0;
     return "";

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1301,6 +1301,8 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
     }
     valid_bytes_to_cpy += char_len;
   }
+  // if invalid chars were not found, return the original string
+  if (out_byte_counter == 0) return text_in;
   // if there are still valid bytes to copy, do it
   if (valid_bytes_to_cpy != 0) {
     memcpy(ret + out_byte_counter, text_in + out_byte_counter, valid_bytes_to_cpy);

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1247,12 +1247,9 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 }
 
 FORCE_INLINE
-const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context,
-                                                    const char* text_in,
-                                                    gdv_int32 text_len,
-                                                    const char* char_to_replace,
-                                                    gdv_int32 /*char_to_replace_len*/,
-                                                    gdv_int32* out_len) {
+const char* convert_replace_invalid_fromUTF8_binary(
+    gdv_int64 context, const char* text_in, gdv_int32 text_len,
+    const char* char_to_replace, gdv_int32 /*char_to_replace_len*/, gdv_int32* out_len) {
   *out_len = text_len;
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -146,7 +146,7 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   EXPECT_EQ(std::string(c_str, c.length()), "all-valid");
   EXPECT_FALSE(ctx.has_error());
 
- ctx.Reset();
+  ctx.Reset();
 }
 
 TEST(TestStringOps, TestCastBoolToVarchar) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -143,14 +143,23 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   const char* c_str = convert_replace_invalid_fromUTF8_binary(
       ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
   EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
+  EXPECT_FALSE(ctx.has_error());
 
   // valid utf8 (महसुस is a 4-byte utf-8 char)
-  std::string e("ok-महसुस-valid-new");
+  std::string d("ok-महसुस-valid-new");
+  auto d_in_out_len = static_cast<int>(d.length());
+  const char* d_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, d.data(), d_in_out_len, "d", 1, &d_in_out_len);
+  EXPECT_EQ(std::string(d_str, d_in_out_len), "ok-महसुस-valid-new");
+  EXPECT_FALSE(ctx.has_error());
+
+  // full valid utf8, but invalid replacement char length
+  std::string e("all-valid");
   auto e_in_out_len = static_cast<int>(e.length());
   const char* e_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, e.data(),e_in_out_len, "bk", 2, &e_in_out_len);
-  EXPECT_EQ(std::string(e_str, e_in_out_len), "ok-महसुस-valid-new");
-  EXPECT_FALSE(ctx.has_error());
+      ctx_ptr, e.data(), e_in_out_len, "ee", 2, &e_in_out_len);
+  EXPECT_EQ(std::string(e_str, e_in_out_len), "");
+  EXPECT_TRUE(ctx.has_error());
 
   ctx.Reset();
 }

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -123,26 +123,26 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   std::string a(
       "ok-\xf8\x28"
       "-a");
-  gdv_int32 a_in_out_len = a.length();
+  auto a_in_out_len = static_cast<int>(a.length());
   const char* a_str = convert_replace_invalid_fromUTF8_binary(
       ctx_ptr, a.data(), a_in_out_len, "a", 1, &a_in_out_len);
-  EXPECT_EQ(std::string(a_str, a.length()), "ok-a(-a");
+  EXPECT_EQ(std::string(a_str, a_in_out_len), "ok-a(-a");
   EXPECT_FALSE(ctx.has_error());
 
   // invalid utf8 (xa0 and xa1 are invalid)
   std::string b("ok-\xa0\xa1-valid");
-  gdv_int32 b_in_out_len = b.length();
+  auto b_in_out_len = static_cast<int>(b.length());
   const char* b_str = convert_replace_invalid_fromUTF8_binary(
       ctx_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
-  EXPECT_EQ(std::string(b_str, b.length()), "ok-bb-valid");
+  EXPECT_EQ(std::string(b_str, b_in_out_len), "ok-bb-valid");
   EXPECT_FALSE(ctx.has_error());
 
   // full valid utf8
   std::string c("all-valid");
-  gdv_int32 c_in_out_len = c.length();
+  auto c_in_out_len = static_cast<int>(c.length());
   const char* c_str = convert_replace_invalid_fromUTF8_binary(
       ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
-  EXPECT_EQ(std::string(c_str, c.length()), "all-valid");
+  EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
   EXPECT_FALSE(ctx.has_error());
 
   ctx.Reset();

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -120,29 +120,28 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
 
   // invalid utf8 (xf8 is invalid but x28 is not - x28 = '(')
-  std::string a("ok-\xf8\x28""-a");
+  std::string a(
+      "ok-\xf8\x28"
+      "-a");
   gdv_int32 a_in_out_len = a.length();
-  const char* a_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, a.data(),
-                                                              a_in_out_len, "a", 1,
-                                                              &a_in_out_len);
+  const char* a_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, a.data(), a_in_out_len, "a", 1, &a_in_out_len);
   EXPECT_EQ(std::string(a_str, a.length()), "ok-a(-a");
   EXPECT_FALSE(ctx.has_error());
 
   // invalid utf8 (xa0 and xa1 are invalid)
   std::string b("ok-\xa0\xa1-valid");
   gdv_int32 b_in_out_len = b.length();
-  const char* b_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, b.data(),
-                                                              b_in_out_len, "b", 1,
-                                                              &b_in_out_len);
+  const char* b_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
   EXPECT_EQ(std::string(b_str, b.length()), "ok-bb-valid");
   EXPECT_FALSE(ctx.has_error());
 
   // full valid utf8
   std::string c("all-valid");
   gdv_int32 c_in_out_len = c.length();
-  const char* c_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, c.data(),
-                                                              c_in_out_len, "c", 1,
-                                                              &c_in_out_len);
+  const char* c_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
   EXPECT_EQ(std::string(c_str, c.length()), "all-valid");
   EXPECT_FALSE(ctx.has_error());
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -160,6 +160,15 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
       ctx_ptr, e.data(), e_in_out_len, "ee", 2, &e_in_out_len);
   EXPECT_EQ(std::string(e_str, e_in_out_len), "");
   EXPECT_TRUE(ctx.has_error());
+  ctx.Reset();
+
+  // full valid utf8, but invalid replacement char length
+  std::string f("ok-\xa0\xa1-valid");
+  auto f_in_out_len = static_cast<int>(f.length());
+  const char* f_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, f.data(), f_in_out_len, "", 0, &f_in_out_len);
+  EXPECT_EQ(std::string(f_str, f_in_out_len), "ok-\xa0\xa1-valid");
+  EXPECT_FALSE(ctx.has_error());
 
   ctx.Reset();
 }

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -129,6 +129,21 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   EXPECT_EQ(std::string(a_str, a_in_out_len), "ok-a(-a");
   EXPECT_FALSE(ctx.has_error());
 
+  // invalid utf8 (xa0 and xa1 are invalid)
+  std::string b("ok-\xa0\xa1-valid");
+  auto b_in_out_len = static_cast<int>(b.length());
+  const char* b_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
+  EXPECT_EQ(std::string(b_str, b_in_out_len), "ok-bb-valid");
+  EXPECT_FALSE(ctx.has_error());
+
+  // full valid utf8
+  std::string c("all-valid");
+  auto c_in_out_len = static_cast<int>(c.length());
+  const char* c_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
+  EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
+
   // valid utf8 (महसुस is a 4-byte utf-8 char)
   std::string e("ok-महसुस-valid-new");
   auto e_in_out_len = static_cast<int>(e.length());

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -145,7 +145,7 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
   EXPECT_FALSE(ctx.has_error());
 
-  // valid utf8 (महसुस is a 4-byte utf-8 char)
+  // valid utf8 (महसुस is 4-char string, each char of which is likely a multibyte char)
   std::string d("ok-महसुस-valid-new");
   auto d_in_out_len = static_cast<int>(d.length());
   const char* d_str = convert_replace_invalid_fromUTF8_binary(

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -129,20 +129,12 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   EXPECT_EQ(std::string(a_str, a_in_out_len), "ok-a(-a");
   EXPECT_FALSE(ctx.has_error());
 
-  // invalid utf8 (xa0 and xa1 are invalid)
-  std::string b("ok-\xa0\xa1-valid");
-  auto b_in_out_len = static_cast<int>(b.length());
-  const char* b_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
-  EXPECT_EQ(std::string(b_str, b_in_out_len), "ok-bb-valid");
-  EXPECT_FALSE(ctx.has_error());
-
-  // full valid utf8
-  std::string c("all-valid");
-  auto c_in_out_len = static_cast<int>(c.length());
-  const char* c_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
-  EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
+  // valid utf8 (महसुस is a 4-byte utf-8 char)
+  std::string e("ok-महसुस-valid-new");
+  auto e_in_out_len = static_cast<int>(e.length());
+  const char* e_str = convert_replace_invalid_fromUTF8_binary(
+      ctx_ptr, e.data(),e_in_out_len, "bk", 2, &e_in_out_len);
+  EXPECT_EQ(std::string(e_str, e_in_out_len), "ok-महसुस-valid-new");
   EXPECT_FALSE(ctx.has_error());
 
   ctx.Reset();

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -123,7 +123,7 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   std::string a("ok-\xf8\x28""-a");
   gdv_int32 a_in_out_len = a.length();
   const char* a_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, a.data(),
-                                                              a_in_out_len, "a",
+                                                              a_in_out_len, "a", 1,
                                                               &a_in_out_len);
   EXPECT_EQ(std::string(a_str, a.length()), "ok-a(-a");
   EXPECT_FALSE(ctx.has_error());
@@ -132,7 +132,7 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   std::string b("ok-\xa0\xa1-valid");
   gdv_int32 b_in_out_len = b.length();
   const char* b_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, b.data(),
-                                                              b_in_out_len, "b",
+                                                              b_in_out_len, "b", 1,
                                                               &b_in_out_len);
   EXPECT_EQ(std::string(b_str, b.length()), "ok-bb-valid");
   EXPECT_FALSE(ctx.has_error());
@@ -141,7 +141,7 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
   std::string c("all-valid");
   gdv_int32 c_in_out_len = c.length();
   const char* c_str = convert_replace_invalid_fromUTF8_binary(ctx_ptr, c.data(),
-                                                              c_in_out_len, "c",
+                                                              c_in_out_len, "c", 1,
                                                               &c_in_out_len);
   EXPECT_EQ(std::string(c_str, c.length()), "all-valid");
   EXPECT_FALSE(ctx.has_error());

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -417,9 +417,11 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
-const char* convert_replace_invalid_fromUTF8_binary(
-    int64_t context, const char* text_in, int32_t text_len,
-    const char* char_to_replace, int32_t char_to_replace_len, int32_t* out_len);
+const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char* text_in,
+                                                    int32_t text_len,
+                                                    const char* char_to_replace,
+                                                    int32_t char_to_replace_len,
+                                                    int32_t* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -418,8 +418,8 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
 const char* convert_replace_invalid_fromUTF8_binary(
-    gdv_int64 context, const char* text_in, gdv_int32 text_len,
-    const char* char_to_replace, gdv_int32 char_to_replace_len, gdv_int32* out_len);
+    int64_t context, const char* text_in, int32_t text_len,
+    const char* char_to_replace, int32_t char_to_replace_len, int32_t* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -417,7 +417,8 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
-const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context, const char* text_in,
+const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context,
+                                                    const char* text_in,
                                                     gdv_int32 text_len,
                                                     const char* char_to_replace,
                                                     gdv_int32 char_to_replace_len,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -420,6 +420,7 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
 const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context, const char* text_in,
                                                     gdv_int32 text_len,
                                                     const char* char_to_replace,
+                                                    gdv_int32 char_to_replace_len,
                                                     gdv_int32* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -417,12 +417,9 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
-const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context,
-                                                    const char* text_in,
-                                                    gdv_int32 text_len,
-                                                    const char* char_to_replace,
-                                                    gdv_int32 char_to_replace_len,
-                                                    gdv_int32* out_len);
+const char* convert_replace_invalid_fromUTF8_binary(
+    gdv_int64 context, const char* text_in, gdv_int32 text_len,
+    const char* char_to_replace, gdv_int32 char_to_replace_len, gdv_int32* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -417,6 +417,11 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
+const char* convert_replace_invalid_fromUTF8_binary(gdv_int64 context, const char* text_in,
+                                                    gdv_int32 text_len,
+                                                    const char* char_to_replace,
+                                                    gdv_int32* out_len);
+
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,
                        gdv_int32* out_len);

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -557,8 +557,8 @@ TEST_F(TestUtf8, TestConvertUtf8) {
 
   auto convert_replace_utf8 =
       TreeExprBuilder::MakeFunction("convert_fromUTF8", {node_a, node_b}, utf8());
-  auto equals = TreeExprBuilder::MakeFunction("equal",
-                                              {convert_replace_utf8, node_c}, boolean());
+  auto equals =
+      TreeExprBuilder::MakeFunction("equal", {convert_replace_utf8, node_c}, boolean());
   auto expr = TreeExprBuilder::MakeExpression(equals, res);
 
   // Build a projector for the expressions.
@@ -567,14 +567,14 @@ TEST_F(TestUtf8, TestConvertUtf8) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 1;
-  auto array_a = MakeArrowArrayUtf8(
-      {"ok-\xf8\x28""-a", "all-valid", "ok-\xa0\xa1-valid"},
-      {true, true, true});
+  int num_records = 3;
+  auto array_a = MakeArrowArrayUtf8({"ok-\xf8\x28"
+                                     "-a",
+                                     "all-valid", "ok-\xa0\xa1-valid"},
+                                    {true, true, true});
 
   auto array_b =
-      MakeArrowArrayUtf8({"ok-z(-a", "all-valid", "ok-zz-valid"},
-                         {true, true, true});
+      MakeArrowArrayUtf8({"ok-z(-a", "all-valid", "ok-zz-valid"}, {true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_a, array_b});
@@ -584,8 +584,7 @@ TEST_F(TestUtf8, TestConvertUtf8) {
   status = projector->Evaluate(*in_batch, pool_, &outputs);
   EXPECT_TRUE(status.ok()) << status.message();
 
-  auto exp = MakeArrowArrayBool({true},
-                                 {true});
+  auto exp = MakeArrowArrayBool({true, true, true}, {true, true, true});
   // Validate results
   EXPECT_ARROW_ARRAY_EQUALS(exp, outputs[0]);
 }

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -539,6 +539,56 @@ TEST_F(TestUtf8, TestVarlenOutput) {
   EXPECT_ARROW_ARRAY_EQUALS(exp, outputs.at(0));
 }
 
+TEST_F(TestUtf8, TestConvertUtf8) {
+  // schema for input fields
+  auto field_a = field("a", arrow::binary());
+  auto field_c = field("c", utf8());
+  auto schema = arrow::schema({field_a, field_c});
+
+  // output fields
+  auto res = field("res", boolean());
+
+  // build expressions.
+  auto node_a = TreeExprBuilder::MakeField(field_a);
+  auto node_c = TreeExprBuilder::MakeField(field_c);
+
+  // define char to replace
+  auto node_b = TreeExprBuilder::MakeStringLiteral("z");
+
+  auto convert_replace_utf8 =
+      TreeExprBuilder::MakeFunction("convert_fromUTF8", {node_a, node_b}, utf8());
+  auto equals = TreeExprBuilder::MakeFunction("equal", {convert_replace_utf8, node_c}, boolean());
+  auto expr = TreeExprBuilder::MakeExpression(equals, res);
+
+  // Build a projector for the expressions.
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 1;
+  auto array_a = MakeArrowArrayUtf8(
+      {"ok-\xf8\x28""-a", "all-valid", "ok-\xa0\xa1-valid"},
+      {true, true, true});
+
+  auto array_b =
+      MakeArrowArrayUtf8({"ok-z(-a", "all-valid", "ok-zz-valid"},
+                         {true, true, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_a, array_b});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  auto exp = MakeArrowArrayBool({true},
+                                 {true});
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp, outputs[0]);
+}
+
 TEST_F(TestUtf8, TestCastVarChar) {
   // schema for input fields
   auto field_a = field("a", utf8());

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -556,7 +556,7 @@ TEST_F(TestUtf8, TestConvertUtf8) {
   auto node_b = TreeExprBuilder::MakeStringLiteral("z");
 
   auto convert_replace_utf8 =
-      TreeExprBuilder::MakeFunction("convert_fromUTF8", {node_a, node_b}, utf8());
+      TreeExprBuilder::MakeFunction("convert_replaceUTF8", {node_a, node_b}, utf8());
   auto equals =
       TreeExprBuilder::MakeFunction("equal", {convert_replace_utf8, node_c}, boolean());
   auto expr = TreeExprBuilder::MakeExpression(equals, res);

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -557,7 +557,8 @@ TEST_F(TestUtf8, TestConvertUtf8) {
 
   auto convert_replace_utf8 =
       TreeExprBuilder::MakeFunction("convert_fromUTF8", {node_a, node_b}, utf8());
-  auto equals = TreeExprBuilder::MakeFunction("equal", {convert_replace_utf8, node_c}, boolean());
+  auto equals = TreeExprBuilder::MakeFunction("equal",
+                                              {convert_replace_utf8, node_c}, boolean());
   auto expr = TreeExprBuilder::MakeExpression(equals, res);
 
   // Build a projector for the expressions.


### PR DESCRIPTION
Implement CONVERT_FROM(expression, ‘UTF8’, replacement char)

Converts the byte data in expression to UTF-8. Expression can be a literal string or a field name. Will replace any invalid UTF-8 characters with the replacement character.

Obs.: Actually we will only support a single byte replacement char