### PR TITLE
ARROW-12500: [C++][Datasets] Ensure better test coverage of Dataset file formats

### DIFF
--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -90,9 +90,9 @@ static inline Result<csv::ConvertOptions> GetConvertOptions(
       GetFragmentScanOptions<CsvFragmentScanOptions>(
           kCsvTypeName, scan_options.get(), format.default_fragment_scan_options));
   auto convert_options = csv_scan_options->convert_options;
-  for (FieldRef ref : scan_options->MaterializedFields()) {
-    ARROW_ASSIGN_OR_RAISE(auto field, ref.GetOne(*scan_options->dataset_schema));
-
+  // Properly set conversion types even for non-materialized fields
+  // (since we're reading all of them anyways)
+  for (auto field : scan_options->dataset_schema->fields()) {
     if (column_names.find(field->name()) == column_names.end()) continue;
     convert_options.column_types[field->name()] = field->type();
   }

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -94,12 +94,13 @@ static inline Result<csv::ConvertOptions> GetConvertOptions(
   std::unordered_set<std::string> materialized_fields(materialized.begin(),
                                                       materialized.end());
   for (auto field : scan_options->dataset_schema->fields()) {
-    // Properly set conversion types for all fields
-    if (column_names.find(field->name()) == column_names.end()) continue;
-    convert_options.column_types[field->name()] = field->type();
-    // Only read the requested columns
     if (materialized_fields.find(field->name()) == materialized_fields.end()) continue;
+    // Ignore virtual columns.
+    if (column_names.find(field->name()) == column_names.end()) continue;
+    // Only read the requested columns
     convert_options.include_columns.push_back(field->name());
+    // Properly set conversion types
+    convert_options.column_types[field->name()] = field->type();
   }
   return convert_options;
 }

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -326,8 +326,8 @@ TEST_P(TestCsvFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
 }
 
 INSTANTIATE_TEST_SUITE_P(TestScan, TestCsvFileFormatScan,
-                         ::testing::ValuesIn(TestScannerParams::Values()),
-                         TestScannerParams::ToTestNameString);
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -44,94 +44,37 @@ constexpr int64_t kBatchRepetitions = 1 << 5;
 
 using internal::checked_pointer_cast;
 
-class ArrowIpcWriterMixin : public ::testing::Test {
+class ArrowIpcWriterMixin {
  public:
-  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
+  static std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
     EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
-
     EXPECT_OK_AND_ASSIGN(auto writer, ipc::MakeFileWriter(sink, reader->schema()));
-
     std::vector<std::shared_ptr<RecordBatch>> batches;
     ARROW_EXPECT_OK(reader->ReadAll(&batches));
     for (auto batch : batches) {
       ARROW_EXPECT_OK(writer->WriteRecordBatch(*batch));
     }
-
     ARROW_EXPECT_OK(writer->Close());
-
-    EXPECT_OK_AND_ASSIGN(auto out, sink->Finish());
-    return out;
-  }
-
-  std::shared_ptr<Buffer> Write(const Table& table) {
-    EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
-    EXPECT_OK_AND_ASSIGN(auto writer, ipc::MakeFileWriter(sink, table.schema()));
-
-    ARROW_EXPECT_OK(writer->WriteTable(table));
-
-    ARROW_EXPECT_OK(writer->Close());
-
     EXPECT_OK_AND_ASSIGN(auto out, sink->Finish());
     return out;
   }
 };
 
-class TestIpcFileFormat : public ArrowIpcWriterMixin {
- public:
-  std::unique_ptr<FileSource> GetFileSource(RecordBatchReader* reader) {
-    auto buffer = Write(reader);
-    return internal::make_unique<FileSource>(std::move(buffer));
-  }
-
-  std::unique_ptr<RecordBatchReader> GetRecordBatchReader(
-      std::shared_ptr<Schema> schema) {
-    return MakeGeneratedRecordBatch(schema, kBatchSize, kBatchRepetitions);
-  }
-
-  Result<std::shared_ptr<io::BufferOutputStream>> GetFileSink() {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ResizableBuffer> buffer,
-                          AllocateResizableBuffer(0));
-    return std::make_shared<io::BufferOutputStream>(buffer);
-  }
-
-  void SetSchema(std::vector<std::shared_ptr<Field>> fields) {
-    opts_ = std::make_shared<ScanOptions>();
-    opts_->dataset_schema = schema(std::move(fields));
-    ASSERT_OK(SetProjection(opts_.get(), opts_->dataset_schema->field_names()));
-  }
-
+class TestIpcFileFormat : public FileFormatFixtureMixin<ArrowIpcWriterMixin> {
  protected:
   std::shared_ptr<IpcFileFormat> format_ = std::make_shared<IpcFileFormat>();
-  std::shared_ptr<ScanOptions> opts_;
 };
 
 TEST_F(TestIpcFileFormat, WriteRecordBatchReader) {
   auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
   auto source = GetFileSource(reader.get());
-
-  SetSchema(reader->schema()->fields());
-
-  EXPECT_OK_AND_ASSIGN(auto sink, GetFileSink());
-
-  auto options = format_->DefaultWriteOptions();
-  EXPECT_OK_AND_ASSIGN(auto writer, format_->MakeWriter(sink, reader->schema(), options));
-
-  ASSERT_OK(writer->Write(GetRecordBatchReader(schema({field("f64", float64())})).get()));
-  ASSERT_OK(writer->Finish());
-
-  EXPECT_OK_AND_ASSIGN(auto written, sink->Finish());
-
+  auto written = TestWrite(format_.get(), reader->schema());
   AssertBufferEqual(*written, *source->buffer());
 }
 
 TEST_F(TestIpcFileFormat, WriteRecordBatchReaderCustomOptions) {
   auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
   auto source = GetFileSource(reader.get());
-
-  SetSchema(reader->schema()->fields());
-
-  EXPECT_OK_AND_ASSIGN(auto sink, GetFileSink());
-
   auto ipc_options =
       checked_pointer_cast<IpcFileWriteOptions>(format_->DefaultWriteOptions());
   if (util::Codec::IsAvailable(Compression::ZSTD)) {
@@ -139,58 +82,20 @@ TEST_F(TestIpcFileFormat, WriteRecordBatchReaderCustomOptions) {
                          util::Codec::Create(Compression::ZSTD));
   }
   ipc_options->metadata = key_value_metadata({{"hello", "world"}});
-  EXPECT_OK_AND_ASSIGN(auto writer,
-                       format_->MakeWriter(sink, reader->schema(), ipc_options));
-  ASSERT_OK(writer->Write(GetRecordBatchReader(schema({field("f64", float64())})).get()));
-  ASSERT_OK(writer->Finish());
 
-  EXPECT_OK_AND_ASSIGN(auto written, sink->Finish());
+  auto written = TestWrite(format_.get(), reader->schema(), ipc_options);
+
   EXPECT_OK_AND_ASSIGN(auto ipc_reader, ipc::RecordBatchFileReader::Open(
                                             std::make_shared<io::BufferReader>(written)));
-
   EXPECT_EQ(ipc_reader->metadata()->sorted_pairs(),
             ipc_options->metadata->sorted_pairs());
 }
 
 TEST_F(TestIpcFileFormat, OpenFailureWithRelevantError) {
-  std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(util::string_view(""));
-  auto result = format_->Inspect(FileSource(buf));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("<Buffer>"),
-                                  result.status());
-
-  constexpr auto file_name = "herp/derp";
-  ASSERT_OK_AND_ASSIGN(
-      auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {fs::File(file_name)}));
-  result = format_->Inspect({file_name, fs});
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr(file_name),
-                                  result.status());
+  TestOpenFailureWithRelevantError(format_.get(), StatusCode::Invalid);
 }
-
-TEST_F(TestIpcFileFormat, Inspect) {
-  auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
-  auto source = GetFileSource(reader.get());
-
-  ASSERT_OK_AND_ASSIGN(auto actual, format_->Inspect(*source.get()));
-  EXPECT_EQ(*actual, *reader->schema());
-}
-
-TEST_F(TestIpcFileFormat, IsSupported) {
-  auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
-  auto source = GetFileSource(reader.get());
-
-  bool supported = false;
-
-  std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(util::string_view(""));
-  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(FileSource(buf)));
-  ASSERT_EQ(supported, false);
-
-  buf = std::make_shared<Buffer>(util::string_view("corrupted"));
-  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(FileSource(buf)));
-  ASSERT_EQ(supported, false);
-
-  ASSERT_OK_AND_ASSIGN(supported, format_->IsSupported(*source));
-  EXPECT_EQ(supported, true);
-}
+TEST_F(TestIpcFileFormat, Inspect) { TestInspect(format_.get()); }
+TEST_F(TestIpcFileFormat, IsSupported) { TestIsSupported(format_.get()); }
 
 class TestIpcFileSystemDataset : public testing::Test,
                                  public WriteFileSystemDatasetMixin {
@@ -238,59 +143,21 @@ TEST_F(TestIpcFileSystemDataset, WriteExceedsMaxPartitions) {
                                   FileSystemDataset::Write(write_options_, scanner));
 }
 
-class TestIpcFileFormatScan : public TestIpcFileFormat,
-                              public ::testing::WithParamInterface<TestScannerParams> {
- public:
-  std::unique_ptr<RecordBatchReader> GetRecordBatchReader(
-      std::shared_ptr<Schema> schema) {
-    return MakeGeneratedRecordBatch(schema, GetParam().items_per_batch,
-                                    GetParam().total_batches());
-  }
-
-  // Scan the fragment through the scanner
-  RecordBatchIterator Batches(std::shared_ptr<Fragment> fragment) {
-    EXPECT_OK_AND_ASSIGN(auto schema, fragment->ReadPhysicalSchema());
-    auto dataset = std::make_shared<FragmentDataset>(schema, FragmentVector{fragment});
-    ScannerBuilder builder(dataset, opts_);
-    ARROW_EXPECT_OK(builder.UseAsync(GetParam().use_async));
-    ARROW_EXPECT_OK(builder.UseThreads(GetParam().use_threads));
-    EXPECT_OK_AND_ASSIGN(auto scanner, builder.Finish());
-    EXPECT_OK_AND_ASSIGN(auto batch_it, scanner->ScanBatches());
-    return MakeMapIterator([](TaggedRecordBatch tagged) { return tagged.record_batch; },
-                           std::move(batch_it));
-  }
-
-  // Scan the fragment directly
-  RecordBatchIterator PhysicalBatches(std::shared_ptr<Fragment> fragment) {
-    if (GetParam().use_async) {
-      EXPECT_OK_AND_ASSIGN(auto batch_gen, fragment->ScanBatchesAsync(opts_));
-      EXPECT_OK_AND_ASSIGN(auto batch_it, MakeGeneratorIterator(std::move(batch_gen)));
-      return batch_it;
-    }
-    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(opts_));
-    return MakeFlattenIterator(MakeMaybeMapIterator(
-        [](std::shared_ptr<ScanTask> scan_task) { return scan_task->Execute(); },
-        std::move(scan_task_it)));
-  }
+class TestIpcFileFormatScan : public FileFormatScanMixin<ArrowIpcWriterMixin> {
+ protected:
+  std::shared_ptr<IpcFileFormat> format_ = std::make_shared<IpcFileFormat>();
 };
 
-TEST_P(TestIpcFileFormatScan, ScanRecordBatchReader) {
-  auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
-  auto source = GetFileSource(reader.get());
-
-  SetSchema(reader->schema()->fields());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
-
-  int64_t row_count = 0;
-
-  for (auto maybe_batch : Batches(fragment)) {
-    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-    row_count += batch->num_rows();
-  }
-
-  ASSERT_EQ(row_count, GetParam().expected_rows());
+TEST_P(TestIpcFileFormatScan, ScanRecordBatchReader) { TestScan(format_.get()); }
+TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
+  TestScanWithVirtualColumn(format_.get());
 }
-
+TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderProjected) {
+  TestScanProjected(format_.get());
+}
+TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
+  TestScanProjectedMissingCols(format_.get());
+}
 TEST_P(TestIpcFileFormatScan, FragmentScanOptions) {
   auto reader = GetRecordBatchReader(
       // ARROW-12077: on Windows/mimalloc/release, nullable list column leads to crash
@@ -312,110 +179,6 @@ TEST_P(TestIpcFileFormatScan, FragmentScanOptions) {
   ASSERT_OK_AND_ASSIGN(auto batches, scan_task->Execute());
   ASSERT_RAISES(Invalid, batches.Next());
 }
-
-TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
-  auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
-  auto source = GetFileSource(reader.get());
-
-  // NB: dataset_schema includes a column not present in the file
-  SetSchema({reader->schema()->field(0), field("virtual", int32())});
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
-
-  ASSERT_OK_AND_ASSIGN(auto physical_schema, fragment->ReadPhysicalSchema());
-  AssertSchemaEqual(Schema({field("f64", float64())}), *physical_schema);
-  {
-    int64_t row_count = 0;
-    for (auto maybe_batch : Batches(fragment)) {
-      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-      AssertSchemaEqual(*batch->schema(), *opts_->projected_schema);
-      row_count += batch->num_rows();
-    }
-    ASSERT_EQ(row_count, GetParam().expected_rows());
-  }
-  {
-    int64_t row_count = 0;
-    for (auto maybe_batch : PhysicalBatches(fragment)) {
-      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-      AssertSchemaEqual(*batch->schema(), *physical_schema);
-      row_count += batch->num_rows();
-    }
-    ASSERT_EQ(row_count, GetParam().expected_rows());
-  }
-}
-
-static auto f32 = field("f32", float32());
-static auto f64 = field("f64", float64());
-static auto i32 = field("i32", int32());
-static auto i64 = field("i64", int64());
-
-TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderProjected) {
-  SetSchema({f64, i64, f32, i32});
-  ASSERT_OK(SetProjection(opts_.get(), {"f64"}));
-  opts_->filter = equal(field_ref("i32"), literal(0));
-
-  // NB: projection is applied by the scanner; FileFragment does not evaluate it so
-  // we will not drop "i32" even though it is not projected since we need it for
-  // filtering
-  auto expected_schema = schema({f64, i32});
-
-  auto reader = GetRecordBatchReader(opts_->dataset_schema);
-  auto source = GetFileSource(reader.get());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
-
-  int64_t row_count = 0;
-
-  for (auto maybe_batch : PhysicalBatches(fragment)) {
-    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-    row_count += batch->num_rows();
-    AssertSchemaEqual(*batch->schema(), *expected_schema,
-                      /*check_metadata=*/false);
-  }
-
-  ASSERT_EQ(row_count, GetParam().expected_rows());
-}
-
-TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
-  SetSchema({f64, i64, f32, i32});
-  ASSERT_OK(SetProjection(opts_.get(), {"f64"}));
-  opts_->filter = equal(field_ref("i32"), literal(0));
-
-  auto reader_without_i32 = GetRecordBatchReader(schema({f64, i64, f32}));
-  auto reader_without_f64 = GetRecordBatchReader(schema({i64, f32, i32}));
-  auto reader = GetRecordBatchReader(schema({f64, i64, f32, i32}));
-
-  auto readers = {reader.get(), reader_without_i32.get(), reader_without_f64.get()};
-  for (auto reader : readers) {
-    auto source = GetFileSource(reader);
-    ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
-
-    // NB: projection is applied by the scanner; FileFragment does not evaluate it so
-    // we will not drop "i32" even though it is not projected since we need it for
-    // filtering
-    //
-    // in the case where a file doesn't contain a referenced field, we won't
-    // materialize it as nulls later
-    std::shared_ptr<Schema> expected_schema;
-    if (reader == reader_without_i32.get()) {
-      expected_schema = schema({f64});
-    } else if (reader == reader_without_f64.get()) {
-      expected_schema = schema({i32});
-    } else {
-      expected_schema = schema({f64, i32});
-    }
-
-    int64_t row_count = 0;
-
-    for (auto maybe_batch : PhysicalBatches(fragment)) {
-      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-      row_count += batch->num_rows();
-      AssertSchemaEqual(*batch->schema(), *expected_schema,
-                        /*check_metadata=*/false);
-    }
-
-    ASSERT_EQ(row_count, GetParam().expected_rows());
-  }
-}
-
 INSTANTIATE_TEST_SUITE_P(TestScan, TestIpcFileFormatScan,
                          ::testing::ValuesIn(TestScannerParams::Values()),
                          TestScannerParams::ToTestNameString);

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -168,8 +168,8 @@ TEST_P(TestIpcFileFormatScan, FragmentScanOptions) {
   ASSERT_RAISES(Invalid, batches.Next());
 }
 INSTANTIATE_TEST_SUITE_P(TestScan, TestIpcFileFormatScan,
-                         ::testing::ValuesIn(TestScannerParams::Values()),
-                         TestScannerParams::ToTestNameString);
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -39,9 +39,6 @@
 namespace arrow {
 namespace dataset {
 
-constexpr int64_t kBatchSize = 1UL << 12;
-constexpr int64_t kBatchRepetitions = 1 << 5;
-
 using internal::checked_pointer_cast;
 
 class ArrowIpcWriterMixin {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -346,10 +346,6 @@ TEST_P(TestParquetFileFormatScan, PredicatePushdown) {
   // rows and returned row groups is a good enough proxy to check if pushdown
   // predicate is working.
 
-  // Note this test ignores the dataset size params and only respects UseAsync.
-  if (GetParam().num_child_datasets != 1) GTEST_SKIP() << "Skipping redundant case";
-  if (GetParam().use_threads) GTEST_SKIP() << "Skipping redundant case";
-
   constexpr int64_t kNumRowGroups = 16;
   constexpr int64_t kTotalNumRows = kNumRowGroups * (kNumRowGroups + 1) / 2;
 
@@ -392,10 +388,6 @@ TEST_P(TestParquetFileFormatScan, PredicatePushdown) {
 }
 
 TEST_P(TestParquetFileFormatScan, PredicatePushdownRowGroupFragments) {
-  // Note this test ignores the dataset size params and only respects UseAsync.
-  if (GetParam().num_child_datasets != 1) GTEST_SKIP() << "Skipping redundant case";
-  if (GetParam().use_threads) GTEST_SKIP() << "Skipping redundant case";
-
   constexpr int64_t kNumRowGroups = 16;
 
   auto reader = ArithmeticDatasetFixture::GetRecordBatchReader(kNumRowGroups);
@@ -447,10 +439,6 @@ TEST_P(TestParquetFileFormatScan, PredicatePushdownRowGroupFragments) {
 }
 
 TEST_P(TestParquetFileFormatScan, ExplicitRowGroupSelection) {
-  // Note this test ignores the dataset size params and only respects UseAsync.
-  if (GetParam().num_child_datasets != 1) GTEST_SKIP() << "Skipping redundant case";
-  if (GetParam().use_threads) GTEST_SKIP() << "Skipping redundant case";
-
   constexpr int64_t kNumRowGroups = 16;
   constexpr int64_t kTotalNumRows = kNumRowGroups * (kNumRowGroups + 1) / 2;
 
@@ -508,10 +496,6 @@ TEST_P(TestParquetFileFormatScan, ExplicitRowGroupSelection) {
 }
 
 TEST_P(TestParquetFileFormatScan, PredicatePushdownRowGroupFragmentsUsingStringColumn) {
-  // Note this test ignores the dataset size params and only respects UseAsync.
-  if (GetParam().num_child_datasets != 1) GTEST_SKIP() << "Skipping redundant case";
-  if (GetParam().use_threads) GTEST_SKIP() << "Skipping redundant case";
-
   auto table = TableFromJSON(schema({field("x", utf8())}),
                              {
                                  R"([{"x": "a"}])",
@@ -529,8 +513,8 @@ TEST_P(TestParquetFileFormatScan, PredicatePushdownRowGroupFragmentsUsingStringC
 }
 
 INSTANTIATE_TEST_SUITE_P(TestScan, TestParquetFileFormatScan,
-                         ::testing::ValuesIn(TestScannerParams::Values()),
-                         TestScannerParams::ToTestNameString);
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -18,7 +18,6 @@
 #include "arrow/dataset/scanner.h"
 
 #include <memory>
-#include <ostream>
 
 #include <gmock/gmock.h>
 
@@ -40,34 +39,6 @@ using testing::IsEmpty;
 
 namespace arrow {
 namespace dataset {
-
-struct TestScannerParams {
-  bool use_async;
-  bool use_threads;
-  int num_child_datasets;
-  int num_batches;
-  int items_per_batch;
-
-  static std::vector<TestScannerParams> Values() {
-    std::vector<TestScannerParams> values;
-    for (int sync = 0; sync < 2; sync++) {
-      for (int use_threads = 0; use_threads < 2; use_threads++) {
-        values.push_back(
-            {static_cast<bool>(sync), static_cast<bool>(use_threads), 1, 1, 1024});
-        values.push_back(
-            {static_cast<bool>(sync), static_cast<bool>(use_threads), 2, 16, 1024});
-      }
-    }
-    return values;
-  }
-};
-
-std::ostream& operator<<(std::ostream& out, const TestScannerParams& params) {
-  out << (params.use_async ? "async-" : "sync-")
-      << (params.use_threads ? "threaded-" : "serial-") << params.num_child_datasets
-      << "d-" << params.num_batches << "b-" << params.items_per_batch << "i";
-  return out;
-}
 
 class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
  protected:

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -40,6 +40,47 @@ using testing::IsEmpty;
 namespace arrow {
 namespace dataset {
 
+struct TestScannerParams {
+  bool use_async;
+  bool use_threads;
+  int num_child_datasets;
+  int num_batches;
+  int items_per_batch;
+
+  std::string ToString() const {
+    // GTest requires this to be alphanumeric
+    std::stringstream ss;
+    ss << (use_async ? "Async" : "Sync") << (use_threads ? "Threaded" : "Serial")
+       << num_child_datasets << "d" << num_batches << "b" << items_per_batch << "r";
+    return ss.str();
+  }
+
+  static std::string ToTestNameString(
+      const ::testing::TestParamInfo<TestScannerParams>& info) {
+    return std::to_string(info.index) + info.param.ToString();
+  }
+
+  static std::vector<TestScannerParams> Values() {
+    std::vector<TestScannerParams> values;
+    for (int sync = 0; sync < 2; sync++) {
+      for (int use_threads = 0; use_threads < 2; use_threads++) {
+        values.push_back(
+            {static_cast<bool>(sync), static_cast<bool>(use_threads), 1, 1, 1024});
+        values.push_back(
+            {static_cast<bool>(sync), static_cast<bool>(use_threads), 2, 16, 1024});
+      }
+    }
+    return values;
+  }
+};
+
+std::ostream& operator<<(std::ostream& out, const TestScannerParams& params) {
+  out << (params.use_async ? "async-" : "sync-")
+      << (params.use_threads ? "threaded-" : "serial-") << params.num_child_datasets
+      << "d-" << params.num_batches << "b-" << params.items_per_batch << "i";
+  return out;
+}
+
 class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
  protected:
   std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<Dataset> dataset) {

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -467,7 +467,7 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<Writer>,
                                     GetParam().total_batches());
   }
 
-  // Scan the fragment through the scanner
+  // Scan the fragment through the scanner.
   RecordBatchIterator Batches(std::shared_ptr<Fragment> fragment) {
     EXPECT_OK_AND_ASSIGN(auto schema, fragment->ReadPhysicalSchema());
     EXPECT_NE(nullptr, opts_) << "Must call SetSchema() in test";
@@ -481,7 +481,7 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<Writer>,
                            std::move(batch_it));
   }
 
-  // Scan the fragment directly
+  // Scan the fragment directly, without using the scanner.
   RecordBatchIterator PhysicalBatches(std::shared_ptr<Fragment> fragment) {
     EXPECT_NE(nullptr, opts_) << "Must call SetSchema() in test";
     if (GetParam().use_async) {


### PR DESCRIPTION
This unifies (most of) the tests across Parquet, Feather, and CSV (with carve-outs for particular cases). In particular, this means all formats are now tested in conjunction with async/sync and serial/threaded scanners. Also, a set of common file format tests were refactored out of the individual tests and centralized.