### PR TITLE
ARROW-12290: [Rust][DataFusion] Add input_file_name function [WIP]

### DIFF
--- a/rust/datafusion/src/datasource/empty.rs
+++ b/rust/datafusion/src/datasource/empty.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::*;
 
-use crate::datasource::datasource::Statistics;
+use crate::datasource::datasource::{PartitionStatistics, Statistics};
 use crate::datasource::TableProvider;
 use crate::error::Result;
 use crate::logical_plan::Expr;
@@ -72,9 +72,12 @@ impl TableProvider for EmptyTable {
 
     fn statistics(&self) -> Statistics {
         Statistics {
-            num_rows: Some(0),
-            total_byte_size: Some(0),
-            column_statistics: None,
+            partition_statistics: vec![PartitionStatistics {
+                filename: None,
+                num_rows: Some(0),
+                total_byte_size: Some(0),
+                column_statistics: None,
+            }],
         }
     }
 }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -48,7 +48,9 @@ impl ParquetTable {
         Ok(Self {
             path: path.to_string(),
             schema,
-            statistics: parquet_exec.statistics().to_owned(),
+            statistics: Statistics {
+                partition_statistics: parquet_exec.partitions().to_owned(),
+            },
             max_concurrency,
         })
     }
@@ -130,8 +132,8 @@ mod tests {
             .await;
 
         // test metadata
-        assert_eq!(table.statistics().num_rows, Some(8));
-        assert_eq!(table.statistics().total_byte_size, Some(671));
+        assert_eq!(table.statistics().num_rows(), Some(8));
+        assert_eq!(table.statistics().total_byte_size(), Some(671));
 
         Ok(())
     }

--- a/rust/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/rust/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -1,5 +1,5 @@
-// Licensed to the Apache Software Found filename: (), num_rows: (), total_byte_size: (), column_statistics: ()ation (ASF) under one
-// or more c total_byte_size: (), column_statistics: ()ontri, total_byte_size: (), column_statistics: ()butor license agreements.  See the NOTICE file
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
@@ -13,7 +13,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
-// under the License
+// under the License.
 
 //! Optimizer rule to switch build and probe order of hash join
 //! based on statistics of a `TableProvider`. If the number of

--- a/rust/datafusion/src/physical_optimizer/repartition.rs
+++ b/rust/datafusion/src/physical_optimizer/repartition.rs
@@ -106,8 +106,8 @@ mod tests {
     use arrow::datatypes::Schema;
 
     use super::*;
-    use crate::datasource::datasource::Statistics;
-    use crate::physical_plan::parquet::{ParquetExec, ParquetPartition};
+    use crate::datasource::datasource::PartitionStatistics;
+    use crate::physical_plan::parquet::ParquetExec;
     use crate::physical_plan::projection::ProjectionExec;
 
     #[test]
@@ -115,9 +115,11 @@ mod tests {
         let parquet_project = ProjectionExec::try_new(
             vec![],
             Arc::new(ParquetExec::new(
-                vec![ParquetPartition {
-                    filenames: vec!["x".to_string()],
-                    statistics: Statistics::default(),
+                vec![PartitionStatistics {
+                    filename: Some("x".to_string()),
+                    num_rows: None,
+                    total_byte_size: None,
+                    column_statistics: None,
                 }],
                 Schema::empty(),
                 None,
@@ -151,9 +153,11 @@ mod tests {
             Arc::new(ProjectionExec::try_new(
                 vec![],
                 Arc::new(ParquetExec::new(
-                    vec![ParquetPartition {
-                        filenames: vec!["x".to_string()],
-                        statistics: Statistics::default(),
+                    vec![PartitionStatistics {
+                        filename: Some("x".to_string()),
+                        num_rows: None,
+                        total_byte_size: None,
+                        column_statistics: None,
                     }],
                     Schema::empty(),
                     None,


### PR DESCRIPTION
@alamb @jorgecarleitao @andygrove 

This is a WIP start of work to re-implement the `input_file_name` function by not using the `metadata` of the `RecordBatch` and instead relying on plan traversal. Inspired by @jorgecarleitao's comment: https://github.com/apache/arrow/pull/9944#pullrequestreview-632013179 I have tried to initially extend the `TableProvider` to capture this information by means of the `Statistics`.

This code collects statistics at the **partition** level not the **table** level and provides methods for calculating the table level statistics. It can easily be extended to do things like `TableProvider::file_name(partition: usize)` to get a specific `partition` filename. Calculating things like `distinct_count` per column will be a fun future problem and may require something like `HyperLogLog`.

This code also assumes that a 1:1 mapping of Parquet file to logical partition - but it still has a lot of the initial implementation for future many:one mapping of files to partition. I think it would be fair to fix a 1:1 mapping of file:partition and then down the line a `repartition` operator used to merge them. If agreed I can make those changes.

I don't like to make these changes in a vacuum and the mailing list is not ideal to demonstrate ideas so I hoped to review here.