### PR TITLE
ARROW-12303: [JS] Use iterator instead of yield

### DIFF
--- a/js/perf/index.js
+++ b/js/perf/index.js
@@ -48,11 +48,13 @@ for (let {name, buffers, countBys, counts} of require('./table_config')) {
     const dfCountBySuiteName = `DataFrame Count By "${name}"`;
     const dfFilterCountSuiteName = `DataFrame Filter-Scan Count "${name}"`;
     const dfDirectCountSuiteName = `DataFrame Direct Count "${name}"`;
+    const dfFilterIterSuiteName = `DataFrame Filter-Iterate "${name}"`;
 
     suites.push(createTestSuite(tableIterateSuiteName, createTableIterateTest(table)));
     suites.push(...countBys.map((countBy) => createTestSuite(dfCountBySuiteName, createDataFrameCountByTest(table, countBy))));
     suites.push(...counts.map(({ col, test, value }) => createTestSuite(dfFilterCountSuiteName, createDataFrameFilterCountTest(table, col, test, value))));
     suites.push(...counts.map(({ col, test, value }) => createTestSuite(dfDirectCountSuiteName, createDataFrameDirectCountTest(table, col, test, value))));
+    suites.push(...counts.map(({ col, test, value }) => createTestSuite(dfFilterIterSuiteName, createDataFrameFilterIterateTest(table, col, test, value))));
 }
 
 console.log('Running apache-arrow performance tests...\n');
@@ -224,3 +226,23 @@ function createDataFrameFilterCountTest(table, column, test, value) {
         }
     };
 }
+
+function createDataFrameFilterIterateTest(table, column, test, value) {
+    let colidx = table.schema.fields.findIndex((c)=> c.name === column);
+    let df;
+
+    if (test == 'gt') {
+        df = table.filter(col(column).gt(value));
+    } else if (test == 'eq') {
+        df = table.filter(col(column).eq(value));
+    } else {
+        throw new Error(`Unrecognized test "${test}"`);
+    }
+
+    return {
+        async: true,
+        name: `name: '${column}', length: ${table.length}, type: ${table.getColumnAt(colidx).type}, test: ${test}, value: ${value}\n`,
+        fn() { for (value of df) {} }
+    };
+}
+

--- a/js/src/compute/dataframe.ts
+++ b/js/src/compute/dataframe.ts
@@ -134,28 +134,24 @@ class FilteredBatchIterator<T extends { [key: string]: DataType }> implements It
     }
 
     next(): IteratorResult<Struct<T>['TValue']> {
-        if (this.batchIndex >= this.batches.length) {
-            return { done: true, value: null };
-        }
-
-        while (this.index < this.batch.length) {
-            if (this.predicateFunc(this.index, this.batch)) {
-                return {
-                    value: this.batch.get(this.index++) as any,
-                };
+        while (this.batchIndex < this.batches.length) {
+            while (this.index < this.batch.length) {
+                if (this.predicateFunc(this.index, this.batch)) {
+                    return {
+                        value: this.batch.get(this.index++) as any,
+                    };
+                }
+                this.index++;
             }
-            this.index++;
+
+            if (++this.batchIndex < this.batches.length) {
+                this.index = 0;
+                this.batch = this.batches[this.batchIndex];
+                this.predicateFunc = this.predicate.bind(this.batch);
+            }
         }
 
-        this.batchIndex++;
-        this.index = 0;
-
-        if (this.batchIndex < this.batches.length) {
-            this.batch = this.batches[this.batchIndex];
-            this.predicateFunc = this.predicate.bind(this.batch);
-        }
-
-        return this.next();
+        return {done: true, value: null};
     }
 
     [Symbol.iterator]() {

--- a/js/src/compute/dataframe.ts
+++ b/js/src/compute/dataframe.ts
@@ -159,8 +159,6 @@ class FilteredBatchIterator<T extends { [key: string]: DataType }> implements It
     }
 
     [Symbol.iterator]() {
-        this.batchIndex = 0;
-        this.index = 0;
         return this;
     }
 }

--- a/js/src/util/bit.ts
+++ b/js/src/util/bit.ts
@@ -84,27 +84,17 @@ export class BitIterator<T> implements IterableIterator<T> {
     }
 
     next(): IteratorResult<T> {
-        if (this.index >= this.length) {
+        if (this.index < this.length) {
+            if (this.bit === 8) {
+                this.bit = 0;
+                this.byte = this.bytes[this.byteIndex++];
+            }
             return {
-                done: true,
-                value: null
-            };
-        }
-
-        if (this.bit < 8) {
-            return {
+                done: false,
                 value: this.get(this.context, this.index++, this.byte, this.bit++)
             };
         }
-
-        this.byteIndex++;
-        this.bit = 0;
-
-        if (this.byteIndex < this.bytes.length) {
-            this.byte = this.bytes[this.byteIndex];
-        }
-
-        return this.next();
+        return { done: true, value: null };
     }
 
     [Symbol.iterator]() {

--- a/js/src/util/bit.ts
+++ b/js/src/util/bit.ts
@@ -40,7 +40,7 @@ export function truncateBitmap(offset: number, length: number, bitmap: Uint8Arra
         // If the offset is a multiple of 8 bits, it's safe to slice the bitmap
         bytes.set(offset % 8 === 0 ? bitmap.subarray(offset >> 3) :
             // Otherwise iterate each bit from the offset and return a new one
-            packBools(iterateBits(bitmap, offset, length, null, getBool)).subarray(0, alignedSize));
+            packBools(new BitIterator(bitmap, offset, length, null, getBool)).subarray(0, alignedSize));
         return bytes;
     }
     return bitmap;
@@ -64,16 +64,52 @@ export function packBools(values: Iterable<any>) {
 }
 
 /** @ignore */
-export function* iterateBits<T>(bytes: Uint8Array, begin: number, length: number, context: any,
-                                get: (context: any, index: number, byte: number, bit: number) => T) {
-    let bit = begin % 8;
-    let byteIndex = begin >> 3;
-    let index = 0, remaining = length;
-    for (; remaining > 0; bit = 0) {
-        let byte = bytes[byteIndex++];
-        do {
-            yield get(context, index++, byte, bit);
-        } while (--remaining > 0 && ++bit < 8);
+// @ts-ignore
+export class BitIterator<T> implements IterableIterator<T> {
+    bit: number;
+    byte: number;
+    byteIndex: number;
+    index: number;
+
+    constructor(
+        private bytes: Uint8Array,
+        begin: number,
+        private length: number,
+        private context: any,
+        private get: (context: any, index: number, byte: number, bit: number) => T
+    ) {
+        this.bit = begin % 8;
+        this.byteIndex = begin >> 3;
+        this.byte = bytes[this.byteIndex];
+        this.index = 0;
+    }
+
+    next(): IteratorResult<T> {
+        if (this.index >= this.length) {
+            return {
+                done: true,
+                value: null
+            };
+        }
+
+        if (this.bit < 8) {
+            return {
+                value: this.get(this.context, this.index++, this.byte, this.bit++)
+            };
+        }
+
+        this.byteIndex++;
+        this.bit = 0;
+
+        if (this.byteIndex < this.bytes.length) {
+            this.byte = this.bytes[this.byteIndex];
+        }
+
+        return this.next();
+    }
+
+    [Symbol.iterator]() {
+        return this;
     }
 }
 
@@ -89,7 +125,7 @@ export function popcnt_bit_range(data: Uint8Array, lhs: number, rhs: number): nu
     // If the bit range is less than one byte, sum the 1 bits in the bit range
     if (rhs - lhs < 8) {
         let sum = 0;
-        for (const bit of iterateBits(data, lhs, rhs - lhs, data, getBit)) {
+        for (const bit of new BitIterator(data, lhs, rhs - lhs, data, getBit)) {
             sum += bit;
         }
         return sum;

--- a/js/src/util/bit.ts
+++ b/js/src/util/bit.ts
@@ -79,7 +79,7 @@ export class BitIterator<T> implements IterableIterator<T> {
     ) {
         this.bit = begin % 8;
         this.byteIndex = begin >> 3;
-        this.byte = bytes[this.byteIndex];
+        this.byte = bytes[this.byteIndex++];
         this.index = 0;
     }
 

--- a/js/src/util/bit.ts
+++ b/js/src/util/bit.ts
@@ -90,7 +90,6 @@ export class BitIterator<T> implements IterableIterator<T> {
                 this.byte = this.bytes[this.byteIndex++];
             }
             return {
-                done: false,
                 value: this.get(this.context, this.index++, this.byte, this.bit++)
             };
         }

--- a/js/src/util/bit.ts
+++ b/js/src/util/bit.ts
@@ -64,7 +64,6 @@ export function packBools(values: Iterable<any>) {
 }
 
 /** @ignore */
-// @ts-ignore
 export class BitIterator<T> implements IterableIterator<T> {
     bit: number;
     byte: number;

--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -68,8 +68,6 @@ class ChunkedIterator<T extends DataType> implements IterableIterator<T['TValue'
     }
 
     [Symbol.iterator]() {
-        this.chunkIndex = 0;
-        this.chunkIterator = this.getChunkIterator();
         return this;
     }
 }

--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -33,6 +33,48 @@ type ChunkedKeys<T extends DataType> = T extends Dictionary ? Vector<T['indices'
 export type SearchContinuation<T extends Chunked> = (column: T, chunkIndex: number, valueIndex: number) => any;
 
 /** @ignore */
+class ChunkedIterator<T extends DataType> implements IterableIterator<T['TValue'] | null> {
+    private chunkIndex = 0;
+    private chunkIterator: IterableIterator<T['TValue'] | null>;
+
+    constructor(
+        private chunks: Vector<T>[],
+    ) {
+        this.chunkIterator = this.getChunkIterator();
+    }
+
+    next(): IteratorResult<T['TValue'] | null> {
+        if (this.chunkIndex >= this.chunks.length) {
+            return { done: true, value: null };
+        }
+
+        const next = this.chunkIterator.next();
+
+        if (!next.done) {
+            return next;
+        }
+
+        this.chunkIndex++;
+
+        if (this.chunkIndex < this.chunks.length) {
+            this.chunkIterator = this.getChunkIterator();
+        }
+
+        return this.next();
+    }
+
+    getChunkIterator() {
+        return this.chunks[this.chunkIndex][Symbol.iterator]();
+    }
+
+    [Symbol.iterator]() {
+        this.chunkIndex = 0;
+        this.chunkIterator = this.getChunkIterator();
+        return this;
+    }
+}
+
+/** @ignore */
 export class Chunked<T extends DataType = any>
     extends AbstractVector<T>
     implements Clonable<Chunked<T>>,
@@ -110,10 +152,8 @@ export class Chunked<T extends DataType = any>
         return null;
     }
 
-    public *[Symbol.iterator](): IterableIterator<T['TValue'] | null> {
-        for (const chunk of this._chunks) {
-            yield* chunk;
-        }
+    public [Symbol.iterator](): IterableIterator<T['TValue'] | null> {
+        return new ChunkedIterator(this._chunks);
     }
 
     public clone(chunks = this._chunks): Chunked<T> {

--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -44,23 +44,19 @@ class ChunkedIterator<T extends DataType> implements IterableIterator<T['TValue'
     }
 
     next(): IteratorResult<T['TValue'] | null> {
-        if (this.chunkIndex >= this.chunks.length) {
-            return { done: true, value: null };
+        while (this.chunkIndex < this.chunks.length) {
+            const next = this.chunkIterator.next();
+
+            if (!next.done) {
+                return next;
+            }
+
+            if (++this.chunkIndex < this.chunks.length) {
+                this.chunkIterator = this.getChunkIterator();
+            }
         }
 
-        const next = this.chunkIterator.next();
-
-        if (!next.done) {
-            return next;
-        }
-
-        this.chunkIndex++;
-
-        if (this.chunkIndex < this.chunks.length) {
-            this.chunkIterator = this.getChunkIterator();
-        }
-
-        return this.next();
+        return {done: true, value: null};
     }
 
     getChunkIterator() {

--- a/js/src/visitor/indexof.ts
+++ b/js/src/visitor/indexof.ts
@@ -19,7 +19,7 @@ import { Data } from '../data';
 import { Type } from '../enum';
 import { Visitor } from '../visitor';
 import { VectorType } from '../interfaces';
-import { getBool, iterateBits } from '../util/bit';
+import { getBool, BitIterator } from '../util/bit';
 import { createElementComparator } from '../util/vector';
 import {
     DataType, Dictionary,
@@ -100,7 +100,7 @@ function indexOfNull<T extends DataType>(vector: VectorType<T>, fromIndex?: numb
         return -1;
     }
     let i = 0;
-    for (const isValid of iterateBits(nullBitmap, vector.data.offset + (fromIndex || 0), vector.length, nullBitmap, getBool)) {
+    for (const isValid of new BitIterator(nullBitmap, vector.data.offset + (fromIndex || 0), vector.length, nullBitmap, getBool)) {
         if (!isValid) { return i; }
         ++i;
     }

--- a/js/src/visitor/iterator.ts
+++ b/js/src/visitor/iterator.ts
@@ -120,7 +120,6 @@ class VectorIterator<T extends DataType> implements IterableIterator<T['TValue']
     }
 
     [Symbol.iterator]() {
-        this.index = 0;
         return this;
     }
 }

--- a/js/src/visitor/iterator.ts
+++ b/js/src/visitor/iterator.ts
@@ -107,16 +107,13 @@ class VectorIterator<T extends DataType> implements IterableIterator<T['TValue']
     ) {}
 
     next(): IteratorResult<T['TValue'] | null> {
-        if (this.index >= this.vector.length) {
+        if (this.index < this.vector.length) {
             return {
-                done: true,
-                value: null
+                value: this.getFn(this.vector, this.index++)
             };
         }
 
-        return {
-            value: this.getFn(this.vector, this.index++)
-        };
+        return {done: true, value: null};
     }
 
     [Symbol.iterator]() {

--- a/js/src/visitor/iterator.ts
+++ b/js/src/visitor/iterator.ts
@@ -19,7 +19,7 @@ import { Data } from '../data';
 import { Type } from '../enum';
 import { Visitor } from '../visitor';
 import { VectorType } from '../interfaces';
-import { iterateBits } from '../util/bit';
+import { BitIterator } from '../util/bit';
 import { instance as getVisitor } from './get';
 import {
     DataType, Dictionary,
@@ -90,7 +90,7 @@ export class IteratorVisitor extends Visitor {}
 /** @ignore */
 function nullableIterator<T extends DataType>(vector: VectorType<T>): IterableIterator<T['TValue'] | null> {
     const getFn = getVisitor.getVisitFn(vector);
-    return iterateBits<T['TValue'] | null>(
+    return new BitIterator<T['TValue'] | null>(
         vector.data.nullBitmap, vector.data.offset, vector.length, vector,
         (vec: VectorType<T>, idx: number, nullByte: number, nullBit: number) =>
             ((nullByte & 1 << nullBit) !== 0) ? getFn(vec, idx) : null

--- a/js/src/visitor/jsonvectorassembler.ts
+++ b/js/src/visitor/jsonvectorassembler.ts
@@ -23,7 +23,7 @@ import { BufferType } from '../enum';
 import { RecordBatch } from '../recordbatch';
 import { VectorType as V } from '../interfaces';
 import { UnionMode, DateUnit, TimeUnit } from '../enum';
-import { iterateBits, getBit, getBool } from '../util/bit';
+import { BitIterator, getBit, getBool } from '../util/bit';
 import { selectColumnChildrenArgs } from '../util/args';
 import {
     DataType,
@@ -75,13 +75,13 @@ export class JSONVectorAssembler extends Visitor {
             'count': length,
             'VALIDITY': DataType.isNull(type) ? undefined
                 : nullCount <= 0 ? Array.from({ length }, () => 1)
-                : [...iterateBits(nullBitmap, offset, length, null, getBit)],
+                : [...new BitIterator(nullBitmap, offset, length, null, getBit)],
             ...super.visit(Vector.new(data.clone(type, offset, length, 0, buffers)))
         };
     }
     public visitNull() { return {}; }
     public visitBool<T extends Bool>({ values, offset, length }: V<T>) {
-        return { 'DATA': [...iterateBits(values, offset, length, null, getBool)] };
+        return { 'DATA': [...new BitIterator(values, offset, length, null, getBool)] };
     }
     public visitInt<T extends Int>(vector: V<T>) {
         return {

--- a/js/test/unit/bit-tests.ts
+++ b/js/test/unit/bit-tests.ts
@@ -19,9 +19,23 @@ import * as Arrow from '../Arrow';
 const { BitIterator, getBool } = Arrow.util;
 
 describe('Bits', () => {
-    test('BitIterator produces correct bits', () => {
-        const actual = [...new BitIterator(new Uint8Array([0b11110000]), 0, 8, null, getBool)];
-        const expected = [false, false, false, false, true, true, true, true];
-        expect(actual).toEqual(expected);
+    test('BitIterator produces correct bits for single byte', () => {
+        const byte = new Uint8Array([0b11110000]);
+        expect([...new BitIterator(byte, 0, 8, null, getBool)]).toEqual(
+            [false, false, false, false, true, true, true, true]);
+
+        expect([...new BitIterator(byte, 2, 5, null, getBool)]).toEqual(
+            [false, false, true, true, true]);
+    });
+
+    test('BitIterator produces correct bits for multiple bytes', () => {
+        const byte = new Uint8Array([0b11110000, 0b10101010]);
+        expect([...new BitIterator(byte, 0, 16, null, getBool)]).toEqual(
+            [false, false, false, false, true, true, true, true,
+             false, true, false, true, false, true, false, true]);
+
+        expect([...new BitIterator(byte, 2, 11, null, getBool)]).toEqual(
+            [false, false, true, true, true, true,
+             false, true, false, true, false]);
     });
 });

--- a/js/test/unit/bit-tests.ts
+++ b/js/test/unit/bit-tests.ts
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import * as Arrow from '../Arrow';
+const { BitIterator, getBool } = Arrow.util;
+
+describe('Bits', () => {
+    test('BitIterator produces correct bits', () => {
+        const actual = [...new BitIterator(new Uint8Array([0b11110000]), 0, 8, null, getBool)];
+        const expected = [false, false, false, false, true, true, true, true];
+        expect(actual).toEqual(expected);
+    });
+});

--- a/js/test/unit/recordbatch/record-batch-tests.ts
+++ b/js/test/unit/recordbatch/record-batch-tests.ts
@@ -20,11 +20,7 @@ import {
     Data, RecordBatch,
     Vector, Int32Vector, Float32Vector, Float32, Int32,
 } from '../../Arrow';
-
-function arange<T extends { length: number; [n: number]: number; }>(arr: T, n = arr.length) {
-    for (let i = -1; ++i < n; arr[i] = i) { }
-    return arr;
-}
+import { arange } from '../utils';
 
 function numsRecordBatch(i32Len: number, f32Len: number) {
     return RecordBatch.new({

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -22,6 +22,7 @@ import {
     Vector, Int32Vector, Float32Vector, Utf8Vector, DictionaryVector,
     Struct, Float32, Int32, Dictionary, Utf8, Int8
 } from '../Arrow';
+import { arange } from './utils';
 
 const { col, lit, custom, and, or, And, Or } = predicate;
 
@@ -97,12 +98,6 @@ describe(`Table`, () => {
     });
 
     describe(`new()`, () => {
-
-        const arange = <T extends { length: number; [n: number]: number; }>(arr: T, n = arr.length) => {
-            for (let i = -1; ++i < n; arr[i] = i) { }
-            return arr;
-        };
-
         test(`creates an empty Table with Columns`, () => {
             let i32 = Column.new('i32', Data.new(new Int32(), 0, 0));
             let f32 = Column.new('f32', Data.new(new Float32(), 0, 0));

--- a/js/test/unit/utils.ts
+++ b/js/test/unit/utils.ts
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+export function arange<T extends { length: number; [n: number]: number; }>(arr: T, n = arr.length) {
+    for (let i = -1; ++i < n; arr[i] = i) { }
+    return arr;
+}


### PR DESCRIPTION
Thanks to @ankoh for the suggestion to use iterators and @trxcllnt for suggesting to remove recursions in the iterators. 

Running `yarn build -t es2015 -m cjs && node perf/index.js`

Master

```
Running apache-arrow performance tests...

Parse "tracks":
Table.from
 x 4,386 ops/sec ±17.33% (61 runs sampled)
   avg: 0.23ms
   1.38% of a frame @ 60FPS 

Parse "tracks":
readBatches
 x 7,813 ops/sec ±1.48% (87 runs sampled)
   avg: 0.13ms
   0.78% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'lat', length: 1000000, type: Float32
 x 38.18 ops/sec ±0.79% (57 runs sampled)
   avg: 26.19ms
   157.14% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'lng', length: 1000000, type: Float32
 x 36.92 ops/sec ±2.63% (48 runs sampled)
   avg: 27.09ms
   162.54% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.25 ops/sec ±17.42% (5 runs sampled)
   avg: 4004.23ms
   24025.38% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.20 ops/sec ±20.92% (5 runs sampled)
   avg: 4902.57ms
   29415.42% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 21.37 ops/sec ±3.48% (39 runs sampled)
   avg: 46.79ms
   280.74% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 22.65 ops/sec ±0.86% (40 runs sampled)
   avg: 44.16ms
   264.96% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.28 ops/sec ±4.71% (5 runs sampled)
   avg: 3587.66ms
   21525.96% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.27 ops/sec ±3.62% (5 runs sampled)
   avg: 3646.73ms
   21880.38% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 561 ops/sec ±3.52% (76 runs sampled)
   avg: 1.78ms
   10.68% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 567 ops/sec ±2.70% (46 runs sampled)
   avg: 1.76ms
   10.56% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.28 ops/sec ±7.41% (5 runs sampled)
   avg: 3631.37ms
   21788.22% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.23 ops/sec ±7.36% (5 runs sampled)
   avg: 4296.18ms
   25777.08% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 1,996,897 ops/sec ±0.57% (92 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 2,114,550 ops/sec ±1.11% (83 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 2,354,063 ops/sec ±0.99% (83 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 2,230,019 ops/sec ±1.67% (84 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Table Iterate "tracks":
length: 1000000
 x 11.14 ops/sec ±2.99% (32 runs sampled)
   avg: 89.73ms
   538.38% of a frame @ 60FPS 

DataFrame Count By "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 437 ops/sec ±0.98% (87 runs sampled)
   avg: 2.29ms
   13.74% of a frame @ 60FPS 

DataFrame Count By "tracks":
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 436 ops/sec ±0.92% (84 runs sampled)
   avg: 2.29ms
   13.74% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'lat', length: 1000000, type: Float32, test: gt, value: 0
 x 63.33 ops/sec ±1.33% (63 runs sampled)
   avg: 15.79ms
   94.74% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'lng', length: 1000000, type: Float32, test: gt, value: 0
 x 64.66 ops/sec ±1.33% (64 runs sampled)
   avg: 15.47ms
   92.82% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>, test: eq, value: Seattle
 x 76.14 ops/sec ±1.09% (63 runs sampled)
   avg: 13.13ms
   78.78% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'lat', length: 1000000, type: Float32, test: gt, value: 0
 x 157 ops/sec ±1.26% (77 runs sampled)
   avg: 6.37ms
   38.22% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'lng', length: 1000000, type: Float32, test: gt, value: 0
 x 148 ops/sec ±1.52% (73 runs sampled)
   avg: 6.76ms
   40.56% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>, test: eq, value: Seattle
 x 0.28 ops/sec ±17.18% (5 runs sampled)
   avg: 3543.03ms
   21258.18% of a frame @ 60FPS 

```

This branch

```
Running apache-arrow performance tests...

Parse "tracks":
Table.from
 x 8,357 ops/sec ±7.74% (84 runs sampled)
   avg: 0.12ms
   0.72% of a frame @ 60FPS 

Parse "tracks":
readBatches
 x 8,842 ops/sec ±1.79% (87 runs sampled)
   avg: 0.11ms
   0.66% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'lat', length: 1000000, type: Float32
 x 38.98 ops/sec ±1.39% (50 runs sampled)
   avg: 25.66ms
   153.96% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'lng', length: 1000000, type: Float32
 x 39.00 ops/sec ±1.88% (50 runs sampled)
   avg: 25.64ms
   153.84% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.29 ops/sec ±3.27% (5 runs sampled)
   avg: 3495.78ms
   20974.68% of a frame @ 60FPS 

Get "tracks" values by index:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.22 ops/sec ±4.01% (5 runs sampled)
   avg: 4592.66ms
   27555.96% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 57.56 ops/sec ±1.73% (57 runs sampled)
   avg: 17.37ms
   104.22% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 58.53 ops/sec ±1.04% (57 runs sampled)
   avg: 17.08ms
   102.48% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.28 ops/sec ±2.04% (5 runs sampled)
   avg: 3618.14ms
   21708.84% of a frame @ 60FPS 

Iterate "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.27 ops/sec ±2.79% (5 runs sampled)
   avg: 3662.97ms
   21977.82% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 615 ops/sec ±3.79% (65 runs sampled)
   avg: 1.63ms
   9.78% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 627 ops/sec ±2.56% (48 runs sampled)
   avg: 1.59ms
   9.54% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.26 ops/sec ±2.74% (5 runs sampled)
   avg: 3790.33ms
   22741.98% of a frame @ 60FPS 

Slice toArray "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 0.26 ops/sec ±1.50% (5 runs sampled)
   avg: 3776.96ms
   22661.76% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'lat', length: 1000000, type: Float32
 x 2,212,355 ops/sec ±1.29% (87 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'lng', length: 1000000, type: Float32
 x 2,215,643 ops/sec ±0.94% (84 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 2,445,650 ops/sec ±1.21% (86 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Slice "tracks" vectors:
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 2,432,760 ops/sec ±0.92% (88 runs sampled)
   avg: 0ms
   0% of a frame @ 60FPS 

Table Iterate "tracks":
length: 1000000
 x 25.91 ops/sec ±1.61% (45 runs sampled)
   avg: 38.59ms
   231.54% of a frame @ 60FPS 

DataFrame Count By "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>
 x 456 ops/sec ±1.12% (83 runs sampled)
   avg: 2.19ms
   13.14% of a frame @ 60FPS 

DataFrame Count By "tracks":
name: 'destination', length: 1000000, type: Dictionary<Int8, Utf8>
 x 459 ops/sec ±0.77% (85 runs sampled)
   avg: 2.18ms
   13.08% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'lat', length: 1000000, type: Float32, test: gt, value: 0
 x 61.19 ops/sec ±2.16% (63 runs sampled)
   avg: 16.34ms
   98.04% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'lng', length: 1000000, type: Float32, test: gt, value: 0
 x 62.97 ops/sec ±1.29% (63 runs sampled)
   avg: 15.88ms
   95.28% of a frame @ 60FPS 

DataFrame Filter-Scan Count "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>, test: eq, value: Seattle
 x 72.84 ops/sec ±1.08% (70 runs sampled)
   avg: 13.73ms
   82.38% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'lat', length: 1000000, type: Float32, test: gt, value: 0
 x 164 ops/sec ±1.05% (79 runs sampled)
   avg: 6.09ms
   36.54% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'lng', length: 1000000, type: Float32, test: gt, value: 0
 x 166 ops/sec ±1.27% (80 runs sampled)
   avg: 6.02ms
   36.12% of a frame @ 60FPS 

DataFrame Direct Count "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>, test: eq, value: Seattle
 x 0.25 ops/sec ±1.56% (5 runs sampled)
   avg: 3947.73ms
   23686.38% of a frame @ 60FPS 

DataFrame Filter-Iterate "tracks":
name: 'lat', length: 1000000, type: Float32, test: gt, value: 0
 x 32.07 ops/sec ±1.53% (53 runs sampled)
   avg: 31.18ms
   187.08% of a frame @ 60FPS 

DataFrame Filter-Iterate "tracks":
name: 'lng', length: 1000000, type: Float32, test: gt, value: 0
 x 31.75 ops/sec ±0.90% (53 runs sampled)
   avg: 31.5ms
   189% of a frame @ 60FPS 

DataFrame Filter-Iterate "tracks":
name: 'origin', length: 1000000, type: Dictionary<Int8, Utf8>, test: eq, value: Seattle
 x 50.33 ops/sec ±0.95% (61 runs sampled)
   avg: 19.87ms
   119.22% of a frame @ 60FPS 

```