### PR TITLE
ARROW-12644: [C++][Python][R][Dataset] URL-decode path segments in partitioning

### DIFF
--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -177,8 +177,8 @@ std::ostream& operator<<(std::ostream& os, SegmentEncoding segment_encoding) {
     case SegmentEncoding::None:
       os << "SegmentEncoding::None";
       break;
-    case SegmentEncoding::Url:
-      os << "SegmentEncoding::Url";
+    case SegmentEncoding::Uri:
+      os << "SegmentEncoding::Uri";
       break;
     default:
       os << "(invalid SegmentEncoding " << static_cast<int8_t>(segment_encoding) << ")";
@@ -310,7 +310,7 @@ Result<std::vector<KeyValuePartitioning::Key>> DirectoryPartitioning::ParseKeys(
       case SegmentEncoding::None:
         keys.push_back({schema_->field(i++)->name(), std::move(segment)});
         break;
-      case SegmentEncoding::Url: {
+      case SegmentEncoding::Uri: {
         ARROW_ASSIGN_OR_RAISE(auto decoded, SafeUriUnescape(segment));
         keys.push_back({schema_->field(i++)->name(), std::move(decoded)});
         break;
@@ -513,7 +513,7 @@ class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {
           case SegmentEncoding::None:
             RETURN_NOT_OK(InsertRepr(static_cast<int>(field_index++), segment));
             break;
-          case SegmentEncoding::Url: {
+          case SegmentEncoding::Uri: {
             ARROW_ASSIGN_OR_RAISE(auto decoded, SafeUriUnescape(segment));
             RETURN_NOT_OK(InsertRepr(static_cast<int>(field_index++), decoded));
             break;
@@ -576,7 +576,7 @@ Result<util::optional<KeyValuePartitioning::Key>> HivePartitioning::ParseKey(
     case SegmentEncoding::None:
       value = segment.substr(name_end + 1);
       break;
-    case SegmentEncoding::Url: {
+    case SegmentEncoding::Uri: {
       // Static method, so we have no better place for it
       util::InitializeUTF8();
       auto raw_value = util::string_view(segment).substr(name_end + 1);

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <functional>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -89,11 +90,22 @@ class ARROW_DS_EXPORT Partitioning {
   std::shared_ptr<Schema> schema_;
 };
 
+/// \brief The encoding of partition segments.
+enum class SegmentEncoding : int8_t {
+  /// No encoding.
+  None = 0,
+  /// Segment values are URL-encoded.
+  Url = 1,
+};
+
+ARROW_EXPORT
+std::ostream& operator<<(std::ostream& os, SegmentEncoding segment_encoding);
+
 /// \brief Options for key-value based partitioning (hive/directory).
 struct ARROW_DS_EXPORT KeyValuePartitioningOptions {
-  /// After splitting a path into components, URL-decode the path components
-  /// before parsing.
-  bool url_decode_segments = true;
+  /// After splitting a path into components, decode the path components
+  /// before parsing according to this scheme.
+  SegmentEncoding segment_encoding = SegmentEncoding::Url;
 };
 
 /// \brief Options for inferring a partitioning.
@@ -107,9 +119,9 @@ struct ARROW_DS_EXPORT PartitioningFactoryOptions {
   /// will only check discovered fields against the schema and update internal
   /// state (such as dictionaries).
   std::shared_ptr<Schema> schema;
-  /// After splitting a path into components, URL-decode the path components
-  /// before parsing.
-  bool url_decode_segments = true;
+  /// After splitting a path into components, decode the path components
+  /// before parsing according to this scheme.
+  SegmentEncoding segment_encoding = SegmentEncoding::Url;
 
   KeyValuePartitioningOptions AsPartitioningOptions() const;
 };
@@ -192,9 +204,9 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  public:
   /// If a field in schema is of dictionary type, the corresponding element of
   /// dictionaries must be contain the dictionary of values for that field.
-  explicit DirectoryPartitioning(
-      std::shared_ptr<Schema> schema, ArrayVector dictionaries = {},
-      KeyValuePartitioningOptions options = KeyValuePartitioningOptions());
+  explicit DirectoryPartitioning(std::shared_ptr<Schema> schema,
+                                 ArrayVector dictionaries = {},
+                                 KeyValuePartitioningOptions options = {});
 
   std::string type_name() const override { return "schema"; }
 

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -89,8 +89,15 @@ class ARROW_DS_EXPORT Partitioning {
   std::shared_ptr<Schema> schema_;
 };
 
+/// \brief Options for key-value based partitioning (hive/directory).
+struct ARROW_DS_EXPORT KeyValuePartitioningOptions {
+  /// After splitting a path into components, URL-decode the path components
+  /// before parsing.
+  bool url_decode_segments = true;
+};
+
 /// \brief Options for inferring a partitioning.
-struct PartitioningFactoryOptions {
+struct ARROW_DS_EXPORT PartitioningFactoryOptions {
   /// When inferring a schema for partition fields, yield dictionary encoded types
   /// instead of plain. This can be more efficient when materializing virtual
   /// columns, and Expressions parsed by the finished Partitioning will include
@@ -100,12 +107,19 @@ struct PartitioningFactoryOptions {
   /// will only check discovered fields against the schema and update internal
   /// state (such as dictionaries).
   std::shared_ptr<Schema> schema;
+  /// After splitting a path into components, URL-decode the path components
+  /// before parsing.
+  bool url_decode_segments = true;
+
+  KeyValuePartitioningOptions AsPartitioningOptions() const;
 };
 
 /// \brief Options for inferring a hive-style partitioning.
-struct HivePartitioningFactoryOptions : PartitioningFactoryOptions {
+struct ARROW_DS_EXPORT HivePartitioningFactoryOptions : PartitioningFactoryOptions {
   /// The hive partitioning scheme maps null to a hard coded fallback string.
   std::string null_fallback;
+
+  HivePartitioningOptions AsHivePartitioningOptions() const;
 };
 
 /// \brief PartitioningFactory provides creation of a partitioning  when the
@@ -147,8 +161,11 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   Result<std::string> Format(const compute::Expression& expr) const override;
 
  protected:
-  KeyValuePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries)
-      : Partitioning(std::move(schema)), dictionaries_(std::move(dictionaries)) {
+  KeyValuePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries,
+                       KeyValuePartitioningOptions options)
+      : Partitioning(std::move(schema)),
+        dictionaries_(std::move(dictionaries)),
+        options_(options) {
     if (dictionaries_.empty()) {
       dictionaries_.resize(schema_->num_fields());
     }
@@ -162,6 +179,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   Result<compute::Expression> ConvertKey(const Key& key) const;
 
   ArrayVector dictionaries_;
+  KeyValuePartitioningOptions options_;
 };
 
 /// \brief DirectoryPartitioning parses one segment of a path for each field in its
@@ -174,9 +192,10 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  public:
   /// If a field in schema is of dictionary type, the corresponding element of
   /// dictionaries must be contain the dictionary of values for that field.
-  explicit DirectoryPartitioning(std::shared_ptr<Schema> schema,
-                                 ArrayVector dictionaries = {})
-      : KeyValuePartitioning(std::move(schema), std::move(dictionaries)) {}
+  explicit DirectoryPartitioning(
+      std::shared_ptr<Schema> schema, ArrayVector dictionaries = {},
+      KeyValuePartitioningOptions options = KeyValuePartitioningOptions())
+      : KeyValuePartitioning(std::move(schema), std::move(dictionaries), options) {}
 
   std::string type_name() const override { return "schema"; }
 
@@ -196,6 +215,16 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
 /// \brief The default fallback used for null values in a Hive-style partitioning.
 static constexpr char kDefaultHiveNullFallback[] = "__HIVE_DEFAULT_PARTITION__";
 
+struct ARROW_DS_EXPORT HivePartitioningOptions : public KeyValuePartitioningOptions {
+  std::string null_fallback = kDefaultHiveNullFallback;
+
+  static HivePartitioningOptions DefaultsWithNullFallback(std::string fallback) {
+    HivePartitioningOptions options;
+    options.null_fallback = std::move(fallback);
+    return options;
+  }
+};
+
 /// \brief Multi-level, directory based partitioning
 /// originating from Apache Hive with all data files stored in the
 /// leaf directories. Data is partitioned by static values of a
@@ -211,21 +240,30 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   /// dictionaries must be contain the dictionary of values for that field.
   explicit HivePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries = {},
                             std::string null_fallback = kDefaultHiveNullFallback)
-      : KeyValuePartitioning(std::move(schema), std::move(dictionaries)),
-        null_fallback_(std::move(null_fallback)) {}
+      : KeyValuePartitioning(std::move(schema), std::move(dictionaries),
+                             KeyValuePartitioningOptions()),
+        hive_options_(
+            HivePartitioningOptions::DefaultsWithNullFallback(std::move(null_fallback))) {
+  }
+
+  explicit HivePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries,
+                            HivePartitioningOptions options)
+      : KeyValuePartitioning(std::move(schema), std::move(dictionaries), options),
+        hive_options_(options) {}
 
   std::string type_name() const override { return "hive"; }
-  std::string null_fallback() const { return null_fallback_; }
+  std::string null_fallback() const { return hive_options_.null_fallback; }
+  const HivePartitioningOptions& options() const { return hive_options_; }
 
   static util::optional<Key> ParseKey(const std::string& segment,
-                                      const std::string& null_fallback);
+                                      const HivePartitioningOptions& options);
 
   /// \brief Create a factory for a hive partitioning.
   static std::shared_ptr<PartitioningFactory> MakeFactory(
       HivePartitioningFactoryOptions = {});
 
  private:
-  const std::string null_fallback_;
+  const HivePartitioningOptions hive_options_;
   std::vector<Key> ParseKeys(const std::string& path) const override;
 
   Result<std::string> FormatValues(const ScalarVector& values) const override;

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -171,7 +171,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
     }
   }
 
-  virtual std::vector<Key> ParseKeys(const std::string& path) const = 0;
+  virtual Result<std::vector<Key>> ParseKeys(const std::string& path) const = 0;
 
   virtual Result<std::string> FormatValues(const ScalarVector& values) const = 0;
 
@@ -194,8 +194,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
   /// dictionaries must be contain the dictionary of values for that field.
   explicit DirectoryPartitioning(
       std::shared_ptr<Schema> schema, ArrayVector dictionaries = {},
-      KeyValuePartitioningOptions options = KeyValuePartitioningOptions())
-      : KeyValuePartitioning(std::move(schema), std::move(dictionaries), options) {}
+      KeyValuePartitioningOptions options = KeyValuePartitioningOptions());
 
   std::string type_name() const override { return "schema"; }
 
@@ -207,7 +206,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
       std::vector<std::string> field_names, PartitioningFactoryOptions = {});
 
  private:
-  std::vector<Key> ParseKeys(const std::string& path) const override;
+  Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
   Result<std::string> FormatValues(const ScalarVector& values) const override;
 };
@@ -255,8 +254,8 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   std::string null_fallback() const { return hive_options_.null_fallback; }
   const HivePartitioningOptions& options() const { return hive_options_; }
 
-  static util::optional<Key> ParseKey(const std::string& segment,
-                                      const HivePartitioningOptions& options);
+  static Result<util::optional<Key>> ParseKey(const std::string& segment,
+                                              const HivePartitioningOptions& options);
 
   /// \brief Create a factory for a hive partitioning.
   static std::shared_ptr<PartitioningFactory> MakeFactory(
@@ -264,7 +263,7 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
 
  private:
   const HivePartitioningOptions hive_options_;
-  std::vector<Key> ParseKeys(const std::string& path) const override;
+  Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
   Result<std::string> FormatValues(const ScalarVector& values) const override;
 };

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -98,7 +98,7 @@ enum class SegmentEncoding : int8_t {
   Uri = 1,
 };
 
-ARROW_EXPORT
+ARROW_DS_EXPORT
 std::ostream& operator<<(std::ostream& os, SegmentEncoding segment_encoding);
 
 /// \brief Options for key-value based partitioning (hive/directory).

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -95,7 +95,7 @@ enum class SegmentEncoding : int8_t {
   /// No encoding.
   None = 0,
   /// Segment values are URL-encoded.
-  Url = 1,
+  Uri = 1,
 };
 
 ARROW_EXPORT
@@ -105,7 +105,7 @@ std::ostream& operator<<(std::ostream& os, SegmentEncoding segment_encoding);
 struct ARROW_DS_EXPORT KeyValuePartitioningOptions {
   /// After splitting a path into components, decode the path components
   /// before parsing according to this scheme.
-  SegmentEncoding segment_encoding = SegmentEncoding::Url;
+  SegmentEncoding segment_encoding = SegmentEncoding::Uri;
 };
 
 /// \brief Options for inferring a partitioning.
@@ -121,7 +121,7 @@ struct ARROW_DS_EXPORT PartitioningFactoryOptions {
   std::shared_ptr<Schema> schema;
   /// After splitting a path into components, decode the path components
   /// before parsing according to this scheme.
-  SegmentEncoding segment_encoding = SegmentEncoding::Url;
+  SegmentEncoding segment_encoding = SegmentEncoding::Uri;
 
   KeyValuePartitioningOptions AsPartitioningOptions() const;
 };

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -558,6 +558,84 @@ TEST_F(TestPartitioning, ExistingSchemaHive) {
   AssertInspect({"/a=0/b=1", "/b=2"}, options.schema->fields());
 }
 
+TEST_F(TestPartitioning, UrlEncodedDirectory) {
+  PartitioningFactoryOptions options;
+  auto ts = timestamp(TimeUnit::type::SECOND);
+  options.schema = schema({field("date", ts), field("time", ts), field("str", utf8())});
+  factory_ = DirectoryPartitioning::MakeFactory(options.schema->field_names(), options);
+
+  AssertInspect({"/2021-05-04 00:00:00/2021-05-04 07:27:00/%24",
+                 "/2021-05-04 00%3A00%3A00/2021-05-04 07%3A27%3A00/foo"},
+                options.schema->fields());
+  auto date = std::make_shared<TimestampScalar>(1620086400, ts);
+  auto time = std::make_shared<TimestampScalar>(1620113220, ts);
+  partitioning_ = std::make_shared<DirectoryPartitioning>(options.schema, ArrayVector());
+  AssertParse("/2021-05-04 00%3A00%3A00/2021-05-04 07%3A27%3A00/%24",
+              and_({equal(field_ref("date"), literal(date)),
+                    equal(field_ref("time"), literal(time)),
+                    equal(field_ref("str"), literal("$"))}));
+
+  options.url_decode_segments = false;
+  options.schema =
+      schema({field("date", utf8()), field("time", utf8()), field("str", utf8())});
+  factory_ = DirectoryPartitioning::MakeFactory(options.schema->field_names(), options);
+  AssertInspect({"/2021-05-04 00:00:00/2021-05-04 07:27:00/%E3%81%8F%E3%81%BE",
+                 "/2021-05-04 00%3A00%3A00/2021-05-04 07%3A27%3A00/foo"},
+                options.schema->fields());
+  partitioning_ = std::make_shared<DirectoryPartitioning>(
+      options.schema, ArrayVector(), options.AsPartitioningOptions());
+  AssertParse("/2021-05-04 00%3A00%3A00/2021-05-04 07%3A27%3A00/%24",
+              and_({equal(field_ref("date"), literal("2021-05-04 00%3A00%3A00")),
+                    equal(field_ref("time"), literal("2021-05-04 07%3A27%3A00")),
+                    equal(field_ref("str"), literal("%24"))}));
+}
+
+TEST_F(TestPartitioning, UrlEncodedHive) {
+  HivePartitioningFactoryOptions options;
+  auto ts = timestamp(TimeUnit::type::SECOND);
+  options.schema = schema({field("date", ts), field("time", ts), field("str", utf8())});
+  options.null_fallback = "$";
+  factory_ = HivePartitioning::MakeFactory(options);
+
+  AssertInspect(
+      {"/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=$",
+       "/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=%E3%81%8F%E3%81%BE",
+       "/date=2021-05-04 00%3A00%3A00/time=2021-05-04 07%3A27%3A00/str=%24"},
+      options.schema->fields());
+
+  auto date = std::make_shared<TimestampScalar>(1620086400, ts);
+  auto time = std::make_shared<TimestampScalar>(1620113220, ts);
+  partitioning_ = std::make_shared<HivePartitioning>(options.schema, ArrayVector(),
+                                                     options.AsHivePartitioningOptions());
+  AssertParse("/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=$",
+              and_({equal(field_ref("date"), literal(date)),
+                    equal(field_ref("time"), literal(time)), is_null(field_ref("str"))}));
+  AssertParse("/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=%E3%81%8F%E3%81%BE",
+              and_({equal(field_ref("date"), literal(date)),
+                    equal(field_ref("time"), literal(time)),
+                    equal(field_ref("str"), literal("\xE3\x81\x8F\xE3\x81\xBE"))}));
+  // URL-encoded null fallback value
+  AssertParse("/date=2021-05-04 00%3A00%3A00/time=2021-05-04 07%3A27%3A00/str=%24",
+              and_({equal(field_ref("date"), literal(date)),
+                    equal(field_ref("time"), literal(time)), is_null(field_ref("str"))}));
+
+  options.url_decode_segments = false;
+  options.schema =
+      schema({field("date", utf8()), field("time", utf8()), field("str", utf8())});
+  factory_ = HivePartitioning::MakeFactory(options);
+  AssertInspect(
+      {"/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=$",
+       "/date=2021-05-04 00:00:00/time=2021-05-04 07:27:00/str=%E3%81%8F%E3%81%BE",
+       "/date=2021-05-04 00%3A00%3A00/time=2021-05-04 07%3A27%3A00/str=%24"},
+      options.schema->fields());
+  partitioning_ = std::make_shared<HivePartitioning>(options.schema, ArrayVector(),
+                                                     options.AsHivePartitioningOptions());
+  AssertParse("/date=2021-05-04 00%3A00%3A00/time=2021-05-04 07%3A27%3A00/str=%24",
+              and_({equal(field_ref("date"), literal("2021-05-04 00%3A00%3A00")),
+                    equal(field_ref("time"), literal("2021-05-04 07%3A27%3A00")),
+                    equal(field_ref("str"), literal("%24"))}));
+}
+
 TEST_F(TestPartitioning, EtlThenHive) {
   FieldVector etl_fields{field("year", int16()), field("month", int8()),
                          field("day", int8()), field("hour", int8())};
@@ -655,8 +733,9 @@ class RangePartitioning : public Partitioning {
   Result<compute::Expression> Parse(const std::string& path) const override {
     std::vector<compute::Expression> ranges;
 
+    HivePartitioningOptions options;
     for (auto segment : fs::internal::SplitAbstractPath(path)) {
-      auto key = HivePartitioning::ParseKey(segment, "");
+      auto key = HivePartitioning::ParseKey(segment, options);
       if (!key) {
         return Status::Invalid("can't parse '", segment, "' as a range");
       }

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -581,7 +581,7 @@ TEST_F(TestPartitioning, UrlEncodedDirectory) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("was not valid UTF-8"),
                                   partitioning_->Parse({"/%AF/%BF/%CF"}));
 
-  options.url_decode_segments = false;
+  options.segment_encoding = SegmentEncoding::None;
   options.schema =
       schema({field("date", utf8()), field("time", utf8()), field("str", utf8())});
   factory_ = DirectoryPartitioning::MakeFactory(options.schema->field_names(), options);
@@ -631,7 +631,7 @@ TEST_F(TestPartitioning, UrlEncodedHive) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("was not valid UTF-8"),
                                   partitioning_->Parse({"/date=%AF/time=%BF/str=%CF"}));
 
-  options.url_decode_segments = false;
+  options.segment_encoding = SegmentEncoding::None;
   options.schema =
       schema({field("date", utf8()), field("time", utf8()), field("str", utf8())});
   factory_ = HivePartitioning::MakeFactory(options);

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -646,6 +646,13 @@ TEST_F(TestPartitioning, UrlEncodedHive) {
               and_({equal(field_ref("date"), literal("2021-05-04 00%3A00%3A00")),
                     equal(field_ref("time"), literal("2021-05-04 07%3A27%3A00")),
                     equal(field_ref("str"), literal("%24"))}));
+
+  // Invalid UTF-8
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("was not valid UTF-8"),
+                                  factory_->Inspect({"/date=\xAF/time=\xBF/str=\xCF"}));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("was not valid UTF-8"),
+      partitioning_->Parse({"/date=\xAF/time=\xBF/str=\xCF"}));
 }
 
 TEST_F(TestPartitioning, EtlThenHive) {

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -71,8 +71,10 @@ class ParquetFileWriteOptions;
 class Partitioning;
 class PartitioningFactory;
 class PartitioningOrFactory;
+struct KeyValuePartitioningOptions;
 class DirectoryPartitioning;
 class HivePartitioning;
+struct HivePartitioningOptions;
 
 struct ScanOptions;
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -88,8 +88,8 @@ cdef CFileSource _make_file_source(object file, FileSystem filesystem=None):
 cdef SegmentEncoding _get_segment_encoding(str segment_encoding):
     if segment_encoding == "none":
         return SegmentEncoding_NONE
-    elif segment_encoding == "url":
-        return SegmentEncoding_URL
+    elif segment_encoding == "uri":
+        return SegmentEncoding_URI
     raise ValueError(f"Unknown segment encoding: {segment_encoding}")
 
 
@@ -1938,9 +1938,9 @@ cdef class DirectoryPartitioning(Partitioning):
         corresponding entry of `dictionaries` must be an array containing
         every value which may be taken by the corresponding column or an
         error will be raised in parsing.
-    segment_encoding : str, default "url"
+    segment_encoding : str, default "uri"
         After splitting paths into segments, decode the segments. Valid
-        values are "url" (URL-decode segments) and "none" (leave as-is).
+        values are "uri" (URI-decode segments) and "none" (leave as-is).
 
     Returns
     -------
@@ -1959,7 +1959,7 @@ cdef class DirectoryPartitioning(Partitioning):
         CDirectoryPartitioning* directory_partitioning
 
     def __init__(self, Schema schema not None, dictionaries=None,
-                 segment_encoding="url"):
+                 segment_encoding="uri"):
         cdef:
             shared_ptr[CDirectoryPartitioning] c_partitioning
             CKeyValuePartitioningOptions c_options
@@ -1979,7 +1979,7 @@ cdef class DirectoryPartitioning(Partitioning):
     @staticmethod
     def discover(field_names=None, infer_dictionary=False,
                  max_partition_dictionary_size=0,
-                 schema=None, segment_encoding="url"):
+                 schema=None, segment_encoding="uri"):
         """
         Discover a DirectoryPartitioning.
 
@@ -2002,9 +2002,9 @@ cdef class DirectoryPartitioning(Partitioning):
             Use this schema instead of inferring a schema from partition
             values. Partition values will be validated against this schema
             before accumulation into the Partitioning's dictionary.
-        segment_encoding : str, default "url"
+        segment_encoding : str, default "uri"
             After splitting paths into segments, decode the segments. Valid
-            values are "url" (URL-decode segments) and "none" (leave as-is).
+            values are "uri" (URI-decode segments) and "none" (leave as-is).
 
         Returns
         -------
@@ -2065,9 +2065,9 @@ cdef class HivePartitioning(Partitioning):
         error will be raised in parsing.
     null_fallback : str, default "__HIVE_DEFAULT_PARTITION__"
         If any field is None then this fallback will be used as a label
-    segment_encoding : str, default "url"
+    segment_encoding : str, default "uri"
         After splitting paths into segments, decode the segments. Valid
-        values are "url" (URL-decode segments) and "none" (leave as-is).
+        values are "uri" (URI-decode segments) and "none" (leave as-is).
 
     Returns
     -------
@@ -2090,7 +2090,7 @@ cdef class HivePartitioning(Partitioning):
                  Schema schema not None,
                  dictionaries=None,
                  null_fallback="__HIVE_DEFAULT_PARTITION__",
-                 segment_encoding="url"):
+                 segment_encoding="uri"):
 
         cdef:
             shared_ptr[CHivePartitioning] c_partitioning
@@ -2115,7 +2115,7 @@ cdef class HivePartitioning(Partitioning):
                  max_partition_dictionary_size=0,
                  null_fallback="__HIVE_DEFAULT_PARTITION__",
                  schema=None,
-                 segment_encoding="url"):
+                 segment_encoding="uri"):
         """
         Discover a HivePartitioning.
 
@@ -2139,9 +2139,9 @@ cdef class HivePartitioning(Partitioning):
             Use this schema instead of inferring a schema from partition
             values. Partition values will be validated against this schema
             before accumulation into the Partitioning's dictionary.
-        segment_encoding : str, default "url"
+        segment_encoding : str, default "uri"
             After splitting paths into segments, decode the segments. Valid
-            values are "url" (URL-decode segments) and "none" (leave as-is).
+            values are "uri" (URI-decode segments) and "none" (leave as-is).
 
         Returns
         -------

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -85,11 +85,11 @@ cdef CFileSource _make_file_source(object file, FileSystem filesystem=None):
     return c_source
 
 
-cdef SegmentEncoding _get_segment_encoding(str segment_encoding):
+cdef CSegmentEncoding _get_segment_encoding(str segment_encoding):
     if segment_encoding == "none":
-        return SegmentEncoding_NONE
+        return CSegmentEncodingNone
     elif segment_encoding == "uri":
-        return SegmentEncoding_URI
+        return CSegmentEncodingUri
     raise ValueError(f"Unknown segment encoding: {segment_encoding}")
 
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -305,31 +305,35 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CExpression] Parse(const c_string & path) const
         const shared_ptr[CSchema] & schema()
 
-    enum SegmentEncoding" arrow::dataset::SegmentEncoding":
-        SegmentEncoding_NONE" arrow::dataset::SegmentEncoding::None"
-        SegmentEncoding_URI" arrow::dataset::SegmentEncoding::Uri"
+    cdef cppclass CSegmentEncoding" arrow::dataset::SegmentEncoding":
+        pass
+
+    CSegmentEncoding CSegmentEncodingNone\
+        " arrow::dataset::SegmentEncoding::None"
+    CSegmentEncoding CSegmentEncodingUri\
+        " arrow::dataset::SegmentEncoding::Uri"
 
     cdef cppclass CKeyValuePartitioningOptions \
             "arrow::dataset::KeyValuePartitioningOptions":
-        SegmentEncoding segment_encoding
+        CSegmentEncoding segment_encoding
 
     cdef cppclass CHivePartitioningOptions \
             "arrow::dataset::HivePartitioningOptions":
-        SegmentEncoding segment_encoding
+        CSegmentEncoding segment_encoding
         c_string null_fallback
 
     cdef cppclass CPartitioningFactoryOptions \
             "arrow::dataset::PartitioningFactoryOptions":
         c_bool infer_dictionary
         shared_ptr[CSchema] schema
-        SegmentEncoding segment_encoding
+        CSegmentEncoding segment_encoding
 
     cdef cppclass CHivePartitioningFactoryOptions \
             "arrow::dataset::HivePartitioningFactoryOptions":
         c_bool infer_dictionary
         c_string null_fallback
         shared_ptr[CSchema] schema
-        SegmentEncoding segment_encoding
+        CSegmentEncoding segment_encoding
 
     cdef cppclass CPartitioningFactory "arrow::dataset::PartitioningFactory":
         pass

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -307,7 +307,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     enum SegmentEncoding" arrow::dataset::SegmentEncoding":
         SegmentEncoding_NONE" arrow::dataset::SegmentEncoding::None"
-        SegmentEncoding_URL" arrow::dataset::SegmentEncoding::Url"
+        SegmentEncoding_URI" arrow::dataset::SegmentEncoding::Uri"
 
     cdef cppclass CKeyValuePartitioningOptions \
             "arrow::dataset::KeyValuePartitioningOptions":

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -305,16 +305,27 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CExpression] Parse(const c_string & path) const
         const shared_ptr[CSchema] & schema()
 
+    cdef cppclass CKeyValuePartitioningOptions \
+            "arrow::dataset::KeyValuePartitioningOptions":
+        c_bool url_decode_segments
+
+    cdef cppclass CHivePartitioningOptions \
+            "arrow::dataset::HivePartitioningOptions":
+        c_bool url_decode_segments
+        c_string null_fallback
+
     cdef cppclass CPartitioningFactoryOptions \
             "arrow::dataset::PartitioningFactoryOptions":
         c_bool infer_dictionary
         shared_ptr[CSchema] schema
+        c_bool url_decode_segments
 
     cdef cppclass CHivePartitioningFactoryOptions \
             "arrow::dataset::HivePartitioningFactoryOptions":
-        c_bool infer_dictionary,
+        c_bool infer_dictionary
         c_string null_fallback
         shared_ptr[CSchema] schema
+        c_bool url_decode_segments
 
     cdef cppclass CPartitioningFactory "arrow::dataset::PartitioningFactory":
         pass
@@ -331,7 +342,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CHivePartitioning \
             "arrow::dataset::HivePartitioning"(CPartitioning):
         CHivePartitioning(shared_ptr[CSchema] schema,
-                          vector[shared_ptr[CArray]] dictionaries)
+                          vector[shared_ptr[CArray]] dictionaries,
+                          CHivePartitioningOptions options)
 
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -305,27 +305,31 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CExpression] Parse(const c_string & path) const
         const shared_ptr[CSchema] & schema()
 
+    enum SegmentEncoding" arrow::dataset::SegmentEncoding":
+        SegmentEncoding_NONE" arrow::dataset::SegmentEncoding::None"
+        SegmentEncoding_URL" arrow::dataset::SegmentEncoding::Url"
+
     cdef cppclass CKeyValuePartitioningOptions \
             "arrow::dataset::KeyValuePartitioningOptions":
-        c_bool url_decode_segments
+        SegmentEncoding segment_encoding
 
     cdef cppclass CHivePartitioningOptions \
             "arrow::dataset::HivePartitioningOptions":
-        c_bool url_decode_segments
+        SegmentEncoding segment_encoding
         c_string null_fallback
 
     cdef cppclass CPartitioningFactoryOptions \
             "arrow::dataset::PartitioningFactoryOptions":
         c_bool infer_dictionary
         shared_ptr[CSchema] schema
-        c_bool url_decode_segments
+        SegmentEncoding segment_encoding
 
     cdef cppclass CHivePartitioningFactoryOptions \
             "arrow::dataset::HivePartitioningFactoryOptions":
         c_bool infer_dictionary
         c_string null_fallback
         shared_ptr[CSchema] schema
-        c_bool url_decode_segments
+        SegmentEncoding segment_encoding
 
     cdef cppclass CPartitioningFactory "arrow::dataset::PartitioningFactory":
         pass

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1424,7 +1424,7 @@ def test_partitioning_factory_dictionary(mockfs, infer_dictionary):
         assert inferred_schema.field('key').type == pa.string()
 
 
-def test_partitioning_factory_url_decode():
+def test_partitioning_factory_segment_encoding():
     mockfs = fs._MockFileSystem()
     format = ds.IpcFileFormat()
     schema = pa.schema([("i64", pa.int64())])
@@ -1458,7 +1458,7 @@ def test_partitioning_factory_url_decode():
     assert actual[0][0].as_py() == 1620086400
 
     options.partitioning_factory = ds.DirectoryPartitioning.discover(
-        ["date", "string"], url_decode_segments=False)
+        ["date", "string"], segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     fragments = list(factory.finish().get_fragments())
     assert fragments[0].partition_expression.equals(
@@ -1466,7 +1466,7 @@ def test_partitioning_factory_url_decode():
         (ds.field("string") == "%24"))
 
     options.partitioning = ds.DirectoryPartitioning(
-        string_partition_schema, url_decode_segments=False)
+        string_partition_schema, segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     fragments = list(factory.finish().get_fragments())
     assert fragments[0].partition_expression.equals(
@@ -1474,7 +1474,7 @@ def test_partitioning_factory_url_decode():
         (ds.field("string") == "%24"))
 
     options.partitioning_factory = ds.DirectoryPartitioning.discover(
-        schema=partition_schema, url_decode_segments=False)
+        schema=partition_schema, segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     with pytest.raises(pa.ArrowInvalid,
                        match="Could not cast segments for partition field"):
@@ -1494,7 +1494,7 @@ def test_partitioning_factory_url_decode():
     assert actual[0][0].as_py() == 1620086400
 
     options.partitioning_factory = ds.HivePartitioning.discover(
-        url_decode_segments=False)
+        segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     fragments = list(factory.finish().get_fragments())
     assert fragments[0].partition_expression.equals(
@@ -1502,7 +1502,7 @@ def test_partitioning_factory_url_decode():
         (ds.field("string") == "%24"))
 
     options.partitioning = ds.HivePartitioning(
-        string_partition_schema, url_decode_segments=False)
+        string_partition_schema, segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     fragments = list(factory.finish().get_fragments())
     assert fragments[0].partition_expression.equals(
@@ -1510,7 +1510,7 @@ def test_partitioning_factory_url_decode():
         (ds.field("string") == "%24"))
 
     options.partitioning_factory = ds.HivePartitioning.discover(
-        schema=partition_schema, url_decode_segments=False)
+        schema=partition_schema, segment_encoding="none")
     factory = ds.FileSystemDatasetFactory(mockfs, selector, format, options)
     with pytest.raises(pa.ArrowInvalid,
                        match="Could not cast segments for partition field"):

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -472,20 +472,20 @@ dataset___ParquetFragmentScanOptions__Make <- function(use_buffered_stream, buff
     .Call(`_arrow_dataset___ParquetFragmentScanOptions__Make`, use_buffered_stream, buffer_size, pre_buffer)
 }
 
-dataset___DirectoryPartitioning <- function(schm){
-    .Call(`_arrow_dataset___DirectoryPartitioning`, schm)
+dataset___DirectoryPartitioning <- function(schm, url_decode_segments){
+    .Call(`_arrow_dataset___DirectoryPartitioning`, schm, url_decode_segments)
 }
 
-dataset___DirectoryPartitioning__MakeFactory <- function(field_names){
-    .Call(`_arrow_dataset___DirectoryPartitioning__MakeFactory`, field_names)
+dataset___DirectoryPartitioning__MakeFactory <- function(field_names, url_decode_segments){
+    .Call(`_arrow_dataset___DirectoryPartitioning__MakeFactory`, field_names, url_decode_segments)
 }
 
-dataset___HivePartitioning <- function(schm, null_fallback){
-    .Call(`_arrow_dataset___HivePartitioning`, schm, null_fallback)
+dataset___HivePartitioning <- function(schm, null_fallback, url_decode_segments){
+    .Call(`_arrow_dataset___HivePartitioning`, schm, null_fallback, url_decode_segments)
 }
 
-dataset___HivePartitioning__MakeFactory <- function(null_fallback){
-    .Call(`_arrow_dataset___HivePartitioning__MakeFactory`, null_fallback)
+dataset___HivePartitioning__MakeFactory <- function(null_fallback, url_decode_segments){
+    .Call(`_arrow_dataset___HivePartitioning__MakeFactory`, null_fallback, url_decode_segments)
 }
 
 dataset___ScannerBuilder__ProjectNames <- function(sb, cols){

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -472,20 +472,20 @@ dataset___ParquetFragmentScanOptions__Make <- function(use_buffered_stream, buff
     .Call(`_arrow_dataset___ParquetFragmentScanOptions__Make`, use_buffered_stream, buffer_size, pre_buffer)
 }
 
-dataset___DirectoryPartitioning <- function(schm, url_decode_segments){
-    .Call(`_arrow_dataset___DirectoryPartitioning`, schm, url_decode_segments)
+dataset___DirectoryPartitioning <- function(schm, segment_encoding){
+    .Call(`_arrow_dataset___DirectoryPartitioning`, schm, segment_encoding)
 }
 
-dataset___DirectoryPartitioning__MakeFactory <- function(field_names, url_decode_segments){
-    .Call(`_arrow_dataset___DirectoryPartitioning__MakeFactory`, field_names, url_decode_segments)
+dataset___DirectoryPartitioning__MakeFactory <- function(field_names, segment_encoding){
+    .Call(`_arrow_dataset___DirectoryPartitioning__MakeFactory`, field_names, segment_encoding)
 }
 
-dataset___HivePartitioning <- function(schm, null_fallback, url_decode_segments){
-    .Call(`_arrow_dataset___HivePartitioning`, schm, null_fallback, url_decode_segments)
+dataset___HivePartitioning <- function(schm, null_fallback, segment_encoding){
+    .Call(`_arrow_dataset___HivePartitioning`, schm, null_fallback, segment_encoding)
 }
 
-dataset___HivePartitioning__MakeFactory <- function(null_fallback, url_decode_segments){
-    .Call(`_arrow_dataset___HivePartitioning__MakeFactory`, null_fallback, url_decode_segments)
+dataset___HivePartitioning__MakeFactory <- function(null_fallback, segment_encoding){
+    .Call(`_arrow_dataset___HivePartitioning__MakeFactory`, null_fallback, segment_encoding)
 }
 
 dataset___ScannerBuilder__ProjectNames <- function(sb, cols){

--- a/r/R/dataset-partition.R
+++ b/r/R/dataset-partition.R
@@ -64,7 +64,7 @@ Partitioning <- R6Class("Partitioning", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioning <- R6Class("DirectoryPartitioning", inherit = Partitioning)
-DirectoryPartitioning$create <- function(schm, segment_encoding = "url") {
+DirectoryPartitioning$create <- function(schm, segment_encoding = "uri") {
   dataset___DirectoryPartitioning(schm, segment_encoding = segment_encoding)
 }
 
@@ -73,7 +73,7 @@ DirectoryPartitioning$create <- function(schm, segment_encoding = "url") {
 #' @rdname Partitioning
 #' @export
 HivePartitioning <- R6Class("HivePartitioning", inherit = Partitioning)
-HivePartitioning$create <- function(schm, null_fallback = NULL, segment_encoding = "url") {
+HivePartitioning$create <- function(schm, null_fallback = NULL, segment_encoding = "uri") {
   dataset___HivePartitioning(schm,
                              null_fallback = null_fallback_or_default(null_fallback),
                              segment_encoding = segment_encoding)
@@ -91,13 +91,13 @@ HivePartitioning$create <- function(schm, null_fallback = NULL, segment_encoding
 #' in partition columns. Default is `"__HIVE_DEFAULT_PARTITION__"`,
 #' which is what Hive uses.
 #' @param segment_encoding Decode partition segments after splitting paths.
-#' Default is `"url"` (URL-decode segments). May also be `"none"` (leave as-is).
+#' Default is `"uri"` (URI-decode segments). May also be `"none"` (leave as-is).
 #' @return A [HivePartitioning][Partitioning], or a `HivePartitioningFactory` if
 #' calling `hive_partition()` with no arguments.
 #' @examplesIf arrow_with_dataset()
 #' hive_partition(year = int16(), month = int8())
 #' @export
-hive_partition <- function(..., null_fallback = NULL, segment_encoding = "url") {
+hive_partition <- function(..., null_fallback = NULL, segment_encoding = "uri") {
   schm <- schema(...)
   if (length(schm) == 0) {
     HivePartitioningFactory$create(null_fallback, segment_encoding)
@@ -113,7 +113,7 @@ PartitioningFactory <- R6Class("PartitioningFactory", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioningFactory <- R6Class("DirectoryPartitioningFactory ", inherit = PartitioningFactory)
-DirectoryPartitioningFactory$create <- function(field_names, segment_encoding = "url") {
+DirectoryPartitioningFactory$create <- function(field_names, segment_encoding = "uri") {
   dataset___DirectoryPartitioning__MakeFactory(field_names, segment_encoding)
 }
 
@@ -122,7 +122,7 @@ DirectoryPartitioningFactory$create <- function(field_names, segment_encoding = 
 #' @rdname Partitioning
 #' @export
 HivePartitioningFactory <- R6Class("HivePartitioningFactory", inherit = PartitioningFactory)
-HivePartitioningFactory$create <- function(null_fallback = NULL, segment_encoding = "url") {
+HivePartitioningFactory$create <- function(null_fallback = NULL, segment_encoding = "uri") {
   dataset___HivePartitioning__MakeFactory(null_fallback_or_default(null_fallback), segment_encoding)
 }
 

--- a/r/R/dataset-partition.R
+++ b/r/R/dataset-partition.R
@@ -64,15 +64,19 @@ Partitioning <- R6Class("Partitioning", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioning <- R6Class("DirectoryPartitioning", inherit = Partitioning)
-DirectoryPartitioning$create <- dataset___DirectoryPartitioning
+DirectoryPartitioning$create <- function(schm, url_decode_segments = TRUE) {
+  dataset___DirectoryPartitioning(schm, url_decode_segments = url_decode_segments)
+}
 
 #' @usage NULL
 #' @format NULL
 #' @rdname Partitioning
 #' @export
 HivePartitioning <- R6Class("HivePartitioning", inherit = Partitioning)
-HivePartitioning$create <- function(schm, null_fallback = NULL) {
-  dataset___HivePartitioning(schm, null_fallback = null_fallback_or_default(null_fallback))
+HivePartitioning$create <- function(schm, null_fallback = NULL, url_decode_segments = TRUE) {
+  dataset___HivePartitioning(schm,
+                             null_fallback = null_fallback_or_default(null_fallback),
+                             url_decode_segments = url_decode_segments)
 }
 
 #' Construct Hive partitioning
@@ -86,17 +90,19 @@ HivePartitioning$create <- function(schm, null_fallback = NULL) {
 #' @param null_fallback character to be used in place of missing values (`NA` or `NULL`)
 #' in partition columns. Default is `"__HIVE_DEFAULT_PARTITION__"`,
 #' which is what Hive uses.
+#' @param url_decode_segments URL-decode partition segments after splitting paths.
+#' Default is `TRUE`.
 #' @return A [HivePartitioning][Partitioning], or a `HivePartitioningFactory` if
 #' calling `hive_partition()` with no arguments.
 #' @examplesIf arrow_with_dataset()
 #' hive_partition(year = int16(), month = int8())
 #' @export
-hive_partition <- function(..., null_fallback = NULL) {
+hive_partition <- function(..., null_fallback = NULL, url_decode_segments = TRUE) {
   schm <- schema(...)
   if (length(schm) == 0) {
-    HivePartitioningFactory$create(null_fallback)
+    HivePartitioningFactory$create(null_fallback, url_decode_segments)
   } else {
-    HivePartitioning$create(schm, null_fallback)
+    HivePartitioning$create(schm, null_fallback, url_decode_segments)
   }
 }
 
@@ -107,15 +113,17 @@ PartitioningFactory <- R6Class("PartitioningFactory", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioningFactory <- R6Class("DirectoryPartitioningFactory ", inherit = PartitioningFactory)
-DirectoryPartitioningFactory$create <- dataset___DirectoryPartitioning__MakeFactory
+DirectoryPartitioningFactory$create <- function(field_names, url_decode_segments = TRUE) {
+  dataset___DirectoryPartitioning__MakeFactory(field_names, url_decode_segments)
+}
 
 #' @usage NULL
 #' @format NULL
 #' @rdname Partitioning
 #' @export
 HivePartitioningFactory <- R6Class("HivePartitioningFactory", inherit = PartitioningFactory)
-HivePartitioningFactory$create <- function(null_fallback = NULL) {
-  dataset___HivePartitioning__MakeFactory(null_fallback_or_default(null_fallback))
+HivePartitioningFactory$create <- function(null_fallback = NULL, url_decode_segments = TRUE) {
+  dataset___HivePartitioning__MakeFactory(null_fallback_or_default(null_fallback), url_decode_segments)
 }
 
 null_fallback_or_default <- function(null_fallback) {

--- a/r/R/dataset-partition.R
+++ b/r/R/dataset-partition.R
@@ -64,8 +64,8 @@ Partitioning <- R6Class("Partitioning", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioning <- R6Class("DirectoryPartitioning", inherit = Partitioning)
-DirectoryPartitioning$create <- function(schm, url_decode_segments = TRUE) {
-  dataset___DirectoryPartitioning(schm, url_decode_segments = url_decode_segments)
+DirectoryPartitioning$create <- function(schm, segment_encoding = "url") {
+  dataset___DirectoryPartitioning(schm, segment_encoding = segment_encoding)
 }
 
 #' @usage NULL
@@ -73,10 +73,10 @@ DirectoryPartitioning$create <- function(schm, url_decode_segments = TRUE) {
 #' @rdname Partitioning
 #' @export
 HivePartitioning <- R6Class("HivePartitioning", inherit = Partitioning)
-HivePartitioning$create <- function(schm, null_fallback = NULL, url_decode_segments = TRUE) {
+HivePartitioning$create <- function(schm, null_fallback = NULL, segment_encoding = "url") {
   dataset___HivePartitioning(schm,
                              null_fallback = null_fallback_or_default(null_fallback),
-                             url_decode_segments = url_decode_segments)
+                             segment_encoding = segment_encoding)
 }
 
 #' Construct Hive partitioning
@@ -90,19 +90,19 @@ HivePartitioning$create <- function(schm, null_fallback = NULL, url_decode_segme
 #' @param null_fallback character to be used in place of missing values (`NA` or `NULL`)
 #' in partition columns. Default is `"__HIVE_DEFAULT_PARTITION__"`,
 #' which is what Hive uses.
-#' @param url_decode_segments URL-decode partition segments after splitting paths.
-#' Default is `TRUE`.
+#' @param segment_encoding Decode partition segments after splitting paths.
+#' Default is `"url"` (URL-decode segments). May also be `"none"` (leave as-is).
 #' @return A [HivePartitioning][Partitioning], or a `HivePartitioningFactory` if
 #' calling `hive_partition()` with no arguments.
 #' @examplesIf arrow_with_dataset()
 #' hive_partition(year = int16(), month = int8())
 #' @export
-hive_partition <- function(..., null_fallback = NULL, url_decode_segments = TRUE) {
+hive_partition <- function(..., null_fallback = NULL, segment_encoding = "url") {
   schm <- schema(...)
   if (length(schm) == 0) {
-    HivePartitioningFactory$create(null_fallback, url_decode_segments)
+    HivePartitioningFactory$create(null_fallback, segment_encoding)
   } else {
-    HivePartitioning$create(schm, null_fallback, url_decode_segments)
+    HivePartitioning$create(schm, null_fallback, segment_encoding)
   }
 }
 
@@ -113,8 +113,8 @@ PartitioningFactory <- R6Class("PartitioningFactory", inherit = ArrowObject)
 #' @rdname Partitioning
 #' @export
 DirectoryPartitioningFactory <- R6Class("DirectoryPartitioningFactory ", inherit = PartitioningFactory)
-DirectoryPartitioningFactory$create <- function(field_names, url_decode_segments = TRUE) {
-  dataset___DirectoryPartitioning__MakeFactory(field_names, url_decode_segments)
+DirectoryPartitioningFactory$create <- function(field_names, segment_encoding = "url") {
+  dataset___DirectoryPartitioning__MakeFactory(field_names, segment_encoding)
 }
 
 #' @usage NULL
@@ -122,8 +122,8 @@ DirectoryPartitioningFactory$create <- function(field_names, url_decode_segments
 #' @rdname Partitioning
 #' @export
 HivePartitioningFactory <- R6Class("HivePartitioningFactory", inherit = PartitioningFactory)
-HivePartitioningFactory$create <- function(null_fallback = NULL, url_decode_segments = TRUE) {
-  dataset___HivePartitioning__MakeFactory(null_fallback_or_default(null_fallback), url_decode_segments)
+HivePartitioningFactory$create <- function(null_fallback = NULL, segment_encoding = "url") {
+  dataset___HivePartitioning__MakeFactory(null_fallback_or_default(null_fallback), segment_encoding)
 }
 
 null_fallback_or_default <- function(null_fallback) {

--- a/r/man/hive_partition.Rd
+++ b/r/man/hive_partition.Rd
@@ -4,7 +4,7 @@
 \alias{hive_partition}
 \title{Construct Hive partitioning}
 \usage{
-hive_partition(..., null_fallback = NULL)
+hive_partition(..., null_fallback = NULL, url_decode_segments = TRUE)
 }
 \arguments{
 \item{...}{named list of \link[=data-type]{data types}, passed to \code{\link[=schema]{schema()}}}
@@ -12,6 +12,9 @@ hive_partition(..., null_fallback = NULL)
 \item{null_fallback}{character to be used in place of missing values (\code{NA} or \code{NULL})
 in partition columns. Default is \code{"__HIVE_DEFAULT_PARTITION__"},
 which is what Hive uses.}
+
+\item{url_decode_segments}{URL-decode partition segments after splitting paths.
+Default is \code{TRUE}.}
 }
 \value{
 A \link[=Partitioning]{HivePartitioning}, or a \code{HivePartitioningFactory} if

--- a/r/man/hive_partition.Rd
+++ b/r/man/hive_partition.Rd
@@ -4,7 +4,7 @@
 \alias{hive_partition}
 \title{Construct Hive partitioning}
 \usage{
-hive_partition(..., null_fallback = NULL, segment_encoding = "url")
+hive_partition(..., null_fallback = NULL, segment_encoding = "uri")
 }
 \arguments{
 \item{...}{named list of \link[=data-type]{data types}, passed to \code{\link[=schema]{schema()}}}
@@ -14,7 +14,7 @@ in partition columns. Default is \code{"__HIVE_DEFAULT_PARTITION__"},
 which is what Hive uses.}
 
 \item{segment_encoding}{Decode partition segments after splitting paths.
-Default is \code{"url"} (URL-decode segments). May also be \code{"none"} (leave as-is).}
+Default is \code{"uri"} (URI-decode segments). May also be \code{"none"} (leave as-is).}
 }
 \value{
 A \link[=Partitioning]{HivePartitioning}, or a \code{HivePartitioningFactory} if

--- a/r/man/hive_partition.Rd
+++ b/r/man/hive_partition.Rd
@@ -4,7 +4,7 @@
 \alias{hive_partition}
 \title{Construct Hive partitioning}
 \usage{
-hive_partition(..., null_fallback = NULL, url_decode_segments = TRUE)
+hive_partition(..., null_fallback = NULL, segment_encoding = "url")
 }
 \arguments{
 \item{...}{named list of \link[=data-type]{data types}, passed to \code{\link[=schema]{schema()}}}
@@ -13,8 +13,8 @@ hive_partition(..., null_fallback = NULL, url_decode_segments = TRUE)
 in partition columns. Default is \code{"__HIVE_DEFAULT_PARTITION__"},
 which is what Hive uses.}
 
-\item{url_decode_segments}{URL-decode partition segments after splitting paths.
-Default is \code{TRUE}.}
+\item{segment_encoding}{Decode partition segments after splitting paths.
+Default is \code{"url"} (URL-decode segments). May also be \code{"none"} (leave as-is).}
 }
 \value{
 A \link[=Partitioning]{HivePartitioning}, or a \code{HivePartitioningFactory} if

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1856,65 +1856,65 @@ extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffe
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(const std::shared_ptr<arrow::Schema>& schm, bool url_decode_segments);
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP url_decode_segments_sexp){
+std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(const std::shared_ptr<arrow::Schema>& schm, const std::string& segment_encoding);
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP segment_encoding_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Schema>&>::type schm(schm_sexp);
-	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
-	return cpp11::as_sexp(dataset___DirectoryPartitioning(schm, url_decode_segments));
+	arrow::r::Input<const std::string&>::type segment_encoding(segment_encoding_sexp);
+	return cpp11::as_sexp(dataset___DirectoryPartitioning(schm, segment_encoding));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP url_decode_segments_sexp){
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP segment_encoding_sexp){
 	Rf_error("Cannot call dataset___DirectoryPartitioning(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(const std::vector<std::string>& field_names, bool url_decode_segments);
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP url_decode_segments_sexp){
+std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(const std::vector<std::string>& field_names, const std::string& segment_encoding);
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP segment_encoding_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::vector<std::string>&>::type field_names(field_names_sexp);
-	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
-	return cpp11::as_sexp(dataset___DirectoryPartitioning__MakeFactory(field_names, url_decode_segments));
+	arrow::r::Input<const std::string&>::type segment_encoding(segment_encoding_sexp);
+	return cpp11::as_sexp(dataset___DirectoryPartitioning__MakeFactory(field_names, segment_encoding));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP url_decode_segments_sexp){
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP segment_encoding_sexp){
 	Rf_error("Cannot call dataset___DirectoryPartitioning__MakeFactory(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback, bool url_decode_segments);
-extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
+std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback, const std::string& segment_encoding);
+extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP segment_encoding_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Schema>&>::type schm(schm_sexp);
 	arrow::r::Input<const std::string&>::type null_fallback(null_fallback_sexp);
-	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
-	return cpp11::as_sexp(dataset___HivePartitioning(schm, null_fallback, url_decode_segments));
+	arrow::r::Input<const std::string&>::type segment_encoding(segment_encoding_sexp);
+	return cpp11::as_sexp(dataset___HivePartitioning(schm, null_fallback, segment_encoding));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
+extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP segment_encoding_sexp){
 	Rf_error("Cannot call dataset___HivePartitioning(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(const std::string& null_fallback, bool url_decode_segments);
-extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
+std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(const std::string& null_fallback, const std::string& segment_encoding);
+extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP segment_encoding_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::string&>::type null_fallback(null_fallback_sexp);
-	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
-	return cpp11::as_sexp(dataset___HivePartitioning__MakeFactory(null_fallback, url_decode_segments));
+	arrow::r::Input<const std::string&>::type segment_encoding(segment_encoding_sexp);
+	return cpp11::as_sexp(dataset___HivePartitioning__MakeFactory(null_fallback, segment_encoding));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
+extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP segment_encoding_sexp){
 	Rf_error("Cannot call dataset___HivePartitioning__MakeFactory(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1856,61 +1856,65 @@ extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffe
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(const std::shared_ptr<arrow::Schema>& schm);
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp){
+std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(const std::shared_ptr<arrow::Schema>& schm, bool url_decode_segments);
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP url_decode_segments_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Schema>&>::type schm(schm_sexp);
-	return cpp11::as_sexp(dataset___DirectoryPartitioning(schm));
+	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
+	return cpp11::as_sexp(dataset___DirectoryPartitioning(schm, url_decode_segments));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp){
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning(SEXP schm_sexp, SEXP url_decode_segments_sexp){
 	Rf_error("Cannot call dataset___DirectoryPartitioning(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(const std::vector<std::string>& field_names);
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp){
+std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(const std::vector<std::string>& field_names, bool url_decode_segments);
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP url_decode_segments_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::vector<std::string>&>::type field_names(field_names_sexp);
-	return cpp11::as_sexp(dataset___DirectoryPartitioning__MakeFactory(field_names));
+	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
+	return cpp11::as_sexp(dataset___DirectoryPartitioning__MakeFactory(field_names, url_decode_segments));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp){
+extern "C" SEXP _arrow_dataset___DirectoryPartitioning__MakeFactory(SEXP field_names_sexp, SEXP url_decode_segments_sexp){
 	Rf_error("Cannot call dataset___DirectoryPartitioning__MakeFactory(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback);
-extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp){
+std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback, bool url_decode_segments);
+extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Schema>&>::type schm(schm_sexp);
 	arrow::r::Input<const std::string&>::type null_fallback(null_fallback_sexp);
-	return cpp11::as_sexp(dataset___HivePartitioning(schm, null_fallback));
+	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
+	return cpp11::as_sexp(dataset___HivePartitioning(schm, null_fallback, url_decode_segments));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp){
+extern "C" SEXP _arrow_dataset___HivePartitioning(SEXP schm_sexp, SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
 	Rf_error("Cannot call dataset___HivePartitioning(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(const std::string& null_fallback);
-extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp){
+std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(const std::string& null_fallback, bool url_decode_segments);
+extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::string&>::type null_fallback(null_fallback_sexp);
-	return cpp11::as_sexp(dataset___HivePartitioning__MakeFactory(null_fallback));
+	arrow::r::Input<bool>::type url_decode_segments(url_decode_segments_sexp);
+	return cpp11::as_sexp(dataset___HivePartitioning__MakeFactory(null_fallback, url_decode_segments));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp){
+extern "C" SEXP _arrow_dataset___HivePartitioning__MakeFactory(SEXP null_fallback_sexp, SEXP url_decode_segments_sexp){
 	Rf_error("Cannot call dataset___HivePartitioning__MakeFactory(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -7005,10 +7009,10 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___FragmentScanOptions__type_name", (DL_FUNC) &_arrow_dataset___FragmentScanOptions__type_name, 1}, 
 		{ "_arrow_dataset___CsvFragmentScanOptions__Make", (DL_FUNC) &_arrow_dataset___CsvFragmentScanOptions__Make, 2}, 
 		{ "_arrow_dataset___ParquetFragmentScanOptions__Make", (DL_FUNC) &_arrow_dataset___ParquetFragmentScanOptions__Make, 3}, 
-		{ "_arrow_dataset___DirectoryPartitioning", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning, 1}, 
-		{ "_arrow_dataset___DirectoryPartitioning__MakeFactory", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning__MakeFactory, 1}, 
-		{ "_arrow_dataset___HivePartitioning", (DL_FUNC) &_arrow_dataset___HivePartitioning, 2}, 
-		{ "_arrow_dataset___HivePartitioning__MakeFactory", (DL_FUNC) &_arrow_dataset___HivePartitioning__MakeFactory, 1}, 
+		{ "_arrow_dataset___DirectoryPartitioning", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning, 2}, 
+		{ "_arrow_dataset___DirectoryPartitioning__MakeFactory", (DL_FUNC) &_arrow_dataset___DirectoryPartitioning__MakeFactory, 2}, 
+		{ "_arrow_dataset___HivePartitioning", (DL_FUNC) &_arrow_dataset___HivePartitioning, 3}, 
+		{ "_arrow_dataset___HivePartitioning__MakeFactory", (DL_FUNC) &_arrow_dataset___HivePartitioning__MakeFactory, 2}, 
 		{ "_arrow_dataset___ScannerBuilder__ProjectNames", (DL_FUNC) &_arrow_dataset___ScannerBuilder__ProjectNames, 2}, 
 		{ "_arrow_dataset___ScannerBuilder__ProjectExprs", (DL_FUNC) &_arrow_dataset___ScannerBuilder__ProjectExprs, 3}, 
 		{ "_arrow_dataset___ScannerBuilder__Filter", (DL_FUNC) &_arrow_dataset___ScannerBuilder__Filter, 2}, 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -336,8 +336,8 @@ dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buf
 ds::SegmentEncoding GetSegmentEncoding(const std::string& segment_encoding) {
   if (segment_encoding == "none") {
     return ds::SegmentEncoding::None;
-  } else if (segment_encoding == "url") {
-    return ds::SegmentEncoding::Url;
+  } else if (segment_encoding == "uri") {
+    return ds::SegmentEncoding::Uri;
   }
   cpp11::stop("invalid segment encoding: " + segment_encoding);
   return ds::SegmentEncoding::None;

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -335,28 +335,38 @@ dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buf
 
 // [[dataset::export]]
 std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(
-    const std::shared_ptr<arrow::Schema>& schm) {
-  return std::make_shared<ds::DirectoryPartitioning>(schm);
+    const std::shared_ptr<arrow::Schema>& schm, bool url_decode_segments) {
+  ds::KeyValuePartitioningOptions options;
+  options.url_decode_segments = url_decode_segments;
+  std::vector<std::shared_ptr<arrow::Array>> dictionaries;
+  return std::make_shared<ds::DirectoryPartitioning>(schm, dictionaries, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(
-    const std::vector<std::string>& field_names) {
-  return ds::DirectoryPartitioning::MakeFactory(field_names);
+    const std::vector<std::string>& field_names, bool url_decode_segments) {
+  ds::PartitioningFactoryOptions options;
+  options.url_decode_segments = url_decode_segments;
+  return ds::DirectoryPartitioning::MakeFactory(field_names, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(
-    const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback) {
+    const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback,
+    bool url_decode_segments) {
+  ds::HivePartitioningOptions options;
+  options.null_fallback = null_fallback;
+  options.url_decode_segments = url_decode_segments;
   std::vector<std::shared_ptr<arrow::Array>> dictionaries;
-  return std::make_shared<ds::HivePartitioning>(schm, dictionaries, null_fallback);
+  return std::make_shared<ds::HivePartitioning>(schm, dictionaries, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(
-    const std::string& null_fallback) {
+    const std::string& null_fallback, bool url_decode_segments) {
   ds::HivePartitioningFactoryOptions options;
   options.null_fallback = null_fallback;
+  options.url_decode_segments = url_decode_segments;
   return ds::HivePartitioning::MakeFactory(options);
 }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -333,40 +333,50 @@ dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buf
 
 // DirectoryPartitioning, HivePartitioning
 
+ds::SegmentEncoding GetSegmentEncoding(const std::string& segment_encoding) {
+  if (segment_encoding == "none") {
+    return ds::SegmentEncoding::None;
+  } else if (segment_encoding == "url") {
+    return ds::SegmentEncoding::Url;
+  }
+  cpp11::stop("invalid segment encoding: " + segment_encoding);
+  return ds::SegmentEncoding::None;
+}
+
 // [[dataset::export]]
 std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(
-    const std::shared_ptr<arrow::Schema>& schm, bool url_decode_segments) {
+    const std::shared_ptr<arrow::Schema>& schm, const std::string& segment_encoding) {
   ds::KeyValuePartitioningOptions options;
-  options.url_decode_segments = url_decode_segments;
+  options.segment_encoding = GetSegmentEncoding(segment_encoding);
   std::vector<std::shared_ptr<arrow::Array>> dictionaries;
   return std::make_shared<ds::DirectoryPartitioning>(schm, dictionaries, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::PartitioningFactory> dataset___DirectoryPartitioning__MakeFactory(
-    const std::vector<std::string>& field_names, bool url_decode_segments) {
+    const std::vector<std::string>& field_names, const std::string& segment_encoding) {
   ds::PartitioningFactoryOptions options;
-  options.url_decode_segments = url_decode_segments;
+  options.segment_encoding = GetSegmentEncoding(segment_encoding);
   return ds::DirectoryPartitioning::MakeFactory(field_names, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(
     const std::shared_ptr<arrow::Schema>& schm, const std::string& null_fallback,
-    bool url_decode_segments) {
+    const std::string& segment_encoding) {
   ds::HivePartitioningOptions options;
   options.null_fallback = null_fallback;
-  options.url_decode_segments = url_decode_segments;
+  options.segment_encoding = GetSegmentEncoding(segment_encoding);
   std::vector<std::shared_ptr<arrow::Array>> dictionaries;
   return std::make_shared<ds::HivePartitioning>(schm, dictionaries, options);
 }
 
 // [[dataset::export]]
 std::shared_ptr<ds::PartitioningFactory> dataset___HivePartitioning__MakeFactory(
-    const std::string& null_fallback, bool url_decode_segments) {
+    const std::string& null_fallback, const std::string& segment_encoding) {
   ds::HivePartitioningFactoryOptions options;
   options.null_fallback = null_fallback;
-  options.url_decode_segments = url_decode_segments;
+  options.segment_encoding = GetSegmentEncoding(segment_encoding);
   return ds::HivePartitioning::MakeFactory(options);
 }
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1127,7 +1127,7 @@ test_that("URL-decoding with directory partitioning", {
 
   partitioning <- DirectoryPartitioning$create(
     schema(date = timestamp(unit = "s"), string = utf8()),
-    url_decode_segments = FALSE)
+    segment_encoding = "none")
   factory <- FileSystemDatasetFactory$create(
     fs, selector, NULL, fmt, partitioning = partitioning)
   schm <- factory$Inspect()
@@ -1149,7 +1149,7 @@ test_that("URL-decoding with directory partitioning", {
   )
 
   partitioning_factory <- DirectoryPartitioningFactory$create(
-    c("date", "string"), url_decode_segments = FALSE)
+    c("date", "string"), segment_encoding = "none")
   factory <- FileSystemDatasetFactory$create(
     fs, selector, NULL, fmt, partitioning_factory)
   schm <- factory$Inspect()
@@ -1180,7 +1180,7 @@ test_that("URL-decoding with hive partitioning", {
   expect_scan_result(ds, schm)
 
   partitioning <- hive_partition(
-    date = timestamp(unit = "s"), string = utf8(), url_decode_segments = FALSE)
+    date = timestamp(unit = "s"), string = utf8(), segment_encoding = "none")
   factory <- FileSystemDatasetFactory$create(
     fs, selector, NULL, fmt, partitioning = partitioning)
   expect_error(factory$Finish(schm), "Invalid: error parsing")
@@ -1199,7 +1199,7 @@ test_that("URL-decoding with hive partitioning", {
     df1 %>% select(int) %>% collect()
   )
 
-  partitioning_factory <- hive_partition(url_decode_segments = FALSE)
+  partitioning_factory <- hive_partition(segment_encoding = "none")
   factory <- FileSystemDatasetFactory$create(
     fs, selector, NULL, fmt, partitioning_factory)
   schm <- factory$Inspect()

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1108,7 +1108,7 @@ test_that("Assembling a Dataset manually and getting a Table", {
   expect_scan_result(ds, schm)
 })
 
-test_that("URL-decoding with directory partitioning", {
+test_that("URI-decoding with directory partitioning", {
   root <- make_temp_dir()
   fmt <- FileFormat$create("feather")
   fs <- LocalFileSystem$create()
@@ -1163,7 +1163,7 @@ test_that("URL-decoding with directory partitioning", {
   )
 })
 
-test_that("URL-decoding with hive partitioning", {
+test_that("URI-decoding with hive partitioning", {
   root <- make_temp_dir()
   fmt <- FileFormat$create("feather")
   fs <- LocalFileSystem$create()

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1108,6 +1108,117 @@ test_that("Assembling a Dataset manually and getting a Table", {
   expect_scan_result(ds, schm)
 })
 
+test_that("URL-decoding with directory partitioning", {
+  root <- make_temp_dir()
+  fmt <- FileFormat$create("feather")
+  fs <- LocalFileSystem$create()
+  selector <- FileSelector$create(root, recursive = TRUE)
+  dir1 <- file.path(root, "2021-05-04 00%3A00%3A00", "%24")
+  dir2 <- file.path(root, "2021-05-05 00:00:00", "$")
+  dir.create(dir1, recursive = TRUE)
+  dir.create(dir2, recursive = TRUE)
+  write_feather(df1, file.path(dir1, "data.feather"))
+  write_feather(df2, file.path(dir2, "data.feather"))
+
+  partitioning <- DirectoryPartitioning$create(
+    schema(date = timestamp(unit = "s"), string = utf8()))
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning = partitioning)
+  schm <- factory$Inspect()
+  ds <- factory$Finish(schm)
+  expect_scan_result(ds, schm)
+
+  partitioning <- DirectoryPartitioning$create(
+    schema(date = timestamp(unit = "s"), string = utf8()),
+    url_decode_segments = FALSE)
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning = partitioning)
+  schm <- factory$Inspect()
+  expect_error(factory$Finish(schm), "Invalid: error parsing")
+
+  partitioning_factory <- DirectoryPartitioningFactory$create(
+    c("date", "string"))
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning_factory)
+  schm <- factory$Inspect()
+  ds <- factory$Finish(schm)
+  # Can't directly inspect partition expressions, so do it implicitly via scan
+  expect_equal(
+    ds %>%
+      filter(date == "2021-05-04 00:00:00") %>%
+      select(int) %>%
+      collect(),
+    df1 %>% select(int) %>% collect()
+  )
+
+  partitioning_factory <- DirectoryPartitioningFactory$create(
+    c("date", "string"), url_decode_segments = FALSE)
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning_factory)
+  schm <- factory$Inspect()
+  ds <- factory$Finish(schm)
+  expect_equal(
+    ds %>%
+      filter(date == "2021-05-04 00%3A00%3A00") %>%
+      select(int) %>%
+      collect(),
+    df1 %>% select(int) %>% collect()
+  )
+})
+
+test_that("URL-decoding with hive partitioning", {
+  root <- make_temp_dir()
+  fmt <- FileFormat$create("feather")
+  fs <- LocalFileSystem$create()
+  selector <- FileSelector$create(root, recursive = TRUE)
+  dir1 <- file.path(root, "date=2021-05-04 00%3A00%3A00", "string=%24")
+  dir2 <- file.path(root, "date=2021-05-05 00:00:00", "string=$")
+  dir.create(dir1, recursive = TRUE)
+  dir.create(dir2, recursive = TRUE)
+  write_feather(df1, file.path(dir1, "data.feather"))
+  write_feather(df2, file.path(dir2, "data.feather"))
+
+  partitioning <- hive_partition(
+    date = timestamp(unit = "s"), string = utf8())
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning = partitioning)
+  ds <- factory$Finish(schm)
+  expect_scan_result(ds, schm)
+
+  partitioning <- hive_partition(
+    date = timestamp(unit = "s"), string = utf8(), url_decode_segments = FALSE)
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning = partitioning)
+  expect_error(factory$Finish(schm), "Invalid: error parsing")
+
+  partitioning_factory <- hive_partition()
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning_factory)
+  schm <- factory$Inspect()
+  ds <- factory$Finish(schm)
+  # Can't directly inspect partition expressions, so do it implicitly via scan
+  expect_equal(
+    ds %>%
+      filter(date == "2021-05-04 00:00:00") %>%
+      select(int) %>%
+      collect(),
+    df1 %>% select(int) %>% collect()
+  )
+
+  partitioning_factory <- hive_partition(url_decode_segments = FALSE)
+  factory <- FileSystemDatasetFactory$create(
+    fs, selector, NULL, fmt, partitioning_factory)
+  schm <- factory$Inspect()
+  ds <- factory$Finish(schm)
+  expect_equal(
+    ds %>%
+      filter(date == "2021-05-04 00%3A00%3A00") %>%
+      select(int) %>%
+      collect(),
+    df1 %>% select(int) %>% collect()
+  )
+})
+
 test_that("Assembling multiple DatasetFactories with DatasetFactory", {
   skip_if_not_available("parquet")
   factory1 <- dataset_factory(file.path(dataset_dir, 1), format = "parquet")

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1114,11 +1114,8 @@ test_that("URL-decoding with directory partitioning", {
   fs <- LocalFileSystem$create()
   selector <- FileSelector$create(root, recursive = TRUE)
   dir1 <- file.path(root, "2021-05-04 00%3A00%3A00", "%24")
-  dir2 <- file.path(root, "2021-05-05 00:00:00", "$")
   dir.create(dir1, recursive = TRUE)
-  dir.create(dir2, recursive = TRUE)
   write_feather(df1, file.path(dir1, "data.feather"))
-  write_feather(df2, file.path(dir2, "data.feather"))
 
   partitioning <- DirectoryPartitioning$create(
     schema(date = timestamp(unit = "s"), string = utf8()))
@@ -1145,7 +1142,7 @@ test_that("URL-decoding with directory partitioning", {
   # Can't directly inspect partition expressions, so do it implicitly via scan
   expect_equal(
     ds %>%
-      filter(date == "2021-05-04 00:00:00") %>%
+      filter(date == "2021-05-04 00:00:00", string == "$") %>%
       select(int) %>%
       collect(),
     df1 %>% select(int) %>% collect()
@@ -1159,7 +1156,7 @@ test_that("URL-decoding with directory partitioning", {
   ds <- factory$Finish(schm)
   expect_equal(
     ds %>%
-      filter(date == "2021-05-04 00%3A00%3A00") %>%
+      filter(date == "2021-05-04 00%3A00%3A00", string == "%24") %>%
       select(int) %>%
       collect(),
     df1 %>% select(int) %>% collect()
@@ -1172,11 +1169,8 @@ test_that("URL-decoding with hive partitioning", {
   fs <- LocalFileSystem$create()
   selector <- FileSelector$create(root, recursive = TRUE)
   dir1 <- file.path(root, "date=2021-05-04 00%3A00%3A00", "string=%24")
-  dir2 <- file.path(root, "date=2021-05-05 00:00:00", "string=$")
   dir.create(dir1, recursive = TRUE)
-  dir.create(dir2, recursive = TRUE)
   write_feather(df1, file.path(dir1, "data.feather"))
-  write_feather(df2, file.path(dir2, "data.feather"))
 
   partitioning <- hive_partition(
     date = timestamp(unit = "s"), string = utf8())
@@ -1199,7 +1193,7 @@ test_that("URL-decoding with hive partitioning", {
   # Can't directly inspect partition expressions, so do it implicitly via scan
   expect_equal(
     ds %>%
-      filter(date == "2021-05-04 00:00:00") %>%
+      filter(date == "2021-05-04 00:00:00", string == "$") %>%
       select(int) %>%
       collect(),
     df1 %>% select(int) %>% collect()
@@ -1212,7 +1206,7 @@ test_that("URL-decoding with hive partitioning", {
   ds <- factory$Finish(schm)
   expect_equal(
     ds %>%
-      filter(date == "2021-05-04 00%3A00%3A00") %>%
+      filter(date == "2021-05-04 00%3A00%3A00", string == "%24") %>%
       select(int) %>%
       collect(),
     df1 %>% select(int) %>% collect()


### PR DESCRIPTION
Now by default, directory/hive partitioning will URL-decode potential partition values before trying to parse them, since systems like Spark apparently may URL-encode the values in some cases. Note for Hive partitioning, this applies only to the value, not to the key itself. This behavior can be toggled.