### PR TITLE
ARROW-11906 [R]: Make FeatherReader print method more informative

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -780,8 +780,8 @@ ipc___feather___Reader__Open <- function(stream){
     .Call(`_arrow_ipc___feather___Reader__Open`, stream)
 }
 
-ipc___feather___Reader__column_names <- function(reader){
-    .Call(`_arrow_ipc___feather___Reader__column_names`, reader)
+ipc___feather___Reader__schema <- function(reader){
+    .Call(`_arrow_ipc___feather___Reader__schema`, reader)
 }
 
 Field__initialize <- function(name, field, nullable){

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -183,6 +183,8 @@ read_feather <- function(file, col_select = NULL, as_data_frame = TRUE, ...) {
 #'
 #' - `$Read(columns)`: Returns a `Table` of the selected columns, a vector of
 #'   integer indices
+#' - `$column_names`: Active binding, returns the column names in the Feather file
+#' - `$schema`: Active binding, returns the schema of the Feather file
 #' - `$version`: Active binding, returns `1` or `2`, according to the Feather
 #'   file version
 #'
@@ -192,12 +194,18 @@ FeatherReader <- R6Class("FeatherReader", inherit = ArrowObject,
   public = list(
     Read = function(columns) {
       ipc___feather___Reader__Read(self, columns)
+    },
+    print = function(...) {
+      cat("FeatherReader:\n")
+      print(self$schema)
+      invisible(self)
     }
   ),
   active = list(
     # versions are officially 2 for V1 and 3 for V2 :shrug:
     version = function() ipc___feather___Reader__version(self) - 1L,
-    column_names = function() ipc___feather___Reader__column_names(self)
+    column_names = function() names(self$schema),
+    schema = function() ipc___feather___Reader__schema(self)
   )
 )
 

--- a/r/man/FeatherReader.Rd
+++ b/r/man/FeatherReader.Rd
@@ -24,6 +24,8 @@ takes the following argument:
 \itemize{
 \item \verb{$Read(columns)}: Returns a \code{Table} of the selected columns, a vector of
 integer indices
+\item \verb{$column_names}: Active binding, returns the column names in the Feather file
+\item \verb{$schema}: Active binding, returns the schema of the Feather file
 \item \verb{$version}: Active binding, returns \code{1} or \code{2}, according to the Feather
 file version
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2014,11 +2014,11 @@ BEGIN_CPP11
 END_CPP11
 }
 // feather.cpp
-cpp11::writable::strings ipc___feather___Reader__column_names(const std::shared_ptr<arrow::ipc::feather::Reader>& reader);
-extern "C" SEXP _arrow_ipc___feather___Reader__column_names(SEXP reader_sexp){
+std::shared_ptr<arrow::Schema> ipc___feather___Reader__schema(const std::shared_ptr<arrow::ipc::feather::Reader>& reader);
+extern "C" SEXP _arrow_ipc___feather___Reader__schema(SEXP reader_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ipc::feather::Reader>&>::type reader(reader_sexp);
-	return cpp11::as_sexp(ipc___feather___Reader__column_names(reader));
+	return cpp11::as_sexp(ipc___feather___Reader__schema(reader));
 END_CPP11
 }
 // field.cpp
@@ -4388,7 +4388,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ipc___feather___Reader__version", (DL_FUNC) &_arrow_ipc___feather___Reader__version, 1}, 
 		{ "_arrow_ipc___feather___Reader__Read", (DL_FUNC) &_arrow_ipc___feather___Reader__Read, 2}, 
 		{ "_arrow_ipc___feather___Reader__Open", (DL_FUNC) &_arrow_ipc___feather___Reader__Open, 1}, 
-		{ "_arrow_ipc___feather___Reader__column_names", (DL_FUNC) &_arrow_ipc___feather___Reader__column_names, 1}, 
+		{ "_arrow_ipc___feather___Reader__schema", (DL_FUNC) &_arrow_ipc___feather___Reader__schema, 1}, 
 		{ "_arrow_Field__initialize", (DL_FUNC) &_arrow_Field__initialize, 3}, 
 		{ "_arrow_Field__ToString", (DL_FUNC) &_arrow_Field__ToString, 1}, 
 		{ "_arrow_Field__name", (DL_FUNC) &_arrow_Field__name, 1}, 

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -79,11 +79,9 @@ std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
 }
 
 // [[arrow::export]]
-cpp11::writable::strings ipc___feather___Reader__column_names(
+std::shared_ptr<arrow::Schema> ipc___feather___Reader__schema(
     const std::shared_ptr<arrow::ipc::feather::Reader>& reader) {
-  return arrow::r::to_r_strings(
-      reader->schema()->fields(),
-      [](const std::shared_ptr<arrow::Field>& field) { return field->name(); });
+  return reader->schema();
 }
 
 #endif

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-context("Feather")
-
 feather_file <- tempfile()
 tib <- tibble::tibble(x = 1:10, y = rnorm(10), z = letters[1:10])
 
@@ -193,6 +191,32 @@ test_that("Character vectors > 2GB can write to feather", {
   on.exit(unlink(tf))
   write_feather(df, tf)
   expect_identical(read_feather(tf), df)
+})
+
+test_that("FeatherReader methods", {
+  # Setup a feather file to use in the test
+  feather_temp <- tempfile()
+  on.exit({
+    unlink(feather_temp)
+  })
+  write_feather(tib, feather_temp)
+  feather_temp_RA <- make_readable_file(feather_temp)
+
+  reader <- FeatherReader$create(feather_temp_RA)
+  feather_temp_RA$close()
+
+  # column_names
+  expect_identical(
+    reader$column_names,
+    c("x", "y", "z")
+  )
+
+  # print method
+  expect_identical(
+    capture.output(print(reader)),
+    # TODO: can we get  rows/columns?
+    c("FeatherReader:", "Schema", "x: int32", "y: double", "z: string")
+  )
 })
 
 unlink(feather_file)


### PR DESCRIPTION
Add a print method for FeatherReader objects, use the new schema method for column_names too.