### PR TITLE
ARROW-9530: [C++] Add option to disable jemalloc background thread on Linux

### DIFF
--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -154,7 +154,7 @@ ARROW_EXPORT MemoryPool* system_memory_pool();
 
 /// \brief Return a process-wide memory pool based on jemalloc.
 ///
-/// May return NotImplemented if jemalloc is not available.
+/// returns NotImplemented if jemalloc is not available.
 ARROW_EXPORT Status jemalloc_memory_pool(MemoryPool** out);
 
 /// \brief Set jemalloc memory page purging behavior for future-created arenas
@@ -165,8 +165,47 @@ ARROW_EXPORT Status jemalloc_memory_pool(MemoryPool** out);
 /// seconds. If you set the value to 0, dirty / muzzy pages will be released
 /// immediately rather than with a time decay, but this may reduce application
 /// performance.
+///
+/// returns NotImplemented if jemalloc is not available.
 ARROW_EXPORT
 Status jemalloc_set_decay_ms(int ms);
+
+/// \brief Configure whether jemalloc should use background threads for purging
+/// data.  This has been shown to give better performance and is enabled by
+/// default.
+///
+/// However, the creation of extra background threads can be undesirable in some
+/// situations (ARROW-9530).  Setting this configuration to false will synchronously
+/// terminate all existing background threads and prevent new ones from being created.
+///
+/// In addition, jemalloc disables background thread creation on fork on the child
+/// process.  You may need to use this option to re-enable background threads after
+/// a fork.
+///
+/// This is a process wide setting.
+///
+/// returns NotImplemented if jemalloc is not available.
+ARROW_EXPORT Status jemalloc_set_background_thread(bool use_background_thread);
+
+/// \brief Returns true if jemalloc background threads are currently enabled.
+///
+/// returns NotImplemented if jemalloc is not available.
+ARROW_EXPORT Result<bool> jemalloc_get_background_thread();
+
+/// \brief Returns true if jemalloc was compiled with statistics
+///
+/// returns NotImplemented if jemalloc is not available.
+ARROW_EXPORT Result<bool> jemalloc_has_stats();
+
+/// \brief Returns the number of jemalloc background threads currently running
+///
+/// returns NotImplemented if jemalloc is not available.
+ARROW_EXPORT Result<std::size_t> jemalloc_num_threads();
+
+/// \brief Updates jemalloc statistics by bumping the epoch (see jemalloc docs)
+///
+/// returns NotImplemented if jemalloc is not available.
+ARROW_EXPORT Status jemalloc_update_stats();
 
 /// \brief Return a process-wide memory pool based on mimalloc.
 ///

--- a/cpp/src/arrow/memory_pool_test.cc
+++ b/cpp/src/arrow/memory_pool_test.cc
@@ -186,7 +186,6 @@ void TestBackgroundJemallocWithBackgroundThread() {
 
 void TestBackgroundJemallocWithoutBackgroundThread() {
   ASSERT_OK_AND_ASSIGN(auto has_stats, jemalloc_has_stats());
-  ASSERT_OK_AND_EQ(false, jemalloc_get_background_thread());
   if (!has_stats) {
     GTEST_SKIP() << "Jemalloc was not compiled with statistics";
   }

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -161,7 +161,9 @@ from pyarrow.lib import (MemoryPool, LoggingMemoryPool, ProxyMemoryPool,
                          default_memory_pool, system_memory_pool,
                          jemalloc_memory_pool, mimalloc_memory_pool,
                          logging_memory_pool, proxy_memory_pool,
-                         log_memory_allocations, jemalloc_set_decay_ms)
+                         log_memory_allocations, jemalloc_set_decay_ms,
+                         jemalloc_set_background_thread,
+                         jemalloc_get_background_thread)
 
 # I/O
 from pyarrow.lib import (NativeFile, PythonFile,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -332,6 +332,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CMemoryPool** out)
 
     CStatus c_jemalloc_set_decay_ms" arrow::jemalloc_set_decay_ms"(int ms)
+    CStatus c_jemalloc_set_background_thread" arrow::jemalloc_set_background_thread"(c_bool use_background_thread)
+    CResult[c_bool] c_jemalloc_get_background_thread" arrow::jemalloc_get_background_thread"()
 
     cdef cppclass CListType" arrow::ListType"(CDataType):
         CListType(const shared_ptr[CDataType]& value_type)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -332,8 +332,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CMemoryPool** out)
 
     CStatus c_jemalloc_set_decay_ms" arrow::jemalloc_set_decay_ms"(int ms)
-    CStatus c_jemalloc_set_background_thread" arrow::jemalloc_set_background_thread"(c_bool use_background_thread)
-    CResult[c_bool] c_jemalloc_get_background_thread" arrow::jemalloc_get_background_thread"()
+    CStatus c_jemalloc_set_background_thread\
+        " arrow::jemalloc_set_background_thread"(c_bool use_background_thread)
+    CResult[c_bool] c_jemalloc_get_background_thread\
+        " arrow::jemalloc_get_background_thread"()
 
     cdef cppclass CListType" arrow::ListType"(CDataType):
         CListType(const shared_ptr[CDataType]& value_type)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -214,3 +214,29 @@ def jemalloc_set_decay_ms(decay_ms):
         that this change will only affect future memory arenas
     """
     check_status(c_jemalloc_set_decay_ms(decay_ms))
+
+def jemalloc_set_background_thread(use_background_thread):
+    """
+    Enables or disables background threads for dirty page purging.  If true
+    then jemalloc will start background threads to release pages to the OS.
+    This generally has better performance.  If this is set to false then any
+    existing threads will synchronously terminate.  This may be desired in
+    situations where precise control over threads is needed.  See the
+    jemalloc docs for more information.
+
+    It's best to set this at the start of your application.
+
+    Parameters
+    ----------
+    use_background_thread : bool
+        Set to True to enable background threads.  Setting to false will
+        terminate existing threads.
+    """
+    check_status(c_jemalloc_set_background_thread(use_background_thread))
+
+def jemalloc_get_background_thread():
+    """
+    Returns True if jemalloc is configured to use background threads and
+    False otherwise.
+    """
+    return GetResultValue(c_jemalloc_get_background_thread())

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -215,6 +215,7 @@ def jemalloc_set_decay_ms(decay_ms):
     """
     check_status(c_jemalloc_set_decay_ms(decay_ms))
 
+
 def jemalloc_set_background_thread(use_background_thread):
     """
     Enables or disables background threads for dirty page purging.  If true
@@ -233,6 +234,7 @@ def jemalloc_set_background_thread(use_background_thread):
         terminate existing threads.
     """
     check_status(c_jemalloc_set_background_thread(use_background_thread))
+
 
 def jemalloc_get_background_thread():
     """

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -21,6 +21,8 @@ import subprocess
 import sys
 import weakref
 
+import pytest
+
 import pyarrow as pa
 
 
@@ -84,6 +86,20 @@ def test_logging_memory_pool(capfd):
     assert err == ""
     assert out.count("Allocate:") > 0
     assert out.count("Allocate:") == out.count("Free:")
+
+
+def test_enable_disable_background_threads():
+    if should_have_jemalloc:
+        was_true = pa.jemalloc_get_background_thread()
+        pa.jemalloc_set_background_thread(False)
+        assert pa.jemalloc_get_background_thread() == False
+        if was_true:
+            # Apple currently has the background thread disabled and
+            # we don't want to enable it so we check was_true
+            pa.jemalloc_set_background_thread(True)
+            assert pa.jemalloc_get_background_thread() == True
+    else:
+        pytest.skip("jemalloc not enabled")
 
 
 def test_set_memory_pool():

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -92,12 +92,12 @@ def test_enable_disable_background_threads():
     if should_have_jemalloc:
         was_true = pa.jemalloc_get_background_thread()
         pa.jemalloc_set_background_thread(False)
-        assert pa.jemalloc_get_background_thread() == False
+        assert not pa.jemalloc_get_background_thread()
         if was_true:
             # Apple currently has the background thread disabled and
             # we don't want to enable it so we check was_true
             pa.jemalloc_set_background_thread(True)
-            assert pa.jemalloc_get_background_thread() == True
+            assert pa.jemalloc_get_background_thread()
     else:
         pytest.skip("jemalloc not enabled")
 

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1092,6 +1092,14 @@ supported_memory_backends <- function(){
     .Call(`_arrow_supported_memory_backends`)
 }
 
+jemalloc_set_background_thread <- function(use_background_threads){
+    invisible(.Call(`_arrow_jemalloc_set_background_thread`, use_background_threads))
+}
+
+jemalloc_get_background_thread <- function(){
+    .Call(`_arrow_jemalloc_get_background_thread`)
+}
+
 ipc___Message__body_length <- function(message){
     .Call(`_arrow_ipc___Message__body_length`, message)
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -4265,6 +4265,36 @@ extern "C" SEXP _arrow_supported_memory_backends(){
 }
 #endif
 
+// memorypool.cpp
+#if defined(ARROW_R_WITH_ARROW)
+void jemalloc_set_background_thread(bool use_background_threads);
+extern "C" SEXP _arrow_jemalloc_set_background_thread(SEXP use_background_threads_sexp){
+BEGIN_CPP11
+	arrow::r::Input<bool>::type use_background_threads(use_background_threads_sexp);
+	jemalloc_set_background_thread(use_background_threads);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_jemalloc_set_background_thread(SEXP use_background_threads_sexp){
+	Rf_error("Cannot call jemalloc_set_background_thread(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// memorypool.cpp
+#if defined(ARROW_R_WITH_ARROW)
+bool jemalloc_get_background_thread();
+extern "C" SEXP _arrow_jemalloc_get_background_thread(){
+BEGIN_CPP11
+	return cpp11::as_sexp(jemalloc_get_background_thread());
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_jemalloc_get_background_thread(){
+	Rf_error("Cannot call jemalloc_get_background_thread(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // message.cpp
 #if defined(ARROW_R_WITH_ARROW)
 int64_t ipc___Message__body_length(const std::unique_ptr<arrow::ipc::Message>& message);
@@ -6877,6 +6907,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_MemoryPool__max_memory", (DL_FUNC) &_arrow_MemoryPool__max_memory, 1}, 
 		{ "_arrow_MemoryPool__backend_name", (DL_FUNC) &_arrow_MemoryPool__backend_name, 1}, 
 		{ "_arrow_supported_memory_backends", (DL_FUNC) &_arrow_supported_memory_backends, 0}, 
+		{ "_arrow_jemalloc_set_background_thread", (DL_FUNC) &_arrow_jemalloc_set_background_thread, 1}, 
+		{ "_arrow_jemalloc_get_background_thread", (DL_FUNC) &_arrow_jemalloc_get_background_thread, 0}, 
 		{ "_arrow_ipc___Message__body_length", (DL_FUNC) &_arrow_ipc___Message__body_length, 1}, 
 		{ "_arrow_ipc___Message__metadata", (DL_FUNC) &_arrow_ipc___Message__metadata, 1}, 
 		{ "_arrow_ipc___Message__body", (DL_FUNC) &_arrow_ipc___Message__body, 1}, 

--- a/r/src/memorypool.cpp
+++ b/r/src/memorypool.cpp
@@ -89,4 +89,14 @@ std::vector<std::string> supported_memory_backends() {
   return arrow::SupportedMemoryBackendNames();
 }
 
+// [[arrow::export]]
+void jemalloc_set_background_thread(bool use_background_threads) {
+  StopIfNotOk(arrow::jemalloc_set_background_thread(use_background_threads));
+}
+
+// [[arrow::export]]
+bool jemalloc_get_background_thread() {
+  return ValueOrStop(arrow::jemalloc_get_background_thread());
+}
+
 #endif

--- a/r/tests/testthat/test-memory-pool.R
+++ b/r/tests/testthat/test-memory-pool.R
@@ -24,3 +24,20 @@ test_that("default_memory_pool and its attributes", {
 
   expect_true(all(supported_memory_backends() %in% c("system", "jemalloc", "mimalloc")))
 })
+
+test_that("set_jemalloc_background_thread works", {
+  if ("jemalloc" %in% supported_memory_backends()) {
+    was_true <- jemalloc_get_background_thread()
+    jemalloc_set_background_thread(FALSE);
+    expect_false(jemalloc_get_background_thread());
+    if (was_true) {
+      # Some environments (e.g. Apple) have the background
+      # thread disabled so don't turn it back on unless it was
+      # originally on
+      jemalloc_set_background_thread(TRUE);
+      expect_true(jemalloc_get_background_thread());
+    }
+  } else {
+    skip("Jemalloc not enabled")
+  }
+})


### PR DESCRIPTION
Currently Arrow builds that enable jemalloc also enable background threads.  There is no way to disable this without recompiling arrow.

* MALLOC_CONF and /etc/malloc.conf are ignored as they are lower precedence than global variable initialization
* Disabling dirty page purging via `jemalloc_set_decay_ms` does not terminate the background threads
* Switching to a different allocator (e.g. python's `set_default_memory_pool`) does not terminate the background threads.

This PR adds a capability to do so.  In a future PR it may be worth looking into some mechanism to prevent the threads from starting at all (e.g. migrate away from global variable initialization) but there is no good lifecycle hook for this and adding a run-once initial configuration step when the allocator is first accessed adds complexity and potential race cases.

* As best I can tell this method should be thread safe but I can't find any good jemalloc documentation on this so I just left it vague.  I figure most users will be shutting down the background threads before they start using Arrow anyways.
* I confirmed that shutting down the background threads did indeed shutdown the threads and that the valgrind potential leak goes away (FYI, the leak is a valgrind error as valgrind is not properly waiting for detached threads to shut down, more on that here: https://bugs.kde.org/show_bug.cgi?id=415141)