### PR TITLE
ARROW-11472: [Python][CI] Remove temporary pin of numpy in kartothek integration build

### DIFF
--- a/ci/docker/conda-python-kartothek.dockerfile
+++ b/ci/docker/conda-python-kartothek.dockerfile
@@ -38,9 +38,7 @@ RUN conda install -c conda-forge -q \
         storefact \
         toolz \
         urlquote \
-        zstandard \
-        # temporary pin for numpy (see https://issues.apache.org/jira/browse/ARROW-11472)
-        numpy=1.19 && \
+        zstandard && \
     conda clean --all
 
 ARG kartothek=latest


### PR DESCRIPTION
Follow-up on https://github.com/apache/arrow/pull/9396