### PR TITLE
ARROW-10421: [R] Use gc_memory_pool in more places

### DIFF
--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -231,7 +231,9 @@ std::string fs___FileSystem__type_name(
 
 // [[arrow::export]]
 std::shared_ptr<fs::LocalFileSystem> fs___LocalFileSystem__create() {
-  return std::make_shared<fs::LocalFileSystem>();
+  // Affects OpenInputFile/OpenInputStream
+  auto io_context = arrow::io::IOContext(gc_memory_pool());
+  return std::make_shared<fs::LocalFileSystem>(io_context);
 }
 
 // [[arrow::export]]
@@ -315,7 +317,8 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
   s3_opts.background_writes = background_writes;
 
   StopIfNotOk(fs::EnsureS3Initialized());
-  return ValueOrStop(fs::S3FileSystem::Make(s3_opts));
+  auto io_context = arrow::io::IOContext(gc_memory_pool());
+  return ValueOrStop(fs::S3FileSystem::Make(s3_opts, io_context));
 }
 
 // [[s3::export]]

--- a/r/src/recordbatchreader.cpp
+++ b/r/src/recordbatchreader.cpp
@@ -40,7 +40,9 @@ std::shared_ptr<arrow::RecordBatch> RecordBatchReader__ReadNext(
 // [[arrow::export]]
 std::shared_ptr<arrow::ipc::RecordBatchStreamReader> ipc___RecordBatchStreamReader__Open(
     const std::shared_ptr<arrow::io::InputStream>& stream) {
-  return ValueOrStop(arrow::ipc::RecordBatchStreamReader::Open(stream));
+  auto options = arrow::ipc::IpcReadOptions::Defaults();
+  options.memory_pool = gc_memory_pool();
+  return ValueOrStop(arrow::ipc::RecordBatchStreamReader::Open(stream, options));
 }
 
 // [[arrow::export]]
@@ -85,7 +87,9 @@ std::shared_ptr<arrow::RecordBatch> ipc___RecordBatchFileReader__ReadRecordBatch
 // [[arrow::export]]
 std::shared_ptr<arrow::ipc::RecordBatchFileReader> ipc___RecordBatchFileReader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& file) {
-  return ValueOrStop(arrow::ipc::RecordBatchFileReader::Open(file));
+  auto options = arrow::ipc::IpcReadOptions::Defaults();
+  options.memory_pool = gc_memory_pool();
+  return ValueOrStop(arrow::ipc::RecordBatchFileReader::Open(file, options));
 }
 
 // [[arrow::export]]

--- a/r/src/recordbatchwriter.cpp
+++ b/r/src/recordbatchwriter.cpp
@@ -48,6 +48,7 @@ std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc___RecordBatchFileWriter__Open
   auto options = arrow::ipc::IpcWriteOptions::Defaults();
   options.write_legacy_ipc_format = use_legacy_format;
   options.metadata_version = metadata_version;
+  options.memory_pool = gc_memory_pool();
   return ValueOrStop(arrow::ipc::MakeFileWriter(stream, schema, options));
 }
 
@@ -59,6 +60,7 @@ std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc___RecordBatchStreamWriter__Op
   auto options = arrow::ipc::IpcWriteOptions::Defaults();
   options.write_legacy_ipc_format = use_legacy_format;
   options.metadata_version = metadata_version;
+  options.memory_pool = gc_memory_pool();
   return ValueOrStop(MakeStreamWriter(stream, schema, options));
 }
 


### PR DESCRIPTION
Fixes the cases mentioned in https://github.com/apache/arrow/pull/8533#issuecomment-717516187. 