### PR TITLE
ARROW-11464: [Python] Fix parquet.read_pandas to support all keywords of read_table

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1757,26 +1757,15 @@ switched to False.""",
     "\n".join((_read_docstring_common,
                """use_pandas_metadata : bool, default False
     If True and file has custom pandas schema metadata, ensure that
-    index columns are also loaded""")),
+    index columns are also loaded.""")),
     """pyarrow.Table
     Content of the file as a table (of columns)""",
     _DNF_filter_doc)
 
 
-def read_pandas(source, columns=None, use_threads=True, memory_map=False,
-                metadata=None, filters=None, buffer_size=0,
-                use_legacy_dataset=True, ignore_prefixes=None):
+def read_pandas(source, columns=None, **kwargs):
     return read_table(
-        source,
-        columns=columns,
-        use_threads=use_threads,
-        metadata=metadata,
-        filters=filters,
-        memory_map=memory_map,
-        buffer_size=buffer_size,
-        use_pandas_metadata=True,
-        use_legacy_dataset=use_legacy_dataset,
-        ignore_prefixes=ignore_prefixes
+        source, columns=columns, use_pandas_metadata=True, **kwargs
     )
 
 

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import pyarrow as pa
+from pyarrow.fs import LocalFileSystem, SubTreeFileSystem
 from pyarrow.tests.parquet.common import (
     parametrize_legacy_dataset, parametrize_legacy_dataset_not_supported)
 from pyarrow.util import guid
@@ -668,3 +669,18 @@ def test_dataset_read_pandas_common_metadata(tempdir, preserve_index):
     expected.index.name = (
         df.index.name if preserve_index is not False else None)
     tm.assert_frame_equal(result, expected)
+
+
+def test_read_pandas_passthrough_keywords(tempdir):
+    # ARROW-11464 - previously not all keywords were passed through (such as
+    # the filesystem keyword)
+    df = pd.DataFrame({'a': [1, 2, 3]})
+
+    filename = tempdir / 'data.parquet'
+    _write_table(df, filename)
+
+    result = pq.read_pandas(
+        'data.parquet',
+        filesystem=SubTreeFileSystem(str(tempdir), LocalFileSystem())
+    )
+    assert result.equals(pa.table(df))

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -671,6 +671,7 @@ def test_dataset_read_pandas_common_metadata(tempdir, preserve_index):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.pandas
 def test_read_pandas_passthrough_keywords(tempdir):
     # ARROW-11464 - previously not all keywords were passed through (such as
     # the filesystem keyword)


### PR DESCRIPTION
* Passes through all keywords to `read_table`, which also means that the docstring is correct now
* Because of this, it changes `use_legacy_dataset` from True to False (which I think was an oversight that it was not yet done, as this follows `read_table`)