### PR TITLE
ARROW-12411: [Rust] Add Builder interface for adding Arrays to RecordBatches

### DIFF
--- a/rust/arrow/src/datatypes/schema.rs
+++ b/rust/arrow/src/datatypes/schema.rs
@@ -152,6 +152,12 @@ impl Schema {
             })
     }
 
+    /// Appends a new field to this `Schema` as a field named
+    /// `field_name`.
+    pub fn push(&mut self, field: Field) {
+        self.fields.push(field)
+    }
+
     /// Returns an immutable reference of the vector of `Field` instances.
     #[inline]
     pub const fn fields(&self) -> &Vec<Field> {

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -295,6 +295,12 @@ impl RecordBatch {
     }
 }
 
+impl Default for RecordBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Options that control the behaviour used when creating a [`RecordBatch`].
 #[derive(Debug)]
 pub struct RecordBatchOptions {
@@ -389,7 +395,13 @@ mod tests {
 
     #[test]
     fn create_record_batch_builder() {
-        let a = Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4), Some(5)]));
+        let a = Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            None,
+            Some(4),
+            Some(5),
+        ]));
         let b = Arc::new(StringArray::from(vec!["a", "b", "c", "d", "e"]));
 
         let record_batch = RecordBatch::new()


### PR DESCRIPTION
# Purpose

This PR is a draft for comment / review. If people generally like this idea, I will polish up this PR with doc examples / comments and more test for real review.

# Rationle / Usecase:

While writing tests (both in IOx and in DataFusion) where I need a single `RecordBatch`, I often find myself doing something like this (copied directly from IOx source code):

```rust
let schema = Arc::new(Schema::new(vec![
    ArrowField::new("float_field", ArrowDataType::Float64, true),
    ArrowField::new("time", ArrowDataType::Int64, true),
]));

let float_array: ArrayRef = Arc::new(Float64Array::from(vec![10.1, 20.1, 30.1, 40.1]));
let timestamp_array: ArrayRef = Arc::new(Int64Array::from(vec![1000, 2000, 3000, 4000]));

let batch = RecordBatch::try_new(schema, vec![float_array, timestamp_array])
    .expect("created new record batch");
```

This is annoying because I have to redundantly (and verbosely) encode the information that `float_field` is a Float64 both in the `Schema` and the `Float64Array`

I would much rather  be able to construct `RecordBatches` using a more Rust like style to avoid the the redundancy and reduce the amount of typing / redundancy:


# Proposal:

Add `RecordBatch::append` so the following syntax can be supported:


```rust
let float_array: ArrayRef = Arc::new(Float64Array::from(vec![10.1, 20.1, 30.1, 40.1]));
let timestamp_array: ArrayRef = Arc::new(Int64Array::from(vec![1000, 2000, 3000, 4000]));

let batch = RecordBatch::empty()
  .append("float_field", timestamp_array).unwrap()
  .append("time", float_array).unwrap;

```

# Existing APIs
The existing APIs to create a `RecordBatch` from a `Schema` and `Vec<ArrayRef>` would not be changed as there are plenty of use cases where the Schema is known up front and should not be checked each time.
