### PR TITLE
ARROW-12661: [C++] Add ReaderOptions::skip_rows_after_names

### DIFF
--- a/cpp/src/arrow/csv/chunker.cc
+++ b/cpp/src/arrow/csv/chunker.cc
@@ -235,10 +235,10 @@ class LexingBoundaryFinder : public BoundaryFinder {
     return Status::OK();
   }
 
-  Status FindNth(util::string_view partial, util::string_view block, uint64_t count,
-                 int64_t* out_pos, uint64_t* num_found) override {
+  Status FindNth(util::string_view partial, util::string_view block, int64_t count,
+                 int64_t* out_pos, int64_t* num_found) override {
     Lexer<quoting, escaping> lexer(options_);
-    uint64_t found = 0;
+    int64_t found = 0;
     const char* data = block.data();
     const char* const data_end = block.data() + block.size();
 

--- a/cpp/src/arrow/csv/chunker.cc
+++ b/cpp/src/arrow/csv/chunker.cc
@@ -171,6 +171,7 @@ class Lexer {
     goto FieldStart;
 
   LineEnd:
+    state_ = FIELD_START;
     return data;
 
   AbortLine:

--- a/cpp/src/arrow/csv/chunker_test.cc
+++ b/cpp/src/arrow/csv/chunker_test.cc
@@ -71,6 +71,39 @@ class BaseChunkerTest : public ::testing::TestWithParam<bool> {
 
   void MakeChunker() { chunker_ = ::arrow::csv::MakeChunker(options_); }
 
+  void AssertSkip(const std::string& str, const uint64_t count, const uint64_t rem_count,
+                  const int64_t rest_size) {
+    MakeChunker();
+
+    {
+      auto test_count = count;
+      auto partial = std::make_shared<Buffer>("");
+      auto block = std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(str.data()),
+                                            static_cast<int64_t>(str.size()));
+      std::shared_ptr<Buffer> rest;
+      ASSERT_OK(chunker_->ProcessSkip(partial, block, true, &test_count, &rest));
+      ASSERT_EQ(rem_count, test_count);
+      ASSERT_EQ(rest_size, rest->size());
+      ASSERT_TRUE(
+          SliceBuffer(block, block->size() - rest_size, rest_size)->Equals(*rest));
+    }
+
+    {
+      auto test_count = count;
+      auto split = static_cast<int64_t>(str.find_first_of('\n'));
+      auto partial =
+          std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(str.data()), split);
+      auto data =
+          std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(str.data() + split),
+                                   static_cast<int64_t>(str.size()) - split);
+      std::shared_ptr<Buffer> rest;
+      ASSERT_OK(chunker_->ProcessSkip(partial, data, true, &test_count, &rest));
+      ASSERT_EQ(rem_count, test_count);
+      ASSERT_EQ(rest_size, rest->size());
+      ASSERT_TRUE(SliceBuffer(data, data->size() - rest_size, rest_size)->Equals(*rest));
+    }
+  }
+
   ParseOptions options_;
   std::unique_ptr<Chunker> chunker_;
 };
@@ -258,6 +291,44 @@ TEST_P(BaseChunkerTest, EscapingNewline) {
       MakeChunker();
       AssertChunking(*chunker_, csv, lengths);
     }
+  }
+}
+
+TEST_P(BaseChunkerTest, ParseSkip) {
+  {
+    auto csv = MakeCSVData({"ab,c,\n", "def,,gh\n", ",ij,kl\n"});
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 1, 0, 15));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 2, 0, 7));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 3, 0, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 4, 1, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 6, 3, 0));
+  }
+
+  // Test with no trailing new line
+  {
+    auto csv = MakeCSVData({"ab,c,\n", "def,,gh\n", ",ij,kl"});
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 2, 0, 6));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 3, 0, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 4, 1, 0));
+  }
+
+  // Test skip with new lines in values
+  {
+    auto csv = MakeCSVData({"ab,\"c\n\",\n", "\"d\nef\",,gh\n", ",ij,\"nkl\"\n"});
+    options_.newlines_in_values = true;
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 1, 0, 21));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 2, 0, 10));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 3, 0, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 4, 1, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 6, 3, 0));
+  }
+
+  // Test with no trailing new line and new lines in values
+  {
+    auto csv = MakeCSVData({"ab,\"c\n\",\n", "\"d\nef\",,gh\n", ",ij,\"nkl\""});
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 2, 0, 9));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 3, 0, 0));
+    ASSERT_NO_FATAL_FAILURE(AssertSkip(csv, 4, 1, 0));
   }
 }
 

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -129,6 +129,9 @@ struct ARROW_EXPORT ReadOptions {
   /// Number of header rows to skip (not including the row of column names, if any)
   int32_t skip_rows = 0;
 
+  /// Number of rows to skip after the column names are read, if any
+  int32_t skip_rows_after_names = 0;
+
   /// Column names for the target table.
   /// If empty, fall back on autogenerate_column_names.
   std::vector<std::string> column_names;

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -254,17 +254,6 @@ class ThreadedBlockReader : public BlockReader {
  public:
   using BlockReader::BlockReader;
 
-  static Iterator<CSVBlock> MakeIterator(
-      Iterator<std::shared_ptr<Buffer>> buffer_iterator, std::unique_ptr<Chunker> chunker,
-      std::shared_ptr<Buffer> first_buffer) {
-    auto block_reader =
-        std::make_shared<ThreadedBlockReader>(std::move(chunker), first_buffer);
-    // Wrap shared pointer in callable
-    Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
-        [block_reader](std::shared_ptr<Buffer> next) { return (*block_reader)(next); };
-    return MakeTransformedIterator(std::move(buffer_iterator), block_reader_fn);
-  }
-
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
       std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer) {

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -167,7 +167,7 @@ namespace {
 class BlockReader {
  public:
   BlockReader(std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
-              uint64_t skip_rows)
+              int64_t skip_rows)
       : chunker_(std::move(chunker)),
         partial_(std::make_shared<Buffer>("")),
         buffer_(std::move(first_buffer)),
@@ -176,7 +176,7 @@ class BlockReader {
  protected:
   std::unique_ptr<Chunker> chunker_;
   std::shared_ptr<Buffer> partial_, buffer_;
-  uint64_t skip_rows_;
+  int64_t skip_rows_;
   int64_t block_index_ = 0;
   // Whether there was a trailing CR at the end of last received buffer
   bool trailing_cr_ = false;
@@ -191,7 +191,7 @@ class SerialBlockReader : public BlockReader {
 
   static Iterator<CSVBlock> MakeIterator(
       Iterator<std::shared_ptr<Buffer>> buffer_iterator, std::unique_ptr<Chunker> chunker,
-      std::shared_ptr<Buffer> first_buffer, uint64_t skip_rows) {
+      std::shared_ptr<Buffer> first_buffer, int64_t skip_rows) {
     auto block_reader =
         std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
     // Wrap shared pointer in callable
@@ -205,7 +205,7 @@ class SerialBlockReader : public BlockReader {
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
       std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
-      uint64_t skip_rows) {
+      int64_t skip_rows) {
     auto block_reader =
         std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
     // Wrap shared pointer in callable
@@ -275,7 +275,7 @@ class ThreadedBlockReader : public BlockReader {
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
       std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
-      uint64_t skip_rows) {
+      int64_t skip_rows) {
     auto block_reader = std::make_shared<ThreadedBlockReader>(std::move(chunker),
                                                               first_buffer, skip_rows);
     // Wrap shared pointer in callable

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -166,14 +166,17 @@ namespace {
 // iterator APIs (e.g. Visit)) even though an empty optional is never used in this code.
 class BlockReader {
  public:
-  BlockReader(std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer)
+  BlockReader(std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
+              uint64_t skip_rows)
       : chunker_(std::move(chunker)),
         partial_(std::make_shared<Buffer>("")),
-        buffer_(std::move(first_buffer)) {}
+        buffer_(std::move(first_buffer)),
+        skip_rows_(skip_rows) {}
 
  protected:
   std::unique_ptr<Chunker> chunker_;
   std::shared_ptr<Buffer> partial_, buffer_;
+  uint64_t skip_rows_;
   int64_t block_index_ = 0;
   // Whether there was a trailing CR at the end of last received buffer
   bool trailing_cr_ = false;
@@ -188,9 +191,9 @@ class SerialBlockReader : public BlockReader {
 
   static Iterator<CSVBlock> MakeIterator(
       Iterator<std::shared_ptr<Buffer>> buffer_iterator, std::unique_ptr<Chunker> chunker,
-      std::shared_ptr<Buffer> first_buffer) {
+      std::shared_ptr<Buffer> first_buffer, uint64_t skip_rows) {
     auto block_reader =
-        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer);
+        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
     // Wrap shared pointer in callable
     Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
         [block_reader](std::shared_ptr<Buffer> buf) {
@@ -201,9 +204,10 @@ class SerialBlockReader : public BlockReader {
 
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
-      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer) {
+      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
+      uint64_t skip_rows) {
     auto block_reader =
-        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer);
+        std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
     // Wrap shared pointer in callable
     Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
         [block_reader](std::shared_ptr<Buffer> next) {
@@ -217,8 +221,22 @@ class SerialBlockReader : public BlockReader {
       return TransformFinish();
     }
 
-    std::shared_ptr<Buffer> completion;
     bool is_final = (next_buffer == nullptr);
+
+    if (skip_rows_) {
+      RETURN_NOT_OK(
+          chunker_->ProcessSkip(partial_, buffer_, is_final, &skip_rows_, &buffer_));
+      partial_ = SliceBuffer(buffer_, 0, 0);
+      if (skip_rows_) {
+        // Still have rows beyond this buffer to skip return empty block
+        buffer_ = next_buffer;
+        return TransformYield<CSVBlock>(CSVBlock{partial_, partial_, partial_,
+                                                 block_index_++, is_final,
+                                                 [](int64_t) { return Status::OK(); }});
+      }
+    }
+
+    std::shared_ptr<Buffer> completion;
 
     if (is_final) {
       // End of file reached => compute completion from penultimate block
@@ -256,9 +274,10 @@ class ThreadedBlockReader : public BlockReader {
 
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
-      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer) {
-    auto block_reader =
-        std::make_shared<ThreadedBlockReader>(std::move(chunker), first_buffer);
+      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
+      uint64_t skip_rows) {
+    auto block_reader = std::make_shared<ThreadedBlockReader>(std::move(chunker),
+                                                              first_buffer, skip_rows);
     // Wrap shared pointer in callable
     Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
         [block_reader](std::shared_ptr<Buffer> next) { return (*block_reader)(next); };
@@ -271,11 +290,28 @@ class ThreadedBlockReader : public BlockReader {
       return TransformFinish();
     }
 
-    std::shared_ptr<Buffer> whole, completion, next_partial;
     bool is_final = (next_buffer == nullptr);
 
     auto current_partial = std::move(partial_);
     auto current_buffer = std::move(buffer_);
+
+    if (skip_rows_) {
+      RETURN_NOT_OK(chunker_->ProcessSkip(current_partial, current_buffer, is_final,
+                                          &skip_rows_, &current_buffer));
+      current_partial = SliceBuffer(current_buffer, 0, 0);
+      if (skip_rows_) {
+        partial_ = std::move(current_buffer);
+        buffer_ = std::move(next_buffer);
+        return TransformYield<CSVBlock>(CSVBlock{current_partial,
+                                                 current_partial,
+                                                 current_partial,
+                                                 block_index_++,
+                                                 is_final,
+                                                 {}});
+      }
+    }
+
+    std::shared_ptr<Buffer> whole, completion, next_partial;
 
     if (is_final) {
       // End of file reached => compute completion from penultimate block
@@ -376,6 +412,12 @@ class ReaderMixin {
     } else {
       column_names_ = read_options_.column_names;
     }
+
+    if (count_rows_) {
+      // increase rows seen to skip past rows which will be skipped
+      num_rows_seen_ += read_options_.skip_rows_after_names;
+    }
+
     *rest = SliceBuffer(buf, data - buf->data());
 
     num_csv_cols_ = static_cast<int32_t>(column_names_.size());
@@ -817,7 +859,7 @@ class SerialStreamingReader : public BaseStreamingReader,
 
       self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
           std::move(self->buffer_generator_), MakeChunker(self->parse_options_),
-          std::move(own_first_buffer));
+          std::move(own_first_buffer), self->read_options_.skip_rows_after_names);
       return Status::OK();
     });
   }
@@ -857,9 +899,9 @@ class SerialTableReader : public BaseTableReader {
     RETURN_NOT_OK(ProcessHeader(first_buffer, &first_buffer));
     RETURN_NOT_OK(MakeColumnBuilders());
 
-    auto block_iterator = SerialBlockReader::MakeIterator(std::move(buffer_iterator_),
-                                                          MakeChunker(parse_options_),
-                                                          std::move(first_buffer));
+    auto block_iterator = SerialBlockReader::MakeIterator(
+        std::move(buffer_iterator_), MakeChunker(parse_options_), std::move(first_buffer),
+        read_options_.skip_rows_after_names);
     while (true) {
       RETURN_NOT_OK(io_context_.stop_token().Poll());
 
@@ -933,7 +975,7 @@ class AsyncThreadedTableReader
     return ProcessFirstBuffer().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
       auto block_generator = ThreadedBlockReader::MakeAsyncIterator(
           self->buffer_generator_, MakeChunker(self->parse_options_),
-          std::move(first_buffer));
+          std::move(first_buffer), self->read_options_.skip_rows_after_names);
 
       std::function<Status(CSVBlock)> block_visitor =
           [self](CSVBlock maybe_block) -> Status {
@@ -1045,16 +1087,17 @@ class CSVRowCounter : public ReaderMixin,
     auto transferred_it = MakeTransferredGenerator(bg_it, cpu_executor_);
     auto buffer_generator = CSVBufferIterator::MakeAsync(std::move(transferred_it));
 
-    return buffer_generator().Then([self, buffer_generator](
-                                       std::shared_ptr<Buffer> first_buffer) {
-      if (!first_buffer) {
-        return Status::Invalid("Empty CSV file");
-      }
-      RETURN_NOT_OK(self->ProcessHeader(first_buffer, &first_buffer));
-      self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
-          buffer_generator, MakeChunker(self->parse_options_), std::move(first_buffer));
-      return Status::OK();
-    });
+    return buffer_generator().Then(
+        [self, buffer_generator](std::shared_ptr<Buffer> first_buffer) {
+          if (!first_buffer) {
+            return Status::Invalid("Empty CSV file");
+          }
+          RETURN_NOT_OK(self->ProcessHeader(first_buffer, &first_buffer));
+          self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
+              buffer_generator, MakeChunker(self->parse_options_),
+              std::move(first_buffer), 0);
+          return Status::OK();
+        });
   }
 
   Future<int64_t> DoCount(const std::shared_ptr<CSVRowCounter>& self) {

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -164,8 +164,8 @@ class ParsingBoundaryFinder : public BoundaryFinder {
     return Status::OK();
   }
 
-  Status FindNth(util::string_view partial, util::string_view block, uint64_t count,
-                 int64_t* out_pos, uint64_t* num_found) override {
+  Status FindNth(util::string_view partial, util::string_view block, int64_t count,
+                 int64_t* out_pos, int64_t* num_found) override {
     return Status::NotImplemented("ParsingBoundaryFinder::FindNth");
   }
 };

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -163,6 +163,11 @@ class ParsingBoundaryFinder : public BoundaryFinder {
     }
     return Status::OK();
   }
+
+  Status FindNth(util::string_view partial, util::string_view block, uint64_t count,
+                 int64_t* out_pos, uint64_t* num_found) override {
+    return Status::NotImplemented("ParsingBoundaryFinder::FindNth");
+  }
 };
 
 }  // namespace

--- a/cpp/src/arrow/util/delimiting.cc
+++ b/cpp/src/arrow/util/delimiting.cc
@@ -61,11 +61,11 @@ class NewlineBoundaryFinder : public BoundaryFinder {
     return Status::OK();
   }
 
-  Status FindNth(util::string_view partial, util::string_view block, uint64_t count,
-                 int64_t* out_pos, uint64_t* num_found) override {
+  Status FindNth(util::string_view partial, util::string_view block, int64_t count,
+                 int64_t* out_pos, int64_t* num_found) override {
     DCHECK(partial.find_first_of(newline_delimiters) == util::string_view::npos);
 
-    uint64_t found = 0;
+    int64_t found = 0;
     int64_t pos = kNoDelimiterFound;
 
     auto cur_pos = block.find_first_of(newline_delimiters);
@@ -169,11 +169,11 @@ Status Chunker::ProcessFinal(std::shared_ptr<Buffer> partial,
 }
 
 Status Chunker::ProcessSkip(std::shared_ptr<Buffer> partial,
-                            std::shared_ptr<Buffer> block, bool final, uint64_t* count,
+                            std::shared_ptr<Buffer> block, bool final, int64_t* count,
                             std::shared_ptr<Buffer>* rest) {
   DCHECK_GT(*count, 0);
   int64_t pos;
-  uint64_t num_found;
+  int64_t num_found;
   ARROW_RETURN_NOT_OK(boundary_finder_->FindNth(
       util::string_view(*partial), util::string_view(*block), *count, &pos, &num_found));
   if (pos == BoundaryFinder::kNoDelimiterFound) {

--- a/cpp/src/arrow/util/delimiting.cc
+++ b/cpp/src/arrow/util/delimiting.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/util/delimiting.h"
 #include "arrow/buffer.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 
@@ -57,6 +58,35 @@ class NewlineBoundaryFinder : public BoundaryFinder {
       }
       *out_pos = static_cast<int64_t>(end);
     }
+    return Status::OK();
+  }
+
+  Status FindNth(util::string_view partial, util::string_view block, uint64_t count,
+                 int64_t* out_pos, uint64_t* num_found) override {
+    DCHECK(partial.find_first_of(newline_delimiters) == util::string_view::npos);
+
+    uint64_t found = 0;
+    int64_t pos = kNoDelimiterFound;
+
+    auto cur_pos = block.find_first_of(newline_delimiters);
+    while (cur_pos != util::string_view::npos) {
+      if (block[cur_pos] == '\r' && cur_pos + 1 < block.length() &&
+          block[cur_pos + 1] == '\n') {
+        cur_pos += 2;
+      } else {
+        ++cur_pos;
+      }
+
+      pos = static_cast<int64_t>(cur_pos);
+      if (++found >= count) {
+        break;
+      }
+
+      cur_pos = block.find_first_of(newline_delimiters, cur_pos);
+    }
+
+    *out_pos = pos;
+    *num_found = found;
     return Status::OK();
   }
 
@@ -135,6 +165,28 @@ Status Chunker::ProcessFinal(std::shared_ptr<Buffer> partial,
     *completion = SliceBuffer(block, 0, first_pos);
     *rest = SliceBuffer(block, first_pos);
   }
+  return Status::OK();
+}
+
+Status Chunker::ProcessSkip(std::shared_ptr<Buffer> partial,
+                            std::shared_ptr<Buffer> block, bool final, uint64_t* count,
+                            std::shared_ptr<Buffer>* rest) {
+  DCHECK_GT(*count, 0);
+  int64_t pos;
+  uint64_t num_found;
+  ARROW_RETURN_NOT_OK(boundary_finder_->FindNth(
+      util::string_view(*partial), util::string_view(*block), *count, &pos, &num_found));
+  if (pos == BoundaryFinder::kNoDelimiterFound) {
+    return StraddlingTooLarge();
+  }
+  if (ARROW_PREDICT_FALSE(final && *count > num_found && block->size() != pos)) {
+    // Skip the last row in the final block which does not have a delimiter
+    ++num_found;
+    *rest = SliceBuffer(block, 0, 0);
+  } else {
+    *rest = SliceBuffer(block, pos);
+  }
+  *count -= num_found;
   return Status::OK();
 }
 

--- a/cpp/src/arrow/util/delimiting.h
+++ b/cpp/src/arrow/util/delimiting.h
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <memory>
 
-#include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string_view.h"
@@ -65,7 +64,7 @@ class ARROW_EXPORT BoundaryFinder {
   ///
   /// The returned `num_found` is the number of delimiters actually found
   virtual Status FindNth(util::string_view partial, util::string_view block,
-                         uint64_t count, int64_t* out_pos, uint64_t* num_found) = 0;
+                         int64_t count, int64_t* out_pos, int64_t* num_found) = 0;
 
   static constexpr int64_t kNoDelimiterFound = -1;
 
@@ -171,7 +170,7 @@ class ARROW_EXPORT Chunker {
   /// \param[in,out] count number of rows that need to be skipped
   /// \param[out] rest subrange of block containing what was not skipped
   Status ProcessSkip(std::shared_ptr<Buffer> partial, std::shared_ptr<Buffer> block,
-                     bool final, uint64_t* count, std::shared_ptr<Buffer>* rest);
+                     bool final, int64_t* count, std::shared_ptr<Buffer>* rest);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Chunker);

--- a/cpp/src/arrow/util/delimiting.h
+++ b/cpp/src/arrow/util/delimiting.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string_view.h"
@@ -52,6 +53,19 @@ class ARROW_EXPORT BoundaryFinder {
   /// to the first character after the last delimiter.
   /// `out_pos` will be -1 if no delimiter is found.
   virtual Status FindLast(util::string_view block, int64_t* out_pos) = 0;
+
+  /// \brief Find the position of the Nth delimiter inside the block
+  ///
+  /// `partial` is taken to be the beginning of the block, and `block`
+  /// its continuation.  Also, `partial` doesn't contain a delimiter.
+  ///
+  /// The returned `out_pos` is relative to `block`'s start and should point
+  /// to the first character after the first delimiter.
+  /// `out_pos` will be -1 if no delimiter is found.
+  ///
+  /// The returned `num_found` is the number of delimiters actually found
+  virtual Status FindNth(util::string_view partial, util::string_view block,
+                         uint64_t count, int64_t* out_pos, uint64_t* num_found) = 0;
 
   static constexpr int64_t kNoDelimiterFound = -1;
 
@@ -137,6 +151,27 @@ class ARROW_EXPORT Chunker {
   ///
   Status ProcessFinal(std::shared_ptr<Buffer> partial, std::shared_ptr<Buffer> block,
                       std::shared_ptr<Buffer>* completion, std::shared_ptr<Buffer>* rest);
+
+  /// \brief Skip count number of rows
+  /// Pre-conditions:
+  /// - `partial` is the start of a valid block of delimited data
+  ///   (i.e. starts just after a delimiter)
+  /// - `block` follows `partial` in file order
+  ///
+  /// Post-conditions:
+  /// - `count` is updated to indicate the number of rows that still need to be skipped
+  /// - If `count` is > 0 then `rest` is an incomplete block that should be a future
+  /// `partial`
+  /// - Else `rest` could be one or more valid blocks of delimited data which need to be
+  /// parsed
+  ///
+  /// \param[in] partial incomplete delimited data
+  /// \param[in] block delimited data following partial
+  /// \param[in] final whether this is the final chunk
+  /// \param[in,out] count number of rows that need to be skipped
+  /// \param[out] rest subrange of block containing what was not skipped
+  Status ProcessSkip(std::shared_ptr<Buffer> partial, std::shared_ptr<Buffer> block,
+                     bool final, uint64_t* count, std::shared_ptr<Buffer>* rest);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Chunker);

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -61,6 +61,13 @@ cdef class ReadOptions(_Weakrefable):
     skip_rows: int, optional (default 0)
         The number of rows to skip before the column names (if any)
         and the CSV data.
+    skip_rows_after_names: int, optional (default 0)
+        Number of csv rows to skip after the column names.
+        The number can be larger than the number of rows in one
+        block and empty rows are counted.
+        If skip_rows is also specified that skip occurs first
+        then the column names are read if configured to do so
+        then this skip is applied.
     column_names: list, optional
         The column names of the target table.  If empty, fall back on
         `autogenerate_column_names`.
@@ -83,7 +90,7 @@ cdef class ReadOptions(_Weakrefable):
 
     def __init__(self, *, use_threads=None, block_size=None, skip_rows=None,
                  column_names=None, autogenerate_column_names=None,
-                 encoding='utf8'):
+                 encoding='utf8', skip_rows_after_names=None):
         if use_threads is not None:
             self.use_threads = use_threads
         if block_size is not None:
@@ -96,6 +103,8 @@ cdef class ReadOptions(_Weakrefable):
             self.autogenerate_column_names= autogenerate_column_names
         # Python-specific option
         self.encoding = encoding
+        if skip_rows_after_names is not None:
+            self.skip_rows_after_names = skip_rows_after_names
 
     @property
     def use_threads(self):
@@ -126,6 +135,7 @@ cdef class ReadOptions(_Weakrefable):
         """
         The number of rows to skip before the column names (if any)
         and the CSV data.
+        See skip_rows_after_names for interaction description
         """
         return deref(self.options).skip_rows
 
@@ -161,6 +171,22 @@ cdef class ReadOptions(_Weakrefable):
     def autogenerate_column_names(self, value):
         deref(self.options).autogenerate_column_names = value
 
+    @property
+    def skip_rows_after_names(self):
+        """
+        Number of csv rows to skip after the column names.
+        The number can be larger than the number of rows in one
+        block and empty rows are counted.
+        If skip_rows is also specified that skip occurs first
+        then the column names are read if configured to do so
+        then this skip is applied.
+        """
+        return deref(self.options).skip_rows_after_names
+
+    @skip_rows_after_names.setter
+    def skip_rows_after_names(self, value):
+        deref(self.options).skip_rows_after_names = value
+
     def equals(self, ReadOptions other):
         return (
             self.use_threads == other.use_threads and
@@ -169,7 +195,8 @@ cdef class ReadOptions(_Weakrefable):
             self.column_names == other.column_names and
             self.autogenerate_column_names ==
             other.autogenerate_column_names and
-            self.encoding == other.encoding
+            self.encoding == other.encoding and
+            self.skip_rows_after_names == other.skip_rows_after_names
         )
 
     @staticmethod
@@ -182,12 +209,12 @@ cdef class ReadOptions(_Weakrefable):
     def __getstate__(self):
         return (self.use_threads, self.block_size, self.skip_rows,
                 self.column_names, self.autogenerate_column_names,
-                self.encoding)
+                self.encoding, self.skip_rows_after_names)
 
     def __setstate__(self, state):
         (self.use_threads, self.block_size, self.skip_rows,
          self.column_names, self.autogenerate_column_names,
-         self.encoding) = state
+         self.encoding, self.skip_rows_after_names) = state
 
     def __eq__(self, other):
         try:

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -62,12 +62,13 @@ cdef class ReadOptions(_Weakrefable):
         The number of rows to skip before the column names (if any)
         and the CSV data.
     skip_rows_after_names: int, optional (default 0)
-        Number of csv rows to skip after the column names.
-        The number can be larger than the number of rows in one
-        block and empty rows are counted.
-        If skip_rows is also specified that skip occurs first
-        then the column names are read if configured to do so
-        then this skip is applied.
+        The number of rows to skip after the column names.
+        This number can be larger than the number of rows in one
+        block, and empty rows are counted.
+        The order of application is as follows:
+        - `skip_rows` is applied (if non-zero);
+        - column names aread (unless `column_names` is set);
+        - `skip_rows_after_names` is applied (if non-zero).
     column_names: list, optional
         The column names of the target table.  If empty, fall back on
         `autogenerate_column_names`.
@@ -135,7 +136,7 @@ cdef class ReadOptions(_Weakrefable):
         """
         The number of rows to skip before the column names (if any)
         and the CSV data.
-        See skip_rows_after_names for interaction description
+        See `skip_rows_after_names` for interaction description
         """
         return deref(self.options).skip_rows
 
@@ -174,12 +175,13 @@ cdef class ReadOptions(_Weakrefable):
     @property
     def skip_rows_after_names(self):
         """
-        Number of csv rows to skip after the column names.
-        The number can be larger than the number of rows in one
-        block and empty rows are counted.
-        If skip_rows is also specified that skip occurs first
-        then the column names are read if configured to do so
-        then this skip is applied.
+        The number of rows to skip after the column names.
+        This number can be larger than the number of rows in one
+        block, and empty rows are counted.
+        The order of application is as follows:
+        - `skip_rows` is applied (if non-zero);
+        - column names aread (unless `column_names` is set);
+        - `skip_rows_after_names` is applied (if non-zero).
         """
         return deref(self.options).skip_rows_after_names
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1617,6 +1617,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool use_threads
         int32_t block_size
         int32_t skip_rows
+        int32_t skip_rows_after_names
         vector[c_string] column_names
         c_bool autogenerate_column_names
 


### PR DESCRIPTION
Add a new csv reader option which allows the reader to skip rows after reading the column names from the csv.