### PR TITLE
ARROW-12677: [Python] Add a mask argument to pyarrow.StructArray.from_arrays

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2231,13 +2231,13 @@ cdef class StructArray(Array):
             c_mask = shared_ptr[CBuffer]()
         elif isinstance(mask, Array):
             if mask.type != bool_():
-                raise ValueError('Mask must be a pyarray.Array of type bool')
+                raise ValueError('Mask must be a pyarrow.Array of type bool')
             if mask.null_count != 0:
                 raise ValueError('Mask must not contain nulls')
             inverted_mask = _pc().invert(mask, memory_pool=memory_pool)
             c_mask = pyarrow_unwrap_buffer(inverted_mask.buffers()[1])
         else:
-            raise ValueError('Mask must be a pyarray.Array of type bool')
+            raise ValueError('Mask must be a pyarrow.Array of type bool')
 
         arrays = [asarray(x) for x in arrays]
         for arr in arrays:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2186,7 +2186,8 @@ cdef class StructArray(Array):
         return [pyarrow_wrap_array(arr) for arr in arrays]
 
     @staticmethod
-    def from_arrays(arrays, names=None, fields=None, mask=None, memory_pool=None):
+    def from_arrays(arrays, names=None, fields=None, mask=None,
+                    memory_pool=None):
         """
         Construct StructArray from collection of arrays representing
         each field in the struct.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2230,7 +2230,7 @@ cdef class StructArray(Array):
         if mask is None:
             c_mask = shared_ptr[CBuffer]()
         elif isinstance(mask, Array):
-            if mask.type != bool_():
+            if mask.type.id != Type_BOOL:
                 raise ValueError('Mask must be a pyarrow.Array of type bool')
             if mask.null_count != 0:
                 raise ValueError('Mask must not contain nulls')

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2153,7 +2153,7 @@ cdef class StructArray(Array):
         return [pyarrow_wrap_array(arr) for arr in arrays]
 
     @staticmethod
-    def from_arrays(arrays, names=None, fields=None):
+    def from_arrays(arrays, names=None, fields=None, mask=None):
         """
         Construct StructArray from collection of arrays representing
         each field in the struct.
@@ -2167,6 +2167,8 @@ cdef class StructArray(Array):
             Field names for each struct child.
         fields : List[Field] (optional)
             Field instances for each struct child.
+        mask : pyarrow.Array[bool] (optional)
+            Indicate which values are null (False) or not null (True).
 
         Returns
         -------
@@ -2174,6 +2176,7 @@ cdef class StructArray(Array):
         """
         cdef:
             shared_ptr[CArray] c_array
+            shared_ptr[CBuffer] c_mask
             vector[shared_ptr[CArray]] c_arrays
             vector[c_string] c_names
             vector[shared_ptr[CField]] c_fields
@@ -2188,6 +2191,17 @@ cdef class StructArray(Array):
             raise ValueError('Must pass either names or fields')
         if names is not None and fields is not None:
             raise ValueError('Must pass either names or fields, not both')
+
+        if mask is None:
+            c_mask = shared_ptr[CBuffer]()
+        elif isinstance(mask, Array):
+            if mask.type != bool_():
+                raise ValueError('Mask must be a pyarray.Array of type bool')
+            if mask.null_count != 0:
+                raise ValueError('Mask must not contain nulls')
+            c_mask = pyarrow_unwrap_buffer(mask.buffers()[1])
+        else:
+            raise ValueError('Mask must be a pyarray.Array of type bool')
 
         arrays = [asarray(x) for x in arrays]
         for arr in arrays:
@@ -2215,10 +2229,10 @@ cdef class StructArray(Array):
             # XXX Cannot pass "nullptr" for a shared_ptr<T> argument:
             # https://github.com/cython/cython/issues/3020
             c_result = CStructArray.MakeFromFieldNames(
-                c_arrays, c_names, shared_ptr[CBuffer](), -1, 0)
+                c_arrays, c_names, c_mask, -1, 0)
         else:
             c_result = CStructArray.MakeFromFields(
-                c_arrays, c_fields, shared_ptr[CBuffer](), -1, 0)
+                c_arrays, c_fields, c_mask, -1, 0)
         cdef Array result = pyarrow_wrap_array(GetResultValue(c_result))
         result.validate()
         return result

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -671,7 +671,7 @@ def test_struct_from_arrays():
     arrays = [a, b, c]
     fields = [fa, fb, fc]
     # With mask
-    mask = pa.array([False, True, True])
+    mask = pa.array([True, False, False])
     arr = pa.StructArray.from_arrays(arrays, fields=fields, mask=mask)
     assert arr.to_pylist() == [None] + expected_list[1:]
 
@@ -953,6 +953,24 @@ def test_fixed_size_list_from_arrays():
         # length of values not multiple of 5
         pa.FixedSizeListArray.from_arrays(values, 5)
 
+
+def test_variable_list_from_arrays():
+    values = pa.array([1, 2, 3, 4], pa.int64())
+    offsets = pa.array([0, 2, 4])
+    result = pa.ListArray.from_arrays(offsets, values)
+    assert result.to_pylist() == [[1, 2], [3, 4]]
+    assert result.type.equals(pa.list_(pa.int64()))
+
+    offsets = pa.array([0, None, 2, 4])
+    result = pa.ListArray.from_arrays(offsets, values)
+    assert result.to_pylist() == [[1, 2], None, [3, 4]]
+
+    # raise if offset out of bounds
+    with pytest.raises(ValueError):
+        pa.ListArray.from_arrays(pa.array([-1, 2, 4]), values)
+
+    with pytest.raises(ValueError):
+        pa.ListArray.from_arrays(pa.array([0, 2, 5]), values)
 
 def test_union_from_dense():
     binary = pa.array([b'a', b'b', b'c', b'd'], type='binary')

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -668,6 +668,28 @@ def test_struct_from_arrays():
     with pytest.raises(ValueError, match="int64 vs int32"):
         pa.StructArray.from_arrays([a, b, c], fields=[fa2, fb, fc])
 
+    arrays = [a, b, c]
+    fields = [fa, fb, fc]
+    # With mask
+    mask = pa.array([False, True, True])
+    arr = pa.StructArray.from_arrays(arrays, fields=fields, mask=mask)
+    assert arr.to_pylist() == [None] + expected_list[1:]
+
+    arr = pa.StructArray.from_arrays(arrays, names=['a', 'b', 'c'], mask=mask)
+    assert arr.to_pylist() == [None] + expected_list[1:]
+
+    # Bad masks
+    with pytest.raises(ValueError):
+        pa.StructArray.from_arrays(arrays, fields, mask=[True, False, False])
+
+    with pytest.raises(ValueError):
+        pa.StructArray.from_arrays(
+            arrays, fields, mask=pa.array([True, False, None]))
+
+    with pytest.raises(ValueError):
+        pa.StructArray.from_arrays(
+            arrays, fields, mask=pa.chunked_array([mask]))
+
 
 def test_struct_array_from_chunked():
     # ARROW-11780

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -679,14 +679,14 @@ def test_struct_from_arrays():
     assert arr.to_pylist() == [None] + expected_list[1:]
 
     # Bad masks
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Mask must be'):
         pa.StructArray.from_arrays(arrays, fields, mask=[True, False, False])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='not contain nulls'):
         pa.StructArray.from_arrays(
             arrays, fields, mask=pa.array([True, False, None]))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Mask must be'):
         pa.StructArray.from_arrays(
             arrays, fields, mask=pa.chunked_array([mask]))
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -972,6 +972,7 @@ def test_variable_list_from_arrays():
     with pytest.raises(ValueError):
         pa.ListArray.from_arrays(pa.array([0, 2, 5]), values)
 
+
 def test_union_from_dense():
     binary = pa.array([b'a', b'b', b'c', b'd'], type='binary')
     int64 = pa.array([1, 2, 3], type='int64')


### PR DESCRIPTION
This allows the user to supply an optional `mask` when creating a struct array.

 * The mask requirements are pretty strict (must be a boolean arrow array without nulls) compared with some of the other functions (e.g. `array.mask` accepts a wide variety of inputs).  I think this should be ok since this use case is probably rarer and there are other plenty of existing ways to convert other datatypes to an arrow array.
 * ~~Unfortunately, StructArray::Make interprets the "null buffer" as more of a validity buffer (1 = valid, 0 = null).  This is the opposite of everywhere else a `mask` is used.  I was torn between inverting the input buffer to mimic the python API and passing through directly to the C interface for simplicity.  I chose the simpler option but could be convinced otherwise.~~ Per request, I now invert the mask to align with the python API.