### PR TITLE
ARROW-12154: [C++][Gandiva] Fix gandiva crash in certain OS/CPU combinations

### DIFF
--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -31,6 +31,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include "arrow/util/logging.h"
+
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4141)
@@ -95,13 +97,17 @@ void Engine::InitOnce() {
 
   cpu_name = llvm::sys::getHostCPUName();
   llvm::StringMap<bool> host_features;
+  std::string cpu_attrs_str;
   if (llvm::sys::getHostCPUFeatures(host_features)) {
     for (auto& f : host_features) {
       std::string attr = f.second ? std::string("+") + f.first().str()
                                   : std::string("-") + f.first().str();
       cpu_attrs.push_back(attr);
+      cpu_attrs_str += " " + attr;
     }
   }
+  ARROW_LOG(INFO) << "Detected CPU Name : " << cpu_name.str();
+  ARROW_LOG(INFO) << "Detected CPU Features:" << cpu_attrs_str;
   llvm_init = true;
 }
 

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -69,11 +69,10 @@
 #pragma warning(pop)
 #endif
 
+#include "arrow/util/make_unique.h"
 #include "gandiva/configuration.h"
 #include "gandiva/decimal_ir.h"
 #include "gandiva/exported_funcs_registry.h"
-
-#include "arrow/util/make_unique.h"
 
 namespace gandiva {
 
@@ -82,6 +81,8 @@ extern const size_t kPrecompiledBitcodeSize;
 
 std::once_flag llvm_init_once_flag;
 static bool llvm_init = false;
+static llvm::StringRef cpu_name;
+static llvm::SmallVector<std::string, 10> cpu_attrs;
 
 void Engine::InitOnce() {
   DCHECK_EQ(llvm_init, false);
@@ -92,6 +93,15 @@ void Engine::InitOnce() {
   llvm::InitializeNativeTargetDisassembler();
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
 
+  cpu_name = llvm::sys::getHostCPUName();
+  llvm::StringMap<bool> host_features;
+  if (llvm::sys::getHostCPUFeatures(host_features)) {
+    for (auto& f : host_features) {
+      std::string attr = f.second ? std::string("+") + f.first().str()
+                                  : std::string("-") + f.first().str();
+      cpu_attrs.push_back(attr);
+    }
+  }
   llvm_init = true;
 }
 
@@ -129,13 +139,15 @@ Status Engine::Make(const std::shared_ptr<Configuration>& conf,
 
   auto opt_level =
       conf->optimize() ? llvm::CodeGenOpt::Aggressive : llvm::CodeGenOpt::None;
+
   // Note that the lifetime of the error string is not captured by the
   // ExecutionEngine but only for the lifetime of the builder. Found by
   // inspecting LLVM sources.
   std::string builder_error;
   std::unique_ptr<llvm::ExecutionEngine> exec_engine{
       llvm::EngineBuilder(std::move(module))
-          .setMCPU(llvm::sys::getHostCPUName())
+          .setMCPU(cpu_name)
+          .setMAttrs(cpu_attrs)
           .setEngineKind(llvm::EngineKind::JIT)
           .setOptLevel(opt_level)
           .setErrorStr(&builder_error)


### PR DESCRIPTION
Currently when running gandiva in a OS where the OS doesn't support all the features of the host cpu, specifically vector instructions like AVX, AVX512 which needs OS support (because the OS or the VM running the OS  is older version and doesn't support them, or passthrough is disabled for these features in the VM), llvm::sys::getHostCPUName detects the processor with these features and so gandiva generates jit compiled code with these vector instructions, which the cpu is unable to execute and hence faults.
Hence we need to detect the cpu features also and set it to the engine builder, since the OS might not support all the features of the detected cpu. This would also protect against other issues such as low end versions of SandyBridge, Haswell, and SkyLake processesors not supporting AVX at all.