### PR TITLE
ARROW-12208: [C++] Add the ability to run async tasks without using the CPU thread pool

### DIFF
--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -1001,9 +1001,8 @@ Result<std::shared_ptr<TableReader>> MakeTableReader(
 
 Future<std::shared_ptr<StreamingReader>> MakeStreamingReader(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
-    const ReadOptions& read_options, const ParseOptions& parse_options,
-    const ConvertOptions& convert_options) {
-  auto cpu_executor = internal::GetCpuThreadPool();
+    internal::Executor* cpu_executor, const ReadOptions& read_options,
+    const ParseOptions& parse_options, const ConvertOptions& convert_options) {
   std::shared_ptr<BaseStreamingReader> reader;
   reader = std::make_shared<SerialStreamingReader>(
       io_context, cpu_executor, input, read_options, parse_options, convert_options);
@@ -1036,8 +1035,9 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
   auto io_context = io::IOContext(pool);
-  auto reader_fut = MakeStreamingReader(io_context, std::move(input), read_options,
-                                        parse_options, convert_options);
+  auto cpu_executor = internal::GetCpuThreadPool();
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,
+                                        read_options, parse_options, convert_options);
   auto reader_result = reader_fut.result();
   ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
   return reader;
@@ -1047,8 +1047,9 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
-  auto reader_fut = MakeStreamingReader(io_context, std::move(input), read_options,
-                                        parse_options, convert_options);
+  auto cpu_executor = internal::GetCpuThreadPool();
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,
+                                        read_options, parse_options, convert_options);
   auto reader_result = reader_fut.result();
   ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
   return reader;
@@ -1056,10 +1057,10 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
 
 Future<std::shared_ptr<StreamingReader>> StreamingReader::MakeAsync(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
-    const ReadOptions& read_options, const ParseOptions& parse_options,
-    const ConvertOptions& convert_options) {
-  return MakeStreamingReader(io_context, std::move(input), read_options, parse_options,
-                             convert_options);
+    internal::Executor* cpu_executor, const ReadOptions& read_options,
+    const ParseOptions& parse_options, const ConvertOptions& convert_options) {
+  return MakeStreamingReader(io_context, std::move(input), cpu_executor, read_options,
+                             parse_options, convert_options);
 }
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -26,6 +26,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/future.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -72,7 +73,8 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
   /// parsing (see ARROW-11889)
   static Future<std::shared_ptr<StreamingReader>> MakeAsync(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,
-      const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+      internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&,
+      const ConvertOptions&);
 
   static Result<std::shared_ptr<StreamingReader>> Make(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -448,7 +448,7 @@ Future<> WriteInternal(const ScanOptions& scan_options, WriteState& state,
       });
     }
   }
-  RETURN_NOT_OK(task_group->Finish());
+  scan_futs.push_back(task_group->FinishAsync());
   return AllComplete(scan_futs);
 }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -418,51 +418,18 @@ Status WriteNextBatch(WriteState& state, const std::shared_ptr<ScanTask>& scan_t
   return Status::OK();
 }
 
-}  // namespace
-
-Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_options,
-                                std::shared_ptr<Scanner> scanner) {
-  RETURN_NOT_OK(ValidateBasenameTemplate(write_options.basename_template));
-
-  auto task_group = scanner->options()->TaskGroup();
-
-  // Things we'll un-lazy for the sake of simplicity, with the tradeoff they represent:
-  //
-  // - Fragment iteration. Keeping this lazy would allow us to start partitioning/writing
-  //   any fragments we have before waiting for discovery to complete. This isn't
-  //   currently implemented for FileSystemDataset anyway: ARROW-8613
-  //
-  // - ScanTask iteration. Keeping this lazy would save some unnecessary blocking when
-  //   writing Fragments which produce scan tasks slowly. No Fragments do this.
-  //
-  // NB: neither of these will have any impact whatsoever on the common case of writing
-  //     an in-memory table to disk.
-  ARROW_ASSIGN_OR_RAISE(auto fragment_it, scanner->GetFragments());
-  ARROW_ASSIGN_OR_RAISE(FragmentVector fragments, fragment_it.ToVector());
-  ScanTaskVector scan_tasks;
-  std::vector<Future<>> scan_futs;
-
-  for (const auto& fragment : fragments) {
-    auto options = std::make_shared<ScanOptions>(*scanner->options());
-    // Avoid contention with multithreaded readers
-    options->use_threads = false;
-    ARROW_ASSIGN_OR_RAISE(auto scan_task_it,
-                          Scanner(fragment, std::move(options)).Scan());
-    for (auto maybe_scan_task : scan_task_it) {
-      ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
-      scan_tasks.push_back(std::move(scan_task));
-    }
-  }
-
+Future<> WriteInternal(const ScanOptions& scan_options, WriteState& state,
+                       ScanTaskVector scan_tasks, internal::Executor* cpu_executor) {
   // Store a mapping from partitions (represened by their formatted partition expressions)
   // to a WriteQueue which flushes batches into that partition's output file. In principle
   // any thread could produce a batch for any partition, so each task alternates between
   // pushing batches and flushing them to disk.
-  WriteState state(write_options);
+  std::vector<Future<>> scan_futs;
+  auto task_group = scan_options.TaskGroup();
 
   for (const auto& scan_task : scan_tasks) {
     if (scan_task->supports_async()) {
-      ARROW_ASSIGN_OR_RAISE(auto batches_gen, scan_task->ExecuteAsync());
+      ARROW_ASSIGN_OR_RAISE(auto batches_gen, scan_task->ExecuteAsync(cpu_executor));
       std::function<Status(std::shared_ptr<RecordBatch> batch)> batch_visitor =
           [&, scan_task](std::shared_ptr<RecordBatch> batch) {
             return WriteNextBatch(state, scan_task, std::move(batch));
@@ -482,10 +449,52 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
     }
   }
   RETURN_NOT_OK(task_group->Finish());
-  auto scan_futs_all_done = AllComplete(scan_futs);
-  RETURN_NOT_OK(scan_futs_all_done.status());
+  return AllComplete(scan_futs);
+}
 
-  task_group = scanner->options()->TaskGroup();
+}  // namespace
+
+Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_options,
+                                std::shared_ptr<Scanner> scanner) {
+  RETURN_NOT_OK(ValidateBasenameTemplate(write_options.basename_template));
+
+  // Things we'll un-lazy for the sake of simplicity, with the tradeoff they represent:
+  //
+  // - Fragment iteration. Keeping this lazy would allow us to start partitioning/writing
+  //   any fragments we have before waiting for discovery to complete. This isn't
+  //   currently implemented for FileSystemDataset anyway: ARROW-8613
+  //
+  // - ScanTask iteration. Keeping this lazy would save some unnecessary blocking when
+  //   writing Fragments which produce scan tasks slowly. No Fragments do this.
+  //
+  // NB: neither of these will have any impact whatsoever on the common case of writing
+  //     an in-memory table to disk.
+  ARROW_ASSIGN_OR_RAISE(auto fragment_it, scanner->GetFragments());
+  ARROW_ASSIGN_OR_RAISE(FragmentVector fragments, fragment_it.ToVector());
+  ScanTaskVector scan_tasks;
+
+  for (const auto& fragment : fragments) {
+    auto options = std::make_shared<ScanOptions>(*scanner->options());
+    // Avoid contention with multithreaded readers
+    options->use_threads = false;
+    ARROW_ASSIGN_OR_RAISE(auto scan_task_it,
+                          Scanner(fragment, std::move(options)).Scan());
+    for (auto maybe_scan_task : scan_task_it) {
+      ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
+      scan_tasks.push_back(std::move(scan_task));
+    }
+  }
+
+  WriteState state(write_options);
+  auto res = internal::RunSynchronously<arrow::detail::Empty>(
+      [&](internal::Executor* cpu_executor) -> Future<> {
+        return WriteInternal(*scanner->options(), state, std::move(scan_tasks),
+                             cpu_executor);
+      },
+      scanner->options()->use_threads);
+  RETURN_NOT_OK(res);
+
+  auto task_group = scanner->options()->TaskGroup();
   for (const auto& part_queue : state.queues) {
     task_group->Append([&] { return part_queue.second->writer()->Finish(); });
   }

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -227,18 +227,18 @@ TEST_P(TestCsvFileFormat, IsSupported) {
   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
   ASSERT_EQ(supported, false);
 
-  //   source = GetFileSource(R"(declare,two
-  //   1,2,3)");
-  //   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
-  //   ASSERT_EQ(supported, false);
+  source = GetFileSource(R"(declare,two
+    1,2,3)");
+  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
+  ASSERT_EQ(supported, false);
 
-  //   source = GetFileSource(R"(f64
-  // 1.0
+  source = GetFileSource(R"(f64
+  1.0
 
-  // N/A
-  // 2)");
-  //   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
-  //   EXPECT_EQ(supported, true);
+  N/A
+  2)");
+  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
+  EXPECT_EQ(supported, true);
 }
 
 TEST_P(TestCsvFileFormat, NonProjectedFieldWithDifferingTypeFromInferred) {

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -227,18 +227,18 @@ TEST_P(TestCsvFileFormat, IsSupported) {
   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
   ASSERT_EQ(supported, false);
 
-  source = GetFileSource(R"(declare,two
-  1,2,3)");
-  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
-  ASSERT_EQ(supported, false);
+  //   source = GetFileSource(R"(declare,two
+  //   1,2,3)");
+  //   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
+  //   ASSERT_EQ(supported, false);
 
-  source = GetFileSource(R"(f64
-1.0
+  //   source = GetFileSource(R"(f64
+  // 1.0
 
-N/A
-2)");
-  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
-  EXPECT_EQ(supported, true);
+  // N/A
+  // 2)");
+  //   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
+  //   EXPECT_EQ(supported, true);
 }
 
 TEST_P(TestCsvFileFormat, NonProjectedFieldWithDifferingTypeFromInferred) {

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -228,15 +228,15 @@ TEST_P(TestCsvFileFormat, IsSupported) {
   ASSERT_EQ(supported, false);
 
   source = GetFileSource(R"(declare,two
-    1,2,3)");
+  1,2,3)");
   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
   ASSERT_EQ(supported, false);
 
   source = GetFileSource(R"(f64
-  1.0
+1.0
 
-  N/A
-  2)");
+N/A
+2)");
   ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
   EXPECT_EQ(supported, true);
 }

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -26,6 +26,7 @@
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/scanner_internal.h"
 #include "arrow/table.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/task_group.h"

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -47,6 +47,8 @@ std::vector<std::string> ScanOptions::MaterializedFields() const {
   return fields;
 }
 
+using arrow::internal::Executor;
+using arrow::internal::SerialExecutor;
 using arrow::internal::TaskGroup;
 
 std::shared_ptr<TaskGroup> ScanOptions::TaskGroup() const {
@@ -61,7 +63,7 @@ Result<RecordBatchIterator> InMemoryScanTask::Execute() {
   return MakeVectorIterator(record_batches_);
 }
 
-Result<RecordBatchGenerator> ScanTask::ExecuteAsync() {
+Result<RecordBatchGenerator> ScanTask::ExecuteAsync(internal::Executor*) {
   return Status::NotImplemented("Async is not implemented for this scan task yet");
 }
 
@@ -200,6 +202,13 @@ struct TableAssemblyState {
 };
 
 Result<std::shared_ptr<Table>> Scanner::ToTable() {
+  return internal::RunSynchronously<std::shared_ptr<Table>>(
+      [this](Executor* executor) { return ToTableInternal(executor); },
+      scan_options_->use_threads);
+}
+
+Future<std::shared_ptr<Table>> Scanner::ToTableInternal(
+    internal::Executor* cpu_executor) {
   ARROW_ASSIGN_OR_RAISE(auto scan_task_it, Scan());
   auto task_group = scan_options_->TaskGroup();
 
@@ -215,7 +224,7 @@ Result<std::shared_ptr<Table>> Scanner::ToTable() {
 
     auto id = scan_task_id++;
     if (scan_task->supports_async()) {
-      ARROW_ASSIGN_OR_RAISE(auto scan_gen, scan_task->ExecuteAsync());
+      ARROW_ASSIGN_OR_RAISE(auto scan_gen, scan_task->ExecuteAsync(cpu_executor));
       auto scan_fut = CollectAsyncGenerator(std::move(scan_gen))
                           .Then([state, id](const RecordBatchVector& rbs) {
                             state->Emplace(rbs, id);
@@ -230,14 +239,18 @@ Result<std::shared_ptr<Table>> Scanner::ToTable() {
       });
     }
   }
+  auto scan_options = scan_options_;
   // Wait for all async tasks to complete, or the first error
-  RETURN_NOT_OK(AllComplete(scan_futures).status());
+  return AllComplete(scan_futures)
+      .Then([task_group, scan_options,
+             state](const detail::Empty&) -> Result<std::shared_ptr<Table>> {
+        // Wait for all sync tasks to complete, or the first error.
+        RETURN_NOT_OK(task_group->Finish());
 
-  // Wait for all sync tasks to complete, or the first error.
-  RETURN_NOT_OK(task_group->Finish());
-
-  return Table::FromRecordBatches(scan_options_->projected_schema,
-                                  FlattenRecordBatchVector(std::move(state->batches)));
+        return Table::FromRecordBatches(
+            scan_options->projected_schema,
+            FlattenRecordBatchVector(std::move(state->batches)));
+      });
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -32,11 +32,12 @@
 #include "arrow/dataset/visibility.h"
 #include "arrow/memory_pool.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/thread_pool.h"
 #include "arrow/util/type_fwd.h"
 
 namespace arrow {
+
 using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
+
 namespace dataset {
 
 constexpr int64_t kDefaultBatchSize = 1 << 20;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -32,6 +32,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/async_generator.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/type_fwd.h"
 
 namespace arrow {
@@ -103,7 +104,7 @@ class ARROW_DS_EXPORT ScanTask {
   /// resulting from the Scan. Execution semantics are encapsulated in the
   /// particular ScanTask implementation
   virtual Result<RecordBatchIterator> Execute() = 0;
-  virtual Result<RecordBatchGenerator> ExecuteAsync();
+  virtual Result<RecordBatchGenerator> ExecuteAsync(internal::Executor* cpu_executor);
   virtual bool supports_async() const;
 
   virtual ~ScanTask() = default;
@@ -175,6 +176,8 @@ class ARROW_DS_EXPORT Scanner {
   const std::shared_ptr<ScanOptions>& options() const { return scan_options_; }
 
  protected:
+  Future<std::shared_ptr<Table>> ToTableInternal(internal::Executor* cpu_executor);
+
   std::shared_ptr<Dataset> dataset_;
   // TODO(ARROW-8065) remove fragment_ after a Dataset is constuctible from fragments
   std::shared_ptr<Fragment> fragment_;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -31,12 +32,11 @@
 #include "arrow/dataset/visibility.h"
 #include "arrow/memory_pool.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/async_generator.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/type_fwd.h"
 
 namespace arrow {
-using RecordBatchGenerator = AsyncGenerator<std::shared_ptr<RecordBatch>>;
+using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
 namespace dataset {
 
 constexpr int64_t kDefaultBatchSize = 1 << 20;

--- a/cpp/src/arrow/dataset/scanner_internal.h
+++ b/cpp/src/arrow/dataset/scanner_internal.h
@@ -29,10 +29,12 @@
 #include "arrow/dataset/partition.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 
 using internal::checked_cast;
+using internal::Executor;
 
 namespace dataset {
 
@@ -171,22 +173,15 @@ class FilterAndProjectScanTask : public ScanTask {
                               options_->pool);
   }
 
-  Result<RecordBatchIterator> Execute() override {
-    if (task_->supports_async()) {
-      ARROW_ASSIGN_OR_RAISE(auto gen, ExecuteAsync());
-      return MakeGeneratorIterator(std::move(gen));
-    } else {
-      return ExecuteSync();
-    }
-  }
+  Result<RecordBatchIterator> Execute() override { return ExecuteSync(); }
 
-  Result<RecordBatchGenerator> ExecuteAsync() override {
+  Result<RecordBatchGenerator> ExecuteAsync(Executor* cpu_executor) override {
     if (!task_->supports_async()) {
       return Status::Invalid(
           "ExecuteAsync should not have been called on FilterAndProjectScanTask if the "
           "source task did not support async");
     }
-    ARROW_ASSIGN_OR_RAISE(auto gen, task_->ExecuteAsync());
+    ARROW_ASSIGN_OR_RAISE(auto gen, task_->ExecuteAsync(cpu_executor));
 
     ARROW_ASSIGN_OR_RAISE(Expression simplified_filter,
                           SimplifyWithGuarantee(options()->filter, partition_));

--- a/cpp/src/arrow/dataset/scanner_internal.h
+++ b/cpp/src/arrow/dataset/scanner_internal.h
@@ -29,7 +29,6 @@
 #include "arrow/dataset/partition.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/util/logging.h"
-#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/dataset/scanner_internal.h
+++ b/cpp/src/arrow/dataset/scanner_internal.h
@@ -28,6 +28,7 @@
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/partition.h"
 #include "arrow/dataset/scanner.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -69,7 +69,7 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
 
 void SerialExecutor::MarkFinished(bool& finished) {
   {
-    std::lock_guard<std::mutex>(state_->mutex);
+    std::lock_guard<std::mutex> lk(state_->mutex);
     finished = true;
   }
   state_->wait_for_tasks.notify_one();

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -22,6 +22,7 @@
 #include <deque>
 #include <list>
 #include <mutex>
+#include <queue>
 #include <string>
 #include <thread>
 #include <vector>
@@ -69,10 +70,10 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
 }
 
 void SerialExecutor::MarkFinished() {
-  {
-    std::lock_guard<std::mutex> lk(state_->mutex);
-    state_->finished = true;
-  }
+  std::lock_guard<std::mutex> lk(state_->mutex);
+  state_->finished = true;
+  // Keep the lock when notifying to avoid situations where the SerialExecutor
+  // would start being destroyed while the notify_one() call is still ongoing.
   state_->wait_for_tasks.notify_one();
 }
 

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -233,15 +233,7 @@ class ARROW_EXPORT SerialExecutor : public Executor {
     if (final_fut.is_finished()) {
       return final_fut.result();
     }
-    final_fut = final_fut.Then(
-        [this](const T& res) {
-          MarkFinished();
-          return res;
-        },
-        [this](const Status& st) -> Result<T> {
-          MarkFinished();
-          return st;
-        });
+    final_fut.AddCallback([this](const Result<T>&) { MarkFinished(); });
     RunLoop();
     return final_fut.result();
   }

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -364,7 +364,7 @@ Result<T> RunSynchronously(FnOnce<Future<T>(Executor*)> get_future, bool use_thr
   }
 }
 
-Status RunSynchronouslyVoid(FnOnce<Future<arrow::detail::Empty>(Executor*)> get_future,
-                            bool use_threads);
+ARROW_EXPORT Status RunSynchronouslyVoid(
+    FnOnce<Future<arrow::detail::Empty>(Executor*)> get_future, bool use_threads);
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
Added a serial executor which can run async code serially without needing to create threads.  In addition, modifies the Scanner::ToTable and FileSystemDataset::Write to execute serially.  Scanner::Scan is still non-serial but I think this is OK.  The I/O thread pool is still being used however.  To truly remove all instances of std::thread we'd need to change the I/O context to use the serial executor but let's see if this makes R happy enough first.