### PR TITLE
ARROW-12232: [Rust][DataFusion] Add SQL support for CAST(.. AS Time) millisecond

### DIFF
--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -1498,6 +1498,7 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
         SQLDataType::Double => Ok(DataType::Float64),
         SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
         SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        SQLDataType::Time => Ok(DataType::Timestamp(TimeUnit::Millisecond, None)),
         SQLDataType::Date => Ok(DataType::Date32),
         other => Err(DataFusionError::NotImplemented(format!(
             "Unsupported SQL type {:?}",

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -758,6 +758,30 @@ async fn csv_query_cast() -> Result<()> {
 }
 
 #[tokio::test]
+async fn query_cast_time() {
+    let mut ctx = ExecutionContext::new();
+    register_alltypes_parquet(&mut ctx);
+    let sql = "SELECT CAST(timestamp_col AS Time) FROM alltypes_plain LIMIT 3";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["2009-03-01 00:00:00"],
+        vec!["2009-03-01 00:01:00"],
+        vec!["2009-04-01 00:00:00"],
+    ];
+    assert_eq!(expected, actual);
+
+    // Now, check that the int64 values are also OK
+    let sql = "SELECT CAST(CAST(timestamp_col AS Time) AS BIGINT) FROM alltypes_plain LIMIT 3";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["1235865600000"],
+        vec!["1235865660000"],
+        vec!["1238544000000"],
+    ];
+    assert_eq!(expected, actual);
+}
+
+#[tokio::test]
 async fn csv_query_cast_literal() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx)?;


### PR DESCRIPTION
According to DataFusion README, the `TIME` SQL type is supported, corresponding to Timestamp millis.  However, trying to CAST a column AS TIME results in "Unsupported" error.  This quick and small PR adds support for this CAST, and adds a test as well.