### PR TITLE
ARROW-12310: [Java] ValueVector#getObject should support covariance for complex types

### DIFF
--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroTestBase.java
@@ -36,7 +36,6 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
-import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.Text;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -88,7 +87,7 @@ public class AvroTestBase {
   protected void checkArrayResult(List<List<?>> expected, ListVector vector) {
     assertEquals(expected.size(), vector.getValueCount());
     for (int i = 0; i < expected.size(); i++) {
-      checkArrayElement(expected.get(i), (JsonStringArrayList) vector.getObject(i));
+      checkArrayElement(expected.get(i), vector.getObject(i));
     }
   }
 
@@ -177,7 +176,7 @@ public class AvroTestBase {
     int index = 0;
     for (ListVector vector : vectors) {
       for (int i = 0; i < vector.getValueCount(); i++) {
-        checkArrayElement(expected.get(index++), (JsonStringArrayList) vector.getObject(i));
+        checkArrayElement(expected.get(index++), vector.getObject(i));
       }
     }
   }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/dictionary/TestHashTableDictionaryEncoder.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/dictionary/TestHashTableDictionaryEncoder.java
@@ -250,7 +250,7 @@ public class TestHashTableDictionaryEncoder {
 
         assertEquals(vector.getValueCount(), decoded.getValueCount());
         for (int i = 0; i < 5; i++) {
-          assertEquals(vector.getObject(i), ((VarCharVector) decoded).getObject(i));
+          assertEquals(vector.getObject(i), decoded.getObject(i));
         }
       }
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -445,7 +445,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   }
 
   @Override
-  public Object getObject(int index) {
+  public List<?> getObject(int index) {
     if (isSet(index) == 0) {
       return null;
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -822,7 +822,7 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
    * @return Object at given position
    */
   @Override
-  public Object getObject(int index) {
+  public List<?> getObject(int index) {
     if (isSet(index) == 0) {
       return null;
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -699,7 +699,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
    * @return Object at given position
    */
   @Override
-  public Object getObject(int index) {
+  public List<?> getObject(int index) {
     if (isSet(index) == 0) {
       return null;
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -315,7 +315,7 @@ public class NonNullableStructVector extends AbstractStructVector {
   }
 
   @Override
-  public Object getObject(int index) {
+  public Map<String, ?> getObject(int index) {
     Map<String, Object> vv = new JsonStringHashMap<>();
     for (String child : getChildFieldNames()) {
       ValueVector v = getChild(child);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -23,6 +23,7 @@ import static org.apache.arrow.util.Preconditions.checkNotNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
@@ -507,7 +508,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   }
 
   @Override
-  public Object getObject(int index) {
+  public Map<String, ?> getObject(int index) {
     if (isSet(index) == 0) {
       return null;
     } else {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.ToIntBiFunction;
 
@@ -51,8 +52,6 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.util.JsonStringArrayList;
-import org.apache.arrow.vector.util.JsonStringHashMap;
 import org.apache.arrow.vector.util.Text;
 import org.junit.After;
 import org.junit.Before;
@@ -654,17 +653,17 @@ public class TestDictionaryVector {
         assertEquals(ListVector.class, encoded.getClass());
 
         assertEquals(6, encoded.getValueCount());
-        int[] realValue1 = convertListToIntArray((JsonStringArrayList) encoded.getObject(0));
+        int[] realValue1 = convertListToIntArray(encoded.getObject(0));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue1));
-        int[] realValue2 = convertListToIntArray((JsonStringArrayList) encoded.getObject(1));
+        int[] realValue2 = convertListToIntArray(encoded.getObject(1));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue2));
-        int[] realValue3 = convertListToIntArray((JsonStringArrayList) encoded.getObject(2));
+        int[] realValue3 = convertListToIntArray(encoded.getObject(2));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue3));
-        int[] realValue4 = convertListToIntArray((JsonStringArrayList) encoded.getObject(3));
+        int[] realValue4 = convertListToIntArray(encoded.getObject(3));
         assertTrue(Arrays.equals(new int[] {2, 3, 4}, realValue4));
-        int[] realValue5 = convertListToIntArray((JsonStringArrayList) encoded.getObject(4));
+        int[] realValue5 = convertListToIntArray(encoded.getObject(4));
         assertTrue(Arrays.equals(new int[] {2, 3, 4}, realValue5));
-        int[] realValue6 = convertListToIntArray((JsonStringArrayList) encoded.getObject(5));
+        int[] realValue6 = convertListToIntArray(encoded.getObject(5));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue6));
 
         // now run through the decoder and verify we get the original back
@@ -732,13 +731,13 @@ public class TestDictionaryVector {
         assertEquals(FixedSizeListVector.class, encoded.getClass());
 
         assertEquals(4, encoded.getValueCount());
-        int[] realValue1 = convertListToIntArray((JsonStringArrayList) encoded.getObject(0));
+        int[] realValue1 = convertListToIntArray(encoded.getObject(0));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue1));
-        int[] realValue2 = convertListToIntArray((JsonStringArrayList) encoded.getObject(1));
+        int[] realValue2 = convertListToIntArray(encoded.getObject(1));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue2));
-        int[] realValue3 = convertListToIntArray((JsonStringArrayList) encoded.getObject(2));
+        int[] realValue3 = convertListToIntArray(encoded.getObject(2));
         assertTrue(Arrays.equals(new int[] {2, 3}, realValue3));
-        int[] realValue4 = convertListToIntArray((JsonStringArrayList) encoded.getObject(3));
+        int[] realValue4 = convertListToIntArray(encoded.getObject(3));
         assertTrue(Arrays.equals(new int[] {0, 1}, realValue4));
 
         // now run through the decoder and verify we get the original back
@@ -799,15 +798,15 @@ public class TestDictionaryVector {
         assertEquals(StructVector.class, encoded.getClass());
 
         assertEquals(5, encoded.getValueCount());
-        Object[] realValue1 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(0));
+        Object[] realValue1 = convertMapValuesToArray(encoded.getObject(0));
         assertTrue(Arrays.equals(new Object[] {0, 1}, realValue1));
-        Object[] realValue2 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(1));
+        Object[] realValue2 = convertMapValuesToArray(encoded.getObject(1));
         assertTrue(Arrays.equals(new Object[] {1, 2}, realValue2));
-        Object[] realValue3 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(2));
+        Object[] realValue3 = convertMapValuesToArray(encoded.getObject(2));
         assertTrue(Arrays.equals(new Object[] {2, 0}, realValue3));
-        Object[] realValue4 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(3));
+        Object[] realValue4 = convertMapValuesToArray(encoded.getObject(3));
         assertTrue(Arrays.equals(new Object[] {0, 0}, realValue4));
-        Object[] realValue5 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(4));
+        Object[] realValue5 = convertMapValuesToArray(encoded.getObject(4));
         assertTrue(Arrays.equals(new Object[] {3, 0}, realValue5));
 
         // now run through the decoder and verify we get the original back
@@ -856,15 +855,15 @@ public class TestDictionaryVector {
         assertEquals(StructVector.class, encoded.getClass());
 
         assertEquals(5, encoded.getValueCount());
-        Object[] realValue1 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(0));
+        Object[] realValue1 = convertMapValuesToArray(encoded.getObject(0));
         assertTrue(Arrays.equals(new Object[] {0, new Text("baz")}, realValue1));
-        Object[] realValue2 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(1));
+        Object[] realValue2 = convertMapValuesToArray(encoded.getObject(1));
         assertTrue(Arrays.equals(new Object[] {1, new Text("bar")}, realValue2));
-        Object[] realValue3 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(2));
+        Object[] realValue3 = convertMapValuesToArray(encoded.getObject(2));
         assertTrue(Arrays.equals(new Object[] {2, new Text("foo")}, realValue3));
-        Object[] realValue4 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(3));
+        Object[] realValue4 = convertMapValuesToArray(encoded.getObject(3));
         assertTrue(Arrays.equals(new Object[] {0, new Text("foo")}, realValue4));
-        Object[] realValue5 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(4));
+        Object[] realValue5 = convertMapValuesToArray(encoded.getObject(4));
         assertTrue(Arrays.equals(new Object[] {3, new Text("foo")}, realValue5));
 
         // now run through the decoder and verify we get the original back
@@ -982,7 +981,7 @@ public class TestDictionaryVector {
     }
   }
 
-  private int[] convertListToIntArray(JsonStringArrayList list) {
+  private int[] convertListToIntArray(List list) {
     int[] values = new int[list.size()];
     for (int i = 0; i < list.size(); i++) {
       values[i] = (int) list.get(i);
@@ -990,7 +989,7 @@ public class TestDictionaryVector {
     return values;
   }
 
-  private Object[] convertMapValuesToArray(JsonStringHashMap map) {
+  private Object[] convertMapValuesToArray(Map map) {
     Object[] values = new Object[map.size()];
     Iterator valueIterator = map.values().iterator();
     for (int i = 0; i < map.size(); i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
@@ -37,7 +37,6 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
 import org.junit.Assert;
@@ -293,11 +292,11 @@ public class TestFixedSizeListVector {
 
       assertEquals(3, vector1.getValueCount());
 
-      int[] realValue1 = convertListToIntArray((JsonStringArrayList) vector1.getObject(0));
+      int[] realValue1 = convertListToIntArray(vector1.getObject(0));
       assertTrue(Arrays.equals(values1, realValue1));
-      int[] realValue2 = convertListToIntArray((JsonStringArrayList) vector1.getObject(1));
+      int[] realValue2 = convertListToIntArray(vector1.getObject(1));
       assertTrue(Arrays.equals(values2, realValue2));
-      int[] realValue3 = convertListToIntArray((JsonStringArrayList) vector1.getObject(2));
+      int[] realValue3 = convertListToIntArray(vector1.getObject(2));
       assertTrue(Arrays.equals(values3, realValue3));
     }
   }
@@ -366,9 +365,9 @@ public class TestFixedSizeListVector {
       writer1.setValueCount(3);
 
       assertEquals(3, vector1.getValueCount());
-      int[] realValue1 = convertListToIntArray((JsonStringArrayList) vector1.getObject(0));
+      int[] realValue1 = convertListToIntArray(vector1.getObject(0));
       assertTrue(Arrays.equals(values1, realValue1));
-      int[] realValue2 = convertListToIntArray((JsonStringArrayList) vector1.getObject(1));
+      int[] realValue2 = convertListToIntArray(vector1.getObject(1));
       assertTrue(Arrays.equals(values2, realValue2));
     }
   }
@@ -395,9 +394,9 @@ public class TestFixedSizeListVector {
       FixedSizeListVector targetVector = (FixedSizeListVector) transferPair.getTo();
 
       assertEquals(2, targetVector.getValueCount());
-      int[] realValue1 = convertListToIntArray((JsonStringArrayList) targetVector.getObject(0));
+      int[] realValue1 = convertListToIntArray(targetVector.getObject(0));
       assertTrue(Arrays.equals(values1, realValue1));
-      int[] realValue2 = convertListToIntArray((JsonStringArrayList) targetVector.getObject(1));
+      int[] realValue2 = convertListToIntArray(targetVector.getObject(1));
       assertTrue(Arrays.equals(values2, realValue2));
 
       targetVector.clear();
@@ -425,12 +424,12 @@ public class TestFixedSizeListVector {
 
       assertEquals(4, vector1.getValueCount());
 
-      int[] realValue1 = convertListToIntArray((JsonStringArrayList) vector1.getObject(0));
+      int[] realValue1 = convertListToIntArray(vector1.getObject(0));
       assertArrayEquals(values1, realValue1);
-      int[] realValue2 = convertListToIntArray((JsonStringArrayList) vector1.getObject(1));
+      int[] realValue2 = convertListToIntArray(vector1.getObject(1));
       assertArrayEquals(values2, realValue2);
       assertNull(vector1.getObject(2));
-      int[] realValue4 = convertListToIntArray((JsonStringArrayList) vector1.getObject(3));
+      int[] realValue4 = convertListToIntArray(vector1.getObject(3));
       assertArrayEquals(values4, realValue4);
     }
   }
@@ -456,18 +455,18 @@ public class TestFixedSizeListVector {
 
       assertEquals(4, vector1.getValueCount());
 
-      List realValue1 = (JsonStringArrayList) vector1.getObject(0);
+      List realValue1 = vector1.getObject(0);
       assertEquals(values1, realValue1);
-      List realValue2 = (JsonStringArrayList) vector1.getObject(1);
+      List realValue2 = vector1.getObject(1);
       assertEquals(values2, realValue2);
-      List realValue3 = (JsonStringArrayList) vector1.getObject(2);
+      List realValue3 = vector1.getObject(2);
       assertEquals(values3, realValue3);
-      List realValue4 = (JsonStringArrayList) vector1.getObject(3);
+      List realValue4 = vector1.getObject(3);
       assertEquals(values4, realValue4);
     }
   }
 
-  private int[] convertListToIntArray(JsonStringArrayList list) {
+  private int[] convertListToIntArray(List list) {
     int[] values = new int[list.size()];
     for (int i = 0; i < list.size(); i++) {
       values[i] = (int) list.get(i);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -101,9 +101,9 @@ public class TestLargeListVector {
       Object result = outVector.getObject(0);
       ArrayList<Long> resultSet = (ArrayList<Long>) result;
       assertEquals(3, resultSet.size());
-      assertEquals(new Long(1), (Long) resultSet.get(0));
-      assertEquals(new Long(2), (Long) resultSet.get(1));
-      assertEquals(new Long(3), (Long) resultSet.get(2));
+      assertEquals(new Long(1), resultSet.get(0));
+      assertEquals(new Long(2), resultSet.get(1));
+      assertEquals(new Long(3), resultSet.get(2));
 
       /* index 1 */
       result = outVector.getObject(1);
@@ -220,37 +220,37 @@ public class TestLargeListVector {
       offset = (int) offsetBuffer.getLong(index * LargeListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
-      Object actual = dataVector.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      Long actual = dataVector.getObject(offset);
+      assertEquals(new Long(10), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), actual);
 
       index++;
       offset = (int) offsetBuffer.getLong(index * LargeListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), actual);
 
       index++;
       offset = (int) offsetBuffer.getLong(index * LargeListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), actual);
 
       index++;
       offset = (int) offsetBuffer.getLong(index * LargeListVector.OFFSET_WIDTH);
@@ -323,7 +323,7 @@ public class TestLargeListVector {
 
       int index = 0;
       int offset = 0;
-      Object actual = null;
+      Long actual = null;
 
       /* index 0 */
       assertFalse(listVector.isNull(index));
@@ -331,13 +331,13 @@ public class TestLargeListVector {
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      assertEquals(new Long(10), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), actual);
 
       /* index 1 */
       index++;
@@ -346,10 +346,10 @@ public class TestLargeListVector {
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), actual);
 
       /* index 2 */
       index++;
@@ -358,16 +358,16 @@ public class TestLargeListVector {
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(18), (Long) actual);
+      assertEquals(new Long(18), actual);
 
       /* index 3 */
       index++;
@@ -376,7 +376,7 @@ public class TestLargeListVector {
       assertEquals(Integer.toString(9), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(19), (Long) actual);
+      assertEquals(new Long(19), actual);
 
       /* index 4 */
       index++;
@@ -385,16 +385,16 @@ public class TestLargeListVector {
       assertEquals(Integer.toString(10), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(20), (Long) actual);
+      assertEquals(new Long(20), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(21), (Long) actual);
+      assertEquals(new Long(21), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(22), (Long) actual);
+      assertEquals(new Long(22), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(23), (Long) actual);
+      assertEquals(new Long(23), actual);
 
       /* index 5 */
       index++;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -219,37 +219,37 @@ public class TestListVector {
       offset = offsetBuffer.getInt(index * ListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
-      Object actual = dataVector.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      Long actual = dataVector.getObject(offset);
+      assertEquals(new Long(10), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), actual);
 
       index++;
       offset = offsetBuffer.getInt(index * ListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), actual);
 
       index++;
       offset = offsetBuffer.getInt(index * ListVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), actual);
 
       index++;
       offset = offsetBuffer.getInt(index * ListVector.OFFSET_WIDTH);
@@ -322,7 +322,7 @@ public class TestListVector {
 
       int index = 0;
       int offset = 0;
-      Object actual = null;
+      Long actual = null;
 
       /* index 0 */
       assertFalse(listVector.isNull(index));
@@ -330,13 +330,13 @@ public class TestListVector {
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      assertEquals(new Long(10), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), actual);
 
       /* index 1 */
       index++;
@@ -345,10 +345,10 @@ public class TestListVector {
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), actual);
 
       /* index 2 */
       index++;
@@ -357,16 +357,16 @@ public class TestListVector {
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(18), (Long) actual);
+      assertEquals(new Long(18), actual);
 
       /* index 3 */
       index++;
@@ -375,7 +375,7 @@ public class TestListVector {
       assertEquals(Integer.toString(9), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(19), (Long) actual);
+      assertEquals(new Long(19), actual);
 
       /* index 4 */
       index++;
@@ -384,16 +384,16 @@ public class TestListVector {
       assertEquals(Integer.toString(10), Integer.toString(offset));
 
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(20), (Long) actual);
+      assertEquals(new Long(20), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(21), (Long) actual);
+      assertEquals(new Long(21), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(22), (Long) actual);
+      assertEquals(new Long(22), actual);
       offset++;
       actual = dataVector.getObject(offset);
-      assertEquals(new Long(23), (Long) actual);
+      assertEquals(new Long(23), actual);
 
       /* index 5 */
       index++;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -341,15 +341,15 @@ public class TestMapVector {
       offset = offsetBuffer.getInt(index * MapVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(10L, getResultKey(result));
       assertEquals(1.0, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(11L, getResultKey(result));
       assertEquals(1.1, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(12L, getResultKey(result));
       assertEquals(1.2, getResultValue(result));
 
@@ -359,11 +359,11 @@ public class TestMapVector {
       offset = offsetBuffer.getInt(index * MapVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(13L, getResultKey(result));
       assertEquals(1.3, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(14L, getResultKey(result));
       assertEquals(1.4, getResultValue(result));
 
@@ -373,19 +373,19 @@ public class TestMapVector {
       offset = offsetBuffer.getInt(index * MapVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(15L, getResultKey(result));
       assertEquals(1.5, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(16L, getResultKey(result));
       assertEquals(1.6, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(17L, getResultKey(result));
       assertEquals(1.7, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(18L, getResultKey(result));
       assertEquals(1.8, getResultValue(result));
 
@@ -395,7 +395,7 @@ public class TestMapVector {
       offset = offsetBuffer.getInt(index * MapVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(9), Integer.toString(offset));
 
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(19L, getResultKey(result));
       assertEquals(1.9, getResultValue(result));
 
@@ -405,19 +405,19 @@ public class TestMapVector {
       offset = offsetBuffer.getInt(index * MapVector.OFFSET_WIDTH);
       assertEquals(Integer.toString(10), Integer.toString(offset));
 
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(20L, getResultKey(result));
       assertEquals(2.0, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(21L, getResultKey(result));
       assertEquals(2.1, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(22L, getResultKey(result));
       assertEquals(2.2, getResultValue(result));
       offset++;
-      result = (Map<?, ?>) dataVector.getObject(offset);
+      result = dataVector.getObject(offset);
       assertEquals(23L, getResultKey(result));
       assertEquals(2.3, getResultValue(result));
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -648,8 +648,7 @@ public class BaseFileTest {
     int numVarBinaryValues = 0;
     for (int i = 0; i < count; i++) {
       expectedArray[i] = (byte) i;
-      Object obj = listVector.getObject(i);
-      List<?> objList = (List) obj;
+      List<?> objList = listVector.getObject(i);
       if (i % 3 == 0) {
         Assert.assertTrue(objList.isEmpty());
       } else {


### PR DESCRIPTION
Currently, the `ValueVector#getObject` API supports covariance for primitive types.
For example, `IntVector#getObject` returns `Integer` while `BitVector#getObject` returns `Boolean`.

For complex types, we should also support covariance. For example, `ListVector#getObject` should return a List

This will help reduce unnecessary casts, and enforce type safety.