### PR TITLE
ARROW-12421: [Rust] [DataFusion] Disable repartition rule

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -59,7 +59,6 @@ use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
 use crate::physical_optimizer::coalesce_batches::CoalesceBatches;
 use crate::physical_optimizer::merge_exec::AddMergeExec;
-use crate::physical_optimizer::repartition::Repartition;
 
 use crate::physical_plan::csv::CsvReadOptions;
 use crate::physical_plan::planner::DefaultPhysicalPlanner;
@@ -642,7 +641,6 @@ impl ExecutionConfig {
                 Arc::new(LimitPushDown::new()),
             ],
             physical_optimizers: vec![
-                Arc::new(Repartition::new()),
                 Arc::new(CoalesceBatches::new()),
                 Arc::new(AddMergeExec::new()),
             ],


### PR DESCRIPTION
Remove repartition rule to fix test regression when running on 24 core threadripper CPU.

This will need further investigation but this patch is needed for the 4.0.0 release.