### PR TITLE
ARROW-12437: [Rust] [Ballista] Create DataFusion context without repartition

### DIFF
--- a/rust/ballista/rust/client/src/context.rs
+++ b/rust/ballista/rust/client/src/context.rs
@@ -33,11 +33,11 @@ use ballista_core::{
     datasource::DFTableAdapter,
     error::{BallistaError, Result},
     memory_stream::MemoryStream,
+    utils::create_datafusion_context,
 };
 
 use arrow::datatypes::Schema;
 use datafusion::catalog::TableReference;
-use datafusion::execution::context::ExecutionContext;
 use datafusion::logical_plan::{DFSchema, Expr, LogicalPlan, Partitioning};
 use datafusion::physical_plan::csv::CsvReadOptions;
 use datafusion::{dataframe::DataFrame, physical_plan::RecordBatchStream};
@@ -94,7 +94,7 @@ impl BallistaContext {
         let path = fs::canonicalize(&path)?;
 
         // use local DataFusion context for now but later this might call the scheduler
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = create_datafusion_context();
         let df = ctx.read_parquet(path.to_str().unwrap())?;
         Ok(BallistaDataFrame::from(self.state.clone(), df))
     }
@@ -111,7 +111,7 @@ impl BallistaContext {
         let path = fs::canonicalize(&path)?;
 
         // use local DataFusion context for now but later this might call the scheduler
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = create_datafusion_context();
         let df = ctx.read_csv(path.to_str().unwrap(), options)?;
         Ok(BallistaDataFrame::from(self.state.clone(), df))
     }
@@ -143,7 +143,7 @@ impl BallistaContext {
     /// Create a DataFrame from a SQL statement
     pub fn sql(&self, sql: &str) -> Result<BallistaDataFrame> {
         // use local DataFusion context for now but later this might call the scheduler
-        let mut ctx = ExecutionContext::new();
+        let mut ctx = create_datafusion_context();
         // register tables
         let state = self.state.lock().unwrap();
         for (name, plan) in &state.tables {


### PR DESCRIPTION
Ballista plans must not include `RepartitionExec` because it results in incorrect results. Ballista needs to manage it's own repartitioning in a distributed-aware way later on. For now, we just need to configure the DataFusion context to disable repartition.