### PR TITLE
ARROW-12622: [Python] Fix segfault in read_csv when not on main thread

### DIFF
--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -188,8 +188,8 @@ cdef class SignalStopHandler:
                 if signal.getsignal(sig) not in (signal.SIG_DFL,
                                                  signal.SIG_IGN, None)]
 
+        self._stop_token = StopToken()
         if not self._signals.empty():
-            self._stop_token = StopToken()
             self._stop_token.init(GetResultValue(
                 SetSignalStopSource()).token())
             self._enabled = True

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -942,6 +942,14 @@ class BaseTestCSVRead:
         assert isinstance(e, pa.ArrowCancelled)
         assert e.signum == signal.SIGINT
 
+    def test_cancellation_disabled(self):
+        # ARROW-12622: reader would segfault when the cancelling signal
+        # handler was not enabled (e.g. if disabled, or if not on the
+        # main thread)
+        t = threading.Thread(target=lambda: self.read_bytes(b"f64\n0.1"))
+        t.start()
+        t.join()
+
 
 class TestSerialCSVRead(BaseTestCSVRead, unittest.TestCase):
 


### PR DESCRIPTION
An uninitialized StopToken caused segfaults if you ever called read_csv with cancellation disabled or when not on the main thread (e.g. if used in a Flight server). If we have a 4.0.1 I think this qualifies as a regression.