### PR TITLE
ARROW-8900: [C++][Python] Expose Proxy Options as parameters for S3FileSystem

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -189,6 +189,11 @@ Result<S3ProxyOptions> S3ProxyOptions::FromUri(const std::string& uri_string) {
   return FromUri(uri);
 }
 
+bool S3ProxyOptions::Equals(const S3ProxyOptions& other) const {
+  return (scheme == other.scheme && host == other.host && port == other.port &&
+          username == other.username && password == other.password);
+}
+
 // -----------------------------------------------------------------------
 // S3Options implementation
 
@@ -334,6 +339,7 @@ Result<S3Options> S3Options::FromUri(const std::string& uri_string,
 bool S3Options::Equals(const S3Options& other) const {
   return (region == other.region && endpoint_override == other.endpoint_override &&
           scheme == other.scheme && background_writes == other.background_writes &&
+          proxy_options.Equals(other.proxy_options) &&
           GetAccessKey() == other.GetAccessKey() &&
           GetSecretKey() == other.GetSecretKey() &&
           GetSessionToken() == other.GetSessionToken());

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -541,7 +541,7 @@ class ClientBuilder {
         client_config_.proxyScheme = Aws::Http::Scheme::HTTPS;
       } else {
         return Status::Invalid("Invalid proxy connection scheme '",
-                                options_.proxy_options.scheme, "'");
+                               options_.proxy_options.scheme, "'");
       }
     }
     if (!options_.proxy_options.host.empty()) {

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -540,7 +540,8 @@ class ClientBuilder {
       } else if (options_.proxy_options.scheme == "https") {
         client_config_.proxyScheme = Aws::Http::Scheme::HTTPS;
       } else {
-        return Status::Invalid("Invalid proxy connection scheme '", options_.proxy_options.scheme, "'");
+        return Status::Invalid("Invalid proxy connection scheme '",
+                                options_.proxy_options.scheme, "'");
       }
     }
     if (!options_.proxy_options.host.empty()) {
@@ -555,7 +556,7 @@ class ClientBuilder {
     if (!options_.proxy_options.password.empty()) {
       client_config_.proxyPassword = ToAwsString(options_.proxy_options.password);
     }
-    
+
     return std::make_shared<S3Client>(
         credentials_provider_, client_config_,
         Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -545,6 +545,8 @@ class ClientBuilder {
     }
     if (!options_.proxy_options.host.empty()) {
       client_config_.proxyHost = ToAwsString(options_.proxy_options.host);
+    }
+    if (options_.proxy_options.port != -1) {
       client_config_.proxyPort = options_.proxy_options.port;
     }
     if (!options_.proxy_options.username.empty()) {

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -83,7 +83,7 @@ struct ARROW_EXPORT S3Options {
 
   /// If connection is through a proxy, set options here
   S3ProxyOptions proxy_options;
-  
+
   /// AWS credentials provider
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -40,6 +40,21 @@ class STSClient;
 namespace arrow {
 namespace fs {
 
+/// Options for using a proxy for S3
+struct ARROW_EXPORT S3ProxyOptions {
+    std::string scheme;
+    std::string host;
+    int port;
+    std::string username;
+    std::string password;
+
+    /// Initialize from URI such as http://username:password@host:port
+    /// or http://host:port
+    static Result<S3ProxyOptions> FromUri(const std::string& uri);
+
+    static Result<S3ProxyOptions> FromUri(const ::arrow::internal::Uri& uri);
+};
+
 /// Options for the S3FileSystem implementation.
 struct ARROW_EXPORT S3Options {
   /// AWS region to connect to.
@@ -66,6 +81,9 @@ struct ARROW_EXPORT S3Options {
   /// Frequency (in seconds) to refresh temporary credentials from assumed role
   int load_frequency;
 
+  /// If connection is through a proxy, set options here
+  S3ProxyOptions proxy_options;
+  
   /// AWS credentials provider
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -52,6 +52,8 @@ struct ARROW_EXPORT S3ProxyOptions {
   /// or http://host:port
   static Result<S3ProxyOptions> FromUri(const std::string& uri);
   static Result<S3ProxyOptions> FromUri(const ::arrow::internal::Uri& uri);
+
+  bool Equals(const S3ProxyOptions& other) const;
 };
 
 /// Options for the S3FileSystem implementation.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -44,7 +44,7 @@ namespace fs {
 struct ARROW_EXPORT S3ProxyOptions {
     std::string scheme;
     std::string host;
-    int port;
+    int port = -1;
     std::string username;
     std::string password;
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -42,17 +42,16 @@ namespace fs {
 
 /// Options for using a proxy for S3
 struct ARROW_EXPORT S3ProxyOptions {
-    std::string scheme;
-    std::string host;
-    int port = -1;
-    std::string username;
-    std::string password;
+  std::string scheme;
+  std::string host;
+  int port = -1;
+  std::string username;
+  std::string password;
 
-    /// Initialize from URI such as http://username:password@host:port
-    /// or http://host:port
-    static Result<S3ProxyOptions> FromUri(const std::string& uri);
-
-    static Result<S3ProxyOptions> FromUri(const ::arrow::internal::Uri& uri);
+  /// Initialize from URI such as http://username:password@host:port
+  /// or http://host:port
+  static Result<S3ProxyOptions> FromUri(const std::string& uri);
+  static Result<S3ProxyOptions> FromUri(const ::arrow::internal::Uri& uri);
 };
 
 /// Options for the S3FileSystem implementation.

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -131,14 +131,8 @@ cdef class S3ProxyOptions:
         """
         cdef:
             S3ProxyOptions self = S3ProxyOptions.__new__(S3ProxyOptions)
-            CS3ProxyOptions options
 
-        options = GetResultValue(CS3ProxyOptions.FromUriString(tobytes(uri)))
-        self.proxy_options.scheme = options.scheme
-        self.proxy_options.host = options.host
-        self.proxy_options.port = options.port
-        self.proxy_options.username = options.username
-        self.proxy_options.password = options.password
+        self.proxy_options = GetResultValue(CS3ProxyOptions.FromUriString(tobytes(uri)))
         return self
 
 

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -64,12 +64,51 @@ cdef class S3ProxyOptions:
         Password to use to authenticate connection to proxy.
     """
 
+    cdef:
+        CS3ProxyOptions proxy_options
+
     def __init__(self, scheme="", host="", port=-1, username="", password=""):
-        self.scheme = scheme
-        self.host = host
-        self.port = port
-        self.username = username
-        self.password = password
+
+        self.proxy_options.scheme = tobytes(scheme)
+        self.proxy_options.host = tobytes(host)
+        self.proxy_options.port = port
+        self.proxy_options.username = tobytes(username)
+        self.proxy_options.password = tobytes(password)
+    
+    @property
+    def scheme(self):
+        """
+        The scheme this proxy uses.
+        """
+        return frombytes(self.proxy_options.scheme)
+    
+    @property
+    def host(self):
+        """
+        The host for this proxy.
+        """
+        return frombytes(self.proxy_options.host)
+    
+    @property
+    def port(self):
+        """
+        The port for this proxy.
+        """
+        return self.proxy_options.port
+    
+    @property
+    def username(self):
+        """
+        The username uses to authenticate connection to proxy.
+        """
+        return frombytes(self.proxy_options.username)
+    
+    @property
+    def password(self):
+        """
+        The password uses to authenticate connection to proxy.
+        """
+        return frombytes(self.proxy_options.password)
     
     @staticmethod
     def from_uri(uri):
@@ -95,11 +134,11 @@ cdef class S3ProxyOptions:
             CS3ProxyOptions options
 
         options = GetResultValue(CS3ProxyOptions.FromUriString(tobytes(uri)))
-        self.scheme = frombytes(options.scheme)
-        self.host = frombytes(options.host)
-        self.port = options.port
-        self.username = frombytes(options.username)
-        self.password = frombytes(options.password)
+        self.proxy_options.scheme = options.scheme
+        self.proxy_options.host = options.host
+        self.proxy_options.port = options.port
+        self.proxy_options.username = options.username
+        self.proxy_options.password = options.password
         return self
 
 

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -74,42 +74,42 @@ cdef class S3ProxyOptions:
         self.proxy_options.port = port
         self.proxy_options.username = tobytes(username)
         self.proxy_options.password = tobytes(password)
-    
+
     @property
     def scheme(self):
         """
         The scheme this proxy uses.
         """
         return frombytes(self.proxy_options.scheme)
-    
+
     @property
     def host(self):
         """
         The host for this proxy.
         """
         return frombytes(self.proxy_options.host)
-    
+
     @property
     def port(self):
         """
         The port for this proxy.
         """
         return self.proxy_options.port
-    
+
     @property
     def username(self):
         """
         The username uses to authenticate connection to proxy.
         """
         return frombytes(self.proxy_options.username)
-    
+
     @property
     def password(self):
         """
         The password uses to authenticate connection to proxy.
         """
         return frombytes(self.proxy_options.password)
-    
+
     @staticmethod
     def from_uri(uri):
         """
@@ -119,12 +119,12 @@ cdef class S3ProxyOptions:
         * S3ProxyOptions.from_uri('http://username:password@localhost:8020')
         * S3ProxyOptions(scheme='http', host='localhost', port=8020, 
                          username='username', password='password')
-        
+
         Parameters
         ----------
         uri : str
             A string URI describing the connection to the proxy.
-        
+
         Returns
         -------
         S3ProxyOptions
@@ -132,7 +132,8 @@ cdef class S3ProxyOptions:
         cdef:
             S3ProxyOptions self = S3ProxyOptions.__new__(S3ProxyOptions)
 
-        self.proxy_options = GetResultValue(CS3ProxyOptions.FromUriString(tobytes(uri)))
+        self.proxy_options = GetResultValue(
+            CS3ProxyOptions.FromUriString(tobytes(uri)))
         return self
 
 
@@ -284,10 +285,13 @@ cdef class S3FileSystem(FileSystem):
                 options.proxy_options.scheme = tobytes(proxy_options.scheme)
                 options.proxy_options.host = tobytes(proxy_options.host)
                 options.proxy_options.port = proxy_options.port
-                options.proxy_options.username = tobytes(proxy_options.username)
-                options.proxy_options.password = tobytes(proxy_options.password)
+                options.proxy_options.username = tobytes(
+                    proxy_options.username)
+                options.proxy_options.password = tobytes(
+                    proxy_options.password)
             else:
-                raise TypeError(f"'proxy_options' expected to be of type 'dict' or 'S3ProxyOptions', got {type(proxy_options)} instead.")
+                raise TypeError(
+                    f"'proxy_options' expected to be of type 'dict' or 'S3ProxyOptions', got {type(proxy_options)} instead.")
 
         with nogil:
             wrapped = GetResultValue(CS3FileSystem.Make(options))

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -182,15 +182,9 @@ cdef class S3FileSystem(FileSystem):
 
         if proxy_options is not None:
             if isinstance(proxy_options, dict):
-                proxy_scheme = proxy_options.get("scheme", None)
-                if proxy_scheme:
-                    options.proxy_options.scheme = tobytes(proxy_scheme)
-                proxy_host = proxy_options.get("host", None)
-                if proxy_host:
-                    options.proxy_options.host = tobytes(proxy_host)
-                proxy_port = proxy_options.get("port", None)
-                if proxy_port:
-                    options.proxy_options.port = proxy_port
+                options.proxy_options.scheme = tobytes(proxy_options["scheme"])
+                options.proxy_options.host = tobytes(proxy_options["host"])
+                options.proxy_options.port = proxy_options["port"]
                 proxy_username = proxy_options.get("username", None)
                 if proxy_username:
                     options.proxy_options.username = tobytes(proxy_username)

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -241,7 +241,14 @@ cdef class S3FileSystem(FileSystem):
                 session_name=frombytes(opts.session_name),
                 external_id=frombytes(opts.external_id),
                 load_frequency=opts.load_frequency,
-                background_writes=opts.background_writes
+                background_writes=opts.background_writes,
+                proxy_options={'scheme': frombytes(opts.proxy_options.scheme),
+                               'host': frombytes(opts.proxy_options.host),
+                               'port': opts.proxy_options.port,
+                               'username': frombytes(
+                                   opts.proxy_options.username),
+                               'password': frombytes(
+                                   opts.proxy_options.password)}
             ),)
         )
 

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -117,7 +117,7 @@ cdef class S3ProxyOptions:
 
         The following two calls are equivalent
         * S3ProxyOptions.from_uri('http://username:password@localhost:8020')
-        * S3ProxyOptions(scheme='http', host='localhost', port=8020, 
+        * S3ProxyOptions(scheme='http', host='localhost', port=8020,
                          username='username', password='password')
 
         Parameters
@@ -188,8 +188,9 @@ cdef class S3FileSystem(FileSystem):
         blocking.
     proxy_options: dict or pyarrow._s3fs.S3ProxyOptions, default None
         If a proxy is used, provide the options here. Supported options are:
-        'scheme' (str: 'http' or 'https'; required), 'host' (str; required), 
-        'port' (int; required), 'username' (str; optional), 'password' (str; optional).
+        'scheme' (str: 'http' or 'https'; required), 'host' (str; required),
+        'port' (int; required), 'username' (str; optional),
+        'password' (str; optional).
     """
 
     cdef:
@@ -291,7 +292,8 @@ cdef class S3FileSystem(FileSystem):
                     proxy_options.password)
             else:
                 raise TypeError(
-                    f"'proxy_options' expected to be of type 'dict' or 'S3ProxyOptions', got {type(proxy_options)} instead.")
+                    "'proxy_options': expected 'dict' or 'S3ProxyOptions', "
+                    f"got {type(proxy_options)} instead.")
 
         with nogil:
             wrapped = GetResultValue(CS3FileSystem.Make(options))

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -102,7 +102,7 @@ cdef class S3FileSystem(FileSystem):
         A proxy URI (str) can also be provided, in which case these options
         will be derived from the provided URI.
         The following are equivalent::
-        
+
             S3FileSystem(proxy_options='http://username:password@localhost:8020')
             S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
                                         'port': 8020, 'username': 'username',

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -101,11 +101,12 @@ cdef class S3FileSystem(FileSystem):
         'password' (str; optional).
         A proxy URI (str) can also be provided, in which case these options
         will be derived from the provided URI.
-        The following are equivalent:
-        * S3FileSystem(proxy_options='http://username:password@localhost:8020')
-        * S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
-                                      'port': 8020, 'username': 'username',
-                                      'password': 'password'})
+        The following are equivalent::
+        
+            S3FileSystem(proxy_options='http://username:password@localhost:8020')
+            S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
+                                        'port': 8020, 'username': 'username',
+                                        'password': 'password'})
     """
 
     cdef:

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -233,7 +233,7 @@ cdef class S3FileSystem(FileSystem):
         if proxy_options is not None:
             proxy_scheme = proxy_options.get("scheme", None)
             if proxy_scheme:
-                options.proxy_options.schema = tobytes(proxy_scheme)
+                options.proxy_options.scheme = tobytes(proxy_scheme)
             proxy_host = proxy_options.get("host", None)
             if proxy_host:
                 options.proxy_options.host = tobytes(proxy_host)

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -45,7 +45,7 @@ except ImportError:
 
 try:
     from pyarrow._s3fs import (  # noqa
-        S3FileSystem, S3LogLevel, initialize_s3, finalize_s3,)
+        S3FileSystem, S3LogLevel, initialize_s3, finalize_s3)
 except ImportError:
     _not_imported.append("S3FileSystem")
 else:

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -64,7 +64,8 @@ def __getattr__(name):
             "'{0}'".format(name)
         )
 
-    raise AttributeError("module 'pyarrow.fs' has no attribute '{0}'".format(name))
+    raise AttributeError(
+        "module 'pyarrow.fs' has no attribute '{0}'".format(name))
 
 
 def _filesystem_from_str(uri):
@@ -121,7 +122,8 @@ def _ensure_filesystem(filesystem, use_mmap=False, allow_legacy_filesystem=False
 
     raise TypeError(
         "Unrecognized filesystem: {}. `filesystem` argument must be a "
-        "FileSystem instance or a valid file system URI'".format(type(filesystem))
+        "FileSystem instance or a valid file system URI'".format(
+            type(filesystem))
     )
 
 

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -45,7 +45,12 @@ except ImportError:
 
 try:
     from pyarrow._s3fs import (  # noqa
-        S3FileSystem, S3LogLevel, initialize_s3, finalize_s3)
+        S3FileSystem,
+        S3LogLevel,
+        initialize_s3,
+        finalize_s3,
+        S3ProxyOptions,
+    )
 except ImportError:
     _not_imported.append("S3FileSystem")
 else:
@@ -59,9 +64,7 @@ def __getattr__(name):
             "'{0}'".format(name)
         )
 
-    raise AttributeError(
-        "module 'pyarrow.fs' has no attribute '{0}'".format(name)
-    )
+    raise AttributeError("module 'pyarrow.fs' has no attribute '{0}'".format(name))
 
 
 def _filesystem_from_str(uri):
@@ -84,9 +87,7 @@ def _filesystem_from_str(uri):
     return filesystem
 
 
-def _ensure_filesystem(
-    filesystem, use_mmap=False, allow_legacy_filesystem=False
-):
+def _ensure_filesystem(filesystem, use_mmap=False, allow_legacy_filesystem=False):
     if isinstance(filesystem, FileSystem):
         return filesystem
     elif isinstance(filesystem, str):
@@ -104,7 +105,7 @@ def _ensure_filesystem(
         pass
     else:
         if isinstance(filesystem, fsspec.AbstractFileSystem):
-            if type(filesystem).__name__ == 'LocalFileSystem':
+            if type(filesystem).__name__ == "LocalFileSystem":
                 # In case its a simple LocalFileSystem, use native arrow one
                 return LocalFileSystem(use_mmap=use_mmap)
             return PyFileSystem(FSSpecHandler(filesystem))
@@ -120,14 +121,11 @@ def _ensure_filesystem(
 
     raise TypeError(
         "Unrecognized filesystem: {}. `filesystem` argument must be a "
-        "FileSystem instance or a valid file system URI'".format(
-            type(filesystem))
+        "FileSystem instance or a valid file system URI'".format(type(filesystem))
     )
 
 
-def _resolve_filesystem_and_path(
-    path, filesystem=None, allow_legacy_filesystem=False
-):
+def _resolve_filesystem_and_path(path, filesystem=None, allow_legacy_filesystem=False):
     """
     Return filesystem/path from path which could be an URI or a plain
     filesystem path.
@@ -165,7 +163,7 @@ def _resolve_filesystem_and_path(
         file_info = None
         exists_locally = False
     else:
-        exists_locally = (file_info.type != FileType.NotFound)
+        exists_locally = file_info.type != FileType.NotFound
 
     # if the file or directory doesn't exists locally, then assume that
     # the path is an URI describing the file system as well
@@ -277,8 +275,7 @@ class FSSpecHandler(FileSystemHandler):
 
     def delete_dir_contents(self, path):
         if path.strip("/") == "":
-            raise ValueError(
-                "delete_dir_contents called on path '", path, "'")
+            raise ValueError("delete_dir_contents called on path '", path, "'")
         self._delete_dir_contents(path)
 
     def delete_root_dir_contents(self):

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -65,7 +65,8 @@ def __getattr__(name):
         )
 
     raise AttributeError(
-        "module 'pyarrow.fs' has no attribute '{0}'".format(name))
+        "module 'pyarrow.fs' has no attribute '{0}'".format(name)
+    )
 
 
 def _filesystem_from_str(uri):
@@ -88,7 +89,9 @@ def _filesystem_from_str(uri):
     return filesystem
 
 
-def _ensure_filesystem(filesystem, use_mmap=False, allow_legacy_filesystem=False):
+def _ensure_filesystem(
+    filesystem, use_mmap=False, allow_legacy_filesystem=False
+):
     if isinstance(filesystem, FileSystem):
         return filesystem
     elif isinstance(filesystem, str):
@@ -106,7 +109,7 @@ def _ensure_filesystem(filesystem, use_mmap=False, allow_legacy_filesystem=False
         pass
     else:
         if isinstance(filesystem, fsspec.AbstractFileSystem):
-            if type(filesystem).__name__ == "LocalFileSystem":
+            if type(filesystem).__name__ == 'LocalFileSystem':
                 # In case its a simple LocalFileSystem, use native arrow one
                 return LocalFileSystem(use_mmap=use_mmap)
             return PyFileSystem(FSSpecHandler(filesystem))
@@ -127,7 +130,9 @@ def _ensure_filesystem(filesystem, use_mmap=False, allow_legacy_filesystem=False
     )
 
 
-def _resolve_filesystem_and_path(path, filesystem=None, allow_legacy_filesystem=False):
+def _resolve_filesystem_and_path(
+    path, filesystem=None, allow_legacy_filesystem=False
+):
     """
     Return filesystem/path from path which could be an URI or a plain
     filesystem path.
@@ -165,7 +170,7 @@ def _resolve_filesystem_and_path(path, filesystem=None, allow_legacy_filesystem=
         file_info = None
         exists_locally = False
     else:
-        exists_locally = file_info.type != FileType.NotFound
+        exists_locally = (file_info.type != FileType.NotFound)
 
     # if the file or directory doesn't exists locally, then assume that
     # the path is an URI describing the file system as well
@@ -277,7 +282,8 @@ class FSSpecHandler(FileSystemHandler):
 
     def delete_dir_contents(self, path):
         if path.strip("/") == "":
-            raise ValueError("delete_dir_contents called on path '", path, "'")
+            raise ValueError(
+                "delete_dir_contents called on path '", path, "'")
         self._delete_dir_contents(path)
 
     def delete_root_dir_contents(self):

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -45,12 +45,7 @@ except ImportError:
 
 try:
     from pyarrow._s3fs import (  # noqa
-        S3FileSystem,
-        S3LogLevel,
-        initialize_s3,
-        finalize_s3,
-        S3ProxyOptions,
-    )
+        S3FileSystem, S3LogLevel, initialize_s3, finalize_s3,)
 except ImportError:
     _not_imported.append("S3FileSystem")
 else:

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -125,6 +125,17 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
     cdef struct CS3GlobalOptions "arrow::fs::S3GlobalOptions":
         CS3LogLevel log_level
 
+    cdef cppclass CS3ProxyOptions "arrow::fs::S3ProxyOptions":
+        c_string scheme
+        c_string host
+        int port
+        c_string username
+        c_string password
+
+        @staticmethod
+        CResult[CS3ProxyOptions] FromUriString "FromUri"(
+            const c_string& uri_string)
+
     cdef cppclass CS3Options "arrow::fs::S3Options":
         c_string region
         c_string endpoint_override
@@ -134,6 +145,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string session_name
         c_string external_id
         int load_frequency
+        CS3ProxyOptions proxy_options
         void ConfigureDefaultCredentials()
         void ConfigureAccessKey(const c_string& access_key,
                                 const c_string& secret_key,

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -131,6 +131,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         int port
         c_string username
         c_string password
+        c_bool Equals(const CS3ProxyOptions& other)
 
         @staticmethod
         CResult[CS3ProxyOptions] FromUriString "FromUri"(

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1061,7 +1061,7 @@ def test_s3_proxy_options(monkeypatch):
     proxy_opts_1_str = 'http://localhost:8999'
     # The following two are equivalent:
     proxy_opts_2_dict = {'scheme': 'https', 'host': 'localhost', 'port': 8080}
-    proxy_opts_2_str = 'http://localhost:8080'
+    proxy_opts_2_str = 'https://localhost:8080'
 
     # Check dict case for 'proxy_options'
     fs = S3FileSystem(proxy_options=proxy_opts_1_dict)
@@ -1088,9 +1088,21 @@ def test_s3_proxy_options(monkeypatch):
     assert pickle.loads(pickle.dumps(fs1)) == fs2
     assert pickle.loads(pickle.dumps(fs2)) == fs1
 
+    fs1 = S3FileSystem(proxy_options=proxy_opts_2_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_dict)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
     # Check that two FSs using the same proxy_options str are equal
     fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
     fs2 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_2_str)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_str)
     assert fs1 == fs2
     assert pickle.loads(pickle.dumps(fs1)) == fs2
     assert pickle.loads(pickle.dumps(fs2)) == fs1
@@ -1099,6 +1111,12 @@ def test_s3_proxy_options(monkeypatch):
     # (one dict, one str) are equal
     fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
     fs2 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_2_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_str)
     assert fs1 == fs2
     assert pickle.loads(pickle.dumps(fs1)) == fs2
     assert pickle.loads(pickle.dumps(fs2)) == fs1
@@ -1112,6 +1130,12 @@ def test_s3_proxy_options(monkeypatch):
 
     fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
     fs2 = S3FileSystem(proxy_options=proxy_opts_2_str)
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_dict)
     assert fs1 != fs2
     assert pickle.loads(pickle.dumps(fs1)) != fs2
     assert pickle.loads(pickle.dumps(fs2)) != fs1
@@ -1131,6 +1155,18 @@ def test_s3_proxy_options(monkeypatch):
     assert pickle.loads(pickle.dumps(fs2)) != fs1
 
     fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    fs2 = S3FileSystem()
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_2_dict)
+    fs2 = S3FileSystem()
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_2_str)
     fs2 = S3FileSystem()
     assert fs1 != fs2
     assert pickle.loads(pickle.dumps(fs1)) != fs2

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1060,15 +1060,20 @@ def test_s3_proxy_options(monkeypatch):
     monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
 
     # Check dict case for 'proxy_options'
-    fs = S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
-                                     'port': 8999})
-    assert isinstance(fs, S3FileSystem)
-    assert pickle.loads(pickle.dumps(fs)) == fs
+    fs1 = S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
+                                      'port': 8999})
+    assert isinstance(fs1, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs1)) == fs1
 
     # Check str case for 'proxy_options'
-    fs = S3FileSystem(proxy_options='http://localhost:8999')
-    assert isinstance(fs, S3FileSystem)
-    assert pickle.loads(pickle.dumps(fs)) == fs
+    fs2 = S3FileSystem(proxy_options='http://localhost:9000')
+    assert isinstance(fs2, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs2)) == fs2
+
+    # Check that filesystems with different proxy_options are not equal
+    assert fs1 != fs2
+    # Check that filesystems with and without proxy_options are not equal
+    assert fs1 != S3FileSystem()
 
     # Only dict and str are supported
     with pytest.raises(TypeError):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1060,11 +1060,15 @@ def test_s3_proxy_options(monkeypatch):
     proxy_opts_1_dict = {'scheme': 'http', 'host': 'localhost', 'port': 8999}
     proxy_opts_1_str = 'http://localhost:8999'
     # The following two are equivalent:
-    proxy_opts_2_dict = {'scheme': 'http', 'host': 'localhost', 'port': 8080}
+    proxy_opts_2_dict = {'scheme': 'https', 'host': 'localhost', 'port': 8080}
     proxy_opts_2_str = 'http://localhost:8080'
 
     # Check dict case for 'proxy_options'
     fs = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
+    fs = S3FileSystem(proxy_options=proxy_opts_2_dict)
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
@@ -1073,27 +1077,64 @@ def test_s3_proxy_options(monkeypatch):
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
+    fs = S3FileSystem(proxy_options=proxy_opts_2_str)
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
     # Check that two FSs using the same proxy_options dict are equal
-    assert S3FileSystem(proxy_options=proxy_opts_1_dict) == S3FileSystem(
-        proxy_options=proxy_opts_1_dict)
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
     # Check that two FSs using the same proxy_options str are equal
-    assert S3FileSystem(proxy_options=proxy_opts_1_str) == S3FileSystem(
-        proxy_options=proxy_opts_1_str)
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
     # Check that two FSs using equivalent proxy_options
     # (one dict, one str) are equal
-    assert S3FileSystem(proxy_options=proxy_opts_1_dict) == S3FileSystem(
-        proxy_options=proxy_opts_1_str)
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    assert fs1 == fs2
+    assert pickle.loads(pickle.dumps(fs1)) == fs2
+    assert pickle.loads(pickle.dumps(fs2)) == fs1
+
     # Check that two FSs using nonequivalent proxy_options are not equal
-    assert S3FileSystem(proxy_options=proxy_opts_1_dict) != S3FileSystem(
-        proxy_options=proxy_opts_2_dict)
-    assert S3FileSystem(proxy_options=proxy_opts_1_dict) != S3FileSystem(
-        proxy_options=proxy_opts_2_str)
-    assert S3FileSystem(proxy_options=proxy_opts_1_str) != S3FileSystem(
-        proxy_options=proxy_opts_2_str)
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_dict)
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_str)
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    fs2 = S3FileSystem(proxy_options=proxy_opts_2_str)
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
     # Check that two FSs (one using proxy_options and the other not)
     # are not equal
-    assert S3FileSystem(proxy_options=proxy_opts_1_dict) != S3FileSystem()
-    assert S3FileSystem(proxy_options=proxy_opts_1_str) != S3FileSystem()
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_dict)
+    fs2 = S3FileSystem()
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
+
+    fs1 = S3FileSystem(proxy_options=proxy_opts_1_str)
+    fs2 = S3FileSystem()
+    assert fs1 != fs2
+    assert pickle.loads(pickle.dumps(fs1)) != fs2
+    assert pickle.loads(pickle.dumps(fs2)) != fs1
 
     # Only dict and str are supported
     with pytest.raises(TypeError):
@@ -1103,7 +1144,7 @@ def test_s3_proxy_options(monkeypatch):
         S3FileSystem(proxy_options={'host': 'localhost', 'port': 9090})
     # Missing host
     with pytest.raises(KeyError):
-        S3FileSystem(proxy_options={'scheme': 'http', 'port': 9090})
+        S3FileSystem(proxy_options={'scheme': 'https', 'port': 9090})
     # Missing port
     with pytest.raises(KeyError):
         S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost'})


### PR DESCRIPTION
As discussed in the comments on the JIRA issue, I've added a simple struct called `S3ProxyOptions` which holds the fields for proxy-related information to pass to the AWS SDK when building the S3 client.
I added a simple `FromUri` helper function since these options can be derived from environment variables like `http_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, etc. I didn't automatically honor these environment variables, but that is something we could do in a follow-up PR (or leave it for the users to do).
Also added the options to the pyarrow interface for the file-system.

I tested the proxy functionality by setting up a simple proxy on my local machine and checking the logs to ensure that the traffic from the file-system was flowing through it.