### PR TITLE
ARROW-12286: [C++] Create AsyncGenerator from Future<AsyncGenerator<T>>

### DIFF
--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -640,6 +640,7 @@ class SerialReadaheadGenerator {
   std::shared_ptr<State> state_;
 };
 
+/// \see MakeFromFuture
 template <typename T>
 class FutureFirstGenerator {
  public:
@@ -669,6 +670,12 @@ class FutureFirstGenerator {
   std::shared_ptr<State> state_;
 };
 
+/// \brief Transforms a Future<AsyncGenerator<T>> into an AsyncGenerator<T>
+/// that waits for the future to complete as part of the first item.
+///
+/// This generator is not async-reentrant (even if the generator yielded by future is)
+///
+/// This generator does not queue
 template <typename T>
 AsyncGenerator<T> MakeFromFuture(Future<AsyncGenerator<T>> future) {
   return FutureFirstGenerator<T>(std::move(future));


### PR DESCRIPTION
It looks like the actual implementation of this generator snuck in as part of ARROW-12161 but it did not include the comments or tests later added to ARROW-7001.