### PR TITLE
ARROW-12288: [C++] Create Scanner interface

### DIFF
--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -64,9 +64,6 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   /// To receive a record batch stream which is fully filtered and projected, use Scanner.
   virtual Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options) = 0;
 
-  /// \brief Return true if the fragment can benefit from parallel scanning.
-  virtual bool splittable() const = 0;
-
   virtual std::string type_name() const = 0;
   virtual std::string ToString() const { return type_name(); }
 
@@ -110,8 +107,6 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
   explicit InMemoryFragment(RecordBatchVector record_batches, Expression = literal(true));
 
   Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options) override;
-
-  bool splittable() const override { return false; }
 
   std::string type_name() const override { return "in-memory"; }
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -442,7 +442,7 @@ TEST_F(TestEndToEnd, EndToEndSingleDataset) {
   // In the simplest case, consumption is simply conversion to a Table.
   ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
 
-  auto expected = TableFromJSON(scanner->schema(), {R"([
+  auto expected = TableFromJSON(scanner_builder->projected_schema(), {R"([
     {"sales": 152.25, "model": "3", "country": "CA"},
     {"sales": 273.5, "model": "3", "country": "US"}
   ])"});
@@ -547,7 +547,7 @@ class TestSchemaUnification : public TestUnionDataset {
   void AssertScanEquals(std::shared_ptr<Scanner> scanner,
                         const std::vector<TupleType>& expected_rows) {
     std::vector<std::string> columns;
-    for (const auto& field : scanner->schema()->fields()) {
+    for (const auto& field : scanner->options()->projected_schema->fields()) {
       columns.push_back(field->name());
     }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -470,12 +470,7 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
   // NB: neither of these will have any impact whatsoever on the common case of writing
   //     an in-memory table to disk.
   ARROW_ASSIGN_OR_RAISE(auto scan_task_it, scanner->Scan());
-  ScanTaskVector scan_tasks;
-
-  for (const auto& maybe_scan_task : scan_task_it) {
-    ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
-    scan_tasks.push_back(scan_task);
-  }
+  ARROW_ASSIGN_OR_RAISE(ScanTaskVector scan_tasks, scan_task_it.ToVector());
 
   WriteState state(write_options);
   auto res = internal::RunSynchronously<arrow::detail::Empty>(

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -369,7 +369,7 @@ struct WriteState {
   std::unordered_map<std::string, std::unique_ptr<WriteQueue>> queues;
 };
 
-Status WriteNextBatch(WriteState& state, const std::shared_ptr<ScanTask>& scan_task,
+Status WriteNextBatch(WriteState& state, const std::shared_ptr<Fragment>& fragment,
                       std::shared_ptr<RecordBatch> batch) {
   ARROW_ASSIGN_OR_RAISE(auto groups, state.write_options.partitioning->Partition(batch));
   batch.reset();  // drop to hopefully conserve memory
@@ -382,8 +382,8 @@ Status WriteNextBatch(WriteState& state, const std::shared_ptr<ScanTask>& scan_t
 
   std::unordered_set<WriteQueue*> need_flushed;
   for (size_t i = 0; i < groups.batches.size(); ++i) {
-    auto partition_expression = and_(std::move(groups.expressions[i]),
-                                     scan_task->fragment()->partition_expression());
+    auto partition_expression =
+        and_(std::move(groups.expressions[i]), fragment->partition_expression());
     auto batch = std::move(groups.batches[i]);
 
     ARROW_ASSIGN_OR_RAISE(auto part,
@@ -432,7 +432,7 @@ Future<> WriteInternal(const ScanOptions& scan_options, WriteState& state,
       ARROW_ASSIGN_OR_RAISE(auto batches_gen, scan_task->ExecuteAsync(cpu_executor));
       std::function<Status(std::shared_ptr<RecordBatch> batch)> batch_visitor =
           [&, scan_task](std::shared_ptr<RecordBatch> batch) {
-            return WriteNextBatch(state, scan_task, std::move(batch));
+            return WriteNextBatch(state, scan_task->fragment(), std::move(batch));
           };
       scan_futs.push_back(VisitAsyncGenerator(batches_gen, batch_visitor));
     } else {
@@ -441,7 +441,7 @@ Future<> WriteInternal(const ScanOptions& scan_options, WriteState& state,
 
         for (auto maybe_batch : batches) {
           ARROW_ASSIGN_OR_RAISE(auto batch, maybe_batch);
-          RETURN_NOT_OK(WriteNextBatch(state, scan_task, std::move(batch)));
+          RETURN_NOT_OK(WriteNextBatch(state, scan_task->fragment(), std::move(batch)));
         }
 
         return Status::OK();
@@ -469,20 +469,12 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
   //
   // NB: neither of these will have any impact whatsoever on the common case of writing
   //     an in-memory table to disk.
-  ARROW_ASSIGN_OR_RAISE(auto fragment_it, scanner->GetFragments());
-  ARROW_ASSIGN_OR_RAISE(FragmentVector fragments, fragment_it.ToVector());
+  ARROW_ASSIGN_OR_RAISE(auto scan_task_it, scanner->Scan());
   ScanTaskVector scan_tasks;
 
-  for (const auto& fragment : fragments) {
-    auto options = std::make_shared<ScanOptions>(*scanner->options());
-    // Avoid contention with multithreaded readers
-    options->use_threads = false;
-    ARROW_ASSIGN_OR_RAISE(auto scan_task_it,
-                          Scanner(fragment, std::move(options)).Scan());
-    for (auto maybe_scan_task : scan_task_it) {
-      ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
-      scan_tasks.push_back(std::move(scan_task));
-    }
+  for (const auto& maybe_scan_task : scan_task_it) {
+    ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
+    scan_tasks.push_back(scan_task);
   }
 
   WriteState state(write_options);

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -134,9 +134,6 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
   /// \brief The name identifying the kind of file format
   virtual std::string type_name() const = 0;
 
-  /// \brief Return true if fragments of this format can benefit from parallel scanning.
-  virtual bool splittable() const { return false; }
-
   virtual bool Equals(const FileFormat& other) const = 0;
 
   /// \brief Indicate if the FileSource is supported/readable by this format.
@@ -176,7 +173,6 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
 
   std::string type_name() const override { return format_->type_name(); }
   std::string ToString() const override { return source_.path(); };
-  bool splittable() const override { return format_->splittable(); }
 
   const FileSource& source() const { return source_; }
   const std::shared_ptr<FileFormat>& format() const { return format_; }

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -45,7 +45,7 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::Executor;
 using internal::SerialExecutor;
-using RecordBatchGenerator = AsyncGenerator<std::shared_ptr<RecordBatch>>;
+using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
 
 Result<std::unordered_set<std::string>> GetColumnNames(
     const csv::ParseOptions& parse_options, util::string_view first_block,

--- a/cpp/src/arrow/dataset/file_ipc.h
+++ b/cpp/src/arrow/dataset/file_ipc.h
@@ -42,8 +42,6 @@ class ARROW_DS_EXPORT IpcFileFormat : public FileFormat {
     return type_name() == other.type_name();
   }
 
-  bool splittable() const override { return true; }
-
   Result<bool> IsSupported(const FileSource& source) const override;
 
   /// \brief Return the schema of the file if possible.

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -234,6 +234,13 @@ class TestIpcFileSystemDataset : public testing::Test,
     format_ = ipc_format;
     SetWriteOptions(ipc_format->DefaultWriteOptions());
   }
+
+  std::shared_ptr<Scanner> MakeScanner(const std::shared_ptr<Dataset>& dataset,
+                                       const std::shared_ptr<ScanOptions>& scan_options) {
+    ScannerBuilder builder(dataset, scan_options);
+    EXPECT_OK_AND_ASSIGN(auto scanner, builder.Finish());
+    return scanner;
+  }
 };
 
 TEST_F(TestIpcFileSystemDataset, WriteWithIdenticalPartitioningSchema) {
@@ -259,7 +266,7 @@ TEST_F(TestIpcFileSystemDataset, WriteExceedsMaxPartitions) {
   // require that no batch be grouped into more than 2 written batches:
   write_options_.max_partitions = 2;
 
-  auto scanner = std::make_shared<Scanner>(dataset_, scan_options_);
+  auto scanner = MakeScanner(dataset_, scan_options_);
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("This exceeds the maximum"),
                                   FileSystemDataset::Write(write_options_, scanner));
 }

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -70,8 +70,6 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
 
   std::string type_name() const override { return kParquetTypeName; }
 
-  bool splittable() const override { return true; }
-
   bool Equals(const FileFormat& other) const override;
 
   struct ReaderOptions {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -140,7 +140,8 @@ Result<TaggedRecordBatchIterator> SyncScanner::ScanBatches() {
   // unit testing
   ARROW_ASSIGN_OR_RAISE(auto scan_task_it, Scan());
   struct BatchIter {
-    BatchIter(ScanTaskIterator scan_task_it) : scan_task_it(std::move(scan_task_it)) {}
+    explicit BatchIter(ScanTaskIterator scan_task_it)
+        : scan_task_it(std::move(scan_task_it)) {}
 
     Result<TaggedRecordBatch> Next() {
       while (true) {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -70,18 +70,6 @@ Result<RecordBatchGenerator> ScanTask::ExecuteAsync(internal::Executor*) {
 
 bool ScanTask::supports_async() const { return false; }
 
-Result<TaggedRecordBatchGenerator> Scanner::ScanBatchesAsync() {
-  // TODO(ARROW-12289) A default implementation based on
-  // Scanner::ScanBatchesUnorderedAsync() will be provided in Scanner
-  return Status::NotImplemented("This scanner does not support asynchronous scanning");
-};
-
-Result<EnumeratedRecordBatchGenerator> Scanner::ScanBatchesUnorderedAsync() {
-  // TODO(ARROW-12289) This is the primary override for the async scanner, all other scan
-  // methods will be based on this
-  return Status::NotImplemented("This scanner does not support asynchronous scanning");
-}
-
 Result<ScanTaskIterator> Scanner::Scan() {
   // TODO(ARROW-12289) This is overridden in SyncScanner and will never be implemented in
   // AsyncScanner.  It is deprecated and will eventually go away.
@@ -177,14 +165,6 @@ Result<TaggedRecordBatchIterator> SyncScanner::ScanBatches() {
     std::shared_ptr<ScanTask> current_task;
   };
   return TaggedRecordBatchIterator(BatchIter(std::move(scan_task_it)));
-}
-
-Result<EnumeratedRecordBatchGenerator> SyncScanner::ScanBatchesUnorderedAsync() {
-  // TODO(ARROW-12289) This will never be implemented and will remain this way until
-  // the SyncScanner goes away.  Since the async interfaces are not publically exposed
-  // this should be fine.
-  return Status::NotImplemented(
-      "Asynchronous dataset scanning is not supported by the synchronous scanner");
 }
 
 Result<FragmentIterator> SyncScanner::GetFragments() {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -70,7 +70,124 @@ Result<RecordBatchGenerator> ScanTask::ExecuteAsync(internal::Executor*) {
 
 bool ScanTask::supports_async() const { return false; }
 
-Result<FragmentIterator> Scanner::GetFragments() {
+Result<TaggedRecordBatchGenerator> Scanner::ScanBatchesAsync() {
+  // TODO(ARROW-12289) A default implementation based on
+  // Scanner::ScanBatchesUnorderedAsync() will be provided in Scanner
+  return Status::NotImplemented("This scanner does not support asynchronous scanning");
+};
+
+Result<EnumeratedRecordBatchGenerator> Scanner::ScanBatchesUnorderedAsync() {
+  // TODO(ARROW-12289) This is the primary override for the async scanner, all other scan
+  // methods will be based on this
+  return Status::NotImplemented("This scanner does not support asynchronous scanning");
+}
+
+Result<ScanTaskIterator> Scanner::Scan() {
+  // TODO(ARROW-12289) This is overridden in SyncScanner and will never be implemented in
+  // AsyncScanner.  It is deprecated and will eventually go away.
+  return Status::NotImplemented("This scanner does not support the legacy Scan() method");
+}
+
+Result<EnumeratedRecordBatchIterator> Scanner::ScanBatchesUnordered() {
+  // If a scanner doesn't support unordered scanning (i.e. SyncScanner) then we just
+  // fall back to an ordered scan and assign the appropriate tagging
+  ARROW_ASSIGN_OR_RAISE(auto ordered_scan, ScanBatches());
+  return AddPositioningToInOrderScan(std::move(ordered_scan));
+}
+
+Result<EnumeratedRecordBatchIterator> Scanner::AddPositioningToInOrderScan(
+    TaggedRecordBatchIterator scan) {
+  ARROW_ASSIGN_OR_RAISE(auto first, scan.Next());
+  if (IsIterationEnd(first)) {
+    return MakeEmptyIterator<EnumeratedRecordBatch>();
+  }
+  struct State {
+    State(TaggedRecordBatchIterator source, TaggedRecordBatch first)
+        : source(std::move(source)),
+          batch_index(1),
+          finished(false),
+          prev_batch(TaggedRecordBatch{nullptr, nullptr}) {}
+    TaggedRecordBatchIterator source;
+    int batch_index;
+    int fragment_index;
+    bool finished;
+    TaggedRecordBatch prev_batch;
+  };
+  struct TaggingIterator {
+    Result<EnumeratedRecordBatch> Next() {
+      if (state->finished) {
+        return IterationEnd<EnumeratedRecordBatch>();
+      }
+      ARROW_ASSIGN_OR_RAISE(auto next, state->source.Next());
+      if (IsIterationEnd<TaggedRecordBatch>(next)) {
+        state->finished = true;
+        return EnumeratedRecordBatch{
+            {std::move(state->prev_batch.record_batch), state->batch_index, true},
+            {std::move(state->prev_batch.fragment), state->fragment_index, true}};
+      }
+      auto prev = std::move(state->prev_batch);
+      bool prev_is_last_batch = false;
+      // Reference equality here seems risky but a dataset should have a constant set of
+      // fragments which should be consistent for the lifetime of a scan
+      if (prev.fragment.get() != next.fragment.get()) {
+        state->batch_index = 0;
+        state->fragment_index++;
+        prev_is_last_batch = true;
+      } else {
+        state->batch_index++;
+      }
+      state->prev_batch = std::move(next);
+      return EnumeratedRecordBatch{
+          {std::move(prev.record_batch), state->batch_index, prev_is_last_batch},
+          {std::move(prev.fragment), state->fragment_index, false}};
+    }
+    std::shared_ptr<State> state;
+  };
+  return EnumeratedRecordBatchIterator(
+      TaggingIterator{std::make_shared<State>(std::move(scan), std::move(first))});
+}
+
+Result<TaggedRecordBatchIterator> SyncScanner::ScanBatches() {
+  // TODO(ARROW-11797) Provide a better implementation that does readahead.  Also, add
+  // unit testing
+  ARROW_ASSIGN_OR_RAISE(auto scan_task_it, Scan());
+  struct BatchIter {
+    BatchIter(ScanTaskIterator scan_task_it) : scan_task_it(std::move(scan_task_it)) {}
+
+    Result<TaggedRecordBatch> Next() {
+      while (true) {
+        if (current_task == nullptr) {
+          ARROW_ASSIGN_OR_RAISE(current_task, scan_task_it.Next());
+          if (IsIterationEnd<std::shared_ptr<ScanTask>>(current_task)) {
+            return IterationEnd<TaggedRecordBatch>();
+          }
+          ARROW_ASSIGN_OR_RAISE(batch_it, current_task->Execute());
+        }
+        ARROW_ASSIGN_OR_RAISE(auto next, batch_it.Next());
+        if (IsIterationEnd<std::shared_ptr<RecordBatch>>(next)) {
+          current_task = nullptr;
+        } else {
+          return TaggedRecordBatch{next, current_task->fragment()};
+        }
+      }
+    }
+
+    ScanTaskIterator scan_task_it;
+    RecordBatchIterator batch_it;
+    std::shared_ptr<ScanTask> current_task;
+  };
+  return TaggedRecordBatchIterator(BatchIter(std::move(scan_task_it)));
+}
+
+Result<EnumeratedRecordBatchGenerator> SyncScanner::ScanBatchesUnorderedAsync() {
+  // TODO(ARROW-12289) This will never be implemented and will remain this way until
+  // the SyncScanner goes away.  Since the async interfaces are not publically exposed
+  // this should be fine.
+  return Status::NotImplemented(
+      "Asynchronous dataset scanning is not supported by the synchronous scanner");
+}
+
+Result<FragmentIterator> SyncScanner::GetFragments() {
   if (fragment_ != nullptr) {
     return MakeVectorIterator(FragmentVector{fragment_});
   }
@@ -81,7 +198,7 @@ Result<FragmentIterator> Scanner::GetFragments() {
   return GetFragmentsFromDatasets({dataset_}, scan_options_->filter);
 }
 
-Result<ScanTaskIterator> Scanner::Scan() {
+Result<ScanTaskIterator> SyncScanner::Scan() {
   // Transforms Iterator<Fragment> into a unified
   // Iterator<ScanTask>. The first Iterator::Next invocation is going to do
   // all the work of unwinding the chained iterators.
@@ -110,7 +227,7 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<Dataset> dataset,
       fragment_(nullptr),
       scan_options_(std::move(scan_options)) {
   scan_options_->dataset_schema = dataset_->schema();
-  DCHECK_OK(Filter(literal(true)));
+  DCHECK_OK(Filter(scan_options_->filter));
 }
 
 ScannerBuilder::ScannerBuilder(std::shared_ptr<Schema> schema,
@@ -120,11 +237,15 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<Schema> schema,
       fragment_(std::move(fragment)),
       scan_options_(std::move(scan_options)) {
   scan_options_->dataset_schema = std::move(schema);
-  DCHECK_OK(Filter(literal(true)));
+  DCHECK_OK(Filter(scan_options_->filter));
 }
 
 const std::shared_ptr<Schema>& ScannerBuilder::schema() const {
   return scan_options_->dataset_schema;
+}
+
+const std::shared_ptr<Schema>& ScannerBuilder::projected_schema() const {
+  return scan_options_->projected_schema;
 }
 
 Status ScannerBuilder::Project(std::vector<std::string> columns) {
@@ -170,9 +291,15 @@ Result<std::shared_ptr<Scanner>> ScannerBuilder::Finish() {
   }
 
   if (dataset_ == nullptr) {
-    return std::make_shared<Scanner>(fragment_, scan_options_);
+    // AsyncScanner does not support this method of running.  It may in the future
+    return std::make_shared<SyncScanner>(fragment_, scan_options_);
   }
-  return std::make_shared<Scanner>(dataset_, scan_options_);
+  if (scan_options_->use_async) {
+    // TODO(ARROW-12289)
+    return Status::NotImplemented("The asynchronous scanner is not yet available");
+  } else {
+    return std::make_shared<SyncScanner>(dataset_, scan_options_);
+  }
 }
 
 static inline RecordBatchVector FlattenRecordBatchVector(
@@ -202,13 +329,13 @@ struct TableAssemblyState {
   }
 };
 
-Result<std::shared_ptr<Table>> Scanner::ToTable() {
+Result<std::shared_ptr<Table>> SyncScanner::ToTable() {
   return internal::RunSynchronously<std::shared_ptr<Table>>(
       [this](Executor* executor) { return ToTableInternal(executor); },
       scan_options_->use_threads);
 }
 
-Future<std::shared_ptr<Table>> Scanner::ToTableInternal(
+Future<std::shared_ptr<Table>> SyncScanner::ToTableInternal(
     internal::Executor* cpu_executor) {
   ARROW_ASSIGN_OR_RAISE(auto scan_task_it, Scan());
   auto task_group = scan_options_->TaskGroup();
@@ -218,6 +345,7 @@ Future<std::shared_ptr<Table>> Scanner::ToTableInternal(
   /// and the mutex/batches fail out of scope.
   auto state = std::make_shared<TableAssemblyState>();
 
+  // TODO (ARROW-11797) Migrate to using ScanBatches()
   size_t scan_task_id = 0;
   std::vector<Future<>> scan_futures;
   for (auto maybe_scan_task : scan_task_it) {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -90,7 +90,7 @@ Result<EnumeratedRecordBatchIterator> Scanner::AddPositioningToInOrderScan(
     return MakeEmptyIterator<EnumeratedRecordBatch>();
   }
   struct State {
-    State(TaggedRecordBatchIterator source, TaggedRecordBatch first)
+    State(TaggedRecordBatchIterator source)
         : source(std::move(source)),
           batch_index(1),
           finished(false),
@@ -101,7 +101,7 @@ Result<EnumeratedRecordBatchIterator> Scanner::AddPositioningToInOrderScan(
     bool finished;
     TaggedRecordBatch prev_batch;
   };
-  struct TaggingIterator {
+  struct EnumeratingIterator {
     Result<EnumeratedRecordBatch> Next() {
       if (state->finished) {
         return IterationEnd<EnumeratedRecordBatch>();
@@ -132,7 +132,7 @@ Result<EnumeratedRecordBatchIterator> Scanner::AddPositioningToInOrderScan(
     std::shared_ptr<State> state;
   };
   return EnumeratedRecordBatchIterator(
-      TaggingIterator{std::make_shared<State>(std::move(scan), std::move(first))});
+      EnumeratingIterator{std::make_shared<State>(std::move(scan), std::move(first))});
 }
 
 Result<TaggedRecordBatchIterator> SyncScanner::ScanBatches() {

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -263,7 +263,7 @@ class ARROW_DS_EXPORT Scanner {
   /// in a concurrent fashion and outlive the iterator.
   ///
   /// Note: Not supported by the async scanner
-  ARROW_DEPRECATED("Deprecated in 3.0.0 Use ScanBatches")
+  /// TODO(ARROW-11797) Deprecate Scan()
   virtual Result<ScanTaskIterator> Scan();
   /// \brief Convert a Scanner into a Table.
   ///

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -111,7 +111,7 @@ struct ARROW_DS_EXPORT ScanOptions {
 
   /// If true then an asycnhronous implementation of the scanner will be used.
   /// This implementation is newer and generally performs better.  However, it
-  /// makes extensive use of testing and is still considered experimental
+  /// makes extensive use of threading and is still considered experimental
   bool use_async = false;
 
   /// Fragment-specific scan options.
@@ -236,7 +236,7 @@ namespace dataset {
 /// \brief A scanner glues together several dataset classes to load in data.
 /// The dataset contains a collection of fragments and partitioning rules.
 ///
-/// The fragments identify independently loadable units of data (e.g. each fragment has
+/// The fragments identify independently loadable units of data (i.e. each fragment has
 /// a potentially unique schema and possibly even format.  It should be possible to read
 /// fragments in parallel if desired).
 ///

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -30,8 +30,11 @@
 #include "arrow/dataset/projector.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
+#include "arrow/io/interfaces.h"
 #include "arrow/memory_pool.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/iterator.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/type_fwd.h"
 
 namespace arrow {
@@ -41,6 +44,8 @@ using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>(
 namespace dataset {
 
 constexpr int64_t kDefaultBatchSize = 1 << 20;
+constexpr int32_t kDefaultBatchReadahead = 32;
+constexpr int32_t kDefaultFragmentReadahead = 8;
 
 struct ARROW_DS_EXPORT ScanOptions {
   // Filter and projection
@@ -67,11 +72,47 @@ struct ARROW_DS_EXPORT ScanOptions {
   // Maximum row count for scanned batches.
   int64_t batch_size = kDefaultBatchSize;
 
+  /// How many batches to read ahead within a file
+  ///
+  /// Set to 0 to disable batch readahead
+  ///
+  /// Note: May not be supported by all formats
+  /// Note: May not be supported by all scanners
+  /// Note: Will be ignored if use_threads is set to false
+  int32_t batch_readahead = kDefaultBatchReadahead;
+
+  /// How many files to read ahead
+  ///
+  /// Set to 0 to disable fragment readahead
+  ///
+  /// Note: May not be enforced by all scanners
+  /// Note: Will be ignored if use_threads is set to false
+  int32_t fragment_readahead = kDefaultFragmentReadahead;
+
   /// A pool from which materialized and scanned arrays will be allocated.
   MemoryPool* pool = arrow::default_memory_pool();
 
-  /// Indicate if the Scanner should make use of a ThreadPool.
+  /// Executor on which to run any CPU tasks
+  ///
+  /// Note: Will be ignored if use_threads is set to false
+  internal::Executor* cpu_executor = internal::GetCpuThreadPool();
+
+  /// IOContext for any IO tasks
+  ///
+  /// Note: The IOContext executor will be ignored if use_threads is set to false
+  io::IOContext io_context;
+
+  /// If true the scanner will scan in parallel
+  ///
+  /// Note: If true, this will use threads from both the cpu_executor and the
+  /// io_context.executor
+  /// Note: This  must be true in order for any readahead to happen
   bool use_threads = false;
+
+  /// If true then an asycnhronous implementation of the scanner will be used.
+  /// This implementation is newer and generally performs better.  However, it
+  /// makes extensive use of testing and is still considered experimental
+  bool use_async = false;
 
   /// Fragment-specific scan options.
   std::shared_ptr<FragmentScanOptions> fragment_scan_options;
@@ -140,32 +181,122 @@ ARROW_DS_EXPORT Result<ScanTaskIterator> ScanTaskIteratorFromRecordBatch(
     std::vector<std::shared_ptr<RecordBatch>> batches,
     std::shared_ptr<ScanOptions> options);
 
-/// \brief Scanner is a materialized scan operation with context and options
-/// bound. A scanner is the class that glues ScanTask, Fragment,
-/// and Dataset. In python pseudo code, it performs the following:
+template <typename T>
+struct Enumerated {
+  T value;
+  int index;
+  bool last;
+};
+
+/// \brief Combines a record batch with the fragment that the record batch originated
+/// from
 ///
-///  def Scan():
-///    for fragment in self.dataset.GetFragments(this.options.filter):
-///      for scan_task in fragment.Scan(this.options):
-///        yield scan_task
+/// Knowing the source fragment can be useful for debugging & understanding loaded data
+struct TaggedRecordBatch {
+  std::shared_ptr<RecordBatch> record_batch;
+  std::shared_ptr<Fragment> fragment;
+};
+using TaggedRecordBatchGenerator = std::function<Future<TaggedRecordBatch>()>;
+using TaggedRecordBatchIterator = Iterator<TaggedRecordBatch>;
+
+/// \brief Combines a tagged batch with positional information
+///
+/// This is returned when scanning batches in an unordered fashion.  This information is
+/// needed if you ever want to reassemble the batches in order
+struct EnumeratedRecordBatch {
+  Enumerated<std::shared_ptr<RecordBatch>> record_batch;
+  Enumerated<std::shared_ptr<Fragment>> fragment;
+};
+using EnumeratedRecordBatchGenerator = std::function<Future<EnumeratedRecordBatch>()>;
+using EnumeratedRecordBatchIterator = Iterator<EnumeratedRecordBatch>;
+
+}  // namespace dataset
+
+template <>
+struct IterationTraits<dataset::TaggedRecordBatch> {
+  static dataset::TaggedRecordBatch End() {
+    return dataset::TaggedRecordBatch{NULL, NULL};
+  }
+  static bool IsEnd(const dataset::TaggedRecordBatch& val) {
+    return val.record_batch == NULL;
+  }
+};
+
+template <>
+struct IterationTraits<dataset::EnumeratedRecordBatch> {
+  static dataset::EnumeratedRecordBatch End() {
+    return dataset::EnumeratedRecordBatch{{NULL, -1, false}, {NULL, -1, false}};
+  }
+  static bool IsEnd(const dataset::EnumeratedRecordBatch& val) {
+    return val.fragment.value == NULL;
+  }
+};
+
+namespace dataset {
+/// \brief A scanner glues together several dataset classes to load in data.
+/// The dataset contains a collection of fragments and partitioning rules.
+///
+/// The fragments identify independently loadable units of data (e.g. each fragment has
+/// a potentially unique schema and possibly even format.  It should be possible to read
+/// fragments in parallel if desired).
+///
+/// The fragment's format contains the logic necessary to actually create a task to load
+/// the fragment into memory.  That task may or may not support parallel execution of
+/// its own.
+///
+/// The scanner is then responsible for creating scan tasks from every fragment in the
+/// dataset and (potentially) sequencing the loaded record batches together.
+///
+/// The scanner should not buffer the entire dataset in memory (unless asked) but should
+/// return record batches as soon as they are ready to scan.  Various readahead
+/// properties control how much data is allowed to be scanned before pausing to let a
+/// slow consumer catchup.
+///
+/// Today the scanner also delegates projection & filtering although that may change in
+/// the future.
 class ARROW_DS_EXPORT Scanner {
  public:
-  Scanner(std::shared_ptr<Dataset> dataset, std::shared_ptr<ScanOptions> scan_options)
-      : dataset_(std::move(dataset)), scan_options_(std::move(scan_options)) {}
-
-  Scanner(std::shared_ptr<Fragment> fragment, std::shared_ptr<ScanOptions> scan_options)
-      : fragment_(std::move(fragment)), scan_options_(std::move(scan_options)) {}
-
   /// \brief The Scan operator returns a stream of ScanTask. The caller is
   /// responsible to dispatch/schedule said tasks. Tasks should be safe to run
   /// in a concurrent fashion and outlive the iterator.
-  Result<ScanTaskIterator> Scan();
-
+  ///
+  /// Note: Not supported by the async scanner
+  ARROW_DEPRECATED("Deprecated in 3.0.0 Use ScanBatches")
+  virtual Result<ScanTaskIterator> Scan();
   /// \brief Convert a Scanner into a Table.
   ///
   /// Use this convenience utility with care. This will serially materialize the
   /// Scan result in memory before creating the Table.
-  Result<std::shared_ptr<Table>> ToTable();
+  virtual Result<std::shared_ptr<Table>> ToTable() = 0;
+  virtual Result<TaggedRecordBatchIterator> ScanBatches() = 0;
+  virtual Result<EnumeratedRecordBatchIterator> ScanBatchesUnordered();
+  virtual Result<TaggedRecordBatchGenerator> ScanBatchesAsync();
+  virtual Result<EnumeratedRecordBatchGenerator> ScanBatchesUnorderedAsync();
+
+  virtual const std::shared_ptr<ScanOptions>& options() const { return scan_options_; }
+
+ protected:
+  Result<EnumeratedRecordBatchIterator> AddPositioningToInOrderScan(
+      TaggedRecordBatchIterator scan);
+
+  const std::shared_ptr<ScanOptions> scan_options_;
+};
+
+class ARROW_DS_EXPORT SyncScanner : public Scanner {
+ public:
+  SyncScanner(std::shared_ptr<Dataset> dataset, std::shared_ptr<ScanOptions> scan_options)
+      : dataset_(std::move(dataset)), scan_options_(std::move(scan_options)) {}
+
+  SyncScanner(std::shared_ptr<Fragment> fragment,
+              std::shared_ptr<ScanOptions> scan_options)
+      : fragment_(std::move(fragment)), scan_options_(std::move(scan_options)) {}
+
+  Result<TaggedRecordBatchIterator> ScanBatches() override;
+  Result<EnumeratedRecordBatchGenerator> ScanBatchesUnorderedAsync() override;
+
+  Result<ScanTaskIterator> Scan() override;
+
+  Result<std::shared_ptr<Table>> ToTable() override;
 
   /// \brief GetFragments returns an iterator over all Fragments in this scan.
   Result<FragmentIterator> GetFragments();
@@ -209,7 +340,8 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///         Schema.
   Status Project(std::vector<std::string> columns);
 
-  /// \brief Set expressions which will be evaluated to produce the materialized columns.
+  /// \brief Set expressions which will be evaluated to produce the materialized
+  /// columns.
   ///
   /// Columns which are not referenced may not be read from fragments.
   ///
@@ -255,6 +387,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   Result<std::shared_ptr<Scanner>> Finish();
 
   const std::shared_ptr<Schema>& schema() const;
+  const std::shared_ptr<Schema>& projected_schema() const;
 
  private:
   std::shared_ptr<Dataset> dataset_;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -247,12 +247,12 @@ namespace dataset {
 /// The scanner is then responsible for creating scan tasks from every fragment in the
 /// dataset and (potentially) sequencing the loaded record batches together.
 ///
-/// The scanner should not buffer the entire dataset in memory (unless asked) but should
-/// return record batches as soon as they are ready to scan.  Various readahead
+/// The scanner should not buffer the entire dataset in memory (unless asked) instead
+/// yielding record batches as soon as they are ready to scan.  Various readahead
 /// properties control how much data is allowed to be scanned before pausing to let a
 /// slow consumer catchup.
 ///
-/// Today the scanner also delegates projection & filtering although that may change in
+/// Today the scanner also handles projection & filtering although that may change in
 /// the future.
 class ARROW_DS_EXPORT Scanner {
  public:
@@ -281,8 +281,8 @@ class ARROW_DS_EXPORT Scanner {
   virtual Result<TaggedRecordBatchIterator> ScanBatches() = 0;
   /// \brief Scan the dataset into a stream of record batches.  Unlike ScanBatches this
   /// method may allow record batches to be returned out of order.  This allows for more
-  /// efficient scanning some fragments may be accessed more quickly than others (e.g. may
-  /// be cached in RAM or just happen to get scheduled earlier by the I/O)
+  /// efficient scanning: some fragments may be accessed more quickly than others (e.g.
+  /// may be cached in RAM or just happen to get scheduled earlier by the I/O)
   ///
   /// To make up for the out-of-order iteration each batch is further tagged with
   /// positional information.

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -61,12 +61,40 @@ class TestScanner : public DatasetFixtureMixin {
     // structures of the scanner, i.e. Scanner[Dataset[ScanTask[RecordBatch]]]
     AssertScannerEquals(expected.get(), scanner.get());
   }
+
+  void AssertScanBatchesEqualRepetitionsOf(
+      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
+      const int64_t total_batches = kNumberChildDatasets * kNumberBatches) {
+    auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
+
+    AssertScanBatchesEquals(expected.get(), scanner.get());
+  }
+
+  void AssertScanBatchesUnorderedEqualRepetitionsOf(
+      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
+      const int64_t total_batches = kNumberChildDatasets * kNumberBatches) {
+    auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
+
+    AssertScanBatchesUnorderedEquals(expected.get(), scanner.get());
+  }
 };
 
 TEST_F(TestScanner, Scan) {
   SetSchema({field("i32", int32()), field("f64", float64())});
   auto batch = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
   AssertScannerEqualsRepetitionsOf(MakeScanner(batch), batch);
+}
+
+TEST_F(TestScanner, ScanBatches) {
+  SetSchema({field("i32", int32()), field("f64", float64())});
+  auto batch = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
+  AssertScanBatchesEqualRepetitionsOf(MakeScanner(batch), batch);
+}
+
+TEST_F(TestScanner, ScanBatchesUnordered) {
+  SetSchema({field("i32", int32()), field("f64", float64())});
+  auto batch = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
+  AssertScanBatchesUnorderedEqualRepetitionsOf(MakeScanner(batch), batch);
 }
 
 TEST_F(TestScanner, ScanWithCappedBatchSize) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -38,7 +38,7 @@ constexpr int64_t kBatchSize = 1024;
 
 class TestScanner : public DatasetFixtureMixin {
  protected:
-  Scanner MakeScanner(std::shared_ptr<RecordBatch> batch) {
+  std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<RecordBatch> batch) {
     std::vector<std::shared_ptr<RecordBatch>> batches{static_cast<size_t>(kNumberBatches),
                                                       batch};
 
@@ -47,17 +47,19 @@ class TestScanner : public DatasetFixtureMixin {
 
     EXPECT_OK_AND_ASSIGN(auto dataset, UnionDataset::Make(batch->schema(), children));
 
-    return Scanner{dataset, options_};
+    ScannerBuilder builder(dataset, options_);
+    EXPECT_OK_AND_ASSIGN(auto scanner, builder.Finish());
+    return scanner;
   }
 
   void AssertScannerEqualsRepetitionsOf(
-      Scanner scanner, std::shared_ptr<RecordBatch> batch,
+      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
       const int64_t total_batches = kNumberChildDatasets * kNumberBatches) {
     auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
 
     // Verifies that the unified BatchReader is equivalent to flattening all the
     // structures of the scanner, i.e. Scanner[Dataset[ScanTask[RecordBatch]]]
-    AssertScannerEquals(expected.get(), &scanner);
+    AssertScannerEquals(expected.get(), scanner.get());
   }
 };
 
@@ -126,7 +128,7 @@ TEST_F(TestScanner, MaterializeMissingColumn) {
   ScannerBuilder builder{schema_, fragment_missing_f64, options_};
   ASSERT_OK_AND_ASSIGN(auto scanner, builder.Finish());
 
-  AssertScannerEqualsRepetitionsOf(*scanner, batch_with_f64);
+  AssertScannerEqualsRepetitionsOf(scanner, batch_with_f64);
 }
 
 TEST_F(TestScanner, ToTable) {
@@ -141,13 +143,13 @@ TEST_F(TestScanner, ToTable) {
   std::shared_ptr<Table> actual;
 
   options_->use_threads = false;
-  ASSERT_OK_AND_ASSIGN(actual, scanner.ToTable());
+  ASSERT_OK_AND_ASSIGN(actual, scanner->ToTable());
   AssertTablesEqual(*expected, *actual);
 
   // There is no guarantee on the ordering when using multiple threads, but
   // since the RecordBatch is always the same it will pass.
   options_->use_threads = true;
-  ASSERT_OK_AND_ASSIGN(actual, scanner.ToTable());
+  ASSERT_OK_AND_ASSIGN(actual, scanner->ToTable());
   AssertTablesEqual(*expected, *actual);
 }
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -43,10 +43,12 @@
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
+#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 namespace dataset {
@@ -584,7 +586,8 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
 
   void DoWrite(std::shared_ptr<Partitioning> desired_partitioning) {
     write_options_.partitioning = desired_partitioning;
-    auto scanner = std::make_shared<Scanner>(dataset_, scan_options_);
+    auto scanner_builder = ScannerBuilder(dataset_, scan_options_);
+    ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder.Finish());
     ASSERT_OK(FileSystemDataset::Write(write_options_, scanner));
 
     // re-discover the written dataset

--- a/cpp/src/jni/dataset/jni_wrapper.cc
+++ b/cpp/src/jni/dataset/jni_wrapper.cc
@@ -475,7 +475,8 @@ Java_org_apache_arrow_dataset_jni_JniWrapper_getSchemaFromScanner(JNIEnv* env, j
   std::shared_ptr<arrow::Schema> schema =
       RetrieveNativeInstance<DisposableScannerAdaptor>(scanner_id)
           ->GetScanner()
-          ->schema();
+          ->options()
+          ->projected_schema;
   return JniGetOrThrow(ToSchemaByteArray(env, schema));
   JNI_METHOD_END(nullptr)
 }

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2791,6 +2791,7 @@ cdef class Scanner(_Weakrefable):
 
         return pyarrow_wrap_table(GetResultValue(result))
 
+
 def _get_partition_keys(Expression partition_expression):
     """
     Extract partition keys (equality constraints between a field and a scalar)

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2791,15 +2791,6 @@ cdef class Scanner(_Weakrefable):
 
         return pyarrow_wrap_table(GetResultValue(result))
 
-    def get_fragments(self):
-        """Returns an iterator over the fragments in this scan.
-        """
-        cdef CFragmentIterator c_fragments = move(GetResultValue(
-            self.scanner.GetFragments()))
-        for maybe_fragment in c_fragments:
-            yield Fragment.wrap(GetResultValue(move(maybe_fragment)))
-
-
 def _get_partition_keys(Expression partition_expression):
     """
     Extract partition keys (equality constraints between a field and a scalar)

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -457,7 +457,7 @@ cpp11::list dataset___Scanner__Scan(const std::shared_ptr<ds::Scanner>& scanner)
 // [[dataset::export]]
 std::shared_ptr<arrow::Schema> dataset___Scanner__schema(
     const std::shared_ptr<ds::Scanner>& sc) {
-  return sc->schema();
+  return sc->options()->projected_schema;
 }
 
 // [[dataset::export]]


### PR DESCRIPTION
To prepare for the AsyncScanner this PR creates a Scanner interface and, along the way, simplifies the current Scanner API so that the new scanner won't need to match.

## What is removed:

* `Scanner::GetFragments` was only used in `FileSystemDataset::Write`.  The correct source of truth for fragments is the `Dataset`.  Note: The python implementation exposed this method but it was not documented or used in any unit test.  I think it can be safely removed and we need not worry about deprecation.
* `Scanner::schema` is redundant and ambiguous.  There are two schemas at the scan level.  The dataset schema (the unified master schema that we expect all fragment schemas to be a subset of) and the projection schema (a combination of the dataset schema and the projection expression).  Both of these are available on the scan options object and there is an accessor for these options so the caller might as well get them from there.  This schema function was exposed via R and used internally there but I think any uses can be easily changed to using the options.
* `FileFormat::splittable` and `Fragment::splittable`.  These were intended to advertise that batch readahead was available on the given fragment/format.  However, there is no need to advertise this.  They are not used by the `SyncScanner` and the `AsyncScanner` will just assume that the format/fragment's will utilize readahead if they can (respecting the readahead options in `ScanOptions`)
* Direct instantiation of `Scanner`.  All `Scanner` creation should go through `ScannerBuilder` now.  This allows the `ScannerBuilder` to determine what implementation to use.  This was mostly the way things were implemented already.  Only a few tests instantiated a `Scanner` directly.

## What is deprecated

* `Scanner::Scan` is going to be deprecated (ARROW-11797).  It will not be implemented by `AsyncScanner`.  I do not actually deprecate it in this PR as I reserve that for ARROW-11797.  Unfortunately, this method was exposed via python & R and likely was used so deprecation is recommended over outright removal.

## What is new

* `Scanner::ScanBatches` and `Scanner::ScanBatchesUnordered` have been added.  These functions will be the new preferred "scan" method going forward.  This allows the parallelization (batch readahead, file readahead, etc.) to be handled by C++ and simplifies the user's life.
* `ScanOptions::batch_readahead` and `ScanOptions::fragment_readahead` options allow more fine grained control over how to perform readahead.  One technicality is that these options will not be respected well by the `SyncScanner` (although I think the current ARROW-11797 utilizes batch readahead) so they are more placeholders for when we implement `AsyncScanner`.
* `ScanOptions::cpu_executor` and `ScanOptions::io_context` are added and should be fairly self explanatory.
* `ScanOptions::use_async` will toggle which scanner to use.