### PR TITLE
ARROW-12589: [C++] Compiling on windows doesn't work when -DARROW_WITH_BACKTRACE=OFF

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -515,11 +515,14 @@ if(ARROW_BUILD_STATIC AND WIN32)
   target_compile_definitions(arrow_static PUBLIC ARROW_STATIC)
 endif()
 
+foreach(LIB_TARGET ${ARROW_LIBRARIES})
+    target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
+endforeach()
+
 if(ARROW_WITH_BACKTRACE)
   find_package(Backtrace)
 
   foreach(LIB_TARGET ${ARROW_LIBRARIES})
-    target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
     if(Backtrace_FOUND AND ARROW_WITH_BACKTRACE)
       target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_WITH_BACKTRACE)
     endif()

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -516,7 +516,7 @@ if(ARROW_BUILD_STATIC AND WIN32)
 endif()
 
 foreach(LIB_TARGET ${ARROW_LIBRARIES})
-    target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
 endforeach()
 
 if(ARROW_WITH_BACKTRACE)


### PR DESCRIPTION
    [4/116] Building CXX object src/arrow/CMakeFiles/arrow_shared.dir/Unity/unity_17_cxx.cxx.obj
    FAILED: src/arrow/CMakeFiles/arrow_shared.dir/Unity/unity_17_cxx.cxx.obj
    C:/msys64/mingw64/bin/ccache.exe C:\msys64\mingw64\bin\c++.exe ...
    In file included from src/arrow/CMakeFiles/arrow_shared.dir/Unity/unity_17_cxx.cxx:3:
    C:/msys64/home/javan/arrow/arrow-master/cpp/src/arrow/filesystem/filesystem.cc:81:28: error: function 'std::ostream& arrow::fs::operator<<(std::ostream&, arrow::fs::FileType)' definition is marked dllimport
    81 | ARROW_EXPORT std::ostream& operator<<(std::ostream& os, FileType ftype) {
    |                            ^~~~~~~~
    [5/116] Building CXX object src/arrow/CMakeFiles/arrow_shared.dir/Unity/unity_2_cxx.cxx.obj
