### PR TITLE
ARROW-12166: [C++][Gandiva] Implements CONVERT_TO(value, type) function

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -229,17 +229,33 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      binary(), kResultNullIfNull, "convert_toDOUBLE_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toDOUBLE_BE", {"convert_todouble_be"},
+                     DataTypeVector{float64()}, binary(), kResultNullIfNull,
+                     "convert_toDOUBLE_binary_be", NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toFLOAT", {"convert_tofloat"}, DataTypeVector{float32()},
                      binary(), kResultNullIfNull, "convert_toFLOAT_binary",
                      NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toFLOAT_BE", {"convert_tofloat_be"},
+                     DataTypeVector{float32()}, binary(), kResultNullIfNull,
+                     "convert_toFLOAT_binary_be", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toINT", {"convert_toint"}, DataTypeVector{int32()},
                      binary(), kResultNullIfNull, "convert_toINT_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toINT_BE", {"convert_toint_be"}, DataTypeVector{int32()},
+                     binary(), kResultNullIfNull, "convert_toINT_binary_be",
+                     NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toBIGINT", {"convert_tobigint"}, DataTypeVector{int64()},
                      binary(), kResultNullIfNull, "convert_toBIGINT_binary",
                      NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toBIGINT_BE", {"convert_tobigint_be"},
+                     DataTypeVector{int64()}, binary(), kResultNullIfNull,
+                     "convert_toBIGINT_binary_be", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toBOOLEAN_BYTE", {"convert_toboolean_byte"},
                      DataTypeVector{boolean()}, binary(), kResultNullIfNull,
@@ -249,13 +265,26 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      DataTypeVector{time32()}, binary(), kResultNullIfNull,
                      "convert_toTIME_EPOCH_binary", NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toTIME_EPOCH_BE", {"convert_totime_epoch_be"},
+                     DataTypeVector{time32()}, binary(), kResultNullIfNull,
+                     "convert_toTIME_EPOCH_binary_be", NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toTIMESTAMP_EPOCH", {"convert_totimestamp_epoch"},
                      DataTypeVector{timestamp()}, binary(), kResultNullIfNull,
                      "convert_toTIMESTAMP_EPOCH_binary", NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toTIMESTAMP_EPOCH_BE", {"convert_totimestamp_epoch_be"},
+                     DataTypeVector{timestamp()}, binary(), kResultNullIfNull,
+                     "convert_toTIMESTAMP_EPOCH_binary_be",
+                     NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toDATE_EPOCH", {"convert_todate_epoch"},
                      DataTypeVector{date64()}, binary(), kResultNullIfNull,
                      "convert_toDATE_EPOCH_binary", NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toDATE_EPOCH_BE", {"convert_todate_epoch_be"},
+                     DataTypeVector{date64()}, binary(), kResultNullIfNull,
+                     "convert_toDATE_EPOCH_binary_be", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toUTF8", {"convert_toutf8"}, DataTypeVector{utf8()},
                      binary(), kResultNullIfNull, "convert_toUTF8_binary",

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -241,9 +241,21 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      binary(), kResultNullIfNull, "convert_toBIGINT_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toBOOLEAN_BYTE", {"convert_toboolean_byte"},
+                     DataTypeVector{boolean()}, binary(), kResultNullIfNull,
+                     "convert_toBOOLEAN_binary", NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toTIME_EPOCH", {"convert_totime_epoch"},
                      DataTypeVector{time32()}, binary(), kResultNullIfNull,
                      "convert_toTIME_EPOCH_binary", NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toTIMESTAMP_EPOCH", {"convert_totimestamp_epoch"},
+                     DataTypeVector{timestamp()}, binary(), kResultNullIfNull,
+                     "convert_toTIMESTAMP_EPOCH_binary", NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toDATE_EPOCH", {"convert_todate_epoch"},
+                     DataTypeVector{date64()}, binary(), kResultNullIfNull,
+                     "convert_toDATE_EPOCH_binary", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toUTF8", {"convert_toutf8"}, DataTypeVector{utf8()},
                      binary(), kResultNullIfNull, "convert_toUTF8_binary",

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -225,6 +225,11 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toDOUBLE", {"convert_todouble"},
+                     DataTypeVector{float64()}, binary(), kResultNullIfNull,
+                     "convert_toDOUBLE_binary",
+                     NativeFunction::kNeedsContext),
+
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},
                      int32(), kResultNullIfNull, "locate_utf8_utf8_int32",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -225,65 +225,65 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_todouble", {}, DataTypeVector{float64()}, binary(),
+      NativeFunction("convert_toDOUBLE", {}, DataTypeVector{float64()}, binary(),
                      kResultNullIfNull, "convert_toDOUBLE",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_todouble_be", {}, DataTypeVector{float64()}, binary(),
+      NativeFunction("convert_toDOUBLE_be", {}, DataTypeVector{float64()}, binary(),
                      kResultNullIfNull, "convert_toDOUBLE_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_tofloat", {}, DataTypeVector{float32()}, binary(),
+      NativeFunction("convert_toFLOAT", {}, DataTypeVector{float32()}, binary(),
                      kResultNullIfNull, "convert_toFLOAT", NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_tofloat_be", {}, DataTypeVector{float32()}, binary(),
+      NativeFunction("convert_toFLOAT_be", {}, DataTypeVector{float32()}, binary(),
                      kResultNullIfNull, "convert_toFLOAT_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toint", {}, DataTypeVector{int32()}, binary(),
+      NativeFunction("convert_toINT", {}, DataTypeVector{int32()}, binary(),
                      kResultNullIfNull, "convert_toINT", NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toint_be", {}, DataTypeVector{int32()}, binary(),
+      NativeFunction("convert_toINT_be", {}, DataTypeVector{int32()}, binary(),
                      kResultNullIfNull, "convert_toINT_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_tobigint", {}, DataTypeVector{int64()}, binary(),
+      NativeFunction("convert_toBIGINT", {}, DataTypeVector{int64()}, binary(),
                      kResultNullIfNull, "convert_toBIGINT",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_tobigint_be", {}, DataTypeVector{int64()}, binary(),
+      NativeFunction("convert_toBIGINT_be", {}, DataTypeVector{int64()}, binary(),
                      kResultNullIfNull, "convert_toBIGINT_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toboolean_byte", {}, DataTypeVector{boolean()}, binary(),
+      NativeFunction("convert_toBOOLEAN_BYTE", {}, DataTypeVector{boolean()}, binary(),
                      kResultNullIfNull, "convert_toBOOLEAN",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_totime_epoch", {}, DataTypeVector{time32()}, binary(),
+      NativeFunction("convert_toTIME_EPOCH", {}, DataTypeVector{time32()}, binary(),
                      kResultNullIfNull, "convert_toTIME_EPOCH",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_totime_epoch_be", {}, DataTypeVector{time32()}, binary(),
+      NativeFunction("convert_toTIME_EPOCH_be", {}, DataTypeVector{time32()}, binary(),
                      kResultNullIfNull, "convert_toTIME_EPOCH_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_totimestamp_epoch", {}, DataTypeVector{timestamp()},
+      NativeFunction("convert_toTIMESTAMP_EPOCH", {}, DataTypeVector{timestamp()},
                      binary(), kResultNullIfNull, "convert_toTIMESTAMP_EPOCH",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_totimestamp_epoch_be", {}, DataTypeVector{timestamp()},
+      NativeFunction("convert_toTIMESTAMP_EPOCH_be", {}, DataTypeVector{timestamp()},
                      binary(), kResultNullIfNull, "convert_toTIMESTAMP_EPOCH_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_todate_epoch", {}, DataTypeVector{date64()}, binary(),
+      NativeFunction("convert_toDATE_EPOCH", {}, DataTypeVector{date64()}, binary(),
                      kResultNullIfNull, "convert_toDATE_EPOCH",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_todate_epoch_be", {}, DataTypeVector{date64()}, binary(),
+      NativeFunction("convert_toDATE_EPOCH_be", {}, DataTypeVector{date64()}, binary(),
                      kResultNullIfNull, "convert_toDATE_EPOCH_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toutf8", {}, DataTypeVector{utf8()}, binary(),
+      NativeFunction("convert_toUTF8", {}, DataTypeVector{utf8()}, binary(),
                      kResultNullIfNull, "convert_toUTF8", NativeFunction::kNeedsContext),
 
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -233,6 +233,10 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      binary(), kResultNullIfNull, "convert_toINT_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toTIME_EPOCH", {"convert_totime_epoch"},
+                     DataTypeVector{time32()}, binary(), kResultNullIfNull,
+                     "convert_toTIME_EPOCH_binary", NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toUTF8", {"convert_toutf8"}, DataTypeVector{utf8()},
                      binary(), kResultNullIfNull, "convert_toUTF8_binary",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -229,8 +229,16 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      binary(), kResultNullIfNull, "convert_toDOUBLE_binary",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("convert_toFLOAT", {"convert_tofloat"}, DataTypeVector{float32()},
+                     binary(), kResultNullIfNull, "convert_toFLOAT_binary",
+                     NativeFunction::kNeedsContext),
+
       NativeFunction("convert_toINT", {"convert_toint"}, DataTypeVector{int32()},
                      binary(), kResultNullIfNull, "convert_toINT_binary",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toBIGINT", {"convert_tobigint"}, DataTypeVector{int64()},
+                     binary(), kResultNullIfNull, "convert_toBIGINT_binary",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toTIME_EPOCH", {"convert_totime_epoch"},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -225,9 +225,16 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toDOUBLE", {"convert_todouble"},
-                     DataTypeVector{float64()}, binary(), kResultNullIfNull,
-                     "convert_toDOUBLE_binary",
+      NativeFunction("convert_toDOUBLE", {"convert_todouble"}, DataTypeVector{float64()},
+                     binary(), kResultNullIfNull, "convert_toDOUBLE_binary",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toINT", {"convert_toint"}, DataTypeVector{int32()},
+                     binary(), kResultNullIfNull, "convert_toINT_binary",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toUTF8", {"convert_toutf8"}, DataTypeVector{utf8()},
+                     binary(), kResultNullIfNull, "convert_toUTF8_binary",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -225,69 +225,68 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "convert_replace_invalid_fromUTF8_binary",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toDOUBLE", {"convert_todouble"}, DataTypeVector{float64()},
-                     binary(), kResultNullIfNull, "convert_toDOUBLE_binary",
+      NativeFunction("convert_todouble", {}, DataTypeVector{float64()}, binary(),
+                     kResultNullIfNull, "convert_toDOUBLE",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toDOUBLE_BE", {"convert_todouble_be"},
-                     DataTypeVector{float64()}, binary(), kResultNullIfNull,
-                     "convert_toDOUBLE_binary_be", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toFLOAT", {"convert_tofloat"}, DataTypeVector{float32()},
-                     binary(), kResultNullIfNull, "convert_toFLOAT_binary",
+      NativeFunction("convert_todouble_be", {}, DataTypeVector{float64()}, binary(),
+                     kResultNullIfNull, "convert_toDOUBLE_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toFLOAT_BE", {"convert_tofloat_be"},
-                     DataTypeVector{float32()}, binary(), kResultNullIfNull,
-                     "convert_toFLOAT_binary_be", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toINT", {"convert_toint"}, DataTypeVector{int32()},
-                     binary(), kResultNullIfNull, "convert_toINT_binary",
+      NativeFunction("convert_tofloat", {}, DataTypeVector{float32()}, binary(),
+                     kResultNullIfNull, "convert_toFLOAT",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toINT_BE", {"convert_toint_be"}, DataTypeVector{int32()},
-                     binary(), kResultNullIfNull, "convert_toINT_binary_be",
+      NativeFunction("convert_tofloat_be", {}, DataTypeVector{float32()}, binary(),
+                     kResultNullIfNull, "convert_toFLOAT_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toBIGINT", {"convert_tobigint"}, DataTypeVector{int64()},
-                     binary(), kResultNullIfNull, "convert_toBIGINT_binary",
+      NativeFunction("convert_toint", {}, DataTypeVector{int32()}, binary(),
+                     kResultNullIfNull, "convert_toINT",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toBIGINT_BE", {"convert_tobigint_be"},
-                     DataTypeVector{int64()}, binary(), kResultNullIfNull,
-                     "convert_toBIGINT_binary_be", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toBOOLEAN_BYTE", {"convert_toboolean_byte"},
-                     DataTypeVector{boolean()}, binary(), kResultNullIfNull,
-                     "convert_toBOOLEAN_binary", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toTIME_EPOCH", {"convert_totime_epoch"},
-                     DataTypeVector{time32()}, binary(), kResultNullIfNull,
-                     "convert_toTIME_EPOCH_binary", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toTIME_EPOCH_BE", {"convert_totime_epoch_be"},
-                     DataTypeVector{time32()}, binary(), kResultNullIfNull,
-                     "convert_toTIME_EPOCH_binary_be", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toTIMESTAMP_EPOCH", {"convert_totimestamp_epoch"},
-                     DataTypeVector{timestamp()}, binary(), kResultNullIfNull,
-                     "convert_toTIMESTAMP_EPOCH_binary", NativeFunction::kNeedsContext),
-
-      NativeFunction("convert_toTIMESTAMP_EPOCH_BE", {"convert_totimestamp_epoch_be"},
-                     DataTypeVector{timestamp()}, binary(), kResultNullIfNull,
-                     "convert_toTIMESTAMP_EPOCH_binary_be",
+      NativeFunction("convert_toint_be", {}, DataTypeVector{int32()}, binary(),
+                     kResultNullIfNull, "convert_toINT_be",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toDATE_EPOCH", {"convert_todate_epoch"},
-                     DataTypeVector{date64()}, binary(), kResultNullIfNull,
-                     "convert_toDATE_EPOCH_binary", NativeFunction::kNeedsContext),
+      NativeFunction("convert_tobigint", {}, DataTypeVector{int64()}, binary(),
+                     kResultNullIfNull, "convert_toBIGINT",
+                     NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toDATE_EPOCH_BE", {"convert_todate_epoch_be"},
-                     DataTypeVector{date64()}, binary(), kResultNullIfNull,
-                     "convert_toDATE_EPOCH_binary_be", NativeFunction::kNeedsContext),
+      NativeFunction("convert_tobigint_be", {}, DataTypeVector{int64()}, binary(),
+                     kResultNullIfNull, "convert_toBIGINT_be",
+                     NativeFunction::kNeedsContext),
 
-      NativeFunction("convert_toUTF8", {"convert_toutf8"}, DataTypeVector{utf8()},
-                     binary(), kResultNullIfNull, "convert_toUTF8_binary",
+      NativeFunction("convert_toboolean_byte", {}, DataTypeVector{boolean()}, binary(),
+                     kResultNullIfNull, "convert_toBOOLEAN",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_totime_epoch", {}, DataTypeVector{time32()}, binary(),
+                     kResultNullIfNull, "convert_toTIME_EPOCH",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_totime_epoch_be", {}, DataTypeVector{time32()}, binary(),
+                     kResultNullIfNull, "convert_toTIME_EPOCH_be",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_totimestamp_epoch", {}, DataTypeVector{timestamp()},
+                     binary(), kResultNullIfNull, "convert_toTIMESTAMP_EPOCH",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_totimestamp_epoch_be", {}, DataTypeVector{timestamp()},
+                     binary(), kResultNullIfNull, "convert_toTIMESTAMP_EPOCH_be",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_todate_epoch", {}, DataTypeVector{date64()}, binary(),
+                     kResultNullIfNull, "convert_toDATE_EPOCH",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_todate_epoch_be", {}, DataTypeVector{date64()}, binary(),
+                     kResultNullIfNull, "convert_toDATE_EPOCH_be",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("convert_toutf8", {}, DataTypeVector{utf8()}, binary(),
+                     kResultNullIfNull, "convert_toUTF8",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -234,16 +234,14 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("convert_tofloat", {}, DataTypeVector{float32()}, binary(),
-                     kResultNullIfNull, "convert_toFLOAT",
-                     NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "convert_toFLOAT", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_tofloat_be", {}, DataTypeVector{float32()}, binary(),
                      kResultNullIfNull, "convert_toFLOAT_be",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toint", {}, DataTypeVector{int32()}, binary(),
-                     kResultNullIfNull, "convert_toINT",
-                     NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "convert_toINT", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toint_be", {}, DataTypeVector{int32()}, binary(),
                      kResultNullIfNull, "convert_toINT_be",
@@ -286,8 +284,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("convert_toutf8", {}, DataTypeVector{utf8()}, binary(),
-                     kResultNullIfNull, "convert_toUTF8",
-                     NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "convert_toUTF8", NativeFunction::kNeedsContext),
 
       NativeFunction("locate", {"position"}, DataTypeVector{utf8(), utf8(), int32()},
                      int32(), kResultNullIfNull, "locate_utf8_utf8_int32",

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1328,6 +1328,31 @@ const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_
   return ret;
 }
 
+FORCE_INLINE
+const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len) {
+  *out_len = sizeof(value);
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context,
+                                 "Could not allocate memory for the output string");
+
+    *out_len = 0;
+    return "";
+  }
+
+  memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
+const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
+                                  int32_t* out_len){
+  *out_len = value_len;
+  return value;
+}
+
 // Search for a string within another string
 FORCE_INLINE
 gdv_int32 locate_utf8_utf8(gdv_int64 context, const char* sub_str, gdv_int32 sub_str_len,

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1311,8 +1311,9 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
   return ret;
 }
 
+// Converts a double variable to binary
 FORCE_INLINE
-const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len) {
+const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
 
@@ -1330,10 +1331,10 @@ const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_
 }
 
 FORCE_INLINE
-const char* convert_toDOUBLE_binary_be(int64_t context, double value, int32_t* out_len) {
-  // The function behaves like convert_toDOUBLE_binary, but always return the result
+const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len) {
+  // The function behaves like convert_toDOUBLE, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toDOUBLE_binary(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toDOUBLE(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   std::reverse(ret, ret + *out_len);
@@ -1342,8 +1343,9 @@ const char* convert_toDOUBLE_binary_be(int64_t context, double value, int32_t* o
   return ret;
 }
 
+// Converts a float variable to binary
 FORCE_INLINE
-const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len) {
+const char* convert_toFLOAT(int64_t context, float value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
 
@@ -1361,10 +1363,10 @@ const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_le
 }
 
 FORCE_INLINE
-const char* convert_toFLOAT_binary_be(int64_t context, float value, int32_t* out_len) {
-  // The function behaves like convert_toFLOAT_binary, but always return the result
+const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len) {
+  // The function behaves like convert_toFLOAT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toFLOAT_binary(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toFLOAT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   std::reverse(ret, ret + *out_len);
@@ -1373,8 +1375,9 @@ const char* convert_toFLOAT_binary_be(int64_t context, float value, int32_t* out
   return ret;
 }
 
+// Converts a bigint(int with 64 bits) variable to binary
 FORCE_INLINE
-const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out_len) {
+const char* convert_toBIGINT(int64_t context, int64_t value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
 
@@ -1392,10 +1395,10 @@ const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out
 }
 
 FORCE_INLINE
-const char* convert_toBIGINT_binary_be(int64_t context, int64_t value, int32_t* out_len) {
-  // The function behaves like convert_toBIGINT_binary, but always return the result
+const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len) {
+  // The function behaves like convert_toBIGINT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toBIGINT_binary(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toBIGINT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   std::reverse(ret, ret + *out_len);
@@ -1404,8 +1407,9 @@ const char* convert_toBIGINT_binary_be(int64_t context, int64_t value, int32_t* 
   return ret;
 }
 
+// Converts an integer(with 32 bits) variable to binary
 FORCE_INLINE
-const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len) {
+const char* convert_toINT(int64_t context, int32_t value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
 
@@ -1423,10 +1427,10 @@ const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_le
 }
 
 FORCE_INLINE
-const char* convert_toINT_binary_be(int64_t context, int32_t value, int32_t* out_len) {
-  // The function behaves like convert_toINT_binary, but always return the result
+const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len) {
+  // The function behaves like convert_toINT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toINT_binary(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toINT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   std::reverse(ret, ret + *out_len);
@@ -1435,8 +1439,9 @@ const char* convert_toINT_binary_be(int64_t context, int32_t value, int32_t* out
   return ret;
 }
 
+// Converts a boolean variable to binary
 FORCE_INLINE
-const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_len) {
+const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
 
@@ -1453,49 +1458,53 @@ const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_l
   return ret;
 }
 
+// Converts a time variable to binary
 FORCE_INLINE
-const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value,
+const char* convert_toTIME_EPOCH(int64_t context, int32_t value,
                                         int32_t* out_len) {
-  return convert_toINT_binary(context, value, out_len);
+  return convert_toINT(context, value, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toTIME_EPOCH_binary_be(int64_t context, int32_t value,
+const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value,
                                            int32_t* out_len) {
-  // The function behaves as convert_toTIME_EPOCH_binary, but
+  // The function behaves as convert_toTIME_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toINT_binary_be(context, value, out_len);
+  return convert_toINT_be(context, value, out_len);
 }
 
+// Converts a timestamp variable to binary
 FORCE_INLINE
-const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
                                              int32_t* out_len) {
-  return convert_toBIGINT_binary(context, timestamp, out_len);
+  return convert_toBIGINT(context, timestamp, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toTIMESTAMP_EPOCH_binary_be(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
                                                 int32_t* out_len) {
-  // The function behaves as convert_toTIMESTAMP_EPOCH_binary, but
+  // The function behaves as convert_toTIMESTAMP_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toBIGINT_binary_be(context, timestamp, out_len);
+  return convert_toBIGINT_be(context, timestamp, out_len);
+}
+
+// Converts a date variable to binary
+FORCE_INLINE
+const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len) {
+  return convert_toBIGINT(context, date, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len) {
-  return convert_toBIGINT_binary(context, date, out_len);
-}
-
-FORCE_INLINE
-const char* convert_toDATE_EPOCH_binary_be(int64_t context, int64_t date,
+const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date,
                                            int32_t* out_len) {
-  // The function behaves as convert_toDATE_EPOCH_binary, but
+  // The function behaves as convert_toDATE_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toBIGINT_binary_be(context, date, out_len);
+  return convert_toBIGINT_be(context, date, out_len);
 }
 
+// Converts a string variable to binary
 FORCE_INLINE
-const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
+const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
                                   int32_t* out_len) {
   *out_len = value_len;
   return value;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1310,6 +1310,24 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
   return ret;
 }
 
+FORCE_INLINE
+const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len) {
+  *out_len = sizeof(value);
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context,
+                                 "Could not allocate memory for the output string");
+
+    *out_len = 0;
+    return "";
+  }
+
+  memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
 // Search for a string within another string
 FORCE_INLINE
 gdv_int32 locate_utf8_utf8(gdv_int64 context, const char* sub_str, gdv_int32 sub_str_len,

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1311,6 +1311,18 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
   return ret;
 }
 
+// The function reverse a char array in-place
+static inline void reverse_char_buf(char* buf, int32_t len) {
+  char temp;
+
+  for (int32_t i = 0; i < len / 2; i++) {
+    int32_t pos_swp = len - (1 + i);
+    temp = buf[pos_swp];
+    buf[pos_swp] = buf[i];
+    buf[i] = temp;
+  }
+}
+
 // Converts a double variable to binary
 FORCE_INLINE
 const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len) {
@@ -1337,7 +1349,7 @@ const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len)
   char* ret = const_cast<char*>(convert_toDOUBLE(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
-  std::reverse(ret, ret + *out_len);
+  reverse_char_buf(ret, *out_len);
 #endif
 
   return ret;
@@ -1369,7 +1381,7 @@ const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len) {
   char* ret = const_cast<char*>(convert_toFLOAT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
-  std::reverse(ret, ret + *out_len);
+  reverse_char_buf(ret, *out_len);
 #endif
 
   return ret;
@@ -1401,7 +1413,7 @@ const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len
   char* ret = const_cast<char*>(convert_toBIGINT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
-  std::reverse(ret, ret + *out_len);
+  reverse_char_buf(ret, *out_len);
 #endif
 
   return ret;
@@ -1433,7 +1445,7 @@ const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len) {
   char* ret = const_cast<char*>(convert_toINT(context, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
-  std::reverse(ret, ret + *out_len);
+  reverse_char_buf(ret, *out_len);
 #endif
 
   return ret;
@@ -1460,14 +1472,12 @@ const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len) {
 
 // Converts a time variable to binary
 FORCE_INLINE
-const char* convert_toTIME_EPOCH(int64_t context, int32_t value,
-                                        int32_t* out_len) {
+const char* convert_toTIME_EPOCH(int64_t context, int32_t value, int32_t* out_len) {
   return convert_toINT(context, value, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value,
-                                           int32_t* out_len) {
+const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value, int32_t* out_len) {
   // The function behaves as convert_toTIME_EPOCH, but
   // returns the bytes in big endian format
   return convert_toINT_be(context, value, out_len);
@@ -1476,13 +1486,13 @@ const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value,
 // Converts a timestamp variable to binary
 FORCE_INLINE
 const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
-                                             int32_t* out_len) {
+                                      int32_t* out_len) {
   return convert_toBIGINT(context, timestamp, out_len);
 }
 
 FORCE_INLINE
 const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
-                                                int32_t* out_len) {
+                                         int32_t* out_len) {
   // The function behaves as convert_toTIMESTAMP_EPOCH, but
   // returns the bytes in big endian format
   return convert_toBIGINT_be(context, timestamp, out_len);
@@ -1495,8 +1505,7 @@ const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len
 }
 
 FORCE_INLINE
-const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date,
-                                           int32_t* out_len) {
+const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date, int32_t* out_len) {
   // The function behaves as convert_toDATE_EPOCH, but
   // returns the bytes in big endian format
   return convert_toBIGINT_be(context, date, out_len);
@@ -1505,7 +1514,7 @@ const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date,
 // Converts a string variable to binary
 FORCE_INLINE
 const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
-                                  int32_t* out_len) {
+                           int32_t* out_len) {
   *out_len = value_len;
   return value;
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1489,7 +1489,7 @@ const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* 
 FORCE_INLINE
 const char* convert_toDATE_EPOCH_binary_be(int64_t context, int64_t date,
                                            int32_t* out_len) {
-  // The function behaves as convert_toBIGINT_binary, but
+  // The function behaves as convert_toDATE_EPOCH_binary, but
   // returns the bytes in big endian format
   return convert_toBIGINT_binary_be(context, date, out_len);
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -19,10 +19,11 @@
 #include "arrow/util/value_parsing.h"
 extern "C" {
 
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <algorithm>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "./types.h"
 
@@ -1347,8 +1348,14 @@ const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_le
 }
 
 FORCE_INLINE
+const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value,
+                                        int32_t* out_len) {
+  return convert_toINT_binary(context, value, out_len);
+}
+
+FORCE_INLINE
 const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
-                                  int32_t* out_len){
+                                  int32_t* out_len) {
   *out_len = value_len;
   return value;
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1330,6 +1330,19 @@ const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_
 }
 
 FORCE_INLINE
+const char* convert_toDOUBLE_binary_be(int64_t context, double value, int32_t* out_len) {
+  // The function behaves like convert_toDOUBLE_binary, but always return the result
+  // in big endian format
+  char* ret = const_cast<char*>(convert_toDOUBLE_binary(context, value, out_len));
+
+#if ARROW_LITTLE_ENDIAN
+  std::reverse(ret, ret + *out_len);
+#endif
+
+  return ret;
+}
+
+FORCE_INLINE
 const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
@@ -1343,6 +1356,19 @@ const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_le
   }
 
   memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
+const char* convert_toFLOAT_binary_be(int64_t context, float value, int32_t* out_len) {
+  // The function behaves like convert_toFLOAT_binary, but always return the result
+  // in big endian format
+  char* ret = const_cast<char*>(convert_toFLOAT_binary(context, value, out_len));
+
+#if ARROW_LITTLE_ENDIAN
+  std::reverse(ret, ret + *out_len);
+#endif
 
   return ret;
 }
@@ -1366,6 +1392,19 @@ const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out
 }
 
 FORCE_INLINE
+const char* convert_toBIGINT_binary_be(int64_t context, int64_t value, int32_t* out_len) {
+  // The function behaves like convert_toBIGINT_binary, but always return the result
+  // in big endian format
+  char* ret = const_cast<char*>(convert_toBIGINT_binary(context, value, out_len));
+
+#if ARROW_LITTLE_ENDIAN
+  std::reverse(ret, ret + *out_len);
+#endif
+
+  return ret;
+}
+
+FORCE_INLINE
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
@@ -1379,6 +1418,19 @@ const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_le
   }
 
   memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
+const char* convert_toINT_binary_be(int64_t context, int32_t value, int32_t* out_len) {
+  // The function behaves like convert_toINT_binary, but always return the result
+  // in big endian format
+  char* ret = const_cast<char*>(convert_toINT_binary(context, value, out_len));
+
+#if ARROW_LITTLE_ENDIAN
+  std::reverse(ret, ret + *out_len);
+#endif
 
   return ret;
 }
@@ -1408,14 +1460,38 @@ const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value,
 }
 
 FORCE_INLINE
+const char* convert_toTIME_EPOCH_binary_be(int64_t context, int32_t value,
+                                           int32_t* out_len) {
+  // The function behaves as convert_toTIME_EPOCH_binary, but
+  // returns the bytes in big endian format
+  return convert_toINT_binary_be(context, value, out_len);
+}
+
+FORCE_INLINE
 const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
                                              int32_t* out_len) {
   return convert_toBIGINT_binary(context, timestamp, out_len);
 }
 
 FORCE_INLINE
+const char* convert_toTIMESTAMP_EPOCH_binary_be(int64_t context, int64_t timestamp,
+                                                int32_t* out_len) {
+  // The function behaves as convert_toTIMESTAMP_EPOCH_binary, but
+  // returns the bytes in big endian format
+  return convert_toBIGINT_binary_be(context, timestamp, out_len);
+}
+
+FORCE_INLINE
 const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len) {
   return convert_toBIGINT_binary(context, date, out_len);
+}
+
+FORCE_INLINE
+const char* convert_toDATE_EPOCH_binary_be(int64_t context, int64_t date,
+                                           int32_t* out_len) {
+  // The function behaves as convert_toBIGINT_binary, but
+  // returns the bytes in big endian format
+  return convert_toBIGINT_binary_be(context, date, out_len);
 }
 
 FORCE_INLINE

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1384,9 +1384,38 @@ const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_le
 }
 
 FORCE_INLINE
+const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_len) {
+  *out_len = sizeof(value);
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context,
+                                 "Could not allocate memory for the output string");
+
+    *out_len = 0;
+    return "";
+  }
+
+  memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
 const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value,
                                         int32_t* out_len) {
   return convert_toINT_binary(context, value, out_len);
+}
+
+FORCE_INLINE
+const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
+                                             int32_t* out_len) {
+  return convert_toBIGINT_binary(context, timestamp, out_len);
+}
+
+FORCE_INLINE
+const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len) {
+  return convert_toBIGINT_binary(context, date, out_len);
 }
 
 FORCE_INLINE

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1330,6 +1330,42 @@ const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_
 }
 
 FORCE_INLINE
+const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len) {
+  *out_len = sizeof(value);
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context,
+                                 "Could not allocate memory for the output string");
+
+    *out_len = 0;
+    return "";
+  }
+
+  memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
+const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out_len) {
+  *out_len = sizeof(value);
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context,
+                                 "Could not allocate memory for the output string");
+
+    *out_len = 0;
+    return "";
+  }
+
+  memcpy(ret, &value, *out_len);
+
+  return ret;
+}
+
+FORCE_INLINE
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len) {
   *out_len = sizeof(value);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -18,6 +18,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/types.h"
 
@@ -1086,6 +1088,31 @@ TEST(TestStringOps, TestSplitPart) {
 
   out_str = split_part(ctx_ptr, "ç†ååçåå†", 18, "†", 3, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ååçåå");
+}
+
+TEST(TestStringOps, TestConvertTo) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+  const char* out_str;
+
+  const int32_t ALL_BYTES_MATCH = 0;
+
+  int32_t integer_value = std::numeric_limits<int32_t>::max();
+  out_str = convert_toINT_binary(ctx_ptr, integer_value, &out_len);
+  EXPECT_EQ(out_len, sizeof(integer_value));
+  EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &integer_value, out_len));
+
+  int64_t big_integer_value = std::numeric_limits<int64_t>::max();
+  out_str = convert_toBIGINT_binary(ctx_ptr, big_integer_value, &out_len);
+  EXPECT_EQ(out_len, sizeof(big_integer_value));
+  EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &big_integer_value, out_len));
+
+  const char* test_string = "test string";
+  int32_t str_len = 11;
+  out_str = convert_toUTF8_binary(ctx_ptr, test_string, str_len, &out_len);
+  EXPECT_EQ(out_len, str_len);
+  EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, test_string, out_len));
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1099,28 +1099,28 @@ TEST(TestStringOps, TestConvertTo) {
   const int32_t ALL_BYTES_MATCH = 0;
 
   int32_t integer_value = std::numeric_limits<int32_t>::max();
-  out_str = convert_toINT_binary(ctx_ptr, integer_value, &out_len);
+  out_str = convert_toINT(ctx_ptr, integer_value, &out_len);
   EXPECT_EQ(out_len, sizeof(integer_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &integer_value, out_len));
 
   int64_t big_integer_value = std::numeric_limits<int64_t>::max();
-  out_str = convert_toBIGINT_binary(ctx_ptr, big_integer_value, &out_len);
+  out_str = convert_toBIGINT(ctx_ptr, big_integer_value, &out_len);
   EXPECT_EQ(out_len, sizeof(big_integer_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &big_integer_value, out_len));
 
   float float_value = std::numeric_limits<float>::max();
-  out_str = convert_toFLOAT_binary(ctx_ptr, float_value, &out_len);
+  out_str = convert_toFLOAT(ctx_ptr, float_value, &out_len);
   EXPECT_EQ(out_len, sizeof(float_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &float_value, out_len));
 
   double double_value = std::numeric_limits<double>::max();
-  out_str = convert_toDOUBLE_binary(ctx_ptr, double_value, &out_len);
+  out_str = convert_toDOUBLE(ctx_ptr, double_value, &out_len);
   EXPECT_EQ(out_len, sizeof(double_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &double_value, out_len));
 
   const char* test_string = "test string";
   int32_t str_len = 11;
-  out_str = convert_toUTF8_binary(ctx_ptr, test_string, str_len, &out_len);
+  out_str = convert_toUTF8(ctx_ptr, test_string, str_len, &out_len);
   EXPECT_EQ(out_len, str_len);
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, test_string, out_len));
 }
@@ -1134,9 +1134,9 @@ TEST(TestStringOps, TestConvertToBigEndian) {
   const char* out_str_big_endian;
 
   int64_t big_integer_value = std::numeric_limits<int64_t>::max();
-  out_str = convert_toBIGINT_binary(ctx_ptr, big_integer_value, &out_len);
+  out_str = convert_toBIGINT(ctx_ptr, big_integer_value, &out_len);
   out_str_big_endian =
-      convert_toBIGINT_binary_be(ctx_ptr, big_integer_value, &out_len_big_endian);
+      convert_toBIGINT_be(ctx_ptr, big_integer_value, &out_len_big_endian);
   EXPECT_EQ(out_len_big_endian, sizeof(big_integer_value));
   EXPECT_EQ(out_len_big_endian, out_len);
 
@@ -1152,9 +1152,9 @@ TEST(TestStringOps, TestConvertToBigEndian) {
 #endif
 
   double double_value = std::numeric_limits<double>::max();
-  out_str = convert_toDOUBLE_binary(ctx_ptr, double_value, &out_len);
+  out_str = convert_toDOUBLE(ctx_ptr, double_value, &out_len);
   out_str_big_endian =
-      convert_toDOUBLE_binary_be(ctx_ptr, double_value, &out_len_big_endian);
+      convert_toDOUBLE_be(ctx_ptr, double_value, &out_len_big_endian);
   EXPECT_EQ(out_len_big_endian, sizeof(double_value));
   EXPECT_EQ(out_len_big_endian, out_len);
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1108,6 +1108,16 @@ TEST(TestStringOps, TestConvertTo) {
   EXPECT_EQ(out_len, sizeof(big_integer_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &big_integer_value, out_len));
 
+  float float_value = std::numeric_limits<float>::max();
+  out_str = convert_toFLOAT_binary(ctx_ptr, float_value, &out_len);
+  EXPECT_EQ(out_len, sizeof(float_value));
+  EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &float_value, out_len));
+
+  double double_value = std::numeric_limits<double>::max();
+  out_str = convert_toDOUBLE_binary(ctx_ptr, double_value, &out_len);
+  EXPECT_EQ(out_len, sizeof(double_value));
+  EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &double_value, out_len));
+
   const char* test_string = "test string";
   int32_t str_len = 11;
   out_str = convert_toUTF8_binary(ctx_ptr, test_string, str_len, &out_len);
@@ -1115,4 +1125,40 @@ TEST(TestStringOps, TestConvertTo) {
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, test_string, out_len));
 }
 
+TEST(TestStringOps, TestConvertToBigEndian) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+  gdv_int32 out_len_big_endian = 0;
+  const char* out_str;
+  const char* out_str_big_endian;
+
+  int64_t big_integer_value = std::numeric_limits<int64_t>::max();
+  out_str = convert_toBIGINT_binary(ctx_ptr, big_integer_value, &out_len);
+  out_str_big_endian =
+      convert_toBIGINT_binary_be(ctx_ptr, big_integer_value, &out_len_big_endian);
+  EXPECT_EQ(out_len_big_endian, sizeof(big_integer_value));
+  EXPECT_EQ(out_len_big_endian, out_len);
+
+#if ARROW_LITTLE_ENDIAN
+  // Checks that bytes are in reverse order
+  for (auto i = 0; i < out_len; i++) {
+    EXPECT_EQ(out_str[i], out_str_big_endian[out_len - (i + 1)]);
+  }
+#endif
+
+  double double_value = std::numeric_limits<double>::max();
+  out_str = convert_toDOUBLE_binary(ctx_ptr, double_value, &out_len);
+  out_str_big_endian =
+      convert_toDOUBLE_binary_be(ctx_ptr, double_value, &out_len_big_endian);
+  EXPECT_EQ(out_len_big_endian, sizeof(double_value));
+  EXPECT_EQ(out_len_big_endian, out_len);
+
+#if ARROW_LITTLE_ENDIAN
+  // Checks that bytes are in reverse order
+  for (auto i = 0; i < out_len; i++) {
+    EXPECT_EQ(out_str[i], out_str_big_endian[out_len - (i + 1)]);
+  }
+#endif
+}
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1153,8 +1153,7 @@ TEST(TestStringOps, TestConvertToBigEndian) {
 
   double double_value = std::numeric_limits<double>::max();
   out_str = convert_toDOUBLE(ctx_ptr, double_value, &out_len);
-  out_str_big_endian =
-      convert_toDOUBLE_be(ctx_ptr, double_value, &out_len_big_endian);
+  out_str_big_endian = convert_toDOUBLE_be(ctx_ptr, double_value, &out_len_big_endian);
   EXPECT_EQ(out_len_big_endian, sizeof(double_value));
   EXPECT_EQ(out_len_big_endian, out_len);
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1145,6 +1145,10 @@ TEST(TestStringOps, TestConvertToBigEndian) {
   for (auto i = 0; i < out_len; i++) {
     EXPECT_EQ(out_str[i], out_str_big_endian[out_len - (i + 1)]);
   }
+#else
+  for (auto i = 0; i < out_len; i++) {
+    EXPECT_EQ(out_str[i], out_str_big_endian[i]);
+  }
 #endif
 
   double double_value = std::numeric_limits<double>::max();
@@ -1158,6 +1162,10 @@ TEST(TestStringOps, TestConvertToBigEndian) {
   // Checks that bytes are in reverse order
   for (auto i = 0; i < out_len; i++) {
     EXPECT_EQ(out_str[i], out_str_big_endian[out_len - (i + 1)]);
+  }
+#else
+  for (auto i = 0; i < out_len; i++) {
+    EXPECT_EQ(out_str[i], out_str_big_endian[i]);
   }
 #endif
 }

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -425,40 +425,40 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
                                                     int32_t char_to_replace_len,
                                                     int32_t* out_len);
 
-const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len);
+const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len);
 
-const char* convert_toDOUBLE_binary_be(int64_t context, double value, int32_t* out_len);
+const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len);
 
-const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len);
+const char* convert_toFLOAT(int64_t context, float value, int32_t* out_len);
 
-const char* convert_toFLOAT_binary_be(int64_t context, float value, int32_t* out_len);
+const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len);
 
-const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out_len);
+const char* convert_toBIGINT(int64_t context, int64_t value, int32_t* out_len);
 
-const char* convert_toBIGINT_binary_be(int64_t context, int64_t value, int32_t* out_len);
+const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len);
 
-const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toINT(int64_t context, int32_t value, int32_t* out_len);
 
-const char* convert_toINT_binary_be(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len);
 
-const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_len);
+const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len);
 
-const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toTIME_EPOCH(int64_t context, int32_t value, int32_t* out_len);
 
-const char* convert_toTIME_EPOCH_binary_be(int64_t context, int32_t value,
+const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value,
                                            int32_t* out_len);
 
-const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
                                              int32_t* out_len);
-const char* convert_toTIMESTAMP_EPOCH_binary_be(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
                                                 int32_t* out_len);
 
-const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len);
+const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len);
 
-const char* convert_toDATE_EPOCH_binary_be(int64_t context, int64_t date,
+const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date,
                                            int32_t* out_len);
 
-const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
+const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
                                   int32_t* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -429,6 +429,8 @@ const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_
 
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
 
+const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value, int32_t* out_len);
+
 const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
                                   int32_t* out_len);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -445,21 +445,19 @@ const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len);
 
 const char* convert_toTIME_EPOCH(int64_t context, int32_t value, int32_t* out_len);
 
-const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value,
-                                           int32_t* out_len);
+const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value, int32_t* out_len);
 
 const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
-                                             int32_t* out_len);
+                                      int32_t* out_len);
 const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
-                                                int32_t* out_len);
+                                         int32_t* out_len);
 
 const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len);
 
-const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date,
-                                           int32_t* out_len);
+const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date, int32_t* out_len);
 
 const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
-                                  int32_t* out_len);
+                           int32_t* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -427,6 +427,10 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
 
 const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len);
 
+const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len);
+
+const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out_len);
+
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
 
 const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value, int32_t* out_len);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -427,20 +427,36 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
 
 const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len);
 
+const char* convert_toDOUBLE_binary_be(int64_t context, double value, int32_t* out_len);
+
 const char* convert_toFLOAT_binary(int64_t context, float value, int32_t* out_len);
+
+const char* convert_toFLOAT_binary_be(int64_t context, float value, int32_t* out_len);
 
 const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out_len);
 
+const char* convert_toBIGINT_binary_be(int64_t context, int64_t value, int32_t* out_len);
+
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
+
+const char* convert_toINT_binary_be(int64_t context, int32_t value, int32_t* out_len);
 
 const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_len);
 
 const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value, int32_t* out_len);
 
+const char* convert_toTIME_EPOCH_binary_be(int64_t context, int32_t value,
+                                           int32_t* out_len);
+
 const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
                                              int32_t* out_len);
+const char* convert_toTIMESTAMP_EPOCH_binary_be(int64_t context, int64_t timestamp,
+                                                int32_t* out_len);
 
 const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len);
+
+const char* convert_toDATE_EPOCH_binary_be(int64_t context, int64_t date,
+                                           int32_t* out_len);
 
 const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
                                   int32_t* out_len);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -427,6 +427,11 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
 
 const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len);
 
+const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
+
+const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
+                                  int32_t* out_len);
+
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,
                        gdv_int32* out_len);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "gandiva/gdv_function_stubs.h"
 
 // Use the same names as in arrow data types. Makes it easy to write pre-processor macros.
@@ -423,6 +424,8 @@ const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char*
                                                     const char* char_to_replace,
                                                     int32_t char_to_replace_len,
                                                     int32_t* out_len);
+
+const char* convert_toDOUBLE_binary(int64_t context, double value, int32_t* out_len);
 
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -433,7 +433,14 @@ const char* convert_toBIGINT_binary(int64_t context, int64_t value, int32_t* out
 
 const char* convert_toINT_binary(int64_t context, int32_t value, int32_t* out_len);
 
+const char* convert_toBOOLEAN_binary(int64_t context, bool value, int32_t* out_len);
+
 const char* convert_toTIME_EPOCH_binary(int64_t context, int32_t value, int32_t* out_len);
+
+const char* convert_toTIMESTAMP_EPOCH_binary(int64_t context, int64_t timestamp,
+                                             int32_t* out_len);
+
+const char* convert_toDATE_EPOCH_binary(int64_t context, int64_t date, int32_t* out_len);
 
 const char* convert_toUTF8_binary(int64_t context, const char* value, int32_t value_len,
                                   int32_t* out_len);


### PR DESCRIPTION
Implements the CONVERT_TO function inside the Gandiva, which receives a value for a defined type and returns its bytes representation.

The behavior is based on Apache Drill implementation: https://drill.apache.org/docs/data-type-conversion/#convert_to-and-convert_from