### PR TITLE
ARROW-12645: [Python] Fix numpydoc validation

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -348,7 +348,7 @@ def numpydoc(src, symbols, allow_rule, disallow_rule):
     disallow_rule = disallow_rule or {'GL01', 'SA01', 'EX01', 'ES01'}
     try:
         results = python_numpydoc(symbols, allow_rules=allow_rule,
-                                  disallow_rule=disallow_rule)
+                                  disallow_rules=disallow_rule)
         for result in results:
             result.ok()
     except LintValidationException:

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -106,8 +106,7 @@ class NumpyDoc:
         if not have_numpydoc:
             raise RuntimeError(
                 'Numpydoc is not available, install the development version '
-                'with command: pip install '
-                'git+https://github.com/numpy/numpydoc'
+                'with command: pip install numpydoc==1.1.0'
             )
         self.symbols = set(symbols or {'pyarrow'})
 

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -26,6 +26,7 @@ except ImportError:
 else:
     have_numpydoc = True
 
+from ..utils.logger import logger
 from ..utils.command import Command, capture_stdout, default_bin
 
 
@@ -192,7 +193,12 @@ class NumpyDoc:
         results = []
 
         def callback(obj):
-            result = validate(obj)
+            try:
+                result = validate(obj)
+            except OSError as e:
+                symbol = f"{obj.__module__}.{obj.__name__}"
+                logger.warning(f"Unable to validate `{symbol}` due to `{e}`")
+                return
 
             errors = []
             for errcode, errmsg in result.get('errors', []):

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -28,6 +28,7 @@ if sys.version_info < (3, 6):
 jinja_req = 'jinja2>=2.11'
 
 extras = {
+    'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8', 'cmake_format==0.5.2'],
     'benchmark': ['pandas'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
     'release': [jinja_req, 'jira', 'semver', 'gitpython'],


### PR DESCRIPTION
Numpydoc helps identifying issues with our docstrings, for example we can list the undocumented parameters using the following command:

```bash
archery numpydoc -a PR01
```

parts of the output:

```console
pyarrow.parquet.write_table
PR01: Parameters {'use_compliant_nested_type', 'where', 'row_group_size', 'use_byte_stream_split', 'compression_level', '**kwargs'} not documented

pyarrow.parquet.write_metadata
PR01: Parameters {'where', 'metadata_collector'} not documented

pyarrow.parquet.read_table
PR01: Parameters {'source', 'columns'} not documented

pyarrow.parquet.read_pandas
PR01: Parameters {'source', '**kwargs', 'columns'} not documented

pyarrow.parquet.PartitionSet
PR01: Parameters {'keys', 'name'} not documented

pyarrow.parquet.PartitionSet.get_index
PR01: Parameters {'key'} not documented

pyarrow.parquet.ParquetWriter
PR01: Parameters {'writer_engine_version', 'use_compliant_nested_type', 'use_byte_stream_split', 'compression_level'} not documented
```

```console
pyarrow._flight.RecordBatchStream
-> pyarrow._flight.RecordBatchStream(data_source, options=None)
PR01: Parameters {'options', 'data_source'} not documented

pyarrow._flight.Location
-> pyarrow._flight.Location(uri)
PR01: Parameters {'uri'} not documented

pyarrow._flight.for_grpc_unix
-> pyarrow._flight.Location.for_grpc_unix(path)
PR01: Parameters {'path'} not documented

pyarrow._flight.for_grpc_tls
-> pyarrow._flight.Location.for_grpc_tls(host, port)
PR01: Parameters {'host', 'port'} not documented

pyarrow._flight.for_grpc_tcp
-> pyarrow._flight.Location.for_grpc_tcp(host, port)
PR01: Parameters {'host', 'port'} not documented

pyarrow._flight.GeneratorStream
-> pyarrow._flight.GeneratorStream(schema, generator, options=None)
PR01: Parameters {'options', 'schema', 'generator'} not documented

pyarrow._flight.FlightWriteSizeExceededError
-> pyarrow._flight.A write operation exceeded the client-configured limit.
PR01: Parameters {'actual', 'limit', 'message'} not documented
```