### PR TITLE
ARROW-12560: [C++] Add scheduling option for Future callbacks

### DIFF
--- a/cpp/src/arrow/testing/executor_util.h
+++ b/cpp/src/arrow/testing/executor_util.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/util/thread_pool.h"
+
+namespace arrow {
+
+/// An executor which synchronously runs the task as part of the SpawnReal call.
+class MockExecutor : public internal::Executor {
+ public:
+  int GetCapacity() override { return 0; }
+
+  Status SpawnReal(internal::TaskHints hints, internal::FnOnce<void()> task, StopToken,
+                   StopCallback&&) override {
+    spawn_count++;
+    std::move(task)();
+    return Status::OK();
+  }
+
+  int spawn_count = 0;
+};
+
+/// An executor which does not actually run the task.  Can be used to simulate situations
+/// where the executor schedules a task in a long queue and doesn't get around to running
+/// it for a while
+class DelayedExecutor : public internal::Executor {
+ public:
+  int GetCapacity() override { return 0; }
+
+  Status SpawnReal(internal::TaskHints hints, internal::FnOnce<void()> task, StopToken,
+                   StopCallback&&) override {
+    captured_tasks.push_back(std::move(task));
+    return Status::OK();
+  }
+
+  std::vector<internal::FnOnce<void()>> captured_tasks;
+};
+
+}  // namespace arrow

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -26,6 +26,7 @@
 
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 
@@ -231,23 +232,57 @@ class ConcreteFutureImpl : public FutureImpl {
 
   void DoMarkFailed() { DoMarkFinishedOrFailed(FutureState::FAILURE); }
 
-  void AddCallback(Callback callback) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    if (IsFutureFinished(state_)) {
-      lock.unlock();
-      std::move(callback)();
-    } else {
-      callbacks_.push_back(std::move(callback));
+  void CheckOptions(const CallbackOptions& opts) {
+    if (opts.should_schedule != ShouldSchedule::NEVER) {
+      DCHECK_NE(opts.executor, NULL)
+          << "An executor must be specified when adding a callback that might schedule";
     }
   }
 
-  bool TryAddCallback(const std::function<Callback()>& callback_factory) {
+  void AddCallback(Callback callback, CallbackOptions opts) {
+    CheckOptions(opts);
+    std::unique_lock<std::mutex> lock(mutex_);
+    CallbackRecord callback_record{std::move(callback), opts};
+    if (IsFutureFinished(state_)) {
+      lock.unlock();
+      RunOrScheduleCallback(callback_record, /*from_unfinished=*/false);
+    } else {
+      callbacks_.push_back(std::move(callback_record));
+    }
+  }
+
+  bool TryAddCallback(const std::function<Callback()>& callback_factory,
+                      CallbackOptions opts) {
+    CheckOptions(opts);
     std::unique_lock<std::mutex> lock(mutex_);
     if (IsFutureFinished(state_)) {
       return false;
     } else {
-      callbacks_.push_back(callback_factory());
+      callbacks_.push_back({callback_factory(), opts});
       return true;
+    }
+  }
+
+  bool ShouldSchedule(const CallbackRecord& callback_record, bool from_unfinished) {
+    switch (callback_record.options.should_schedule) {
+      case ShouldSchedule::NEVER:
+        return false;
+      case ShouldSchedule::ALWAYS:
+        return true;
+      case ShouldSchedule::IF_UNFINISHED:
+        return from_unfinished;
+      default:
+        DCHECK(false) << "Unrecognized ShouldSchedule option";
+        return false;
+    }
+  }
+
+  void RunOrScheduleCallback(CallbackRecord& callback_record, bool from_unfinished) {
+    if (ShouldSchedule(callback_record, from_unfinished)) {
+      DCHECK_OK(
+          callback_record.options.executor->Spawn(std::move(callback_record.callback)));
+    } else {
+      std::move(callback_record.callback)();
     }
   }
 
@@ -272,8 +307,8 @@ class ConcreteFutureImpl : public FutureImpl {
     //
     // In fact, it is important not to hold the locks because the callback
     // may be slow or do its own locking on other resources
-    for (auto&& callback : callbacks_) {
-      std::move(callback)();
+    for (auto& callback_record : callbacks_) {
+      RunOrScheduleCallback(callback_record, /*from_unfinished=*/true);
     }
     callbacks_.clear();
   }
@@ -334,12 +369,13 @@ void FutureImpl::MarkFinished() { GetConcreteFuture(this)->DoMarkFinished(); }
 
 void FutureImpl::MarkFailed() { GetConcreteFuture(this)->DoMarkFailed(); }
 
-void FutureImpl::AddCallback(Callback callback) {
-  GetConcreteFuture(this)->AddCallback(std::move(callback));
+void FutureImpl::AddCallback(Callback callback, CallbackOptions opts) {
+  GetConcreteFuture(this)->AddCallback(std::move(callback), opts);
 }
 
-bool FutureImpl::TryAddCallback(const std::function<Callback()>& callback_factory) {
-  return GetConcreteFuture(this)->TryAddCallback(callback_factory);
+bool FutureImpl::TryAddCallback(const std::function<Callback()>& callback_factory,
+                                CallbackOptions opts) {
+  return GetConcreteFuture(this)->TryAddCallback(callback_factory, opts);
 }
 
 Future<> AllComplete(const std::vector<Future<>>& futures) {

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -233,8 +233,8 @@ class ConcreteFutureImpl : public FutureImpl {
   void DoMarkFailed() { DoMarkFinishedOrFailed(FutureState::FAILURE); }
 
   void CheckOptions(const CallbackOptions& opts) {
-    if (opts.should_schedule != ShouldSchedule::NEVER) {
-      DCHECK_NE(opts.executor, NULL)
+    if (opts.should_schedule != ShouldSchedule::Never) {
+      DCHECK_NE(opts.executor, nullptr)
           << "An executor must be specified when adding a callback that might schedule";
     }
   }
@@ -245,7 +245,7 @@ class ConcreteFutureImpl : public FutureImpl {
     CallbackRecord callback_record{std::move(callback), opts};
     if (IsFutureFinished(state_)) {
       lock.unlock();
-      RunOrScheduleCallback(callback_record, /*from_unfinished=*/false);
+      RunOrScheduleCallback(std::move(callback_record), /*from_unfinished=*/false);
     } else {
       callbacks_.push_back(std::move(callback_record));
     }
@@ -265,11 +265,11 @@ class ConcreteFutureImpl : public FutureImpl {
 
   bool ShouldSchedule(const CallbackRecord& callback_record, bool from_unfinished) {
     switch (callback_record.options.should_schedule) {
-      case ShouldSchedule::NEVER:
+      case ShouldSchedule::Never:
         return false;
-      case ShouldSchedule::ALWAYS:
+      case ShouldSchedule::Always:
         return true;
-      case ShouldSchedule::IF_UNFINISHED:
+      case ShouldSchedule::IfUnfinished:
         return from_unfinished;
       default:
         DCHECK(false) << "Unrecognized ShouldSchedule option";
@@ -277,16 +277,16 @@ class ConcreteFutureImpl : public FutureImpl {
     }
   }
 
-  void RunOrScheduleCallback(CallbackRecord& callback_record, bool from_unfinished) {
+  void RunOrScheduleCallback(CallbackRecord&& callback_record, bool from_unfinished) {
     if (ShouldSchedule(callback_record, from_unfinished)) {
-      // Need to make a copy of this to keep it alive until the callback has a chance
-      // to be scheduled.
       struct CallbackTask {
         void operator()() { std::move(callback)(*self); }
 
         Callback callback;
         std::shared_ptr<FutureImpl> self;
       };
+      // Need to make a copy of `this` via `shared_from_this` to keep it alive until the
+      // callback has a chance to be scheduled.
       CallbackTask task{std::move(callback_record.callback), shared_from_this()};
       DCHECK_OK(callback_record.options.executor->Spawn(std::move(task)));
     } else {
@@ -316,7 +316,7 @@ class ConcreteFutureImpl : public FutureImpl {
     // In fact, it is important not to hold the locks because the callback
     // may be slow or do its own locking on other resources
     for (auto& callback_record : callbacks_) {
-      RunOrScheduleCallback(callback_record, /*from_unfinished=*/true);
+      RunOrScheduleCallback(std::move(callback_record), /*from_unfinished=*/true);
     }
     callbacks_.clear();
   }

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -263,7 +263,8 @@ class ConcreteFutureImpl : public FutureImpl {
     }
   }
 
-  bool ShouldSchedule(const CallbackRecord& callback_record, bool in_add_callback) {
+  bool ShouldScheduleCallback(const CallbackRecord& callback_record,
+                              bool in_add_callback) {
     switch (callback_record.options.should_schedule) {
       case ShouldSchedule::Never:
         return false;
@@ -278,7 +279,7 @@ class ConcreteFutureImpl : public FutureImpl {
   }
 
   void RunOrScheduleCallback(CallbackRecord&& callback_record, bool in_add_callback) {
-    if (ShouldSchedule(callback_record, in_add_callback)) {
+    if (ShouldScheduleCallback(callback_record, in_add_callback)) {
       struct CallbackTask {
         void operator()() { std::move(callback)(*self); }
 

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -536,7 +536,7 @@ class Future {
       OnComplete on_complete;
     };
     return impl_->TryAddCallback(
-        [this, &callback_factory]() { return Callback{callback_factory()}; }, opts);
+        [&callback_factory]() { return Callback{callback_factory()}; }, opts);
   }
 
   template <typename CallbackFactory,
@@ -553,7 +553,7 @@ class Future {
     };
 
     return impl_->TryAddCallback(
-        [this, &callback_factory]() { return Callback{callback_factory()}; }, opts);
+        [&callback_factory]() { return Callback{callback_factory()}; }, opts);
   }
 
   /// \brief Consumer API: Register a continuation to run when this future completes

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -202,23 +202,23 @@ enum class FutureState : int8_t { PENDING, SUCCESS, FAILURE };
 
 inline bool IsFutureFinished(FutureState state) { return state != FutureState::PENDING; }
 
-/// \brief Describes whether the callback should be scheduled or run synchronously
+/// \brief Describe whether the callback should be scheduled or run synchronously
 enum ShouldSchedule {
   /// Always run the callback synchronously (the default)
-  NEVER = 0,
+  Never = 0,
   /// Schedule a new task only if the future is not finished when the
   /// callback is added
-  IF_UNFINISHED = 1,
+  IfUnfinished = 1,
   /// Always schedule the callback as a new task
-  ALWAYS = 2
+  Always = 2
 };
 
 /// \brief Options that control how a continuation is run
 struct CallbackOptions {
   /// Describes whether the callback should be run synchronously or scheduled
-  ShouldSchedule should_schedule = ShouldSchedule::NEVER;
+  ShouldSchedule should_schedule = ShouldSchedule::Never;
   /// If the callback is scheduled then this is the executor it should be scheduled
-  /// on.  If this is NULL then should_schedule must be NEVER
+  /// on.  If this is NULL then should_schedule must be Never
   internal::Executor* executor = NULL;
 
   static CallbackOptions Defaults() { return CallbackOptions(); }

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -203,7 +203,7 @@ enum class FutureState : int8_t { PENDING, SUCCESS, FAILURE };
 inline bool IsFutureFinished(FutureState state) { return state != FutureState::PENDING; }
 
 /// \brief Describe whether the callback should be scheduled or run synchronously
-enum ShouldSchedule {
+enum class ShouldSchedule {
   /// Always run the callback synchronously (the default)
   Never = 0,
   /// Schedule a new task only if the future is not finished when the

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -956,7 +956,7 @@ TEST(FutureCompletionTest, FutureVoid) {
 class FutureSchedulingTest : public testing::Test {
  public:
   internal::Executor* executor() { return mock_executor.get(); }
-  int spawn_count() { return mock_executor->captured_tasks.size(); }
+  int spawn_count() { return static_cast<int>(mock_executor->captured_tasks.size()); }
   void AssertRunSynchronously(const std::vector<int>& ids) { AssertIds(ids, true); }
   void AssertScheduled(const std::vector<int>& ids) { AssertIds(ids, false); }
   void AssertIds(const std::vector<int>& ids, bool should_be_synchronous) {

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -962,7 +962,7 @@ class FutureSchedulingTest : public testing::Test {
 
 TEST_F(FutureSchedulingTest, ScheduleAlways) {
   CallbackOptions options;
-  options.should_schedule = ShouldSchedule::ALWAYS;
+  options.should_schedule = ShouldSchedule::Always;
   options.executor = executor();
   // Successful future
   {
@@ -984,7 +984,7 @@ TEST_F(FutureSchedulingTest, ScheduleAlways) {
 
 TEST_F(FutureSchedulingTest, ScheduleIfUnfinished) {
   CallbackOptions options;
-  options.should_schedule = ShouldSchedule::IF_UNFINISHED;
+  options.should_schedule = ShouldSchedule::IfUnfinished;
   options.executor = executor();
   // Successful future
   {
@@ -1019,7 +1019,7 @@ class DelayedExecutor : public internal::Executor {
 
 TEST_F(FutureSchedulingTest, ScheduleAlwaysKeepsFutureAliveUntilCallback) {
   CallbackOptions options;
-  options.should_schedule = ShouldSchedule::ALWAYS;
+  options.should_schedule = ShouldSchedule::Always;
   DelayedExecutor delayed;
   options.executor = &delayed;
   {

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -37,7 +37,6 @@
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/logging.h"
-#include "arrow/util/test_common.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {
@@ -956,9 +955,13 @@ TEST(FutureCompletionTest, FutureVoid) {
 class FutureSchedulingTest : public testing::Test {
  public:
   internal::Executor* executor() { return mock_executor.get(); }
+
   int spawn_count() { return static_cast<int>(mock_executor->captured_tasks.size()); }
+
   void AssertRunSynchronously(const std::vector<int>& ids) { AssertIds(ids, true); }
+
   void AssertScheduled(const std::vector<int>& ids) { AssertIds(ids, false); }
+
   void AssertIds(const std::vector<int>& ids, bool should_be_synchronous) {
     for (auto id : ids) {
       ASSERT_EQ(should_be_synchronous, callbacks_run_synchronously.find(id) !=

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -27,11 +27,13 @@
 #include <random>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include "arrow/testing/executor_util.h"
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/logging.h"
@@ -954,11 +956,47 @@ TEST(FutureCompletionTest, FutureVoid) {
 class FutureSchedulingTest : public testing::Test {
  public:
   internal::Executor* executor() { return mock_executor.get(); }
-  int spawn_count() { return mock_executor->spawn_count; }
+  int spawn_count() { return mock_executor->captured_tasks.size(); }
+  void AssertRunSynchronously(const std::vector<int>& ids) { AssertIds(ids, true); }
+  void AssertScheduled(const std::vector<int>& ids) { AssertIds(ids, false); }
+  void AssertIds(const std::vector<int>& ids, bool should_be_synchronous) {
+    for (auto id : ids) {
+      ASSERT_EQ(should_be_synchronous, callbacks_run_synchronously.find(id) !=
+                                           callbacks_run_synchronously.end());
+    }
+  }
 
-  std::function<void(const Status&)> callback = [](const Status&) {};
-  std::shared_ptr<MockExecutor> mock_executor = std::make_shared<MockExecutor>();
+  std::function<void(const Status&)> callback(int id) {
+    return [this, id](const Status&) { callbacks_run_synchronously.insert(id); };
+  }
+
+  std::shared_ptr<DelayedExecutor> mock_executor = std::make_shared<DelayedExecutor>();
+  std::unordered_set<int> callbacks_run_synchronously;
 };
+
+TEST_F(FutureSchedulingTest, ScheduleNever) {
+  CallbackOptions options;
+  options.should_schedule = ShouldSchedule::Never;
+  options.executor = executor();
+  // Successful future
+  {
+    auto fut = Future<>::Make();
+    fut.AddCallback(callback(1), options);
+    fut.MarkFinished();
+    fut.AddCallback(callback(2), options);
+    ASSERT_EQ(0, spawn_count());
+    AssertRunSynchronously({1, 2});
+  }
+  // Failing future
+  {
+    auto fut = Future<>::Make();
+    fut.AddCallback(callback(3), options);
+    fut.MarkFinished(Status::Invalid("XYZ"));
+    fut.AddCallback(callback(4), options);
+    ASSERT_EQ(0, spawn_count());
+    AssertRunSynchronously({3, 4});
+  }
+}
 
 TEST_F(FutureSchedulingTest, ScheduleAlways) {
   CallbackOptions options;
@@ -967,18 +1005,20 @@ TEST_F(FutureSchedulingTest, ScheduleAlways) {
   // Successful future
   {
     auto fut = Future<>::Make();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(1), options);
     fut.MarkFinished();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(2), options);
     ASSERT_EQ(2, spawn_count());
+    AssertScheduled({1, 2});
   }
   // Failing future
   {
     auto fut = Future<>::Make();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(3), options);
     fut.MarkFinished(Status::Invalid("XYZ"));
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(4), options);
     ASSERT_EQ(4, spawn_count());
+    AssertScheduled({3, 4});
   }
 }
 
@@ -989,45 +1029,35 @@ TEST_F(FutureSchedulingTest, ScheduleIfUnfinished) {
   // Successful future
   {
     auto fut = Future<>::Make();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(1), options);
     fut.MarkFinished();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(2), options);
     ASSERT_EQ(1, spawn_count());
+    AssertRunSynchronously({2});
+    AssertScheduled({1});
   }
   // Failing future
   {
     auto fut = Future<>::Make();
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(3), options);
     fut.MarkFinished(Status::Invalid("XYZ"));
-    fut.AddCallback(callback, options);
+    fut.AddCallback(callback(4), options);
     ASSERT_EQ(2, spawn_count());
+    AssertRunSynchronously({4});
+    AssertScheduled({3});
   }
 }
-
-class DelayedExecutor : public internal::Executor {
- public:
-  int GetCapacity() override { return 0; }
-
-  Status SpawnReal(internal::TaskHints hints, internal::FnOnce<void()> task, StopToken,
-                   StopCallback&&) override {
-    captured_task = std::move(task);
-    return Status::OK();
-  }
-
-  internal::FnOnce<void()> captured_task;
-};
 
 TEST_F(FutureSchedulingTest, ScheduleAlwaysKeepsFutureAliveUntilCallback) {
   CallbackOptions options;
   options.should_schedule = ShouldSchedule::Always;
-  DelayedExecutor delayed;
-  options.executor = &delayed;
+  options.executor = executor();
   {
     auto fut = Future<int>::Make();
     fut.AddCallback([](const Result<int> val) { ASSERT_EQ(7, *val); }, options);
     fut.MarkFinished(7);
   }
-  std::move(delayed.captured_task)();
+  std::move(mock_executor->captured_tasks[0])();
 }
 
 TEST(FutureAllTest, Empty) {

--- a/cpp/src/arrow/util/test_common.h
+++ b/cpp/src/arrow/util/test_common.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include <iosfwd>
 
 #include "arrow/testing/gtest_util.h"

--- a/cpp/src/arrow/util/test_common.h
+++ b/cpp/src/arrow/util/test_common.h
@@ -19,6 +19,7 @@
 
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/iterator.h"
+#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 
@@ -84,5 +85,19 @@ inline void AssertIteratorExhausted(Iterator<T>& it) {
 }
 
 Transformer<TestInt, TestStr> MakeFilter(std::function<bool(TestInt&)> filter);
+
+class MockExecutor : public internal::Executor {
+ public:
+  int GetCapacity() override { return 0; }
+
+  Status SpawnReal(internal::TaskHints hints, internal::FnOnce<void()> task, StopToken,
+                   StopCallback&&) override {
+    spawn_count++;
+    std::move(task)();
+    return Status::OK();
+  }
+
+  int spawn_count = 0;
+};
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/test_common.h
+++ b/cpp/src/arrow/util/test_common.h
@@ -88,18 +88,4 @@ inline void AssertIteratorExhausted(Iterator<T>& it) {
 
 Transformer<TestInt, TestStr> MakeFilter(std::function<bool(TestInt&)> filter);
 
-class MockExecutor : public internal::Executor {
- public:
-  int GetCapacity() override { return 0; }
-
-  Status SpawnReal(internal::TaskHints hints, internal::FnOnce<void()> task, StopToken,
-                   StopCallback&&) override {
-    spawn_count++;
-    std::move(task)();
-    return Status::OK();
-  }
-
-  int spawn_count = 0;
-};
-
 }  // namespace arrow

--- a/cpp/src/arrow/util/test_common.h
+++ b/cpp/src/arrow/util/test_common.h
@@ -21,7 +21,6 @@
 
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/thread_pool.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -113,7 +113,7 @@ class ARROW_EXPORT Executor {
     auto transferred = Future<T>::Make();
     if (always_transfer) {
       CallbackOptions callback_options = CallbackOptions::Defaults();
-      callback_options.should_schedule = ShouldSchedule::ALWAYS;
+      callback_options.should_schedule = ShouldSchedule::Always;
       callback_options.executor = this;
       auto sync_callback = [transferred](const FTSync& result) mutable {
         transferred.MarkFinished(result);
@@ -122,7 +122,7 @@ class ARROW_EXPORT Executor {
       return transferred;
     }
 
-    // We could use AddCallback's ShouldSchedule::IF_UNFINISHED but we can save a bit of
+    // We could use AddCallback's ShouldSchedule::IfUnfinished but we can save a bit of
     // work by doing the test here.
     auto callback = [this, transferred](const FTSync& result) mutable {
       auto spawn_status =

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -108,37 +108,18 @@ class ARROW_EXPORT Executor {
   // no transfer is typically necessary.  However, in cases where you want to force a
   // transfer (e.g. to help the scheduler break up units of work across multiple cores)
   // then you can override this behavior with `always_transfer`.
-  template <typename T, typename FT = Future<T>, typename FTSync = typename FT::SyncType>
-  Future<T> Transfer(Future<T> future, bool always_transfer = false) {
-    auto transferred = Future<T>::Make();
-    if (always_transfer) {
-      CallbackOptions callback_options = CallbackOptions::Defaults();
-      callback_options.should_schedule = ShouldSchedule::Always;
-      callback_options.executor = this;
-      auto sync_callback = [transferred](const FTSync& result) mutable {
-        transferred.MarkFinished(result);
-      };
-      future.AddCallback(sync_callback, callback_options);
-      return transferred;
-    }
+  template <typename T>
+  Future<T> Transfer(Future<T> future) {
+    return DoTransfer(std::move(future), false);
+  }
 
-    // We could use AddCallback's ShouldSchedule::IfUnfinished but we can save a bit of
-    // work by doing the test here.
-    auto callback = [this, transferred](const FTSync& result) mutable {
-      auto spawn_status =
-          Spawn([transferred, result]() mutable { transferred.MarkFinished(result); });
-      if (!spawn_status.ok()) {
-        transferred.MarkFinished(spawn_status);
-      }
-    };
-    auto callback_factory = [&callback]() { return callback; };
-    if (future.TryAddCallback(callback_factory)) {
-      return transferred;
-    }
-    // If the future is already finished and we aren't going to force spawn a thread
-    // then we don't need to add another layer of callback and can return the original
-    // future
-    return future;
+  // Overload of Transfer which will always schedule callbacks on new threads even if the
+  // future is finished when the callback is added.
+  //
+  // This can be useful in cases where you want to ensure parallelism
+  template <typename T>
+  Future<T> TransferAlways(Future<T> future) {
+    return DoTransfer(std::move(future), true);
   }
 
   // Submit a callable and arguments for execution.  Return a future that
@@ -202,6 +183,39 @@ class ARROW_EXPORT Executor {
   ARROW_DISALLOW_COPY_AND_ASSIGN(Executor);
 
   Executor() = default;
+
+  template <typename T, typename FT = Future<T>, typename FTSync = typename FT::SyncType>
+  Future<T> DoTransfer(Future<T> future, bool always_transfer = false) {
+    auto transferred = Future<T>::Make();
+    if (always_transfer) {
+      CallbackOptions callback_options = CallbackOptions::Defaults();
+      callback_options.should_schedule = ShouldSchedule::Always;
+      callback_options.executor = this;
+      auto sync_callback = [transferred](const FTSync& result) mutable {
+        transferred.MarkFinished(result);
+      };
+      future.AddCallback(sync_callback, callback_options);
+      return transferred;
+    }
+
+    // We could use AddCallback's ShouldSchedule::IfUnfinished but we can save a bit of
+    // work by doing the test here.
+    auto callback = [this, transferred](const FTSync& result) mutable {
+      auto spawn_status =
+          Spawn([transferred, result]() mutable { transferred.MarkFinished(result); });
+      if (!spawn_status.ok()) {
+        transferred.MarkFinished(spawn_status);
+      }
+    };
+    auto callback_factory = [&callback]() { return callback; };
+    if (future.TryAddCallback(callback_factory)) {
+      return transferred;
+    }
+    // If the future is already finished and we aren't going to force spawn a thread
+    // then we don't need to add another layer of callback and can return the original
+    // future
+    return future;
+  }
 
   // Subclassing API
   virtual Status SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken,

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -32,9 +32,11 @@
 #include <gtest/gtest.h>
 
 #include "arrow/status.h"
+#include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/test_common.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {
@@ -255,6 +257,42 @@ TEST_P(TestRunSynchronously, PropagatedError) {
 
 INSTANTIATE_TEST_SUITE_P(TestRunSynchronously, TestRunSynchronously,
                          ::testing::Values(false, true));
+
+class TransferTest : public testing::Test {
+ public:
+  internal::Executor* executor() { return mock_executor.get(); }
+  int spawn_count() { return mock_executor->spawn_count; }
+
+  std::function<void(const Status&)> callback = [](const Status&) {};
+  std::shared_ptr<MockExecutor> mock_executor = std::make_shared<MockExecutor>();
+};
+
+TEST_F(TransferTest, DefaultTransferIfNotFinished) {
+  {
+    Future<> fut = Future<>::Make();
+    auto transferred = executor()->Transfer(fut);
+    fut.MarkFinished();
+    ASSERT_FINISHES_OK(transferred);
+    ASSERT_EQ(1, spawn_count());
+  }
+  {
+    Future<> fut = Future<>::Make();
+    fut.MarkFinished();
+    auto transferred = executor()->Transfer(fut);
+    ASSERT_FINISHES_OK(transferred);
+    ASSERT_EQ(1, spawn_count());
+  }
+}
+
+TEST_F(TransferTest, TransferAlways) {
+  {
+    Future<> fut = Future<>::Make();
+    fut.MarkFinished();
+    auto transferred = executor()->Transfer(fut, /*always_transfer=*/true);
+    ASSERT_FINISHES_OK(transferred);
+    ASSERT_EQ(1, spawn_count());
+  }
+}
 
 class TestThreadPool : public ::testing::Test {
  public:

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/status.h"
+#include "arrow/testing/executor_util.h"
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/io_util.h"
@@ -288,7 +289,7 @@ TEST_F(TransferTest, TransferAlways) {
   {
     Future<> fut = Future<>::Make();
     fut.MarkFinished();
-    auto transferred = executor()->Transfer(fut, /*always_transfer=*/true);
+    auto transferred = executor()->TransferAlways(fut);
     ASSERT_FINISHES_OK(transferred);
     ASSERT_EQ(1, spawn_count());
   }


### PR DESCRIPTION
Previously a future's callbacks would always run synchronously, either as part of `Future::MarkFinished` or as part of `Future::AddCallback`.  `Executor::Transfer` made it possible to schedule continuations on a new thread but it would only take effect if the transferred future's callbacks were added before the source future finished.  There are times when the desired behavior is to spawn a new thread task even if the source future is finished already.

This PR adds three scheduling options:
* Never - The default (and existing) behavior, never spawn a new task
* IfUnfinished - Spawn a new task only if the future isn't already finished when the callback is added
* Always - Always spawn a new task, on both finished and unfinished futures, regardless of destination thread pool idleness.

The `Never` option doesn't make any sense for transferring so the transfer only has two choices (always or if unfinished).