### PR TITLE
ARROW-12433: [Rust] Pin flatbuffers to 0.8.3

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -47,7 +47,7 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
-flatbuffers = "^0.8"
+flatbuffers = "=0.8.3" # 0.8.4 introduces const generics
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"


### PR DESCRIPTION
Our builds that require nightly Rust fail with flatbuffers 0.8.4 due to the introduction of const generics