### PR TITLE
ARROW-11780: [Python] Avoid crashing when a ChunkedArray is provided to StructArray.from_arrays()

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -314,8 +314,7 @@ def asarray(values, type=None):
     ----------
     values : array-like
         This can be a sequence, numpy.ndarray, pyarrow.Array or
-        pyarrow.ChunkedArray. 
-        If a ChunkedArray with more than one chunk is passed, the output will be
+        pyarrow.ChunkedArray. If a ChunkedArray is passed, the output will be
         a ChunkedArray, otherwise the output will be a Array.
     type : string or DataType
         Explicitly construct the array with this type. Attempt to cast if

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2182,10 +2182,12 @@ cdef class StructArray(Array):
 
         arrays = [asarray(x) for x in arrays]
         for arr in arrays:
-            if pyarrow_is_chunked_array(arr):
-                raise ValueError("ChunkedArray of more than one chunk "
-                                 "are not currently supported")
-            c_arrays.push_back(pyarrow_unwrap_array(arr))
+            c_array = pyarrow_unwrap_array(arr)
+            if c_array == nullptr:
+                raise TypeError(f"Unsupported arrays type {arr}, "
+                                 "if it's a ChunkedArray, only chunked arrays "
+                                 "of a single chunk are currently supported.")
+            c_arrays.push_back(c_array)
         if names is not None:
             for name in names:
                 c_names.push_back(tobytes(name))

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -316,7 +316,7 @@ def asarray(values, type=None):
         This can be a sequence, numpy.ndarray, pyarrow.Array or
         pyarrow.ChunkedArray. 
         If a ChunkedArray with more than one chunk is passed, the output will be
-        an ChunkedArray, otherwise the output will be a Array.
+        a ChunkedArray, otherwise the output will be a Array.
     type : string or DataType
         Explicitly construct the array with this type. Attempt to cast if
         indicated type is different.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2180,7 +2180,7 @@ cdef class StructArray(Array):
         for arr in arrays:
             c_array = pyarrow_unwrap_array(arr)
             if c_array == nullptr:
-                raise TypeError(f"Unsupported array type {arr.__class__}")
+                raise TypeError(f"Expected Array, got {arr.__class__}")
             c_arrays.push_back(c_array)
         if names is not None:
             for name in names:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -325,9 +325,6 @@ def asarray(values, type=None):
     -------
     arr : Array or ChunkedArray
     """
-    if isinstance(values, ChunkedArray) and values.num_chunks == 1:
-        values = values.chunk(0)
-
     if isinstance(values, (Array, ChunkedArray)):
         if type is not None and not values.type.equals(type):
             values = values.cast(type)
@@ -2184,9 +2181,7 @@ cdef class StructArray(Array):
         for arr in arrays:
             c_array = pyarrow_unwrap_array(arr)
             if c_array == nullptr:
-                raise TypeError(f"Unsupported arrays type {arr}, "
-                                 "if it's a ChunkedArray, only chunked arrays "
-                                 "of a single chunk are currently supported.")
+                raise TypeError(f"Unsupported array type {arr.__class__}")
             c_arrays.push_back(c_array)
         if names is not None:
             for name in names:

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -666,6 +666,14 @@ def test_struct_from_arrays():
         pa.StructArray.from_arrays([a, b, c], fields=[fa2, fb, fc])
 
 
+def test_struct_array_from_chunked():
+    chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
+    arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
+
+    assert arr.to_pylist() == [{'foo': 1}, {'foo': 2}, {'foo': 3},
+                               {'foo': 4}, {'foo': 5}, {'foo': 6}]
+
+
 def test_dictionary_from_numpy():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -668,10 +668,13 @@ def test_struct_from_arrays():
 
 def test_struct_array_from_chunked():
     chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
-    arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
-    assert arr.to_pylist() == [{'foo': 1}, {'foo': 2}, {'foo': 3},
-                               {'foo': 4}, {'foo': 5}, {'foo': 6}]
+    with pytest.raises(ValueError, match="more than one chunk"):
+        arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
+
+    chunked_arr = pa.chunked_array([[1, 2, 3]])
+    arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
+    assert arr.to_pylist() == [{'foo': 1}, {'foo': 2}, {'foo': 3}]
 
 
 def test_dictionary_from_numpy():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -669,7 +669,7 @@ def test_struct_from_arrays():
 def test_struct_array_from_chunked():
     chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
 
-    with pytest.raises(ValueError, match="more than one chunk"):
+    with pytest.raises(TypeError, match="Unsupported arrays type"):
         arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
     chunked_arr = pa.chunked_array([[1, 2, 3]])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -667,9 +667,12 @@ def test_struct_from_arrays():
 
 
 def test_struct_array_from_chunked():
+    # ARROW-11780
+    # Check that we don't segfault when trying to build
+    # a StructArray from a chunked array.
     chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
 
-    with pytest.raises(TypeError, match="Unsupported array type"):
+    with pytest.raises(TypeError, match="Expected Array"):
         pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -670,7 +670,7 @@ def test_struct_array_from_chunked():
     chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
 
     with pytest.raises(TypeError, match="Unsupported array type"):
-        arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
+        pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
 
 def test_dictionary_from_numpy():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -669,12 +669,8 @@ def test_struct_from_arrays():
 def test_struct_array_from_chunked():
     chunked_arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
 
-    with pytest.raises(TypeError, match="Unsupported arrays type"):
+    with pytest.raises(TypeError, match="Unsupported array type"):
         arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
-
-    chunked_arr = pa.chunked_array([[1, 2, 3]])
-    arr = pa.StructArray.from_arrays([chunked_arr], ["foo"])
-    assert arr.to_pylist() == [{'foo': 1}, {'foo': 2}, {'foo': 3}]
 
 
 def test_dictionary_from_numpy():


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-11780