### PR TITLE
ARROW-12396: [Python][Docs] Clarify serialization/filesystem docstrings about deprecated status

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -28,13 +28,13 @@ import pyarrow.lib as lib
 
 class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
     """
-    FileSystem interface for HDFS cluster.
+    DEPRECATED: FileSystem interface for HDFS cluster.
 
     See pyarrow.hdfs.connect for full connection details
 
     .. deprecated:: 2.0
-        `pyarrow.hdfs.HadoopFileSystem` is deprecated,
-        please use `pyarrow.fs.HadoopFileSystem instead.
+        ``pyarrow.hdfs.HadoopFileSystem`` is deprecated,
+        please use ``pyarrow.fs.HadoopFileSystem`` instead.
     """
 
     def __init__(self, host="default", port=0, user=None, kerb_ticket=None,
@@ -198,8 +198,8 @@ def connect(host="default", port=0, user=None, kerb_ticket=None,
     be required.
 
     .. deprecated:: 2.0
-        `pyarrow.hdfs.connect` is deprecated,
-        please use `pyarrow.fs.HadoopFileSystem instead.
+        ``pyarrow.hdfs.connect`` is deprecated,
+        please use ``pyarrow.fs.HadoopFileSystem`` instead.
 
     Parameters
     ----------

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -31,6 +31,10 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
     FileSystem interface for HDFS cluster.
 
     See pyarrow.hdfs.connect for full connection details
+
+    .. deprecated:: 2.0
+        `pyarrow.hdfs.HadoopFileSystem` is deprecated,
+        please use `pyarrow.fs.HadoopFileSystem instead.
     """
 
     def __init__(self, host="default", port=0, user=None, kerb_ticket=None,
@@ -184,12 +188,18 @@ def _libhdfs_walk_files_dirs(top_path, contents):
 def connect(host="default", port=0, user=None, kerb_ticket=None,
             extra_conf=None):
     """
-    Connect to an HDFS cluster. All parameters are optional and should
-    only be set if the defaults need to be overridden.
+    DEPRECATED: Connect to an HDFS cluster.
+
+    All parameters are optional and should only be set if the defaults need
+    to be overridden.
 
     Authentication should be automatic if the HDFS cluster uses Kerberos.
     However, if a username is specified, then the ticket cache will likely
     be required.
+
+    .. deprecated:: 2.0
+        `pyarrow.hdfs.connect` is deprecated,
+        please use `pyarrow.fs.HadoopFileSystem instead.
 
     Parameters
     ----------

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -498,7 +498,8 @@ def deserialize_from(source, object base, SerializationContext context=None):
 
 def deserialize_components(components, SerializationContext context=None):
     """
-    Reconstruct Python object from output of SerializedPyObject.to_components.
+    DEPRECATED: Reconstruct Python object from output of
+    SerializedPyObject.to_components.
 
     .. deprecated:: 2.0
         The custom serialization functionality is deprecated in pyarrow 2.0,

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -355,10 +355,14 @@ cdef class SerializedPyObject(_Weakrefable):
 
 def serialize(object value, SerializationContext context=None):
     """
-    EXPERIMENTAL: Serialize a general Python sequence for transient storage
+    DEPRECATED: Serialize a general Python sequence for transient storage
     and transport.
 
-    This may have better performance and memory efficiency than Python pickle.
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
 
     Notes
     -----
@@ -398,7 +402,13 @@ def _serialize(object value, SerializationContext context=None):
 
 def serialize_to(object value, sink, SerializationContext context=None):
     """
-    EXPERIMENTAL: Serialize a Python sequence to a file.
+    DEPRECATED: Serialize a Python sequence to a file.
+
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
 
     Parameters
     ----------
@@ -417,7 +427,13 @@ def serialize_to(object value, sink, SerializationContext context=None):
 
 def read_serialized(source, base=None):
     """
-    EXPERIMENTAL: Read serialized Python sequence from file-like object.
+    DEPRECATED: Read serialized Python sequence from file-like object.
+
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
 
     Parameters
     ----------
@@ -449,7 +465,13 @@ def _read_serialized(source, base=None):
 
 def deserialize_from(source, object base, SerializationContext context=None):
     """
-    EXPERIMENTAL: Deserialize a Python sequence from a file.
+    DEPRECATED: Deserialize a Python sequence from a file.
+
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
 
     This only can interact with data produced by pyarrow.serialize or
     pyarrow.serialize_to.
@@ -478,6 +500,12 @@ def deserialize_components(components, SerializationContext context=None):
     """
     Reconstruct Python object from output of SerializedPyObject.to_components.
 
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
+
     Parameters
     ----------
     components : dict
@@ -495,8 +523,14 @@ def deserialize_components(components, SerializationContext context=None):
 
 def deserialize(obj, SerializationContext context=None):
     """
-    EXPERIMENTAL: Deserialize Python object from Buffer or other Python
+    DEPRECATED: Deserialize Python object from Buffer or other Python
     object supporting the buffer protocol.
+
+    .. deprecated:: 2.0
+        The custom serialization functionality is deprecated in pyarrow 2.0,
+        and will be removed in a future version. Use the standard library
+        ``pickle`` or the IPC functionality of pyarrow (see :ref:`ipc` for
+        more).
 
     This only can interact with data produced by pyarrow.serialize or
     pyarrow.serialize_to.


### PR DESCRIPTION
Currently the docstring itself says nothing about it, there is only the warning when calling the function.
