### PR TITLE
ARROW-12220: [C++][CI] Thread sanitizer failure

### DIFF
--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1168,7 +1168,6 @@ class BackgroundGenerator {
   }
 
  protected:
-  enum class BackgroundThreadState : char { Reading = 0, Quitting = 1, Idle = 2 };
   struct State {
     State(internal::Executor* io_executor, Iterator<T> it, int max_q, int q_restart)
         : io_executor(io_executor),

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -815,7 +815,8 @@ TEST_P(BackgroundGeneratorTestFixture, StopAndRestart) {
 }
 
 struct TrackingIterator {
-  TrackingIterator(bool slow) : token(std::make_shared<bool>(false)), slow(slow) {}
+  explicit TrackingIterator(bool slow)
+      : token(std::make_shared<bool>(false)), slow(slow) {}
 
   Result<TestInt> Next() {
     if (slow) {

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -848,8 +848,9 @@ TEST_P(BackgroundGeneratorTestFixture, AbortReading) {
   ASSERT_FALSE(tracker.expired());
   // Remove last reference to generator, should trigger and wait for cleanup
   generator.reset();
-  // Cleanup should have ensured no more reference to the source
-  ASSERT_TRUE(tracker.expired());
+  // Cleanup should have ensured no more reference to the source.  It may take a moment
+  // to expire because the background thread has to destruct itself
+  BusyWait(10, [&tracker] { return tracker.expired(); });
 }
 
 TEST_P(BackgroundGeneratorTestFixture, AbortOnIdleBackground) {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -272,6 +272,12 @@ int ThreadPool::GetCapacity() {
   return state_->desired_capacity_;
 }
 
+int ThreadPool::GetNumTasks() {
+  ProtectAgainstFork();
+  std::unique_lock<std::mutex> lock(state_->mutex_);
+  return state_->tasks_queued_or_running_;
+}
+
 int ThreadPool::GetActualCapacity() {
   ProtectAgainstFork();
   std::unique_lock<std::mutex> lock(state_->mutex_);

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -264,6 +264,9 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // match this value.
   int GetCapacity() override;
 
+  // Return the number of tasks either running or in the queue.
+  int GetNumTasks();
+
   // Dynamically change the number of worker threads.
   //
   // This function always returns immediately.


### PR DESCRIPTION
The background generator kept reading from the source even after the downstream had given up on it.  Other than the obvious memory / resource usage problems this also meant that callback handlers could reference deleted state downstream.  Now we block the destructor until the background thread is finished and we stop the background thread early if all consumer references are lost.