### PR TITLE
MINOR: [Python] Document Python 3.9 support

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -28,7 +28,7 @@ using a 64-bit system.
 Python Compatibility
 --------------------
 
-PyArrow is currently compatible with Python 3.6, 3.7 and 3.8.
+PyArrow is currently compatible with Python 3.6, 3.7, 3.8, and 3.9.
 
 Using Conda
 -----------


### PR DESCRIPTION
Missed in #8386.