### PR TITLE
ARROW-12290: [Rust][DataFusion] Add input_file_name function

### DIFF
--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -34,7 +34,8 @@ fn main() {
 
     let file = File::open("test/data/uk_cities.csv").unwrap();
 
-    let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None, None);
+    let mut csv =
+        csv::Reader::new(None, file, Arc::new(schema), false, None, 1024, None, None);
     let _batch = csv.next().unwrap().unwrap();
     #[cfg(feature = "prettyprint")]
     {

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -628,6 +628,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03\n";
         buf.set_position(0);
 
         let mut reader = Reader::new(
+            None,
             buf,
             Arc::new(schema),
             false,

--- a/rust/datafusion-examples/examples/simple_udf.rs
+++ b/rust/datafusion-examples/examples/simple_udf.rs
@@ -15,20 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use arrow::{
     array::{ArrayRef, Float32Array, Float64Array},
-    datatypes::DataType,
+    datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
     util::pretty,
 };
 
 use datafusion::prelude::*;
 use datafusion::{error::Result, physical_plan::functions::make_scalar_function};
-use std::sync::Arc;
 
 // create local execution context with an in-memory table
 fn create_context() -> Result<ExecutionContext> {
-    use arrow::datatypes::{Field, Schema};
     use datafusion::datasource::MemTable;
     // define a schema.
     let schema = Arc::new(Schema::new(vec![
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
     let mut ctx = create_context()?;
 
     // First, declare the actual implementation of the calculation
-    let pow = |args: &[ArrayRef]| {
+    let pow = |args: &[ArrayRef], _: &Schema| {
         // in DataFusion, all `args` and output are dynamically-typed arrays, which means that we need to:
         // 1. cast the values to the type we want
         // 2. perform the computation for every element in the array (using a loop or SIMD) and construct the result

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -172,11 +172,13 @@ DataFusion also includes a simple command-line interactive SQL utility. See the 
   - [x] concat
   - [x] concat_ws
   - [x] initcap
+  - [x] input_file_name
   - [x] left
   - [x] length
   - [x] lpad
   - [x] ltrim
   - [x] octet_length
+  - [x] regexp_match
   - [x] regexp_replace
   - [x] repeat
   - [x] replace

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1881,7 +1881,7 @@ mod tests {
         ctx.register_table("t", table_with_sequence(1, 1).unwrap())
             .unwrap();
 
-        let myfunc = |args: &[ArrayRef]| Ok(Arc::clone(&args[0]));
+        let myfunc = |args: &[ArrayRef], _: &Schema| Ok(Arc::clone(&args[0]));
         let myfunc = make_scalar_function(myfunc);
 
         ctx.register_udf(create_udf(
@@ -2181,7 +2181,7 @@ mod tests {
         let provider = MemTable::try_new(Arc::new(schema), vec![vec![batch]])?;
         ctx.register_table("t", Arc::new(provider))?;
 
-        let myfunc = |args: &[ArrayRef]| {
+        let myfunc = |args: &[ArrayRef], _: &Schema| {
             let l = &args[0]
                 .as_any()
                 .downcast_ref::<Int32Array>()

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -182,7 +182,7 @@ mod tests {
     use crate::logical_plan::*;
     use crate::{datasource::csv::CsvReadOptions, physical_plan::ColumnarValue};
     use crate::{physical_plan::functions::ScalarFunctionImplementation, test};
-    use arrow::datatypes::DataType;
+    use arrow::datatypes::{DataType, Schema};
 
     #[test]
     fn select_columns() -> Result<()> {
@@ -304,7 +304,9 @@ mod tests {
 
         // declare the udf
         let my_fn: ScalarFunctionImplementation =
-            Arc::new(|_: &[ColumnarValue]| unimplemented!("my_fn is not implemented"));
+            Arc::new(|_: &[ColumnarValue], _: &Schema| {
+                unimplemented!("my_fn is not implemented")
+            });
 
         // create and register the udf
         ctx.register_udf(create_udf(

--- a/rust/datafusion/src/physical_plan/array_expressions.rs
+++ b/rust/datafusion/src/physical_plan/array_expressions.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 //! Array expressions
+use std::sync::Arc;
 
 use crate::error::{DataFusionError, Result};
 use arrow::array::*;
-use arrow::datatypes::DataType;
-use std::sync::Arc;
+use arrow::datatypes::{DataType, Schema};
 
 use super::ColumnarValue;
 
@@ -90,7 +90,7 @@ fn array_array(args: &[&dyn Array]) -> Result<ArrayRef> {
 }
 
 /// put values in an array.
-pub fn array(values: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn array(values: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     let arrays: Vec<&dyn Array> = values
         .iter()
         .map(|value| {

--- a/rust/datafusion/src/physical_plan/crypto_expressions.rs
+++ b/rust/datafusion/src/physical_plan/crypto_expressions.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use arrow::{
     array::{Array, BinaryArray, GenericStringArray, StringOffsetSizeTrait},
-    datatypes::DataType,
+    datatypes::{DataType, Schema},
 };
 
 use super::{string_expressions::unary_string_function, ColumnarValue};
@@ -144,7 +144,7 @@ fn md5_array<T: StringOffsetSizeTrait>(
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn md5(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     match &args[0] {
         ColumnarValue::Array(a) => match a.data_type() {
             DataType::Utf8 => Ok(ColumnarValue::Array(Arc::new(md5_array::<i32>(&[
@@ -178,21 +178,21 @@ pub fn md5(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-pub fn sha224(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn sha224(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha224>, "ssh224")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-pub fn sha256(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn sha256(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha256>, "sha256")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-pub fn sha384(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn sha384(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha384>, "sha384")
 }
 
 /// crypto function that accepts Utf8 or LargeUtf8 and returns a [`ColumnarValue`]
-pub fn sha512(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn sha512(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, sha_process::<Sha512>, "sha512")
 }

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -306,6 +306,7 @@ impl CsvStream {
         let bounds = limit.map(|x| (0, x + start_line));
 
         let reader = csv::Reader::new(
+            Some(filename.to_string()),
             file,
             schema,
             has_header,

--- a/rust/datafusion/src/physical_plan/expressions/nullif.rs
+++ b/rust/datafusion/src/physical_plan/expressions/nullif.rs
@@ -28,7 +28,7 @@ use arrow::array::{
 };
 use arrow::compute::kernels::boolean::nullif;
 use arrow::compute::kernels::comparison::{eq, eq_scalar, eq_utf8, eq_utf8_scalar};
-use arrow::datatypes::{DataType, TimeUnit};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
 
 /// Invoke a compute kernel on a primitive array and a Boolean Array
 macro_rules! compute_bool_array_op {
@@ -71,7 +71,7 @@ macro_rules! primitive_bool_array_op {
 /// Args: 0 - left expr is any array
 ///       1 - if the left is equal to this expr2, then the result is NULL, otherwise left value is passed.
 ///
-pub fn nullif_func(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn nullif_func(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     if args.len() != 2 {
         return Err(DataFusionError::Internal(format!(
             "{:?} args were supplied but NULLIF takes exactly two args",
@@ -142,7 +142,7 @@ mod tests {
 
         let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(2i32)));
 
-        let result = nullif_func(&[a, lit_array])?;
+        let result = nullif_func(&[a, lit_array], &Schema::empty())?;
         let result = result.into_array(0);
 
         let expected = Arc::new(Int32Array::from(vec![
@@ -168,7 +168,7 @@ mod tests {
 
         let lit_array = ColumnarValue::Scalar(ScalarValue::Int32(Some(1i32)));
 
-        let result = nullif_func(&[a, lit_array])?;
+        let result = nullif_func(&[a, lit_array], &Schema::empty())?;
         let result = result.into_array(0);
 
         let expected = Arc::new(Int32Array::from(vec![

--- a/rust/datafusion/src/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/physical_plan/math_expressions.rs
@@ -19,7 +19,7 @@
 
 use arrow::array::{make_array, Array, ArrayData, Float32Array, Float64Array};
 use arrow::buffer::Buffer;
-use arrow::datatypes::{DataType, ToByteSlice};
+use arrow::datatypes::{DataType, Schema, ToByteSlice};
 
 use super::{ColumnarValue, ScalarValue};
 use crate::error::{DataFusionError, Result};
@@ -93,7 +93,7 @@ macro_rules! unary_primitive_array_op {
 macro_rules! math_unary_function {
     ($NAME:expr, $FUNC:ident) => {
         /// mathematical function that accepts f32 or f64 and returns f64
-        pub fn $FUNC(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+        pub fn $FUNC(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
             unary_primitive_array_op!(&args[0], $NAME, $FUNC)
         }
     };

--- a/rust/datafusion/src/physical_plan/regex_expressions.rs
+++ b/rust/datafusion/src/physical_plan/regex_expressions.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use crate::error::{DataFusionError, Result};
 use arrow::array::{ArrayRef, GenericStringArray, StringOffsetSizeTrait};
 use arrow::compute;
+use arrow::datatypes::Schema;
 use hashbrown::HashMap;
 use regex::Regex;
 
@@ -45,7 +46,10 @@ macro_rules! downcast_string_arg {
 }
 
 /// extract a specific group from a string column, using a regular expression
-pub fn regexp_match<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn regexp_match<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     match args.len() {
         2 => compute::regexp_match(downcast_string_arg!(args[0], "string", T), downcast_string_arg!(args[1], "pattern", T), None)
         .map_err(DataFusionError::ArrowError),
@@ -72,7 +76,10 @@ fn regex_replace_posix_groups(replacement: &str) -> String {
 /// Replaces substring(s) matching a POSIX regular expression.
 ///
 /// example: `regexp_replace('Thomas', '.[mN]a.', 'M') = 'ThM'`
-pub fn regexp_replace<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn regexp_replace<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     // creating Regex is expensive so create hashmap for memoization
     let mut patterns: HashMap<String, Regex> = HashMap::new();
 

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -33,7 +33,7 @@ use arrow::{
         Array, ArrayRef, BooleanArray, GenericStringArray, Int32Array, Int64Array,
         PrimitiveArray, StringArray, StringOffsetSizeTrait,
     },
-    datatypes::{ArrowNativeType, ArrowPrimitiveType, DataType},
+    datatypes::{ArrowNativeType, ArrowPrimitiveType, DataType, Schema},
 };
 
 use super::ColumnarValue;
@@ -174,7 +174,10 @@ where
 
 /// Returns the numeric code of the first character of the argument.
 /// ascii('x') = 120
-pub fn ascii<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn ascii<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
 
     let result = string_array
@@ -192,7 +195,10 @@ pub fn ascii<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Removes the longest string containing only characters in characters (a space by default) from the start and end of string.
 /// btrim('xyxtrimyyx', 'xyz') = 'trim'
-pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn btrim<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     match args.len() {
         1 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -240,7 +246,7 @@ pub fn btrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Returns the character with the given code. chr(0) is disallowed because text data types cannot store that character.
 /// chr(65) = 'A'
-pub fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn chr(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef> {
     let integer_array = downcast_arg!(args[0], "integer", Int64Array);
 
     // first map is the iterator, second is for the `Option<_>`
@@ -271,7 +277,7 @@ pub fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Concatenates the text representations of all the arguments. NULL arguments are ignored.
 /// concat('abcde', 2, NULL, 22) = 'abcde222'
-pub fn concat(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn concat(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     // do not accept 0 arguments.
     if args.is_empty() {
         return Err(DataFusionError::Internal(format!(
@@ -331,7 +337,7 @@ pub fn concat(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 
 /// Concatenates all but the first argument, with separators. The first argument is used as the separator string, and should not be NULL. Other NULL arguments are ignored.
 /// concat_ws(',', 'abcde', 2, NULL, 22) = 'abcde,2,22'
-pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn concat_ws(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef> {
     // downcast all arguments to strings
     let args = downcast_vec!(args, StringArray).collect::<Result<Vec<&StringArray>>>()?;
 
@@ -370,7 +376,10 @@ pub fn concat_ws(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Converts the first letter of each word to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.
 /// initcap('hi THOMAS') = 'Hi Thomas'
-pub fn initcap<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn initcap<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
 
     // first map is the iterator, second is for the `Option<_>`
@@ -400,13 +409,16 @@ pub fn initcap<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> 
 
 /// Converts the string to all lower case.
 /// lower('TOM') = 'tom'
-pub fn lower(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn lower(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, |string| string.to_ascii_lowercase(), "lower")
 }
 
 /// Removes the longest string containing only characters in characters (a space by default) from the start of string.
 /// ltrim('zzzytest', 'xyz') = 'test'
-pub fn ltrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn ltrim<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     match args.len() {
         1 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -445,7 +457,10 @@ pub fn ltrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Repeats string the specified number of times.
 /// repeat('Pg', 4) = 'PgPgPgPg'
-pub fn repeat<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn repeat<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let number_array = downcast_arg!(args[1], "number", Int64Array);
 
@@ -463,7 +478,10 @@ pub fn repeat<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Replaces all occurrences in string of substring from with substring to.
 /// replace('abcdefabcdef', 'cd', 'XX') = 'abXXefabXXef'
-pub fn replace<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn replace<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let from_array = downcast_string_arg!(args[1], "from", T);
     let to_array = downcast_string_arg!(args[2], "to", T);
@@ -481,9 +499,23 @@ pub fn replace<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> 
     Ok(Arc::new(result) as ArrayRef)
 }
 
+/// Returns the name of the file being read or null if not available.
+/// input_file_name() = './alltypes_plain.parquet'
+pub fn input_file_name(args: &[ArrayRef], schema: &Schema) -> Result<ArrayRef> {
+    let result = (0..args[0].len())
+        .into_iter()
+        .map(|_| schema.metadata().get("filename"))
+        .collect::<GenericStringArray<i32>>();
+
+    Ok(Arc::new(result) as ArrayRef)
+}
+
 /// Removes the longest string containing only characters in characters (a space by default) from the end of string.
 /// rtrim('testxxzx', 'xyz') = 'test'
-pub fn rtrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn rtrim<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     match args.len() {
         1 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -522,7 +554,10 @@ pub fn rtrim<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Splits string at occurrences of delimiter and returns the n'th field (counting from one).
 /// split_part('abc~@~def~@~ghi', '~@~', 2) = 'def'
-pub fn split_part<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn split_part<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let delimiter_array = downcast_string_arg!(args[1], "delimiter", T);
     let n_array = downcast_arg!(args[2], "n", Int64Array);
@@ -554,7 +589,10 @@ pub fn split_part<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRe
 
 /// Returns true if string starts with prefix.
 /// starts_with('alphabet', 'alph') = 't'
-pub fn starts_with<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn starts_with<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let prefix_array = downcast_string_arg!(args[1], "prefix", T);
 
@@ -572,7 +610,7 @@ pub fn starts_with<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayR
 
 /// Converts the number to its equivalent hexadecimal representation.
 /// to_hex(2147483647) = '7fffffff'
-pub fn to_hex<T: ArrowPrimitiveType>(args: &[ArrayRef]) -> Result<ArrayRef>
+pub fn to_hex<T: ArrowPrimitiveType>(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef>
 where
     T::Native: StringOffsetSizeTrait,
 {
@@ -590,6 +628,6 @@ where
 
 /// Converts the string to all upper case.
 /// upper('tom') = 'TOM'
-pub fn upper(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+pub fn upper(args: &[ColumnarValue], _: &Schema) -> Result<ColumnarValue> {
     handle(args, |string| string.to_ascii_uppercase(), "upper")
 }

--- a/rust/datafusion/src/physical_plan/unicode_expressions.rs
+++ b/rust/datafusion/src/physical_plan/unicode_expressions.rs
@@ -30,7 +30,7 @@ use arrow::{
     array::{
         ArrayRef, GenericStringArray, Int64Array, PrimitiveArray, StringOffsetSizeTrait,
     },
-    datatypes::{ArrowNativeType, ArrowPrimitiveType},
+    datatypes::{ArrowNativeType, ArrowPrimitiveType, Schema},
 };
 use hashbrown::HashMap;
 use unicode_segmentation::UnicodeSegmentation;
@@ -63,7 +63,10 @@ macro_rules! downcast_arg {
 
 /// Returns number of characters in the string.
 /// character_length('josé') = 4
-pub fn character_length<T: ArrowPrimitiveType>(args: &[ArrayRef]) -> Result<ArrayRef>
+pub fn character_length<T: ArrowPrimitiveType>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef>
 where
     T::Native: StringOffsetSizeTrait,
 {
@@ -90,7 +93,7 @@ where
 
 /// Returns first n characters in the string, or when n is negative, returns all but last |n| characters.
 /// left('abcde', 2) = 'ab'
-pub fn left<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn left<T: StringOffsetSizeTrait>(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let n_array = downcast_arg!(args[1], "n", Int64Array);
 
@@ -124,7 +127,7 @@ pub fn left<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Extends the string to length 'length' by prepending the characters fill (a space by default). If the string is already longer than length then it is truncated (on the right).
 /// lpad('hi', 5, 'xy') = 'xyxhi'
-pub fn lpad<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn lpad<T: StringOffsetSizeTrait>(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -213,7 +216,10 @@ pub fn lpad<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Reverses the order of the characters in the string.
 /// reverse('abcde') = 'edcba'
-pub fn reverse<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn reverse<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
 
     let result = string_array
@@ -228,7 +234,10 @@ pub fn reverse<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> 
 
 /// Returns last n characters in the string, or when n is negative, returns all but first |n| characters.
 /// right('abcde', 2) = 'de'
-pub fn right<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn right<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let n_array = downcast_arg!(args[1], "n", Int64Array);
 
@@ -276,7 +285,7 @@ pub fn right<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Extends the string to length 'length' by appending the characters fill (a space by default). If the string is already longer than length then it is truncated.
 /// rpad('hi', 5, 'xy') = 'hixyx'
-pub fn rpad<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn rpad<T: StringOffsetSizeTrait>(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -353,7 +362,7 @@ pub fn rpad<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Returns starting index of specified substring within string, or zero if it's not present. (Same as position(substring in string), but note the reversed argument order.)
 /// strpos('high', 'ig') = 2
-pub fn strpos<T: ArrowPrimitiveType>(args: &[ArrayRef]) -> Result<ArrayRef>
+pub fn strpos<T: ArrowPrimitiveType>(args: &[ArrayRef], _: &Schema) -> Result<ArrayRef>
 where
     T::Native: StringOffsetSizeTrait,
 {
@@ -412,7 +421,10 @@ where
 /// Extracts the substring of string starting at the start'th character, and extending for count characters if that is specified. (Same as substring(string from start for count).)
 /// substr('alphabet', 3) = 'phabet'
 /// substr('alphabet', 3, 2) = 'ph'
-pub fn substr<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn substr<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     match args.len() {
         2 => {
             let string_array = downcast_string_arg!(args[0], "string", T);
@@ -489,7 +501,10 @@ pub fn substr<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 /// Replaces each character in string that matches a character in the from set with the corresponding character in the to set. If from is longer than to, occurrences of the extra characters in from are deleted.
 /// translate('12345', '143', 'ax') = 'a2x5'
-pub fn translate<T: StringOffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn translate<T: StringOffsetSizeTrait>(
+    args: &[ArrayRef],
+    _: &Schema,
+) -> Result<ArrayRef> {
     let string_array = downcast_string_arg!(args[0], "string", T);
     let from_array = downcast_string_arg!(args[1], "from", T);
     let to_array = downcast_string_arg!(args[2], "to", T);

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -2704,7 +2704,7 @@ mod tests {
 
         fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
             let f: ScalarFunctionImplementation =
-                Arc::new(|_| Err(DataFusionError::NotImplemented("".to_string())));
+                Arc::new(|_, _| Err(DataFusionError::NotImplemented("".to_string())));
             match name {
                 "my_sqrt" => Some(Arc::new(create_udf(
                     "my_sqrt",


### PR DESCRIPTION
For lineage and diffing purposes (used by protocols like DeltaLake) it can be useful to know the source of input data for a Dataframe. This adds the `input_file_name` function which, like Spark, returns the name of the file being read, or NULL if not available.

Unfortunately the Arrow RecordBatch does not have the ability to serialise this information correctly so this is runtime only. See: https://lists.apache.org/thread.html/rd1ab179db7e899635351df7d5de2286915cc439fd1f48e0057a373db%40%3Cdev.arrow.apache.org%3E