### PR TITLE
ARROW-12542: [R] SF columns in datasets with filters [WIP]

### DIFF
--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1798,7 +1798,7 @@ test_that("metadata of list elements (ARROW-12542)", {
   write_dataset(df, tmp, partitioning = "part", format = "parquet")
   ds <- open_dataset(tmp)
 
-  # arrange is necesary here because of the collation order for
+  # arrange is necessary here because of the collation order for
   expect_equal(
     arrange(df, part, a),
     collect(arrange(df, part, a))


### PR DESCRIPTION
This is only the failing test for this. When collecting the whole dataset everything is fine. But when we filter, we have the filtered data but try to apply the whole list of metdata to it. This is the branch that is being called, but we might want/need to filter the metadata higher https://github.com/apache/arrow/blob/master/r/R/metadata.R#L62-L65