### PR TITLE
ARROW-12215: [C++] Allow null values in fixed-size binary columns read from CSV

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -155,8 +155,6 @@ struct FixedSizeBinaryValueDecoder : public ValueDecoder {
     return Status::OK();
   }
 
-  bool IsNull(const uint8_t* data, uint32_t size, bool quoted) { return false; }
-
  protected:
   const uint32_t byte_width_;
 };


### PR DESCRIPTION
Give the CSV converter for reading fixed size binary columns the same behavior for detecting nulls as other datatypes.

Update tests to reflect the fact that fixed size binary types are now nullable in this context.