### PR TITLE
ARROW-12506: [Python] Improve modularity of pyarrow codebase: _ipc module

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -358,6 +358,11 @@ variable to 1.
 If you wish to delete stale PyArrow build artifacts before rebuilding, navigate
 to the ``arrow/python`` folder and run ``git clean -Xfd .``.
 
+.. note::
+
+   The build process can be parallelized using the ``PYARROW_PARALLEL=N``
+   environment variable, which will result in faster builds.
+
 Now you are ready to install test dependencies and run `Unit Testing`_, as
 described above.
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -403,6 +403,7 @@ set(CYTHON_EXTENSIONS
     _feather
     _fs
     _hdfsio
+    _ipc
     _json)
 
 set(LINK_LIBS arrow_shared arrow_python_shared)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -250,8 +250,7 @@ from pyarrow.lib import (NativeFile, PythonFile,
 from pyarrow._hdfsio import HdfsFile, have_libhdfs
 
 from pyarrow.lib import (ChunkedArray, RecordBatch, Table, table,
-                         concat_arrays, concat_tables, TableGroupBy,
-                         RecordBatchReader)
+                         concat_arrays, concat_tables, TableGroupBy)
 
 # Exceptions
 from pyarrow.lib import (ArrowCancelled,
@@ -275,7 +274,7 @@ from pyarrow.lib import (deserialize_from, deserialize,
 
 import pyarrow.hdfs as hdfs
 
-from pyarrow.ipc import serialize_pandas, deserialize_pandas
+from pyarrow.ipc import serialize_pandas, deserialize_pandas, RecordBatchReader
 import pyarrow.ipc as ipc
 
 from pyarrow.serialization import (default_serialization_context,

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -37,8 +37,8 @@ from pyarrow.lib cimport (check_status, Field, MemoryPool, Schema,
                           pyarrow_unwrap_table, pyarrow_wrap_schema,
                           pyarrow_wrap_table, pyarrow_wrap_data_type,
                           pyarrow_unwrap_data_type, Table, RecordBatch,
-                          StopToken, _CRecordBatchWriter)
-from pyarrow._ipc cimport RecordBatchReader
+                          StopToken)
+from pyarrow._ipc cimport RecordBatchReader, _CRecordBatchWriter
 from pyarrow.lib import frombytes, tobytes, SignalStopHandler
 from pyarrow.util import _stringify_path
 

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -30,8 +30,8 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_python cimport (MakeInvalidRowHandler,
                                                PyInvalidRowCallback)
 from pyarrow.lib cimport (check_status, Field, MemoryPool, Schema,
-                          ensure_type, maybe_unbox_memory_pool, 
-                          get_input_stream, get_writer, 
+                          ensure_type, maybe_unbox_memory_pool,
+                          get_input_stream, get_writer,
                           native_transcoding_input_stream,
                           pyarrow_unwrap_batch, pyarrow_unwrap_schema,
                           pyarrow_unwrap_table, pyarrow_wrap_schema,

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -30,14 +30,15 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_python cimport (MakeInvalidRowHandler,
                                                PyInvalidRowCallback)
 from pyarrow.lib cimport (check_status, Field, MemoryPool, Schema,
-                          RecordBatchReader, ensure_type,
-                          maybe_unbox_memory_pool, get_input_stream,
-                          get_writer, native_transcoding_input_stream,
+                          ensure_type, maybe_unbox_memory_pool, 
+                          get_input_stream, get_writer, 
+                          native_transcoding_input_stream,
                           pyarrow_unwrap_batch, pyarrow_unwrap_schema,
                           pyarrow_unwrap_table, pyarrow_wrap_schema,
                           pyarrow_wrap_table, pyarrow_wrap_data_type,
                           pyarrow_unwrap_data_type, Table, RecordBatch,
                           StopToken, _CRecordBatchWriter)
+from pyarrow._ipc cimport RecordBatchReader
 from pyarrow.lib import frombytes, tobytes, SignalStopHandler
 from pyarrow.util import _stringify_path
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -36,6 +36,8 @@ from pyarrow._csv cimport (
     ConvertOptions, ParseOptions, ReadOptions, WriteOptions)
 from pyarrow.util import _is_iterable, _is_path_like, _stringify_path
 
+from pyarrow._ipc cimport RecordBatchReader
+
 
 def _forbid_instantiation(klass, subclasses_instead=True):
     msg = '{} is an abstract class thus cannot be initialized.'.format(

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -29,6 +29,7 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_dataset cimport *
 from pyarrow.lib cimport (Table, check_status, pyarrow_unwrap_table, pyarrow_wrap_table)
 from pyarrow.lib import tobytes
+from pyarrow.ipc import RecordBatchReader
 from pyarrow._compute cimport Expression, _true
 from pyarrow._dataset cimport Dataset
 from pyarrow._dataset import InMemoryDataset

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -33,6 +33,7 @@ from libcpp cimport bool as c_bool
 from pyarrow.lib cimport *
 from pyarrow.lib import (ArrowCancelled, ArrowException, ArrowInvalid,
                          SignalStopHandler)
+from pyarrow._ipc cimport *
 from pyarrow.lib import as_buffer, frombytes, tobytes
 from pyarrow.includes.libarrow_flight cimport *
 from pyarrow.ipc import _get_legacy_format_default, _ReadPandasMixin

--- a/python/pyarrow/_ipc.pxd
+++ b/python/pyarrow/_ipc.pxd
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# cython: language_level = 3
+
+from pyarrow.includes.common cimport *
+from pyarrow.includes.libarrow cimport *
+from pyarrow.lib cimport _Weakrefable
+
+
+cdef class IpcWriteOptions(_Weakrefable):
+    cdef:
+        CIpcWriteOptions c_options
+
+
+cdef class IpcReadOptions(_Weakrefable):
+    cdef:
+        CIpcReadOptions c_options
+
+
+cdef class Message(_Weakrefable):
+    cdef:
+        unique_ptr[CMessage] message
+
+
+cdef class _CRecordBatchWriter(_Weakrefable):
+    cdef:
+        shared_ptr[CRecordBatchWriter] writer
+
+
+cdef class RecordBatchReader(_Weakrefable):
+    cdef:
+        shared_ptr[CRecordBatchReader] reader

--- a/python/pyarrow/_ipc.pyx
+++ b/python/pyarrow/_ipc.pyx
@@ -27,7 +27,7 @@ from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport (check_status, _Weakrefable, NativeFile, Table,
                           RecordBatch, Schema, Tensor, DictionaryMemo,
-                          pyarrow_wrap_buffer,
+                          pyarrow_wrap_buffer, Codec,
                           get_writer, get_reader, get_input_stream,
                           pyarrow_wrap_schema, pyarrow_unwrap_schema,
                           pyarrow_wrap_batch, pyarrow_wrap_table,

--- a/python/pyarrow/_ipc.pyx
+++ b/python/pyarrow/_ipc.pyx
@@ -15,8 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# cython: language_level = 3
+# cython: profile = False
+# cython: embedsignature = True
+# cython: nonecheck = True
+# distutils: language = c++
+
+from cython.operator cimport dereference as deref
+
+from pyarrow.includes.common cimport *
+from pyarrow.includes.libarrow cimport *
+from pyarrow.lib cimport (check_status, _Weakrefable, NativeFile, Table,
+                          RecordBatch, Schema, Tensor, DictionaryMemo,
+                          pyarrow_wrap_buffer,
+                          get_writer, get_reader, get_input_stream,
+                          pyarrow_wrap_schema, pyarrow_unwrap_schema,
+                          pyarrow_wrap_batch, pyarrow_wrap_table,
+                          pyarrow_wrap_tensor, _ensure_compression)
+
 from collections import namedtuple
 import warnings
+
+from pyarrow.lib import (as_buffer, tobytes, frombytes, BufferOutputStream,
+                         PythonFile, BufferReader)
 
 
 cpdef enum MetadataVersion:

--- a/python/pyarrow/_ipc.pyx
+++ b/python/pyarrow/_ipc.pyx
@@ -836,7 +836,7 @@ cdef class RecordBatchReader(_Weakrefable):
             t_reader.get().set_chunksize(max_chunksize)
 
         c_reader = dynamic_pointer_cast[CRecordBatchReader, TableBatchReader](
-           t_reader)
+            t_reader)
 
         reader = RecordBatchReader.__new__(RecordBatchReader)
         reader.reader = c_reader

--- a/python/pyarrow/_ipc.pyx
+++ b/python/pyarrow/_ipc.pyx
@@ -807,6 +807,24 @@ cdef class RecordBatchReader(_Weakrefable):
 
     @staticmethod
     def from_table(Table table, max_chunksize=None):
+        """
+        Create a RecordBatchReader from a Table.
+
+        Note that this method is zero-copy, it merely exposes the same data
+        under a different API.
+
+        Parameters
+        ----------
+        table : Table
+            The table from which the RecordBatchReader should be created.
+        max_chunksize : int, default None
+            Maximum size for RecordBatch chunks. Individual chunks may be
+            smaller depending on the chunk layout of individual columns.
+
+        Returns
+        -------
+        RecordBatchReader
+        """
         cdef:
             RecordBatchReader reader
             shared_ptr[CRecordBatchReader] c_reader

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -20,18 +20,17 @@
 import os
 
 import pyarrow as pa
+from pyarrow._ipc import (IpcReadOptions, IpcWriteOptions, ReadStats, WriteStats,  # noqa
+                          _ReadPandasMixin, MetadataVersion,
+                          Message, MessageReader,
+                          RecordBatchReader, read_message,
+                          read_record_batch, read_schema,
+                          read_tensor, write_tensor,
+                          get_record_batch_size, get_tensor_size)
+import pyarrow._ipc as _ipc
 
-from pyarrow.lib import (IpcReadOptions, IpcWriteOptions, ReadStats, WriteStats,  # noqa
-                         Message, MessageReader,
-                         RecordBatchReader, _ReadPandasMixin,
-                         MetadataVersion,
-                         read_message, read_record_batch, read_schema,
-                         read_tensor, write_tensor,
-                         get_record_batch_size, get_tensor_size)
-import pyarrow.lib as lib
 
-
-class RecordBatchStreamReader(lib._RecordBatchStreamReader):
+class RecordBatchStreamReader(_ipc._RecordBatchStreamReader):
     """
     Reader for the Arrow streaming binary format.
 
@@ -74,7 +73,7 @@ use_legacy_format : bool, default None
     setting the environment variable ARROW_PRE_0_15_IPC_FORMAT=1"""
 
 
-class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
+class RecordBatchStreamWriter(_ipc._RecordBatchStreamWriter):
     __doc__ = """Writer for the Arrow streaming binary format
 
 {}""".format(_ipc_writer_class_doc)
@@ -84,7 +83,7 @@ class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
         self._open(sink, schema, options=options)
 
 
-class RecordBatchFileReader(lib._RecordBatchFileReader):
+class RecordBatchFileReader(_ipc._RecordBatchFileReader):
     """
     Class for reading Arrow record batch data from the Arrow binary file format
 
@@ -109,7 +108,7 @@ class RecordBatchFileReader(lib._RecordBatchFileReader):
                    options=options, memory_pool=memory_pool)
 
 
-class RecordBatchFileWriter(lib._RecordBatchFileWriter):
+class RecordBatchFileWriter(_ipc._RecordBatchFileWriter):
 
     __doc__ = """Writer to create the Arrow binary file format
 

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -37,20 +37,6 @@ cdef class _Weakrefable:
     cdef object __weakref__
 
 
-cdef class IpcWriteOptions(_Weakrefable):
-    cdef:
-        CIpcWriteOptions c_options
-
-cdef class IpcReadOptions(_Weakrefable):
-    cdef:
-        CIpcReadOptions c_options
-
-
-cdef class Message(_Weakrefable):
-    cdef:
-        unique_ptr[CMessage] message
-
-
 cdef class MemoryPool(_Weakrefable):
     cdef:
         CMemoryPool* pool
@@ -500,14 +486,7 @@ cdef class CompressedOutputStream(NativeFile):
     pass
 
 
-cdef class _CRecordBatchWriter(_Weakrefable):
-    cdef:
-        shared_ptr[CRecordBatchWriter] writer
-
-
-cdef class RecordBatchReader(_Weakrefable):
-    cdef:
-        shared_ptr[CRecordBatchReader] reader
+cdef CCompressionType _ensure_compression(str name) except *
 
 
 cdef class Codec(_Weakrefable):

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -50,6 +50,9 @@ cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)
 cdef object box_memory_pool(CMemoryPool* pool)
 
 
+cdef void* _as_c_pointer(v, allow_null=*) except *
+
+
 cdef class DataType(_Weakrefable):
     cdef:
         shared_ptr[CDataType] sp_type

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -175,9 +175,6 @@ include "tensor.pxi"
 # File IO
 include "io.pxi"
 
-# IPC / Messaging
-include "ipc.pxi"
-
 # Python serialization
 include "serialization.pxi"
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3868,20 +3868,8 @@ cdef class Table(_PandasConvertible):
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
         """
-        cdef:
-            shared_ptr[CRecordBatchReader] c_reader
-            RecordBatchReader reader
-            shared_ptr[TableBatchReader] t_reader
-        t_reader = make_shared[TableBatchReader](self.sp_table)
-
-        if max_chunksize is not None:
-            t_reader.get().set_chunksize(max_chunksize)
-
-        c_reader = dynamic_pointer_cast[CRecordBatchReader, TableBatchReader](
-            t_reader)
-        reader = RecordBatchReader.__new__(RecordBatchReader)
-        reader.reader = c_reader
-        return reader
+        from pyarrow._ipc import RecordBatchReader
+        return RecordBatchReader.from_table(self, max_chunksize=max_chunksize)
 
     def _to_pandas(self, options, categories=None, ignore_metadata=False,
                    types_mapper=None):

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -32,7 +32,8 @@ import numpy as np
 import pytest
 import pyarrow as pa
 
-from pyarrow.lib import IpcReadOptions, tobytes
+from pyarrow.ipc import IpcReadOptions
+from pyarrow.lib import tobytes
 from pyarrow.util import find_free_port
 from pyarrow.tests import util
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -216,6 +216,7 @@ class build_ext(_build_ext):
         '_s3fs',
         '_hdfs',
         '_hdfsio',
+        '_ipc',
         'gandiva']
 
     def _run_cmake(self):


### PR DESCRIPTION
Third batch of changes related to making pyarrow build more modular. ipc is no longer included in pyarrow.lib but has been separated to its own `_ipc` module.

This PR is based on #10159