### PR TITLE
(NOT FOR MERGING) Print out the size of docker container after ARROW-12112

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1179,6 +1179,9 @@ services:
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/go_build.sh /arrow &&
         /arrow/ci/scripts/java_build.sh /arrow /build &&
+        df -h &&
+        du -hx --threshold=100M / &&
+        du -hx --threshold=500M /arrow/ &&
         /arrow/ci/scripts/js_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]
 

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Implementation of DataFrame API
+//! Implementation of DataFrame API. Some comments to trigger integration test
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
To answer a question  https://github.com/apache/arrow/pull/9879#pullrequestreview-627471238  from @pitrou, I added some diagnostic information to the integration tests to see where the space is being taken up

This PR is based on master immediately *AFTER* to https://github.com/apache/arrow/pull/9879