### PR TITLE
ARROW-12488: [GLib] Use g_memdup2() with GLib 2.68 or later

### DIFF
--- a/c_glib/plasma-glib/client.cpp
+++ b/c_glib/plasma-glib/client.cpp
@@ -265,6 +265,10 @@ gplasma_client_create_options_new(void)
   return GPLASMA_CLIENT_CREATE_OPTIONS(options);
 }
 
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+#  define g_memdup2(memory, byte_size) g_memdup(memory, byte_size)
+#endif
+
 /**
  * gplasma_client_create_options_set_metadata:
  * @options: A #GPlasmaClientCreateOptions.
@@ -282,7 +286,7 @@ gplasma_client_create_options_set_metadata(GPlasmaClientCreateOptions *options,
   if (priv->metadata) {
     g_free(priv->metadata);
   }
-  priv->metadata = static_cast<guint8 *>(g_memdup(metadata, size));
+  priv->metadata = static_cast<guint8 *>(g_memdup2(metadata, size));
   priv->metadata_size = size;
 }
 


### PR DESCRIPTION
g_memdup() is deprecated.