### PR TITLE
ARROW-12426: [Rust] Fix concatentation of arrow dictionaries

### DIFF
--- a/rust/arrow/src/array/transform/mod.rs
+++ b/rust/arrow/src/array/transform/mod.rs
@@ -437,8 +437,8 @@ impl<'a> MutableArrayData<'a> {
                     .map(|array| {
                         let offset = next_offset;
                         next_offset += array.child_data()[0].len();
-                        Ok(build_extend_dictionary(array, offset, next_offset)
-                            .ok_or(ArrowError::DictionaryKeyOverflowError)?)
+                        build_extend_dictionary(array, offset, next_offset)
+                            .ok_or(ArrowError::DictionaryKeyOverflowError)
                     })
                     .collect();
 

--- a/rust/arrow/src/array/transform/primitive.rs
+++ b/rust/arrow/src/array/transform/primitive.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::mem::size_of;
+use std::ops::Add;
 
 use crate::{array::ArrayData, datatypes::ArrowNativeType};
 
@@ -28,6 +29,20 @@ pub(super) fn build_extend<T: ArrowNativeType>(array: &ArrayData) -> Extend {
             mutable
                 .buffer1
                 .extend_from_slice(&values[start..start + len]);
+        },
+    )
+}
+
+pub(super) fn build_extend_with_offset<T>(array: &ArrayData, offset: T) -> Extend
+where
+    T: ArrowNativeType + Add<Output = T>,
+{
+    let values = array.buffer::<T>(0);
+    Box::new(
+        move |mutable: &mut _MutableArrayData, _, start: usize, len: usize| {
+            mutable
+                .buffer1
+                .extend(values[start..start + len].iter().map(|x| *x + offset));
         },
     )
 }

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -391,28 +391,17 @@ mod tests {
         let values = dictionary.values();
         let values = values.as_any().downcast_ref::<StringArray>().unwrap();
 
-        (0..dictionary.len())
-            .map(move |i| match dictionary.keys().is_valid(i) {
-                true => {
-                    let key = dictionary.keys().value(i);
-                    Some(values.value(key as _).to_string())
-                }
-                false => None,
-            })
+        dictionary
+            .keys()
+            .iter()
+            .map(|key| key.map(|key| values.value(key as _).to_string()))
             .collect()
     }
 
-    #[test]
-    fn test_string_dictionary_array() -> Result<()> {
-        let input_1: DictionaryArray<Int32Type> =
-            vec!["hello", "A", "B", "hello", "hello", "C"]
-                .into_iter()
-                .collect();
-        let input_2: DictionaryArray<Int32Type> =
-            vec!["hello", "E", "E", "hello", "F", "E"]
-                .into_iter()
-                .collect();
-
+    fn test_dictionary_concat(
+        input_1: DictionaryArray<Int32Type>,
+        input_2: DictionaryArray<Int32Type>,
+    ) {
         let concat = concat(&[&input_1 as _, &input_2 as _]).unwrap();
         let concat = concat
             .as_any()
@@ -428,7 +417,32 @@ mod tests {
             .collect();
 
         assert_eq!(concat_collected, expected);
+    }
 
+    #[test]
+    fn test_string_dictionary_array() -> Result<()> {
+        let input_1: DictionaryArray<Int32Type> =
+            vec!["hello", "A", "B", "hello", "hello", "C"]
+                .into_iter()
+                .collect();
+        let input_2: DictionaryArray<Int32Type> =
+            vec!["hello", "E", "E", "hello", "F", "E"]
+                .into_iter()
+                .collect();
+
+        test_dictionary_concat(input_1, input_2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_dictionary_array_nulls() -> Result<()> {
+        let input_1: DictionaryArray<Int32Type> =
+            vec![Some("foo"), Some("bar"), None, Some("fiz")]
+                .into_iter()
+                .collect();
+        let input_2: DictionaryArray<Int32Type> = vec![None].into_iter().collect();
+
+        test_dictionary_concat(input_1, input_2);
         Ok(())
     }
 }

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -398,25 +398,17 @@ mod tests {
             .collect()
     }
 
-    fn test_dictionary_concat(
+    fn concat_dictionary(
         input_1: DictionaryArray<Int32Type>,
         input_2: DictionaryArray<Int32Type>,
-    ) {
+    ) -> Vec<Option<String>> {
         let concat = concat(&[&input_1 as _, &input_2 as _]).unwrap();
         let concat = concat
             .as_any()
             .downcast_ref::<DictionaryArray<Int32Type>>()
             .unwrap();
 
-        let concat_collected = collect_string_dictionary(concat);
-        let input_1_collected = collect_string_dictionary(&input_1);
-        let input_2_collected = collect_string_dictionary(&input_2);
-        let expected: Vec<_> = input_1_collected
-            .into_iter()
-            .chain(input_2_collected.into_iter())
-            .collect();
-
-        assert_eq!(concat_collected, expected);
+        collect_string_dictionary(concat)
     }
 
     #[test]
@@ -430,7 +422,16 @@ mod tests {
                 .into_iter()
                 .collect();
 
-        test_dictionary_concat(input_1, input_2);
+        let expected: Vec<_> = vec![
+            "hello", "A", "B", "hello", "hello", "C", "hello", "E", "E", "hello", "F",
+            "E",
+        ]
+        .into_iter()
+        .map(|x| Some(x.to_string()))
+        .collect();
+
+        let concat = concat_dictionary(input_1, input_2);
+        assert_eq!(concat, expected);
         Ok(())
     }
 
@@ -441,8 +442,16 @@ mod tests {
                 .into_iter()
                 .collect();
         let input_2: DictionaryArray<Int32Type> = vec![None].into_iter().collect();
+        let expected = vec![
+            Some("foo".to_string()),
+            Some("bar".to_string()),
+            None,
+            Some("fiz".to_string()),
+            None,
+        ];
 
-        test_dictionary_concat(input_1, input_2);
+        let concat = concat_dictionary(input_1, input_2);
+        assert_eq!(concat, expected);
         Ok(())
     }
 }


### PR DESCRIPTION
Currently calling concat on two dictionary encoded arrays blindly concatenates the keys arrays, and keeps only the values of the first. This can lead to invalid data, including keys referring to value indexes beyond the bounds of the values array.

This PR alters MutableArrayData to concatenate the child data of any dictionary arrays passed to it, and offset the source keys to correctly map to the relevant "slice" of the resulting child data. This does mean that the resulting dictionary array may contain duplicates, and will not be sorted, but I'm not sure if this is a problem?

Signed-off-by: Raphael Taylor-Davies <r.taylordavies@googlemail.com>