### PR TITLE
ARROW-12357: [Archery] Bump Jinja2 version requirement

### DIFF
--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -24,11 +24,14 @@ from setuptools import setup
 if sys.version_info < (3, 6):
     sys.exit('Python < 3.6 is not supported')
 
+# For pathlib.Path compatibility
+jinja_req = 'jinja2>=2.11'
+
 extras = {
     'benchmark': ['pandas'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
-    'release': ['jinja2', 'jira', 'semver', 'gitpython'],
-    'crossbow': ['github3.py', 'jinja2', 'pygit2', 'ruamel.yaml',
+    'release': [jinja_req, 'jira', 'semver', 'gitpython'],
+    'crossbow': ['github3.py', jinja_req, 'pygit2', 'ruamel.yaml',
                  'setuptools_scm'],
 }
 extras['bot'] = extras['crossbow'] + ['pygithub', 'jira']


### PR DESCRIPTION
Jinja2 < 2.11 doesn't support passing Path objects for filesystem paths.