### PR TITLE
ARROW-12250: [Rust] [Parquet] Fix failing arrow_writer test

### DIFF
--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -1237,7 +1237,7 @@ mod tests {
         builder.append_value(b"1112").unwrap();
         let array = Arc::new(builder.finish());
 
-        one_column_roundtrip("timestamp_millisecond_single_column", array, true);
+        one_column_roundtrip("fixed_size_binary_single_column", array, true);
     }
 
     #[test]


### PR DESCRIPTION
A copy-paste mistake when creating the FSB test.
The sporadic failure happens if two tests try to write to the same file.