### PR TITLE
ARROW-12112: [Rust][CI] Create and store less debug information in CI and integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,10 @@ jobs:
         rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v2
       - name: Cache Cargo
@@ -83,6 +87,9 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
         ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
         PARQUET_TEST_DATA: /__w/arrow/arrow/cpp/submodules/parquet-testing/data
     steps:
@@ -140,6 +147,9 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
         ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
     steps:
       - uses: actions/checkout@v2
@@ -207,6 +217,10 @@ jobs:
         rust: [stable]
     container:
       image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -367,6 +381,9 @@ jobs:
     container:
       image: ${{ matrix.arch }}/rust
       env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
         ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
         PARQUET_TEST_DATA: /__w/arrow/arrow/cpp/submodules/parquet-testing/data
     steps:

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -21,6 +21,9 @@ set -ex
 
 source_dir=${1}/rust
 
+# Disable full debug symbol generation to speed up CI build / reduce memory required
+export RUSTFLAGS="-C debuginfo=1"
+
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
 


### PR DESCRIPTION
# Rationale
Rust debug symbols are quite verbose, taking up memory during the final link time as well as significant disk space. Turning off the creation of symbols should save us compile / test time for CI as well as space on the integration test

# Change
Do not produce debug symbols on Rust CI (keep enough to have line numbers in `panic!` traceback, but not enough to interpret a core file, which no one does to my knowledge anyways)

Note that the integration test passed: https://github.com/apache/arrow/pull/9879/checks?check_run_id=2256148363