### PR TITLE
ARROW-12567: [C++][Gandiva] Implement LPAD and RPAD functions for string input values

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -139,16 +139,14 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "lpad_utf8_int32",
-                     NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "lpad_utf8_int32", NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
                      kResultNullIfNull, "rpad_utf8_int32_utf8",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "rpad_utf8_int32",
-                     NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "rpad_utf8_int32", NativeFunction::kNeedsContext),
 
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -134,6 +134,9 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      utf8(), kResultNullIfNull, "substr_utf8_int64",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("lpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
+                     kResultNullIfNull, "lpad", NativeFunction::kNeedsContext),
+
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -140,6 +140,12 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
                      kResultNullIfNull, "lpad_no_fill_text", NativeFunction::kNeedsContext),
 
+      NativeFunction("rpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
+                     kResultNullIfNull, "rpad", NativeFunction::kNeedsContext),
+
+      NativeFunction("rpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
+                     kResultNullIfNull, "rpad_no_fill_text", NativeFunction::kNeedsContext),
+
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -135,17 +135,19 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
-                     kResultNullIfNull, "lpad", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "lpad_utf8_int32_utf8",
+                     NativeFunction::kNeedsContext),
 
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "lpad_no_fill_text",
+                     kResultNullIfNull, "lpad_utf8_int32",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
-                     kResultNullIfNull, "rpad", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "rpad_utf8_int32_utf8",
+                     NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "rpad_no_fill_text",
+                     kResultNullIfNull, "rpad_utf8_int32",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -138,13 +138,15 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "lpad", NativeFunction::kNeedsContext),
 
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "lpad_no_fill_text", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "lpad_no_fill_text",
+                     NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
                      kResultNullIfNull, "rpad", NativeFunction::kNeedsContext),
 
       NativeFunction("rpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
-                     kResultNullIfNull, "rpad_no_fill_text", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "rpad_no_fill_text",
+                     NativeFunction::kNeedsContext),
 
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -137,6 +137,9 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
       NativeFunction("lpad", {}, DataTypeVector{utf8(), int32(), utf8()}, utf8(),
                      kResultNullIfNull, "lpad", NativeFunction::kNeedsContext),
 
+      NativeFunction("lpad", {}, DataTypeVector{utf8(), int32()}, utf8(),
+                     kResultNullIfNull, "lpad_no_fill_text", NativeFunction::kNeedsContext),
+
       NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",
                      NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1490,6 +1490,58 @@ const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
 }
 
 FORCE_INLINE
+const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
+                              gdv_int32 return_length, gdv_int32* out_len) {
+  // if the text length or the defined return length (number of characters to return)
+  // is <=0, then return an empty string.
+  if (text_len == 0 || return_length <= 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  // initially counts the number of utf8 characters in the defined text and fill_text
+  int32_t text_char_count = utf8_length(context, text, text_len);
+  // text_char_count is zero if input has invalid utf8 char
+  // fill_char_count is zero if fill_text_len is > 0 and its value has invalid utf8 char
+  if (text_char_count == 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  if (return_length == text_char_count) {
+    // case where the return length is same as the text's length, or if it need to
+    // fill into text but "fill_text" is empty, then return text directly.
+    *out_len = text_len;
+    return text;
+  } else if (return_length < text_char_count) {
+    // case where it truncates the result on return length.
+    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    return text;
+  } else {
+    // case (return_length > text_char_count)
+    // case where it needs to copy "fill_text" on the string left. The total number
+    // of chars to copy is given by (return_length -  text_char_count)
+    char* ret =
+        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
+            context,
+            text_len + (return_length - text_char_count)));
+    if (ret == nullptr) {
+      gdv_fn_context_set_error_msg(context,
+                                   "Could not allocate memory for output string");
+      *out_len = 0;
+      return "";
+    }
+    const char* blank_space = " ";
+    for (int i = 0; i < return_length - text_char_count; ++i) {
+      ret[i] = blank_space[0];
+    }
+    memcpy(ret + return_length - text_char_count, text, text_len);
+    *out_len = text_len + (return_length - text_char_count);
+    return ret;
+  }
+}
+
+FORCE_INLINE
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* delimiter, gdv_int32 delim_len, gdv_int32 index,
                        gdv_int32* out_len) {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1490,6 +1490,73 @@ const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
 }
 
 FORCE_INLINE
+const char* rpad(gdv_int64 context, const char* text, gdv_int32 text_len,
+                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
+                 gdv_int32* out_len) {
+  // if the text length or the defined return length (number of characters to return)
+  // is <=0, then return an empty string.
+  if (text_len == 0 || return_length <= 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  // initially counts the number of utf8 characters in the defined text and fill_text
+  int32_t text_char_count = utf8_length(context, text, text_len);
+  int32_t fill_char_count = utf8_length(context, fill_text, fill_text_len);
+  // text_char_count is zero if input has invalid utf8 char
+  // fill_char_count is zero if fill_text_len is > 0 and its value has invalid utf8 char
+  if (text_char_count == 0 || (fill_text_len > 0 && fill_char_count == 0)) {
+    *out_len = 0;
+    return "";
+  }
+
+  if (return_length == text_char_count ||
+      (return_length > text_char_count && fill_text_len == 0)) {
+    // case where the return length is same as the text's length, or if it need to
+    // fill into text but "fill_text" is empty, then return text directly.
+    *out_len = text_len;
+    return text;
+  } else if (return_length < text_char_count) {
+    // case where it truncates the result on return length.
+    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    return text;
+  } else {
+    // case (return_length > text_char_count)
+    // case where it needs to copy "fill_text" on the string right
+    char* ret =
+        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, return_length));
+    if (ret == nullptr) {
+      gdv_fn_context_set_error_msg(context,
+                                   "Could not allocate memory for output string");
+      *out_len = 0;
+      return "";
+    }
+    // fulfill the initial text copying the main input string
+    memcpy(ret, text, text_len);
+    // try to fulfill the return string with the "fill_text" continuously
+    int32_t copied_chars_count = 0;
+    int32_t copied_chars_position = 0;
+    while (text_char_count + copied_chars_count < return_length) {
+      int32_t char_len;
+      int32_t fill_length;
+      // for each char, evaluate its length to consider it when mem copying
+      for (fill_length = 0; fill_length < fill_text_len; fill_length += char_len) {
+        if (text_char_count + copied_chars_count >= return_length) {
+          break;
+        }
+        char_len = utf8_char_length(fill_text[fill_length]);
+        copied_chars_count++;
+      }
+      memcpy(ret + text_len + copied_chars_position, fill_text, fill_length);
+      copied_chars_position += fill_length;
+    }
+    *out_len = copied_chars_position + text_len;
+    return ret;
+  }
+}
+
+
+FORCE_INLINE
 const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
                               gdv_int32 return_length, gdv_int32* out_len) {
   // if the text length or the defined return length (number of characters to return)
@@ -1536,6 +1603,58 @@ const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 tex
       ret[i] = blank_space[0];
     }
     memcpy(ret + return_length - text_char_count, text, text_len);
+    *out_len = text_len + (return_length - text_char_count);
+    return ret;
+  }
+}
+
+FORCE_INLINE
+const char* rpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
+                              gdv_int32 return_length, gdv_int32* out_len) {
+  // if the text length or the defined return length (number of characters to return)
+  // is <=0, then return an empty string.
+  if (text_len == 0 || return_length <= 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  // initially counts the number of utf8 characters in the defined text and fill_text
+  int32_t text_char_count = utf8_length(context, text, text_len);
+  // text_char_count is zero if input has invalid utf8 char
+  // fill_char_count is zero if fill_text_len is > 0 and its value has invalid utf8 char
+  if (text_char_count == 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  if (return_length == text_char_count) {
+    // case where the return length is same as the text's length, or if it need to
+    // fill into text but "fill_text" is empty, then return text directly.
+    *out_len = text_len;
+    return text;
+  } else if (return_length < text_char_count) {
+    // case where it truncates the result on return length.
+    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    return text;
+  } else {
+    // case (return_length > text_char_count)
+    // case where it needs to copy "fill_text" on the string right
+    char* ret =
+        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
+            context,
+            text_len + (return_length - text_char_count)));
+    if (ret == nullptr) {
+      gdv_fn_context_set_error_msg(context,
+                                   "Could not allocate memory for output string");
+      *out_len = 0;
+      return "";
+    }
+    // fulfill the initial text copying the main string input
+    memcpy(ret, text, text_len);
+    const char* blank_space = " ";
+    for (int i = 0; i < return_length - text_char_count; ++i) {
+      ret[text_len + i] = blank_space[0];
+    }
     *out_len = text_len + (return_length - text_char_count);
     return ret;
   }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1423,6 +1423,73 @@ const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
 }
 
 FORCE_INLINE
+const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
+                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
+                 gdv_int32* out_len) {
+  // if the text length or the defined return length (number of characters to return)
+  // is <=0, then return an empty string.
+  if (text_len == 0 || return_length <= 0) {
+    *out_len = 0;
+    return "";
+  }
+
+  // initially counts the number of utf8 characters in the defined text and fill_text
+  int32_t text_char_count = utf8_length(context, text, text_len);
+  int32_t fill_char_count = utf8_length(context, fill_text, fill_text_len);
+  // text_char_count is zero if input has invalid utf8 char
+  // fill_char_count is zero if fill_text_len is > 0 and its value has invalid utf8 char
+  if (text_char_count == 0 || (fill_text_len > 0 && fill_char_count == 0)) {
+    *out_len = 0;
+    return "";
+  }
+
+  if (return_length == text_char_count ||
+      (return_length > text_char_count && fill_text_len == 0)) {
+    // case where the return length is same as the text's length, or if it need to
+    // fill into text but "fill_text" is empty, then return text directly.
+    *out_len = text_len;
+    return text;
+  } else if (return_length < text_char_count) {
+    // case where it truncates the result on return length.
+    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    return text;
+  } else {
+    // case (return_length > text_char_count)
+    // case where it needs to copy "fill_text" on the string left. The total number
+    // of chars to copy is given by (return_length -  text_char_count)
+    char* ret =
+        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, return_length));
+    if (ret == nullptr) {
+      gdv_fn_context_set_error_msg(context,
+                                   "Could not allocate memory for output string");
+      *out_len = 0;
+      return "";
+    }
+    // try to fulfill the return string with the "fill_text" continuously
+    int32_t copied_chars_count = 0;
+    int32_t copied_chars_position = 0;
+    while (copied_chars_count < return_length - text_char_count) {
+      int32_t char_len;
+      int32_t fill_index;
+      // for each char, evaluate its length to consider it when mem copying
+      for (fill_index = 0; fill_index < fill_text_len; fill_index += char_len) {
+        if (copied_chars_count >= return_length - text_char_count) {
+          break;
+        }
+        char_len = utf8_char_length(fill_text[fill_index]);
+        copied_chars_count++;
+      }
+      memcpy(ret + copied_chars_position, fill_text, fill_index);
+      copied_chars_position += fill_index;
+    }
+    // after fulfilling the text, copy the main string
+    memcpy(ret + copied_chars_position, text, text_len);
+    *out_len = copied_chars_position + text_len;
+    return ret;
+  }
+}
+
+FORCE_INLINE
 const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
                        const char* delimiter, gdv_int32 delim_len, gdv_int32 index,
                        gdv_int32* out_len) {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1555,7 +1555,6 @@ const char* rpad(gdv_int64 context, const char* text, gdv_int32 text_len,
   }
 }
 
-
 FORCE_INLINE
 const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
                               gdv_int32 return_length, gdv_int32* out_len) {
@@ -1588,10 +1587,8 @@ const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 tex
     // case (return_length > text_char_count)
     // case where it needs to copy "fill_text" on the string left. The total number
     // of chars to copy is given by (return_length -  text_char_count)
-    char* ret =
-        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
-            context,
-            text_len + (return_length - text_char_count)));
+    char* ret = reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
+        context, text_len + (return_length - text_char_count)));
     if (ret == nullptr) {
       gdv_fn_context_set_error_msg(context,
                                    "Could not allocate memory for output string");
@@ -1639,10 +1636,8 @@ const char* rpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 tex
   } else {
     // case (return_length > text_char_count)
     // case where it needs to copy "fill_text" on the string right
-    char* ret =
-        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
-            context,
-            text_len + (return_length - text_char_count)));
+    char* ret = reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(
+        context, text_len + (return_length - text_char_count)));
     if (ret == nullptr) {
       gdv_fn_context_set_error_msg(context,
                                    "Could not allocate memory for output string");

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -703,65 +703,65 @@ TEST(TestStringOps, TestLpadString) {
   const char* out_str;
 
   // LPAD function tests - with defined fill pad text
-  out_str = lpad(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFillTestString");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFTestString");
 
-  out_str = lpad(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFillFiTestString");
 
-  out_str = lpad(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ддабвгд");
 
-  out_str = lpad(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
 
-  out_str = lpad(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  out_str = lpad_utf8_int32_utf8(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "дhello");
 
   // LPAD function tests - with NO pad text
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 4, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 0, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 18, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "        TestString");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 15, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "     TestString");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "абвгд", 10, 7, &out_len);
+  out_str = lpad_utf8_int32(ctx_ptr, "абвгд", 10, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "  абвгд");
 }
 
@@ -772,65 +772,65 @@ TEST(TestStringOps, TestRpadString) {
   const char* out_str;
 
   // RPAD function tests - with defined fill pad text
-  out_str = rpad(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFill");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillF");
 
-  out_str = rpad(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFillFi");
 
-  out_str = rpad(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгддд");
 
-  out_str = rpad(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
 
-  out_str = rpad(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "helloд");
 
   // RPAD function tests - with NO pad text
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 4, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 0, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 18, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString        ");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 15, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString     ");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "абвгд", 10, 7, &out_len);
+  out_str = rpad_utf8_int32(ctx_ptr, "абвгд", 10, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгд  ");
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -696,6 +696,49 @@ TEST(TestStringOps, TestLtrim) {
   EXPECT_FALSE(ctx.has_error());
 }
 
+TEST(TestStringOps, TestLpadString) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+  const char* out_str;
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Test");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = lpad(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "FillFillTestString");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "FillFTestString");
+
+  out_str = lpad(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "FillFillFiTestString");
+
+  out_str = lpad(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "ддабвгд");
+
+  out_str = lpad(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
+
+  out_str = lpad(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "дhello");
+}
+
 TEST(TestStringOps, TestRtrim) {
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -702,6 +702,7 @@ TEST(TestStringOps, TestLpadString) {
   gdv_int32 out_len = 0;
   const char* out_str;
 
+  // LPAD function tests - with defined fill pad text
   out_str = lpad(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
@@ -737,6 +738,31 @@ TEST(TestStringOps, TestLpadString) {
 
   out_str = lpad(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "дhello");
+
+  // LPAD function tests - with NO pad text
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Test");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 0,&out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 18, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "        TestString");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 15, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "     TestString");
+
+  out_str = lpad_no_fill_text(ctx_ptr, "абвгд", 10, 7, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "  абвгд");
 }
 
 TEST(TestStringOps, TestRtrim) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -765,6 +765,75 @@ TEST(TestStringOps, TestLpadString) {
   EXPECT_EQ(std::string(out_str, out_len), "  абвгд");
 }
 
+TEST(TestStringOps, TestRpadString) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+  const char* out_str;
+
+  // RPAD function tests - with defined fill pad text
+  out_str = rpad(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Test");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = rpad(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFill");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestStringFillF");
+
+  out_str = rpad(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFillFi");
+
+  out_str = rpad(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "абвгддд");
+
+  out_str = rpad(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
+
+  out_str = rpad(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "helloд");
+
+  // RPAD function tests - with NO pad text
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 4, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Test");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 0,&out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 18, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString        ");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 15, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString     ");
+
+  out_str = rpad_no_fill_text(ctx_ptr, "абвгд", 10, 7, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "абвгд  ");
+}
+
 TEST(TestStringOps, TestRtrim) {
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -749,7 +749,7 @@ TEST(TestStringOps, TestLpadString) {
   out_str = lpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 0,&out_len);
+  out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
   out_str = lpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);
@@ -818,7 +818,7 @@ TEST(TestStringOps, TestRpadString) {
   out_str = rpad_no_fill_text(ctx_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 0,&out_len);
+  out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
   out_str = rpad_no_fill_text(ctx_ptr, "TestString", 10, -500, &out_len);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -411,7 +411,14 @@ const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
                  gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
                  gdv_int32* out_len);
 
+const char* rpad(gdv_int64 context, const char* text, gdv_int32 text_len,
+                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
+                 gdv_int32* out_len);
+
 const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
+                              gdv_int32 return_length, gdv_int32* out_len);
+
+const char* rpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
                               gdv_int32 return_length, gdv_int32* out_len);
 
 const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -407,6 +407,10 @@ gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
                                  gdv_int32 sub_str_len, const char* str,
                                  gdv_int32 str_len, gdv_int32 start_pos);
 
+const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
+                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
+                 gdv_int32* out_len);
+
 const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                                 gdv_int32 text_len, const char* from_str,
                                                 gdv_int32 from_str_len,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -411,6 +411,9 @@ const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
                  gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
                  gdv_int32* out_len);
 
+const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
+                              gdv_int32 return_length, gdv_int32* out_len);
+
 const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                                 gdv_int32 text_len, const char* from_str,
                                                 gdv_int32 from_str_len,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -407,18 +407,18 @@ gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
                                  gdv_int32 sub_str_len, const char* str,
                                  gdv_int32 str_len, gdv_int32 start_pos);
 
-const char* lpad(gdv_int64 context, const char* text, gdv_int32 text_len,
-                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
-                 gdv_int32* out_len);
+const char* lpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+                                 gdv_int32 return_length, const char* fill_text,
+                                 gdv_int32 fill_text_len, gdv_int32* out_len);
 
-const char* rpad(gdv_int64 context, const char* text, gdv_int32 text_len,
-                 gdv_int32 return_length, const char* fill_text, gdv_int32 fill_text_len,
-                 gdv_int32* out_len);
+const char* rpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+                                 gdv_int32 return_length, const char* fill_text,
+                                 gdv_int32 fill_text_len, gdv_int32* out_len);
 
-const char* lpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
-                              gdv_int32 return_length, gdv_int32* out_len);
+const char* lpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+                            gdv_int32 return_length, gdv_int32* out_len);
 
-const char* rpad_no_fill_text(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* rpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
                               gdv_int32 return_length, gdv_int32* out_len);
 
 const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -419,7 +419,7 @@ const char* lpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_
                             gdv_int32 return_length, gdv_int32* out_len);
 
 const char* rpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
-                              gdv_int32 return_length, gdv_int32* out_len);
+                            gdv_int32 return_length, gdv_int32* out_len);
 
 const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,
                                                 gdv_int32 text_len, const char* from_str,

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1033,20 +1033,19 @@ TEST_F(TestProjector, TestLpad) {
   auto array0 = MakeArrowArrayUtf8({"ab", "a", "ab", "invalid", "valid", "invalid", ""},
                                    {true, true, true, true, true, true, true});
   auto array1 = MakeArrowArrayInt32({1, 5, 3, 12, 0, 2, 10},
-                                   {true, true, true, true, true, true, true});
+                                    {true, true, true, true, true, true, true});
   auto array2 = MakeArrowArrayUtf8({"z", "z", "c", "valid", "invalid", "invalid", ""},
                                    {true, true, true, true, true, true, true});
   // expected output
   auto exp_lpad = MakeArrowArrayUtf8({"a", "zzzza", "cab", "validinvalid", "", "in", ""},
-                                       {true, true, true, true, true, true, true});
+                                     {true, true, true, true, true, true, true});
 
   // prepare input record batch
-  auto in_batch = arrow::RecordBatch::Make(schema, num_records,
-                                           {array0, array1, array2});
+  auto in = arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
 
   // Evaluate expression
   arrow::ArrayVector outputs;
-  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  status = projector->Evaluate(*in, pool_, &outputs);
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Validate results
@@ -1084,12 +1083,11 @@ TEST_F(TestProjector, TestRpad) {
                                      {true, true, true, true, true, true, true});
 
   // prepare input record batch
-  auto in_batch = arrow::RecordBatch::Make(schema, num_records,
-                                           {array0, array1, array2});
+  auto in = arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
 
   // Evaluate expression
   arrow::ArrayVector outputs;
-  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  status = projector->Evaluate(*in, pool_, &outputs);
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Validate results

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1053,4 +1053,47 @@ TEST_F(TestProjector, TestLpad) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_lpad, outputs.at(0));
 }
 
+TEST_F(TestProjector, TestRpad) {
+  // schema for input fields
+  auto field0 = field("f0", arrow::utf8());
+  auto field1 = field("f1", arrow::int32());
+  auto field2 = field("f2", arrow::utf8());
+  auto schema = arrow::schema({field0, field1, field2});
+
+  // output fields
+  auto field_rpad = field("rpad", arrow::utf8());
+
+  // Build expression
+  auto rpad_expr =
+      TreeExprBuilder::MakeExpression("rpad", {field0, field1, field2}, field_rpad);
+
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {rpad_expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 7;
+  auto array0 = MakeArrowArrayUtf8({"ab", "a", "ab", "invalid", "valid", "invalid", ""},
+                                   {true, true, true, true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({1, 5, 3, 12, 0, 2, 10},
+                                    {true, true, true, true, true, true, true});
+  auto array2 = MakeArrowArrayUtf8({"z", "z", "c", "valid", "invalid", "invalid", ""},
+                                   {true, true, true, true, true, true, true});
+  // expected output
+  auto exp_rpad = MakeArrowArrayUtf8({"a", "azzzz", "abc", "invalidvalid", "", "in", ""},
+                                     {true, true, true, true, true, true, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records,
+                                           {array0, array1, array2});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_rpad, outputs.at(0));
+}
+
 }  // namespace gandiva


### PR DESCRIPTION
#### Implement LPAD and RPAD functions for string input values.

- LPAD([string] basetext, [number] x, [optional string] padtext)
- RPAD([string] basetext, [number] x, [optional string] padtext)

#### Description

lpad - Prepends padtext to basetext in a way that allows as many characters as possible from padtext given an output string length of x. When x is less than or equal to the length of basetext, only characters from basetext are printed in the output. If padtext is omitted then spaces are prepended.

rpad - Appends padtext to basetext in a way that allows as many characters as possible from padtext given an output string length of x. When x is less than or equal to the length of basetext, only characters from basetext are printed in the output. If padtext is omitted then spaces are appended.