### PR TITLE
ARROW-12672: [C++] Fix fill_null kernel to set null_count + cast kernel to handle no-bitmap with unknown null_count case

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -269,7 +269,7 @@ struct NullGeneralization {
 
     // Do not count the bits if they haven't been counted already
     const int64_t known_null_count = arr.null_count.load();
-    if (known_null_count == 0) {
+    if ((known_null_count == 0) || (arr.buffers[0] == NULLPTR)) {
       return ALL_VALID;
     }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1769,6 +1769,20 @@ TEST(Cast, EmptyCasts) {
   }
 }
 
+TEST(Cast, CastWithNoValidityBitmapButUnknownNullCount) {
+  // ARROW-12672 segfault when casting slightly malformed array
+  // (no validity bitmap but atomic null count non-zero)
+  auto values = ArrayFromJSON(boolean(), "[true, true, false]");
+
+  ASSERT_OK_AND_ASSIGN(auto expected, Cast(*values, int8()));
+
+  ASSERT_EQ(values->data()->buffers[0], NULLPTR);
+  values->data()->null_count = kUnknownNullCount;
+  ASSERT_OK_AND_ASSIGN(auto result, Cast(*values, int8()));
+
+  AssertArraysEqual(*expected, *result);
+}
+
 // ----------------------------------------------------------------------
 // Test casting from NullType
 

--- a/cpp/src/arrow/compute/kernels/scalar_fill_null.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_fill_null.cc
@@ -80,6 +80,7 @@ struct FillNullFunctor<Type, enable_if_t<is_number_type<Type>::value>> {
         in_values += block.length;
       }
       output->buffers[1] = out_buf;
+      output->null_count = 0;
     } else {
       *output = data;
     }
@@ -131,6 +132,7 @@ struct FillNullFunctor<Type, enable_if_t<is_boolean_type<Type>::value>> {
         out_offset += block.length;
       }
       output->buffers[1] = out_buf;
+      output->null_count = 0;
     } else {
       *output = data;
     }

--- a/cpp/src/arrow/compute/kernels/scalar_fill_null_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_fill_null_test.cc
@@ -33,12 +33,17 @@
 namespace arrow {
 namespace compute {
 
-void CheckFillNull(const Array& input, const Datum& fill_value, const Array& expected) {
+void CheckFillNull(const Array& input, const Datum& fill_value, const Array& expected,
+                   bool all_valid = true) {
   auto Check = [&](const Array& input, const Array& expected) {
     ASSERT_OK_AND_ASSIGN(Datum datum_out, FillNull(input, fill_value));
     std::shared_ptr<Array> result = datum_out.make_array();
     ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(expected, *result, /*verbose=*/true);
+    if (all_valid) {
+      // Check null count of ArrayData is set, not the computed Array.null_count
+      ASSERT_EQ(result->data()->null_count, 0);
+    }
   };
 
   Check(input, expected);
@@ -48,10 +53,11 @@ void CheckFillNull(const Array& input, const Datum& fill_value, const Array& exp
 }
 
 void CheckFillNull(const std::shared_ptr<DataType>& type, const std::string& in_values,
-                   const Datum& fill_value, const std::string& out_values) {
+                   const Datum& fill_value, const std::string& out_values,
+                   bool all_valid = true) {
   std::shared_ptr<Array> input = ArrayFromJSON(type, in_values);
   std::shared_ptr<Array> expected = ArrayFromJSON(type, out_values);
-  CheckFillNull(*input, fill_value, *expected);
+  CheckFillNull(*input, fill_value, *expected, all_valid);
 }
 
 class TestFillNullKernel : public ::testing::Test {};
@@ -67,7 +73,8 @@ typedef ::testing::Types<Int8Type, UInt8Type, Int16Type, UInt16Type, Int32Type,
 TEST_F(TestFillNullKernel, FillNullInvalidScalar) {
   auto scalar = std::make_shared<Int8Scalar>(3);
   scalar->is_valid = false;
-  CheckFillNull(int8(), "[1, null, 3, 2]", Datum(scalar), "[1, null, 3, 2]");
+  CheckFillNull(int8(), "[1, null, 3, 2]", Datum(scalar), "[1, null, 3, 2]",
+                /*all_valid=*/false);
 }
 
 TYPED_TEST_SUITE(TestFillNullPrimitive, PrimitiveTypes);
@@ -106,7 +113,8 @@ TYPED_TEST(TestFillNullPrimitive, FillNull) {
 
 TEST_F(TestFillNullKernel, FillNullNull) {
   auto datum = Datum(std::make_shared<NullScalar>());
-  CheckFillNull(null(), "[null, null, null, null]", datum, "[null, null, null, null]");
+  CheckFillNull(null(), "[null, null, null, null]", datum, "[null, null, null, null]",
+                /*all_valid=*/false);
 }
 
 TEST_F(TestFillNullKernel, FillNullBoolean) {
@@ -162,6 +170,13 @@ TEST_F(TestFillNullKernel, FillNullString) {
   // some nulls
   CheckFillNull(type, R"(["foo", "bar", null])", Datum(scalar),
                 R"(["foo", "bar", "arrow"])");
+}
+
+TEST_F(TestFillNullKernel, FillNullSetsZeroNullCount) {
+  auto arr = ArrayFromJSON(int32(), "[1, null, 3, 4]");
+  auto fill_value = Datum(std::make_shared<Int32Scalar>(2, int32()));
+  std::shared_ptr<ArrayData> result = (*FillNull(arr, fill_value)).array();
+  ASSERT_EQ(result->null_count, 0);
 }
 
 }  // namespace compute

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1248,3 +1248,10 @@ def test_tdigest():
     arr = pa.chunked_array([pa.array([1, 2]), pa.array([3, 4])])
     result = pc.tdigest(arr, q=[0, 0.5, 1])
     assert result.to_pylist() == [1, 2.5, 4]
+
+
+def test_fill_null_segfault():
+    # ARROW-12672
+    arr = pa.array([None], pa.bool_()).fill_null(False)
+    result = arr.cast(pa.int8())
+    assert result == pa.array([0], pa.int8())


### PR DESCRIPTION
* The "fill_null" kernel was returning a slightly malformed ArrayData with no validity bitmap but unknown null_count. The null_count is now set to 0 if the fill_value was valid.
* The "cast" kernel is made robust to handle such ArrayData with unknown null_count but no validity bitmap