### PR TITLE
MINOR: Remove badges that do not apply to the whole project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 
 # Apache Arrow
 
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/apache/arrow/branch/master?svg=true)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/arrow/branch/master)
-[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/arrow.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:arrow)
 [![License](http://img.shields.io/:license-Apache%202-blue.svg)](https://github.com/apache/arrow/blob/master/LICENSE.txt)
 [![Twitter Follow](https://img.shields.io/twitter/follow/apachearrow.svg?style=social&label=Follow)](https://twitter.com/apachearrow)
 


### PR DESCRIPTION
The build badge shows unknown for me 

<img width="139" alt="Screen Shot 2021-05-08 at 10 02 33" src="https://user-images.githubusercontent.com/589034/117547445-85f8a000-afe4-11eb-911d-c1a4c5cf76a2.png">
