### PR TITLE
ARROW-9594: [Python] Preserve null indexes in DictionaryArray.to_numpy as it's done in DictionaryArray.to_pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -2229,6 +2229,11 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
         checked_cast<const DictionaryType&>(*arr->type()).value_type();
     RETURN_NOT_OK(DecodeDictionaries(options.pool, dense_type, &arr));
     DCHECK_NE(arr->type()->id(), Type::DICTIONARY);
+
+    // The original Python DictionaryArray won't own the memory anymore
+    // as we actually built a new array when we decoded the DictionaryArray
+    // thus let the final resulting numpy array own the memory through a Capsule
+    py_ref = nullptr;
   }
 
   if (options.strings_to_categorical && is_base_binary_like(arr->type()->id())) {

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1160,7 +1160,7 @@ cdef class Array(_PandasConvertible):
                 "Cannot return a writable array if asking for zero-copy")
 
         c_options.zero_copy_only = zero_copy_only
-        c_options.decode_dictionaries = self.null_count
+        c_options.decode_dictionaries = True
 
         with nogil:
             check_status(ConvertArrayToPandas(c_options, self.sp_array,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1170,7 +1170,9 @@ cdef class Array(_PandasConvertible):
         array = PyObject_to_object(out)
 
         if isinstance(array, dict):
+            missings = array["indices"] < 0
             array = np.take(array['dictionary'], array['indices'])
+            array[missings] = None
 
         if writable and not array.flags.writeable:
             # if the conversion already needed to a copy, writeable is True

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2009,16 +2009,6 @@ cdef class DictionaryArray(Array):
 
         return self._indices
 
-    def to_numpy_CONVERT(self, zero_copy_only=True, writable=False):
-        if not zero_copy_only and self.null_count:
-            # When there are NULLs in the dictionary convert to a plain
-            # Array before doing the conversion to numpy.
-            converted_array = self.dictionary.take(self.indices)
-            return converted_array.to_numpy(zero_copy_only=zero_copy_only,
-                                            writable=writable)
-        return super().to_numpy(zero_copy_only=zero_copy_only,
-                                writable=writable)
-
     @staticmethod
     def from_arrays(indices, dictionary, mask=None, bint ordered=False,
                     bint from_pandas=False, bint safe=True,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1160,7 +1160,7 @@ cdef class Array(_PandasConvertible):
                 "Cannot return a writable array if asking for zero-copy")
 
         # If there are nulls and the array is a DictionaryArray
-        # decoding the dictionary will make sure that nulls are correctly handled.
+        # decoding the dictionary will make sure nulls are correctly handled.
         # Decoding a dictionary does imply a copy by the way,
         # so it can't be done if the user requested a zero_copy.
         c_options.decode_dictionaries = not zero_copy_only

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1172,7 +1172,7 @@ cdef class Array(_PandasConvertible):
         if isinstance(array, dict):
             missings = array["indices"] < 0
             array = np.take(array['dictionary'], array['indices'])
-            array[missings] = None
+            array[missings] = np.NaN
 
         if writable and not array.flags.writeable:
             # if the conversion already needed to a copy, writeable is True

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1170,9 +1170,13 @@ cdef class Array(_PandasConvertible):
         array = PyObject_to_object(out)
 
         if isinstance(array, dict):
-            missings = array["indices"] < 0
-            array = np.take(array['dictionary'], array['indices'])
-            array[missings] = np.NaN
+            if zero_copy_only or not self.null_count:
+                # zero_copy doesn't allow for nulls to be in the array
+                array = np.take(array['dictionary'], array['indices'])
+            else:
+                missings = array["indices"] < 0
+                array = np.take(array['dictionary'], array['indices'])
+                array[missings] = np.NaN
 
         if writable and not array.flags.writeable:
             # if the conversion already needed to a copy, writeable is True

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1159,8 +1159,12 @@ cdef class Array(_PandasConvertible):
             raise ValueError(
                 "Cannot return a writable array if asking for zero-copy")
 
+        # If there are nulls and the array is a DictionaryArray
+        # decoding the dictionary will make sure that nulls are correctly handled.
+        # Decoding a dictionary does imply a copy by the way,
+        # so it can't be done if the user requested a zero_copy.
+        c_options.decode_dictionaries = not zero_copy_only
         c_options.zero_copy_only = zero_copy_only
-        c_options.decode_dictionaries = True
 
         with nogil:
             check_status(ConvertArrayToPandas(c_options, self.sp_array,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2143,6 +2143,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
         c_bool safe_cast
         c_bool split_blocks
         c_bool self_destruct
+        c_bool decode_dictionaries
         unordered_set[c_string] categorical_columns
         unordered_set[c_string] extension_columns
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -701,7 +701,7 @@ def test_dictionary_to_numpy():
         assert result == a.to_pandas().tolist()
     except ModuleNotFoundError:
         # arrow compiled without pandas,
-        # skip this specific assertion.
+        # skip this specific assertion.
         pass
 
     with pytest.raises(pa.ArrowInvalid):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -688,6 +688,16 @@ def test_dictionary_from_numpy():
             assert d2[i].as_py() == dictionary[indices[i]]
 
 
+def test_dictionary_to_numpy():
+    a = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1, None, 0]), 
+        pa.array(['foo', 'bar'])
+    )
+
+    expected = ["foo", "bar", None, "foo"]
+    assert a.to_numpy(zero_copy_only=False).tolist() == expected
+
+
 def test_dictionary_from_boxed_arrays():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -687,8 +687,11 @@ def test_dictionary_from_numpy():
         else:
             assert d2[i].as_py() == dictionary[indices[i]]
 
+
 def test_dictionary_to_numpy():
-    expected = pa.array(["foo", "bar", None, "foo"]).to_numpy(zero_copy_only=False)
+    expected = pa.array(
+        ["foo", "bar", None, "foo"]
+    ).to_numpy(zero_copy_only=False)
     a = pa.DictionaryArray.from_arrays(
         pa.array([0, 1, None, 0]),
         pa.array(['foo', 'bar'])
@@ -713,9 +716,11 @@ def test_dictionary_to_numpy():
         pa.array([0, 1, None, 0]),
         pa.array([13.7, 11.0])
     )
-    expected = pa.array([13.7, 11.0, None, 13.7]).to_numpy(zero_copy_only=False)
+    expected = pa.array(
+        [13.7, 11.0, None, 13.7]
+    ).to_numpy(zero_copy_only=False)
     assert np.array_equal(
-        afloat2.to_numpy(zero_copy_only=False), 
+        afloat2.to_numpy(zero_copy_only=False),
         expected,
         equal_nan=True
     )

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -696,7 +696,8 @@ def test_dictionary_to_numpy():
         pa.array([0, 1, None, 0]),
         pa.array(['foo', 'bar'])
     )
-    assert (a.to_numpy(zero_copy_only=False) == expected).all()
+    np.testing.assert_array_equal(a.to_numpy(zero_copy_only=False),
+                                  expected)
 
     with pytest.raises(pa.ArrowInvalid):
         # If this would be changed to no longer raise in the future,
@@ -713,7 +714,8 @@ def test_dictionary_to_numpy():
     expected = pa.array(
         ["foo", "bar", "bar", "foo"]
     ).to_numpy(zero_copy_only=False)
-    assert (anonulls.to_numpy(zero_copy_only=False) == expected).all()
+    np.testing.assert_array_equal(anonulls.to_numpy(zero_copy_only=False),
+                                  expected)
 
     with pytest.raises(pa.ArrowInvalid):
         anonulls.to_numpy(zero_copy_only=True)
@@ -723,8 +725,10 @@ def test_dictionary_to_numpy():
         pa.array([13.7, 11.0])
     )
     expected = pa.array([13.7, 11.0, 11.0, 13.7]).to_numpy()
-    assert (afloat.to_numpy(zero_copy_only=True) == expected).all()
-    assert (afloat.to_numpy(zero_copy_only=False) == expected).all()
+    np.testing.assert_array_equal(afloat.to_numpy(zero_copy_only=True),
+                                  expected)
+    np.testing.assert_array_equal(afloat.to_numpy(zero_copy_only=False),
+                                  expected)
 
     afloat2 = pa.DictionaryArray.from_arrays(
         pa.array([0, 1, None, 0]),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -702,7 +702,7 @@ def test_dictionary_to_numpy():
         # to_numpy takes for granted that when zero_copy_only=True
         # there will be no nulls.
         # If that changes, nulls handling will have to be updated in to_numpy
-        # as we won't be able to rely anymore on decoding the DictionaryArray
+        # as we won't be able to rely anymore on decoding the DictionaryArray
         # to handle nulls.
         a.to_numpy(zero_copy_only=True)
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -690,12 +690,15 @@ def test_dictionary_from_numpy():
 
 def test_dictionary_to_numpy():
     a = pa.DictionaryArray.from_arrays(
-        pa.array([0, 1, None, 0]), 
+        pa.array([0, 1, None, 0]),
         pa.array(['foo', 'bar'])
     )
 
     expected = ["foo", "bar", np.NaN, "foo"]
-    assert a.to_numpy(zero_copy_only=False).tolist() == expected
+    result = a.to_numpy(zero_copy_only=False).tolist()
+    assert result == expected
+
+    assert result == a.to_pandas().tolist()
 
 
 def test_dictionary_from_boxed_arrays():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -694,7 +694,7 @@ def test_dictionary_to_numpy():
         pa.array(['foo', 'bar'])
     )
 
-    expected = ["foo", "bar", None, "foo"]
+    expected = ["foo", "bar", np.NaN, "foo"]
     assert a.to_numpy(zero_copy_only=False).tolist() == expected
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -694,11 +694,27 @@ def test_dictionary_to_numpy():
         pa.array(['foo', 'bar'])
     )
 
-    expected = ["foo", "bar", np.NaN, "foo"]
     result = a.to_numpy(zero_copy_only=False).tolist()
-    assert result == expected
-
+    assert result == ["foo", "bar", np.NaN, "foo"]
     assert result == a.to_pandas().tolist()
+
+    with pytest.raises(pa.ArrowInvalid):
+        # to_numpy takes for granted that when zero_copy_only=True
+        # there will be no nulls.
+        # If that changes, nulls handling will have to be updated in to_numpy.
+        a.to_numpy(zero_copy_only=True)
+
+    afloat = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1, 1, 0]),
+        pa.array([13.7, 11.0])
+    )
+
+    assert afloat.to_numpy(zero_copy_only=True).tolist() == [
+        13.7, 11.0, 11.0, 13.7
+    ]
+    assert afloat.to_numpy(zero_copy_only=False).tolist() == [
+        13.7, 11.0, 11.0, 13.7
+    ]
 
 
 def test_dictionary_from_boxed_arrays():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -743,6 +743,9 @@ def test_dictionary_to_numpy():
         equal_nan=True
     )
 
+    # Testing for integers can reveal problems related to dealing
+    # with None values, as a numpy array of int dtype
+    # can't contain NaN nor None.
     aints = pa.DictionaryArray.from_arrays(
         pa.array([0, 1, None, 0]),
         pa.array([7, 11])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -696,7 +696,13 @@ def test_dictionary_to_numpy():
 
     result = a.to_numpy(zero_copy_only=False).tolist()
     assert result == ["foo", "bar", np.NaN, "foo"]
-    assert result == a.to_pandas().tolist()
+
+    try:
+        assert result == a.to_pandas().tolist()
+    except ModuleNotFoundError:
+        # arrow compiled without pandas,
+        # skip this specific assertion.
+        pass
 
     with pytest.raises(pa.ArrowInvalid):
         # to_numpy takes for granted that when zero_copy_only=True

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -701,8 +701,22 @@ def test_dictionary_to_numpy():
     with pytest.raises(pa.ArrowInvalid):
         # to_numpy takes for granted that when zero_copy_only=True
         # there will be no nulls.
-        # If that changes, nulls handling will have to be updated in to_numpy.
+        # If that changes, nulls handling will have to be updated in to_numpy
+        # as we won't be able to rely anymore on decoding the DictionaryArray
+        # to handle nulls.
         a.to_numpy(zero_copy_only=True)
+
+    anonulls = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1, 1, 0]),
+        pa.array(['foo', 'bar'])
+    )
+    expected = pa.array(
+        ["foo", "bar", "bar", "foo"]
+    ).to_numpy(zero_copy_only=False)
+    assert (anonulls.to_numpy(zero_copy_only=False) == expected).all()
+
+    with pytest.raises(pa.ArrowInvalid):
+        anonulls.to_numpy(zero_copy_only=True)
 
     afloat = pa.DictionaryArray.from_arrays(
         pa.array([0, 1, 1, 0]),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -699,11 +699,11 @@ def test_dictionary_to_numpy():
     assert (a.to_numpy(zero_copy_only=False) == expected).all()
 
     with pytest.raises(pa.ArrowInvalid):
-        # to_numpy takes for granted that when zero_copy_only=True
-        # there will be no nulls.
-        # If that changes, nulls handling will have to be updated in to_numpy
-        # as we won't be able to rely anymore on decoding the DictionaryArray
-        # to handle nulls.
+        # If this would be changed to no longer raise in the future,
+        # ensure to test the actual result because, currently, to_numpy takes
+        # for granted that when zero_copy_only=True there will be no nulls
+        # (it's the decoding of the DictionaryArray that handles the nulls and
+        # this is only activated with zero_copy_only=False)
         a.to_numpy(zero_copy_only=True)
 
     anonulls = pa.DictionaryArray.from_arrays(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-9594