### PR TITLE
ARROW-12343: [Rust] Support auto-vectorization for min/max

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -51,6 +51,7 @@ flatbuffers = "^0.8"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"
+multiversion = "0.6.1"
 
 [features]
 default = []

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -104,7 +104,6 @@ pub fn min_string<T: StringOffsetSizeTrait>(
 }
 
 /// Helper function to perform min/max lambda function on values from a numeric array.
-
 #[multiversion]
 #[clone(target = "x86_64+avx")]
 fn min_max_helper<T, F>(array: &PrimitiveArray<T>, cmp: F) -> Option<T::Native>

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -106,8 +106,8 @@ pub fn min_string<T: StringOffsetSizeTrait>(
 /// Helper function to perform min/max lambda function on values from a numeric array.
 
 #[multiversion]
-#[clone(target = "[x86|x86_64]+avx")]
-#[clone(target = "[x86|x86_64]+avx2")]
+#[clone(target = "x86_64+avx")]
+#[clone(target = "x86_64+avx+avx2")]
 fn min_max_helper<T, F>(array: &PrimitiveArray<T>, cmp: F) -> Option<T::Native>
 where
     T: ArrowNumericType,

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -107,7 +107,6 @@ pub fn min_string<T: StringOffsetSizeTrait>(
 
 #[multiversion]
 #[clone(target = "x86_64+avx")]
-#[clone(target = "x86_64+avx+avx2")]
 fn min_max_helper<T, F>(array: &PrimitiveArray<T>, cmp: F) -> Option<T::Native>
 where
     T: ArrowNumericType,

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -17,6 +17,7 @@
 
 //! Defines aggregations over Arrow arrays.
 
+use multiversion::multiversion;
 use std::ops::Add;
 
 use crate::array::{
@@ -103,6 +104,10 @@ pub fn min_string<T: StringOffsetSizeTrait>(
 }
 
 /// Helper function to perform min/max lambda function on values from a numeric array.
+
+#[multiversion]
+#[clone(target = "[x86|x86_64]+avx")]
+#[clone(target = "[x86|x86_64]+avx2")]
 fn min_max_helper<T, F>(array: &PrimitiveArray<T>, cmp: F) -> Option<T::Native>
 where
     T: ArrowNumericType,


### PR DESCRIPTION
This is a PoC to get some more SIMD instructions in Arrow without requiring the nightly compiler or producing not-portable binaries, inspired by this article shared by @jorgecarleitao :
https://www.nickwilcox.com/blog/autovec2/

This allows dispatching on CPU features, letting the compiler auto-vectorize the code without losing portability or introducing unsafe blocks. Here we use the multiversion crate to easily add more compiled versions with different cpu features.

On my machine:
```
min 512                 time:   [957.16 ns 958.57 ns 960.23 ns]                     
                        change: [-24.964% -24.524% -24.093%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

max 512                 time:   [947.74 ns 949.47 ns 952.04 ns]                     
                        change: [-23.380% -22.955% -22.562%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```