### PR TITLE
ARROW-12407: [Python][Dataset] Remove ScanTask bindings

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -49,7 +49,6 @@ from pyarrow._dataset import (  # noqa
     PartitioningFactory,
     RowGroupInfo,
     Scanner,
-    ScanTask,
     TaggedRecordBatch,
     UnionDataset,
     UnionDatasetFactory,

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -59,6 +59,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
 
+        shared_ptr[CSchema] dataset_schema
+        shared_ptr[CSchema] projected_schema
+
     cdef cppclass CFragmentScanOptions "arrow::dataset::FragmentScanOptions":
         c_string type_name() const
 


### PR DESCRIPTION
For 5.0.0: remove Python bindings to ScanTask to avoid the deprecation warning at build time.

`scan()` is replaced with `scanner()` which takes the same arguments, but gives back the Scanner directly.