### PR TITLE
ARROW-12323: [C++][Gandiva] Implement castTIME(timestamp) function

### DIFF
--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -77,6 +77,9 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
       NativeFunction("castDATE", {"to_date"}, DataTypeVector{timestamp()}, date64(),
                      kResultNullIfNull, "castDATE_timestamp"),
 
+      NativeFunction("castTIME", {}, DataTypeVector{timestamp()}, time32(),
+                     kResultNullIfNull, "castTIME_timestamp"),
+
       NativeFunction("castBIGINT", {}, DataTypeVector{day_time_interval()}, int64(),
                      kResultNullIfNull, "castBIGINT_daytimeinterval"),
 

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -751,7 +751,7 @@ gdv_date64 castDATE_timestamp(gdv_timestamp timestamp_in_millis) {
   return tp.ClearTimeOfDay().MillisSinceEpoch();
 }
 
-int32_t castTIME_timestamp(int64_t timestamp_in_millis) {
+gdv_time32 castTIME_timestamp(gdv_timestamp timestamp_in_millis) {
   // Retrieves a timestamp and returns the number of milliseconds since the midnight
   EpochTimePoint tp(timestamp_in_millis);
   auto tp_at_midnight = tp.ClearTimeOfDay();

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -751,6 +751,17 @@ gdv_date64 castDATE_timestamp(gdv_timestamp timestamp_in_millis) {
   return tp.ClearTimeOfDay().MillisSinceEpoch();
 }
 
+int32_t castTIME_timestamp(int64_t timestamp_in_millis) {
+  // Retrieves a timestamp and returns the number of milliseconds since the midnight
+  EpochTimePoint tp(timestamp_in_millis);
+  auto tp_at_midnight = tp.ClearTimeOfDay();
+
+  int64_t millis_since_midnight =
+      tp.MillisSinceEpoch() - tp_at_midnight.MillisSinceEpoch();
+
+  return static_cast<int32_t>(millis_since_midnight);
+}
+
 const char* castVARCHAR_timestamp_int64(gdv_int64 context, gdv_timestamp in,
                                         gdv_int64 length, gdv_int32* out_len) {
   gdv_int64 year = extractYear_timestamp(in);

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -699,6 +699,25 @@ TEST(TestTime, TestCastTimestampToDate) {
   EXPECT_EQ(StringToTimestamp("2000-05-01 00:00:00"), out);
 }
 
+TEST(TestTime, TestCastTimestampToTime) {
+  gdv_timestamp ts = StringToTimestamp("2000-05-01 10:20:34");
+  auto expected_response =
+      static_cast<int32_t>(ts - StringToTimestamp("2000-05-01 00:00:00"));
+  auto out = castTIME_timestamp(ts);
+  EXPECT_EQ(expected_response, out);
+
+  // Test when the defined value is midnight, so the returned value must 0
+  ts = StringToTimestamp("1998-12-01 00:00:00");
+  expected_response = 0;
+  out = castTIME_timestamp(ts);
+  EXPECT_EQ(expected_response, out);
+
+  ts = StringToTimestamp("2015-09-16 23:59:59");
+  expected_response = static_cast<int32_t>(ts - StringToTimestamp("2015-09-16 00:00:00"));
+  out = castTIME_timestamp(ts);
+  EXPECT_EQ(expected_response, out);
+}
+
 TEST(TestTime, TestLastDay) {
   // leap year test
   gdv_timestamp ts = StringToTimestamp("2016-02-11 03:20:34");

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -251,6 +251,7 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t execution_context, const char* input,
 gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);
+int32_t castTIME_timestamp(int64_t timestamp_in_millis);
 const char* castVARCHAR_timestamp_int64(int64_t, gdv_timestamp, gdv_int64, gdv_int32*);
 gdv_date64 last_day_from_timestamp(gdv_date64 millis);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -251,7 +251,7 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t execution_context, const char* input,
 gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);
-int32_t castTIME_timestamp(int64_t timestamp_in_millis);
+gdv_time32 castTIME_timestamp(gdv_timestamp timestamp_in_millis);
 const char* castVARCHAR_timestamp_int64(int64_t, gdv_timestamp, gdv_int64, gdv_int32*);
 gdv_date64 last_day_from_timestamp(gdv_date64 millis);
 


### PR DESCRIPTION
The function gets a timestamp in milliseconds and returns the number of millisecond since midnight for the day of the defined timestamp.