### PR TITLE
ARROW-12584: [C++][Python] Expose method for benchmarking tools to release unused memory from the allocators

### DIFF
--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -35,7 +35,7 @@
 #include "arrow/util/optional.h"
 #include "arrow/util/string.h"
 
-#ifdef __GLIBCXX__
+#ifdef __GLIBC__
 #include <malloc.h>
 #endif
 
@@ -259,7 +259,7 @@ class SystemAllocator {
   }
 
   static void ReleaseUnused() {
-#ifdef __GLIBCXX__
+#ifdef __GLIBC__
     // The return value of malloc_trim is not an error but to inform
     // you if memory was actually released or not, which we do not care about here
     ARROW_UNUSED(malloc_trim(0));

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -253,6 +253,8 @@ class SystemAllocator {
 #endif
     }
   }
+
+  static void ReleaseUnused() {}
 };
 
 #ifdef ARROW_JEMALLOC
@@ -300,6 +302,8 @@ class JemallocAllocator {
       dallocx(ptr, MALLOCX_ALIGN(kAlignment));
     }
   }
+
+  static void ReleaseUnused() {}
 };
 
 #endif  // defined(ARROW_JEMALLOC)
@@ -321,6 +325,8 @@ class MimallocAllocator {
     }
     return Status::OK();
   }
+
+  static void ReleaseUnused() { mi_collect(true); }
 
   static Status ReallocateAligned(int64_t old_size, int64_t new_size, uint8_t** ptr) {
     uint8_t* previous_ptr = *ptr;
@@ -427,6 +433,8 @@ class BaseMemoryPoolImpl : public MemoryPool {
 
     stats_.UpdateAllocatedBytes(-size);
   }
+
+  void ReleaseUnused() override { Allocator::ReleaseUnused(); }
 
   int64_t bytes_allocated() const override { return stats_.bytes_allocated(); }
 

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -87,6 +87,11 @@ class ARROW_EXPORT MemoryPool {
   ///   faster deallocation if supported by its backend.
   virtual void Free(uint8_t* buffer, int64_t size) = 0;
 
+  /// Returns unused memory to the OS
+  ///
+  /// Only applies to allocators that hold onto unused memory
+  virtual void ReleaseUnused(){};
+
   /// The number of bytes that were allocated and not yet free'd through
   /// this allocator.
   virtual int64_t bytes_allocated() const = 0;

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -87,10 +87,12 @@ class ARROW_EXPORT MemoryPool {
   ///   faster deallocation if supported by its backend.
   virtual void Free(uint8_t* buffer, int64_t size) = 0;
 
-  /// Returns unused memory to the OS
+  /// Return unused memory to the OS
   ///
-  /// Only applies to allocators that hold onto unused memory
-  virtual void ReleaseUnused(){};
+  /// Only applies to allocators that hold onto unused memory.  This will be
+  /// best effort, a memory pool may not implement this feature or may be
+  /// unable to fulfill the request due to fragmentation.
+  virtual void ReleaseUnused() {}
 
   /// The number of bytes that were allocated and not yet free'd through
   /// this allocator.

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -286,6 +286,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t bytes_allocated()
         int64_t max_memory()
         c_string backend_name()
+        void ReleaseUnused()
 
     cdef cppclass CLoggingMemoryPool" arrow::LoggingMemoryPool"(CMemoryPool):
         CLoggingMemoryPool(CMemoryPool*)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -38,12 +38,14 @@ cdef class MemoryPool(_Weakrefable):
 
     def release_unused(self):
         """
-        Attempts to return to the OS any memory being held onto by an allocator.
-        This function should not be called except potentially for benchmarking
-        or debugging as it could be expensive and detrimental to performance.
+        Attempt to return to the OS any memory being held onto by the pool.
 
-        This is best effort and may not have any effect on some memory pools or
-        in some situations (e.g. fragmentation)
+        This function should not be called except potentially for
+        benchmarking or debugging as it could be expensive and detrimental to
+        performance.
+
+        This is best effort and may not have any effect on some memory pools
+        or in some situations (e.g. fragmentation).
         """
         cdef CMemoryPool* pool = c_get_memory_pool()
         with nogil:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -43,7 +43,8 @@ cdef class MemoryPool(_Weakrefable):
         or debugging as it could be expensive and detrimental to performance.
         """
         cdef CMemoryPool* pool = c_get_memory_pool()
-        pool.ReleaseUnused()
+        with nogil:
+            pool.ReleaseUnused()
 
     def bytes_allocated(self):
         """

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -38,9 +38,12 @@ cdef class MemoryPool(_Weakrefable):
 
     def release_unused(self):
         """
-        Attempts to free any memory being held onto by an optimized allocator.
+        Attempts to return to the OS any memory being held onto by an allocator.
         This function should not be called except potentially for benchmarking
         or debugging as it could be expensive and detrimental to performance.
+
+        This is best effort and may not have any effect on some memory pools or
+        in some situations (e.g. fragmentation)
         """
         cdef CMemoryPool* pool = c_get_memory_pool()
         with nogil:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -36,6 +36,15 @@ cdef class MemoryPool(_Weakrefable):
     cdef void init(self, CMemoryPool* pool):
         self.pool = pool
 
+    def release_unused(self):
+        """
+        Attempts to free any memory being held onto by an optimized allocator.
+        This function should not be called except potentially for benchmarking
+        or debugging as it could be expensive and detrimental to performance.
+        """
+        cdef CMemoryPool* pool = c_get_memory_pool()
+        pool.ReleaseUnused()
+
     def bytes_allocated(self):
         """
         Return the number of bytes that are currently allocated from this

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -104,6 +104,11 @@ def test_default_backend_name():
     assert pool.backend_name in possible_backends
 
 
+def test_release_unused():
+    pool = pa.default_memory_pool()
+    pool.release_unused()
+
+
 def check_env_var(name, expected, *, expect_warning=False):
     code = f"""if 1:
         import pyarrow as pa


### PR DESCRIPTION
@pitrou What are your thoughts on this.  It's not urgent (benchmarking can always use the system allocator in the meantime if they are having RAM issues and I think they reduced already which benchmarks they run on the RAM-limited servers)

With mimalloc the following command has a max RSS of ~16GB.
```
conbench file-read fanniemae_2016Q4 --all=true
```

If I add a call to release_unused between runs then the max RSS drops to ~10GB.