### PR TITLE
ARROW-12160: [Rust] Add `into_inner()` to StreamWriter

### DIFF
--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -17,6 +17,7 @@
 
 //! Defines `ArrowError` for representing failures in various Arrow operations.
 use std::fmt::{Debug, Display, Formatter};
+use std::io::Write;
 
 use csv as csv_crate;
 use std::error::Error;
@@ -87,6 +88,12 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
 impl From<serde_json::Error> for ArrowError {
     fn from(error: serde_json::Error) -> Self {
         ArrowError::JsonError(error.to_string())
+    }
+}
+
+impl<W: Write> From<::std::io::IntoInnerError<W>> for ArrowError {
+    fn from(error: std::io::IntoInnerError<W>) -> Self {
+        ArrowError::IoError(error.to_string())
     }
 }
 

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -546,6 +546,53 @@ impl<W: Write> StreamWriter<W> {
 
         Ok(())
     }
+
+    /// Unwraps the BufWriter housed in StreamWriter.writer, returning the underlying
+    /// writer
+    ///
+    /// The buffer is flushed and the StreamWriter is finished before returning the
+    /// writer.
+    ///
+    /// # Errors
+    ///
+    /// An ['Err'] may be returned if an error occurs while finishing the StreamWriter
+    /// or while flushing the buffer.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use arrow::datatypes::{DataType, Field, Schema};
+    /// # use arrow::ipc::writer::StreamWriter;
+    /// # use arrow::error::ArrowError;
+    /// # fn main() -> Result<(), ArrowError> {
+    /// // The result we expect from an empty schema
+    /// let expected = vec![
+    ///     255, 255, 255, 255,  64,   0,   0,   0,
+    ///      16,   0,   0,   0,   0,   0,  10,   0,
+    ///      14,   0,  12,   0,  11,   0,   4,   0,
+    ///      10,   0,   0,   0,  20,   0,   0,   0,
+    ///       0,   0,   0,   1,   4,   0,  10,   0,
+    ///      12,   0,   0,   0,   8,   0,   4,   0,
+    ///      10,   0,   0,   0,   8,   0,   0,   0,
+    ///       8,   0,   0,   0,   0,   0,   0,   0,
+    ///       0,   0,   0,   0,   0,   0,   0,   0,
+    ///     255, 255, 255, 255,   0,   0,   0,   0
+    /// ];
+    ///
+    /// let schema = Schema::new(vec![]);
+    /// let buffer: Vec<u8> = Vec::new();
+    /// let stream_writer = StreamWriter::try_new(buffer, &schema)?;
+    ///
+    /// assert_eq!(stream_writer.into_inner()?, expected);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_inner(mut self) -> Result<W> {
+        if !self.finished {
+            self.finish()?;
+        }
+        self.writer.into_inner().map_err(ArrowError::from)
+    }
 }
 
 /// Stores the encoded data, which is an ipc::Message, and optional Arrow data

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -561,7 +561,7 @@ impl<W: Write> StreamWriter<W> {
     /// # Example
     ///
     /// ```
-    /// # use arrow::datatypes::{DataType, Field, Schema};
+    /// # use arrow::datatypes::Schema;
     /// # use arrow::ipc::writer::StreamWriter;
     /// # use arrow::error::ArrowError;
     /// # fn main() -> Result<(), ArrowError> {


### PR DESCRIPTION
Add an `into_inner()` method to `ipc::writer::StreamWriter`, allowing users to recover the underlying writer, consuming the StreamWriter. Essentially exposes `into_inner()` from the BufWriter contained in the StreamWriter. The StreamWriter will 'finish' itself if not already finished when returning the writer.

Also added `ArrowError::From<std::io::IntoInnerError>` conversion to allow for ergonomic return of the potential `IntoInnerError` returned by `BufWriter.into_inner()`.