### PR TITLE
ARROW-12235: [Rust][DataFusion] LIMIT returns incorrect results when used with several small partitions

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1770,7 +1770,7 @@ mod tests {
         let arr = Arc::new(Int32Array::from(values));
         let arr = arr as ArrayRef;
 
-        RecordBatch::try_new(schema.clone(), vec![arr]).unwrap()
+        RecordBatch::try_new(schema, vec![arr]).unwrap()
     }
 
     #[tokio::test]

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1761,6 +1761,53 @@ mod tests {
         Ok(())
     }
 
+    /// Return a RecordBatch with a single Int32 array with values (0..sz)
+    fn make_partition(sz: i32) -> RecordBatch {
+        let seq_start = 0;
+        let seq_end = sz;
+        let values = (seq_start..seq_end).collect::<Vec<_>>();
+        let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, true)]));
+        let arr = Arc::new(Int32Array::from(values));
+        let arr = arr as ArrayRef;
+
+        RecordBatch::try_new(schema.clone(), vec![arr]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn limit_multi_partitions() -> Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let mut ctx = create_ctx(&tmp_dir, 1)?;
+
+        let partitions = vec![
+            vec![make_partition(0)],
+            vec![make_partition(1)],
+            vec![make_partition(2)],
+            vec![make_partition(3)],
+            vec![make_partition(4)],
+            vec![make_partition(5)],
+        ];
+        let schema = partitions[0][0].schema();
+        let provider = Arc::new(MemTable::try_new(schema, partitions).unwrap());
+
+        ctx.register_table("t", provider).unwrap();
+
+        // select all rows
+        let results = plan_and_collect(&mut ctx, "SELECT i FROM t").await.unwrap();
+
+        let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
+        assert_eq!(num_rows, 15);
+
+        for limit in 1..10 {
+            let query = format!("SELECT i FROM t limit {}", limit);
+            let results = plan_and_collect(&mut ctx, &query).await.unwrap();
+
+            let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
+            assert_eq!(num_rows, limit, "mismatch with query {}", query);
+        }
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn case_sensitive_identifiers_functions() {
         let mut ctx = ExecutionContext::new();

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -183,8 +183,8 @@ impl ExecutionPlan for LocalLimitExec {
         }
     }
 
-    async fn execute(&self, _: usize) -> Result<SendableRecordBatchStream> {
-        let stream = self.input.execute(0).await?;
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        let stream = self.input.execute(partition).await?;
         Ok(Box::pin(LimitStream::new(stream, self.limit)))
     }
 }


### PR DESCRIPTION
Prior to this PR DataFusion could return incorrect results for queries that use LIMIT and have multiple partitions

I noticed when I was running some queries locally that `LIMIT` was not behaving correctly. For my case, a query with `LIMIT 10` was always returning zero rows.

It turns out only the first partition to limit was ever consulted. This PR fixes that bug and adds a test