### PR TITLE
PARQUET-1798: [C++] Review logic around automatic assignment of field_id's

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1204,7 +1204,7 @@ std::vector<int> GetFieldIdsDfs(const ::arrow::FieldVector& fields) {
   return field_ids;
 }
 
-TEST_F(TestConvertRoundTrip, GroupIdDfsIfNotSpecified) {
+TEST_F(TestConvertRoundTrip, GroupIdMissingIfNotSpecified) {
   std::vector<std::shared_ptr<Field>> arrow_fields;
   arrow_fields.push_back(::arrow::field("simple", ::arrow::int32(), false));
   /// { "nested": { "outer": { "inner" }, "sibling" }
@@ -1217,9 +1217,8 @@ TEST_F(TestConvertRoundTrip, GroupIdDfsIfNotSpecified) {
 
   ASSERT_OK(ConvertSchema(arrow_fields));
   auto field_ids = GetFieldIdsDfs(result_schema_->fields());
-  auto field_id_counter = 1;
   for (int actual_id : field_ids) {
-    ASSERT_EQ(actual_id, field_id_counter++);
+    ASSERT_EQ(actual_id, -1);
   }
 }
 
@@ -1242,7 +1241,7 @@ TEST_F(TestConvertRoundTrip, GroupIdPreserveExisting) {
 
   ASSERT_OK(ConvertSchema(arrow_fields));
   auto field_ids = GetFieldIdsDfs(result_schema_->fields());
-  auto expected_field_ids = std::vector<int>{2, 1, 3, 4, 17};
+  auto expected_field_ids = std::vector<int>{2, -1, -1, -1, 17};
   ASSERT_EQ(field_ids, expected_field_ids);
 }
 

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1184,6 +1184,9 @@ class TestConvertRoundTrip : public ::testing::Test {
 };
 
 int GetFieldId(const ::arrow::Field& field) {
+  if (field.metadata() == nullptr) {
+    return -1;
+  }
   auto maybe_field = field.metadata()->Get("PARQUET:field_id");
   if (!maybe_field.ok()) {
     return -1;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -21,8 +21,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "generated/parquet_types.h"
-
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/reader_internal.h"
 #include "parquet/arrow/schema.h"
@@ -30,6 +28,7 @@
 #include "parquet/schema.h"
 #include "parquet/schema_internal.h"
 #include "parquet/test_util.h"
+#include "parquet/thrift_internal.h"
 
 #include "arrow/array.h"
 #include "arrow/testing/gtest_util.h"
@@ -44,6 +43,7 @@ using ParquetType = parquet::Type;
 using parquet::ConvertedType;
 using parquet::LogicalType;
 using parquet::Repetition;
+using parquet::format::SchemaElement;
 using parquet::internal::LevelInfo;
 using parquet::schema::GroupNode;
 using parquet::schema::NodePtr;
@@ -1179,7 +1179,7 @@ class TestConvertRoundTrip : public ::testing::Test {
  protected:
   std::shared_ptr<::arrow::Schema> arrow_schema_;
   std::shared_ptr<SchemaDescriptor> parquet_schema_;
-  std::vector<format::SchemaElement> parquet_format_schema_;
+  std::vector<SchemaElement> parquet_format_schema_;
   std::shared_ptr<::arrow::Schema> result_schema_;
 };
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -65,6 +65,9 @@ class RowGroupReader;
 /// `FileReader::RowGroup(i)->Column(j)->Read` and receive an `arrow::Column`
 /// instance.
 ///
+/// The parquet format supports an optional integer field_id which can be assigned
+/// to a field.  Arrow will convert these field IDs to a metadata key named
+/// PARQUET:field_id on the appropriate field.
 // TODO(wesm): nested data does not always make sense with this user
 // interface unless you are only reading a single leaf node from a branch of
 // a table. For example:

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -43,6 +43,10 @@ namespace arrow {
 ///
 /// Start a new RowGroup or Chunk with NewRowGroup.
 /// Write column-by-column the whole column chunk.
+///
+/// If PARQUET:field_id is present as a metadata key on a field, and the corresponding
+/// value is a nonnegative integer, then it will be used as the field_id in the parquet
+/// file.
 class PARQUET_EXPORT FileWriter {
  public:
   static ::arrow::Status Make(MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer,

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -201,7 +201,7 @@ typedef std::vector<NodePtr> NodeVector;
 class PARQUET_EXPORT PrimitiveNode : public Node {
  public:
   // The field_id here is the default to use if it is not set in the SchemaElement
-  static std::unique_ptr<Node> FromParquet(const void* opaque_element, int field_id = -1);
+  static std::unique_ptr<Node> FromParquet(const void* opaque_element);
 
   // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
@@ -268,7 +268,7 @@ class PARQUET_EXPORT GroupNode : public Node {
  public:
   // The field_id here is the default to use if it is not set in the SchemaElement
   static std::unique_ptr<Node> FromParquet(const void* opaque_element,
-                                           NodeVector fields = {}, int field_id = -1);
+                                           NodeVector fields = {});
 
   // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -200,7 +200,6 @@ typedef std::vector<NodePtr> NodeVector;
 // parameters)
 class PARQUET_EXPORT PrimitiveNode : public Node {
  public:
-  // The field_id here is the default to use if it is not set in the SchemaElement
   static std::unique_ptr<Node> FromParquet(const void* opaque_element);
 
   // A field_id -1 (or any negative value) will be serialized as null in Thrift

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -265,7 +265,6 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
 class PARQUET_EXPORT GroupNode : public Node {
  public:
-  // The field_id here is the default to use if it is not set in the SchemaElement
   static std::unique_ptr<Node> FromParquet(const void* opaque_element,
                                            NodeVector fields = {});
 

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -127,7 +127,6 @@ class TestPrimitiveNode : public ::testing::Test {
   std::string name_;
   const PrimitiveNode* prim_node_;
 
-  int field_id_;
   std::unique_ptr<Node> node_;
 };
 
@@ -168,17 +167,16 @@ TEST_F(TestPrimitiveNode, Attrs) {
 }
 
 TEST_F(TestPrimitiveNode, FromParquet) {
-  SchemaElement elt =
-      NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32, field_id_);
+  SchemaElement elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32);
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(field_id_, prim_node_->field_id());
+  ASSERT_EQ(-1, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::INT32, prim_node_->physical_type());
   ASSERT_EQ(ConvertedType::NONE, prim_node_->converted_type());
 
   // Test a logical type
-  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY, field_id_);
+  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY);
   elt.__set_converted_type(format::ConvertedType::UTF8);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
@@ -187,20 +185,18 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(ConvertedType::UTF8, prim_node_->converted_type());
 
   // FIXED_LEN_BYTE_ARRAY
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
-                     field_id_);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY);
   elt.__set_type_length(16);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(field_id_, prim_node_->field_id());
+  ASSERT_EQ(-1, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, prim_node_->physical_type());
   ASSERT_EQ(16, prim_node_->type_length());
 
   // format::ConvertedType::Decimal
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
-                     field_id_);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY);
   elt.__set_converted_type(format::ConvertedType::DECIMAL);
   elt.__set_type_length(6);
   elt.__set_scale(2);

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -115,7 +115,10 @@ TEST(TestColumnPath, TestAttrs) {
 
 class TestPrimitiveNode : public ::testing::Test {
  public:
-  void SetUp() { name_ = "name"; }
+  void SetUp() {
+    name_ = "name";
+    field_id_ = 5;
+  }
 
   void Convert(const format::SchemaElement* element) {
     node_ = PrimitiveNode::FromParquet(element);
@@ -127,6 +130,7 @@ class TestPrimitiveNode : public ::testing::Test {
   std::string name_;
   const PrimitiveNode* prim_node_;
 
+  int field_id_;
   std::unique_ptr<Node> node_;
 };
 
@@ -167,16 +171,17 @@ TEST_F(TestPrimitiveNode, Attrs) {
 }
 
 TEST_F(TestPrimitiveNode, FromParquet) {
-  SchemaElement elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32);
+  SchemaElement elt =
+      NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32, field_id_);
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(-1, prim_node_->field_id());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::INT32, prim_node_->physical_type());
   ASSERT_EQ(ConvertedType::NONE, prim_node_->converted_type());
 
   // Test a logical type
-  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY);
+  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY, field_id_);
   elt.__set_converted_type(format::ConvertedType::UTF8);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
@@ -185,18 +190,20 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(ConvertedType::UTF8, prim_node_->converted_type());
 
   // FIXED_LEN_BYTE_ARRAY
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                     field_id_);
   elt.__set_type_length(16);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(-1, prim_node_->field_id());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, prim_node_->physical_type());
   ASSERT_EQ(16, prim_node_->type_length());
 
   // format::ConvertedType::Decimal
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                     field_id_);
   elt.__set_converted_type(format::ConvertedType::DECIMAL);
   elt.__set_type_length(6);
   elt.__set_scale(2);

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -115,13 +115,10 @@ TEST(TestColumnPath, TestAttrs) {
 
 class TestPrimitiveNode : public ::testing::Test {
  public:
-  void SetUp() {
-    name_ = "name";
-    field_id_ = 5;
-  }
+  void SetUp() { name_ = "name"; }
 
   void Convert(const format::SchemaElement* element) {
-    node_ = PrimitiveNode::FromParquet(element, field_id_);
+    node_ = PrimitiveNode::FromParquet(element);
     ASSERT_TRUE(node_->is_primitive());
     prim_node_ = static_cast<const PrimitiveNode*>(node_.get());
   }
@@ -1728,7 +1725,7 @@ TEST(TestSchemaNodeCreation, FactoryExceptions) {
   node->ToParquet(&string_intermediary);
   // ... corrupt the Thrift intermediary ....
   string_intermediary.logicalType.__isset.STRING = false;
-  ASSERT_ANY_THROW(node = PrimitiveNode::FromParquet(&string_intermediary, 1));
+  ASSERT_ANY_THROW(node = PrimitiveNode::FromParquet(&string_intermediary));
 
   // Invalid TimeUnit in deserialized TimeLogicalType ...
   node = PrimitiveNode::Make("time", Repetition::REQUIRED,
@@ -1738,7 +1735,7 @@ TEST(TestSchemaNodeCreation, FactoryExceptions) {
   node->ToParquet(&time_intermediary);
   // ... corrupt the Thrift intermediary ....
   time_intermediary.logicalType.TIME.unit.__isset.NANOS = false;
-  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&time_intermediary, 1));
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&time_intermediary));
 
   // Invalid TimeUnit in deserialized TimestampLogicalType ...
   node = PrimitiveNode::Make(
@@ -1748,7 +1745,7 @@ TEST(TestSchemaNodeCreation, FactoryExceptions) {
   node->ToParquet(&timestamp_intermediary);
   // ... corrupt the Thrift intermediary ....
   timestamp_intermediary.logicalType.TIMESTAMP.unit.__isset.NANOS = false;
-  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&timestamp_intermediary, 1));
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&timestamp_intermediary));
 }
 
 struct SchemaElementConstructionArguments {

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -392,6 +392,17 @@ def test_sanitized_spark_field_names():
     expected_name = 'prohib______'
     assert result.schema[0].name == expected_name
 
+def test_field_id():
+    a0 = pa.array([0])
+    a1 = pa.array([1])
+    f0 = pa.field('arr', pa.int32(), metadata={b'PARQUET:field_id': b'17'})
+    f1 = pa.field('arr', pa.int32())
+    table = pa.Table.from_arrays([a0, a1], schema=pa.schema([f0, f1]))
+
+    result = _roundtrip_table(table)
+
+    assert result.schema[0].metadata[b'PARQUET:field_id'] == b'17'
+    assert result.schema[1].metadata is None
 
 @pytest.mark.pandas
 @parametrize_legacy_dataset

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -393,19 +393,6 @@ def test_sanitized_spark_field_names():
     assert result.schema[0].name == expected_name
 
 
-def test_field_id():
-    a0 = pa.array([0])
-    a1 = pa.array([1])
-    f0 = pa.field('arr', pa.int32(), metadata={b'PARQUET:field_id': b'17'})
-    f1 = pa.field('arr', pa.int32())
-    table = pa.Table.from_arrays([a0, a1], schema=pa.schema([f0, f1]))
-
-    result = _roundtrip_table(table)
-
-    assert result.schema[0].metadata[b'PARQUET:field_id'] == b'17'
-    assert result.schema[1].metadata is None
-
-
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_multithreaded_read(use_legacy_dataset):

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -392,6 +392,7 @@ def test_sanitized_spark_field_names():
     expected_name = 'prohib______'
     assert result.schema[0].name == expected_name
 
+
 def test_field_id():
     a0 = pa.array([0])
     a1 = pa.array([1])
@@ -403,6 +404,7 @@ def test_field_id():
 
     assert result.schema[0].metadata[b'PARQUET:field_id'] == b'17'
     assert result.schema[1].metadata is None
+
 
 @pytest.mark.pandas
 @parametrize_legacy_dataset

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -320,30 +320,29 @@ def test_field_id_metadata():
     pf = pq.ParquetFile(pa.BufferReader(contents))
     schema = pf.schema_arrow
 
-    field_name = b'PARQUET:field_id'
-    assert schema[0].metadata[field_name] == b'1'
+    assert schema[0].metadata[field_id] == b'1'
     assert schema[0].metadata[b'other'] == b'abc'
 
     list_field = schema[1]
-    assert list_field.metadata[field_name] == b'11'
+    assert list_field.metadata[field_id] == b'11'
 
     list_item_field = list_field.type.value_field
-    assert list_item_field.metadata[field_name] == b'10'
+    assert list_item_field.metadata[field_id] == b'10'
 
     struct_field = schema[2]
-    assert struct_field.metadata[field_name] == b'102'
+    assert struct_field.metadata[field_id] == b'102'
 
     struct_middle_field = struct_field.type[0]
-    assert struct_middle_field.metadata[field_name] == b'101'
+    assert struct_middle_field.metadata[field_id] == b'101'
 
     struct_inner_field = struct_middle_field.type[0]
-    assert struct_inner_field.metadata[field_name] == b'100'
+    assert struct_inner_field.metadata[field_id] == b'100'
 
     assert schema[3].metadata is None
     # Invalid input is passed through (ok) but does not
     # have field_id in parquet (not tested)
-    assert schema[4].metadata[field_name] == b'xyz'
-    assert schema[5].metadata[field_name] == b'-1000'
+    assert schema[4].metadata[field_id] == b'xyz'
+    assert schema[5].metadata[field_id] == b'-1000'
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -291,10 +291,27 @@ def test_parquet_write_disable_statistics(tempdir):
 
 def test_field_id_metadata():
     # ARROW-7080
-    table = pa.table([pa.array([1], type='int32'),
-                      pa.array([[]], type=pa.list_(pa.int32())),
-                      pa.array([b'boo'], type='binary')],
-                     ['f0', 'f1', 'f2'])
+    field_id = b'PARQUET:field_id'
+    inner = pa.field('inner', pa.int32(), metadata={field_id: b'100'})
+    middle = pa.field('middle', pa.struct(
+        [inner]), metadata={field_id: b'101'})
+    fields = [
+        pa.field('basic', pa.int32(), metadata={
+                 b'other': b'abc', field_id: b'1'}),
+        pa.field(
+            'list',
+            pa.list_(pa.field('list-inner', pa.int32(),
+                              metadata={field_id: b'10'})),
+            metadata={field_id: b'11'}),
+        pa.field('struct', pa.struct([middle]), metadata={field_id: b'102'}),
+        pa.field('no-metadata', pa.int32()),
+        pa.field('non-integral-field-id', pa.int32(),
+                 metadata={field_id: b'xyz'}),
+        pa.field('negative-field-id', pa.int32(),
+                 metadata={field_id: b'-1000'})
+    ]
+    arrs = [[] for _ in fields]
+    table = pa.table(arrs, schema=pa.schema(fields))
 
     bio = pa.BufferOutputStream()
     pq.write_table(table, bio)
@@ -303,28 +320,30 @@ def test_field_id_metadata():
     pf = pq.ParquetFile(pa.BufferReader(contents))
     schema = pf.schema_arrow
 
-    # Expected Parquet schema for reference
-    #
-    # required group field_id=0 schema {
-    #   optional int32 field_id=1 f0;
-    #   optional group field_id=2 f1 (List) {
-    #     repeated group field_id=3 list {
-    #       optional int32 field_id=4 item;
-    #     }
-    #   }
-    #   optional binary field_id=5 f2;
-    # }
-
     field_name = b'PARQUET:field_id'
     assert schema[0].metadata[field_name] == b'1'
+    assert schema[0].metadata[b'other'] == b'abc'
 
     list_field = schema[1]
-    assert list_field.metadata[field_name] == b'2'
+    assert list_field.metadata[field_name] == b'11'
 
     list_item_field = list_field.type.value_field
-    assert list_item_field.metadata[field_name] == b'4'
+    assert list_item_field.metadata[field_name] == b'10'
 
-    assert schema[2].metadata[field_name] == b'5'
+    struct_field = schema[2]
+    assert struct_field.metadata[field_name] == b'102'
+
+    struct_middle_field = struct_field.type[0]
+    assert struct_middle_field.metadata[field_name] == b'101'
+
+    struct_inner_field = struct_middle_field.type[0]
+    assert struct_inner_field.metadata[field_name] == b'100'
+
+    assert schema[3].metadata is None
+    # Invalid input is passed through (ok) but does not
+    # have field_id in parquet (not tested)
+    assert schema[4].metadata[field_name] == b'xyz'
+    assert schema[5].metadata[field_name] == b'-1000'
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -525,7 +525,7 @@ def test_parquet_period(tmpdir, registered_period_type):
     # When reading in, properly create extension type if it is registered
     result = pq.read_table(filename)
     assert result.schema.field("ext").type == period_type
-    assert result.schema.field("ext").metadata == {b'PARQUET:field_id': b'1'}
+    assert result.schema.field("ext").metadata == {}
     # Get the exact array class defined by the registered type.
     result_array = result.column("ext").chunk(0)
     assert type(result_array) is period_class
@@ -537,8 +537,7 @@ def test_parquet_period(tmpdir, registered_period_type):
     # The extension metadata is present for roundtripping.
     assert result.schema.field("ext").metadata == {
         b'ARROW:extension:metadata': b'freq=D',
-        b'ARROW:extension:name': b'test.period',
-        b'PARQUET:field_id': b'1',
+        b'ARROW:extension:name': b'test.period'
     }
 
 


### PR DESCRIPTION
Questions:

- This is my first PR in the parquet namespace, I'm not sure of all the special rules.
- The field ID generation doesn't happen on the `parquet::schema` -> `arrow::schema` phase but on the `parquet::format::schema` -> `parquet::schema` phase.  So in order to test I had to add `#include "generated/parquet_types.h"` to `arrow_schema_test.cc` and I wasn't sure if I was allowed to reference the `generated/*` files like that.
- This PR simply allows user specified field id's to be persisted.  Is that sufficient for PARQUET-1798 (the title is rather general) or should I open up a dedicated JIRA?