### PR TITLE
ARROW-12335: [Rust] [Ballista] Use latest DataFusion

### DIFF
--- a/rust/ballista/.dockerignore
+++ b/rust/ballista/.dockerignore
@@ -1,0 +1,1 @@
+rust/**/target

--- a/rust/ballista/.dockerignore
+++ b/rust/ballista/.dockerignore
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 rust/**/target

--- a/rust/ballista/rust/Cargo.toml
+++ b/rust/ballista/rust/Cargo.toml
@@ -25,6 +25,6 @@ members = [
     "scheduler",
 ]
 
-[profile.release]
-lto = true
-codegen-units = 1
+#[profile.release]
+#lto = true
+#codegen-units = 1

--- a/rust/ballista/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/ballista/rust/benchmarks/tpch/Cargo.toml
@@ -27,9 +27,14 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../client" }
 
-arrow = { path = "../../../../arrow"  }
-datafusion = { path = "../../../../datafusion" }
-parquet = { path = "../../../../parquet"  }
+#arrow = { path = "../../../../arrow"  }
+#datafusion = { path = "../../../../datafusion" }
+#parquet = { path = "../../../../parquet"  }
+
+arrow = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+datafusion = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+parquet = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+
 
 env_logger = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/rust/ballista/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/ballista/rust/benchmarks/tpch/Cargo.toml
@@ -27,9 +27,9 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../client" }
 
-arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
-datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
-parquet = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+parquet = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
 
 
 env_logger = "0.8"

--- a/rust/ballista/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/ballista/rust/benchmarks/tpch/Cargo.toml
@@ -27,10 +27,9 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../client" }
 
-arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-parquet = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-
+arrow = { path = "../../../../arrow"  }
+datafusion = { path = "../../../../datafusion" }
+parquet = { path = "../../../../parquet"  }
 
 env_logger = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/rust/ballista/rust/client/Cargo.toml
+++ b/rust/ballista/rust/client/Cargo.toml
@@ -30,5 +30,6 @@ ballista-core = { path = "../core" }
 futures = "0.3"
 log = "0.4"
 tokio = "1.0"
-arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+
+arrow = { path = "../../../arrow"  }
+datafusion = { path = "../../../datafusion" }

--- a/rust/ballista/rust/client/Cargo.toml
+++ b/rust/ballista/rust/client/Cargo.toml
@@ -30,5 +30,5 @@ ballista-core = { path = "../core" }
 futures = "0.3"
 log = "0.4"
 tokio = "1.0"
-arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
-datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }

--- a/rust/ballista/rust/client/Cargo.toml
+++ b/rust/ballista/rust/client/Cargo.toml
@@ -31,5 +31,8 @@ futures = "0.3"
 log = "0.4"
 tokio = "1.0"
 
-arrow = { path = "../../../arrow"  }
-datafusion = { path = "../../../datafusion" }
+#arrow = { path = "../../../arrow"  }
+#datafusion = { path = "../../../datafusion" }
+
+arrow = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+datafusion = { git = "https://github.com/apache/arrow", rev="fe83dca" }

--- a/rust/ballista/rust/core/Cargo.toml
+++ b/rust/ballista/rust/core/Cargo.toml
@@ -39,9 +39,9 @@ sqlparser = "0.8"
 tokio = "1.0"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="46161d2" }
-datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
 
 
 [dev-dependencies]

--- a/rust/ballista/rust/core/Cargo.toml
+++ b/rust/ballista/rust/core/Cargo.toml
@@ -39,9 +39,10 @@ sqlparser = "0.8"
 tokio = "1.0"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+
+arrow = { path = "../../../arrow"  }
+arrow-flight = { path = "../../../arrow-flight"  }
+datafusion = { path = "../../../datafusion" }
 
 
 [dev-dependencies]

--- a/rust/ballista/rust/core/Cargo.toml
+++ b/rust/ballista/rust/core/Cargo.toml
@@ -40,10 +40,13 @@ tokio = "1.0"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { path = "../../../arrow"  }
-arrow-flight = { path = "../../../arrow-flight"  }
-datafusion = { path = "../../../datafusion" }
+#arrow = { path = "../../../arrow"  }
+#arrow-flight = { path = "../../../arrow-flight"  }
+#datafusion = { path = "../../../datafusion" }
 
+arrow = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+datafusion = { git = "https://github.com/apache/arrow", rev="fe83dca" }
 
 [dev-dependencies]
 

--- a/rust/ballista/rust/core/proto/ballista.proto
+++ b/rust/ballista/rust/core/proto/ballista.proto
@@ -59,6 +59,7 @@ message LogicalExprNode {
     InListNode in_list = 14;
     bool wildcard = 15;
     ScalarFunctionNode scalar_function = 16;
+    TryCastNode try_cast = 17;
   }
 }
 
@@ -168,6 +169,11 @@ message WhenThen {
 }
 
 message CastNode {
+  LogicalExprNode expr = 1;
+  ArrowType arrow_type = 2;
+}
+
+message TryCastNode {
   LogicalExprNode expr = 1;
   ArrowType arrow_type = 2;
 }

--- a/rust/ballista/rust/core/src/datasource.rs
+++ b/rust/ballista/rust/core/src/datasource.rs
@@ -57,6 +57,7 @@ impl TableProvider for DFTableAdapter {
         _projection: &Option<Vec<usize>>,
         _batch_size: usize,
         _filters: &[Expr],
+        _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(self.plan.clone())
     }

--- a/rust/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -510,10 +510,10 @@ fn typechecked_scalar_value_conversion(
             ScalarValue::Date32(Some(*v))
         }
         (Value::TimeMicrosecondValue(v), PrimitiveScalarType::TimeMicrosecond) => {
-            ScalarValue::TimeMicrosecond(Some(*v))
+            ScalarValue::TimestampMicrosecond(Some(*v))
         }
         (Value::TimeNanosecondValue(v), PrimitiveScalarType::TimeMicrosecond) => {
-            ScalarValue::TimeNanosecond(Some(*v))
+            ScalarValue::TimestampNanosecond(Some(*v))
         }
         (Value::Utf8Value(v), PrimitiveScalarType::Utf8) => {
             ScalarValue::Utf8(Some(v.to_owned()))
@@ -546,10 +546,10 @@ fn typechecked_scalar_value_conversion(
                     PrimitiveScalarType::LargeUtf8 => ScalarValue::LargeUtf8(None),
                     PrimitiveScalarType::Date32 => ScalarValue::Date32(None),
                     PrimitiveScalarType::TimeMicrosecond => {
-                        ScalarValue::TimeMicrosecond(None)
+                        ScalarValue::TimestampMicrosecond(None)
                     }
                     PrimitiveScalarType::TimeNanosecond => {
-                        ScalarValue::TimeNanosecond(None)
+                        ScalarValue::TimestampNanosecond(None)
                     }
                     PrimitiveScalarType::Null => {
                         return Err(proto_error(
@@ -609,10 +609,10 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::scalar_value::Value
                 ScalarValue::Date32(Some(*v))
             }
             protobuf::scalar_value::Value::TimeMicrosecondValue(v) => {
-                ScalarValue::TimeMicrosecond(Some(*v))
+                ScalarValue::TimestampMicrosecond(Some(*v))
             }
             protobuf::scalar_value::Value::TimeNanosecondValue(v) => {
-                ScalarValue::TimeNanosecond(Some(*v))
+                ScalarValue::TimestampNanosecond(Some(*v))
             }
             protobuf::scalar_value::Value::ListValue(v) => v.try_into()?,
             protobuf::scalar_value::Value::NullListValue(v) => {
@@ -775,10 +775,10 @@ impl TryInto<datafusion::scalar::ScalarValue> for protobuf::PrimitiveScalarType 
             protobuf::PrimitiveScalarType::LargeUtf8 => ScalarValue::LargeUtf8(None),
             protobuf::PrimitiveScalarType::Date32 => ScalarValue::Date32(None),
             protobuf::PrimitiveScalarType::TimeMicrosecond => {
-                ScalarValue::TimeMicrosecond(None)
+                ScalarValue::TimestampMicrosecond(None)
             }
             protobuf::PrimitiveScalarType::TimeNanosecond => {
-                ScalarValue::TimeNanosecond(None)
+                ScalarValue::TimestampNanosecond(None)
             }
         })
     }
@@ -828,10 +828,10 @@ impl TryInto<datafusion::scalar::ScalarValue> for &protobuf::ScalarValue {
                 ScalarValue::Date32(Some(*v))
             }
             protobuf::scalar_value::Value::TimeMicrosecondValue(v) => {
-                ScalarValue::TimeMicrosecond(Some(*v))
+                ScalarValue::TimestampMicrosecond(Some(*v))
             }
             protobuf::scalar_value::Value::TimeNanosecondValue(v) => {
-                ScalarValue::TimeNanosecond(Some(*v))
+                ScalarValue::TimestampNanosecond(Some(*v))
             }
             protobuf::scalar_value::Value::ListValue(scalar_list) => {
                 let protobuf::ScalarListValue {
@@ -960,6 +960,15 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                     .ok_or_else(|| proto_error("Protobuf deserialization error: CastNode message missing required field 'arrow_type'"))?;
                 let data_type = arrow_type.try_into()?;
                 Ok(Expr::Cast { expr, data_type })
+            }
+            ExprType::TryCast(cast) => {
+                let expr = Box::new(parse_required_expr(&cast.expr)?);
+                let arrow_type: &protobuf::ArrowType = cast
+                    .arrow_type
+                    .as_ref()
+                    .ok_or_else(|| proto_error("Protobuf deserialization error: CastNode message missing required field 'arrow_type'"))?;
+                let data_type = arrow_type.try_into()?;
+                Ok(Expr::TryCast { expr, data_type })
             }
             ExprType::Sort(sort) => Ok(Expr::Sort {
                 expr: Box::new(parse_required_expr(&sort.expr)?),

--- a/rust/ballista/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/from_proto.rs
@@ -52,14 +52,13 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
         match plan {
             LogicalPlanType::Projection(projection) => {
                 let input: LogicalPlan = convert_box_required!(projection.input)?;
+                let x: Vec<Expr> = projection
+                    .expr
+                    .iter()
+                    .map(|expr| expr.try_into())
+                    .collect::<Result<Vec<_>, _>>()?;
                 LogicalPlanBuilder::from(&input)
-                    .project(
-                        &projection
-                            .expr
-                            .iter()
-                            .map(|expr| expr.try_into())
-                            .collect::<Result<Vec<_>, _>>()?,
-                    )?
+                    .project(x)?
                     .build()
                     .map_err(|e| e.into())
             }
@@ -89,7 +88,7 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                     .map(|expr| expr.try_into())
                     .collect::<Result<Vec<_>, _>>()?;
                 LogicalPlanBuilder::from(&input)
-                    .aggregate(&group_expr, &aggr_expr)?
+                    .aggregate(group_expr, aggr_expr)?
                     .build()
                     .map_err(|e| e.into())
             }
@@ -148,7 +147,7 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                     .map(|expr| expr.try_into())
                     .collect::<Result<Vec<Expr>, _>>()?;
                 LogicalPlanBuilder::from(&input)
-                    .sort(&sort_expr)?
+                    .sort(sort_expr)?
                     .build()
                     .map_err(|e| e.into())
             }

--- a/rust/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -82,7 +82,7 @@ mod roundtrip_tests {
                 CsvReadOptions::new().schema(&schema).has_header(true),
                 Some(vec![3, 4]),
             )
-            .and_then(|plan| plan.sort(&[col("salary")]))
+            .and_then(|plan| plan.sort(vec![col("salary")]))
             .and_then(|plan| plan.build())
             .map_err(BallistaError::DataFusionError)?,
         );
@@ -679,7 +679,7 @@ mod roundtrip_tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             Some(vec![3, 4]),
         )
-        .and_then(|plan| plan.sort(&[col("salary")]))
+        .and_then(|plan| plan.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(true))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -689,7 +689,7 @@ mod roundtrip_tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             Some(vec![3, 4]),
         )
-        .and_then(|plan| plan.sort(&[col("salary")]))
+        .and_then(|plan| plan.sort(vec![col("salary")]))
         .and_then(|plan| plan.explain(false))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
@@ -742,7 +742,7 @@ mod roundtrip_tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             Some(vec![3, 4]),
         )
-        .and_then(|plan| plan.sort(&[col("salary")]))
+        .and_then(|plan| plan.sort(vec![col("salary")]))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
         roundtrip_test!(plan);
@@ -784,7 +784,7 @@ mod roundtrip_tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             Some(vec![3, 4]),
         )
-        .and_then(|plan| plan.aggregate(&[col("state")], &[max(col("salary"))]))
+        .and_then(|plan| plan.aggregate(vec![col("state")], vec![max(col("salary"))]))
         .and_then(|plan| plan.build())
         .map_err(BallistaError::DataFusionError)?;
 

--- a/rust/ballista/rust/core/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/mod.rs
@@ -212,8 +212,8 @@ mod roundtrip_tests {
             ScalarValue::LargeUtf8(None),
             ScalarValue::List(None, DataType::Boolean),
             ScalarValue::Date32(None),
-            ScalarValue::TimeMicrosecond(None),
-            ScalarValue::TimeNanosecond(None),
+            ScalarValue::TimestampMicrosecond(None),
+            ScalarValue::TimestampNanosecond(None),
             ScalarValue::Boolean(Some(true)),
             ScalarValue::Boolean(Some(false)),
             ScalarValue::Float32(Some(1.0)),
@@ -252,11 +252,11 @@ mod roundtrip_tests {
             ScalarValue::LargeUtf8(Some(String::from("Test Large utf8"))),
             ScalarValue::Date32(Some(0)),
             ScalarValue::Date32(Some(i32::MAX)),
-            ScalarValue::TimeNanosecond(Some(0)),
-            ScalarValue::TimeNanosecond(Some(i64::MAX)),
-            ScalarValue::TimeMicrosecond(Some(0)),
-            ScalarValue::TimeMicrosecond(Some(i64::MAX)),
-            ScalarValue::TimeMicrosecond(None),
+            ScalarValue::TimestampNanosecond(Some(0)),
+            ScalarValue::TimestampNanosecond(Some(i64::MAX)),
+            ScalarValue::TimestampMicrosecond(Some(0)),
+            ScalarValue::TimestampMicrosecond(Some(i64::MAX)),
+            ScalarValue::TimestampMicrosecond(None),
             ScalarValue::List(
                 Some(vec![
                     ScalarValue::Float32(Some(-213.1)),
@@ -610,8 +610,8 @@ mod roundtrip_tests {
             ScalarValue::Utf8(None),
             ScalarValue::LargeUtf8(None),
             ScalarValue::Date32(None),
-            ScalarValue::TimeMicrosecond(None),
-            ScalarValue::TimeNanosecond(None),
+            ScalarValue::TimestampMicrosecond(None),
+            ScalarValue::TimestampNanosecond(None),
             //ScalarValue::List(None, DataType::Boolean)
         ];
 

--- a/rust/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -641,12 +641,12 @@ impl TryFrom<&datafusion::scalar::ScalarValue> for protobuf::ScalarValue {
             datafusion::scalar::ScalarValue::Date32(val) => {
                 create_proto_scalar(val, PrimitiveScalarType::Date32, |s| Value::Date32Value(*s))
             }
-            datafusion::scalar::ScalarValue::TimeMicrosecond(val) => {
+            datafusion::scalar::ScalarValue::TimestampMicrosecond(val) => {
                 create_proto_scalar(val, PrimitiveScalarType::TimeMicrosecond, |s| {
                     Value::TimeMicrosecondValue(*s)
                 })
             }
-            datafusion::scalar::ScalarValue::TimeNanosecond(val) => {
+            datafusion::scalar::ScalarValue::TimestampNanosecond(val) => {
                 create_proto_scalar(val, PrimitiveScalarType::TimeNanosecond, |s| {
                     Value::TimeNanosecondValue(*s)
                 })

--- a/rust/ballista/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/rust/core/src/serde/logical_plan/to_proto.rs
@@ -939,10 +939,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                 })
             }
             LogicalPlan::Extension { .. } => unimplemented!(),
-            // _ => Err(BallistaError::General(format!(
-            //     "logical plan to_proto {:?}",
-            //     self
-            // ))),
+            LogicalPlan::Union { .. } => unimplemented!(),
         }
     }
 }
@@ -1161,10 +1158,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
             Expr::Wildcard => Ok(protobuf::LogicalExprNode {
                 expr_type: Some(protobuf::logical_expr_node::ExprType::Wildcard(true)),
             }),
-            // _ => Err(BallistaError::General(format!(
-            //     "logical expr to_proto {:?}",
-            //     self
-            // ))),
+            Expr::TryCast { .. } => unimplemented!(),
         }
     }
 }

--- a/rust/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/rust/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -106,15 +106,12 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                     .file_extension(&scan.file_extension)
                     .delimiter(scan.delimiter.as_bytes()[0])
                     .schema(&schema);
-                // TODO we don't care what the DataFusion batch size was because Ballista will
-                // have its own configs. Hard-code for now.
-                let batch_size = 32768;
                 let projection = scan.projection.iter().map(|i| *i as usize).collect();
                 Ok(Arc::new(CsvExec::try_new(
                     &scan.path,
                     options,
                     Some(projection),
-                    batch_size,
+                    scan.batch_size as usize,
                     None,
                 )?))
             }

--- a/rust/ballista/rust/core/src/serde/physical_plan/mod.rs
+++ b/rust/ballista/rust/core/src/serde/physical_plan/mod.rs
@@ -40,6 +40,7 @@ mod roundtrip_tests {
 
     use super::super::super::error::Result;
     use super::super::protobuf;
+    use datafusion::physical_plan::hash_join::PartitionMode;
 
     fn roundtrip_test(exec_plan: Arc<dyn ExecutionPlan>) -> Result<()> {
         let proto: protobuf::PhysicalPlanNode = exec_plan.clone().try_into()?;
@@ -84,6 +85,7 @@ mod roundtrip_tests {
             Arc::new(EmptyExec::new(false, Arc::new(schema_right))),
             &[("col".to_string(), "col".to_string())],
             &JoinType::Inner,
+            PartitionMode::CollectLeft,
         )?))
     }
 

--- a/rust/ballista/rust/executor/Cargo.toml
+++ b/rust/ballista/rust/executor/Cargo.toml
@@ -45,9 +45,9 @@ tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="46161d2" }
-datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
 
 [dev-dependencies]
 

--- a/rust/ballista/rust/executor/Cargo.toml
+++ b/rust/ballista/rust/executor/Cargo.toml
@@ -45,9 +45,9 @@ tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+arrow = { path = "../../../arrow"  }
+arrow-flight = { path = "../../../arrow-flight"  }
+datafusion = { path = "../../../datafusion" }
 
 [dev-dependencies]
 

--- a/rust/ballista/rust/executor/Cargo.toml
+++ b/rust/ballista/rust/executor/Cargo.toml
@@ -45,9 +45,13 @@ tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { path = "../../../arrow"  }
-arrow-flight = { path = "../../../arrow-flight"  }
-datafusion = { path = "../../../datafusion" }
+#arrow = { path = "../../../arrow"  }
+#arrow-flight = { path = "../../../arrow-flight"  }
+#datafusion = { path = "../../../datafusion" }
+
+arrow = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+datafusion = { git = "https://github.com/apache/arrow", rev="fe83dca" }
 
 [dev-dependencies]
 

--- a/rust/ballista/rust/scheduler/Cargo.toml
+++ b/rust/ballista/rust/scheduler/Cargo.toml
@@ -52,8 +52,8 @@ tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"
 
-arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
-datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
 
 [dev-dependencies]
 ballista-core = { path = "../core" }

--- a/rust/ballista/rust/scheduler/Cargo.toml
+++ b/rust/ballista/rust/scheduler/Cargo.toml
@@ -52,8 +52,8 @@ tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"
 
-arrow = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
-datafusion = { git = "https://github.com/apache/arrow", rev="f1f4f2b" }
+arrow = { path = "../../../arrow"  }
+datafusion = { path = "../../../datafusion" }
 
 [dev-dependencies]
 ballista-core = { path = "../core" }

--- a/rust/ballista/rust/scheduler/Cargo.toml
+++ b/rust/ballista/rust/scheduler/Cargo.toml
@@ -52,8 +52,11 @@ tonic = "0.4"
 tower = { version = "0.4" }
 warp = "0.3"
 
-arrow = { path = "../../../arrow"  }
-datafusion = { path = "../../../datafusion" }
+#arrow = { path = "../../../arrow"  }
+#datafusion = { path = "../../../datafusion" }
+
+arrow = { git = "https://github.com/apache/arrow", rev="fe83dca" }
+datafusion = { git = "https://github.com/apache/arrow", rev="fe83dca" }
 
 [dev-dependencies]
 ballista-core = { path = "../core" }

--- a/rust/ballista/rust/scheduler/src/api/mod.rs
+++ b/rust/ballista/rust/scheduler/src/api/mod.rs
@@ -30,11 +30,11 @@ pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type HttpBody = dyn http_body::Body<Data = dyn Buf, Error = Error> + 'static;
 
 impl<A, B> http_body::Body for EitherBody<A, B>
-    where
-        A: http_body::Body + Send + Unpin,
-        B: http_body::Body<Data = A::Data> + Send + Unpin,
-        A::Error: Into<Error>,
-        B::Error: Into<Error>,
+where
+    A: http_body::Body + Send + Unpin,
+    B: http_body::Body<Data = A::Data> + Send + Unpin,
+    A::Error: Into<Error>,
+    B::Error: Into<Error>,
 {
     type Data = A::Data;
     type Error = Error;
@@ -67,7 +67,9 @@ impl<A, B> http_body::Body for EitherBody<A, B>
     }
 }
 
-fn map_option_err<T, U: Into<Error>>(err: Option<Result<T, U>>) -> Option<Result<T, Error>> {
+fn map_option_err<T, U: Into<Error>>(
+    err: Option<Result<T, U>>,
+) -> Option<Result<T, Error>> {
     err.map(|e| e.map_err(Into::into))
 }
 

--- a/rust/ballista/rust/scheduler/src/lib.rs
+++ b/rust/ballista/rust/scheduler/src/lib.rs
@@ -201,12 +201,13 @@ impl SchedulerGrpc for SchedulerServer {
 
         match file_type {
             FileType::Parquet => {
-                let parquet_exec = ParquetExec::try_from_path(&path, None, None, 1024, 1)
-                    .map_err(|e| {
-                        let msg = format!("Error opening parquet files: {}", e);
-                        error!("{}", msg);
-                        tonic::Status::internal(msg)
-                    })?;
+                let parquet_exec =
+                    ParquetExec::try_from_path(&path, None, None, 1024, 1, None)
+                        .map_err(|e| {
+                            let msg = format!("Error opening parquet files: {}", e);
+                            error!("{}", msg);
+                            tonic::Status::internal(msg)
+                        })?;
 
                 //TODO include statistics and any other info needed to reconstruct ParquetExec
                 Ok(Response::new(GetFileMetadataResult {

--- a/rust/ballista/rust/scheduler/src/main.rs
+++ b/rust/ballista/rust/scheduler/src/main.rs
@@ -29,12 +29,12 @@ use ballista_core::BALLISTA_VERSION;
 use ballista_core::{
     print_version, serde::protobuf::scheduler_grpc_server::SchedulerGrpcServer,
 };
+use ballista_scheduler::api::{get_routes, EitherBody, Error};
 #[cfg(feature = "etcd")]
 use ballista_scheduler::state::EtcdClient;
 #[cfg(feature = "sled")]
 use ballista_scheduler::state::StandaloneClient;
 use ballista_scheduler::{state::ConfigBackendClient, ConfigBackend, SchedulerServer};
-use ballista_scheduler::api::{get_routes, EitherBody, Error};
 
 use log::info;
 
@@ -63,8 +63,10 @@ async fn start_server(
     );
     Ok(Server::bind(&addr)
         .serve(make_service_fn(move |_| {
-            let scheduler_server = SchedulerServer::new(config_backend.clone(), namespace.clone());
-            let scheduler_grpc_server = SchedulerGrpcServer::new(scheduler_server.clone());
+            let scheduler_server =
+                SchedulerServer::new(config_backend.clone(), namespace.clone());
+            let scheduler_grpc_server =
+                SchedulerGrpcServer::new(scheduler_server.clone());
 
             let mut tonic = TonicServer::builder()
                 .add_service(scheduler_grpc_server)

--- a/rust/ballista/rust/scheduler/src/planner.rs
+++ b/rust/ballista/rust/scheduler/src/planner.rs
@@ -34,13 +34,13 @@ use ballista_core::{
     execution_plans::{QueryStageExec, ShuffleReaderExec, UnresolvedShuffleExec},
     serde::scheduler::PartitionLocation,
 };
-use datafusion::execution::context::ExecutionContext;
+use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
 use datafusion::physical_optimizer::coalesce_batches::CoalesceBatches;
+use datafusion::physical_optimizer::merge_exec::AddMergeExec;
 use datafusion::physical_optimizer::optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
 use datafusion::physical_plan::hash_join::HashJoinExec;
 use datafusion::physical_plan::merge::MergeExec;
-use datafusion::physical_optimizer::merge_exec::AddMergeExec;
 use datafusion::physical_plan::ExecutionPlan;
 use log::{debug, info};
 use tokio::task::JoinHandle;
@@ -139,12 +139,13 @@ impl DistributedPlanner {
         }
 
         if let Some(adapter) = execution_plan.as_any().downcast_ref::<DFTableAdapter>() {
+            // remove Repartition rule because that isn't supported yet
             let rules: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> = vec![
                 Arc::new(CoalesceBatches::new()),
                 Arc::new(AddMergeExec::new()),
             ];
-            let mut ctx = ExecutionContext::new();
-            let ctx = ctx.with_physical_optimizers(rules);
+            let config = ExecutionConfig::new().with_physical_optimizer_rules(rules);
+            let ctx = ExecutionContext::with_config(config);
             Ok((ctx.create_physical_plan(&adapter.logical_plan)?, stages))
         } else if let Some(merge) = execution_plan.as_any().downcast_ref::<MergeExec>() {
             let query_stage = create_query_stage(


### PR DESCRIPTION
Updates Ballista to use the most recent DataFusion version.

Changes made:

- Ballista overrides physical optimizer rules to remove `Repartition`
- Added serde support for new `TryCast` expression
- Updated DataFrame API usage to use `Vec<_>` instead of `&[_]`
- Renamed some timestamp scalar variants
- HashJoinExec updated to take new `CollectLeft` argument
- Removed hard-coded batch size from serde code for `CsvScanExec`
