### PR TITLE
MINOR: [Python] Fix documentation to allow_truncated_timestamps

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -510,7 +510,9 @@ data_page_size : int, default None
 allow_truncated_timestamps : bool, default False
     Allow loss of data when coercing timestamps to a particular
     resolution. E.g. if microsecond or nanosecond data is lost when coercing to
-    'ms', do not raise an exception.
+    'ms', do not raise an exception. Passing ``allow_truncated_timestamp=True``
+    will NOT result in the truncation exception being ignored unless
+    ``coerce_timestamps`` is not None.
 compression : str or dict
     Specify the compression codec, either on a general basis or per-column.
     Valid values: {'NONE', 'SNAPPY', 'GZIP', 'BROTLI', 'LZ4', 'ZSTD'}.


### PR DESCRIPTION
This surprised me when trying to use this flag to avoid this exception:

```python
df.to_parquet("test.parquet")                        
*** pyarrow.lib.ArrowInvalid: Casting from timestamp[ns, tz=UTC] to timestamp[us] would lose data: 
1520751599999999999

df.to_parquet("test.parquet", coerce_timestamps='us')                        
*** pyarrow.lib.ArrowInvalid: Casting from timestamp[ns, tz=UTC] to timestamp[us] would lose data: 
1520751599999999999

df.to_parquet("test.parquet", allow_truncated_timestamps=True)                        
*** pyarrow.lib.ArrowInvalid: Casting from timestamp[ns, tz=UTC] to timestamp[us] would lose data: 
1520751599999999999

df.to_parquet("test.parquet", coerce_timestamps='us', allow_truncated_timestamps=True)                       
# Succeeded without exception
```