### PR TITLE
ARROW-12251: [Rust] Add Ballista to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cd rust/ballilsta
+          cd rust/ballista
           cargo test
 
   # test the --features "simd" of the arrow crate. This requires nightly.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,8 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd rust/ballista/rust
-          cargo build
+          # snmalloc requires cmake so build without default features
+          cargo build --no-default-features
 
   # test the crate
   linux-test:
@@ -144,7 +145,8 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd rust/ballista/rust
-          cargo test
+          # snmalloc requires cmake so build without default features
+          cargo test --no-default-features
 
   # test the --features "simd" of the arrow crate. This requires nightly.
   linux-test-simd:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cd rust/ballista
+          cd rust/ballista/rust
           cargo build
 
   # test the crate
@@ -138,11 +138,12 @@ jobs:
           cargo run --example dynamic_types
           cargo run --example read_csv
           cargo run --example read_csv_infer_schema
+      # Ballista is currently not part of the main workspace so requires a separate test step
       - name: Run Ballista tests
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cd rust/ballista
+          cd rust/ballista/rust
           cargo test
 
   # test the --features "simd" of the arrow crate. This requires nightly.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,11 +66,18 @@ jobs:
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
-      - name: Build
+      - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cd rust
+          cargo build
+      # Ballista is currently not part of the main workspace so requires a separate build step
+      - name: Build Ballista
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cd rust/ballista
           cargo build
 
   # test the crate
@@ -131,6 +138,12 @@ jobs:
           cargo run --example dynamic_types
           cargo run --example read_csv
           cargo run --example read_csv_infer_schema
+      - name: Run Ballista tests
+        run: |
+          export CARGO_HOME="/github/home/.cargo"
+          export CARGO_TARGET_DIR="/github/home/target"
+          cd rust/ballilsta
+          cargo test
 
   # test the --features "simd" of the arrow crate. This requires nightly.
   linux-test-simd:


### PR DESCRIPTION
Add `cargo build` and `cargo test` steps for Ballista. I will address fmt and clippy separately.