### PR TITLE
ARROW-12227: [R] Fix RE2 and median nightly build failures

### DIFF
--- a/r/tests/testthat/test-compute-aggregate.R
+++ b/r/tests/testthat/test-compute-aggregate.R
@@ -246,13 +246,6 @@ test_that("quantile and median NAs, edge cases, and exceptions", {
     quantile(Array$create(rep(NA_integer_, 3)), na.rm = TRUE),
     Array$create(rep(NA_real_, 5))
   )
-  expect_error(
-    median(Array$create(c(1, 2)), probs = c(.25, .75))
-  )
-  expect_equal(
-    median(Array$create(c(1, 2)), interpolation = "higher"),
-    Scalar$create(2)
-  )
   expect_equal(
     quantile(Scalar$create(0L)),
     Array$create(rep(0, 5))
@@ -264,6 +257,20 @@ test_that("quantile and median NAs, edge cases, and exceptions", {
   expect_error(
     quantile(Array$create(1:3), type = 9),
     "not supported"
+  )
+})
+
+test_that("median passes ... args to quantile", {
+  skip_if(
+    !"..." %in% names(formals(median)),
+    "The median generic lacks dots in R 3.3.0 and earlier"
+  )
+  expect_equal(
+    median(Array$create(c(1, 2)), interpolation = "higher"),
+    Scalar$create(2)
+  )
+  expect_error(
+    median(Array$create(c(1, 2)), probs = c(.25, .75))
   )
 })
 

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -29,7 +29,7 @@ test_that("sub and gsub with ignore.case = FALSE and fixed = TRUE", {
   )
   expect_dplyr_equal(
     input %>%
-      transmute(x = gub("Foo", "baz", x, fixed = TRUE)) %>%
+      transmute(x = gub("o", "u", x, fixed = TRUE)) %>%
       collect(),
     df
   )

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -18,6 +18,27 @@
 library(dplyr)
 library(stringr)
 
+test_that("sub and gsub with ignore.case = FALSE and fixed = TRUE", {
+  df <- tibble(x = c("Foo", "bar"))
+
+  expect_dplyr_equal(
+    input %>%
+      transmute(x = sub("Foo", "baz", x, fixed = TRUE)) %>%
+      collect(),
+    df
+  )
+  expect_dplyr_equal(
+    input %>%
+      transmute(x = gub("Foo", "baz", x, fixed = TRUE)) %>%
+      collect(),
+    df
+  )
+
+})
+
+# many of the remainder of these tests require RE2
+skip_if_not_available("re2")
+
 test_that("sub and gsub", {
   df <- tibble(x = c("Foo", "bar"))
 

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+skip_if_not_available("utf8proc")
+
 library(dplyr)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -29,7 +29,7 @@ test_that("sub and gsub with ignore.case = FALSE and fixed = TRUE", {
   )
   expect_dplyr_equal(
     input %>%
-      transmute(x = gub("o", "u", x, fixed = TRUE)) %>%
+      transmute(x = gsub("o", "u", x, fixed = TRUE)) %>%
       collect(),
     df
   )


### PR DESCRIPTION
The `test-r-minimal-build` nightly failed because of a change in ARROW-11513. The `test-r-versions` nightly failed on R 3.3 because of a change in ARROW-11338. This fixes both of those failures.