### PR TITLE
ARROW-12556: [C++][Gandiva] Implement BYTESUBSTRING function on Gandiva

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -246,7 +246,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("byte_substr", {"bytesubstring"},
-                     DataTypeVector{utf8(), int32(), int32()}, utf8(),
+                     DataTypeVector{binary(), int32(), int32()}, binary(),
                      kResultNullIfNull, "byte_substr", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -246,7 +246,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("byte_substr", {"bytesubstring"},
-                     DataTypeVector{binary(), int32(), int32()}, binary(),
+                     DataTypeVector{utf8(), int32(), int32()}, utf8(),
                      kResultNullIfNull, "byte_substr", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -245,6 +245,10 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("byte_substr", {"bytesubstring"},
+                     DataTypeVector{utf8(), int32(), int32()}, utf8(),
+                     kResultNullIfNull, "byte_substr", NativeFunction::kNeedsContext),
+
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -247,7 +247,8 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
 
       NativeFunction("byte_substr", {"bytesubstring"},
                      DataTypeVector{binary(), int32(), int32()}, binary(),
-                     kResultNullIfNull, "byte_substr", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "byte_substr_binary_int32_int32",
+                     NativeFunction::kNeedsContext),
 
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1936,8 +1936,9 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
 }
 
 FORCE_INLINE
-const char* byte_substr(gdv_int64 context, const char* text, gdv_int32 text_len,
-                        gdv_int32 offset, gdv_int32 length, gdv_int32* out_len) {
+const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
+                                           gdv_int32 text_len, gdv_int32 offset,
+                                           gdv_int32 length, gdv_int32* out_len) {
   // the first offset position for a string is 1, so not consider offset == 0
   // also, the length should be always a positive number
   if (text_len == 0 || offset == 0 || length <= 0) {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1934,4 +1934,41 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
   *out_len = j;
   return ret;
 }
+
+FORCE_INLINE
+const char* byte_substr(gdv_int64 context, const char* text, gdv_int32 text_len,
+                        gdv_int32 offset, gdv_int32 length, gdv_int32* out_len) {
+  // the first offset position for a string is 1, so not consider offset == 0
+  // also, the length should be always a positive number
+  if (text_len == 0 || offset == 0 || length <= 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  char* ret =
+      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, text_len));
+
+  if (ret == nullptr) {
+    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    *out_len = 0;
+    return "";
+  }
+
+  int32_t startPos;
+  if (offset < 0) {
+    startPos = text_len + offset;
+  } else {
+    startPos = offset - 1;
+  }
+  // calculate end position from length and truncate to upper value bounds
+  if (startPos + length > text_len) {
+    *out_len = text_len - startPos;
+  } else {
+    *out_len = length;
+  }
+
+  memcpy(ret, text + startPos, *out_len);
+  return ret;
+}
+
 }  // extern "C"

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1980,5 +1980,4 @@ const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
   memcpy(ret, text + startPos, *out_len);
   return ret;
 }
-
 }  // extern "C"

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1935,6 +1935,14 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
   return ret;
 }
 
+// Produces the binary representation of a string y characters long derived by starting
+// at offset 'x' and considering the defined length 'y'. Notice that the offset index
+// may be a negative number (starting from the end of the string), or a positive number
+// starting on index 1. Cases:
+//     BYTE_SUBSTR("TestString", 1, 10) => "TestString"
+//     BYTE_SUBSTR("TestString", 5, 10) => "String"
+//     BYTE_SUBSTR("TestString", -6, 10) => "String"
+//     BYTE_SUBSTR("TestString", -600, 10) => "TestString"
 FORCE_INLINE
 const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
                                            gdv_int32 text_len, gdv_int32 offset,
@@ -1955,12 +1963,13 @@ const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
     return "";
   }
 
-  int32_t startPos;
-  if (offset < 0) {
-    startPos = text_len + offset;
-  } else {
+  int32_t startPos = 0;
+  if (offset >= 0) {
     startPos = offset - 1;
+  } else if (text_len + offset >= 0) {
+    startPos = text_len + offset;
   }
+
   // calculate end position from length and truncate to upper value bounds
   if (startPos + length > text_len) {
     *out_len = text_len - startPos;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1206,39 +1206,39 @@ TEST(TestStringOps, TestByteSubstr) {
   gdv_int32 out_len = 0;
 
   const char* out_str;
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, -6, 10, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, -6, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 0, 10, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 0, -500, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 0, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 10, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 4, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 1000, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 1000, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 3, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Str");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
   EXPECT_FALSE(ctx.has_error());
 }

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1200,6 +1200,49 @@ TEST(TestStringOps, TestLocate) {
   ctx.Reset();
 }
 
+TEST(TestStringOps, TestByteSubstr) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+
+  const char* out_str;
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "String");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, -6, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "String");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 0, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 0, -500, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Test");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 1, 1000, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 3, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Str");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "String");
+  EXPECT_FALSE(ctx.has_error());
+}
+
 TEST(TestStringOps, TestReplace) {
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1241,6 +1241,10 @@ TEST(TestStringOps, TestByteSubstr) {
   out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
   EXPECT_FALSE(ctx.has_error());
+
+  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, -100, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+  EXPECT_FALSE(ctx.has_error());
 }
 
 TEST(TestStringOps, TestReplace) {

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -490,6 +490,9 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,
                        gdv_int32* out_len);
 
+const char* byte_substr(gdv_int64 context, const char* text, gdv_int32 text_len,
+                        gdv_int32 offset, gdv_int32 length, gdv_int32* out_len);
+
 const char* castVARCHAR_bool_int64(gdv_int64 context, gdv_boolean value,
                                    gdv_int64 out_len, gdv_int32* out_length);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -490,8 +490,9 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,
                        gdv_int32* out_len);
 
-const char* byte_substr(gdv_int64 context, const char* text, gdv_int32 text_len,
-                        gdv_int32 offset, gdv_int32 length, gdv_int32* out_len);
+const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
+                                           gdv_int32 text_len, gdv_int32 offset,
+                                           gdv_int32 length, gdv_int32* out_len);
 
 const char* castVARCHAR_bool_int64(gdv_int64 context, gdv_boolean value,
                                    gdv_int64 out_len, gdv_int32* out_length);

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -935,13 +935,13 @@ TEST_F(TestProjector, TestOffset) {
 
 TEST_F(TestProjector, TestByteSubString) {
   // schema for input fields
-  auto field0 = field("f0", arrow::utf8());
+  auto field0 = field("f0", arrow::binary());
   auto field1 = field("f1", arrow::int32());
   auto field2 = field("f2", arrow::int32());
   auto schema = arrow::schema({field0, field1, field2});
 
   // output fields
-  auto field_byte_substr = field("bytesubstring", arrow::utf8());
+  auto field_byte_substr = field("bytesubstring", arrow::binary());
 
   // Build expression
   auto byte_substr_expr =
@@ -955,15 +955,15 @@ TEST_F(TestProjector, TestByteSubString) {
 
   // Create a row-batch with some sample data
   int num_records = 6;
-  auto array0 = MakeArrowArrayUtf8({"ab", "", "ab", "invalid", "valid", "invalid"},
-                                   {true, true, true, true, true, true});
+  auto array0 = MakeArrowArrayBinary({"ab", "", "ab", "invalid", "valid", "invalid"},
+                                     {true, true, true, true, true, true});
   auto array1 = MakeArrowArrayInt32({0, 1, 1, 1, 3, 3},
                                    {true, true, true, true, true, true});
   auto array2 = MakeArrowArrayInt32({0, 1, 1, 2, 3, 3},
                                     {true, true, true, true, true, true});
   // expected output
-  auto exp_byte_substr = MakeArrowArrayUtf8({"", "", "a", "in", "lid", "val"},
-                                            {true, true, true, true, true, true});
+  auto exp_byte_substr = MakeArrowArrayBinary({"", "", "a", "in", "lid", "val"},
+                                              {true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch =

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -944,9 +944,8 @@ TEST_F(TestProjector, TestByteSubString) {
   auto field_byte_substr = field("bytesubstring", arrow::binary());
 
   // Build expression
-  auto byte_substr_expr =
-      TreeExprBuilder::MakeExpression("bytesubstring",
-                                      {field0, field1, field2}, field_byte_substr);
+  auto byte_substr_expr = TreeExprBuilder::MakeExpression(
+      "bytesubstring", {field0, field1, field2}, field_byte_substr);
 
   std::shared_ptr<Projector> projector;
   auto status =
@@ -957,21 +956,20 @@ TEST_F(TestProjector, TestByteSubString) {
   int num_records = 6;
   auto array0 = MakeArrowArrayBinary({"ab", "", "ab", "invalid", "valid", "invalid"},
                                      {true, true, true, true, true, true});
-  auto array1 = MakeArrowArrayInt32({0, 1, 1, 1, 3, 3},
-                                   {true, true, true, true, true, true});
-  auto array2 = MakeArrowArrayInt32({0, 1, 1, 2, 3, 3},
-                                    {true, true, true, true, true, true});
+  auto array1 =
+      MakeArrowArrayInt32({0, 1, 1, 1, 3, 3}, {true, true, true, true, true, true});
+  auto array2 =
+      MakeArrowArrayInt32({0, 1, 1, 2, 3, 3}, {true, true, true, true, true, true});
   // expected output
   auto exp_byte_substr = MakeArrowArrayBinary({"", "", "a", "in", "lid", "val"},
                                               {true, true, true, true, true, true});
 
   // prepare input record batch
-  auto in_batch =
-      arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
+  auto in = arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
 
   // Evaluate expression
   arrow::ArrayVector outputs;
-  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  status = projector->Evaluate(*in, pool_, &outputs);
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Validate results

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -933,6 +933,51 @@ TEST_F(TestProjector, TestOffset) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_sum, outputs.at(0));
 }
 
+TEST_F(TestProjector, TestByteSubString) {
+  // schema for input fields
+  auto field0 = field("f0", arrow::utf8());
+  auto field1 = field("f1", arrow::int32());
+  auto field2 = field("f2", arrow::int32());
+  auto schema = arrow::schema({field0, field1, field2});
+
+  // output fields
+  auto field_byte_substr = field("bytesubstring", arrow::utf8());
+
+  // Build expression
+  auto byte_substr_expr =
+      TreeExprBuilder::MakeExpression("bytesubstring",
+                                      {field0, field1, field2}, field_byte_substr);
+
+  std::shared_ptr<Projector> projector;
+  auto status =
+      Projector::Make(schema, {byte_substr_expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 6;
+  auto array0 = MakeArrowArrayUtf8({"ab", "", "ab", "invalid", "valid", "invalid"},
+                                   {true, true, true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({0, 1, 1, 1, 3, 3},
+                                   {true, true, true, true, true, true});
+  auto array2 = MakeArrowArrayInt32({0, 1, 1, 2, 3, 3},
+                                    {true, true, true, true, true, true});
+  // expected output
+  auto exp_byte_substr = MakeArrowArrayUtf8({"", "", "a", "in", "lid", "val"},
+                                            {true, true, true, true, true, true});
+
+  // prepare input record batch
+  auto in_batch =
+      arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_byte_substr, outputs.at(0));
+}
+
 // Test to ensure behaviour of cast functions when the validity is false for an input. The
 // function should not run for that input.
 TEST_F(TestProjector, TestCastFunction) {


### PR DESCRIPTION
Implement BYTE_SUBSTR([string] giventext, [number] x, [number] y)

Produces the binary representation of a string y characters long derived by starting at position x in the string giventext. y may also be given by the expression LENGTH(giventext), which indicates that you wish to convert every remaining character in giventext.