### PR TITLE
ARROW-12351: [CI][Ruby] Use ruby/setup-ruby instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: '3.6'
       - name: Install Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
       - name: Install Dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -223,7 +223,7 @@ jobs:
         shell: bash
         run: ci/scripts/util_checkout.sh
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Upgrade MSYS2

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -28,7 +28,7 @@ jobs:
       {{ macros.github_login_dockerhub()|indent }}
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
       - name: Free Up Disk Space
         shell: bash
         run: arrow/ci/scripts/util_cleanup.sh

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
       - name: Free Up Disk Space
         shell: bash
         run: arrow/ci/scripts/util_cleanup.sh


### PR DESCRIPTION
Because actions/setup-ruby is deprecated:

    Please note: This action is deprecated and should no longer be
    used. The team at GitHub has ceased making and accepting code
    contributions or maintaining issues tracker. Please, migrate your
    workflows to the ruby/setup-ruby, which is being actively
    maintained by the official Ruby organization.

https://github.com/actions/setup-ruby#setup-ruby