### PR TITLE
ARROW-12392: [C++] Restore asynchronous streaming CSV reader

### DIFF
--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -199,6 +199,19 @@ class SerialBlockReader : public BlockReader {
     return MakeTransformedIterator(std::move(buffer_iterator), block_reader_fn);
   }
 
+  static AsyncGenerator<CSVBlock> MakeAsyncIterator(
+      AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
+      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer) {
+    auto block_reader =
+        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer);
+    // Wrap shared pointer in callable
+    Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
+        [block_reader](std::shared_ptr<Buffer> next) {
+          return (*block_reader)(std::move(next));
+        };
+    return MakeTransformedGenerator(std::move(buffer_generator), block_reader_fn);
+  }
+
   Result<TransformFlow<CSVBlock>> operator()(std::shared_ptr<Buffer> next_buffer) {
     if (buffer_ == nullptr) {
       return TransformFinish();
@@ -572,22 +585,25 @@ class BaseTableReader : public ReaderMixin, public csv::TableReader {
 
 class BaseStreamingReader : public ReaderMixin, public csv::StreamingReader {
  public:
-  using ReaderMixin::ReaderMixin;
+  BaseStreamingReader(io::IOContext io_context, Executor* cpu_executor,
+                      std::shared_ptr<io::InputStream> input,
+                      const ReadOptions& read_options, const ParseOptions& parse_options,
+                      const ConvertOptions& convert_options)
+      : ReaderMixin(io_context, std::move(input), read_options, parse_options,
+                    convert_options),
+        cpu_executor_(cpu_executor) {}
 
-  virtual Status Init() = 0;
+  virtual Future<std::shared_ptr<csv::StreamingReader>> Init() = 0;
 
   std::shared_ptr<Schema> schema() const override { return schema_; }
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
-    do {
-      RETURN_NOT_OK(ReadNext().Value(batch));
-    } while (*batch != nullptr && (*batch)->num_rows() == 0);
-    return Status::OK();
+    auto next_fut = ReadNextAsync();
+    auto next_result = next_fut.result();
+    return std::move(next_result).Value(batch);
   }
 
  protected:
-  virtual Result<std::shared_ptr<RecordBatch>> ReadNext() = 0;
-
   // Make column decoders from conversion schema
   Status MakeColumnDecoders() {
     for (const auto& column : conversion_schema_.columns) {
@@ -670,101 +686,141 @@ class BaseStreamingReader : public ReaderMixin, public csv::StreamingReader {
   std::vector<std::shared_ptr<ColumnDecoder>> column_decoders_;
   std::shared_ptr<Schema> schema_;
   std::shared_ptr<RecordBatch> pending_batch_;
-  Iterator<std::shared_ptr<Buffer>> buffer_iterator_;
+  AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator_;
+  Executor* cpu_executor_;
   bool eof_ = false;
 };
 
 /////////////////////////////////////////////////////////////////////////
 // Serial StreamingReader implementation
 
-class SerialStreamingReader : public BaseStreamingReader {
+class SerialStreamingReader : public BaseStreamingReader,
+                              public std::enable_shared_from_this<SerialStreamingReader> {
  public:
   using BaseStreamingReader::BaseStreamingReader;
 
-  Status Init() override {
+  Future<std::shared_ptr<csv::StreamingReader>> Init() override {
     ARROW_ASSIGN_OR_RAISE(auto istream_it,
                           io::MakeInputStreamIterator(input_, read_options_.block_size));
 
-    // Since we're converting serially, no need to readahead more than one block
-    int32_t block_queue_size = 1;
-    ARROW_ASSIGN_OR_RAISE(auto rh_it,
-                          MakeReadaheadIterator(std::move(istream_it), block_queue_size));
-    buffer_iterator_ = CSVBufferIterator::Make(std::move(rh_it));
+    // TODO Consider exposing readahead as a read option (ARROW-12090)
+    ARROW_ASSIGN_OR_RAISE(auto bg_it, MakeBackgroundGenerator(std::move(istream_it),
+                                                              io_context_.executor()));
+
+    auto transferred_it = MakeTransferredGenerator(bg_it, cpu_executor_);
+
+    buffer_generator_ = CSVBufferIterator::MakeAsync(std::move(transferred_it));
     task_group_ = internal::TaskGroup::MakeSerial(io_context_.stop_token());
 
+    auto self = shared_from_this();
     // Read schema from first batch
-    ARROW_ASSIGN_OR_RAISE(pending_batch_, ReadNext());
-    DCHECK_NE(schema_, nullptr);
-    return Status::OK();
+    return ReadNextAsync().Then([self](const std::shared_ptr<RecordBatch>& first_batch)
+                                    -> Result<std::shared_ptr<csv::StreamingReader>> {
+      self->pending_batch_ = first_batch;
+      DCHECK_NE(self->schema_, nullptr);
+      return self;
+    });
   }
 
- protected:
-  Result<std::shared_ptr<RecordBatch>> ReadNext() override {
-    if (eof_) {
-      return nullptr;
-    }
-    if (io_context_.stop_token().IsStopRequested()) {
-      eof_ = true;
-      return io_context_.stop_token().Poll();
-    }
-    if (!block_iterator_) {
-      Status st = SetupReader();
-      if (!st.ok()) {
-        // Can't setup reader => bail out
-        eof_ = true;
-        return st;
-      }
-    }
-    auto batch = std::move(pending_batch_);
-    if (batch != nullptr) {
-      return batch;
-    }
-
-    if (!source_eof_) {
-      ARROW_ASSIGN_OR_RAISE(auto maybe_block, block_iterator_.Next());
-      if (!IsIterationEnd(maybe_block)) {
-        last_block_index_ = maybe_block.block_index;
-        auto maybe_parsed = ParseAndInsert(maybe_block.partial, maybe_block.completion,
-                                           maybe_block.buffer, maybe_block.block_index,
-                                           maybe_block.is_final);
-        if (!maybe_parsed.ok()) {
-          // Parse error => bail out
-          eof_ = true;
-          return maybe_parsed.status();
-        }
-        RETURN_NOT_OK(maybe_block.consume_bytes(*maybe_parsed));
-      } else {
-        source_eof_ = true;
-        for (auto& decoder : column_decoders_) {
-          decoder->SetEOF(last_block_index_ + 1);
-        }
-      }
-    }
-
+  Result<std::shared_ptr<RecordBatch>> DecodeBatchAndUpdateSchema() {
     auto maybe_batch = DecodeNextBatch();
     if (schema_ == nullptr && maybe_batch.ok()) {
       schema_ = (*maybe_batch)->schema();
     }
     return maybe_batch;
+  }
+
+  Future<std::shared_ptr<RecordBatch>> DoReadNext(
+      std::shared_ptr<SerialStreamingReader> self) {
+    auto batch = std::move(pending_batch_);
+    if (batch != nullptr) {
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
+    }
+
+    if (!source_eof_) {
+      return block_generator_()
+          .Then([self](const CSVBlock& maybe_block) -> Status {
+            if (!IsIterationEnd(maybe_block)) {
+              self->last_block_index_ = maybe_block.block_index;
+              auto maybe_parsed = self->ParseAndInsert(
+                  maybe_block.partial, maybe_block.completion, maybe_block.buffer,
+                  maybe_block.block_index, maybe_block.is_final);
+              if (!maybe_parsed.ok()) {
+                // Parse error => bail out
+                self->eof_ = true;
+                return maybe_parsed.status();
+              }
+              RETURN_NOT_OK(maybe_block.consume_bytes(*maybe_parsed));
+            } else {
+              self->source_eof_ = true;
+              for (auto& decoder : self->column_decoders_) {
+                decoder->SetEOF(self->last_block_index_ + 1);
+              }
+            }
+            return Status::OK();
+          })
+          .Then([self](const ::arrow::detail::Empty& st)
+                    -> Result<std::shared_ptr<RecordBatch>> {
+            return self->DecodeBatchAndUpdateSchema();
+          });
+    }
+    return Future<std::shared_ptr<RecordBatch>>::MakeFinished(
+        DecodeBatchAndUpdateSchema());
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextSkippingEmpty(
+      std::shared_ptr<SerialStreamingReader> self) {
+    return DoReadNext(self).Then([self](const std::shared_ptr<RecordBatch>& batch) {
+      if (batch != nullptr && batch->num_rows() == 0) {
+        return self->ReadNextSkippingEmpty(self);
+      }
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
+    });
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextAsync() override {
+    if (eof_) {
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(nullptr);
+    }
+    if (io_context_.stop_token().IsStopRequested()) {
+      eof_ = true;
+      return io_context_.stop_token().Poll();
+    }
+    auto self = shared_from_this();
+    if (!block_generator_) {
+      return SetupReader(self).Then([self](const Result<::arrow::detail::Empty>& res)
+                                        -> Future<std::shared_ptr<RecordBatch>> {
+        if (!res.ok()) {
+          self->eof_ = true;
+          return res.status();
+        }
+        return self->ReadNextSkippingEmpty(self);
+      });
+    } else {
+      return self->ReadNextSkippingEmpty(self);
+    }
   };
 
-  Status SetupReader() {
-    ARROW_ASSIGN_OR_RAISE(auto first_buffer, buffer_iterator_.Next());
-    if (first_buffer == nullptr) {
-      return Status::Invalid("Empty CSV file");
-    }
-    RETURN_NOT_OK(ProcessHeader(first_buffer, &first_buffer));
-    RETURN_NOT_OK(MakeColumnDecoders());
+ protected:
+  Future<> SetupReader(std::shared_ptr<SerialStreamingReader> self) {
+    return buffer_generator_().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
+      if (first_buffer == nullptr) {
+        return Status::Invalid("Empty CSV file");
+      }
+      auto own_first_buffer = first_buffer;
+      RETURN_NOT_OK(self->ProcessHeader(own_first_buffer, &own_first_buffer));
+      RETURN_NOT_OK(self->MakeColumnDecoders());
 
-    block_iterator_ = SerialBlockReader::MakeIterator(std::move(buffer_iterator_),
-                                                      MakeChunker(parse_options_),
-                                                      std::move(first_buffer));
-    return Status::OK();
+      self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
+          std::move(self->buffer_generator_), MakeChunker(self->parse_options_),
+          std::move(own_first_buffer));
+      return Status::OK();
+    });
   }
 
   bool source_eof_ = false;
   int64_t last_block_index_ = 0;
-  Iterator<CSVBlock> block_iterator_;
+  AsyncGenerator<CSVBlock> block_generator_;
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -943,15 +999,14 @@ Result<std::shared_ptr<TableReader>> MakeTableReader(
   return reader;
 }
 
-Result<std::shared_ptr<StreamingReader>> MakeStreamingReader(
+Future<std::shared_ptr<StreamingReader>> MakeStreamingReader(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
     internal::Executor* cpu_executor, const ReadOptions& read_options,
     const ParseOptions& parse_options, const ConvertOptions& convert_options) {
   std::shared_ptr<BaseStreamingReader> reader;
-  reader = std::make_shared<SerialStreamingReader>(io_context, input, read_options,
-                                                   parse_options, convert_options);
-  RETURN_NOT_OK(reader->Init());
-  return reader;
+  reader = std::make_shared<SerialStreamingReader>(
+      io_context, cpu_executor, input, read_options, parse_options, convert_options);
+  return reader->Init();
 }
 
 }  // namespace
@@ -981,8 +1036,11 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     const ConvertOptions& convert_options) {
   auto io_context = io::IOContext(pool);
   auto cpu_executor = internal::GetCpuThreadPool();
-  return MakeStreamingReader(io_context, std::move(input), cpu_executor, read_options,
-                             parse_options, convert_options);
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,
+                                        read_options, parse_options, convert_options);
+  auto reader_result = reader_fut.result();
+  ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
+  return reader;
 }
 
 Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
@@ -990,6 +1048,17 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
   auto cpu_executor = internal::GetCpuThreadPool();
+  auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,
+                                        read_options, parse_options, convert_options);
+  auto reader_result = reader_fut.result();
+  ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
+  return reader;
+}
+
+Future<std::shared_ptr<StreamingReader>> StreamingReader::MakeAsync(
+    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    internal::Executor* cpu_executor, const ReadOptions& read_options,
+    const ParseOptions& parse_options, const ConvertOptions& convert_options) {
   return MakeStreamingReader(io_context, std::move(input), cpu_executor, read_options,
                              parse_options, convert_options);
 }

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -64,7 +64,20 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
  public:
   virtual ~StreamingReader() = default;
 
+  virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
+
   /// Create a StreamingReader instance
+  ///
+  /// This involves some I/O as the first batch must be loaded during the creation process
+  /// so it is returned as a future
+  ///
+  /// Currently, the StreamingReader is not async-reentrant and does not do any fan-out
+  /// parsing (see ARROW-11889)
+  static Future<std::shared_ptr<StreamingReader>> MakeAsync(
+      io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+      internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&,
+      const ConvertOptions&);
+
   static Result<std::shared_ptr<StreamingReader>> Make(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,
       const ReadOptions&, const ParseOptions&, const ConvertOptions&);

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -34,6 +34,7 @@
 #include "arrow/io/compressed.h"
 #include "arrow/result.h"
 #include "arrow/type.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 
@@ -119,34 +120,59 @@ static inline Result<csv::ReadOptions> GetReadOptions(
   return read_options;
 }
 
-static inline Result<std::shared_ptr<csv::StreamingReader>> OpenReader(
+static inline Future<std::shared_ptr<csv::StreamingReader>> OpenReaderAsync(
     const FileSource& source, const CsvFileFormat& format,
-    const std::shared_ptr<ScanOptions>& scan_options = nullptr,
-    MemoryPool* pool = default_memory_pool()) {
+    const std::shared_ptr<ScanOptions>& scan_options, internal::Executor* cpu_executor,
+    MemoryPool* pool) {
   ARROW_ASSIGN_OR_RAISE(auto reader_options, GetReadOptions(format, scan_options));
 
-  util::string_view first_block;
   ARROW_ASSIGN_OR_RAISE(auto input, source.OpenCompressed());
   ARROW_ASSIGN_OR_RAISE(
       input, io::BufferedInputStream::Create(reader_options.block_size,
                                              default_memory_pool(), std::move(input)));
-  ARROW_ASSIGN_OR_RAISE(first_block, input->Peek(reader_options.block_size));
 
-  const auto& parse_options = format.parse_options;
-  auto convert_options = csv::ConvertOptions::Defaults();
-  if (scan_options != nullptr) {
-    ARROW_ASSIGN_OR_RAISE(convert_options,
-                          GetConvertOptions(format, scan_options, first_block, pool));
-  }
+  // Grab the first block and use it to determine the schema and create a reader.  The
+  // input->Peek call blocks so we run the whole thing on the I/O thread pool.
+  return DeferNotOk(input->io_context().executor()->Submit(
+      [=]() -> Future<std::shared_ptr<csv::StreamingReader>> {
+        ARROW_ASSIGN_OR_RAISE(auto first_block, input->Peek(reader_options.block_size));
+        const auto& parse_options = format.parse_options;
+        auto convert_options = csv::ConvertOptions::Defaults();
+        if (scan_options != nullptr) {
+          ARROW_ASSIGN_OR_RAISE(convert_options, GetConvertOptions(format, scan_options,
+                                                                   first_block, pool));
+        }
 
-  auto maybe_reader =
-      csv::StreamingReader::Make(io::IOContext(pool), std::move(input), reader_options,
-                                 parse_options, convert_options);
-  if (!maybe_reader.ok()) {
-    return maybe_reader.status().WithMessage("Could not open CSV input source '",
-                                             source.path(), "': ", maybe_reader.status());
-  }
-  return maybe_reader;
+        auto reader_fut = csv::StreamingReader::MakeAsync(
+            io::default_io_context(), std::move(input), cpu_executor, reader_options,
+            parse_options, convert_options);
+        // Adds the filename to the error
+        return reader_fut.Then(
+            [](const std::shared_ptr<csv::StreamingReader>& maybe_reader)
+                -> Result<std::shared_ptr<csv::StreamingReader>> { return maybe_reader; },
+            [source](const Status& err) -> Result<std::shared_ptr<csv::StreamingReader>> {
+              return err.WithMessage("Could not open CSV input source '", source.path(),
+                                     "': ", err);
+            });
+      }));
+}
+
+static inline Result<std::shared_ptr<csv::StreamingReader>> OpenReader(
+    const FileSource& source, const CsvFileFormat& format,
+    const std::shared_ptr<ScanOptions>& scan_options = nullptr,
+    MemoryPool* pool = default_memory_pool()) {
+  auto open_reader_fut =
+      OpenReaderAsync(source, format, scan_options, internal::GetCpuThreadPool(), pool);
+  return open_reader_fut.result();
+}
+
+static RecordBatchGenerator GeneratorFromReader(
+    const Future<std::shared_ptr<csv::StreamingReader>>& reader) {
+  auto gen_fut = reader.Then(
+      [](const std::shared_ptr<csv::StreamingReader>& reader) -> RecordBatchGenerator {
+        return [reader]() { return reader->ReadNextAsync(); };
+      });
+  return MakeFromFuture(std::move(gen_fut));
 }
 
 /// \brief A ScanTask backed by an Csv file.
@@ -160,9 +186,26 @@ class CsvScanTask : public ScanTask {
         source_(fragment->source()) {}
 
   Result<RecordBatchIterator> Execute() override {
-    ARROW_ASSIGN_OR_RAISE(auto reader,
-                          OpenReader(source_, *format_, options(), options()->pool));
-    return IteratorFromReader(std::move(reader));
+    auto reader_fut = OpenReaderAsync(source_, *format_, options(),
+                                      internal::GetCpuThreadPool(), options()->pool);
+    auto reader_gen = GeneratorFromReader(std::move(reader_fut));
+    return MakeGeneratorIterator(std::move(reader_gen));
+  }
+
+  Future<RecordBatchVector> SafeExecute(internal::Executor* executor) override {
+    auto reader_fut =
+        OpenReaderAsync(source_, *format_, options(), executor, options()->pool);
+    auto reader_gen = GeneratorFromReader(std::move(reader_fut));
+    return CollectAsyncGenerator(reader_gen);
+  }
+
+  Future<> SafeVisit(
+      internal::Executor* executor,
+      std::function<Status(std::shared_ptr<RecordBatch>)> visitor) override {
+    auto reader_fut =
+        OpenReaderAsync(source_, *format_, options(), executor, options()->pool);
+    auto reader_gen = GeneratorFromReader(std::move(reader_fut));
+    return VisitAsyncGenerator(reader_gen, visitor);
   }
 
  private:

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -148,6 +148,9 @@ class ARROW_DS_EXPORT ScanTask {
   /// resulting from the Scan. Execution semantics are encapsulated in the
   /// particular ScanTask implementation
   virtual Result<RecordBatchIterator> Execute() = 0;
+  virtual Future<RecordBatchVector> SafeExecute(internal::Executor* executor);
+  virtual Future<> SafeVisit(internal::Executor* executor,
+                             std::function<Status(std::shared_ptr<RecordBatch>)> visitor);
 
   virtual ~ScanTask() = default;
 


### PR DESCRIPTION
This restores ARROW-11887.  The only difference is that I kept the async path out of RecordBatchReader.  I now know the file formats do not use RecordBatchReader for the read so there was no need to add it in there yet.

It also now properly consumes (using RunInSerialExecutor) the reader via the nested parallel paths in the synchronous scanner.