### PR TITLE
ARROW-12108: [Rust] [DataFusion] Implement SHOW TABLES

### DIFF
--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -45,16 +45,19 @@ use hashbrown::HashMap;
 use crate::prelude::JoinType;
 use sqlparser::ast::{
     BinaryOperator, DataType as SQLDataType, DateTimeField, Expr as SQLExpr, FunctionArg,
-    Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr, SetOperator,
-    TableFactor, TableWithJoins, UnaryOperator, Value,
+    Ident, Join, JoinConstraint, JoinOperator, ObjectName, Query, Select, SelectItem,
+    SetExpr, SetOperator, TableFactor, TableWithJoins, UnaryOperator, Value,
 };
 use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption};
 use sqlparser::ast::{OrderByExpr, Statement};
 use sqlparser::parser::ParserError::ParserError;
 
-use super::utils::{
-    can_columns_satisfy_exprs, expand_wildcard, expr_as_column_expr, extract_aliases,
-    find_aggregate_exprs, find_column_exprs, rebase_expr, resolve_aliases_to_exprs,
+use super::{
+    parser::DFParser,
+    utils::{
+        can_columns_satisfy_exprs, expand_wildcard, expr_as_column_expr, extract_aliases,
+        find_aggregate_exprs, find_column_exprs, rebase_expr, resolve_aliases_to_exprs,
+    },
 };
 
 /// The ContextProvider trait allows the query planner to obtain meta-data about tables and
@@ -96,6 +99,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 analyze: _,
             } => self.explain_statement_to_plan(*verbose, &statement),
             Statement::Query(query) => self.query_to_plan(&query),
+            Statement::ShowVariable { variable } => self.show_variable_to_plan(&variable),
             _ => Err(DataFusionError::NotImplemented(
                 "Only SELECT statements are implemented".to_string(),
             )),
@@ -1270,6 +1274,36 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         let result: i64 = (result_days << 32) | result_millis;
         Ok(Expr::Literal(ScalarValue::IntervalDayTime(Some(result))))
+    }
+
+    fn show_variable_to_plan(&self, variable: &[Ident]) -> Result<LogicalPlan> {
+        // Special case SHOW TABLES
+        let variable = ObjectName(variable.to_vec()).to_string();
+        if variable.as_str().eq_ignore_ascii_case("tables") {
+            let tables_reference = TableReference::Partial {
+                schema: "information_schema",
+                table: "tables",
+            };
+            if self
+                .schema_provider
+                .get_table_provider(tables_reference)
+                .is_some()
+            {
+                let rewrite =
+                    DFParser::parse_sql("SELECT * FROM information_schema.tables;")?;
+                self.statement_to_plan(&rewrite[0])
+            } else {
+                Err(DataFusionError::Plan(
+                    "SHOW TABLES is not supported unless information_schema is enabled"
+                        .to_string(),
+                ))
+            }
+        } else {
+            Err(DataFusionError::NotImplemented(format!(
+                "SHOW {} not implemented. Supported syntax: SHOW <TABLES>",
+                variable
+            )))
+        }
     }
 }
 


### PR DESCRIPTION
# Rationale
Accessing the list of tables via `select * from information_schema.tables` (introduced in https://github.com/apache/arrow/pull/9818) is a lot to type

See the doc for background: https://docs.google.com/document/d/12cpZUSNPqVH9Z0BBx6O8REu7TFqL-NPPAYCUPpDls1k/edit#

# Proposal

Add support for `SHOW TABLES` command.

# Commentary

This is different than both postgres (which uses `\d` in `psql` for this purpose), and MySQL (which uses `DESCRIBE`).

I could be convinced that we should not add `SHOW TABLES` at all (and just stay with `select * from information_schema.tables` but I wanted to add the proposal)


# Example Use


Setup:
```
echo "1,Foo,44.9" > /tmp/table.csv
echo "2,Bar,22.1" >> /tmp/table.csv
cargo run --bin datafusion-cli
```

Then run :

```
CREATE EXTERNAL TABLE t(a int, b varchar, c float)
STORED AS CSV
LOCATION '/tmp/table.csv';

> show tables;
+---------------+--------------------+------------+------------+
| table_catalog | table_schema       | table_name | table_type |
+---------------+--------------------+------------+------------+
| datafusion    | public             | t          | BASE TABLE |
| datafusion    | information_schema | tables     | VIEW       |
+---------------+--------------------+------------+------------+
2 row in set. Query took 0 seconds.

```