### PR TITLE
ARROW-12640: [C++] Fix errors from VS 2019 in cpp/src/parquet/types.h

### DIFF
--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -17,16 +17,6 @@
 
 #pragma once
 
-#ifdef _WIN32
-
-// parquet.thrift's OPTIONAL RepetitionType conflicts with a #define from
-// above, so we undefine it
-#ifdef OPTIONAL
-#undef OPTIONAL
-#endif
-
-#endif
-
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -38,6 +28,16 @@
 
 #include "parquet/platform.h"
 #include "parquet/type_fwd.h"
+
+#ifdef _WIN32
+
+// parquet.thrift's OPTIONAL RepetitionType conflicts with a #define,
+// so we undefine it
+#ifdef OPTIONAL
+#undef OPTIONAL
+#endif
+
+#endif // _WIN32
 
 namespace arrow {
 namespace util {

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -31,13 +31,12 @@
 
 #ifdef _WIN32
 
-// parquet.thrift's OPTIONAL RepetitionType conflicts with a #define,
-// so we undefine it
+// Repetition::OPTIONAL conflicts with a #define, so we undefine it
 #ifdef OPTIONAL
 #undef OPTIONAL
 #endif
 
-#endif // _WIN32
+#endif  // _WIN32
 
 namespace arrow {
 namespace util {

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -17,6 +17,16 @@
 
 #pragma once
 
+#ifdef _WIN32
+
+// parquet.thrift's OPTIONAL RepetitionType conflicts with a #define from
+// above, so we undefine it
+#ifdef OPTIONAL
+#undef OPTIONAL
+#endif
+
+#endif
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
This resolves a problem where Visual Studio 2019 reported syntax errors in `cpp/src/parquet/types.h` after ARROW-11929