### PR TITLE
ARROW-12300: [C++] Remove linking of cuda runtime library

### DIFF
--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -32,11 +32,9 @@ endif()
 find_package(CUDA REQUIRED)
 include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 
-message(STATUS "CUDA Libraries: ${CUDA_LIBRARIES}")
-
 set(ARROW_CUDA_SRCS cuda_arrow_ipc.cc cuda_context.cc cuda_internal.cc cuda_memory.cc)
 
-set(ARROW_CUDA_SHARED_LINK_LIBS ${CUDA_LIBRARIES} ${CUDA_CUDA_LIBRARY})
+set(ARROW_CUDA_SHARED_LINK_LIBS ${CUDA_CUDA_LIBRARY})
 
 add_arrow_lib(arrow_cuda
               CMAKE_PACKAGE_NAME


### PR DESCRIPTION
This PR fixes: https://issues.apache.org/jira/browse/ARROW-12300

