### PR TITLE
MINOR: Typo in argument in R’s NEWS.md

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -27,7 +27,7 @@ Many more `dplyr` verbs are supported on Arrow objects:
 
 * `dplyr::mutate()` is now supported in Arrow for many applications. For queries on `Table` and `RecordBatch` that are not yet supported in Arrow, the implementation falls back to pulling data into an in-memory R `data.frame` first, as in the previous release. For queries on `Dataset` (which can be larger than memory), it raises an error if the function is not implemented. The main `mutate()` features that cannot yet be called on Arrow objects are (1) `mutate()` after `group_by()` (which is typically used in combination with aggregation) and (2) queries that use `dplyr::across()`.
 * `dplyr::transmute()` (which calls `mutate()`)
-* `dplyr::group_by()` now preserves the `.drop()` argument and supports on-the-fly definition of columns
+* `dplyr::group_by()` now preserves the `.drop` argument and supports on-the-fly definition of columns
 * `dplyr::relocate()` to reorder columns
 * `dplyr::arrange()` to sort rows
 * `dplyr::compute()` to evaluate the lazy expressions and return an Arrow Table. This is equivalent to `dplyr::collect(as_data_frame = FALSE)`, which was added in 2.0.0.


### PR DESCRIPTION
I believe there was a typo in the argument. Thanks for the ongoing work on this package. 