### PR TITLE
ARROW-12648: [C++][FlightRPC] Enable TLS for Flight benchmark

### DIFF
--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -86,7 +86,7 @@ Status ResolveCurrentExecutable(fs::path* out) {
 
 }  // namespace
 
-void TestServer::Start() {
+void TestServer::Start(const std::vector<std::string>& extra_args) {
   namespace fs = boost::filesystem;
 
   std::string str_port = std::to_string(port_);
@@ -104,11 +104,13 @@ void TestServer::Start() {
 
   try {
     if (unix_sock_.empty()) {
-      server_process_ = std::make_shared<bp::child>(
-          bp::search_path(executable_name_, search_path), "-port", str_port);
+      server_process_ =
+          std::make_shared<bp::child>(bp::search_path(executable_name_, search_path),
+                                      "-port", str_port, bp::args(extra_args));
     } else {
-      server_process_ = std::make_shared<bp::child>(
-          bp::search_path(executable_name_, search_path), "-server_unix", unix_sock_);
+      server_process_ =
+          std::make_shared<bp::child>(bp::search_path(executable_name_, search_path),
+                                      "-server_unix", unix_sock_, bp::args(extra_args));
     }
   } catch (...) {
     std::stringstream ss;

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -56,7 +56,8 @@ class ARROW_FLIGHT_EXPORT TestServer {
   TestServer(const std::string& executable_name, const std::string& unix_sock)
       : executable_name_(executable_name), unix_sock_(unix_sock) {}
 
-  void Start();
+  void Start(const std::vector<std::string>& extra_args);
+  void Start() { Start({}); }
 
   int Stop();
 


### PR DESCRIPTION
This allows you to enable TLS with a self-signed certificate in the Flight benchmark. Quick testing shows about a 20% performance impact.