### PR TITLE
ARROW-12155: [R] Require Table columns to be same length

### DIFF
--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -465,3 +465,9 @@ test_that("RecordBatch name assignment", {
   expect_error(names(rb) <- NULL)
   expect_error(names(rb) <- c(TRUE, FALSE))
 })
+
+test_that("record_batch() with different length arrays", {
+  msg <- "All arrays must have the same length"
+  expect_error(record_batch(a=1:5, b = 42), msg)
+  expect_error(record_batch(a=1:5, b = 1:6), msg)
+})

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -469,3 +469,9 @@ test_that("Table name assignment", {
   expect_error(names(tab) <- NULL)
   expect_error(names(tab) <- c(TRUE, FALSE))
 })
+
+test_that("Table$create() with different length columns", {
+  msg <- "All columns must have the same length"
+  expect_error(Table$create(a=1:5, b = 42), msg)
+  expect_error(Table$create(a=1:5, b = 1:6), msg)
+})


### PR DESCRIPTION
This throws an error if the user attempts to create a Table with columns of different lengths. We already had this for RecordBatches but not for Tables.