### PR TITLE
ARROW-12242: [Python][Doc] Tweak nightly build instructions

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -87,4 +87,4 @@ Install the development version from an `alternative PyPI
 .. code-block:: bash
 
     pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
-        --pre pyarrow
+        --prefer-binary --pre pyarrow


### PR DESCRIPTION
Nudge pip towards downloading a binary build, even if slightly outdated, rather than build from source.