### PR TITLE
ARROW-12176: [C++] Fix some typos of cpp examples

### DIFF
--- a/cpp/examples/parquet/low-level-api/reader-writer.cc
+++ b/cpp/examples/parquet/low-level-api/reader-writer.cc
@@ -27,7 +27,7 @@
  * reference to the API.
  * The file contains all the physical data types supported by Parquet.
  * This example uses the RowGroupWriter API that supports writing RowGroups optimized for
- *memory consumption
+ * memory consumption.
  **/
 
 /* Parquet is a structured columnar file format

--- a/cpp/examples/parquet/low-level-api/reader-writer2.cc
+++ b/cpp/examples/parquet/low-level-api/reader-writer2.cc
@@ -27,7 +27,7 @@
  * reference to the API.
  * The file contains all the physical data types supported by Parquet.
  * This example uses the RowGroupWriter API that supports writing RowGroups based on a
- *certain size
+ * certain size.
  **/
 
 /* Parquet is a structured columnar file format


### PR DESCRIPTION
There are two typos:

1. In comment: `*memory consumption.` -> `* memory consumption`.
2. reader_writer.h and reader-writer.cc are not compatible, when you use vim to edit them, it's confuse why `:A` doesn't work.