### PR TITLE
ARROW-12466: [Python] Avoid AttributeError crash when comparing with None

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1021,9 +1021,11 @@ cdef class Array(_PandasConvertible):
         try:
             return self.equals(other)
         except TypeError:
+            # This also handles comparing with None
+            # as Array.equals(None) raises a TypeError.
             return NotImplemented
 
-    def equals(Array self, Array other):
+    def equals(Array self, Array other not None):
         return self.ap.Equals(deref(other.ap))
 
     def __len__(self):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2615,6 +2615,8 @@ def test_array_protocol():
     expected = pa.array([1, 2, 3], type=pa.float64())
     assert result.equals(expected)
 
+    assert (result == None) is False
+
     # raise error when passing size or mask keywords
     with pytest.raises(ValueError):
         pa.array(arr, mask=np.array([True, False, True]))

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -522,6 +522,9 @@ def test_array_eq():
     assert (arr1 == arr3) is False
     assert (arr1 != arr3) is True
 
+    assert (arr1 == 1) is False
+    assert (arr1 == None) is False  # noqa: E711
+
 
 def test_array_from_buffers():
     values_buf = pa.py_buffer(np.int16([4, 5, 6, 7]))
@@ -2614,8 +2617,6 @@ def test_array_protocol():
     result = pa.array(arr, type=pa.float64())
     expected = pa.array([1, 2, 3], type=pa.float64())
     assert result.equals(expected)
-
-    assert (result == None) is False
 
     # raise error when passing size or mask keywords
     with pytest.raises(ValueError):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-12466