### PR TITLE
ARROW-12641: [C++] Provide thread local state for tasks in a thread pool

### DIFF
--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -256,7 +256,7 @@ class GeneratorTestFixture : public ::testing::TestWithParam<bool> {
 template <typename T>
 class ManualIteratorControl {
  public:
-  virtual ~ManualIteratorControl() {}
+  virtual ~ManualIteratorControl() = default;
   virtual void Push(Result<T> result) = 0;
   virtual uint32_t times_polled() = 0;
 };
@@ -265,7 +265,7 @@ template <typename T>
 class PushIterator : public ManualIteratorControl<T> {
  public:
   PushIterator() : state_(std::make_shared<State>()) {}
-  virtual ~PushIterator() {}
+  ~PushIterator() override = default;
 
   Result<T> Next() {
     std::unique_lock<std::mutex> lk(state_->mx);

--- a/cpp/src/arrow/util/borrowed.h
+++ b/cpp/src/arrow/util/borrowed.h
@@ -22,30 +22,51 @@
 #include <utility>
 #include <vector>
 
-#include "arrow/util/functional.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/mutex.h"
+#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 namespace internal {
 
 /// A thread safe set of values which can be borrowed (for example by tasks running in a
-/// ThreadPool). Borrowing a value will either lazily construct or pop from a cache.
-/// Calls to the constructor and destructor are not synchronized. In addition to releasing
-/// any resources not handled by T::~T(), the destructor has the responsibility of
-/// finalizing any associated accumulations for each instance.
+/// ThreadPool). Borrowing a value will either lazily construct it or pop from a cache.
+/// Calls to the constructor and destructor are not synchronized.
 template <typename T>
 class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
  public:
-  static std::shared_ptr<BorrowSet> Make(std::function<T()> construct,
-                                         std::function<void(T&&)> destroy) {
+  /// Construct a BorrowSet with static capacity.
+  static std::shared_ptr<BorrowSet> Make(int capacity) {
     std::shared_ptr<BorrowSet> set(new BorrowSet);
-    set->construct_ = std::move(construct);
-    set->destroy_ = std::move(destroy);
+    set->SetCapacity(capacity);
+    return set;
+  }
+
+  /// Construct a BorrowSet whose capacity tracks that of an Executor.
+  static std::shared_ptr<BorrowSet> Make(Executor* executor) {
+    std::shared_ptr<BorrowSet> set(new BorrowSet);
+
+    std::weak_ptr<BorrowSet> weak_set(set);
+    executor->OnCapacityChanged([weak_set](int capacity) {
+      if (auto set = weak_set.lock()) {
+        set->SetCapacity(capacity);
+        return true;
+      }
+      // set was discarded, delete this callback
+      return false;
+    });
+
     return set;
   }
 
   ~BorrowSet() { SetCapacity(0); }
+
+  /// Add a callback which will be invoked whenever the BorrowSet is done with an instance
+  /// of T. This will be called in ~BorrowSet() and whenever capacity is decreased. This
+  /// method is not thread safe, invoke it before multiple threads are accessing the
+  /// BorrowSet. Only one callback is supported; multiple calls to this function will
+  /// overwrite the previous callback.
+  void OnDone(std::function<void(T&&)> on_done) { on_done_ = std::move(on_done); }
 
   struct Value {
    public:
@@ -55,35 +76,20 @@ class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
     ARROW_DEFAULT_MOVE_AND_ASSIGN(Value);
     ARROW_DISALLOW_COPY_AND_ASSIGN(Value);
 
-    ~Value() { set_->ReturnOne(std::move(value_)); }
+    ~Value() {
+      if (set_) {
+        set_->ReturnOne(std::move(value_));
+      }
+    }
 
-    T& get() { return value_; }
+    T* get() { return &value_; }
+    T& operator*() { return value_; }
+    T* operator->() { return &value_; }
 
    private:
     T value_;
     std::shared_ptr<BorrowSet> set_;
   };
-
-  void SetCapacity(int capacity) {
-    auto lock = mutex_.Lock();
-
-    capacity_ = capacity;
-    cache_.reserve(capacity_);
-
-    // If capacity has been reduced there may be cached instances which we
-    // can destroy immediately.
-    std::vector<T> destroy_now;
-    while (GetInstanceCountUnlocked() > capacity_) {
-      if (cache_.empty()) break;
-      destroy_now.push_back(std::move(cache_.back()));
-      cache_.pop_back();
-    }
-    lock.Unlock();
-
-    for (auto&& extra : destroy_now) {
-      destroy_(std::move(extra));
-    }
-  }
 
   Value BorrowOne() {
     auto lock = mutex_.Lock();
@@ -95,7 +101,7 @@ class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
     if (cache_.empty()) {
       // create a new value and borrow that
       lock.Unlock();
-      return Value(construct_(), this);
+      return Value(T{}, this);
     }
 
     // pop a value from the cache
@@ -106,10 +112,6 @@ class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
 
  private:
   BorrowSet() = default;
-
-  int GetInstanceCountUnlocked() const {
-    return borrowed_count_ + static_cast<int>(cache_.size());
-  }
 
   void ReturnOne(T returned) {
     auto lock = mutex_.Lock();
@@ -123,12 +125,38 @@ class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
     // returning an instance after capacity has been decreased;
     // just destroy this extra now
     lock.Unlock();
-    destroy_(std::move(returned));
+    on_done_(std::move(returned));
+  }
+
+  int GetInstanceCountUnlocked() const {
+    return borrowed_count_ + static_cast<int>(cache_.size());
+  }
+
+  void SetCapacity(int capacity) {
+    auto lock = mutex_.Lock();
+
+    capacity_ = capacity;
+    cache_.reserve(capacity_);
+
+    // If capacity has been reduced there may be cached instances which we
+    // can be done with immediately.
+    int extra_count = GetInstanceCountUnlocked() - capacity_;
+    if (extra_count <= 0) return;
+
+    extra_count = std::min(static_cast<int>(cache_.size()), extra_count);
+
+    std::vector<T> done_now(extra_count);
+    std::move(cache_.end() - extra_count, cache_.end(), done_now.begin());
+    cache_.erase(cache_.end() - extra_count, cache_.end());
+    lock.Unlock();
+
+    for (auto&& extra : done_now) {
+      on_done_(std::move(extra));
+    }
   }
 
   util::Mutex mutex_;
-  std::function<T()> construct_;
-  std::function<void(T&&)> destroy_;
+  std::function<void(T&&)> on_done_ = [](T&&) {};
   std::vector<T> cache_;
   int borrowed_count_ = 0, capacity_ = 0;
 };

--- a/cpp/src/arrow/util/borrowed.h
+++ b/cpp/src/arrow/util/borrowed.h
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/util/functional.h"
+#include "arrow/util/mutex.h"
+
+namespace arrow {
+namespace internal {
+
+/// A wrapper for a value borrowed from another context.
+/// Includes a callback which returns the value to that context in ~Borrowed.
+template <typename T>
+class Borrowed {
+ public:
+  Borrowed(T value, FnOnce<void(T)> ret)
+      : borrowed_(std::move(value)), return_(std::move(ret)) {}
+
+  Borrowed(Borrowed&&) = default;
+  Borrowed& operator=(Borrowed&&) = default;
+
+  ~Borrowed() { std::move(return_)(std::move(borrowed_)); }
+
+  T& get() { return borrowed_; }
+
+ private:
+  T borrowed_;
+  FnOnce<void(T)> return_;
+};
+
+/// A thread safe set of values which can be borrowed (for example by tasks running in a
+/// ThreadPool). Borrowing a value will either lazily construct or pop from a cache.
+/// Calls to the constructor and destructor are not synchronized. In addition to releasing
+/// any resources not handled by T::~T(), the destructor has the responsibility of
+/// finalizing any associated accumulations for each instance.
+template <typename T>
+class BorrowSet : public std::enable_shared_from_this<BorrowSet<T>> {
+ public:
+  static std::shared_ptr<BorrowSet> Make(std::function<T()> construct,
+                                         std::function<void(T&&)> destroy) {
+    std::shared_ptr<BorrowSet> set(new BorrowSet);
+    set->construct_ = std::move(construct);
+    set->destroy_ = std::move(destroy);
+    return set;
+  }
+
+  ~BorrowSet() { SetCapacity(0); }
+
+  void SetCapacity(int capacity) {
+    auto lock = mutex_.Lock();
+
+    capacity_ = capacity;
+    cache_.reserve(capacity_);
+
+    // If capacity has been reduced there may be cached instances which we
+    // can destroy immediately.
+    std::vector<T> destroy_now;
+    while (GetInstanceCountUnlocked() > capacity_) {
+      if (cache_.empty()) break;
+      destroy_now.push_back(std::move(cache_.back()));
+      cache_.pop_back();
+    }
+    lock.Unlock();
+
+    for (auto&& extra : destroy_now) {
+      destroy_(std::move(extra));
+    }
+  }
+
+  Borrowed<T> BorrowOne() {
+    auto lock = mutex_.Lock();
+    // NB: can't assert that we haven't exceeded capacity because we might
+    // have multiple still-borrowed instances after a capacity change
+
+    ++borrowed_count_;
+
+    if (cache_.empty()) {
+      // create a new value and borrow that
+      lock.Unlock();
+      return Borrow(construct_());
+    }
+
+    // pop a value from the cache
+    auto cached = std::move(cache_.back());
+    cache_.pop_back();
+    return Borrow(std::move(cached));
+  }
+
+ private:
+  BorrowSet() = default;
+
+  int GetInstanceCountUnlocked() const {
+    return borrowed_count_ + static_cast<int>(cache_.size());
+  }
+
+  Borrowed<T> Borrow(T value) {
+    auto self = this->shared_from_this();
+    return Borrowed<T>(std::move(value),
+                       [self](T returned) { self->ReturnOne(std::move(returned)); });
+  }
+
+  void ReturnOne(T returned) {
+    auto lock = mutex_.Lock();
+
+    --borrowed_count_;
+
+    if (GetInstanceCountUnlocked() < capacity_) {
+      return cache_.push_back(std::move(returned));
+    }
+
+    // returning an instance after capacity has been decreased;
+    // just destroy this extra now
+    lock.Unlock();
+    destroy_(std::move(returned));
+  }
+
+  util::Mutex mutex_;
+  std::function<T()> construct_;
+  std::function<void(T&&)> destroy_;
+  std::vector<T> cache_;
+  int borrowed_count_ = 0, capacity_ = 0;
+};
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -573,6 +573,15 @@ class ARROW_MUST_USE_TYPE Future {
   FRIEND_TEST(FutureRefTest, HeadRemoved);
 };
 
+namespace internal {
+
+template <typename T>
+inline Status GenericToStatus(const Future<T>& fut) {
+  return fut.status();
+}
+
+}  // namespace internal
+
 template <typename T>
 class WeakFuture {
  public:

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -573,15 +573,6 @@ class ARROW_MUST_USE_TYPE Future {
   FRIEND_TEST(FutureRefTest, HeadRemoved);
 };
 
-namespace internal {
-
-template <typename T>
-inline Status GenericToStatus(const Future<T>& fut) {
-  return fut.status();
-}
-
-}  // namespace internal
-
 template <typename T>
 class WeakFuture {
  public:

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -50,8 +50,6 @@ struct SerialExecutor::State {
 
 SerialExecutor::SerialExecutor() : state_(std::make_shared<State>()) {}
 
-SerialExecutor::~SerialExecutor() = default;
-
 Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
                                  StopToken stop_token, StopCallback&& stop_callback) {
   // While the SerialExecutor runs tasks synchronously on its main thread,
@@ -297,7 +295,7 @@ int ThreadPool::GetActualCapacity() {
   return static_cast<int>(state_->workers_.size());
 }
 
-void ThreadPool::AddCapacityCallback(std::function<bool(int)> callback) {
+void ThreadPool::OnCapacityChanged(std::function<bool(int)> callback) {
   ProtectAgainstFork();
   std::unique_lock<std::mutex> lock(state_->mutex_);
   if (callback(state_->desired_capacity_)) {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -325,9 +325,9 @@ thread_local ThreadPool* g_current_thread_pool = nullptr;
 
 ThreadPool* ThreadPool::GetCurrentThreadPool() { return g_current_thread_pool; }
 
-thread_local int g_current_thread_id = 0;
+thread_local int g_current_thread_index = 0;
 
-int ThreadPool::GetCurrentThreadId() { return g_current_thread_id; }
+int ThreadPool::GetCurrentThreadIndex() { return g_current_thread_index; }
 
 void ThreadPool::LaunchWorkersUnlocked(int threads) {
   std::shared_ptr<State> state = sp_state_;
@@ -340,7 +340,7 @@ void ThreadPool::LaunchWorkersUnlocked(int threads) {
     auto it = --(state_->workers_.end());
     *it = std::thread([this, id, state, it] {
       g_current_thread_pool = this;
-      g_current_thread_id = id;
+      g_current_thread_index = id;
       WorkerLoop(state, it);
     });
   }

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -286,6 +286,16 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // tasks are finished.
   Status Shutdown(bool wait = true);
 
+  /// Return the ThreadPool associated with the current thread of execution,
+  /// or nullptr if the current thread of execution is not associated with a
+  /// ThreadPool.
+  static ThreadPool* GetCurrentThreadPool();
+
+  /// Return an id associated with the current thread of execution. The returned
+  /// value will be in the range [0, capacity), and if the current thread is not
+  /// associated with a ThreadPool will always be 0.
+  static int GetCurrentThreadId();
+
   struct State;
 
  protected:

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -291,10 +291,10 @@ class ARROW_EXPORT ThreadPool : public Executor {
   /// ThreadPool.
   static ThreadPool* GetCurrentThreadPool();
 
-  /// Return an id associated with the current thread of execution. The returned
+  /// Return an index associated with the current thread of execution. The returned
   /// value will be in the range [0, capacity), and if the current thread is not
   /// associated with a ThreadPool will always be 0.
-  static int GetCurrentThreadId();
+  static int GetCurrentThreadIndex();
 
   struct State;
 

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -541,7 +541,7 @@ TEST_F(TestThreadPool, ParallelSummationWithThreadLocalState) {
     ASSERT_OK_AND_ASSIGN(futures[i], pool->Submit([&, local_sums] {
       // Acquire thread local state. Each task may safely mutate since tasks
       // running in another thread will acquire a different local_sum
-      Borrowed<int64_t> local_sum = local_sums->BorrowOne();
+      auto local_sum = local_sums->BorrowOne();
 
       // Assemble a batch of addends
       int64_t addends_begin = next_addend.fetch_add(kBatchSize);

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -528,14 +528,14 @@ TEST_F(TestThreadPool, GetCurrentThreadPool) {
     }));
   }
 
-  ASSERT_OK(AllComplete(futures));
+  ASSERT_OK(AllComplete(futures).status());
   ASSERT_OK(pool->Shutdown());
 }
 
-TEST_F(TestThreadPool, GetCurrentThreadId) {
-  ASSERT_EQ(ThreadPool::GetCurrentThreadId(), 0);
+TEST_F(TestThreadPool, GetCurrentThreadIndex) {
+  ASSERT_EQ(ThreadPool::GetCurrentThreadIndex(), 0);
 
-  const int capacity = 5;
+  constexpr int capacity = 5;
 
   auto pool = this->MakeThreadPool(capacity);
 
@@ -543,8 +543,8 @@ TEST_F(TestThreadPool, GetCurrentThreadId) {
   std::vector<util::optional<std::thread::id>> std_ids(capacity);
 
   for (size_t i = 0; i < futures.size(); ++i) {
-    ASSERT_OK_AND_ASSIGN(futures[i], pool->Submit([&std_ids, i, pool] {
-      auto id = ThreadPool::GetCurrentThreadId();
+    ASSERT_OK_AND_ASSIGN(futures[i], pool->Submit([&std_ids, i] {
+      auto id = ThreadPool::GetCurrentThreadIndex();
       if (!std_ids[id].has_value()) {
         std_ids[id] = std::this_thread::get_id();
         return Status::OK();
@@ -558,8 +558,50 @@ TEST_F(TestThreadPool, GetCurrentThreadId) {
     }));
   }
 
-  ASSERT_OK(AllComplete(futures));
+  ASSERT_OK(AllComplete(futures).status());
   ASSERT_OK(pool->Shutdown());
+}
+
+TEST_F(TestThreadPool, ParallelSummationWithThreadLocalState) {
+  // Sum all integers in [0, 1000000) in parallel using thread local sums.
+  constexpr int kThreadPoolCapacity = 5;
+  constexpr int kBatchSize = 1000;
+  constexpr int kBatchCount = 1000;
+
+  auto pool = this->MakeThreadPool(kThreadPoolCapacity);
+
+  std::vector<std::unique_ptr<int64_t>> local_sums(kThreadPoolCapacity);
+  for (auto& local_sum : local_sums) {
+    local_sum.reset(new int64_t{0});
+  }
+
+  std::atomic<int64_t> next_addend{0};
+
+  for (int i = 0; i < kBatchCount; ++i) {
+    ASSERT_OK(pool->Spawn([&] {
+      // Acquire thread local state. Each task may safely mutate since tasks
+      // running in another thread will acquire a different local_sum
+      auto thread_index = ThreadPool::GetCurrentThreadIndex();
+      int64_t* local_sum = local_sums[thread_index].get();
+
+      // Assemble a batch of addends
+      int64_t addends_begin = next_addend.fetch_add(kBatchSize);
+      int64_t addends_end = addends_begin + kBatchSize;
+      for (int64_t addend = addends_begin; addend < addends_end; ++addend) {
+        *local_sum += addend;
+      }
+    }));
+  }
+
+  ASSERT_OK(pool->Shutdown());
+
+  int64_t sum = 0;
+  for (const auto& local_sum : local_sums) {
+    sum += *local_sum;
+  }
+
+  int64_t max_addend = kBatchSize * kBatchCount - 1;
+  ASSERT_EQ(sum, max_addend * (max_addend + 1) / 2);
 }
 
 TEST_F(TestThreadPool, SubmitWithStopToken) {


### PR DESCRIPTION
For some workflows, a task must mutate expensive state. To ensure this is safe and efficient, it's advantageous to have an instance of that state for each worker thread which can be used by each related task.

@westonpace