### PR TITLE
ARROW-12570: [JS] Fix issues that blocked the v4.0.0 release

### DIFF
--- a/js/lerna.json
+++ b/js/lerna.json
@@ -1,4 +1,6 @@
 {
+  "lerna": "3.22.1",
+  "version": "4.0.0",
   "npmClient": "yarn",
   "packages": [
     "targets/ts",

--- a/js/npm-release.sh
+++ b/js/npm-release.sh
@@ -22,5 +22,7 @@ set -e
 yarn --frozen-lockfile
 yarn gulp
 
+read -p "Please enter your npm 2FA one-time password (or leave empty if you don't have 2FA enabled): " NPM_OTP </dev/tty
+
 # publish the JS target modules to npm
-yarn lerna exec --no-bail -- npm publish
+yarn lerna exec --concurrency 1 --no-bail "npm publish${NPM_OTP:+ --otp=$NPM_OTP}"

--- a/js/test/jest-extensions.ts
+++ b/js/test/jest-extensions.ts
@@ -105,7 +105,7 @@ function toEqualVector<
     if (v1 == null || v2 == null) {
         return {
             pass: false,
-            message: [
+            message: () => [
                 [columnName, `(${format(this, format1, format2, ' !== ')})`].filter(Boolean).join(':'),
                 `${v1 == null ? 'actual' : 'expected'} is null`
             ].join('\n')


### PR DESCRIPTION
A few issues had to be fixed manually for the v4.0.0 release:

* ts-jest throwing a type error running the tests on the TS source
* lerna.json really does need those version numbers
* npm has introduced rate limits since v3.0.0
* support npm 2FA one-time-passwords for publish

Closes https://issues.apache.org/jira/browse/ARROW-12570