### PR TITLE
ARROW-12673: [C++] Add parser handler for incorrect column counts

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -18,12 +18,15 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "arrow/csv/type_fwd.h"
+#include "arrow/status.h"
+#include "arrow/util/optional.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -35,6 +38,9 @@ namespace csv {
 
 // Silly workaround for https://github.com/michaeljones/breathe/issues/453
 constexpr char kDefaultEscapeChar = '\\';
+
+/// Function used to handle when a parsed row does not have the correct column count
+using InvalidRowHandler = std::function<Status(RowModifier&)>;
 
 struct ARROW_EXPORT ParseOptions {
   // Parsing options
@@ -56,6 +62,8 @@ struct ARROW_EXPORT ParseOptions {
   /// Whether empty lines are ignored.  If false, an empty line represents
   /// a single empty value (assuming a one-column CSV file).
   bool ignore_empty_lines = true;
+  /// A handler function for rows which do not have the correct number of columns
+  util::optional<InvalidRowHandler> invalid_row_handler;
 
   /// Create parsing options with default values
   static ParseOptions Defaults();

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -188,5 +188,48 @@ class ARROW_EXPORT BlockParser {
   const detail::DataBatch& parsed_batch() const;
 };
 
+/// \class RowModifier
+/// \brief Interface used to modify the current row being parsed
+///
+/// Currently used by InvalidRowHandler when a row does not have the correct number of
+/// columns
+class ARROW_EXPORT RowModifier {
+ public:
+  virtual ~RowModifier() = default;
+
+  /// \brief skip this row
+  virtual void Skip() = 0;
+
+  /// \brief Add a new field to the row
+  ///
+  /// \note If field is not an empty string this will cause extra memory allocations
+  /// \param field to be added
+  /// \return status of the addition
+  virtual Status AddField(const std::string& field) = 0;
+
+  /// \brief Add a field multiple times to the row
+  ///
+  /// \note If field is not an empty string this will cause extra memory allocations
+  /// \param field to be added
+  /// \param count number of times to add the field
+  /// \return status of the addition
+  virtual Status AddFields(const std::string& field, int count) = 0;
+
+  /// \brief Remove the last field from the column
+  ///
+  /// \param count number of fields to remove
+  /// \return failure if there is no field to remove
+  virtual Status RemoveFields(int count) = 0;
+
+  /// \brief return the expected number of columns in the row
+  virtual int32_t expected_num_columns() const = 0;
+
+  /// \brief return the current number of columns in the row
+  virtual int32_t num_columns() const = 0;
+
+  /// \brief return the raw line which was parsed for this row
+  virtual const util::string_view& line() const = 0;
+};
+
 }  // namespace csv
 }  // namespace arrow

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -231,5 +231,34 @@ class ARROW_EXPORT RowModifier {
   virtual const util::string_view& line() const = 0;
 };
 
+/// \class InvalidRowHandlers
+/// \brief Utility class for builtin InvalidRowHandler
+class ARROW_EXPORT InvalidRowHandlers {
+ public:
+  /// \brief Creates a InvalidRowHandler which skips rows with incorrect columns
+  static InvalidRowHandler Skip();
+
+  /// \brief Create a InvalidRowHandler which adds nulls for missing columns
+  ///
+  /// \note Using a null_value other than "" can cause extra memory reallocations during
+  /// parsing if there are rows without enough columns
+  ///
+  /// \param null_value Value to insert for null. Default is ""
+  /// \return InvalidRowHandler which adds null_value
+  static InvalidRowHandler AddNulls(const std::string& null_value = "");
+
+  /// \brief Create a InvalidRowHandler which either adds nulls or removes columns
+  ///
+  /// \note Using a null_value other than "" can cause extra memory reallocations during
+  /// parsing if there are rows without enough columns
+  ///
+  /// \param null_value Value to insert for null. Default is ""
+  /// \return InvalidRowHandler which forces the number of columns to be correct
+  static InvalidRowHandler Force(const std::string& null_value = "");
+
+ private:
+  InvalidRowHandlers() = delete;
+};
+
 }  // namespace csv
 }  // namespace arrow

--- a/cpp/src/arrow/csv/type_fwd.h
+++ b/cpp/src/arrow/csv/type_fwd.h
@@ -19,6 +19,7 @@ namespace arrow {
 namespace csv {
 
 class TableReader;
+class RowModifier;
 struct ConvertOptions;
 struct ReadOptions;
 struct ParseOptions;


### PR DESCRIPTION
Add a new callback to ParseOption which is invoked when a row does not have the correct number of columns. Using the RowModifier interface the callback can skip the row or add or remove fields.

Some basic handlers were added to skip all invalid rows, add a null value for missing columns and one that forces the row to the correct number of columns by adding null values or removing the columns at the end of the row.