### PR TITLE
ARROW-12659: [C++][Compute] Support is_valid as a guarantee

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -87,7 +87,8 @@ class ARROW_EXPORT Expression {
   /// Return true if this expression is literal and entirely null.
   bool IsNullLiteral() const;
 
-  /// Return true if this expression could evaluate to true.
+  /// Return true if this expression could evaluate to true. Will return true for any
+  /// unbound, non-boolean, or unsimplified Expressions
   bool IsSatisfiable() const;
 
   // XXX someday
@@ -161,7 +162,8 @@ std::vector<FieldRef> FieldsInExpression(const Expression&);
 ARROW_EXPORT
 bool ExpressionHasFieldRefs(const Expression&);
 
-/// Assemble a mapping from field references to known values.
+/// Assemble a mapping from field references to known values. This derives known values
+/// from "equal" and "is_null" Expressions referencing a field and a literal.
 ARROW_EXPORT
 Result<std::unordered_map<FieldRef, Datum, FieldRef::Hash>> ExtractKnownFieldValues(
     const Expression& guaranteed_true_predicate);

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -912,8 +912,7 @@ TEST(Expression, CanonicalizeAnd) {
                         and_(and_(and_(and_(null_, null_), true_), b), c));
 
   // catches and_kleene even when it's a subexpression
-  ExpectCanonicalizesTo(call("is_valid", {and_(b, true_)}),
-                        call("is_valid", {and_(true_, b)}));
+  ExpectCanonicalizesTo(is_valid(and_(b, true_)), is_valid(and_(true_, b)));
 }
 
 TEST(Expression, CanonicalizeComparison) {
@@ -1128,8 +1127,20 @@ TEST(Expression, SimplifyWithGuarantee) {
       .Expect(literal(true));
 
   Simplify{is_valid(field_ref("i32"))}
+      .WithGuarantee(is_null(field_ref("i32")))
+      .Expect(literal(false));
+
+  Simplify{is_valid(field_ref("i32"))}
       .WithGuarantee(is_valid(field_ref("i32")))
+      .Expect(literal(true));
+
+  Simplify{is_valid(field_ref("i32"))}
+      .WithGuarantee(is_valid(field_ref("dict_i32")))  // different field
       .Expect(is_valid(field_ref("i32")));
+
+  Simplify{is_null(field_ref("i32"))}
+      .WithGuarantee(is_valid(field_ref("i32")))
+      .Expect(literal(false));
 }
 
 TEST(Expression, SimplifyThenExecute) {

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -64,6 +64,12 @@ Expression cast(Expression argument, std::shared_ptr<DataType> to_type) {
               compute::CastOptions::Safe(std::move(to_type)));
 }
 
+Expression invert(Expression argument) { return call("invert", {std::move(argument)}); }
+
+Expression true_unless_null(Expression argument) {
+  return call("true_unless_null", {std::move(argument)});
+}
+
 template <typename Actual, typename Expected>
 void ExpectResultsEqual(Actual&& actual, Expected&& expected) {
   using MaybeActual = typename EnsureResult<typename std::decay<Actual>::type>::type;
@@ -305,29 +311,42 @@ TEST(Expression, IsScalarExpression) {
 }
 
 TEST(Expression, IsSatisfiable) {
+  auto Bind = [](Expression expr) { return expr.Bind(*kBoringSchema).ValueOrDie(); };
+
   EXPECT_TRUE(literal(true).IsSatisfiable());
   EXPECT_FALSE(literal(false).IsSatisfiable());
 
   auto null = std::make_shared<BooleanScalar>();
   EXPECT_FALSE(literal(null).IsSatisfiable());
 
-  EXPECT_TRUE(field_ref("a").IsSatisfiable());
+  // NB: no implicit conversion to bool
+  EXPECT_TRUE(literal(0).IsSatisfiable());
 
-  EXPECT_TRUE(equal(field_ref("a"), literal(1)).IsSatisfiable());
+  EXPECT_TRUE(field_ref("i32").IsSatisfiable());
+  EXPECT_TRUE(Bind(field_ref("i32")).IsSatisfiable());
+
+  EXPECT_TRUE(equal(field_ref("i32"), literal(1)).IsSatisfiable());
+  EXPECT_TRUE(Bind(equal(field_ref("i32"), literal(1))).IsSatisfiable());
 
   // NB: no constant folding here
-  EXPECT_TRUE(equal(literal(0), literal(1)).IsSatisfiable());
+  EXPECT_TRUE(Bind(equal(literal(0), literal(1))).IsSatisfiable());
 
-  // When a top level conjunction contains an Expression which is certain to evaluate to
-  // null, it can only evaluate to null or false.
-  auto never_true = and_(literal(null), field_ref("a"));
-  // This may appear in satisfiable filters if coalesced (for example, wrapped in fill_na)
-  EXPECT_TRUE(call("is_null", {never_true}).IsSatisfiable());
-  // ... but at the top level it is not satisfiable.
+  // Special case invert(true_unless_null(x)): arises in simplification against a
+  // guarantee with a nullable caveat.
+  EXPECT_FALSE(Bind(invert(true_unless_null(field_ref("i32")))).IsSatisfiable());
+  // NB: no effort to examine unbound expressions
+  EXPECT_TRUE(invert(true_unless_null(field_ref("i32"))).IsSatisfiable());
+
+  // When a top level conjunction contains an Expression which is not satisfiable
+  // (guaranteed to evaluate to null or false), it can only evaluate to null or false.
   // This special case arises when (for example) an absent column has made
-  // one member of the conjunction always-null. This is fairly common and
-  // would be a worthwhile optimization to support.
-  // EXPECT_FALSE(null_or_false).IsSatisfiable());
+  // one member of the conjunction always-null.
+  auto never_true = and_(literal(null), field_ref("bool"));
+  EXPECT_FALSE(Bind(never_true).IsSatisfiable());
+
+  // ... but it may appear in satisfiable filters if coalesced (for example, wrapped in
+  // fill_na)
+  EXPECT_TRUE(Bind(call("is_null", {never_true})).IsSatisfiable());
 }
 
 TEST(Expression, FieldsInExpression) {
@@ -1121,7 +1140,9 @@ TEST(Expression, SimplifyWithGuarantee) {
   Simplify{equal(field_ref("i32"), literal(7))}
       .WithGuarantee(not_(equal(field_ref("i32"), literal(7))))
       .Expect(equal(field_ref("i32"), literal(7)));
+}
 
+TEST(Expression, SimplifyWithValidityGuarantee) {
   Simplify{is_null(field_ref("i32"))}
       .WithGuarantee(is_null(field_ref("i32")))
       .Expect(literal(true));
@@ -1141,6 +1162,22 @@ TEST(Expression, SimplifyWithGuarantee) {
   Simplify{is_null(field_ref("i32"))}
       .WithGuarantee(is_valid(field_ref("i32")))
       .Expect(literal(false));
+}
+
+TEST(Expression, SimplifyWithComparisonAndNullableCaveat) {
+  auto i32_is_2_or_null =
+      or_(equal(field_ref("i32"), literal(2)), is_null(field_ref("i32")));
+
+  Simplify{equal(field_ref("i32"), literal(2))}
+      .WithGuarantee(i32_is_2_or_null)
+      .Expect(true_unless_null(field_ref("i32")));
+
+  // Simplify{i32_is_2_or_null}.WithGuarantee(i32_is_2_or_null).Expect(literal(true));
+
+  Simplify{equal(field_ref("i32"), literal(3))}
+      .WithGuarantee(i32_is_2_or_null)
+      .Expect(invert(
+          true_unless_null(field_ref("i32"))));  // not satisfiable, will drop row group
 }
 
 TEST(Expression, SimplifyThenExecute) {

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -38,6 +38,15 @@ struct IsValidOperator {
   }
 
   static Status Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
+    if (arr.type->id() == Type::NA) {
+      // Input is all nulls => output is entirely false.
+      ARROW_ASSIGN_OR_RAISE(out->buffers[1],
+                            ctx->AllocateBitmap(out->length + out->offset));
+      BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length,
+                         false);
+      return Status::OK();
+    }
+
     DCHECK_EQ(out->offset, 0);
     DCHECK_LE(out->length, arr.length);
     if (arr.MayHaveNulls()) {
@@ -67,6 +76,14 @@ struct IsNullOperator {
   }
 
   static Status Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
+    if (arr.type->id() == Type::NA) {
+      // Input is all nulls => output is entirely true.
+      ARROW_ASSIGN_OR_RAISE(out->buffers[1],
+                            ctx->AllocateBitmap(out->length + out->offset));
+      BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length, true);
+      return Status::OK();
+    }
+
     if (arr.MayHaveNulls()) {
       // Input has nulls => output is the inverted null (validity) bitmap.
       InvertBitmap(arr.buffers[0]->data(), arr.offset, arr.length,
@@ -76,6 +93,22 @@ struct IsNullOperator {
       BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length,
                          false);
     }
+    return Status::OK();
+  }
+};
+
+struct TrueUnlessNullOperator {
+  static Status Call(KernelContext* ctx, const Scalar& in, Scalar* out) {
+    checked_cast<BooleanScalar*>(out)->is_valid = in.is_valid;
+    checked_cast<BooleanScalar*>(out)->value = true;
+    return Status::OK();
+  }
+
+  static Status Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
+    // NullHandling::INTERSECTION with a single input means the execution engine
+    // has already reused or allocated a null_bitmap which can be reused as the values
+    // buffer.
+    out->buffers[1] = out->buffers[0];
     return Status::OK();
   }
 };
@@ -90,12 +123,13 @@ struct IsNanOperator {
 void MakeFunction(std::string name, const FunctionDoc* doc,
                   std::vector<InputType> in_types, OutputType out_type,
                   ArrayKernelExec exec, FunctionRegistry* registry,
-                  MemAllocation::type mem_allocation, bool can_write_into_slices) {
+                  MemAllocation::type mem_allocation, bool can_write_into_slices,
+                  NullHandling::type null_handling = NullHandling::OUTPUT_NOT_NULL) {
   Arity arity{static_cast<int>(in_types.size())};
   auto func = std::make_shared<ScalarFunction>(name, arity, doc);
 
   ScalarKernel kernel(std::move(in_types), out_type, exec);
-  kernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
+  kernel.null_handling = null_handling;
   kernel.can_write_into_slices = can_write_into_slices;
   kernel.mem_allocation = mem_allocation;
 
@@ -121,38 +155,15 @@ std::shared_ptr<ScalarFunction> MakeIsNanFunction(std::string name,
 }
 
 Status IsValidExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  const Datum& arg0 = batch[0];
-  if (arg0.type()->id() == Type::NA) {
-    auto false_value = std::make_shared<BooleanScalar>(false);
-    if (arg0.kind() == Datum::SCALAR) {
-      out->value = false_value;
-    } else {
-      std::shared_ptr<Array> false_values;
-      RETURN_NOT_OK(MakeArrayFromScalar(*false_value, out->length(), ctx->memory_pool())
-                        .Value(&false_values));
-      out->value = false_values->data();
-    }
-    return Status::OK();
-  } else {
-    return applicator::SimpleUnary<IsValidOperator>(ctx, batch, out);
-  }
+  return applicator::SimpleUnary<IsValidOperator>(ctx, batch, out);
 }
 
 Status IsNullExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  const Datum& arg0 = batch[0];
-  if (arg0.type()->id() == Type::NA) {
-    if (arg0.kind() == Datum::SCALAR) {
-      out->value = std::make_shared<BooleanScalar>(true);
-    } else {
-      // Data is preallocated
-      ArrayData* out_arr = out->mutable_array();
-      BitUtil::SetBitsTo(out_arr->buffers[1]->mutable_data(), out_arr->offset,
-                         out_arr->length, true);
-    }
-    return Status::OK();
-  } else {
-    return applicator::SimpleUnary<IsNullOperator>(ctx, batch, out);
-  }
+  return applicator::SimpleUnary<IsNullOperator>(ctx, batch, out);
+}
+
+Status TrueUnlessNullExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+  return applicator::SimpleUnary<TrueUnlessNullOperator>(ctx, batch, out);
 }
 
 const FunctionDoc is_valid_doc(
@@ -162,6 +173,11 @@ const FunctionDoc is_valid_doc(
 const FunctionDoc is_null_doc("Return true if null",
                               ("For each input value, emit true iff the value is null."),
                               {"values"});
+
+const FunctionDoc true_unless_null_doc("Return true if non-null, else return null",
+                                       ("For each input value, emit true iff the value "
+                                        "is valid (non-null), otherwise emit null."),
+                                       {"values"});
 
 const FunctionDoc is_nan_doc("Return true if NaN",
                              ("For each input value, emit true iff the value is NaN."),
@@ -176,6 +192,11 @@ void RegisterScalarValidity(FunctionRegistry* registry) {
   MakeFunction("is_null", &is_null_doc, {ValueDescr::ANY}, boolean(), IsNullExec,
                registry, MemAllocation::PREALLOCATE,
                /*can_write_into_slices=*/true);
+
+  MakeFunction("true_unless_null", &true_unless_null_doc, {ValueDescr::ANY}, boolean(),
+               TrueUnlessNullExec, registry, MemAllocation::NO_PREALLOCATE,
+               /*can_write_into_slices=*/false,
+               /*null_handling=*/NullHandling::INTERSECTION);
 
   DCHECK_OK(registry->AddFunction(MakeIsNanFunction("is_nan", &is_nan_doc)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -51,6 +51,16 @@ TEST_F(TestBooleanValidityKernels, ArrayIsValid) {
                    "[false, true, true, false]");
 }
 
+TEST_F(TestBooleanValidityKernels, TrueUnlessNull) {
+  CheckScalarUnary("true_unless_null", type_singleton(), "[]", type_singleton(), "[]");
+  CheckScalarUnary("true_unless_null", type_singleton(), "[null]", type_singleton(),
+                   "[null]");
+  CheckScalarUnary("true_unless_null", type_singleton(), "[1]", type_singleton(),
+                   "[true]");
+  CheckScalarUnary("true_unless_null", type_singleton(), "[null, 1, 0, null]",
+                   type_singleton(), "[null, true, true, null]");
+}
+
 TEST_F(TestBooleanValidityKernels, IsValidIsNullNullType) {
   CheckScalarUnary("is_null", std::make_shared<NullArray>(5),
                    ArrayFromJSON(boolean(), "[true, true, true, true, true]"));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -200,20 +200,26 @@ static util::optional<compute::Expression> ColumnChunkStatisticsAsExpression(
   if (maybe_min.ok() && maybe_max.ok()) {
     min = maybe_min.MoveValueUnsafe();
     max = maybe_max.MoveValueUnsafe();
+
+    compute::Expression range;
     if (min->Equals(max)) {
-      return compute::equal(std::move(field_expr), compute::literal(std::move(min)));
+      auto single_value = compute::equal(field_expr, compute::literal(std::move(min)));
+
+      if (statistics->null_count() == 0) {
+        return single_value;
+      }
+      return compute::or_(std::move(single_value), is_null(std::move(field_expr)));
     }
 
     auto lower_bound =
         compute::greater_equal(field_expr, compute::literal(std::move(min)));
     auto upper_bound = compute::less_equal(field_expr, compute::literal(std::move(max)));
 
-    auto range = compute::and_(std::move(lower_bound), std::move(upper_bound));
     if (statistics->null_count() == 0) {
-      return compute::and_(std::move(range), is_valid(std::move(field_expr)));
+      lower_bound = compute::or_(std::move(lower_bound), is_null(field_expr));
+      upper_bound = compute::or_(std::move(upper_bound), is_null(std::move(field_expr)));
     }
-
-    return range;
+    return compute::and_(std::move(lower_bound), std::move(upper_bound));
   }
 
   return util::nullopt;

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -797,13 +797,11 @@ struct MakeFileSystemDatasetMixin {
         continue;
       }
 
-      ASSERT_OK_AND_ASSIGN(partitions[i], partitions[i].Bind(*s));
       ASSERT_OK_AND_ASSIGN(auto fragment,
                            format->MakeFragment({info, fs_}, partitions[i]));
       fragments.push_back(std::move(fragment));
     }
 
-    ASSERT_OK_AND_ASSIGN(root_partition, root_partition.Bind(*s));
     ASSERT_OK_AND_ASSIGN(dataset_, FileSystemDataset::Make(s, root_partition, format, fs_,
                                                            std::move(fragments)));
   }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1535,6 +1535,7 @@ class ARROW_EXPORT FieldRef {
 
   bool Equals(const FieldRef& other) const { return impl_ == other.impl_; }
   bool operator==(const FieldRef& other) const { return Equals(other); }
+  bool operator!=(const FieldRef& other) const { return !Equals(other); }
 
   std::string ToString() const;
 

--- a/cpp/src/arrow/util/stl_util_test.cc
+++ b/cpp/src/arrow/util/stl_util_test.cc
@@ -103,6 +103,15 @@ TEST(StlUtilTest, VectorFlatten) {
   ASSERT_EQ(expected, actual);
 }
 
+TEST(StlUtilTest, VectorFilter) {
+  std::vector<int> input{1, 2, 3, 4, 5, 6, 7, 8, 9}, excluded;
+  auto filtered = FilterVector(
+      input, [](int i) { return i % 3 == 0; }, &excluded);
+
+  EXPECT_THAT(filtered, ::testing::ElementsAre(3, 6, 9));
+  EXPECT_THAT(excluded, ::testing::ElementsAre(1, 2, 4, 5, 7, 8));
+}
+
 static std::string int_to_str(int val) { return std::to_string(val); }
 
 TEST(StlUtilTest, VectorMap) {

--- a/cpp/src/arrow/util/vector.h
+++ b/cpp/src/arrow/util/vector.h
@@ -77,9 +77,14 @@ std::vector<T> ReplaceVectorElement(const std::vector<T>& values, size_t index,
 }
 
 template <typename T, typename Predicate>
-std::vector<T> FilterVector(std::vector<T> values, Predicate&& predicate) {
-  auto new_end =
-      std::remove_if(values.begin(), values.end(), std::forward<Predicate>(predicate));
+std::vector<T> FilterVector(std::vector<T> values, Predicate&& predicate,
+                            std::vector<T>* filtered_out = NULLPTR) {
+  auto new_end = std::stable_partition(values.begin(), values.end(),
+                                       std::forward<Predicate>(predicate));
+  if (filtered_out) {
+    filtered_out->resize(values.end() - new_end);
+    std::move(new_end, values.end(), filtered_out->begin());
+  }
   values.erase(new_end, values.end());
   return values;
 }


### PR DESCRIPTION
This allows us to take advantage of a partition expression like `f32 >= 1 and f32 <= 2 and is_valid(f32)`, which could be generated for a row group with no null values.

Note this implies that `f32 >= 1 and f32 <= 2` is a guarantee that "f32 is between 1 and 2, or is null". This is probably fine vs the more pedantic `(f32 >= 1 and f32 <= 2) or is_null(f32)`, but requires a potentially problematic addendum to the contract of guarantees: guarantees do not apply to null arguments unless an explicit is_null or is_valid is included