### PR TITLE
ARROW-12143: [CI] R builds should timeout and fail after some threshold and dump the output.

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -239,12 +239,22 @@ jobs:
             build_args = '--no-build-vignettes',
             args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'),
             error_on = 'warning',
-            check_dir = 'check'
+            check_dir = 'check',
+            timeout = 3600
           )
       - name: Dump install logs
         shell: cmd
         run: cat check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: r/check/arrow.Rcheck/tests/testthat.Rout*
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -247,14 +247,14 @@ jobs:
         run: cat check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
-        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
+        run: cat check/arrow.Rcheck/tests/testthat.Rout*
         if: always()
       - name: Save the test output
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: test-output
-          path: r/check/arrow.Rcheck/tests/testthat.Rout*
+          path: check/arrow.Rcheck/tests/testthat.Rout*
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout
+        if: always()
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
@@ -133,6 +136,9 @@ jobs:
           archery docker run r
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
+        if: always()
+      - name: Dump test logs
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout
         if: always()
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -246,15 +246,6 @@ jobs:
         shell: cmd
         run: cat check/arrow.Rcheck/00install.out
         if: always()
-      - name: Dump test logs
-        run: cat check/arrow.Rcheck/tests/testthat.Rout*
-        if: always()
-      - name: Save the test output
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-output
-          path: check/arrow.Rcheck/tests/testthat.Rout*
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -20,24 +20,24 @@ name: R
 on:
   push:
     paths:
-      - '.github/workflows/r.yml'
-      - 'ci/scripts/r_*.sh'
-      - 'ci/scripts/cpp_*.sh'
-      - 'ci/scripts/PKGBUILD'
-      - 'ci/etc/rprofile'
-      - 'ci/docker/**'
-      - 'cpp/**'
-      - 'r/**'
+      - ".github/workflows/r.yml"
+      - "ci/scripts/r_*.sh"
+      - "ci/scripts/cpp_*.sh"
+      - "ci/scripts/PKGBUILD"
+      - "ci/etc/rprofile"
+      - "ci/docker/**"
+      - "cpp/**"
+      - "r/**"
   pull_request:
     paths:
-      - '.github/workflows/r.yml'
-      - 'ci/scripts/r_*.sh'
-      - 'ci/scripts/cpp_*.sh'
-      - 'ci/scripts/PKGBUILD'
-      - 'ci/etc/rprofile'
-      - 'ci/docker/**'
-      - 'cpp/**'
-      - 'r/**'
+      - ".github/workflows/r.yml"
+      - "ci/scripts/r_*.sh"
+      - "ci/scripts/cpp_*.sh"
+      - "ci/scripts/PKGBUILD"
+      - "ci/etc/rprofile"
+      - "ci/docker/**"
+      - "cpp/**"
+      - "r/**"
 
 env:
   DOCKER_VOLUME_PREFIX: ".docker/"
@@ -87,8 +87,14 @@ jobs:
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
-        run: cat r/check/arrow.Rcheck/tests/testthat.Rout
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
         if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: r/check/arrow.Rcheck/tests/testthat.Rout*
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
@@ -102,8 +108,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {org: 'rstudio', image: 'r-base', tag: '4.0-centos7'}
-          - {org: 'rhub', image: 'debian-gcc-devel', tag: 'latest'}
+          - { org: "rstudio", image: "r-base", tag: "4.0-centos7" }
+          - { org: "rhub", image: "debian-gcc-devel", tag: "latest" }
     env:
       R_ORG: ${{ matrix.config.org }}
       R_IMAGE: ${{ matrix.config.image }}
@@ -138,8 +144,14 @@ jobs:
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
-        run: cat r/check/arrow.Rcheck/tests/testthat.Rout
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
         if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: r/check/arrow.Rcheck/tests/testthat.Rout*
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
@@ -155,7 +167,7 @@ jobs:
         rtools: [35, 40]
     env:
       TEST_R_WITH_ARROW: "TRUE"
-      ARROW_R_CXXFLAGS: '-Werror'
+      ARROW_R_CXXFLAGS: "-Werror"
       _R_CHECK_TESTS_NLINES_: 0
     steps:
       - run: git config --global core.autocrlf false
@@ -193,13 +205,13 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           rtools-version: 40
-          r-version: '4.0'
+          r-version: "4.0"
           Ncpus: 2
       - uses: r-lib/actions/setup-r@master
         if: ${{ matrix.rtools == 35 }}
         with:
           rtools-version: 35
-          r-version: '3.6'
+          r-version: "3.6"
           Ncpus: 2
       - name: Build Arrow C++
         shell: bash

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -71,9 +71,9 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
       pid <- sys::exec_background('minio', c('server', minio_dir))
       on.exit(tools::pskill(pid))
     }
-    rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')
+    rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check', timeout = 3600)
   }"
-echo "$SCRIPT" | timeout -k 3600 3600 ${R_BIN} --no-save
+echo "$SCRIPT" | ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -62,7 +62,7 @@ BEFORE=$(ls -alh ~/)
 
 SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   if (as_cran) {
-    rcmdcheck::rcmdcheck(args = c('--as-cran', '--run-donttest'), error_on = 'warning', check_dir = 'check')
+    rcmdcheck::rcmdcheck(args = c('--as-cran', '--run-donttest'), error_on = 'warning', check_dir = 'check', timeout = 3600)
   } else {
     if (nzchar(Sys.which('minio'))) {
       message('Running minio for S3 tests (if build supports them)')

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -73,7 +73,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     }
     rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')
   }"
-echo "$SCRIPT" | ${R_BIN} --no-save
+echo "$SCRIPT" | timeout -k 3600 3600 ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -15,53 +15,58 @@
 # limitations under the License.
 
 jobs:
-- job: linux
-  pool:
-    vmImage: ubuntu-latest
-  timeoutInMinutes: 360
-  steps:
-    - script: |
-        set -ex
-        git clone --no-checkout {{ arrow.remote }} arrow
-        git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-        git -C arrow checkout FETCH_HEAD
-        git -C arrow submodule update --init --recursive
-      displayName: Clone arrow
+  - job: linux
+    pool:
+      vmImage: ubuntu-latest
+    timeoutInMinutes: 360
+    steps:
+      - script: |
+          set -ex
+          git clone --no-checkout {{ arrow.remote }} arrow
+          git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
+          git -C arrow checkout FETCH_HEAD
+          git -C arrow submodule update --init --recursive
+        displayName: Clone arrow
 
-    - script: |
-        set -ex
-        docker -v
-        docker-compose -v
-        cd arrow
-        export R_ORG={{ r_org }}
-        export R_IMAGE={{ r_image }}
-        export R_TAG={{ r_tag }}
-        export DEVTOOLSET_VERSION={{ devtoolset_version|default("-1") }}
-        docker-compose pull --ignore-pull-failures r
-        docker-compose build r
-      displayName: Docker build
+      - script: |
+          set -ex
+          docker -v
+          docker-compose -v
+          cd arrow
+          export R_ORG={{ r_org }}
+          export R_IMAGE={{ r_image }}
+          export R_TAG={{ r_tag }}
+          export DEVTOOLSET_VERSION={{ devtoolset_version|default("-1") }}
+          docker-compose pull --ignore-pull-failures r
+          docker-compose build r
+        displayName: Docker build
 
-    - script: |
-        set -ex
-        cd arrow
-        export R_ORG={{ r_org }}
-        export R_IMAGE={{ r_image }}
-        export R_TAG={{ r_tag }}
-        # we have to export this (right?) because we need it in the build env
-        export ARROW_R_DEV={{ not_cran }}
-        # Note that ci/scripts/r_test.sh sets NOT_CRAN=true if ARROW_R_DEV=TRUE
-        docker-compose run \
-          -e ARROW_DATASET={{ arrow_dataset|default("") }} \
-          -e ARROW_PARQUET={{ arrow_parquet|default("") }} \
-          -e ARROW_S3={{ arrow_s3|default("") }} \
-          -e ARROW_WITH_RE2={{ arrow_with_re2|default("") }} \
-          -e ARROW_WITH_UTF8PROC={{ arrow_with_utf8proc|default("") }} \
-          -e LIBARROW_MINIMAL={{ libarrow_minimal|default("") }} \
-          r
-      displayName: Docker run
+      - script: |
+          set -ex
+          cd arrow
+          export R_ORG={{ r_org }}
+          export R_IMAGE={{ r_image }}
+          export R_TAG={{ r_tag }}
+          # we have to export this (right?) because we need it in the build env
+          export ARROW_R_DEV={{ not_cran }}
+          # Note that ci/scripts/r_test.sh sets NOT_CRAN=true if ARROW_R_DEV=TRUE
+          docker-compose run \
+            -e ARROW_DATASET={{ arrow_dataset|default("") }} \
+            -e ARROW_PARQUET={{ arrow_parquet|default("") }} \
+            -e ARROW_S3={{ arrow_s3|default("") }} \
+            -e ARROW_WITH_RE2={{ arrow_with_re2|default("") }} \
+            -e ARROW_WITH_UTF8PROC={{ arrow_with_utf8proc|default("") }} \
+            -e LIBARROW_MINIMAL={{ libarrow_minimal|default("") }} \
+            r
+        displayName: Docker run
 
-    - script: |
-        set -ex
-        cat arrow/r/check/arrow.Rcheck/00install.out
-      displayName: Dump install logs
-      condition: succeededOrFailed()
+      - script: |
+          set -ex
+          cat arrow/r/check/arrow.Rcheck/00install.out
+        displayName: Dump install logs
+        condition: succeededOrFailed()
+      - script: |
+          set -ex
+          cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
+        displayName: Dump test logs
+        condition: succeededOrFailed()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -40,7 +40,7 @@ jobs:
           - fedora-clang-devel
     env:
       R_ORG: "rhub"
-      R_IMAGE: {{ MATRIX }}
+      R_IMAGE: { { MATRIX } }
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
     steps:
@@ -68,3 +68,12 @@ jobs:
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: arrow/r/check/arrow.Rcheck/tests/testthat.Rout*

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -40,7 +40,7 @@ jobs:
           - fedora-clang-devel
     env:
       R_ORG: "rhub"
-      R_IMAGE: { { MATRIX } }
+      R_IMAGE: {{ MATRIX }}
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
     steps:

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -69,3 +69,12 @@ jobs:
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: arrow/r/check/arrow.Rcheck/tests/testthat.Rout*

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -67,3 +67,12 @@ jobs:
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: arrow/r/check/arrow.Rcheck/tests/testthat.Rout*

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -19,4 +19,9 @@ library(testthat)
 library(arrow)
 library(tibble)
 
-test_check("arrow", reporter="location")
+if (identical(tolower(Sys.getenv("ARROW_R_DEV", FALSE)), "true")) {
+  arrow_reporter <- MultiReporter("check", "location")
+} else {
+  arrow_reporter <- check_reporter()
+}
+test_check("arrow", reporter = arrow_reporter)

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -20,7 +20,8 @@ library(arrow)
 library(tibble)
 
 if (identical(tolower(Sys.getenv("ARROW_R_DEV", FALSE)), "true")) {
-  test_check("arrow", reporter = MultiReporter("check", "location"))
+  arrow_reporter <- MultiReporter$new(list(CheckReporter$new(), LocationReporter$new()))
 } else {
-  test_check("arrow")
+  arrow_reporter <- check_reporter()
 }
+test_check("arrow", reporter = arrow_reporter)

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -19,7 +19,7 @@ library(testthat)
 library(arrow)
 library(tibble)
 
-if (identical(tolower(Sys.getenv("ARROW_R_DEV", FALSE)), "true")) {
+if (identical(tolower(Sys.getenv("ARROW_R_DEV", "false")), "true")) {
   arrow_reporter <- MultiReporter$new(list(CheckReporter$new(), LocationReporter$new()))
 } else {
   arrow_reporter <- check_reporter()

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -20,8 +20,7 @@ library(arrow)
 library(tibble)
 
 if (identical(tolower(Sys.getenv("ARROW_R_DEV", FALSE)), "true")) {
-  arrow_reporter <- MultiReporter("check", "location")
+  test_check("arrow", reporter = MultiReporter("check", "location"))
 } else {
-  arrow_reporter <- check_reporter()
+  test_check("arrow")
 }
-test_check("arrow", reporter = arrow_reporter)

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -19,4 +19,4 @@ library(testthat)
 library(arrow)
 library(tibble)
 
-test_check("arrow")
+test_check("arrow", reporter="location")


### PR DESCRIPTION
This adds a one hour timeout to the R builds.  It changes the R CI test script to use `reporter="location"` by default.  It adds a dump test logs step to the end of the build that will always dump the test output regardless of success/failure.

These three changes combined will make it much easier to debug test failures in R tests.