### PR TITLE
ARROW-12442: [CI] Set job timeouts on GitHub Actions

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -37,6 +37,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     name: Archery Unittests and Crossbow Check Config
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -27,6 +27,7 @@ jobs:
   cancel-stale-workflow-runs:
     name: "Cancel stale workflow runs"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # Unfortunately, we need to define a separate cancellation step for
       # each workflow where we want to cancel stale runs.

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -49,6 +49,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -169,6 +170,7 @@ jobs:
     name: C++ Minimal Build Example
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
     steps:
@@ -185,6 +187,7 @@ jobs:
     name: AMD64 MacOS 10.15 C++
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
     env:
@@ -236,6 +239,7 @@ jobs:
     name: AMD64 ${{ matrix.name }} C++
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -305,6 +309,7 @@ jobs:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -40,6 +40,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') && github.repository == 'apache/arrow' }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +107,7 @@ jobs:
     name: OSS-Fuzz build check
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') && github.repository == 'apache/arrow' }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -35,6 +35,7 @@ jobs:
     name: AMD64 Ubuntu 18.04 C# ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +66,7 @@ jobs:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +96,7 @@ jobs:
     name: AMD64 MacOS 10.15 C# ${{ matrix.dotnet }}
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,7 @@ jobs:
     name: AMD64 Debian 10 Go ${{ matrix.go }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +75,7 @@ jobs:
     name: AMD64 Windows 2019 Go ${{ matrix.go }}
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -101,6 +103,7 @@ jobs:
     name: AMD64 MacOS 10.15 Go ${{ matrix.go }}
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,6 +54,7 @@ jobs:
     name: AMD64 Conda Integration Test
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -46,6 +46,7 @@ jobs:
     name: AMD64 Debian 9 Java JDK ${{ matrix.jdk }} Maven ${{ matrix.maven }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +89,7 @@ jobs:
     name: AMD64 MacOS 10.15 Java JDK ${{ matrix.jdk }}
     runs-on: macos-latest
     if: github.event_name == 'push'
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -46,6 +46,7 @@ jobs:
     name: AMD64 Debian 9 Java JNI (Gandiva, Plasma, ORC, Dataset)
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -41,6 +41,7 @@ jobs:
     name: AMD64 Debian 10 NodeJS 14
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -70,6 +71,7 @@ jobs:
     name: AMD64 MacOS 10.15 NodeJS ${{ matrix.node }}
     runs-on: macos-latest
     if: github.event_name == 'push'
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/julia.yml
+++ b/.github/workflows/julia.yml
@@ -32,6 +32,7 @@ jobs:
     env:
       JULIA_NUM_THREADS: 2
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,6 +42,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +108,7 @@ jobs:
     name: AMD64 MacOS 10.15 Python 3
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     env:
       ARROW_HOME: /usr/local
       ARROW_DATASET: ON

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -39,6 +39,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') && github.repository == 'apache/arrow' }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -49,6 +49,7 @@ jobs:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +107,7 @@ jobs:
     name: "${{ matrix.config.org }}/${{ matrix.config.image }}:${{ matrix.config.tag }}"
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -163,6 +165,7 @@ jobs:
     name: AMD64 Windows RTools ${{ matrix.rtools }}
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -54,6 +54,7 @@ jobs:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} GLib & Ruby
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +101,7 @@ jobs:
     name: AMD64 MacOS 10.15 GLib & Ruby
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
     env:
@@ -171,6 +173,7 @@ jobs:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} GLib & Ruby
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,7 @@ jobs:
   linux-build-lib:
     name: Build Libraries on AMD64 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -86,6 +87,7 @@ jobs:
     name: Test Workspace on AMD64 Rust ${{ matrix.rust }}
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -152,6 +154,7 @@ jobs:
   linux-test-simd:
     name: Test SIMD on AMD64 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -194,6 +197,7 @@ jobs:
   windows-and-macos:
     name: Test on ${{ matrix.os }} Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
@@ -223,6 +227,7 @@ jobs:
     name: Clippy
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -264,6 +269,7 @@ jobs:
   miri-checks:
     name: MIRI
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -299,6 +305,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -340,6 +347,7 @@ jobs:
   pyarrow-integration-test:
     name: Test Pyarrow C Data Interface
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         rust: [stable]
@@ -386,6 +394,7 @@ jobs:
   wasm32-build:
     name: Build wasm32 on AMD64 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]
@@ -430,6 +439,7 @@ jobs:
   default-build:
     name: Check No Defaults on AMD64 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       matrix:
         arch: [amd64]


### PR DESCRIPTION
The default job timeout on Github Actions is 6 hours (360 minutes).

All our jobs normally take much less than that (typically less than 30 minutes for most jobs), but external conditions such as network timeouts may make some jobs take the whole 6 hours before being killed. This in turn prevents other jobs from starting and makes the build queue grow excessively. Also, since build resources on Github Actions are shared between all Apache projects, this impacts other Apache projects as well.

Set a reasonable timeout on most jobs to minimize the repercussion of network issues and such.