### PR TITLE
ARROW-12614: [C++][Compute] Remove support for Tables in ExecuteScalarExpression

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -28,7 +28,6 @@
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/util/atomic_shared_ptr.h"
-#include "arrow/util/iterator.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/optional.h"
@@ -525,25 +524,6 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const Datum& input
   if (!expr.IsScalarExpression()) {
     return Status::Invalid(
         "ExecuteScalarExpression cannot Execute non-scalar expression ", expr.ToString());
-  }
-
-  if (input.kind() == Datum::TABLE) {
-    ArrayVector chunks;
-
-    for (auto maybe_batch :
-         MakeIteratorFromReader(std::make_shared<TableBatchReader>(*input.table()))) {
-      ARROW_ASSIGN_OR_RAISE(auto batch, maybe_batch);
-
-      ARROW_ASSIGN_OR_RAISE(Datum res, ExecuteScalarExpression(expr, batch));
-      if (res.is_scalar()) {
-        ARROW_ASSIGN_OR_RAISE(res, MakeArrayFromScalar(*res.scalar(), batch->num_rows(),
-                                                       exec_context->memory_pool()));
-      }
-
-      chunks.push_back(res.make_array());
-    }
-
-    return ChunkedArray::Make(std::move(chunks), expr.type());
   }
 
   if (auto lit = expr.literal()) return *lit;

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -29,6 +29,7 @@
 #include "arrow/compute/exec/expression_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/iterator.h"
 
 using testing::HasSubstr;
 using testing::UnorderedElementsAreArray;
@@ -172,6 +173,7 @@ TEST(Expression, ToString) {
   EXPECT_EQ(literal("a").ToString(), "\"a\"");
   EXPECT_EQ(literal("a\nb").ToString(), "\"a\\nb\"");
   EXPECT_EQ(literal(std::make_shared<BooleanScalar>()).ToString(), "null");
+  EXPECT_EQ(literal(std::make_shared<Int64Scalar>()).ToString(), "null");
   EXPECT_EQ(literal(std::make_shared<BinaryScalar>(Buffer::FromString("az"))).ToString(),
             "\"617A\"");
 
@@ -520,6 +522,24 @@ Result<Datum> NaiveExecuteScalarExpression(const Expression& expr, const Datum& 
     return ExecuteScalarExpression(expr, input);
   }
 
+  if (input.kind() == Datum::TABLE) {
+    ArrayVector chunks;
+
+    for (auto maybe_batch :
+         MakeIteratorFromReader(std::make_shared<TableBatchReader>(*input.table()))) {
+      ARROW_ASSIGN_OR_RAISE(auto batch, maybe_batch);
+
+      ARROW_ASSIGN_OR_RAISE(Datum res, NaiveExecuteScalarExpression(expr, batch));
+      if (res.is_scalar()) {
+        ARROW_ASSIGN_OR_RAISE(res, MakeArrayFromScalar(*res.scalar(), batch->num_rows()));
+      }
+
+      chunks.push_back(res.make_array());
+    }
+
+    return ChunkedArray::Make(std::move(chunks), expr.type());
+  }
+
   std::vector<Datum> arguments(call->arguments.size());
   for (size_t i = 0; i < arguments.size(); ++i) {
     ARROW_ASSIGN_OR_RAISE(arguments[i],
@@ -540,7 +560,7 @@ void ExpectExecute(Expression expr, Datum in, Datum* actual_out = NULLPTR) {
   if (in.is_value()) {
     ASSERT_OK_AND_ASSIGN(expr, expr.Bind(in.descr()));
   } else {
-    ASSERT_OK_AND_ASSIGN(expr, expr.Bind(*in.record_batch()->schema()));
+    ASSERT_OK_AND_ASSIGN(expr, expr.Bind(*in.schema()));
   }
 
   ASSERT_OK_AND_ASSIGN(Datum actual, ExecuteScalarExpression(expr, in));
@@ -584,6 +604,30 @@ TEST(Expression, ExecuteCall) {
     {"a": 0.0},
     {"a": -1}
   ])"));
+}
+
+TEST(Expression, ExecuteAgainstTable) {
+  ExpectExecute(field_ref("i32"), TableFromJSON(kBoringSchema, {}));
+
+  ExpectExecute(field_ref("i32"), TableFromJSON(kBoringSchema, {R"([
+    {"i32": 32},
+    {"i32": 52}
+    ])",
+                                                                R"([
+    {"i32": 71}
+  ])"}));
+
+  ExpectExecute(call("add", {field_ref("f32"), literal(3.5)}),
+                TableFromJSON(kBoringSchema, {}));
+
+  ExpectExecute(call("add", {field_ref("f32"), literal(3.5)}),
+                TableFromJSON(kBoringSchema, {R"([
+    {"f32": -1.5},
+    {"f32": 2.25}
+    ])",
+                                              R"([
+    {"f32": 3.75}
+  ])"}));
 }
 
 TEST(Expression, ExecuteDictionaryTransparent) {

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -54,11 +54,6 @@ inline Result<FragmentIterator> GetFragmentsFromDatasets(const DatasetVector& da
   return MakeFlattenIterator(std::move(fragments_it));
 }
 
-inline RecordBatchIterator IteratorFromReader(
-    const std::shared_ptr<RecordBatchReader>& reader) {
-  return MakeFunctionIterator([reader] { return reader->Next(); });
-}
-
 inline std::shared_ptr<Schema> SchemaFromColumnNames(
     const std::shared_ptr<Schema>& input, const std::vector<std::string>& column_names) {
   std::vector<std::shared_ptr<Field>> columns;

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -1161,7 +1161,7 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
       std::shared_ptr<Array> actual_struct;
 
       for (auto maybe_batch :
-           IteratorFromReader(std::make_shared<TableBatchReader>(*actual_table))) {
+           MakeIteratorFromReader(std::make_shared<TableBatchReader>(*actual_table))) {
         ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
         ASSERT_OK_AND_ASSIGN(actual_struct, batch->ToStructArray());
       }

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -199,6 +199,8 @@ class ARROW_EXPORT RecordBatch {
 /// \brief Abstract interface for reading stream of record batches
 class ARROW_EXPORT RecordBatchReader {
  public:
+  using ValueType = std::shared_ptr<RecordBatch>;
+
   virtual ~RecordBatchReader() = default;
 
   /// \return the shared schema of the record batches in the stream

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -561,8 +561,8 @@ Iterator<T> MakeFlattenIterator(Iterator<Iterator<T>> it) {
 }
 
 template <typename Reader>
-auto MakeIteratorFromReader(const std::shared_ptr<Reader>& reader)
-    -> Iterator<typename decltype(std::declval<Reader>().Next())::ValueType> {
+Iterator<typename Reader::ValueType> MakeIteratorFromReader(
+    const std::shared_ptr<Reader>& reader) {
   return MakeFunctionIterator([reader] { return reader->Next(); });
 }
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -560,4 +560,10 @@ Iterator<T> MakeFlattenIterator(Iterator<Iterator<T>> it) {
   return Iterator<T>(FlattenIterator<T>(std::move(it)));
 }
 
+template <typename Reader>
+auto MakeIteratorFromReader(const std::shared_ptr<Reader>& reader)
+    -> Iterator<typename decltype(reader->Next())::ValueType> {
+  return MakeFunctionIterator([reader] { return reader->Next(); });
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -562,7 +562,7 @@ Iterator<T> MakeFlattenIterator(Iterator<Iterator<T>> it) {
 
 template <typename Reader>
 auto MakeIteratorFromReader(const std::shared_ptr<Reader>& reader)
-    -> Iterator<typename decltype(reader->Next())::ValueType> {
+    -> Iterator<typename decltype(std::declval<Reader>().Next())::ValueType> {
   return MakeFunctionIterator([reader] { return reader->Next(); });
 }
 


### PR DESCRIPTION
Cleanup PR after ARROW-11929 which added untested support for ExecuteScalarExpression(Table).