### PR TITLE
ARROW-12326: [C++] Avoid needless c-ares detection

### DIFF
--- a/cpp/cmake_modules/Find-c-aresAlt.cmake
+++ b/cpp/cmake_modules/Find-c-aresAlt.cmake
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(find_package_args)
+if(c-aresAlt_FIND_VERSION)
+  list(APPEND find_package_args ${c-aresAlt_FIND_VERSION})
+endif()
+if(c-aresAlt_FIND_QUIETLY)
+  list(APPEND find_package_args QUIET)
+endif()
+find_package(c-ares ${find_package_args})
+if(c-ares_FOUND)
+  set(c-aresAlt_FOUND TRUE)
+  return()
+endif()
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(c-ares_PC libcares)
+if(c-ares_PC_FOUND)
+  set(c-ares_INCLUDE_DIR "${c-ares_PC_INCLUDEDIR}")
+
+  list(APPEND c-ares_PC_LIBRARY_DIRS "${c-ares_PC_LIBDIR}")
+  find_library(c-ares_LIB cares
+               PATHS ${c-ares_PC_LIBRARY_DIRS}
+               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
+               NO_DEFAULT_PATH)
+elseif(c-ares_ROOT)
+  find_library(c-ares_LIB
+               NAMES cares
+                     "${CMAKE_SHARED_LIBRARY_PREFIX}cares${CMAKE_SHARED_LIBRARY_SUFFIX}"
+               PATHS ${c-ares_ROOT}
+               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
+               NO_DEFAULT_PATH)
+  find_path(c-ares_INCLUDE_DIR
+            NAMES ares.h
+            PATHS ${c-ares_ROOT}
+            NO_DEFAULT_PATH
+            PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
+else()
+  find_library(c-ares_LIB
+               NAMES cares
+                     "${CMAKE_SHARED_LIBRARY_PREFIX}cares${CMAKE_SHARED_LIBRARY_SUFFIX}"
+               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
+  find_path(c-ares_INCLUDE_DIR NAMES ares.h PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
+endif()
+
+find_package_handle_standard_args(c-aresAlt REQUIRED_VARS c-ares_LIB c-ares_INCLUDE_DIR)
+
+if(c-aresAlt_FOUND)
+  if(NOT TARGET c-ares::cares)
+    add_library(c-ares::cares UNKNOWN IMPORTED)
+    set_target_properties(
+      c-ares::cares
+      PROPERTIES IMPORTED_LOCATION "${c-ares_LIB}" INTERFACE_INCLUDE_DIRECTORIES
+                 "${c-ares_INCLUDE_DIR}")
+  endif()
+endif()

--- a/cpp/cmake_modules/FindgRPCAlt.cmake
+++ b/cpp/cmake_modules/FindgRPCAlt.cmake
@@ -24,222 +24,57 @@ if(gRPC_FOUND)
   return()
 endif()
 
-unset(GRPC_ALT_VERSION)
-
-if(ARROW_GRPC_USE_SHARED)
-  set(GRPC_GPR_LIB_NAMES)
-  set(GRPC_GRPC_LIB_NAMES)
-  set(GRPC_GRPCPP_LIB_NAMES)
-  set(GRPC_ADDRESS_SORTING_LIB_NAMES)
-  set(GRPC_UPB_LIB_NAMES)
-  if(CMAKE_IMPORT_LIBRARY_SUFFIX)
-    list(APPEND GRPC_GPR_LIB_NAMES
-                "${CMAKE_IMPORT_LIBRARY_PREFIX}gpr${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-    list(APPEND GRPC_GRPC_LIB_NAMES
-                "${CMAKE_IMPORT_LIBRARY_PREFIX}grpc${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-    list(APPEND GRPC_GRPCPP_LIB_NAMES
-                "${CMAKE_IMPORT_LIBRARY_PREFIX}grpc++${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-    list(
-      APPEND GRPC_ADDRESS_SORTING_LIB_NAMES
-             "${CMAKE_IMPORT_LIBRARY_PREFIX}address_sorting${CMAKE_IMPORT_LIBRARY_SUFFIX}"
-      )
-    list(APPEND GRPC_UPB_LIB_NAMES
-                "${CMAKE_IMPORT_LIBRARY_PREFIX}upb${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-  endif()
-  list(APPEND GRPC_GPR_LIB_NAMES
-              "${CMAKE_SHARED_LIBRARY_PREFIX}gpr${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  list(APPEND GRPC_GRPC_LIB_NAMES
-              "${CMAKE_SHARED_LIBRARY_PREFIX}grpc${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  list(APPEND GRPC_GRPCPP_LIB_NAMES
-              "${CMAKE_SHARED_LIBRARY_PREFIX}grpc++${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  list(
-    APPEND GRPC_ADDRESS_SORTING_LIB_NAMES
-           "${CMAKE_SHARED_LIBRARY_PREFIX}address_sorting${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  list(APPEND GRPC_UPB_LIB_NAMES
-              "${CMAKE_SHARED_LIBRARY_PREFIX}upb${CMAKE_SHARED_LIBRARY_SUFFIX}")
-else()
-  set(GRPC_GPR_LIB_NAMES
-      "${CMAKE_STATIC_LIBRARY_PREFIX}gpr${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(GRPC_GRPC_LIB_NAMES
-      "${CMAKE_STATIC_LIBRARY_PREFIX}grpc${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(GRPC_GRPCPP_LIB_NAMES
-      "${CMAKE_STATIC_LIBRARY_PREFIX}grpc++${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(GRPC_ADDRESS_SORTING_LIB_NAMES
-      "${CMAKE_STATIC_LIBRARY_PREFIX}address_sorting${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  set(GRPC_UPB_LIB_NAMES
-      "${CMAKE_STATIC_LIBRARY_PREFIX}upb${CMAKE_STATIC_LIBRARY_SUFFIX}")
-endif()
-
-if(gRPC_ROOT)
-  find_library(GRPC_GPR_LIB
-               NAMES ${GRPC_GPR_LIB_NAMES}
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-               NO_DEFAULT_PATH)
-  find_library(GRPC_GRPC_LIB
-               NAMES ${GRPC_GRPC_LIB_NAMES}
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-               NO_DEFAULT_PATH)
-  find_library(GRPC_GRPCPP_LIB
-               NAMES ${GRPC_GRPCPP_LIB_NAMES}
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-               NO_DEFAULT_PATH)
-  find_library(GRPC_ADDRESS_SORTING_LIB
-               NAMES ${GRPC_ADDRESS_SORTING_LIB_NAMES}
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-               NO_DEFAULT_PATH)
-  find_library(GRPC_UPB_LIB
-               NAMES ${GRPC_UPB_LIB_NAMES}
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-               NO_DEFAULT_PATH)
-  find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin NO_DEFAULT_PATH
-               PATHS ${gRPC_ROOT}
-               PATH_SUFFIXES "bin")
-  find_path(GRPC_INCLUDE_DIR
-            NAMES grpc/grpc.h
-            PATHS ${gRPC_ROOT}
-            NO_DEFAULT_PATH
-            PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
-else()
-  find_package(PkgConfig QUIET)
-  pkg_check_modules(GRPC_PC grpc++)
-  if(GRPC_PC_FOUND)
-    set(GRPC_ALT_VERSION "${GRPC_PC_VERSION}")
-    set(GRPC_INCLUDE_DIR "${GRPC_PC_INCLUDEDIR}")
-    list(APPEND GRPC_PC_LIBRARY_DIRS "${GRPC_PC_LIBDIR}")
-    message(STATUS "${GRPC_PC_LIBRARY_DIRS}")
-
-    find_library(GRPC_GPR_LIB
-                 NAMES ${GRPC_GPR_LIB_NAMES}
-                 PATHS ${GRPC_PC_LIBRARY_DIRS}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-                 NO_DEFAULT_PATH)
-    find_library(GRPC_GRPC_LIB
-                 NAMES ${GRPC_GRPC_LIB_NAMES}
-                 PATHS ${GRPC_PC_LIBRARY_DIRS}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-                 NO_DEFAULT_PATH)
-    find_library(GRPC_GRPCPP_LIB
-                 NAMES ${GRPC_GRPCPP_LIB_NAMES}
-                 PATHS ${GRPC_PC_LIBRARY_DIRS}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-                 NO_DEFAULT_PATH)
-    find_library(GRPC_ADDRESS_SORTING_LIB
-                 NAMES ${GRPC_ADDRESS_SORTING_LIB_NAMES}
-                 PATHS ${GRPC_PC_LIBRARY_DIRS}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-                 NO_DEFAULT_PATH)
-    find_library(GRPC_UPB_LIB
-                 NAMES ${GRPC_UPB_LIB_NAMES}
-                 PATHS ${GRPC_PC_LIBRARY_DIRS}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES}
-                 NO_DEFAULT_PATH)
-    find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin
-                 HINTS ${GRPC_PC_PREFIX}
-                 NO_DEFAULT_PATH
-                 PATH_SUFFIXES "bin")
+find_package(PkgConfig QUIET)
+pkg_check_modules(GRPCPP_PC grpc++)
+if(GRPCPP_PC_FOUND)
+  set(gRPCAlt_VERSION "${GRPCPP_PC_VERSION}")
+  set(GRPCPP_INCLUDE_DIRECTORIES ${GRPCPP_PC_INCLUDEDIR})
+  if(ARROW_GRPC_USE_SHARED)
+    set(GRPCPP_LINK_LIBRARIES ${GRPCPP_PC_LINK_LIBRARIES})
+    set(GRPCPP_LINK_OPTIONS ${GRPCPP_PC_LDFLAGS_OTHER})
+    set(GRPCPP_COMPILE_OPTIONS ${GRPCPP_PC_CFLAGS_OTHER})
   else()
-    find_library(GRPC_GPR_LIB
-                 NAMES ${GRPC_GPR_LIB_NAMES}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
-    find_library(GRPC_GRPC_LIB
-                 NAMES ${GRPC_GRPC_LIB_NAMES}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
-    find_library(GRPC_GRPCPP_LIB
-                 NAMES ${GRPC_GRPCPP_LIB_NAMES}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
-    find_library(GRPC_ADDRESS_SORTING_LIB
-                 NAMES ${GRPC_ADDRESS_SORTING_LIB_NAMES}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
-    find_library(GRPC_UPB_LIB
-                 NAMES ${GRPC_UPB_LIB_NAMES}
-                 PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
-    find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin PATH_SUFFIXES "bin")
-    find_path(GRPC_INCLUDE_DIR
-              NAMES grpc/grpc.h
-              PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
+    set(GRPCPP_LINK_LIBRARIES)
+    foreach(GRPCPP_LIBRARY_NAME ${GRPCPP_PC_STATIC_LIBRARIES})
+      find_library(
+        GRPCPP_LIBRARY_${GRPCPP_LIBRARY_NAME}
+        NAMES
+          "${CMAKE_STATIC_LIBRARY_PREFIX}${GRPCPP_LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        HINTS ${GRPCPP_PC_STATIC_LIBRARY_DIRS})
+      list(APPEND GRPCPP_LINK_LIBRARIES "${GRPCPP_LIBRARY_${GRPCPP_LIBRARY_NAME}}")
+    endforeach()
+    set(GRPCPP_LINK_OPTIONS ${GRPCPP_PC_STATIC_LDFLAGS_OTHER})
+    set(GRPCPP_COMPILE_OPTIONS ${GRPCPP_PC_STATIC_CFLAGS_OTHER})
   endif()
+  list(GET GRPCPP_LINK_LIBRARIES 0 GRPCPP_IMPORTED_LOCATION)
+  list(REMOVE_AT GRPCPP_LINK_LIBRARIES 0)
+  find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin
+               HINTS ${GRPCPP_PC_PREFIX}
+               NO_DEFAULT_PATH
+               PATH_SUFFIXES "bin")
+  set(gRPCAlt_FIND_PACKAGE_ARGS gRPCAlt REQUIRED_VARS GRPCPP_IMPORTED_LOCATION
+                                GRPC_CPP_PLUGIN)
+  if(gRPCAlt_VERSION)
+    list(APPEND gRPCAlt_FIND_PACKAGE_ARGS VERSION_VAR gRPCAlt_VERSION)
+  endif()
+  find_package_handle_standard_args(${gRPCAlt_FIND_PACKAGE_ARGS})
+else()
+  set(gRPCAlt_FOUND FALSE)
 endif()
-
-set(GRPC_ALT_FIND_PACKAGE_ARGS
-    gRPCAlt
-    REQUIRED_VARS
-    GRPC_INCLUDE_DIR
-    GRPC_GPR_LIB
-    GRPC_GRPC_LIB
-    GRPC_GRPCPP_LIB
-    GRPC_CPP_PLUGIN)
-if(GRPC_ALT_VERSION)
-  list(APPEND GRPC_ALT_FIND_PACKAGE_ARGS VERSION_VAR GRPC_ALT_VERSION)
-endif()
-find_package_handle_standard_args(${GRPC_ALT_FIND_PACKAGE_ARGS})
 
 if(gRPCAlt_FOUND)
-  add_library(gRPC::gpr UNKNOWN IMPORTED)
-  set_target_properties(gRPC::gpr
-                        PROPERTIES IMPORTED_LOCATION "${GRPC_GPR_LIB}"
-                                   INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
-
-  add_library(gRPC::grpc UNKNOWN IMPORTED)
-  set_target_properties(
-    gRPC::grpc
-    PROPERTIES IMPORTED_LOCATION
-               "${GRPC_GRPC_LIB}"
-               INTERFACE_INCLUDE_DIRECTORIES
-               "${GRPC_INCLUDE_DIR}"
-               INTERFACE_LINK_LIBRARIES
-               "OpenSSL::SSL;OpenSSL::Crypto;ZLIB::ZLIB;c-ares::cares")
-
-  set(_GRPCPP_LINK_LIBRARIES "gRPC::grpc;gRPC::gpr")
-
-  if(GRPC_ADDRESS_SORTING_LIB)
-    # Address sorting is optional and not always required.
-    add_library(gRPC::address_sorting UNKNOWN IMPORTED)
-    set_target_properties(gRPC::address_sorting
-                          PROPERTIES IMPORTED_LOCATION "${GRPC_ADDRESS_SORTING_LIB}"
-                                     INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
-    set(_GRPCPP_LINK_LIBRARIES "${_GRPCPP_LINK_LIBRARIES};gRPC::address_sorting")
-  endif()
-
-  if(GRPC_UPB_LIB)
-    # upb is used by recent gRPC versions
-    add_library(gRPC::upb UNKNOWN IMPORTED)
-    set_target_properties(gRPC::upb
-                          PROPERTIES IMPORTED_LOCATION "${GRPC_UPB_LIB}"
-                                     INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
-    set(_GRPCPP_LINK_LIBRARIES "${_GRPCPP_LINK_LIBRARIES};gRPC::upb")
-  endif()
-
-  find_package(absl CONFIG)
-  if(absl_FOUND)
-    # Abseil libraries that recent gRPC versions depend on
-    set(_ABSL_LIBS
-        bad_optional_access
-        int128
-        raw_logging_internal
-        str_format_internal
-        strings
-        throw_delegate
-        time
-        time_zone)
-
-    foreach(_ABSL_LIB ${_ABSL_LIBS})
-      set(_GRPCPP_LINK_LIBRARIES "${_GRPCPP_LINK_LIBRARIES};absl::${_ABSL_LIB}")
-    endforeach()
-  endif()
-
   add_library(gRPC::grpc++ UNKNOWN IMPORTED)
   set_target_properties(gRPC::grpc++
                         PROPERTIES IMPORTED_LOCATION
-                                   "${GRPC_GRPCPP_LIB}"
-                                   INTERFACE_LINK_LIBRARIES
-                                   "${_GRPCPP_LINK_LIBRARIES}"
+                                   "${GRPCPP_IMPORTED_LOCATION}"
+                                   INTERFACE_COMPILE_OPTIONS
+                                   "${GRPCPP_COMPILE_OPTIONS}"
                                    INTERFACE_INCLUDE_DIRECTORIES
-                                   "${GRPC_INCLUDE_DIR}")
+                                   "${GRPCPP_INCLUDE_DIRECTORIES}"
+                                   INTERFACE_LINK_LIBRARIES
+                                   "${GRPCPP_LINK_LIBRARIES}"
+                                   INTERFACE_LINK_OPTIONS
+                                   "${GRPCPP_LINK_OPTIONS}")
 
   add_executable(gRPC::grpc_cpp_plugin IMPORTED)
   set_target_properties(gRPC::grpc_cpp_plugin

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2534,35 +2534,37 @@ macro(build_grpc)
                         PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GPR}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
 
-  add_library(gRPC::grpc STATIC IMPORTED)
-  set_target_properties(gRPC::grpc
-                        PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GRPC}"
-                                   INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
-
   add_library(gRPC::address_sorting STATIC IMPORTED)
   set_target_properties(gRPC::address_sorting
                         PROPERTIES IMPORTED_LOCATION
                                    "${GRPC_STATIC_LIBRARY_ADDRESS_SORTING}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
 
-  add_library(gRPC::grpc++ STATIC IMPORTED)
+  add_library(gRPC::grpc STATIC IMPORTED)
   set(GRPC_LINK_LIBRARIES
-      gRPC::grpc
       gRPC::gpr
       gRPC::upb
       gRPC::address_sorting
       ${ABSL_LIBRARIES}
-      ${ARROW_PROTOBUF_LIBPROTOBUF}
       c-ares::cares
       ZLIB::ZLIB
       Threads::Threads)
+  set_target_properties(gRPC::grpc
+                        PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GRPC}"
+                                   INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}"
+                                   INTERFACE_LINK_LIBRARIES "${GRPC_LINK_LIBRARIES}")
+
+  add_library(gRPC::grpc++ STATIC IMPORTED)
+  set(GRPCPP_LINK_LIBRARIES
+      gRPC::grpc
+      ${ARROW_PROTOBUF_LIBPROTOBUF})
   set_target_properties(gRPC::grpc++
                         PROPERTIES IMPORTED_LOCATION
                                    "${GRPC_STATIC_LIBRARY_GRPCPP}"
-                                   INTERFACE_LINK_LIBRARIES
-                                   ${GRPC_LINK_LIBRARIES}
                                    INTERFACE_INCLUDE_DIRECTORIES
-                                   "${GRPC_INCLUDE_DIR}")
+                                   "${GRPC_INCLUDE_DIR}"
+                                   INTERFACE_LINK_LIBRARIES
+                                   "${GRPCPP_LINK_LIBRARIES}")
 
   add_executable(gRPC::grpc_cpp_plugin IMPORTED)
   set_target_properties(gRPC::grpc_cpp_plugin
@@ -2601,11 +2603,11 @@ macro(build_grpc)
 
   list(APPEND ARROW_BUNDLED_STATIC_LIBS
               ${ABSL_LIBRARIES}
-              gRPC::upb
+              gRPC::address_sorting
               gRPC::gpr
               gRPC::grpc
-              gRPC::address_sorting
-              gRPC::grpcpp_for_bundling)
+              gRPC::grpcpp_for_bundling
+              gRPC::upb)
 endmacro()
 
 if(ARROW_WITH_GRPC)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2338,29 +2338,15 @@ macro(build_cares)
   list(APPEND ARROW_BUNDLED_STATIC_LIBS c-ares::cares)
 endmacro()
 
-if(ARROW_WITH_GRPC)
-  if(c-ares_SOURCE STREQUAL "AUTO")
-    find_package(c-ares QUIET CONFIG)
-    if(c-ares_FOUND)
-      set(CARES_INCLUDE_DIR ${c-ares_INCLUDE_DIR})
-    else()
-      build_cares()
-    endif()
-  elseif(c-ares_SOURCE STREQUAL "BUNDLED")
-    build_cares()
-  elseif(c-ares_SOURCE STREQUAL "SYSTEM")
-    find_package(c-ares REQUIRED CONFIG)
-    set(CARES_INCLUDE_DIR ${c-ares_INCLUDE_DIR})
-  endif()
-
-  # TODO: Don't use global includes but rather target_include_directories
-  include_directories(SYSTEM ${CARES_INCLUDE_DIR})
-endif()
-
 # ----------------------------------------------------------------------
 # Dependencies for Arrow Flight RPC
 
 macro(build_grpc)
+  resolve_dependency(c-ares HAVE_ALT TRUE)
+  # TODO: Don't use global includes but rather target_include_directories
+  get_target_property(c-ares_INCLUDE_DIR c-ares::cares INTERFACE_INCLUDE_DIRECTORIES)
+  include_directories(SYSTEM ${c-ares_INCLUDE_DIR})
+
   message(STATUS "Building gRPC from source")
 
   # First need to build Abseil
@@ -2560,15 +2546,23 @@ macro(build_grpc)
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
 
   add_library(gRPC::grpc++ STATIC IMPORTED)
-  set_target_properties(
-    gRPC::grpc++
-    PROPERTIES
-      IMPORTED_LOCATION
-      "${GRPC_STATIC_LIBRARY_GRPCPP}"
-      INTERFACE_LINK_LIBRARIES
-      "gRPC::grpc;gRPC::gpr;gRPC::upb;gRPC::address_sorting;${ABSL_LIBRARIES};Threads::Threads"
-      INTERFACE_INCLUDE_DIRECTORIES
-      "${GRPC_INCLUDE_DIR}")
+  set(GRPC_LINK_LIBRARIES
+      gRPC::grpc
+      gRPC::gpr
+      gRPC::upb
+      gRPC::address_sorting
+      ${ABSL_LIBRARIES}
+      ${ARROW_PROTOBUF_LIBPROTOBUF}
+      c-ares::cares
+      ZLIB::ZLIB
+      Threads::Threads)
+  set_target_properties(gRPC::grpc++
+                        PROPERTIES IMPORTED_LOCATION
+                                   "${GRPC_STATIC_LIBRARY_GRPCPP}"
+                                   INTERFACE_LINK_LIBRARIES
+                                   ${GRPC_LINK_LIBRARIES}
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   "${GRPC_INCLUDE_DIR}")
 
   add_executable(gRPC::grpc_cpp_plugin IMPORTED)
   set_target_properties(gRPC::grpc_cpp_plugin
@@ -2622,14 +2616,8 @@ if(ARROW_WITH_GRPC)
                      REQUIRED_VERSION
                      ${ARROW_GRPC_REQUIRED_VERSION})
 
-  if(TARGET gRPC::address_sorting)
-    set(GRPC_HAS_ADDRESS_SORTING TRUE)
-  else()
-    set(GRPC_HAS_ADDRESS_SORTING FALSE)
-  endif()
-
   # TODO: Don't use global includes but rather target_include_directories
-  get_target_property(GRPC_INCLUDE_DIR gRPC::grpc INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(GRPC_INCLUDE_DIR gRPC::grpc++ INTERFACE_INCLUDE_DIRECTORIES)
   include_directories(SYSTEM ${GRPC_INCLUDE_DIR})
 
   if(GRPC_VENDORED)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2550,14 +2550,15 @@ macro(build_grpc)
       ZLIB::ZLIB
       Threads::Threads)
   set_target_properties(gRPC::grpc
-                        PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GRPC}"
-                                   INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}"
-                                   INTERFACE_LINK_LIBRARIES "${GRPC_LINK_LIBRARIES}")
+                        PROPERTIES IMPORTED_LOCATION
+                                   "${GRPC_STATIC_LIBRARY_GRPC}"
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   "${GRPC_INCLUDE_DIR}"
+                                   INTERFACE_LINK_LIBRARIES
+                                   "${GRPC_LINK_LIBRARIES}")
 
   add_library(gRPC::grpc++ STATIC IMPORTED)
-  set(GRPCPP_LINK_LIBRARIES
-      gRPC::grpc
-      ${ARROW_PROTOBUF_LIBPROTOBUF})
+  set(GRPCPP_LINK_LIBRARIES gRPC::grpc ${ARROW_PROTOBUF_LIBPROTOBUF})
   set_target_properties(gRPC::grpc++
                         PROPERTIES IMPORTED_LOCATION
                                    "${GRPC_STATIC_LIBRARY_GRPCPP}"

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -19,15 +19,10 @@ add_custom_target(arrow_flight)
 
 arrow_install_all_headers("arrow/flight")
 
-set(ARROW_FLIGHT_STATIC_LINK_LIBS
-    gRPC::grpc++
-    ${ABSL_LIBRARIES}
-    ${ARROW_PROTOBUF_LIBPROTOBUF}
-    c-ares::cares
-    ZLIB::ZLIB)
+set(ARROW_FLIGHT_LINK_LIBS gRPC::grpc++)
 
 if(WIN32)
-  list(APPEND ARROW_FLIGHT_STATIC_LINK_LIBS ws2_32.lib)
+  list(APPEND ARROW_FLIGHT_LINK_LIBS ws2_32.lib)
 endif()
 
 if(ARROW_TEST_LINKAGE STREQUAL "static")
@@ -83,7 +78,7 @@ function(test_grpc_version DST_VAR DETECT_VERSION TEST_FILE)
     try_compile(HAS_GRPC_VERSION ${CMAKE_CURRENT_BINARY_DIR}/try_compile SOURCES
                 "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/${TEST_FILE}"
                 CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CURRENT_INCLUDE_DIRECTORIES}"
-                LINK_LIBRARIES gRPC::grpc gRPC::grpc++
+                LINK_LIBRARIES gRPC::grpc++
                 OUTPUT_VARIABLE TLS_CREDENTIALS_OPTIONS_CHECK_OUTPUT CXX_STANDARD 11)
     if(HAS_GRPC_VERSION)
       set(${DST_VAR}
@@ -177,10 +172,10 @@ add_arrow_lib(arrow_flight
               ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
               arrow_shared
-              ${ARROW_FLIGHT_STATIC_LINK_LIBS}
+              ${ARROW_FLIGHT_LINK_LIBS}
               STATIC_LINK_LIBS
               arrow_static
-              ${ARROW_FLIGHT_STATIC_LINK_LIBS})
+              ${ARROW_FLIGHT_LINK_LIBS})
 
 foreach(LIB_TARGET ${ARROW_FLIGHT_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_FLIGHT_EXPORTING)


### PR DESCRIPTION
If we use system gRPC, we don't need to detect c-ares.

This change also simplifies gRPC detection. System gRPC detection
requires CMake config or pkg-config. System gRPC detection by
gRPC_ROOT is removed because we can't maintain Abseil dependencies.