### PR TITLE
ARROW-12172: [Python][Packaging] Pass python version as setuptools pretend version in the macOS wheel builds

### DIFF
--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -18,6 +18,8 @@
 # github comment reports!
 name: Crossbow
 
+SETUPTOOLS_SCM_VERSION
+
 on:
   push:
     branches:
@@ -31,6 +33,7 @@ env:
   PYARROW_BUILD_VERBOSE: 1
   PYARROW_VERSION: {{ arrow.no_rc_version }}
   PYTHON_VERSION: {{ python_version }}
+  SETUPTOOLS_SCM_PRETEND_VERSION: {{ arrow.no_rc_version }}
   VCPKG_DEFAULT_TRIPLET: x64-osx-static-release
   VCPKG_FEATURE_FLAGS: "-manifests"
   VCPKG_OVERLAY_TRIPLETS: {{ "${{ github.workspace }}/arrow/ci/vcpkg" }}

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -18,8 +18,6 @@
 # github comment reports!
 name: Crossbow
 
-SETUPTOOLS_SCM_VERSION
-
 on:
   push:
     branches:


### PR DESCRIPTION
Submitted crossbow job manually with target version 4.0.0: https://github.com/ursacomputing/crossbow/tree/build-124-github-wheel-osx-high-sierra-cp36m