### PR TITLE
ARROW-12527: [Dev] Don't try getting JIRA information for MINOR PR

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -330,6 +330,9 @@ class PullRequest(object):
         return bool(self._pr_data["mergeable"])
 
     def _get_jira(self):
+        if self.title.startswith("MINOR:"):
+            return None
+
         jira_id = None
         for project, regex in PR_TITLE_REGEXEN:
             m = regex.search(self.title)
@@ -337,7 +340,7 @@ class PullRequest(object):
                 jira_id = m.group(1)
                 break
 
-        if jira_id is None and not self.title.startswith("MINOR:"):
+        if jira_id is None:
             options = ' or '.join('{0}-XXX'.format(project)
                                   for project in SUPPORTED_PROJECTS)
             self.cmd.fail("PR title should be prefixed by a jira id "


### PR DESCRIPTION
    $ python3 dev/merge_arrow_pr.py 10146
    Already on 'master'
    Your branch is up to date with 'origin/master'.
    Current branch master is up to date.
    ARROW_HOME = /home/kou/work/cpp/arrow/dev
    PROJECT_NAME = arrow
    Exception ignored in: <function Magic.__del__ at 0x7fa5c912f9d0>
    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/magic/__init__.py", line 155, in __del__
        if self.cookie and magic_close:
    AttributeError: 'Magic' object has no attribute 'cookie'
    Restoring head pointer to f1ac15d3
    Note: switching to 'f1ac15d3'.

    You are in 'detached HEAD' state. You can look around, make experimental
    changes and commit them, and you can discard any commits you make in this
    state without impacting any branches by switching back to a branch.

    If you want to create a new branch to retain commits you create, you may
    do so (now or later) by using -c with the switch command. Example:

      git switch -c <new-branch-name>

    Or undo this operation with:

      git switch -

    Turn off this advice by setting config variable advice.detachedHead to false

    HEAD is now at f1ac15d38 ARROW-12489: [Developer] autotune is broken
    Traceback (most recent call last):
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 147, in __init__
        self.issue = jira_con.issue(jira_id)
      File "/usr/local/lib/python3.9/dist-packages/jira/client.py", line 1071, in issue
        issue.find(id, params=params)
      File "/usr/local/lib/python3.9/dist-packages/jira/resources.py", line 201, in find
        self._load(url, params=params)
      File "/usr/local/lib/python3.9/dist-packages/jira/resources.py", line 316, in _load
        r = self._session.get(url, headers=headers, params=params)
      File "/usr/local/lib/python3.9/dist-packages/jira/resilientsession.py", line 151, in get
        return self.__verb('GET', url, **kwargs)
      File "/usr/local/lib/python3.9/dist-packages/jira/resilientsession.py", line 147, in __verb
        raise_on_error(response, verb=verb, **kwargs)
      File "/usr/local/lib/python3.9/dist-packages/jira/resilientsession.py", line 56, in raise_on_error
        raise JIRAError(
    jira.exceptions.JIRAError: JiraError HTTP 404 url: https://issues.apache.org/jira/rest/api/2/issue/None
            text: Issue Does Not Exist

            response headers = {'Date': 'Sat, 24 Apr 2021 20:44:25 GMT', 'Server': 'Apache', 'X-AREQUESTID': '1244x117037738x6', 'X-ASESSIONID': 'dniwfg', 'X-XSS-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN', 'Content-Security-Policy': "frame-ancestors 'self'", 'X-ASEN': 'SEN-2062203', 'X-Seraph-LoginReason': 'OK', 'X-AUSERNAME': 'kou', 'Cache-Control': 'no-cache, no-store, no-transform', 'Content-Type': 'application/json;charset=UTF-8', 'Via': '1.1 jira2-he-de.apache.org', 'Keep-Alive': 'timeout=15, max=98', 'Connection': 'Keep-Alive', 'Transfer-Encoding': 'chunked'}
            response text = {"errorMessages":["Issue Does Not Exist"],"errors":{}}

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 608, in <module>
        cli()
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 573, in cli
        pr = PullRequest(cmd, github_api, PR_REMOTE_NAME, jira_con, pr_num)
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 313, in __init__
        self.jira_issue = self._get_jira()
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 346, in _get_jira
        return JiraIssue(self.con, jira_id, project, self.cmd)
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 149, in __init__
        self.cmd.fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
      File "/home/kou/work/cpp/arrow/dev/merge_arrow_pr.py", line 274, in fail
        raise Exception(msg)
    Exception: ASF JIRA could not find None
    JiraError HTTP 404 url: https://issues.apache.org/jira/rest/api/2/issue/None
            text: Issue Does Not Exist

            response headers = {'Date': 'Sat, 24 Apr 2021 20:44:25 GMT', 'Server': 'Apache', 'X-AREQUESTID': '1244x117037738x6', 'X-ASESSIONID': 'dniwfg', 'X-XSS-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN', 'Content-Security-Policy': "frame-ancestors 'self'", 'X-ASEN': 'SEN-2062203', 'X-Seraph-LoginReason': 'OK', 'X-AUSERNAME': 'kou', 'Cache-Control': 'no-cache, no-store, no-transform', 'Content-Type': 'application/json;charset=UTF-8', 'Via': '1.1 jira2-he-de.apache.org', 'Keep-Alive': 'timeout=15, max=98', 'Connection': 'Keep-Alive', 'Transfer-Encoding': 'chunked'}
            response text = {"errorMessages":["Issue Does Not Exist"],"errors":{}}