### PR TITLE
ARROW-12150: [Python] Correctly infer type of mixed-precision Decimals

### DIFF
--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -120,16 +120,18 @@ Status DecimalFromStdString(const std::string& decimal_string,
   const int32_t precision = arrow_type.precision();
   const int32_t scale = arrow_type.scale();
 
-  if (ARROW_PREDICT_FALSE(inferred_precision > precision)) {
+  if (scale != inferred_scale) {
+    DCHECK_NE(out, NULLPTR);
+    ARROW_ASSIGN_OR_RAISE(*out, out->Rescale(inferred_scale, scale));
+  }
+
+  auto inferred_scale_delta = inferred_scale - scale;
+  if (ARROW_PREDICT_FALSE((inferred_precision - inferred_scale_delta) > precision)) {
     return Status::Invalid(
         "Decimal type with precision ", inferred_precision,
         " does not fit into precision inferred from first array element: ", precision);
   }
 
-  if (scale != inferred_scale) {
-    DCHECK_NE(out, NULLPTR);
-    ARROW_ASSIGN_OR_RAISE(*out, out->Rescale(inferred_scale, scale));
-  }
   return Status::OK();
 }
 

--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -81,12 +81,17 @@ static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* p
 
     // we have leading zeros, need to add to precision
     num_additional_zeros = abs_exponent - num_digits;
+    *scale = -exponent;
+  } else if (exponent > 0) {
+    // trailing zeros not included in num_digits, need to add to precision
+    num_additional_zeros = exponent;
+    *scale = 0;
   } else {
     // we can use the number of digits as the precision
     num_additional_zeros = 0;
+    *scale = -exponent;
   }
 
-  *scale = -exponent;
   *precision = num_digits + num_additional_zeros;
   return Status::OK();
 }
@@ -226,12 +231,6 @@ Status DecimalMetadata::Update(int32_t suggested_precision, int32_t suggested_sc
     auto num_digits = std::max(current_precision - current_scale,
                                suggested_precision - suggested_scale);
     precision_ = std::max(num_digits + scale_, current_precision);
-  }
-
-  // if our suggested scale is zero and we don't yet have enough precision then we need to
-  // add whatever the current scale is to the precision
-  if (suggested_scale == 0 && suggested_precision > current_precision) {
-    precision_ += scale_;
   }
 
   return Status::OK();

--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -76,18 +76,17 @@ static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* p
 
   int32_t num_additional_zeros;
 
-  if (num_digits <= abs_exponent) {
+  if ((exponent < 0) && (num_digits <= abs_exponent)) {
     DCHECK_NE(exponent, 0) << "exponent should never be zero here";
 
-    // we have leading/trailing zeros, leading if exponent is negative
-    num_additional_zeros = exponent < 0 ? abs_exponent - num_digits : exponent;
-    *scale = static_cast<int32_t>(exponent < 0) * -exponent;
+    // we have leading zeros, need to add to precision
+    num_additional_zeros = abs_exponent - num_digits;
   } else {
     // we can use the number of digits as the precision
     num_additional_zeros = 0;
-    *scale = -exponent;
   }
 
+  *scale = -exponent;
   *precision = num_digits + num_additional_zeros;
   return Status::OK();
 }

--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -214,11 +214,13 @@ DecimalMetadata::DecimalMetadata(int32_t precision, int32_t scale)
     : precision_(precision), scale_(scale) {}
 
 Status DecimalMetadata::Update(int32_t suggested_precision, int32_t suggested_scale) {
-  const int32_t current_precision = precision_;
-  precision_ = std::max(current_precision, suggested_precision);
-
   const int32_t current_scale = scale_;
   scale_ = std::max(current_scale, suggested_scale);
+
+  const int32_t current_precision = precision_;
+  auto n_integral = std::max(std::max(current_precision, 0) - std::max(current_scale, 0),
+                             suggested_precision - suggested_scale);
+  precision_ = std::max(n_integral + scale_, current_precision);
 
   // if our suggested scale is zero and we don't yet have enough precision then we need to
   // add whatever the current scale is to the precision

--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -219,9 +219,14 @@ Status DecimalMetadata::Update(int32_t suggested_precision, int32_t suggested_sc
   scale_ = std::max(current_scale, suggested_scale);
 
   const int32_t current_precision = precision_;
-  auto n_integral = std::max(std::max(current_precision, 0) - std::max(current_scale, 0),
-                             suggested_precision - suggested_scale);
-  precision_ = std::max(n_integral + scale_, current_precision);
+
+  if (current_precision == std::numeric_limits<int32_t>::min()) {
+    precision_ = suggested_precision;
+  } else {
+    auto num_digits = std::max(current_precision - current_scale,
+                               suggested_precision - suggested_scale);
+    precision_ = std::max(num_digits + scale_, current_precision);
+  }
 
   // if our suggested scale is zero and we don't yet have enough precision then we need to
   // add whatever the current scale is to the precision

--- a/cpp/src/arrow/python/python_test.cc
+++ b/cpp/src/arrow/python/python_test.cc
@@ -307,8 +307,8 @@ TEST_F(DecimalTest, TestInferPrecisionAndNegativeScale) {
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal.obj()));
 
-  const auto expected_precision = 9;
-  const int32_t expected_scale = -2;
+  const auto expected_precision = 11;
+  const int32_t expected_scale = 0;
 
   ASSERT_EQ(expected_precision, metadata.precision());
   ASSERT_EQ(expected_scale, metadata.scale());
@@ -329,8 +329,8 @@ TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationPositive) {
   OwnedRef python_decimal(this->CreatePythonDecimal(decimal_string));
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal.obj()));
-  ASSERT_EQ(1, metadata.precision());
-  ASSERT_EQ(-3, metadata.scale());
+  ASSERT_EQ(4, metadata.precision());
+  ASSERT_EQ(0, metadata.scale());
 }
 
 TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationNegative) {
@@ -338,8 +338,8 @@ TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationNegative) {
   OwnedRef python_decimal(this->CreatePythonDecimal(decimal_string));
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal.obj()));
-  ASSERT_EQ(1, metadata.precision());
-  ASSERT_EQ(-1, metadata.scale());
+  ASSERT_EQ(2, metadata.precision());
+  ASSERT_EQ(0, metadata.scale());
 }
 
 TEST(PandasConversionTest, TestObjectBlockWriteFails) {

--- a/cpp/src/arrow/python/python_test.cc
+++ b/cpp/src/arrow/python/python_test.cc
@@ -329,8 +329,8 @@ TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationPositive) {
   OwnedRef python_decimal(this->CreatePythonDecimal(decimal_string));
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal.obj()));
-  ASSERT_EQ(4, metadata.precision());
-  ASSERT_EQ(0, metadata.scale());
+  ASSERT_EQ(1, metadata.precision());
+  ASSERT_EQ(-3, metadata.scale());
 }
 
 TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationNegative) {
@@ -338,8 +338,8 @@ TEST_F(DecimalTest, TestInferAllLeadingZerosExponentialNotationNegative) {
   OwnedRef python_decimal(this->CreatePythonDecimal(decimal_string));
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal.obj()));
-  ASSERT_EQ(2, metadata.precision());
-  ASSERT_EQ(0, metadata.scale());
+  ASSERT_EQ(1, metadata.precision());
+  ASSERT_EQ(-1, metadata.scale());
 }
 
 TEST(PandasConversionTest, TestObjectBlockWriteFails) {

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -240,7 +240,7 @@ def test_decimal_roundtrip(tempdir, use_legacy_dataset):
 
 @pytest.mark.pandas
 @pytest.mark.xfail(
-    raises=pa.ArrowException, reason='Parquet does not support negative scale'
+    raises=OSError, reason='Parquet does not support negative scale'
 )
 def test_decimal_roundtrip_negative_scale(tempdir):
     expected = pd.DataFrame({'decimal_num': [decimal.Decimal('1.23E4')]})

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1509,7 +1509,13 @@ def test_sequence_decimal_infer():
         (decimal.Decimal('12300'), pa.decimal128(5, 0)),
         (decimal.Decimal('12300.0'), pa.decimal128(6, 1)),
         # scientific power notation
+        (decimal.Decimal('1.23E+4'), pa.decimal128(3, -2)),
         (decimal.Decimal('123E+2'), pa.decimal128(3, -2)),
+        (decimal.Decimal('123E+4'), pa.decimal128(7, 0)),
+        # leading zeros
+        (decimal.Decimal('0.0123'), pa.decimal128(4, 4)),
+        (decimal.Decimal('0.01230'), pa.decimal128(5, 5)),
+        (decimal.Decimal('1.230E-2'), pa.decimal128(5, 5)),
     ]:
         assert pa.infer_type([data]) == typ
         arr = pa.array([data])
@@ -1529,6 +1535,10 @@ def test_sequence_decimal_infer_mixed():
          pa.decimal128(6, 3)),
         ([decimal.Decimal('123e2'), decimal.Decimal('4567e3')],
          pa.decimal128(5, -2)),
+        ([decimal.Decimal('123e4'), decimal.Decimal('4567e2')],
+         pa.decimal128(7, 0)),
+        ([decimal.Decimal('0.123'), decimal.Decimal('0.04567')],
+         pa.decimal128(5, 5)),
     ]
     for data, typ in cases:
         assert pa.infer_type(data) == typ

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1511,7 +1511,7 @@ def test_sequence_decimal_infer():
         # scientific power notation
         (decimal.Decimal('1.23E+4'), pa.decimal128(3, -2)),
         (decimal.Decimal('123E+2'), pa.decimal128(3, -2)),
-        (decimal.Decimal('123E+4'), pa.decimal128(7, 0)),
+        (decimal.Decimal('123E+4'), pa.decimal128(3, -4)),
         # leading zeros
         (decimal.Decimal('0.0123'), pa.decimal128(4, 4)),
         (decimal.Decimal('0.01230'), pa.decimal128(5, 5)),
@@ -1536,7 +1536,7 @@ def test_sequence_decimal_infer_mixed():
         ([decimal.Decimal('123e2'), decimal.Decimal('4567e3')],
          pa.decimal128(5, -2)),
         ([decimal.Decimal('123e4'), decimal.Decimal('4567e2')],
-         pa.decimal128(7, 0)),
+         pa.decimal128(5, -2)),
         ([decimal.Decimal('0.123'), decimal.Decimal('0.04567')],
          pa.decimal128(5, 5)),
     ]

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1509,9 +1509,9 @@ def test_sequence_decimal_infer():
         (decimal.Decimal('12300'), pa.decimal128(5, 0)),
         (decimal.Decimal('12300.0'), pa.decimal128(6, 1)),
         # scientific power notation
-        (decimal.Decimal('1.23E+4'), pa.decimal128(3, -2)),
-        (decimal.Decimal('123E+2'), pa.decimal128(3, -2)),
-        (decimal.Decimal('123E+4'), pa.decimal128(3, -4)),
+        (decimal.Decimal('1.23E+4'), pa.decimal128(5, 0)),
+        (decimal.Decimal('123E+2'), pa.decimal128(5, 0)),
+        (decimal.Decimal('123E+4'), pa.decimal128(7, 0)),
         # leading zeros
         (decimal.Decimal('0.0123'), pa.decimal128(4, 4)),
         (decimal.Decimal('0.01230'), pa.decimal128(5, 5)),
@@ -1534,17 +1534,49 @@ def test_sequence_decimal_infer_mixed():
         ([decimal.Decimal('123.4'), decimal.Decimal('4.567')],
          pa.decimal128(6, 3)),
         ([decimal.Decimal('123e2'), decimal.Decimal('4567e3')],
-         pa.decimal128(5, -2)),
+         pa.decimal128(7, 0)),
         ([decimal.Decimal('123e4'), decimal.Decimal('4567e2')],
-         pa.decimal128(5, -2)),
+         pa.decimal128(7, 0)),
         ([decimal.Decimal('0.123'), decimal.Decimal('0.04567')],
          pa.decimal128(5, 5)),
+        ([decimal.Decimal('0.001'), decimal.Decimal('1.01E5')],
+         pa.decimal128(9, 3)),
     ]
     for data, typ in cases:
         assert pa.infer_type(data) == typ
         arr = pa.array(data)
         assert arr.type == typ
         assert arr.to_pylist() == data
+
+
+def test_sequence_decimal_given_type():
+    for data, typs, wrong_typs in [
+        # simple case
+        (
+            decimal.Decimal('1.234'),
+            [pa.decimal128(4, 3), pa.decimal128(5, 3), pa.decimal128(5, 4)],
+            [pa.decimal128(4, 2), pa.decimal128(4, 4)]
+        ),
+        # trailing zeros
+        (
+            decimal.Decimal('12300'),
+            [pa.decimal128(5, 0), pa.decimal128(6, 0), pa.decimal128(3, -2)],
+            [pa.decimal128(4, 0), pa.decimal128(3, -3)]
+        ),
+        # scientific power notation
+        (
+            decimal.Decimal('1.23E+4'),
+            [pa.decimal128(5, 0), pa.decimal128(6, 0), pa.decimal128(3, -2)],
+            [pa.decimal128(4, 0), pa.decimal128(3, -3)]
+        ),
+    ]:
+        for typ in typs:
+            arr = pa.array([data], type=typ)
+            assert arr.type == typ
+            assert arr.to_pylist()[0] == data
+        for typ in wrong_typs:
+            with pytest.raises(ValueError):
+                pa.array([data], type=typ)
 
 
 def test_range_types():

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1501,6 +1501,23 @@ def test_sequence_decimal_too_high_precision():
         pa.array([decimal.Decimal('1' * 80)])
 
 
+def test_sequence_decimal_infer():
+    # ARROW-12150 - ensure mixed precision gets correctly inferred to
+    # common type that can hold all input values
+    cases = [
+        ([decimal.Decimal('1.234'), decimal.Decimal('3.456')],
+         pa.decimal128(4, 3)),
+        ([decimal.Decimal('1.234'), decimal.Decimal('456.7')],
+         pa.decimal128(6, 3)),
+        ([decimal.Decimal('123.4'), decimal.Decimal('4.567')],
+         pa.decimal128(6, 3)),
+    ]
+    for data, typ in cases:
+        arr = pa.array(data)
+        assert arr.type == typ
+        assert arr.to_pylist() == data
+
+
 def test_range_types():
     arr1 = pa.array(range(3))
     arr2 = pa.array((0, 1, 2))


### PR DESCRIPTION
We were currently taking the max of current + new precision and scale, independently. But a new value could require a higher precision if it's number of integrals (precision - scale) is higher than the current set.

