### PR TITLE
ARROW-12419: [Java] Remove to download flatc binary for s390x

### DIFF
--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -30,15 +30,6 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   wget="wget"
   bintray_base_url="https://dl.bintray.com/apache/arrow"
 
-  bintray_dir="flatc-binary"
-  group="com.github.icexelloss"
-  artifact="flatc-linux-s390_64"
-  ver="1.9.0"
-  extension="exe"
-  target=${artifact}-${ver}.${extension}
-  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
-
   bintray_dir="protoc-binary"
   group="com.google.protobuf"
   artifact="protoc"


### PR DESCRIPTION
This PR is a follow-up of #10058. #10058 avoids executing flatc during the Java build process by statically generating Java files from the schema. Now, flatc is not necessary.

Since flatc for s390x is explicitly downloaded in a script, we can drop this download.