### PR TITLE
ARROW-12496: [C++][Dataset] Ensure AsyncScanner is covered by all scanner tests

### DIFF
--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& out, const TestScannerParams& params) {
 class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
  protected:
   std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<Dataset> dataset) {
-    ScannerBuilder builder(dataset, options_);
+    ScannerBuilder builder(std::move(dataset), options_);
     ARROW_EXPECT_OK(builder.UseThreads(GetParam().use_threads));
     ARROW_EXPECT_OK(builder.UseAsync(GetParam().use_async));
     EXPECT_OK_AND_ASSIGN(auto scanner, builder.Finish());

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -128,11 +128,11 @@ class FragmentDataset : public Dataset {
   Result<std::shared_ptr<Dataset>> ReplaceSchema(std::shared_ptr<Schema>) const override {
     return Status::NotImplemented("");
   }
-  Result<FragmentIterator> GetFragmentsImpl(Expression predicate) {
+
+ protected:
+  Result<FragmentIterator> GetFragmentsImpl(Expression predicate) override {
     return MakeVectorIterator(fragments_);
   }
-
- private:
   FragmentVector fragments_;
 };
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -119,6 +119,23 @@ void EnsureRecordBatchReaderDrained(RecordBatchReader* reader) {
   EXPECT_EQ(batch, nullptr);
 }
 
+/// Test dataset that returns one or more fragments.
+class FragmentDataset : public Dataset {
+ public:
+  FragmentDataset(std::shared_ptr<Schema> schema, FragmentVector fragments)
+      : Dataset(schema), fragments_(std::move(fragments)) {}
+  std::string type_name() const override { return "fragment"; }
+  Result<std::shared_ptr<Dataset>> ReplaceSchema(std::shared_ptr<Schema>) const override {
+    return Status::NotImplemented("");
+  }
+  Result<FragmentIterator> GetFragmentsImpl(Expression predicate) {
+    return MakeVectorIterator(fragments_);
+  }
+
+ private:
+  FragmentVector fragments_;
+};
+
 class DatasetFixtureMixin : public ::testing::Test {
  public:
   /// \brief Ensure that record batches found in reader are equals to the

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -123,7 +123,7 @@ void EnsureRecordBatchReaderDrained(RecordBatchReader* reader) {
 class FragmentDataset : public Dataset {
  public:
   FragmentDataset(std::shared_ptr<Schema> schema, FragmentVector fragments)
-      : Dataset(schema), fragments_(std::move(fragments)) {}
+      : Dataset(std::move(schema)), fragments_(std::move(fragments)) {}
   std::string type_name() const override { return "fragment"; }
   Result<std::shared_ptr<Dataset>> ReplaceSchema(std::shared_ptr<Schema>) const override {
     return Status::NotImplemented("");

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -67,16 +67,13 @@
     ASSERT_EQ((message), _st.ToString());                                             \
   } while (false)
 
-#define EXPECT_RAISES_WITH_MESSAGE_THAT(ENUM, matcher, expr)                          \
-  do {                                                                                \
-    auto _res = (expr);                                                               \
-    ::arrow::Status _st = ::arrow::internal::GenericToStatus(_res);                   \
-    if (!_st.Is##ENUM()) {                                                            \
-      FAIL() << "Expected '" ARROW_STRINGIFY(expr) "' to fail with " ARROW_STRINGIFY( \
-                    ENUM) ", but got "                                                \
-             << _st.ToString();                                                       \
-    }                                                                                 \
-    EXPECT_THAT(_st.ToString(), (matcher));                                           \
+#define EXPECT_RAISES_WITH_MESSAGE_THAT(ENUM, matcher, expr)                             \
+  do {                                                                                   \
+    auto _res = (expr);                                                                  \
+    ::arrow::Status _st = ::arrow::internal::GenericToStatus(_res);                      \
+    EXPECT_TRUE(_st.Is##ENUM()) << "Expected '" ARROW_STRINGIFY(expr) "' to fail with "  \
+                                << ARROW_STRINGIFY(ENUM) ", but got " << _st.ToString(); \
+    EXPECT_THAT(_st.ToString(), (matcher));                                              \
   } while (false)
 
 #define EXPECT_RAISES_WITH_CODE_AND_MESSAGE_THAT(code, matcher, expr) \


### PR DESCRIPTION
Some tests directly constructed a Scanner from a Fragment, which isn't supported by the async scanner. This introduces a simple dataset wrapper so all these tests will actually test both sync/async scanners.