### PR TITLE
ARROW-10675 [C++][Python] Support AWS S3 Web identity credentials

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -231,7 +231,8 @@ void S3Options::ConfigureAssumeRoleWithWebIdentityCredentials() {
   // The AWS SDK uses environment variables AWS_DEFAULT_REGION,
   // AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_SESSION_NAME
   // to configure the required credentials
-  credentials_provider = std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>();
+  credentials_provider =
+      std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>();
 }
 
 std::string S3Options::GetAccessKey() const {

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -363,6 +363,7 @@ Result<S3Options> S3Options::FromUri(const std::string& uri_string,
 bool S3Options::Equals(const S3Options& other) const {
   return (region == other.region && endpoint_override == other.endpoint_override &&
           scheme == other.scheme && background_writes == other.background_writes &&
+          credentials_kind == other.credentials_kind &&
           proxy_options.Equals(other.proxy_options) &&
           GetAccessKey() == other.GetAccessKey() &&
           GetSecretKey() == other.GetSecretKey() &&

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -73,6 +73,9 @@ struct ARROW_EXPORT S3Options {
   /// S3 connection transport, default "https"
   std::string scheme = "https";
 
+  /// Whether S3 access should be anonymous (no credentials used)
+  bool anonymous = false;
+
   /// ARN of role to assume
   std::string role_arn;
   /// Optional identifier for an assumed role session.
@@ -91,6 +94,12 @@ struct ARROW_EXPORT S3Options {
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
 
+  /// True when using SimpleAWSCredentialsProvider, else false.
+  bool creds_provided = false;
+
+  /// True when using web identity token to assume role
+  bool use_web_identity = false;
+
   /// Configure with the default AWS credentials provider chain.
   void ConfigureDefaultCredentials();
 
@@ -106,6 +115,9 @@ struct ARROW_EXPORT S3Options {
       const std::string& role_arn, const std::string& session_name = "",
       const std::string& external_id = "", int load_frequency = 900,
       const std::shared_ptr<Aws::STS::STSClient>& stsClient = NULLPTR);
+
+  /// Configure with credentials from role assumed using a web identitiy token
+  void ConfigureAssumeRoleWithWebIdentityCredentials();
 
   std::string GetAccessKey() const;
   std::string GetSecretKey() const;
@@ -137,6 +149,11 @@ struct ARROW_EXPORT S3Options {
       const std::string& role_arn, const std::string& session_name = "",
       const std::string& external_id = "", int load_frequency = 900,
       const std::shared_ptr<Aws::STS::STSClient>& stsClient = NULLPTR);
+
+  /// \brief Initialize from an assumed role with web-identity.
+  /// Uses the AWS SDK which uses environment variables to
+  /// generate temporary credentials.
+  static S3Options FromAssumeRoleWithWebIdentity();
 
   static Result<S3Options> FromUri(const ::arrow::internal::Uri& uri,
                                    std::string* out_path = NULLPTR);

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -56,6 +56,19 @@ struct ARROW_EXPORT S3ProxyOptions {
   bool Equals(const S3ProxyOptions& other) const;
 };
 
+enum class S3CredentialsKind : int8_t {
+  /// Anonymous access (no credentials used)
+  Anonymous,
+  /// Use default AWS credentials, configured through environment variables
+  Default,
+  /// Use explicitly-provided access key pair
+  Explicit,
+  /// Assume role through a role ARN
+  Role,
+  /// Use web identity token to assume role, configured through environment variables
+  WebIdentity
+};
+
 /// Options for the S3FileSystem implementation.
 struct ARROW_EXPORT S3Options {
   /// AWS region to connect to.
@@ -73,9 +86,6 @@ struct ARROW_EXPORT S3Options {
   /// S3 connection transport, default "https"
   std::string scheme = "https";
 
-  /// Whether S3 access should be anonymous (no credentials used)
-  bool anonymous = false;
-
   /// ARN of role to assume
   std::string role_arn;
   /// Optional identifier for an assumed role session.
@@ -91,14 +101,11 @@ struct ARROW_EXPORT S3Options {
   /// AWS credentials provider
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
 
+  /// Type of credentials being used. Set along with credentials_provider.
+  S3CredentialsKind credentials_kind = S3CredentialsKind::Default;
+
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
-
-  /// True when using SimpleAWSCredentialsProvider, else false.
-  bool creds_provided = false;
-
-  /// True when using web identity token to assume role
-  bool use_web_identity = false;
 
   /// Configure with the default AWS credentials provider chain.
   void ConfigureDefaultCredentials();

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -243,11 +243,9 @@ cdef class S3FileSystem(FileSystem):
     def __reduce__(self):
         cdef CS3Options opts = self.s3fs.options()
 
-        creds_provided = opts.creds_provided
-
         # if creds were explicitly provided, then use them
         # else obtain them as they were last time.
-        if creds_provided:
+        if opts.credentials_kind == CS3CredentialsKind_Explicit:
             access_key = frombytes(opts.GetAccessKey())
             secret_key = frombytes(opts.GetSecretKey())
             session_token = frombytes(opts.GetSessionToken())
@@ -261,8 +259,10 @@ cdef class S3FileSystem(FileSystem):
                 access_key=access_key,
                 secret_key=secret_key,
                 session_token=session_token,
-                anonymous=opts.anonymous,
-                use_web_identity=opts.use_web_identity,
+                anonymous=(opts.credentials_kind ==
+                           CS3CredentialsKind_Anonymous),
+                use_web_identity=(opts.credentials_kind ==
+                                  CS3CredentialsKind_WebIdentity),
                 region=frombytes(opts.region),
                 scheme=frombytes(opts.scheme),
                 endpoint_override=frombytes(opts.endpoint_override),

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -120,10 +120,10 @@ cdef class S3FileSystem(FileSystem):
         CS3FileSystem* s3fs
 
     def __init__(self, *, access_key=None, secret_key=None, session_token=None,
-                 bint anonymous=False, bint use_web_identity=False, region=None, scheme=None,
-                 endpoint_override=None, bint background_writes=True,
-                 role_arn=None, session_name=None, external_id=None,
-                 load_frequency=900, proxy_options=None):
+                 bint anonymous=False, bint use_web_identity=False,
+                 region=None, scheme=None, endpoint_override=None,
+                 bint background_writes=True, role_arn=None, session_name=None,
+                 external_id=None, load_frequency=900, proxy_options=None):
         cdef:
             CS3Options options
             shared_ptr[CS3FileSystem] wrapped
@@ -179,12 +179,14 @@ cdef class S3FileSystem(FileSystem):
 
             if use_web_identity:
                 raise ValueError(
-                    'Cannot pass both use_web_identity=True and anonymous=True')
+                    'Cannot pass both use_web_identity=True and '
+                    'anonymous=True')
 
             options = CS3Options.Anonymous()
         elif role_arn:
             if use_web_identity:
-                raise ValueError('Cannot provide role_arn with use_web_identity=True')
+                raise ValueError(
+                    'Cannot provide role_arn with use_web_identity=True')
 
             options = CS3Options.FromAssumeRole(
                 tobytes(role_arn),

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -142,6 +142,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
+        c_bool creds_provided
+        c_bool anonymous
+        c_bool use_web_identity
         c_string role_arn
         c_string session_name
         c_string external_id
@@ -172,6 +175,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
                                   const c_string& session_name,
                                   const c_string& external_id,
                                   const int load_frequency)
+
+        @staticmethod
+        CS3Options FromAssumeRoleWithWebIdentity()
 
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
         @staticmethod

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -150,9 +150,6 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
-        c_bool creds_provided
-        c_bool anonymous
-        c_bool use_web_identity
         c_string role_arn
         c_string session_name
         c_string external_id

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -182,9 +182,6 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
                                   const c_string& external_id,
                                   const int load_frequency)
 
-        @staticmethod
-        CS3Options FromAssumeRoleWithWebIdentity()
-
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
         @staticmethod
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -137,6 +137,14 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CResult[CS3ProxyOptions] FromUriString "FromUri"(
             const c_string& uri_string)
 
+    ctypedef enum CS3CredentialsKind "arrow::fs::S3CredentialsKind":
+        CS3CredentialsKind_Anonymous "arrow::fs::S3CredentialsKind::Anonymous"
+        CS3CredentialsKind_Default "arrow::fs::S3CredentialsKind::Default"
+        CS3CredentialsKind_Explicit "arrow::fs::S3CredentialsKind::Explicit"
+        CS3CredentialsKind_Role "arrow::fs::S3CredentialsKind::Role"
+        CS3CredentialsKind_WebIdentity \
+            "arrow::fs::S3CredentialsKind::WebIdentity"
+
     cdef cppclass CS3Options "arrow::fs::S3Options":
         c_string region
         c_string endpoint_override
@@ -150,6 +158,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string external_id
         int load_frequency
         CS3ProxyOptions proxy_options
+        CS3CredentialsKind credentials_kind
         void ConfigureDefaultCredentials()
         void ConfigureAccessKey(const c_string& access_key,
                                 const c_string& secret_key,

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1038,6 +1038,14 @@ def test_s3_options(monkeypatch):
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
+    fs = S3FileSystem(anonymous=True)
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
+    fs = S3FileSystem(use_web_identity=True)
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
     with pytest.raises(ValueError):
         S3FileSystem(access_key='access')
     with pytest.raises(ValueError):
@@ -1049,6 +1057,26 @@ def test_s3_options(monkeypatch):
     with pytest.raises(ValueError):
         S3FileSystem(
             access_key='access', secret_key='secret', role_arn='arn'
+        )
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            access_key='access', secret_key='secret', anonymous=True
+        )
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            access_key='access', secret_key='secret', use_web_identity=True
+        )
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            role_arn='arn', anonymous=True
+        )
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            anonymous=True, use_web_identity=True
+        )
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            role_arn='arn', use_web_identity=True
         )
 
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1042,10 +1042,6 @@ def test_s3_options(monkeypatch):
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
-    fs = S3FileSystem(use_web_identity=True)
-    assert isinstance(fs, S3FileSystem)
-    assert pickle.loads(pickle.dumps(fs)) == fs
-
     with pytest.raises(ValueError):
         S3FileSystem(access_key='access')
     with pytest.raises(ValueError):
@@ -1063,21 +1059,7 @@ def test_s3_options(monkeypatch):
             access_key='access', secret_key='secret', anonymous=True
         )
     with pytest.raises(ValueError):
-        S3FileSystem(
-            access_key='access', secret_key='secret', use_web_identity=True
-        )
-    with pytest.raises(ValueError):
-        S3FileSystem(
-            role_arn='arn', anonymous=True
-        )
-    with pytest.raises(ValueError):
-        S3FileSystem(
-            anonymous=True, use_web_identity=True
-        )
-    with pytest.raises(ValueError):
-        S3FileSystem(
-            role_arn='arn', use_web_identity=True
-        )
+        S3FileSystem(role_arn="arn", anonymous=True)
 
 
 @pytest.mark.s3


### PR DESCRIPTION
Added basic support for explicitly specifying use of web identity credentials (it's already part of the default credentials provider chain) in the C++ API. Will add Python API in a separate PR.
Also refactored some existing code to make serialization and deserialization in Python more structured by adding an enum class `S3CredentialsKind` which uniquely identifies the credential type being used.
Also adds some missing error-checking and tests in the Python API.