### PR TITLE
ARROW-12169: [C++] Fix decompressing file with empty stream at the end

### DIFF
--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -342,7 +342,7 @@ class CompressedInputStream::Impl {
       RETURN_NOT_OK(EnsureCompressedData());
       if (compressed_pos_ == compressed_->size()) {
         // No more data to decompress
-        if (!fresh_decompressor_) {
+        if (!fresh_decompressor_ && !decompressor_->IsFinished()) {
           return Status::IOError("Truncated compressed stream");
         }
         *has_data = false;


### PR DESCRIPTION
Compressed files such as `.gz` can contain multiple concatenated "streams".
If the last stream in the file decompressed to empty data, we would erroneously raise an error.