### PR TITLE
ARROW-12004: [C++] Result<detail::Empty> is annoying

### DIFF
--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -274,9 +274,7 @@ static Result<RecordBatchGenerator> MakeSlowRecordBatchGenerator(
       std::move(gen), [](const std::shared_ptr<RecordBatch>& batch) {
         auto fut = Future<std::shared_ptr<RecordBatch>>::Make();
         SleepABitAsync().AddCallback(
-            [fut, batch](const Result<::arrow::detail::Empty>&) mutable {
-              fut.MarkFinished(batch);
-            });
+            [fut, batch](const Status& status) mutable { fut.MarkFinished(batch); });
         return fut;
       });
   // Adding readahead implicitly adds parallelism by pulling reentrantly from

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -924,7 +924,7 @@ class AsyncThreadedTableReader
         internal::TaskGroup::MakeThreaded(cpu_executor_, io_context_.stop_token());
 
     auto self = shared_from_this();
-    return ProcessFirstBuffer().Then([self](std::shared_ptr<Buffer> first_buffer) {
+    return ProcessFirstBuffer().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
       auto block_generator = ThreadedBlockReader::MakeAsyncIterator(
           self->buffer_generator_, MakeChunker(self->parse_options_),
           std::move(first_buffer));
@@ -949,12 +949,12 @@ class AsyncThreadedTableReader
       };
 
       return VisitAsyncGenerator(std::move(block_generator), block_visitor)
-          .Then([self](...) -> Future<> {
+          .Then([self]() -> Future<> {
             // By this point we've added all top level tasks so it is safe to call
             // FinishAsync
             return self->task_group_->FinishAsync();
           })
-          .Then([self](...) -> Result<std::shared_ptr<Table>> {
+          .Then([self]() -> Result<std::shared_ptr<Table>> {
             // Finish conversion, create schema and table
             return self->MakeTable();
           });

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -508,10 +508,11 @@ Status WriteInternal(const ScanOptions& scan_options, WriteState& state,
           [&](std::shared_ptr<RecordBatch> batch) {
             return WriteNextBatch(state, scan_task->fragment(), std::move(batch));
           };
-      return internal::SerialExecutor::RunInSerialExecutor<>(
+      return internal::RunSynchronously<Future<>>(
           [&](internal::Executor* executor) {
             return scan_task->SafeVisit(executor, visitor);
-          });
+          },
+          /*use_threads=*/false);
     });
   }
   return task_group->Finish();

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -508,11 +508,10 @@ Status WriteInternal(const ScanOptions& scan_options, WriteState& state,
           [&](std::shared_ptr<RecordBatch> batch) {
             return WriteNextBatch(state, scan_task->fragment(), std::move(batch));
           };
-      return internal::SerialExecutor::RunInSerialExecutor<detail::Empty>(
-                 [&](internal::Executor* executor) {
-                   return scan_task->SafeVisit(executor, visitor);
-                 })
-          .status();
+      return internal::SerialExecutor::RunInSerialExecutor<>(
+          [&](internal::Executor* executor) {
+            return scan_task->SafeVisit(executor, visitor);
+          });
     });
   }
   return task_group->Finish();

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -729,10 +729,9 @@ Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(
   auto table_building_gen = MakeMappedGenerator<EnumeratedRecordBatch>(
       positioned_batch_gen, table_building_task);
 
-  return DiscardAllFromAsyncGenerator(table_building_gen)
-      .Then([state, scan_options](const detail::Empty&) {
-        return Table::FromRecordBatches(scan_options->projected_schema, state->Finish());
-      });
+  return DiscardAllFromAsyncGenerator(table_building_gen).Then([state, scan_options]() {
+    return Table::FromRecordBatches(scan_options->projected_schema, state->Finish());
+  });
 }
 
 Result<int64_t> AsyncScanner::CountRows() {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -698,11 +698,10 @@ struct AsyncTableAssemblyState {
 };
 
 Status AsyncScanner::Scan(std::function<Status(TaggedRecordBatch)> visitor) {
-  return internal::RunSynchronouslyVoid(
-      [this, &visitor](Executor* executor) {
-        return VisitBatchesAsync(visitor, executor);
-      },
-      scan_options_->use_threads);
+  auto top_level_task = [this, &visitor](Executor* executor) {
+    return VisitBatchesAsync(visitor, executor);
+  };
+  return internal::RunSynchronously<Future<>>(top_level_task, scan_options_->use_threads);
 }
 
 Future<> AsyncScanner::VisitBatchesAsync(std::function<Status(TaggedRecordBatch)> visitor,

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1595,8 +1595,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
     TreeWalker::WalkAsync(client_, io_context_, bucket, key, kListObjectsMaxKeys,
                           handle_results, handle_error, handle_recursion)
-        .AddCallback([collector, producer,
-                      self](const Result<::arrow::detail::Empty>& res) mutable {
+        .AddCallback([collector, producer, self](const Status& status) mutable {
           auto st = collector->Finish(self.get());
           if (!st.ok()) {
             producer.Push(st);

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -779,8 +779,8 @@ TEST(RangeReadCache, Concurrency) {
       ASSERT_OK(cache.Cache(ranges));
       std::vector<Future<std::shared_ptr<Buffer>>> futures;
       for (const auto& range : ranges) {
-        futures.push_back(cache.WaitFor({range}).Then(
-            [&cache, range](const detail::Empty&) { return cache.Read(range); }));
+        futures.push_back(
+            cache.WaitFor({range}).Then([&cache, range]() { return cache.Read(range); }));
       }
       for (auto fut : futures) {
         ASSERT_FINISHES_OK(fut);

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -637,7 +637,7 @@ Future<> SleepAsync(double seconds) {
   auto out = Future<>::Make();
   std::thread([out, seconds]() mutable {
     SleepFor(seconds);
-    out.MarkFinished(Status::OK());
+    out.MarkFinished();
   }).detach();
   return out;
 }
@@ -646,7 +646,7 @@ Future<> SleepABitAsync() {
   auto out = Future<>::Make();
   std::thread([out]() mutable {
     SleepABit();
-    out.MarkFinished(Status::OK());
+    out.MarkFinished();
   }).detach();
   return out;
 }

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -37,10 +37,10 @@ class Result;
 
 class Status;
 
-namespace detail {
+namespace internal {
 struct Empty;
-}
-template <typename T = detail::Empty>
+}  // namespace internal
+template <typename T = internal::Empty>
 class Future;
 
 namespace util {

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -78,9 +78,9 @@ Future<> VisitAsyncGenerator(AsyncGenerator<T> generator,
                              std::function<Status(T)> visitor) {
   struct LoopBody {
     struct Callback {
-      Result<ControlFlow<detail::Empty>> operator()(const T& result) {
+      Result<ControlFlow<>> operator()(const T& result) {
         if (IsIterationEnd(result)) {
-          return Break(detail::Empty());
+          return Break();
         } else {
           auto visited = visitor(result);
           if (visited.ok()) {
@@ -94,7 +94,7 @@ Future<> VisitAsyncGenerator(AsyncGenerator<T> generator,
       std::function<Status(T)> visitor;
     };
 
-    Future<ControlFlow<detail::Empty>> operator()() {
+    Future<ControlFlow<>> operator()() {
       Callback callback{visitor};
       auto next = generator();
       return next.Then(std::move(callback));

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1308,7 +1308,7 @@ class BackgroundGenerator {
         // If the task is still cleaning up we need to wait for it to finish before
         // restarting.  We also want to block the consumer until we've restarted the
         // reader to avoid multiple restarts
-        return task_finished.Then([state, next](...) {
+        return task_finished.Then([state, next]() {
           // This may appear dangerous (recursive mutex) but we should be guaranteed the
           // outer guard has been released by this point.  We know...
           // * task_finished is not already finished (it would be invalid in that case)

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -52,8 +52,7 @@ AsyncGenerator<T> FailsAt(AsyncGenerator<T> src, int failing_index) {
 template <typename T>
 AsyncGenerator<T> SlowdownABit(AsyncGenerator<T> source) {
   return MakeMappedGenerator<T, T>(std::move(source), [](const T& res) -> Future<T> {
-    return SleepABitAsync().Then(
-        [res](const Result<detail::Empty>& empty) { return res; });
+    return SleepABitAsync().Then([res]() { return res; });
   });
 }
 
@@ -362,9 +361,7 @@ TEST(TestAsyncUtil, MapAsync) {
   std::vector<TestInt> input = {1, 2, 3};
   auto generator = AsyncVectorIt(input);
   std::function<Future<TestStr>(const TestInt&)> mapper = [](const TestInt& in) {
-    return SleepAsync(1e-3).Then([in](const Result<detail::Empty>& empty) {
-      return TestStr(std::to_string(in.value));
-    });
+    return SleepAsync(1e-3).Then([in]() { return TestStr(std::to_string(in.value)); });
   };
   auto mapped = MakeMappedGenerator(std::move(generator), mapper);
   std::vector<TestStr> expected{"1", "2", "3"};

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -163,7 +163,7 @@ class ReentrantChecker {
     std::atomic<bool> valid;
   };
   struct Callback {
-    Future<T> operator()(const Result<T>& result) {
+    Future<T> operator()(const T& result) {
       state_->generated_unfinished_future.store(false);
       return result;
     }
@@ -648,7 +648,7 @@ TEST(TestAsyncUtil, MakeTransferredGenerator) {
       MakeTransferredGenerator<TestInt>(std::move(slow_generator), thread_pool.get());
 
   auto current_thread_id = std::this_thread::get_id();
-  auto fut = transferred().Then([&current_thread_id](const Result<TestInt>& result) {
+  auto fut = transferred().Then([&current_thread_id](const TestInt&) {
     ASSERT_NE(current_thread_id, std::this_thread::get_id());
   });
 
@@ -1006,8 +1006,8 @@ TEST(TestAsyncUtil, SerialReadaheadStressFailing) {
     AsyncGenerator<TestInt> it = BackgroundAsyncVectorIt(RangeVector(NITEMS));
     AsyncGenerator<TestInt> fails_at_ten = [&it]() {
       auto next = it();
-      return next.Then([](const Result<TestInt>& item) -> Result<TestInt> {
-        if (item->value >= 10) {
+      return next.Then([](const TestInt& item) -> Result<TestInt> {
+        if (item.value >= 10) {
           return Status::Invalid("XYZ");
         } else {
           return item;

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -380,7 +380,7 @@ TEST(TestAsyncUtil, MapReentrant) {
   Future<> can_proceed = Future<>::Make();
   std::function<Future<TestStr>(const TestInt&)> mapper = [&](const TestInt& in) {
     map_tasks_running.fetch_add(1);
-    return can_proceed.Then([in](...) { return TestStr(std::to_string(in.value)); });
+    return can_proceed.Then([in]() { return TestStr(std::to_string(in.value)); });
   };
   auto mapped = MakeMappedGenerator(std::move(source), mapper);
 
@@ -466,7 +466,7 @@ TEST_P(FromFutureFixture, Basic) {
   auto source = Future<std::vector<TestInt>>::MakeFinished(RangeVector(3));
   if (IsSlow()) {
     source = SleepABitAsync().Then(
-        [](...) -> Result<std::vector<TestInt>> { return RangeVector(3); });
+        []() -> Result<std::vector<TestInt>> { return RangeVector(3); });
   }
   auto slow = IsSlow();
   auto to_gen = source.Then([slow](const std::vector<TestInt>& vec) {

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -21,10 +21,20 @@
 #include <tuple>
 #include <type_traits>
 
+#include "arrow/result.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
 namespace internal {
+
+struct Empty {
+  static Result<Empty> ToResult(Status s) {
+    if (ARROW_PREDICT_TRUE(s.ok())) {
+      return Empty{};
+    }
+    return s;
+  }
+};
 
 /// Helper struct for examining lambdas and other callables.
 /// TODO(bkietz) support function pointers
@@ -82,6 +92,13 @@ struct call_traits {
   template <typename F, typename T, typename RT = T>
   using enable_if_return =
       typename std::enable_if<std::is_same<return_type<F>, T>::value, RT>;
+
+  template <typename T, typename R = void>
+  using enable_if_empty = typename std::enable_if<std::is_same<T, Empty>::value, R>::type;
+
+  template <typename T, typename R = void>
+  using enable_if_not_empty =
+      typename std::enable_if<!std::is_same<T, Empty>::value, R>::type;
 };
 
 /// A type erased callable object which may only be invoked once.

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -37,7 +37,7 @@ struct Empty {
 };
 
 /// Helper struct for examining lambdas and other callables.
-/// TODO(bkietz) support function pointers
+/// TODO(ARROW-12655) support function pointers
 struct call_traits {
  public:
   template <typename R, typename... A>

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -67,6 +67,16 @@ struct call_traits {
   static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
       R (F::*)(A...) &&);
 
+  template <typename F, typename R, typename... A>
+  static std::integral_constant<int, sizeof...(A)> argument_count_impl(R (F::*)(A...));
+
+  template <typename F, typename R, typename... A>
+  static std::integral_constant<int, sizeof...(A)> argument_count_impl(R (F::*)(A...)
+                                                                           const);
+
+  template <typename F, typename R, typename... A>
+  static std::integral_constant<int, sizeof...(A)> argument_count_impl(R (F::*)(A...) &&);
+
   /// bool constant indicating whether F is a callable with more than one possible
   /// signature. Will be true_type for objects which define multiple operator() or which
   /// define a template operator()
@@ -85,6 +95,9 @@ struct call_traits {
   /// extracted via call_traits::argument_type<Index, F>
   template <std::size_t I, typename F>
   using argument_type = decltype(argument_type_impl<I>(&std::decay<F>::type::operator()));
+
+  template <typename F>
+  using argument_count = decltype(argument_count_impl(&std::decay<F>::type::operator()));
 
   template <typename F>
   using return_type = decltype(return_type_impl(&std::decay<F>::type::operator()));

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -357,11 +357,11 @@ Future<> AllComplete(const std::vector<Future<>>& futures) {
   auto state = std::make_shared<State>(futures.size());
   auto out = Future<>::Make();
   for (const auto& future : futures) {
-    future.AddCallback([state, out](const Result<detail::Empty>& result) mutable {
-      if (!result.ok()) {
+    future.AddCallback([state, out](const Status& status) mutable {
+      if (!status.ok()) {
         std::unique_lock<std::mutex> lock(state->mutex);
         if (!out.is_finished()) {
-          out.MarkFinished(result);
+          out.MarkFinished(status);
         }
         return;
       }

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -366,7 +366,7 @@ Future<> AllComplete(const std::vector<Future<>>& futures) {
         return;
       }
       if (state->n_remaining.fetch_sub(1) != 1) return;
-      out.MarkFinished(Status::OK());
+      out.MarkFinished();
     });
   }
   return out;

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -560,7 +560,7 @@ class Future {
   ContinuedFuture Then(
       OnSuccess on_success, OnFailure on_failure,
       typename std::enable_if<!detail::has_no_args<OnSuccess>::value>::type* =
-          nullptr) const {
+          NULLPTR) const {
     static_assert(
         std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
                      ContinuedFuture>::value,
@@ -604,7 +604,7 @@ class Future {
   ContinuedFuture Then(
       OnSuccess on_success, OnFailure on_failure,
       typename std::enable_if<detail::has_no_args<OnSuccess>::value>::type* =
-          nullptr) const {
+          NULLPTR) const {
     static_assert(
         std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
                      ContinuedFuture>::value,

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -557,8 +557,10 @@ class Future {
   template <typename OnSuccess, typename OnFailure,
             typename ContinuedFuture =
                 detail::ContinueFuture::ForSignature<OnSuccess && (const T&)>>
-  typename std::enable_if<!detail::has_no_args<OnSuccess>::value, ContinuedFuture>::type
-  Then(OnSuccess on_success, OnFailure on_failure) const {
+  ContinuedFuture Then(
+      OnSuccess on_success, OnFailure on_failure,
+      typename std::enable_if<!detail::has_no_args<OnSuccess>::value>::type* =
+          nullptr) const {
     static_assert(
         std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
                      ContinuedFuture>::value,
@@ -599,8 +601,10 @@ class Future {
   template <
       typename OnSuccess, typename OnFailure,
       typename ContinuedFuture = detail::ContinueFuture::ForSignature<OnSuccess && ()>>
-  typename std::enable_if<detail::has_no_args<OnSuccess>::value, ContinuedFuture>::type
-  Then(OnSuccess on_success, OnFailure on_failure) const {
+  ContinuedFuture Then(
+      OnSuccess on_success, OnFailure on_failure,
+      typename std::enable_if<detail::has_no_args<OnSuccess>::value>::type* =
+          nullptr) const {
     static_assert(
         std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
                      ContinuedFuture>::value,

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -462,7 +462,7 @@ class Future {
       WeakFuture<T> weak_self;
       OnComplete on_complete;
     };
-    Future<T>::impl_->AddCallback(Callback{WeakFuture<T>(*this), std::move(on_complete)});
+    impl_->AddCallback(Callback{WeakFuture<T>(*this), std::move(on_complete)});
   }
 
   /// Overload for callbacks accepting a Status
@@ -501,7 +501,7 @@ class Future {
       WeakFuture<T> weak_self;
       OnComplete on_complete;
     };
-    return Future<T>::impl_->TryAddCallback([this, &callback_factory]() {
+    return impl_->TryAddCallback([this, &callback_factory]() {
       return Callback{WeakFuture<T>(*this), callback_factory()};
     });
   }

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -80,12 +80,6 @@ template <typename Source, typename Dest, bool SourceEmpty = Source::is_empty,
 struct MarkNextFinished {};
 
 template <typename Source, typename Dest>
-struct MarkNextFinished<Source, Dest, true, false> {
-  void operator()(const Status& status) && { next.MarkFinished(status); }
-  Dest next;
-};
-
-template <typename Source, typename Dest>
 struct MarkNextFinished<Source, Dest, true, true> {
   void operator()(const Status& status) && {
     next.MarkFinished(internal::Empty::ToResult(status));

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -538,7 +538,7 @@ TEST(FutureCompletionTest, Void) {
   {
     // Propagate failure by returning it from on_failure
     auto fut = Future<int>::Make();
-    auto fut2 = fut.Then([](...) {}, [](const Status& s) { return s; });
+    auto fut2 = fut.Then([](const int&) {}, [](const Status& s) { return s; });
     fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
@@ -1142,7 +1142,7 @@ TEST(FutureLoopTest, AllowsBreakFutToBeDiscarded) {
     }
     return Future<ControlFlow<int>>::MakeFinished(Break(-1));
   };
-  auto loop_fut = Loop(loop_body).Then([](...) { return Status::OK(); });
+  auto loop_fut = Loop(loop_body).Then([](const int&) { return Status::OK(); });
   ASSERT_TRUE(loop_fut.Wait(0.1));
 }
 

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -424,9 +424,13 @@ ThreadPool* GetCpuThreadPool() {
   return singleton.get();
 }
 
-Status RunSynchronouslyVoid(FnOnce<Future<arrow::detail::Empty>(Executor*)> get_future,
-                            bool use_threads) {
-  return RunSynchronously(std::move(get_future), use_threads).status();
+Status RunSynchronouslyVoid(FnOnce<Future<>(Executor*)> get_future, bool use_threads) {
+  if (use_threads) {
+    return std::move(get_future)(GetCpuThreadPool()).status();
+  } else {
+    return SerialExecutor::RunInSerialExecutor<arrow::internal::Empty>(
+        std::move(get_future));
+  }
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -424,15 +424,6 @@ ThreadPool* GetCpuThreadPool() {
   return singleton.get();
 }
 
-Status RunSynchronouslyVoid(FnOnce<Future<>(Executor*)> get_future, bool use_threads) {
-  if (use_threads) {
-    return std::move(get_future)(GetCpuThreadPool()).status();
-  } else {
-    return SerialExecutor::RunInSerialExecutor<arrow::internal::Empty>(
-        std::move(get_future));
-  }
-}
-
 }  // namespace internal
 
 int GetCpuThreadPoolCapacity() { return internal::GetCpuThreadPool()->GetCapacity(); }

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -217,7 +217,8 @@ class ARROW_EXPORT SerialExecutor : public Executor {
   template <typename T = internal::Empty, typename FT = Future<T>,
             typename FTSync = typename FT::SyncType>
   static FTSync RunInSerialExecutor(TopLevelTask<T> initial_task) {
-    return SerialExecutor().Run<T>(std::move(initial_task)).to_sync();
+    Future<T> fut = SerialExecutor().Run<T>(std::move(initial_task));
+    return FutureToSync(fut);
   }
 
  private:
@@ -333,7 +334,8 @@ template <typename Fut, typename ValueType = typename Fut::ValueType>
 typename Fut::SyncType RunSynchronously(FnOnce<Fut(Executor*)> get_future,
                                         bool use_threads) {
   if (use_threads) {
-    return std::move(get_future)(GetCpuThreadPool()).to_sync();
+    auto fut = std::move(get_future)(GetCpuThreadPool());
+    return FutureToSync(fut);
   } else {
     return SerialExecutor::RunInSerialExecutor<ValueType>(std::move(get_future));
   }

--- a/cpp/src/arrow/util/thread_pool_benchmark.cc
+++ b/cpp/src/arrow/util/thread_pool_benchmark.cc
@@ -110,9 +110,10 @@ static void RunInSerialExecutor(benchmark::State& state) {  // NOLINT non-const 
   Workload workload(workload_size);
 
   for (auto _ : state) {
-    ABORT_NOT_OK(SerialExecutor::RunInSerialExecutor<>([&](internal::Executor* executor) {
-      return DeferNotOk(executor->Submit(std::ref(workload)));
-    }));
+    ABORT_NOT_OK(
+        SerialExecutor::RunInSerialExecutor<Future<>>([&](internal::Executor* executor) {
+          return DeferNotOk(executor->Submit(std::ref(workload)));
+        }));
   }
 
   state.SetItemsProcessed(state.iterations());

--- a/cpp/src/arrow/util/thread_pool_benchmark.cc
+++ b/cpp/src/arrow/util/thread_pool_benchmark.cc
@@ -110,10 +110,9 @@ static void RunInSerialExecutor(benchmark::State& state) {  // NOLINT non-const 
   Workload workload(workload_size);
 
   for (auto _ : state) {
-    ABORT_NOT_OK(SerialExecutor::RunInSerialExecutor<arrow::detail::Empty>(
-        [&](internal::Executor* executor) {
-          return DeferNotOk(executor->Submit(std::ref(workload)));
-        }));
+    ABORT_NOT_OK(SerialExecutor::RunInSerialExecutor<>([&](internal::Executor* executor) {
+      return DeferNotOk(executor->Submit(std::ref(workload)));
+    }));
   }
 
   state.SetItemsProcessed(state.iterations());

--- a/cpp/src/arrow/util/thread_pool_benchmark.cc
+++ b/cpp/src/arrow/util/thread_pool_benchmark.cc
@@ -136,7 +136,7 @@ static void ThreadPoolSubmit(benchmark::State& state) {  // NOLINT non-const ref
 
     for (int32_t i = 0; i < nspawns; ++i) {
       // Pass the task by reference to avoid copying it around
-      (void)DeferNotOk(pool->Submit(std::ref(workload))).Then([&](...) {
+      (void)DeferNotOk(pool->Submit(std::ref(workload))).Then([&]() {
         n_finished.fetch_add(1);
       });
     }

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -189,11 +189,7 @@ TEST_P(TestRunSynchronously, SpawnMoreNested) {
   auto top_level_task = [&](Executor* executor) -> Future<> {
     auto fut_a = DeferNotOk(executor->Submit([&] { nested_ran++; }));
     auto fut_b = DeferNotOk(executor->Submit([&] { nested_ran++; }));
-    return AllComplete({fut_a, fut_b})
-        .Then([&](const Result<arrow::detail::Empty>& result) {
-          nested_ran++;
-          return result;
-        });
+    return AllComplete({fut_a, fut_b}).Then([&]() { nested_ran++; });
   };
   ASSERT_OK(RunVoid(std::move(top_level_task)));
   EXPECT_EQ(nested_ran, 3);

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -133,7 +133,7 @@ class TestRunSynchronously : public testing::TestWithParam<bool> {
   }
 
   Status RunVoid(FnOnce<Future<>(Executor*)> top_level_task) {
-    return RunSynchronouslyVoid(std::move(top_level_task), UseThreads());
+    return RunSynchronously(std::move(top_level_task), UseThreads());
   }
 
   void TestContinueAfterExternal(bool transfer_to_main_thread) {

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -141,7 +141,7 @@ class TestRunSynchronously : public testing::TestWithParam<bool> {
     EXPECT_OK_AND_ASSIGN(auto external_pool, ThreadPool::Make(1));
     auto top_level_task = [&](Executor* executor) {
       struct Callback {
-        Status operator()(...) {
+        Status operator()() {
           *continuation_ran = true;
           return Status::OK();
         }
@@ -166,7 +166,7 @@ TEST_P(TestRunSynchronously, SimpleRun) {
   auto task = [&](Executor* executor) {
     EXPECT_NE(executor, nullptr);
     task_ran = true;
-    return Future<>::MakeFinished(Status::OK());
+    return Future<>::MakeFinished();
   };
   ASSERT_OK(RunVoid(std::move(task)));
   EXPECT_TRUE(task_ran);

--- a/cpp/src/arrow/util/type_fwd.h
+++ b/cpp/src/arrow/util/type_fwd.h
@@ -19,11 +19,11 @@
 
 namespace arrow {
 
-namespace detail {
+namespace internal {
 struct Empty;
-}  // namespace detail
+}  // namespace internal
 
-template <typename T = detail::Empty>
+template <typename T = internal::Empty>
 class WeakFuture;
 class FutureWaiter;
 


### PR DESCRIPTION
Per the JIRA

`Future<>::AddCallback` callbacks receive a `Status`.
`Future<T>::AddCallback` callbacks receive a `Result<T>`
`Future<>::Then` callbacks receive nothing
`Future<T>::Then` callbacks receive `const T&`

To achieve this I had to explicitly specialize the empty `Future` but I introduced `FutureBase` to reduce the amount of duplicated code.  `detail::Empty` is still around (although it got renamed to `internal::Empty` as a side effect of moving into `functional.h`).  It could even be removed if one wanted to create a specialized `FutureImpl` but that doesn't seem to be needed at the moment.
