### PR TITLE
ARROW-12390: [Rust] Inline from_trusted_len_iter, try_from_trusted_len_iter, extend_from_slice

### DIFF
--- a/rust/arrow/src/buffer/immutable.rs
+++ b/rust/arrow/src/buffer/immutable.rs
@@ -275,6 +275,7 @@ impl Buffer {
     // 1. there is no trait `TrustedLen` in stable rust and therefore
     //    we can't specialize `extend` for `TrustedLen` like `Vec` does.
     // 2. `from_trusted_len_iter` is faster.
+    #[inline]
     pub unsafe fn from_trusted_len_iter<T: ArrowNativeType, I: Iterator<Item = T>>(
         iterator: I,
     ) -> Self {

--- a/rust/arrow/src/buffer/immutable.rs
+++ b/rust/arrow/src/buffer/immutable.rs
@@ -288,6 +288,7 @@ impl Buffer {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    #[inline]
     pub unsafe fn try_from_trusted_len_iter<
         E,
         T: ArrowNativeType,

--- a/rust/arrow/src/buffer/mutable.rs
+++ b/rust/arrow/src/buffer/mutable.rs
@@ -433,6 +433,7 @@ impl MutableBuffer {
     // 1. there is no trait `TrustedLen` in stable rust and therefore
     //    we can't specialize `extend` for `TrustedLen` like `Vec` does.
     // 2. `from_trusted_len_iter_bool` is faster.
+    #[inline]
     pub unsafe fn from_trusted_len_iter_bool<I: Iterator<Item = bool>>(
         mut iterator: I,
     ) -> Self {
@@ -477,6 +478,7 @@ impl MutableBuffer {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    #[inline]
     pub unsafe fn try_from_trusted_len_iter<
         E,
         T: ArrowNativeType,

--- a/rust/arrow/src/buffer/mutable.rs
+++ b/rust/arrow/src/buffer/mutable.rs
@@ -263,6 +263,7 @@ impl MutableBuffer {
     /// buffer.extend_from_slice(&[2u32, 0]);
     /// assert_eq!(buffer.len(), 8) // u32 has 4 bytes
     /// ```
+    #[inline]
     pub fn extend_from_slice<T: ToByteSlice>(&mut self, items: &[T]) {
         let len = items.len();
         let additional = len * std::mem::size_of::<T>();

--- a/rust/arrow/src/buffer/mutable.rs
+++ b/rust/arrow/src/buffer/mutable.rs
@@ -391,6 +391,7 @@ impl MutableBuffer {
     // 1. there is no trait `TrustedLen` in stable rust and therefore
     //    we can't specialize `extend` for `TrustedLen` like `Vec` does.
     // 2. `from_trusted_len_iter` is faster.
+    #[inline]
     pub unsafe fn from_trusted_len_iter<T: ArrowNativeType, I: Iterator<Item = T>>(
         iterator: I,
     ) -> Self {


### PR DESCRIPTION
This helps with further optimizing performance on quite some kernels:

```
length                  time:   [721.26 ns 725.59 ns 731.42 ns]                    
                        change: [-69.510% -69.125% -68.566%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
take i32 512            time:   [376.15 ns 378.51 ns 381.09 ns]                         
                        change: [-18.681% -18.212% -17.542%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

take i32 1024           time:   [640.71 ns 641.87 ns 643.19 ns]                           
                        change: [-28.880% -28.695% -28.516%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

take i32 nulls 512      time:   [634.80 ns 635.63 ns 636.56 ns]                                
                        change: [-24.797% -23.403% -22.272%] (p = 0.00 < 0.05)
                        Performance has improved.

take i32 nulls 1024     time:   [1.0084 us 1.0093 us 1.0103 us]                                 
                        change: [-44.482% -42.312% -40.209%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

take bool 512           time:   [1.4068 us 1.4188 us 1.4315 us]                           
                        change: [-49.139% -48.684% -48.208%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

take bool 1024          time:   [2.6662 us 2.6807 us 2.6973 us]                            
                        change: [-55.452% -55.133% -54.803%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

take bool nulls 512     time:   [1.3331 us 1.3452 us 1.3617 us]                                 
                        change: [-31.198% -30.327% -29.414%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

take bool nulls 1024    time:   [2.4789 us 2.4968 us 2.5229 us]                                  
                        change: [-40.358% -39.969% -39.558%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

```

FYI @jorgecarleitao 
