### PR TITLE
ARROW-12409: [R] Remove LazyData from DESCRIPTION

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -22,7 +22,6 @@ URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
 BugReports: https://issues.apache.org/jira/projects/ARROW/issues
 Encoding: UTF-8
 Language: en-US
-LazyData: true
 SystemRequirements: C++11; for AWS S3 support on Linux, libcurl and openssl (optional)
 Biarch: true
 Imports:


### PR DESCRIPTION
Remove LazyData since we don't have data (and CRAN will complain about this soon)