### PR TITLE
[Minor] [Rust] Fixed build of arrow.

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -47,7 +47,7 @@ regex = "1.3"
 lazy_static = "1.4"
 packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
-flatbuffers = "^0.8"
+flatbuffers = "=0.8.4"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 lexical-core = "^0.7"


### PR DESCRIPTION
While we wait for #10096 to land, one of our dependencies broke semver and caused our builds to fail, including all builds on this repo. We already fixed this in arrow-rs, but until #10096 lands, we can do a quick fix here to keep the builds green here.

Either merge this and #10096, or merge #10096 directly and close this one.