### PR TITLE
ARROW-12412: [C++] Add ability to convert an AsyncGenerator to an Iterator by wrapping each run with RunInSerialExecutor 

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -651,10 +651,10 @@ Future<> SleepABitAsync(internal::Executor* cpu_executor) {
       out.MarkFinished(Status::OK());
     }).detach();
   } else {
-    cpu_executor->Spawn([out]() mutable {
+    ARROW_EXPECT_OK(cpu_executor->Spawn([out]() mutable {
       SleepABit();
       out.MarkFinished(Status::OK());
-    });
+    }));
   }
   return out;
 }

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -452,7 +452,7 @@ Future<> SleepAsync(double seconds);
 
 // \see SleepABit
 ARROW_TESTING_EXPORT
-Future<> SleepABitAsync();
+Future<> SleepABitAsync(internal::Executor* = nullptr);
 
 template <typename T>
 std::vector<T> IteratorToVector(Iterator<T> iterator) {


### PR DESCRIPTION
The `ProxyExecutor` feels a bit unfortunate.  It could be avoided by changing `AsyncGenerator<T>` to `std::function<Future<T>(Executor*)>` but that would be a pretty expansive change and I'm not sure this feature justifies it.

I was considering putting `ProxyExecutor` in `async_generator.h` instead of `thread_pool.h` so please let me know if that seems like a more appropriate place for it.