### PR TITLE
ARROW-12646: [C++][CI][Packaging][Python] Bump vcpkg version to its latest release 

### DIFF
--- a/.env
+++ b/.env
@@ -70,4 +70,4 @@ DEVTOOLSET_VERSION=-1
 
 # Used for the manylinux and windows wheels, please update the crossbow configuration on update:
 #   https://github.com/ursacomputing/crossbow/blob/master/.github/workflows/cache_vcpkg.yml
-VCPKG=fced4bef1606260f110d74de1ae1975c2b9ac549
+VCPKG="2021.04.30"

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -1,5 +1,5 @@
 diff --git a/ports/aws-c-common/portfile.cmake b/ports/aws-c-common/portfile.cmake
-index f3704ef05..3af543058 100644
+index f3704ef05b..3af543058d 100644
 --- a/ports/aws-c-common/portfile.cmake
 +++ b/ports/aws-c-common/portfile.cmake
 @@ -1,8 +1,8 @@
@@ -14,20 +14,20 @@ index f3704ef05..3af543058 100644
      PATCHES
          disable-error-4068.patch # This patch fixes dependency port compilation failure
 diff --git a/ports/curl/portfile.cmake b/ports/curl/portfile.cmake
-index 6e18aecd0..2ccecf33c 100644
+index be66d452be..a5ce325e9d 100644
 --- a/ports/curl/portfile.cmake
 +++ b/ports/curl/portfile.cmake
-@@ -76,6 +76,8 @@ vcpkg_configure_cmake(
+@@ -94,6 +94,8 @@ vcpkg_configure_cmake(
          -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON
          -DENABLE_DEBUG=ON
          -DCURL_CA_FALLBACK=ON
 +        -DCURL_CA_PATH=none
 +        -DCURL_CA_BUNDLE=none
- )
- 
- vcpkg_install_cmake()
+     OPTIONS_DEBUG
+         ${EXTRA_ARGS_DEBUG}
+     OPTIONS_RELEASE
 diff --git a/ports/snappy/portfile.cmake b/ports/snappy/portfile.cmake
-index 75dd13302..84345c7ca 100644
+index 75dd133027..84345c7caa 100644
 --- a/ports/snappy/portfile.cmake
 +++ b/ports/snappy/portfile.cmake
 @@ -4,6 +4,7 @@ vcpkg_from_github(
@@ -36,11 +36,11 @@ index 75dd13302..84345c7ca 100644
      HEAD_REF master
 +    PATCHES "snappy-disable-bmi.patch"
  )
- 
+
  vcpkg_configure_cmake(
 diff --git a/ports/snappy/snappy-disable-bmi.patch b/ports/snappy/snappy-disable-bmi.patch
 new file mode 100644
-index 000000000..2cbb1533a
+index 0000000000..2cbb1533a8
 --- /dev/null
 +++ b/ports/snappy/snappy-disable-bmi.patch
 @@ -0,0 +1,17 @@

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -46,3 +46,11 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+
+      {% if arrow.branch == 'master' %}
+      - name: Push Docker Image
+        shell: bash
+        run: |
+          archery docker push python-wheel-manylinux-{{ manylinux_version }}
+          archery docker push python-wheel-manylinux-test-unittests
+      {% endif %}

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -52,7 +52,7 @@ jobs:
           # where we build pre-build the vcpkg packages
           setupOnly: true
           doNotSaveCache: true
-          appendedCacheKey: "-macos-{{ macos_deployment_target }}"
+          appendedCacheKey: "-macos-{{ macos_deployment_target }}-vcpkg-2021.04.30"
           vcpkgDirectory: {{ "${{ github.workspace }}/vcpkg" }}
           vcpkgGitCommitId: fced4bef1606260f110d74de1ae1975c2b9ac549
 

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -52,9 +52,9 @@ jobs:
           # where we build pre-build the vcpkg packages
           setupOnly: true
           doNotSaveCache: true
-          appendedCacheKey: "-macos-{{ macos_deployment_target }}-vcpkg-2021.04.30"
+          appendedCacheKey: "-macos-{{ macos_deployment_target }}"
           vcpkgDirectory: {{ "${{ github.workspace }}/vcpkg" }}
-          vcpkgGitCommitId: fced4bef1606260f110d74de1ae1975c2b9ac549
+          vcpkgGitCommitId: "2021.04.30"
 
       - name: Patch Vcpkg Ports
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -720,7 +720,7 @@ services:
   #    https://quay.io/repository/pypa/manylinux2010_x86_64?tab=tags
   #    only amd64 arch is supported
   python-wheel-manylinux-2010:
-    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010
+    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010-vcpkg-${VCPKG}
     build:
       args:
         arch_alias: ${ARCH_ALIAS}
@@ -731,7 +731,7 @@ services:
       context: .
       dockerfile: ci/docker/python-wheel-manylinux-201x.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010
+        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010-vcpkg-${VCPKG}
     environment:
       <<: *ccache
       MANYLINUX_VERSION: 2010
@@ -743,7 +743,7 @@ services:
   # See available versions at:
   #    https://quay.io/repository/pypa/manylinux2014_x86_64?tab=tags
   python-wheel-manylinux-2014:
-    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014
+    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
     build:
       args:
         arch_alias: ${ARCH_ALIAS}
@@ -754,7 +754,7 @@ services:
       context: .
       dockerfile: ci/docker/python-wheel-manylinux-201x.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014
+        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
     environment:
       <<: *ccache
       MANYLINUX_VERSION: 2014
@@ -786,7 +786,7 @@ services:
     command: /arrow/ci/scripts/python_wheel_manylinux_test.sh unittests
 
   python-wheel-windows-vs2017:
-    image: ${REPO}:python-${PYTHON}-wheel-windows-vs2017
+    image: ${REPO}:python-${PYTHON}-wheel-windows-vs2017-vcpkg-${VCPKG}
     build:
       args:
         vcpkg: ${VCPKG}


### PR DESCRIPTION
- [x] bump vcpkg version
- [x] update vcpkg ports patch
- [x] update windows docker images hosted on ghcr.io
- [x] update crossbow cache builds for macos (https://github.com/ursacomputing/crossbow/pull/4 should be merged after this one)