### PR TITLE
ARROW-11832: [R] Handle conversion of extra nested struct column 

### DIFF
--- a/r/src/arrow_vctrs.h
+++ b/r/src/arrow_vctrs.h
@@ -18,5 +18,5 @@
 #pragma once
 
 namespace vctrs {
-R_len_t short_vec_size(SEXP);
+R_len_t vec_size(SEXP);
 }

--- a/r/src/imports.cpp
+++ b/r/src/imports.cpp
@@ -32,6 +32,12 @@ const vctrs_api_ptrs_t& vctrs_api() {
   return ptrs;
 }
 
-R_len_t short_vec_size(SEXP x) { return vctrs_api().short_vec_size(x); }
+R_len_t vec_size(SEXP x) {
+  if (Rf_inherits(x, "data.frame") || TYPEOF(x) != VECSXP || Rf_inherits(x, "POSIXlt")) {
+    return vctrs_api().short_vec_size(x);
+  } else {
+    return Rf_length(x);
+  }
+}
 
 }  // namespace vctrs

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -809,15 +809,7 @@ class RListConverter : public ListConverter<T, RConverter, RConverterTrait> {
     }
 
     auto append_value = [this](SEXP value) {
-      // TODO: this should always use vctrs::short_vec_size
-      //       but that introduced a regression:
-      //       https://github.com/apache/arrow/pull/8650#issuecomment-786940734
-      int n;
-      if (TYPEOF(value) == VECSXP && !Rf_inherits(value, "data.frame")) {
-        n = Rf_length(value);
-      } else {
-        n = vctrs::short_vec_size(value);
-      }
+      int n = vctrs::vec_size(value);
 
       RETURN_NOT_OK(this->list_builder_->ValidateOverflow(n));
       RETURN_NOT_OK(this->list_builder_->Append());
@@ -879,7 +871,7 @@ class RStructConverter : public StructConverter<RConverter, RConverterTrait> {
 
     for (R_xlen_t i = 0; i < n_columns; i++) {
       SEXP x_i = VECTOR_ELT(x, i);
-      if (vctrs::short_vec_size(x_i) < size) {
+      if (vctrs::vec_size(x_i) < size) {
         return Status::RError("Degenerated data frame");
       }
     }
@@ -1011,7 +1003,7 @@ std::shared_ptr<arrow::Array> vec_to_arrow(SEXP x,
   RConversionOptions options;
   options.strict = !type_inferred;
   options.type = type;
-  options.size = vctrs::short_vec_size(x);
+  options.size = vctrs::vec_size(x);
 
   // maybe short circuit when zero-copy is possible
   if (can_reuse_memory(x, options.type)) {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -457,6 +457,11 @@ test_that("Array$create() handles data frame -> struct arrays (ARROW-3811)", {
   a <- Array$create(df)
   expect_type_equal(a$type, struct(x = int32(), y = float64(), z = utf8()))
   expect_equivalent(as.vector(a), df)
+
+  df <- structure(list(col = structure(list(structure(list(list(structure(1))), class = "inner")), class = "outer")), class = "data.frame", row.names = c(NA, -1L))
+  a <- Array$create(df)
+  expect_type_equal(a$type, struct(col = list_of(list_of(list_of(float64())))))
+  expect_equivalent(as.vector(a), df)
 })
 
 test_that("StructArray methods", {


### PR DESCRIPTION
``` r
library(arrow, warn.conflicts = FALSE)

df <- structure(list(col = structure(list(structure(list(list(structure(1))), class = "inner")), class = "outer")), class = "data.frame", row.names = c(NA, -1L))
Array$create(df)
#> StructArray
#> <struct<col: list<item: list<item: list<item: double>>>>>
#> -- is_valid: all not null
#> -- child 0 type: list<item: list<item: list<item: double>>>
#>   [
#>     [
#>       [
#>         [
#>           1
#>         ]
#>       ]
#>     ]
#>   ]
```

<sup>Created on 2021-04-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>