### PR TITLE
ARROW-12228: [CI] Create base image for conda environments

### DIFF
--- a/ci/conda_env_unix.yml
+++ b/ci/conda_env_unix.yml
@@ -21,4 +21,3 @@ autoconf
 ccache
 orc
 pkg-config
-rsync

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -15,53 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG arch=amd64
-FROM ${arch}/ubuntu:18.04
-
-# arch is unset after the FROM statement, so need to define it again
-ARG arch=amd64
-ARG prefix=/opt/conda
-
-# install build essentials
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update -y -q && \
-    apt-get install -y -q wget tzdata libc6-dbg \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=${prefix}/bin:$PATH
-# install conda and minio
-COPY ci/scripts/install_conda.sh \
-     ci/scripts/install_minio.sh \
-     /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_conda.sh ${arch} linux latest ${prefix}
-RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest ${prefix}
+ARG repo
+ARG arch
+FROM ${repo}:${arch}-conda
 
 # install the required conda packages into the test environment
 COPY ci/conda_env_cpp.yml \
      ci/conda_env_gandiva.yml \
-     ci/conda_env_unix.yml \
      /arrow/ci/
-RUN conda create -n arrow -q \
-        --file arrow/ci/conda_env_unix.yml \
+RUN conda install \
         --file arrow/ci/conda_env_cpp.yml \
         --file arrow/ci/conda_env_gandiva.yml \
         compilers \
-        doxygen \
         gdb \
-        git \
         valgrind && \
     conda clean --all
-
-# activate the created environment by default
-RUN echo "conda activate arrow" >> ~/.profile
-ENV CONDA_PREFIX=${prefix}/envs/arrow
-
-# use login shell to activate arrow environment un the RUN commands
-SHELL [ "/bin/bash", "-c", "-l" ]
-
-# use login shell when running the container
-ENTRYPOINT [ "/bin/bash", "-c", "-l" ]
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -27,6 +27,7 @@ RUN conda install \
         --file arrow/ci/conda_env_cpp.yml \
         --file arrow/ci/conda_env_gandiva.yml \
         compilers \
+        doxygen \
         gdb \
         valgrind && \
     conda clean --all

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -27,8 +27,10 @@ ARG go=1.15
 
 COPY ci/conda_env_archery.yml /arrow/ci/
 RUN conda install -q \
+        --file arrow/ci/conda_env_cpp.yml \
         --file arrow/ci/conda_env_archery.yml \
         numpy \
+        compilers \
         maven=${maven} \
         nodejs=${node} \
         openjdk=${jdk} && \

--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG arch=amd64
+FROM ${arch}/ubuntu:18.04
+
+# arch is unset after the FROM statement, so need to define it again
+ARG arch=amd64
+ARG prefix=/opt/conda
+
+# install build essentials
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y -q && \
+    apt-get install -y -q wget tzdata libc6-dbg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=${prefix}/bin:$PATH
+# install conda and minio
+COPY ci/scripts/install_conda.sh \
+     ci/scripts/install_minio.sh \
+     /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_conda.sh ${arch} linux latest ${prefix}
+RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest ${prefix}
+
+# create a conda environment
+ADD ci/conda_env_unix.yml /arrow/ci/
+RUN conda create -n arrow --file arrow/ci/conda_env_unix.yml git && \
+    conda clean --all
+
+# activate the created environment by default
+RUN echo "conda activate arrow" >> ~/.profile
+ENV CONDA_PREFIX=${prefix}/envs/arrow
+
+# use login shell to activate arrow environment un the RUN commands
+SHELL [ "/bin/bash", "-c", "-l" ]
+
+# use login shell when running the container
+ENTRYPOINT [ "/bin/bash", "-c", "-l" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,18 +79,19 @@ x-hierarchy:
   # Each node must be either a string scalar of a list containing the
   # descendant images if any. Archery checks that all node has a corresponding
   # service entry, so any new image/service must be listed here.
-  - conda-cpp:
-    - conda-cpp-hiveserver2
-    - conda-cpp-valgrind
+  - conda:
+    - conda-cpp:
+      - conda-cpp-hiveserver2
+      - conda-cpp-valgrind
+      - conda-python:
+        - conda-python-pandas
+        - conda-python-dask
+        - conda-python-hdfs
+        - conda-python-jpype
+        - conda-python-turbodbc
+        - conda-python-kartothek
+        - conda-python-spark
     - conda-integration
-    - conda-python:
-      - conda-python-pandas
-      - conda-python-dask
-      - conda-python-hdfs
-      - conda-python-jpype
-      - conda-python-turbodbc
-      - conda-python-kartothek
-      - conda-python-spark
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -160,6 +161,26 @@ services:
   #     -e ARROW_TEST_LINKAGE=static \
   #     conda-cpp|debian-cpp|...
 
+  conda:
+    # Base image for conda builds.
+    #
+    # Usage:
+    #   docker-compose build conda
+    #   docker-compose run --rm conda
+    # Parameters:
+    #   ARCH: amd64, arm32v7
+    image: ${REPO}:${ARCH}-conda
+    build:
+      context: .
+      dockerfile: ci/docker/conda.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-conda
+      args:
+        arch: ${ARCH}
+        prefix: /opt/conda
+    volumes:
+      - .:/arrow:delegated
+
   conda-cpp:
     # C++ build in conda environment, including the doxygen docs.
     #
@@ -175,8 +196,8 @@ services:
       cache_from:
         - ${REPO}:${ARCH}-conda-cpp
       args:
+        repo: ${REPO}
         arch: ${ARCH}
-        prefix: /opt/conda
     shm_size: &shm-size 2G
     ulimits: &ulimits
       core: ${ULIMIT_CORE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
     # Base image for conda builds.
     #
     # Usage:
-    #   docker-compose build conda
+    #   docker-compose build con
     #   docker-compose run --rm conda
     # Parameters:
     #   ARCH: amd64, arm32v7
@@ -185,6 +185,7 @@ services:
     # C++ build in conda environment, including the doxygen docs.
     #
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose run --rm conda-cpp
     # Parameters:
@@ -217,6 +218,7 @@ services:
 
   conda-cpp-valgrind:
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose run --rm conda-cpp-valgrind
     # Parameters:
@@ -544,6 +546,7 @@ services:
 
   conda-python:
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose run --rm conda-python
@@ -816,6 +819,7 @@ services:
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available on conda-forge
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose build conda-python-pandas
@@ -844,6 +848,7 @@ services:
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available on conda-forge
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose build conda-python-dask
@@ -870,6 +875,7 @@ services:
 
   conda-python-jpype:
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose build conda-python-jpype
@@ -902,6 +908,7 @@ services:
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available under github releases
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose build conda-python-turbodbc
@@ -932,6 +939,7 @@ services:
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available under github releases
     # Usage:
+    #   docker-compose build conda
     #   docker-compose build conda-cpp
     #   docker-compose build conda-python
     #   docker-compose build conda-python-kartothek


### PR DESCRIPTION
Using a base image we can reduce the number of installed packages for the conda-integration image. cc @pitrou 