### PR TITLE
ARROW-12394: [Release] Upload binaries to S3 instead of Bintray temporary

### DIFF
--- a/dev/release/binary-common.sh
+++ b/dev/release/binary-common.sh
@@ -61,6 +61,7 @@ docker_run() {
     --publish-all \
     --rm \
     --volume "$PWD":/host \
+    --volume "$HOME/.aws":/home/arrow/.aws \
     ${docker_image_name} \
     bash -c "
 if [ \$(id -u) -ne ${docker_uid} ]; then

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -518,7 +518,7 @@ class BinaryTask
 
     def download
       sh("aws", "s3", "sync",
-         "s3://apache-arrow/#{package}/#{full_version}",
+         "s3://apache-arrow/binaries/#{package}/#{full_version}",
          @destination)
     end
 
@@ -584,7 +584,7 @@ class BinaryTask
     end
 
     def download_file(path, output_path)
-      source = "s3://apache-arrow/#{path}"
+      source = "s3://apache-arrow/binaries/#{path}"
       sh("aws", "s3", "cp", source, output_path, verbose: false)
     end
 
@@ -685,7 +685,7 @@ class BinaryTask
     def upload
       sh("aws", "s3", "sync",
          @source,
-         "s3://apache-arrow/#{package}/#{full_version}/")
+         "s3://apache-arrow/binaries/#{package}/#{full_version}/")
     end
 
     def upload_bintray

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -27,6 +27,7 @@ RUN \
   apt install -y -V ${quiet} \
     apt-utils \
     createrepo \
+    curl \
     devscripts \
     gpg \
     locales \
@@ -34,9 +35,15 @@ RUN \
     rake \
     rpm \
     ruby \
-    sudo && \
+    sudo \
+    unzip && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install
 
 RUN locale-gen en_US.UTF-8
 


### PR DESCRIPTION
We should upload to Artifactory but it's not ready yet.

We'll use S3 as a temporary upload location only for 4.0.0. We'll
rewrite this change once Artifactory is ready.