### PR TITLE
ARROW-9731: [C++][Python][R][Dataset] Implement Scanner::Head

### DIFF
--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -289,6 +289,8 @@ class ARROW_DS_EXPORT Scanner {
   ///
   /// Will only consume as many batches as needed from ScanBatches().
   virtual Result<std::shared_ptr<Table>> TakeRows(const Array& indices);
+  /// \brief Get the first N rows.
+  virtual Result<std::shared_ptr<Table>> Head(int64_t num_rows);
 
   /// \brief Get the options for this scan.
   const std::shared_ptr<ScanOptions>& options() const { return scan_options_; }

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -457,6 +457,17 @@ cdef class Dataset(_Weakrefable):
         """
         return self._scanner(**kwargs).to_table()
 
+    def head(self, int num_rows, **kwargs):
+        """Load the first N rows of the table.
+
+        See scan method parameters documentation.
+
+        Returns
+        -------
+        table : Table instance
+        """
+        return self._scanner(**kwargs).head(num_rows)
+
     @property
     def schema(self):
         """The common schema of the full Dataset"""
@@ -988,6 +999,17 @@ cdef class Fragment(_Weakrefable):
         table : Table
         """
         return self._scanner(schema=schema, **kwargs).to_table()
+
+    def head(self, int num_rows, **kwargs):
+        """Load the first N rows of the table.
+
+        See scan method parameters documentation.
+
+        Returns
+        -------
+        table : Table instance
+        """
+        return self._scanner(**kwargs).head(num_rows)
 
 
 cdef class FileFragment(Fragment):
@@ -2881,6 +2903,18 @@ cdef class Scanner(_Weakrefable):
         cdef shared_ptr[CArray] c_indices = pyarrow_unwrap_array(indices)
         with nogil:
             result = self.scanner.TakeRows(deref(c_indices))
+        return pyarrow_wrap_table(GetResultValue(result))
+
+    def head(self, int num_rows):
+        """Load the first N rows of the table.
+
+        Returns
+        -------
+        table : Table instance
+        """
+        cdef CResult[shared_ptr[CTable]] result
+        with nogil:
+            result = self.scanner.Head(num_rows)
         return pyarrow_wrap_table(GetResultValue(result))
 
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -458,7 +458,7 @@ cdef class Dataset(_Weakrefable):
         return self._scanner(**kwargs).to_table()
 
     def head(self, int num_rows, **kwargs):
-        """Load the first N rows of the table.
+        """Load the first N rows of the dataset.
 
         See scan method parameters documentation.
 
@@ -1001,7 +1001,7 @@ cdef class Fragment(_Weakrefable):
         return self._scanner(schema=schema, **kwargs).to_table()
 
     def head(self, int num_rows, **kwargs):
-        """Load the first N rows of the table.
+        """Load the first N rows of the fragment.
 
         See scan method parameters documentation.
 
@@ -2906,7 +2906,7 @@ cdef class Scanner(_Weakrefable):
         return pyarrow_wrap_table(GetResultValue(result))
 
     def head(self, int num_rows):
-        """Load the first N rows of the table.
+        """Load the first N rows of the dataset.
 
         Returns
         -------

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -100,6 +100,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CTaggedRecordBatchIterator] ScanBatches()
         CResult[shared_ptr[CTable]] ToTable()
         CResult[shared_ptr[CTable]] TakeRows(const CArray& indices)
+        CResult[shared_ptr[CTable]] Head(int64_t num_rows)
         CResult[CFragmentIterator] GetFragments()
         const shared_ptr[CScanOptions]& options()
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -385,6 +385,13 @@ def test_head(dataset):
     result = dataset.head(1024, columns=['i64']).to_pydict()
     assert result == {'i64': list(range(5)) * 2}
 
+    fragment = next(dataset.get_fragments())
+    result = fragment.head(1, columns=['i64']).to_pydict()
+    assert result == {'i64': [0]}
+
+    result = fragment.head(1024, columns=['i64']).to_pydict()
+    assert result == {'i64': list(range(5))}
+
 
 def test_abstract_classes():
     classes = [

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -371,6 +371,21 @@ def test_scanner(dataset):
         scanner.take(pa.array([table.num_rows]))
 
 
+def test_head(dataset):
+    result = dataset.head(0)
+    assert result == pa.Table.from_batches([], schema=dataset.schema)
+
+    result = dataset.head(1, columns=['i64']).to_pydict()
+    assert result == {'i64': [0]}
+
+    result = dataset.head(2, columns=['i64'],
+                          filter=ds.field('i64') > 1).to_pydict()
+    assert result == {'i64': [2, 3]}
+
+    result = dataset.head(1024, columns=['i64']).to_pydict()
+    assert result == {'i64': list(range(5)) * 2}
+
+
 def test_abstract_classes():
     classes = [
         ds.FileFormat,

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -438,16 +438,7 @@ cpp11::list dataset___Scanner__ScanBatches(const std::shared_ptr<ds::Scanner>& s
 std::shared_ptr<arrow::Table> dataset___Scanner__head(
     const std::shared_ptr<ds::Scanner>& scanner, int n) {
   // TODO: make this a full Slice with offset > 0
-  auto it = ValueOrStop(scanner->ScanBatches());
-  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-  while (true) {
-    auto current_batch = ValueOrStop(it.Next());
-    if (arrow::IsIterationEnd(current_batch)) break;
-    batches.push_back(current_batch.record_batch->Slice(0, n));
-    n -= current_batch.record_batch->num_rows();
-    if (n < 0) break;
-  }
-  return ValueOrStop(arrow::Table::FromRecordBatches(std::move(batches)));
+  return ValueOrStop(scanner->Head(n));
 }
 
 // TODO (ARROW-11782) Remove calls to Scan()


### PR DESCRIPTION
This ports the head() method from R to C++ and exposes it in Python. 