### PR TITLE
ARROW-12190: [Rust][DataFusion] Implement parallel / partitioned hash join

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -1459,7 +1459,7 @@ mod tests {
             3 => Schema::new(vec![
                 Field::new("l_orderkey", DataType::Int32, true),
                 Field::new("revenue", DataType::Float64, true),
-                Field::new("o_orderdat", DataType::Date32, true),
+                Field::new("o_orderdate", DataType::Date32, true),
                 Field::new("o_shippriority", DataType::Int32, true),
             ]),
 
@@ -1537,7 +1537,7 @@ mod tests {
                 Field::new("c_name", DataType::Utf8, true),
                 Field::new("c_custkey", DataType::Int32, true),
                 Field::new("o_orderkey", DataType::Int32, true),
-                Field::new("o_orderdat", DataType::Date32, true),
+                Field::new("o_orderdate", DataType::Date32, true),
                 Field::new("o_totalprice", DataType::Float64, true),
                 Field::new("sum_l_quantity", DataType::Float64, true),
             ]),
@@ -1677,7 +1677,6 @@ mod tests {
             let actual_vec = result_vec(&actual);
 
             // basic result comparison
-            assert_eq!(expected_vec.len(), actual_vec.len());
 
             // compare each row. this works as all TPC-H queries have determinisically ordered results
             for i in 0..actual_vec.len() {

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -1677,6 +1677,7 @@ mod tests {
             let actual_vec = result_vec(&actual);
 
             // basic result comparison
+            assert_eq!(expected_vec.len(), actual_vec.len());
 
             // compare each row. this works as all TPC-H queries have determinisically ordered results
             for i in 0..actual_vec.len() {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1386,8 +1386,6 @@ mod tests {
             4,
         )
         .await?;
-        // 4 batches expected
-        assert_eq!(results.len(), 4);
 
         assert_eq!(
             results.iter().map(|b| b.num_rows()).sum::<usize>(),

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -604,6 +604,9 @@ pub struct ExecutionConfig {
     /// Should DataFusion provide access to `information_schema`
     /// virtual tables for displaying schema information
     information_schema: bool,
+    /// Should DataFusion repartition data using the join keys to execute joins in parallel
+    /// using the provided `concurrency` level
+    pub repartition_joins: bool,
 }
 
 impl ExecutionConfig {
@@ -624,6 +627,7 @@ impl ExecutionConfig {
             default_schema: "public".to_owned(),
             create_default_catalog_and_schema: true,
             information_schema: false,
+            repartition_joins: true,
         }
     }
 
@@ -681,6 +685,12 @@ impl ExecutionConfig {
     /// Enables or disables the inclusion of `information_schema` virtual tables
     pub fn with_information_schema(mut self, enabled: bool) -> Self {
         self.information_schema = enabled;
+        self
+    }
+
+    /// Enables or disables the use of repartitioning for joins to improve parallelism
+    pub fn with_repartition_joins(mut self, enabled: bool) -> Self {
+        self.repartition_joins = enabled;
         self
     }
 }
@@ -2566,7 +2576,8 @@ mod tests {
 
     /// Generate a partitioned CSV file and register it with an execution context
     fn create_ctx(tmp_dir: &TempDir, partition_count: usize) -> Result<ExecutionContext> {
-        let mut ctx = ExecutionContext::new();
+        let mut ctx =
+            ExecutionContext::with_config(ExecutionConfig::new().with_concurrency(8));
 
         let schema = populate_csv_partitions(tmp_dir, partition_count, ".csv")?;
 

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -254,12 +254,9 @@ mod tests {
         let right_rows = right.collect().await?;
         let join = left.join(right, JoinType::Inner, &["c1"], &["c1"])?;
         let join_rows = join.collect().await?;
-        assert_eq!(1, left_rows.len());
-        assert_eq!(100, left_rows[0].num_rows());
-        assert_eq!(1, right_rows.len());
-        assert_eq!(100, right_rows[0].num_rows());
-        assert_eq!(1, join_rows.len());
-        assert_eq!(2008, join_rows[0].num_rows());
+        assert_eq!(100, left_rows.iter().map(|x| x.num_rows()).sum::<usize>());
+        assert_eq!(100, right_rows.iter().map(|x| x.num_rows()).sum::<usize>());
+        assert_eq!(2008, join_rows.iter().map(|x| x.num_rows()).sum::<usize>());
         Ok(())
     }
 

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -264,11 +264,7 @@ impl LogicalPlanBuilder {
             Ok(Self::from(&LogicalPlan::Join {
                 left: Arc::new(self.plan.clone()),
                 right: Arc::new(right.clone()),
-                on: left_keys
-                    .iter()
-                    .zip(right_keys.iter())
-                    .map(|(l, r)| (l.to_string(), r.to_string()))
-                    .collect(),
+                on,
                 join_type,
                 schema: DFSchemaRef::new(join_schema),
             }))

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -86,14 +86,14 @@ pub struct HashJoinExec {
     build_side: Arc<Mutex<Option<JoinLeftData>>>,
     /// Shares the `RandomState` for the hashing algorithm
     random_state: RandomState,
-    /// mode to use
+    /// Partitioning mode to use
     mode: PartitionMode,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-/// Mode for
+/// Partitioning mode to use for hash join
 pub enum PartitionMode {
-    /// Partitioned means that left/right children are partitioned on left and right keys
+    /// Left/right children are partitioned using the left and right keys
     Partitioned,
     /// Left side will be merged and collected into one partition
     MergeLeft,

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -86,6 +86,17 @@ pub struct HashJoinExec {
     build_side: Arc<Mutex<Option<JoinLeftData>>>,
     /// Shares the `RandomState` for the hashing algorithm
     random_state: RandomState,
+    /// mode to use
+    mode: PartitionMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// Mode for
+pub enum PartitionMode {
+    /// Partitioned means that left/right children are partitioned on left and right keys
+    Partitioned,
+    /// Left side will be merged and collected into one partition
+    MergeLeft,
 }
 
 /// Information about the index and placement (left or right) of the columns
@@ -105,6 +116,7 @@ impl HashJoinExec {
         right: Arc<dyn ExecutionPlan>,
         on: &JoinOn,
         join_type: &JoinType,
+        partition_mode: PartitionMode,
     ) -> Result<Self> {
         let left_schema = left.schema();
         let right_schema = right.schema();
@@ -122,7 +134,7 @@ impl HashJoinExec {
             .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
 
-        let random_state = RandomState::new();
+        let random_state = RandomState::with_seeds(0, 0, 0, 0);
 
         Ok(HashJoinExec {
             left,
@@ -132,6 +144,7 @@ impl HashJoinExec {
             schema,
             build_side: Arc::new(Mutex::new(None)),
             random_state,
+            mode: partition_mode,
         })
     }
 
@@ -210,6 +223,7 @@ impl ExecutionPlan for HashJoinExec {
                 children[1].clone(),
                 &self.on,
                 &self.join_type,
+                self.mode,
             )?)),
             _ => Err(DataFusionError::Internal(
                 "HashJoinExec wrong number of children".to_string(),
@@ -223,18 +237,76 @@ impl ExecutionPlan for HashJoinExec {
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         let on_left = self.on.iter().map(|on| on.0.clone()).collect::<Vec<_>>();
-
-        // we only want to compute the build side once
+        // we only want to compute the build side once for PartitionMode::MergeLeft
         let left_data = {
-            let mut build_side = self.build_side.lock().await;
-            match build_side.as_ref() {
-                Some(stream) => stream.clone(),
-                None => {
+            match self.mode {
+                PartitionMode::MergeLeft => {
+                    let mut build_side = self.build_side.lock().await;
+
+                    match build_side.as_ref() {
+                        Some(stream) => stream.clone(),
+                        None => {
+                            let start = Instant::now();
+
+                            // merge all left parts into a single stream
+                            let merge = MergeExec::new(self.left.clone());
+                            let stream = merge.execute(0).await?;
+
+                            // This operation performs 2 steps at once:
+                            // 1. creates a [JoinHashMap] of all batches from the stream
+                            // 2. stores the batches in a vector.
+                            let initial = (
+                                JoinHashMap::with_hasher(IdHashBuilder {}),
+                                Vec::new(),
+                                0,
+                                Vec::new(),
+                            );
+                            let (hashmap, batches, num_rows, _) = stream
+                                .try_fold(initial, |mut acc, batch| async {
+                                    let hash = &mut acc.0;
+                                    let values = &mut acc.1;
+                                    let offset = acc.2;
+                                    acc.3.clear();
+                                    acc.3.resize(batch.num_rows(), 0);
+                                    update_hash(
+                                        &on_left,
+                                        &batch,
+                                        hash,
+                                        offset,
+                                        &self.random_state,
+                                        &mut acc.3,
+                                    )
+                                    .unwrap();
+                                    acc.2 += batch.num_rows();
+                                    values.push(batch);
+                                    Ok(acc)
+                                })
+                                .await?;
+
+                            // Merge all batches into a single batch, so we
+                            // can directly index into the arrays
+                            let single_batch =
+                                concat_batches(&self.left.schema(), &batches, num_rows)?;
+
+                            let left_side = Arc::new((hashmap, single_batch));
+
+                            *build_side = Some(left_side.clone());
+
+                            debug!(
+                            "Built build-side of hash join containing {} rows in {} ms",
+                            num_rows,
+                            start.elapsed().as_millis()
+                        );
+
+                            left_side
+                        }
+                    }
+                }
+                PartitionMode::Partitioned => {
                     let start = Instant::now();
 
-                    // merge all left parts into a single stream
-                    let merge = MergeExec::new(self.left.clone());
-                    let stream = merge.execute(0).await?;
+                    // Load 1 partition of left side in memory
+                    let stream = self.left.execute(partition).await?;
 
                     // This operation performs 2 steps at once:
                     // 1. creates a [JoinHashMap] of all batches from the stream
@@ -274,10 +346,9 @@ impl ExecutionPlan for HashJoinExec {
 
                     let left_side = Arc::new((hashmap, single_batch));
 
-                    *build_side = Some(left_side.clone());
-
                     debug!(
-                        "Built build-side of hash join containing {} rows in {} ms",
+                        "Built build-side {} of hash join containing {} rows in {} ms",
+                        partition,
                         num_rows,
                         start.elapsed().as_millis()
                     );
@@ -849,7 +920,7 @@ mod tests {
             .iter()
             .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
-        HashJoinExec::try_new(left, right, &on, join_type)
+        HashJoinExec::try_new(left, right, &on, join_type, PartitionMode::MergeLeft)
     }
 
     #[tokio::test]

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -20,7 +20,8 @@
 use std::sync::Arc;
 
 use super::{
-    aggregates, empty::EmptyExec, expressions::binary, functions, udaf, union::UnionExec,
+    aggregates, empty::EmptyExec, expressions::binary, functions,
+    hash_join::PartitionMode, udaf, union::UnionExec,
 };
 use crate::error::{DataFusionError, Result};
 use crate::execution::context::ExecutionContextState;
@@ -344,12 +345,22 @@ impl DefaultPhysicalPlanner {
                     JoinType::Left => hash_utils::JoinType::Left,
                     JoinType::Right => hash_utils::JoinType::Right,
                 };
+                let left_expr = keys.iter().map(|x| col(&x.0)).collect();
+                let right_expr = keys.iter().map(|x| col(&x.1)).collect();
 
+                // Use hash partition by defualt to parallelize hash joins
                 Ok(Arc::new(HashJoinExec::try_new(
-                    left,
-                    right,
+                    Arc::new(RepartitionExec::try_new(
+                        left,
+                        Partitioning::Hash(left_expr, ctx_state.config.concurrency),
+                    )?),
+                    Arc::new(RepartitionExec::try_new(
+                        right,
+                        Partitioning::Hash(right_expr, ctx_state.config.concurrency),
+                    )?),
                     &keys,
                     &physical_join_type,
+                    PartitionMode::Partitioned,
                 )?))
             }
             LogicalPlan::EmptyRelation {

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -345,23 +345,33 @@ impl DefaultPhysicalPlanner {
                     JoinType::Left => hash_utils::JoinType::Left,
                     JoinType::Right => hash_utils::JoinType::Right,
                 };
-                let left_expr = keys.iter().map(|x| col(&x.0)).collect();
-                let right_expr = keys.iter().map(|x| col(&x.1)).collect();
+                if ctx_state.config.concurrency > 1 {
+                    let left_expr = keys.iter().map(|x| col(&x.0)).collect();
+                    let right_expr = keys.iter().map(|x| col(&x.1)).collect();
 
-                // Use hash partition by defualt to parallelize hash joins
-                Ok(Arc::new(HashJoinExec::try_new(
-                    Arc::new(RepartitionExec::try_new(
+                    // Use hash partition by defualt to parallelize hash joins
+                    Ok(Arc::new(HashJoinExec::try_new(
+                        Arc::new(RepartitionExec::try_new(
+                            left,
+                            Partitioning::Hash(left_expr, ctx_state.config.concurrency),
+                        )?),
+                        Arc::new(RepartitionExec::try_new(
+                            right,
+                            Partitioning::Hash(right_expr, ctx_state.config.concurrency),
+                        )?),
+                        &keys,
+                        &physical_join_type,
+                        PartitionMode::Partitioned,
+                    )?))
+                } else {
+                    Ok(Arc::new(HashJoinExec::try_new(
                         left,
-                        Partitioning::Hash(left_expr, ctx_state.config.concurrency),
-                    )?),
-                    Arc::new(RepartitionExec::try_new(
                         right,
-                        Partitioning::Hash(right_expr, ctx_state.config.concurrency),
-                    )?),
-                    &keys,
-                    &physical_join_type,
-                    PartitionMode::Partitioned,
-                )?))
+                        &keys,
+                        &physical_join_type,
+                        PartitionMode::MergeLeft,
+                    )?))
+                }
             }
             LogicalPlan::EmptyRelation {
                 produce_one_row,

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -369,7 +369,7 @@ impl DefaultPhysicalPlanner {
                         right,
                         &keys,
                         &physical_join_type,
-                        PartitionMode::MergeLeft,
+                        PartitionMode::CollectLeft,
                     )?))
                 }
             }

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -345,7 +345,8 @@ impl DefaultPhysicalPlanner {
                     JoinType::Left => hash_utils::JoinType::Left,
                     JoinType::Right => hash_utils::JoinType::Right,
                 };
-                if ctx_state.config.concurrency > 1 {
+                if ctx_state.config.concurrency > 1 && ctx_state.config.repartition_joins
+                {
                     let left_expr = keys.iter().map(|x| col(&x.0)).collect();
                     let right_expr = keys.iter().map(|x| col(&x.1)).collect();
 

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -72,7 +72,6 @@ async fn join() -> Result<()> {
     let a = df1.join(df2, JoinType::Inner, &["a"], &["a"])?;
 
     let batches = a.collect().await?;
-    assert_eq!(batches.len(), 1);
 
     Ok(())
 }

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -71,7 +71,9 @@ async fn join() -> Result<()> {
 
     let a = df1.join(df2, JoinType::Inner, &["a"], &["a"])?;
 
-    let _ = a.collect().await?;
+    let batches = a.collect().await?;
+
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
 
     Ok(())
 }

--- a/rust/datafusion/tests/dataframe.rs
+++ b/rust/datafusion/tests/dataframe.rs
@@ -71,7 +71,7 @@ async fn join() -> Result<()> {
 
     let a = df1.join(df2, JoinType::Inner, &["a"], &["a"])?;
 
-    let batches = a.collect().await?;
+    let _ = a.collect().await?;
 
     Ok(())
 }


### PR DESCRIPTION
This implements a first version of parallel / partitioned hash join / grace join and uses it by default in the planner (for concurrency > 1)

Master (in memory / 16 threads / partitions, SF=1, batch size = 8192)
```
Query 5 avg time: 141.29 ms
Query 10 avg time: 477.63 ms
```
PR
```
Query 5 avg time: 91.60 ms
Query 10 avg time: 272.25 ms
```

Also when loading from parquet it also achieves ~20% speed up in total and has better utilization of all threads (this is SF=10 with 16 partitions on 16 threads in Parquet running 10 iterations):

![image](https://user-images.githubusercontent.com/163737/113506141-55d06400-9543-11eb-8f7f-e9848b3c5c61.png)


FYI @andygrove 

Note: I think the same approach could also be used by the hash aggregate, rather than the partial / full approach taken now, but this might be only be better when we have a high number of distinct group by by values (in extreme cases - groups with one row), e.g. the "full" hash aggregate takes up a lot of the time/memory.

@alamb 

I think your earlier comment w.r.t. "CoalesceBatches" is especially applicable here - I am seeing quite some overhead in CoalesceBatches/Concat after `RepartitionExec` with hash repartitioning, as this will make each produced batch roughly `num_partitions` times smaller (in contrast to roundrobinbatch repartitioning - which keeps the same batches which makes it almost free on a single node). The overhead is so big that lowering the concurrency setting to 8 instead of 16 on my 8-core / 16-hyperthreads laptop yields better performance. Increasing the batch size (to 32000-64000) also recovers the performance / avoids the overhead penalty mostly - but I recently reduced this as for most queries ~8000 was the sweet spot.
Rewriting to buffer them inside the `RepartitionExec` and only produce them when they exceed the batch size probably would solve this issue and improve the performance of the parallel hash join quite a bit - or maybe by optimizing the `concat` kernel.