### PR TITLE
ARROW-12210: [Rust][DataFusion] Document SHOW TABLES / SHOW COLUMNS / Information Schema

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -266,7 +266,7 @@ More information can be found in the [Postgres docs](https://www.postgresql.org/
 
 To show tables available for use in DataFusion, use the `SHOW TABLES`  command or the `information_schema.tables` view:
 
-```
+```sql
 > show tables;
 +---------------+--------------------+------------+------------+
 | table_catalog | table_schema       | table_name | table_type |
@@ -287,7 +287,7 @@ To show tables available for use in DataFusion, use the `SHOW TABLES`  command o
 
 To show the schema of a table in DataFusion, use the `SHOW COLUMNS`  command or the or `information_schema.columns` view:
 
-```
+```sql
 > show columns from t;
 +---------------+--------------+------------+-------------+-----------+-------------+
 | table_catalog | table_schema | table_name | column_name | data_type | is_nullable |

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -197,6 +197,11 @@ DataFusion also includes a simple command-line interactive SQL utility. See the 
   - [x] Basic timestamp functions
 - nested functions
   - [x] Array of columns
+- [x] Schema Queries
+  - [x] SHOW TABLES
+  - [x] SHOW COLUMNS
+  - [x] information_schema.{tables, columns}
+  - [ ] information_schema other views
 - [x] Sorting
 - [ ] Nested types
 - [ ] Lists
@@ -252,9 +257,56 @@ DataFusion strives to implement a subset of the [PostgreSQL SQL dialect](https:/
 
 Currently, only a subset of the PosgreSQL dialect is implemented, and we will document any deviations.
 
-## Information Schema
+## Schema Metadata / Information Schema Support
 
-DataFusion supports the `TABLES` and `COLUMNS` views of the ISO SQL `information_schema` schema to list tables and columns respectively. More information can be found in the [Postgres docs](https://www.postgresql.org/docs/13/infoschema-schema.html)).
+DataFusion supports the showing metadata about the tables available. This information can be accessed using the views of the ISO SQL `information_schema` schema or the DataFusion specific `SHOW TABLES` and `SHOW COLUMNS` commands.
+
+More information can be found in the [Postgres docs](https://www.postgresql.org/docs/13/infoschema-schema.html)).
+
+
+To show tables available for use in DataFusion, use the `SHOW TABLES`  command or the `information_schema.tables` view:
+
+```
+> show tables;
++---------------+--------------------+------------+------------+
+| table_catalog | table_schema       | table_name | table_type |
++---------------+--------------------+------------+------------+
+| datafusion    | public             | t          | BASE TABLE |
+| datafusion    | information_schema | tables     | VIEW       |
++---------------+--------------------+------------+------------+
+
+> select * from information_schema.tables;
+
++---------------+--------------------+------------+--------------+
+| table_catalog | table_schema       | table_name | table_type   |
++---------------+--------------------+------------+--------------+
+| datafusion    | public             | t          | BASE TABLE   |
+| datafusion    | information_schema | TABLES     | SYSTEM TABLE |
++---------------+--------------------+------------+--------------+
+```
+
+To show the schema of a table in DataFusion, use the `SHOW COLUMNS`  command or the or `information_schema.columns` view:
+
+```
+> show columns from t;
++---------------+--------------+------------+-------------+-----------+-------------+
+| table_catalog | table_schema | table_name | column_name | data_type | is_nullable |
++---------------+--------------+------------+-------------+-----------+-------------+
+| datafusion    | public       | t          | a           | Int32     | NO          |
+| datafusion    | public       | t          | b           | Utf8      | NO          |
+| datafusion    | public       | t          | c           | Float32   | NO          |
++---------------+--------------+------------+-------------+-----------+-------------+
+
+>   select table_name, column_name, ordinal_position, is_nullable, data_type from information_schema.columns;
++------------+-------------+------------------+-------------+-----------+
+| table_name | column_name | ordinal_position | is_nullable | data_type |
++------------+-------------+------------------+-------------+-----------+
+| t          | a           | 0                | NO          | Int32     |
+| t          | b           | 1                | NO          | Utf8      |
+| t          | c           | 2                | NO          | Float32   |
++------------+-------------+------------------+-------------+-----------+
+```
+
 
 
 ## Supported Data Types


### PR DESCRIPTION
# Rationale
As suggested by @jorgecarleitao  and @returnString  on https://github.com/apache/arrow/pull/9866#pullrequestreview-627824431 this PR adds documentation about the information schema and `SHOW TABLES` and `SHOW COLUMNS`

Note this does not document the catalog system more generally. Perhaps @returnString  can comment on that. 