### PR TITLE
ARROW-12254: [Rust][DataFusion] Stop polling limit input once limit is reached

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1824,65 +1824,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn limit_multi_batch() -> Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let mut ctx = create_ctx(&tmp_dir, 1)?;
-
-        let partitions = vec![
-            vec![
-                test::make_partition(0),
-                test::make_partition(1),
-                test::make_partition(2),
-            ],
-            vec![
-                test::make_partition(1),
-                test::make_partition(2),
-                test::make_partition(3),
-            ],
-            vec![
-                test::make_partition(2),
-                test::make_partition(3),
-                test::make_partition(4),
-            ],
-            vec![
-                test::make_partition(3),
-                test::make_partition(4),
-                test::make_partition(5),
-            ],
-            vec![
-                test::make_partition(4),
-                test::make_partition(5),
-                test::make_partition(6),
-            ],
-            vec![
-                test::make_partition(5),
-                test::make_partition(6),
-                test::make_partition(7),
-            ],
-        ];
-        let schema = partitions[0][0].schema();
-        let provider = Arc::new(MemTable::try_new(schema, partitions).unwrap());
-
-        ctx.register_table("t", provider).unwrap();
-
-        // select all rows
-        let results = plan_and_collect(&mut ctx, "SELECT i FROM t").await.unwrap();
-
-        let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
-        assert_eq!(num_rows, 63);
-
-        for limit in 1..10 {
-            let query = format!("SELECT i FROM t limit {}", limit);
-            let results = plan_and_collect(&mut ctx, &query).await.unwrap();
-
-            let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
-            assert_eq!(num_rows, limit, "mismatch with query {}", query);
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn case_sensitive_identifiers_functions() {
         let mut ctx = ExecutionContext::new();
         ctx.register_table("t", test::table_with_sequence(1, 1).unwrap())

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -200,23 +200,31 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> RecordBatch {
 
 /// A Limit stream limits the stream to up to `limit` rows.
 struct LimitStream {
+    /// The maximum number of rows to produce
     limit: usize,
-    input: SendableRecordBatchStream,
-    // the current count
+    /// The input to read from. This is set to None once the limit is
+    /// reached to enable early termination
+    input: Option<SendableRecordBatchStream>,
+    /// Copy of the input schema
+    schema: SchemaRef,
+    // the current number of rows which have been produced
     current_len: usize,
 }
 
 impl LimitStream {
     fn new(input: SendableRecordBatchStream, limit: usize) -> Self {
+        let schema = input.schema();
         Self {
             limit,
-            input,
+            input: Some(input),
+            schema,
             current_len: 0,
         }
     }
 
     fn stream_limit(&mut self, batch: RecordBatch) -> Option<RecordBatch> {
         if self.current_len == self.limit {
+            self.input = None; // clear input so it can be dropped early
             None
         } else if self.current_len + batch.num_rows() <= self.limit {
             self.current_len += batch.num_rows();
@@ -224,6 +232,7 @@ impl LimitStream {
         } else {
             let batch_rows = self.limit - self.current_len;
             self.current_len = self.limit;
+            self.input = None; // clear input so it can be dropped early
             Some(truncate_batch(&batch, batch_rows))
         }
     }
@@ -236,22 +245,28 @@ impl Stream for LimitStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        self.input.poll_next_unpin(cx).map(|x| match x {
-            Some(Ok(batch)) => Ok(self.stream_limit(batch)).transpose(),
-            other => other,
-        })
+        match &mut self.input {
+            Some(input) => input.poll_next_unpin(cx).map(|x| match x {
+                Some(Ok(batch)) => Ok(self.stream_limit(batch)).transpose(),
+                other => other,
+            }),
+            // input has been cleared
+            None => Poll::Ready(None),
+        }
     }
 }
 
 impl RecordBatchStream for LimitStream {
     /// Get the schema
     fn schema(&self) -> SchemaRef {
-        self.input.schema()
+        self.schema.clone()
     }
 }
 
 #[cfg(test)]
 mod tests {
+
+    use common::collect;
 
     use super::*;
     use crate::physical_plan::common;
@@ -287,6 +302,36 @@ mod tests {
         // there should be a total of 100 rows
         let row_count: usize = batches.iter().map(|batch| batch.num_rows()).sum();
         assert_eq!(row_count, 7);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn limit_early_shutdown() -> Result<()> {
+        let batches = vec![
+            test::make_partition(5),
+            test::make_partition(10),
+            test::make_partition(15),
+            test::make_partition(20),
+            test::make_partition(25),
+        ];
+        let input = test::exec::TestStream::new(batches);
+
+        let index = input.index();
+        assert_eq!(index.value(), 0);
+
+        // limit of six needs to consume the entire first record batch
+        // (5 rows) and 1 row from the second (1 row)
+        let limit_stream = LimitStream::new(Box::pin(input), 6);
+        assert_eq!(index.value(), 0);
+
+        let results = collect(Box::pin(limit_stream)).await.unwrap();
+        let num_rows: usize = results.into_iter().map(|b| b.num_rows()).sum();
+        // Only 6 rows should have been produced
+        assert_eq!(num_rows, 6);
+
+        // Only the first two batches should be consumed
+        assert_eq!(index.value(), 2);
 
         Ok(())
     }

--- a/rust/datafusion/src/test/exec.rs
+++ b/rust/datafusion/src/test/exec.rs
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Simple iterator over batches for use in testing
+
+use std::task::{Context, Poll};
+
+use arrow::{
+    datatypes::SchemaRef, error::Result as ArrowResult, record_batch::RecordBatch,
+};
+use futures::Stream;
+
+use crate::physical_plan::RecordBatchStream;
+
+/// Index into the data that has been returned so far
+#[derive(Debug, Default, Clone)]
+pub struct BatchIndex {
+    inner: std::sync::Arc<std::sync::Mutex<usize>>,
+}
+
+impl BatchIndex {
+    /// Return the current index
+    pub fn value(&self) -> usize {
+        let inner = self.inner.lock().unwrap();
+        *inner
+    }
+
+    // increment the current index by one
+    pub fn incr(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        *inner += 1;
+    }
+}
+
+/// Iterator over batches
+#[derive(Debug, Default)]
+pub(crate) struct TestStream {
+    /// Vector of record batches
+    data: Vec<RecordBatch>,
+    /// Index into the data that has been returned so far
+    index: BatchIndex,
+}
+
+impl TestStream {
+    /// Create an iterator for a vector of record batches. Assumes at
+    /// least one entry in data (for the schema)
+    pub fn new(data: Vec<RecordBatch>) -> Self {
+        Self {
+            data,
+            ..Default::default()
+        }
+    }
+
+    /// Return a handle to the index counter for this stream
+    pub fn index(&self) -> BatchIndex {
+        self.index.clone()
+    }
+}
+
+impl Stream for TestStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let next_batch = self.index.value();
+
+        Poll::Ready(if next_batch < self.data.len() {
+            let next_batch = self.index.value();
+            self.index.incr();
+            Some(Ok(self.data[next_batch].clone()))
+        } else {
+            None
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.data.len(), Some(self.data.len()))
+    }
+}
+
+impl RecordBatchStream for TestStream {
+    /// Get the schema
+    fn schema(&self) -> SchemaRef {
+        self.data[0].schema()
+    }
+}

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -20,6 +20,7 @@
 use crate::datasource::{MemTable, TableProvider};
 use crate::error::Result;
 use crate::logical_plan::{LogicalPlan, LogicalPlanBuilder};
+use array::ArrayRef;
 use arrow::array::{self, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
@@ -152,6 +153,33 @@ pub fn build_table_i32(
 /// Returns the column names on the schema
 pub fn columns(schema: &Schema) -> Vec<String> {
     schema.fields().iter().map(|f| f.name().clone()).collect()
+}
+
+/// Return a new table provider that has a single Int32 column with
+/// values between `seq_start` and `seq_end`
+pub fn table_with_sequence(
+    seq_start: i32,
+    seq_end: i32,
+) -> Result<Arc<dyn TableProvider>> {
+    let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, true)]));
+    let arr = Arc::new(Int32Array::from((seq_start..=seq_end).collect::<Vec<_>>()));
+    let partitions = vec![vec![RecordBatch::try_new(
+        schema.clone(),
+        vec![arr as ArrayRef],
+    )?]];
+    Ok(Arc::new(MemTable::try_new(schema, partitions)?))
+}
+
+/// Return a RecordBatch with a single Int32 array with values (0..sz)
+pub fn make_partition(sz: i32) -> RecordBatch {
+    let seq_start = 0;
+    let seq_end = sz;
+    let values = (seq_start..seq_end).collect::<Vec<_>>();
+    let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, true)]));
+    let arr = Arc::new(Int32Array::from(values));
+    let arr = arr as ArrayRef;
+
+    RecordBatch::try_new(schema, vec![arr]).unwrap()
 }
 
 pub mod user_defined;

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -182,6 +182,7 @@ pub fn make_partition(sz: i32) -> RecordBatch {
     RecordBatch::try_new(schema, vec![arr]).unwrap()
 }
 
+pub mod exec;
 pub mod user_defined;
 pub mod variable;
 


### PR DESCRIPTION
# Rationale
Once the number of rows needed for a limit query has been produced, any further work done to read values from its input is wasted.

The current implementation of LimitStream will keep polling its input for the next value, and returning `Poll::Ready(None)` , even once the limit has been reached

For queries like `select * from foo limit 10` used for initial data exploration this is very wasteful.

# Changes

This PR changes `LimitStream` so that it drops its input once the limit has been reached -- this both potentially frees resources (memory, file handles, etc) it also avoids unnecessary computation