### PR TITLE
ARROW-12153: [Rust] [Parquet] Return file stats after writing file

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -524,7 +524,7 @@ impl ExecutionContext {
                             .try_collect()
                             .await
                             .map_err(DataFusionError::from)?;
-                        writer.close().map_err(DataFusionError::from)
+                        writer.close().map_err(DataFusionError::from).map(|_| ())
                     });
                     tasks.push(handle);
                 }

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -578,7 +578,7 @@ mod tests {
         values: &[Vec<T::T>],
         path: &Path,
         schema: TypePtr,
-    ) -> Result<()> {
+    ) -> Result<parquet_format::FileMetaData> {
         let file = File::create(path)?;
         let writer_props = Arc::new(WriterProperties::builder().build());
 

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -99,7 +99,7 @@ impl<W: 'static + ParquetWriter> ArrowWriter<W> {
     }
 
     /// Close and finalize the underlying Parquet writer
-    pub fn close(&mut self) -> Result<()> {
+    pub fn close(&mut self) -> Result<parquet_format::FileMetaData> {
         self.writer.close()
     }
 }


### PR DESCRIPTION
The stats are useful for some writers who need to perform
book-keeping of files writte.