### PR TITLE
ARROW-12226: [C++] Fix Address Sanitizer failures

### DIFF
--- a/cpp/build-support/lsan-suppressions.txt
+++ b/cpp/build-support/lsan-suppressions.txt
@@ -17,3 +17,5 @@
 
 # False positive from atexit() registration in libc
 leak:*__new_exitfn*
+# Leak at shutdown in OpenSSL
+leak:CRYPTO_zalloc

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -789,7 +789,7 @@ class ObjectOutputStream final : public io::OutputStream {
       : client_(std::move(client)),
         io_context_(io_context),
         path_(path),
-        options_(options) {}
+        background_writes_(options.background_writes) {}
 
   ~ObjectOutputStream() override {
     // For compliance with the rest of the IO stack, Close rather than Abort,
@@ -967,7 +967,7 @@ class ObjectOutputStream final : public io::OutputStream {
     req.SetPartNumber(part_number_);
     req.SetContentLength(nbytes);
 
-    if (!options_.background_writes) {
+    if (!background_writes_) {
       req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
       auto outcome = client_->UploadPart(req);
       if (!outcome.IsSuccess()) {
@@ -1071,8 +1071,8 @@ class ObjectOutputStream final : public io::OutputStream {
  protected:
   std::shared_ptr<Aws::S3::S3Client> client_;
   const io::IOContext io_context_;
-  S3Path path_;
-  const S3Options& options_;
+  const S3Path path_;
+  const bool background_writes_;
 
   Aws::String upload_id_;
   bool closed_ = true;

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -424,7 +424,7 @@ struct SwappingTransform {
     ARROW_ASSIGN_OR_RAISE(auto dest, AllocateBuffer(dest_size));
     const uint8_t* data = buf->data();
     uint8_t* out_data = dest->mutable_data();
-    if (has_pending_) {
+    if (has_pending_ && dest_size > 0) {
       *out_data++ = *data++;
       *out_data++ = pending_byte_;
       dest_size -= 2;


### PR DESCRIPTION
Fix two failures seen locally in arrow-s3fs-test and arrow-io-memory-test.