### PR TITLE
ARROW-12334: [Rust] [Ballista] Aggregate queries producing incorrect results

### DIFF
--- a/rust/ballista/rust/scheduler/src/state/mod.rs
+++ b/rust/ballista/rust/scheduler/src/state/mod.rs
@@ -349,6 +349,15 @@ impl SchedulerState {
         }
 
         // Check for job completion
+        let last_stage = statuses
+            .iter()
+            .map(|task| task.partition_id.as_ref().unwrap().stage_id)
+            .max()
+            .unwrap();
+        let statuses: Vec<_> = statuses
+            .into_iter()
+            .filter(|task| task.partition_id.as_ref().unwrap().stage_id == last_stage)
+            .collect();
         let mut job_status = statuses
             .iter()
             .map(|status| match &status.status {


### PR DESCRIPTION
The function that calculated job status from the task status was aggregating all of the partition locations. This is incorrect. Only the partitions of the last stage should be collected.

@andygrove, could you confirm that my assumption that the output of any query is contained in the last stage? If there is a possibility of having multiple output stages, then this fix is incorrect.