### PR TITLE
ARROW-12429: [C++] Fix incorrectly registered test

### DIFF
--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -594,7 +594,7 @@ TEST_P(MergedGeneratorTestFixture, MergedParallelStress) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(MergedGeneratorTests, GeneratorTestFixture,
+INSTANTIATE_TEST_SUITE_P(MergedGeneratorTests, MergedGeneratorTestFixture,
                          ::testing::Values(false, true));
 
 TEST(TestAsyncUtil, FromVector) {


### PR DESCRIPTION
Recent versions of Googletest catch this, but Googletest doesn't have releases anymore - they expect everyone to just use any commit from master. Also, the latest version has link issues when used with Arrow.