### PR TITLE
ARROW-12204: [Rust][CI] Reduce size of Rust build artifacts in integration test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -415,3 +415,46 @@ jobs:
           export RUSTFLAGS="-C debuginfo=0"
           cd rust/arrow
           cargo build --target wasm32-unknown-unknown
+
+  # test the projects can build without default features
+  default-build:
+    name: AMD64 Debian 10 Rust ${{ matrix.rust }} test no defaults
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        rust: [nightly-2020-11-24]
+    container:
+      image: ${{ matrix.arch }}/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+        ARROW_TEST_DATA: /__w/arrow/arrow/testing/data
+        PARQUET_TEST_DATA: /__w/arrow/arrow/cpp/submodules/parquet-testing/data
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /github/home/target
+          key: ${{ runner.os }}-${{ matrix.arch }}-target-wasm32-cache-${{ matrix.rust }}
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup override set ${{ matrix.rust }}
+          rustup component add rustfmt
+      - name: Build arrow crate
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cd rust/arrow
+          cargo check --all-targets --no-default-features

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -21,6 +21,10 @@ set -ex
 
 source_dir=${1}/rust
 
+# This file is used to build the rust binaries needed for the
+# archery integration tests. Testing of the rust implementation
+# in normal CI is handled by github workflows
+
 # Disable full debug symbol generation to speed up CI build / reduce memory required
 export RUSTFLAGS="-C debuginfo=1"
 
@@ -32,12 +36,10 @@ rustup show
 
 pushd ${source_dir}
 
-# build entire project
-cargo build --all-targets
+# build only the integration testing binaries
+cargo build -p arrow-integration-testing
 
-# make sure we can build Arrow sub-crate without default features
-pushd arrow
-cargo check --all-targets --no-default-features
-popd
+# Remove incremental build artifacts to save space
+rm -rf  target/debug/deps/ target/debug/build/
 
 popd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1179,6 +1179,9 @@ services:
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/go_build.sh /arrow &&
         /arrow/ci/scripts/java_build.sh /arrow /build &&
+        df -h &&
+        du -hx --threshold=100M / &&
+        du -hx --threshold=500M /arrow/ &&
         /arrow/ci/scripts/js_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]
 

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Implementation of DataFrame API
+//! Implementation of DataFrame API.
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
# Rationale

The [integration test](https://github.com/apache/arrow/pull/9884/checks?check_run_id=2263730460) has a fixed size builder docker image and has builds from several Arrow implementations.

The Rust build artifacts (compiled binaries) in the integration tests still consume ~ 1GB of space even after https://github.com/apache/arrow/pull/9879 (see @pitrou 's comment on  https://github.com/apache/arrow/pull/9884#issuecomment-813037756).

# Changes
1. Only build the `arrow-integration-testing` crate (which has the binaries needed for integration testing) rather than all of them
2. Remove incremental build artifacts
3. Moves `cargo check`  to ensure we can build arrow without default features to a github action and out of the integration test 

This should both speed up the rust build as part of integration testing as well as reduce the amount of disk space required in the builder (both peak and after the rust build).

# Results

According to this [log](https://pipelines.actions.githubusercontent.com/CKhEcbzaHKPSiCoVWyWCFardoFMA9UN2zDnXYiBlRYO31o0IIv/_apis/pipelines/1/runs/179726/signedlogcontent/3?urlExpires=2021-04-05T12%3A37%3A13.1888704Z&urlSigningMethod=HMACV1&urlSignature=zROZZZham0BGH5f2vbe65n3DL13xXLgD9RJXybRqBAA%3D)  after this PR's changes, the rust artifacts are much smaller. 

Note we could still save space by removing the rust toolchain and `.cargo` files but I think that can be an optimization for another time: 
```
2021-04-05T11:30:22.6164120Z 244M	/opt/go/pkg
2021-04-05T11:30:22.6164599Z 393M	/opt/go
2021-04-05T11:30:22.7201596Z 110M	/opt/conda/envs/arrow/share
2021-04-05T11:30:22.7220002Z 171M	/opt/conda/envs/arrow/libexec/gcc/x86_64-conda-linux-gnu/9.3.0
2021-04-05T11:30:22.7220911Z 171M	/opt/conda/envs/arrow/libexec/gcc/x86_64-conda-linux-gnu
2021-04-05T11:30:22.7221489Z 171M	/opt/conda/envs/arrow/libexec/gcc
2021-04-05T11:30:22.7221945Z 186M	/opt/conda/envs/arrow/libexec
2021-04-05T11:30:22.7314210Z 186M	/opt/conda/envs/arrow/lib/valgrind
2021-04-05T11:30:22.8109246Z 129M	/opt/conda/envs/arrow/lib/python3.8/site-packages
2021-04-05T11:30:22.8290900Z 177M	/opt/conda/envs/arrow/lib/python3.8
2021-04-05T11:30:22.8636030Z 1.8G	/opt/conda/envs/arrow/lib
2021-04-05T11:30:22.9861104Z 171M	/opt/conda/envs/arrow/include/boost
2021-04-05T11:30:23.0128341Z 260M	/opt/conda/envs/arrow/include
2021-04-05T11:30:23.0163805Z 417M	/opt/conda/envs/arrow/bin
2021-04-05T11:30:23.0449297Z 102M	/opt/conda/envs/arrow/x86_64-conda-linux-gnu/sysroot/usr/lib64
2021-04-05T11:30:23.0525177Z 133M	/opt/conda/envs/arrow/x86_64-conda-linux-gnu/sysroot/usr
2021-04-05T11:30:23.0526023Z 139M	/opt/conda/envs/arrow/x86_64-conda-linux-gnu/sysroot
2021-04-05T11:30:23.0527418Z 189M	/opt/conda/envs/arrow/x86_64-conda-linux-gnu
2021-04-05T11:30:23.0612702Z 108M	/opt/conda/envs/arrow/jre/lib
2021-04-05T11:30:23.0613140Z 109M	/opt/conda/envs/arrow/jre
2021-04-05T11:30:23.0618402Z 3.2G	/opt/conda/envs/arrow
2021-04-05T11:30:23.0618775Z 3.2G	/opt/conda/envs
2021-04-05T11:30:23.1055113Z 159M	/opt/conda/lib
2021-04-05T11:30:23.5619580Z 146M	/opt/conda/pkgs/valgrind-3.15.0-he513fc3_0/lib/valgrind
2021-04-05T11:30:23.5625488Z 146M	/opt/conda/pkgs/valgrind-3.15.0-he513fc3_0/lib
2021-04-05T11:30:23.5626989Z 146M	/opt/conda/pkgs/valgrind-3.15.0-he513fc3_0
2021-04-05T11:30:23.5793611Z 349M	/opt/conda/pkgs
2021-04-05T11:30:23.5845265Z 3.7G	/opt/conda
2021-04-05T11:30:23.5846086Z 4.1G	/opt
2021-04-05T11:30:23.6810817Z 131M	/root/.m2/repository/org
2021-04-05T11:30:23.6813841Z 260M	/root/.m2/repository
2021-04-05T11:30:23.6814253Z 260M	/root/.m2
2021-04-05T11:30:23.7360947Z 124M	/root/.cargo/registry/index/github.com-1ecc6299db9ec823/.git/objects/pack
2021-04-05T11:30:23.7362421Z 124M	/root/.cargo/registry/index/github.com-1ecc6299db9ec823/.git/objects
2021-04-05T11:30:23.7376583Z 125M	/root/.cargo/registry/index/github.com-1ecc6299db9ec823/.git
2021-04-05T11:30:23.7447433Z 133M	/root/.cargo/registry/index/github.com-1ecc6299db9ec823
2021-04-05T11:30:23.7448341Z 133M	/root/.cargo/registry/index
2021-04-05T11:30:23.7448796Z 232M	/root/.cargo/registry
2021-04-05T11:30:23.7449202Z 245M	/root/.cargo
2021-04-05T11:30:23.8658627Z 126M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc/rust/html/core
2021-04-05T11:30:23.8663924Z 423M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc/rust/html
2021-04-05T11:30:23.8668130Z 423M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc/rust
2021-04-05T11:30:23.8669570Z 423M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share/doc
2021-04-05T11:30:23.8670941Z 423M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/share
2021-04-05T11:30:23.8672364Z 149M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib
2021-04-05T11:30:23.8673637Z 155M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu
2021-04-05T11:30:23.8674758Z 157M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib
2021-04-05T11:30:23.8675721Z 376M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib
2021-04-05T11:30:23.8676657Z 865M	/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu
2021-04-05T11:30:23.8677417Z 865M	/root/.rustup/toolchains
2021-04-05T11:30:23.8677825Z 865M	/root/.rustup
2021-04-05T11:30:23.8678171Z 1.5G	/root
2021-04-05T11:30:23.9219564Z 113M	/go/pkg/mod/google.golang.org/genproto@v0.0.0-20200911024640-645f7a48b24f/googleapis
2021-04-05T11:30:23.9220667Z 113M	/go/pkg/mod/google.golang.org/genproto@v0.0.0-20200911024640-645f7a48b24f
2021-04-05T11:30:23.9306825Z 129M	/go/pkg/mod/google.golang.org
2021-04-05T11:30:23.9346436Z 264M	/go/pkg/mod
2021-04-05T11:30:23.9346938Z 264M	/go/pkg
2021-04-05T11:30:23.9347281Z 264M	/go
2021-04-05T11:30:23.9383575Z 129M	/build/cpp/src/arrow
2021-04-05T11:30:23.9384025Z 131M	/build/cpp/src
2021-04-05T11:30:23.9387580Z 223M	/build/cpp
2021-04-05T11:30:23.9387915Z 223M	/build
2021-04-05T11:30:23.9388188Z 6.1G	/
2021-04-05T11:30:24.0044084Z 846M	/arrow/
```