### PR TITLE
ARROW-12663: [C++] Fix a cuda 11.2 compiler segfault

### DIFF
--- a/cpp/src/arrow/util/variant.h
+++ b/cpp/src/arrow/util/variant.h
@@ -262,17 +262,16 @@ class Variant : detail::VariantImpl<Variant<T...>, T...>,
 
   Variant(const Variant& other) = default;
   Variant& operator=(const Variant& other) = default;
-
-  using Impl::Impl;
-  using Impl::operator=;
-
-  Variant(Variant&& other) noexcept { other.move_to(this); }
-
   Variant& operator=(Variant&& other) noexcept {
     this->destroy();
     other.move_to(this);
     return *this;
   }
+
+  using Impl::Impl;
+  using Impl::operator=;
+
+  Variant(Variant&& other) noexcept { other.move_to(this); }
 
   ~Variant() {
     static_assert(offsetof(Variant, data_) == 0, "(void*)&Variant::data_ == (void*)this");


### PR DESCRIPTION
With the nvcc 11.2 compiler we have a segfault when we have a copy and move assignment operator : 
```
using Impl::operator=;
``` 
before a move-assignment operator:

 ```
Variant& operator=(Variant&& other) noexcept {
  this->destroy();
  other.move_to(this);
  return *this;
}
```

A minimal repro :

With a segfault : https://godbolt.org/z/h9eYv6zas

Without a segfault : https://godbolt.org/z/oWhK5qPd8

In this PR, as a workaround, we have essentially re-ordered the move-assignment of `Variant` before `using Impl::operator=;`.
