### PR TITLE
ARROW-12325: [C++] [CI] Nightly gandiva build failing due to failure of compiler to move return value

### DIFF
--- a/cpp/src/arrow/util/vector.h
+++ b/cpp/src/arrow/util/vector.h
@@ -92,7 +92,7 @@ Result<std::vector<To>> MaybeMapVector(Fn&& map, const std::vector<From>& src) {
   out.reserve(src.size());
   ARROW_RETURN_NOT_OK(MaybeTransform(src.begin(), src.end(), std::back_inserter(out),
                                      std::forward<Fn>(map)));
-  return out;
+  return std::move(out);
 }
 
 template <typename Fn, typename From,
@@ -130,7 +130,7 @@ Result<std::vector<T>> UnwrapOrRaise(std::vector<Result<T>>&& results) {
     }
     out.push_back(it->MoveValueUnsafe());
   }
-  return out;
+  return std::move(out);
 }
 
 }  // namespace internal


### PR DESCRIPTION
Gandiva build failure caused by failure of GCC 4.8.2 compiler to automatically move return value.

Failed build: https://github.com/ursacomputing/crossbow/runs/2303374510
Godbolt showing I'm not crazy: https://gcc.godbolt.org/z/x138zevhE