### PR TITLE
ARROW-12730: [MATLAB] Update featherreadmex and featherwritemex to build against latest Arrow C++ APIs

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -39,33 +39,42 @@ find_package(Arrow REQUIRED)
 find_package(Matlab REQUIRED)
 
 # Construct the absolute path to featherread's source files
-set(featherread_sources featherreadmex.cc feather_reader.cc
-                        util/handle_status.cc util/unicode_conversion.cc)
+set(featherread_sources featherreadmex.cc feather_reader.cc util/handle_status.cc
+                        util/unicode_conversion.cc)
 list(TRANSFORM featherread_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
 
 # Build featherreadmex MEX binary
 matlab_add_mex(R2018a
-               NAME featherreadmex
-               SRC ${featherread_sources}
-               LINK_TO arrow_shared)
+               NAME
+               featherreadmex
+               SRC
+               ${featherread_sources}
+               LINK_TO
+               arrow_shared)
 
 # Construct the absolute path to featherwrite's source files
-set(featherwrite_sources featherwritemex.cc feather_writer.cc
-                        util/handle_status.cc util/unicode_conversion.cc)
+set(featherwrite_sources featherwritemex.cc feather_writer.cc util/handle_status.cc
+                         util/unicode_conversion.cc)
 list(TRANSFORM featherwrite_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
-
 
 # Build featherwritemex MEX binary
 matlab_add_mex(R2018a
-               NAME featherwritemex
-               SRC ${featherwrite_sources}
-               LINK_TO arrow_shared)
+               NAME
+               featherwritemex
+               SRC
+               ${featherwrite_sources}
+               LINK_TO
+               arrow_shared)
 
 # Ensure the MEX binaries are placed in the src directory on all platforms
-if (WIN32)
-    set_target_properties(featherreadmex PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
-    set_target_properties(featherwritemex PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+if(WIN32)
+  set_target_properties(featherreadmex
+                        PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherwritemex
+                        PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
 else()
-    set_target_properties(featherreadmex PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
-    set_target_properties(featherwritemex PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherreadmex
+                        PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherwritemex
+                        PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
 endif()

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.20)
+
 set(CMAKE_CXX_STANDARD 11)
 
 set(MLARROW_VERSION "5.0.0-SNAPSHOT")
@@ -29,22 +30,42 @@ if(EXISTS "${CPP_CMAKE_MODULES}")
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CPP_CMAKE_MODULES})
 endif()
 
-## Arrow is Required
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake_modules)
+
+# Arrow is Required
 find_package(Arrow REQUIRED)
 
-## MATLAB is required to be installed to build MEX interfaces
-set(MATLAB_ADDITIONAL_VERSIONS "R2018a=9.4")
-find_package(Matlab REQUIRED MX_LIBRARY)
+# MATLAB is Required
+find_package(Matlab REQUIRED)
 
-# Build featherread mex file based on the arrow shared library
-matlab_add_mex(NAME featherreadmex
-               SRC src/featherreadmex.cc src/feather_reader.cc src/util/handle_status.cc
-                   src/util/unicode_conversion.cc
-               LINK_TO ${ARROW_SHARED_LIB})
-target_include_directories(featherreadmex PRIVATE ${ARROW_INCLUDE_DIR})
+# Construct the absolute path to featherread's source files
+set(featherread_sources featherreadmex.cc feather_reader.cc
+                        util/handle_status.cc util/unicode_conversion.cc)
+list(TRANSFORM featherread_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
 
-# Build featherwrite mex file based on the arrow shared library
-matlab_add_mex(NAME featherwritemex
-               SRC src/featherwritemex.cc src/feather_writer.cc src/util/handle_status.cc
-               LINK_TO ${ARROW_SHARED_LIB})
-target_include_directories(featherwritemex PRIVATE ${ARROW_INCLUDE_DIR})
+# Build featherreadmex MEX binary
+matlab_add_mex(R2018a
+               NAME featherreadmex
+               SRC ${featherread_sources}
+               LINK_TO arrow_shared)
+
+# Construct the absolute path to featherwrite's source files
+set(featherwrite_sources featherwritemex.cc feather_writer.cc
+                        util/handle_status.cc util/unicode_conversion.cc)
+list(TRANSFORM featherwrite_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
+
+
+# Build featherwritemex MEX binary
+matlab_add_mex(R2018a
+               NAME featherwritemex
+               SRC ${featherwrite_sources}
+               LINK_TO arrow_shared)
+
+# Ensure the MEX binaries are placed in the src directory on all platforms
+if (WIN32)
+    set_target_properties(featherreadmex PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+    set_target_properties(featherwritemex PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+else()
+    set_target_properties(featherreadmex PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+    set_target_properties(featherwritemex PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+endif()

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -45,12 +45,9 @@ list(TRANSFORM featherread_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
 
 # Build featherreadmex MEX binary
 matlab_add_mex(R2018a
-               NAME
-               featherreadmex
-               SRC
-               ${featherread_sources}
-               LINK_TO
-               arrow_shared)
+               NAME featherreadmex
+               SRC ${featherread_sources}
+               LINK_TO arrow_shared)
 
 # Construct the absolute path to featherwrite's source files
 set(featherwrite_sources featherwritemex.cc feather_writer.cc util/handle_status.cc
@@ -59,22 +56,19 @@ list(TRANSFORM featherwrite_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
 
 # Build featherwritemex MEX binary
 matlab_add_mex(R2018a
-               NAME
-               featherwritemex
-               SRC
-               ${featherwrite_sources}
-               LINK_TO
-               arrow_shared)
+               NAME featherwritemex
+               SRC ${featherwrite_sources}
+               LINK_TO arrow_shared)
 
 # Ensure the MEX binaries are placed in the src directory on all platforms
 if(WIN32)
-  set_target_properties(featherreadmex
-                        PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
-  set_target_properties(featherwritemex
-                        PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherreadmex PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                                  $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherwritemex PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                                   $<1:${CMAKE_SOURCE_DIR}/src>)
 else()
-  set_target_properties(featherreadmex
-                        PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
-  set_target_properties(featherwritemex
-                        PROPERTIES LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherreadmex PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                                                  $<1:${CMAKE_SOURCE_DIR}/src>)
+  set_target_properties(featherwritemex PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                                                   $<1:${CMAKE_SOURCE_DIR}/src>)
 endif()

--- a/matlab/src/+mlarrow/+util/createMetadataStruct.m
+++ b/matlab/src/+mlarrow/+util/createMetadataStruct.m
@@ -1,4 +1,4 @@
-function metadata = createMetadataStruct(description, numRows, numVariables)
+function metadata = createMetadataStruct(numRows, numVariables)
 % CREATEMETADATASTRUCT Helper function for creating Feather MEX metadata
 % struct.
 
@@ -17,8 +17,7 @@ function metadata = createMetadataStruct(description, numRows, numVariables)
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-metadata = struct('Description', description, ...
-                  'NumRows', numRows, ...
+metadata = struct('NumRows', numRows, ...
                   'NumVariables', numVariables);
 end
 

--- a/matlab/src/+mlarrow/+util/table2mlarrow.m
+++ b/matlab/src/+mlarrow/+util/table2mlarrow.m
@@ -23,7 +23,6 @@ function [variables, metadata] = table2mlarrow(t)
 %
 %   Field Name    Class         Description
 %   ------------  -------       ----------------------------------------------
-%   Description   char          Table description (T.Properties.Description)
 %   NumRows       double        Number of table rows (height(T))
 %   NumVariables  double        Number of table variables (width(T))
 %
@@ -51,7 +50,7 @@ import mlarrow.util.*;
 variables = repmat(createVariableStruct('', [], [], ''), 1, width(t));
 
 % Struct representing table-level metadata.
-metadata = createMetadataStruct(t.Properties.Description, height(t), width(t));
+metadata = createMetadataStruct(height(t), width(t));
 
 % Iterate over each variable in the given table,
 % extracting the underlying array data.

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -243,7 +243,7 @@ mxArray* FeatherReader::ReadVariables() {
   mxArray* variables =
       mxCreateStructMatrix(1, num_variables_, num_variable_fields, fieldnames);
 
-  std::shared_ptr<arrow::Table> table = nullptr;
+  std::shared_ptr<arrow::Table> table;
   arrow::Status status = reader_->Read(&table);
   if (!status.ok()) {
     std::string err_msg =

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -61,8 +61,7 @@ mxArray* ReadNumericVariableData(const std::shared_ptr<Array>& column) {
       std::static_pointer_cast<ArrowArrayType>(column);
 
   // Get a raw pointer to the Arrow array data.
-  const MatlabType* source =
-      reinterpret_cast<const MatlabType*>(arrow_numeric_array->values()->data());
+  const MatlabType* source = arrow_numeric_array->raw_values();
 
   // Get a mutable pointer to the MATLAB array data and std::copy the
   // Arrow array data into it.

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -182,8 +182,7 @@ Status FeatherReader::Open(const std::string& filename,
   *feather_reader = std::shared_ptr<FeatherReader>(new FeatherReader());
 
   // Open file with given filename as a ReadableFile.
-  arrow::Result<std::shared_ptr<io::ReadableFile>> maybe_readable_file =
-      io::ReadableFile::Open(filename);
+  ARROW_ASSIGN_OR_RAISE(auto readable_file,  io::ReadableFile::Open(filename));
 
   // TableReader expects a RandomAccessFile.
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<io::RandomAccessFile> random_access_file,

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -57,7 +57,7 @@ mxArray* ReadNumericVariableData(const std::shared_ptr<Array>& column) {
   mxArray* variable_data =
       mxCreateNumericMatrix(column->length(), 1, matlab_class_id, mxREAL);
 
-  std::shared_ptr<ArrowArrayType> arrow_numeric_array =
+  auto arrow_numeric_array =
       std::static_pointer_cast<ArrowArrayType>(column);
 
   // Get a raw pointer to the Arrow array data.

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -182,17 +182,11 @@ Status FeatherReader::Open(const std::string& filename,
   *feather_reader = std::shared_ptr<FeatherReader>(new FeatherReader());
 
   // Open file with given filename as a ReadableFile.
-  ARROW_ASSIGN_OR_RAISE(auto readable_file,  io::ReadableFile::Open(filename));
-
-  // TableReader expects a RandomAccessFile.
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<io::RandomAccessFile> random_access_file,
-                        maybe_readable_file);
-
+  ARROW_ASSIGN_OR_RAISE(auto readable_file, io::ReadableFile::Open(filename));
+ 
   // Open the Feather file for reading with a TableReader.
-  arrow::Result<std::shared_ptr<ipc::feather::Reader>> maybe_reader =
-      ipc::feather::Reader::Open(random_access_file);
-  ARROW_ASSIGN_OR_RAISE(auto reader, maybe_reader);
-
+  ARROW_ASSIGN_OR_RAISE(auto reader, ipc::feather::Reader::Open(readable_file));
+ 
   // Set the internal reader_ object.
   (*feather_reader)->reader_ = reader;
 
@@ -246,7 +240,7 @@ mxArray* FeatherReader::ReadVariables() {
   if (!status.ok()) {
     mexErrMsgIdAndTxt("MATLAB:arrow:FeatherReader::FailedToReadTable",
                       "Failed to read arrow::Table from Feather file. Reason: %s",
-                      status.message());
+                      status.message().c_str());
   }
 
   // Set the number of rows

--- a/matlab/src/feather_reader.cc
+++ b/matlab/src/feather_reader.cc
@@ -15,19 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <algorithm>
-#include <cmath>
+#include "feather_reader.h"
 
+#include <arrow/array/array_base.h>
+#include <arrow/array/builder_base.h>
+#include <arrow/array/builder_primitive.h>
 #include <arrow/io/file.h>
 #include <arrow/ipc/feather.h>
+#include <arrow/result.h>
 #include <arrow/status.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
-#include <arrow/util/bit-util.h>
-
+#include <arrow/type_traits.h>
+#include <arrow/util/bitmap_visit.h>
 #include <mex.h>
 
-#include "feather_reader.h"
+#include <algorithm>
+#include <cmath>
+
 #include "matlab_traits.h"
 #include "util/handle_status.h"
 #include "util/unicode_conversion.h"
@@ -52,11 +57,12 @@ mxArray* ReadNumericVariableData(const std::shared_ptr<Array>& column) {
   mxArray* variable_data =
       mxCreateNumericMatrix(column->length(), 1, matlab_class_id, mxREAL);
 
-  std::shared_ptr<ArrowArrayType> integer_array =
+  std::shared_ptr<ArrowArrayType> arrow_numeric_array =
       std::static_pointer_cast<ArrowArrayType>(column);
 
   // Get a raw pointer to the Arrow array data.
-  const MatlabType* source = integer_array->raw_values();
+  const MatlabType* source =
+      reinterpret_cast<const MatlabType*>(arrow_numeric_array->values()->data());
 
   // Get a mutable pointer to the MATLAB array data and std::copy the
   // Arrow array data into it.
@@ -121,8 +127,7 @@ void BitUnpackBuffer(const std::shared_ptr<Buffer>& source, int64_t length,
 // writes to a zero-initialized destination buffer.
 // Implements a fast path for the fully-valid and fully-invalid cases.
 // Returns true if the destination buffer was successfully populated.
-bool TryBitUnpackFastPath(const std::shared_ptr<Array>& array,
-                          mxLogical* destination) {
+bool TryBitUnpackFastPath(const std::shared_ptr<Array>& array, mxLogical* destination) {
   const int64_t null_count = array->null_count();
   const int64_t length = array->length();
 
@@ -177,32 +182,34 @@ Status FeatherReader::Open(const std::string& filename,
   *feather_reader = std::shared_ptr<FeatherReader>(new FeatherReader());
 
   // Open file with given filename as a ReadableFile.
-  std::shared_ptr<io::ReadableFile> readable_file(nullptr);
-
-  RETURN_NOT_OK(io::ReadableFile::Open(filename, &readable_file));
+  arrow::Result<std::shared_ptr<io::ReadableFile>> maybe_readable_file =
+      io::ReadableFile::Open(filename);
+  RETURN_NOT_OK(maybe_readable_file);
 
   // TableReader expects a RandomAccessFile.
-  std::shared_ptr<io::RandomAccessFile> random_access_file(readable_file);
+  std::shared_ptr<io::RandomAccessFile> random_access_file{
+      maybe_readable_file.ValueOrDie()};
 
   // Open the Feather file for reading with a TableReader.
-  RETURN_NOT_OK(ipc::feather::TableReader::Open(random_access_file,
-                                                &(*feather_reader)->table_reader_));
+  arrow::Result<std::shared_ptr<ipc::feather::Reader>> maybe_reader =
+      ipc::feather::Reader::Open(random_access_file);
+  RETURN_NOT_OK(maybe_reader);
 
-  // Read the table metadata from the Feather file.
-  (*feather_reader)->num_rows_ = (*feather_reader)->table_reader_->num_rows();
-  (*feather_reader)->num_variables_ = (*feather_reader)->table_reader_->num_columns();
-  (*feather_reader)->description_ =
-      (*feather_reader)->table_reader_->HasDescription()
-          ? (*feather_reader)->table_reader_->GetDescription()
-          : "";
+  // Set the internal reader_ object.
+  (*feather_reader)->reader_ = maybe_reader.ValueOrDie();
+  std::shared_ptr<ipc::feather::Reader> reader = (*feather_reader)->reader_;
 
-  if ((*feather_reader)->num_rows_ > internal::MAX_MATLAB_SIZE ||
-      (*feather_reader)->num_variables_ > internal::MAX_MATLAB_SIZE) {
-    mexErrMsgIdAndTxt("MATLAB:arrow:SizeTooLarge",
-                      "The table size exceeds MATLAB limits: %u x %u",
-                      (*feather_reader)->num_rows_, (*feather_reader)->num_variables_);
+  // Check the feather file version
+  int version = reader->version();
+  if (version == ipc::feather::kFeatherV2Version) {
+    return Status::NotImplemented("Support for Feather V2 has not been implemented.");
+  } else if (version != ipc::feather::kFeatherV1Version) {
+    return Status::Invalid("Unknown Feather format version.");
   }
 
+  // read the table metadata from the Feather file
+  std::shared_ptr<Schema> schema = reader->schema();
+  (*feather_reader)->num_variables_ = schema->num_fields();
   return Status::OK();
 }
 
@@ -225,15 +232,11 @@ mxArray* FeatherReader::ReadMetadata() const {
   mxSetField(metadata, 0, "NumVariables",
              mxCreateDoubleScalar(static_cast<double>(num_variables_)));
 
-  // Set the description.
-  mxSetField(metadata, 0, "Description",
-             util::ConvertUTF8StringToUTF16CharMatrix(description_));
-
   return metadata;
 }
 
 // Read the table variables from the Feather file as a mxArray*.
-mxArray* FeatherReader::ReadVariables() const {
+mxArray* FeatherReader::ReadVariables() {
   const int32_t num_variable_fields = 4;
   const char* fieldnames[] = {"Name", "Type", "Data", "Valid"};
 
@@ -242,16 +245,34 @@ mxArray* FeatherReader::ReadVariables() const {
   mxArray* variables =
       mxCreateStructMatrix(1, num_variables_, num_variable_fields, fieldnames);
 
-  // Read all the table variables in the Feather file into memory.
+  // Read the entire table in the Feather file into memory.
+  std::shared_ptr<arrow::Table> table = nullptr;
+  arrow::Status status = reader_->Read(&table);
+  if (!status.ok()) {
+    mexErrMsgIdAndTxt("MATLAB:arrow:FeatherReader::FailedToReadTable",
+                      "Failed to read arrow::Table from Feather file.");
+  }
+
+  // Set the number of rows
+  num_rows_ = table->num_rows();
+
+  if (num_rows_ > internal::MAX_MATLAB_SIZE ||
+      num_variables_ > internal::MAX_MATLAB_SIZE) {
+    mexErrMsgIdAndTxt("MATLAB:arrow:SizeTooLarge",
+                      "The table size exceeds MATLAB limits: %u x %u", num_rows_,
+                      num_variables_);
+  }
+
+  std::vector<std::string> column_names = table->ColumnNames();
+
   for (int64_t i = 0; i < num_variables_; ++i) {
-    std::shared_ptr<ChunkedArray> column;
-    util::HandleStatus(table_reader_->GetColumn(i, &column));
+    std::shared_ptr<ChunkedArray> column = table->column(i);
     if (column->num_chunks() != 1) {
       mexErrMsgIdAndTxt("MATLAB:arrow:FeatherReader::ReadVariables",
                         "Chunked columns not yet supported");
     }
     std::shared_ptr<Array> chunk = column->chunk(0);
-    const std::string column_name = table_reader_->GetColumnName(i);
+    const std::string column_name = column_names[i];
 
     // set the struct fields data
     mxSetField(variables, i, "Name", internal::ReadVariableName(column_name));

--- a/matlab/src/feather_reader.h
+++ b/matlab/src/feather_reader.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-
 #include <arrow/ipc/feather.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
-
 #include <matrix.h>
+
+#include <memory>
+#include <string>
 
 namespace arrow {
 namespace matlab {
@@ -56,7 +55,7 @@ class FeatherReader {
   ///        Clients are responsible for freeing the returned mxArray memory
   ///        when it is no longer needed, or passing it to MATLAB to be managed.
   /// \return variables mxArray* struct array containing table variable data
-  mxArray* ReadVariables() const;
+  mxArray* ReadVariables();
 
   /// \brief Initialize a FeatherReader object from a given Feather file.
   /// \param[in] filename path to a Feather file
@@ -66,7 +65,7 @@ class FeatherReader {
 
  private:
   FeatherReader() = default;
-  std::unique_ptr<ipc::feather::TableReader> table_reader_;
+  std::shared_ptr<ipc::feather::Reader> reader_;
   int64_t num_rows_;
   int64_t num_variables_;
   std::string description_;
@@ -74,4 +73,3 @@ class FeatherReader {
 
 }  // namespace matlab
 }  // namespace arrow
-

--- a/matlab/src/feather_reader.h
+++ b/matlab/src/feather_reader.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include <arrow/ipc/feather.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
 #include <matrix.h>
-
-#include <memory>
-#include <string>
 
 namespace arrow {
 namespace matlab {

--- a/matlab/src/feather_writer.cc
+++ b/matlab/src/feather_writer.cc
@@ -342,7 +342,7 @@ Status FeatherWriter::WriteVariables(const mxArray* variables, const mxArray* me
     internal::BitPackBuffer(valid, validity_bitmap);
 
     // Wrap mxArray data in an arrow::Array of the equivalent type.
-    std::shared_ptr<Array> array =
+    auto array =
         internal::WriteVariableData(data, type_str, validity_bitmap);
 
     // Verify that the arrow::Array has the right number of elements.

--- a/matlab/src/feather_writer.cc
+++ b/matlab/src/feather_writer.cc
@@ -280,7 +280,7 @@ Status FeatherWriter::Open(const std::string& filename,
 
   // Open a FileOutputStream corresponding to the provided filename.
   ARROW_ASSIGN_OR_RAISE((*feather_writer)->file_output_stream_,
-      io::FileOutputStream::Open(filename, &((*feather_writer)->file_output_stream_));
+      io::FileOutputStream::Open(filename, &((*feather_writer)->file_output_stream_)));
   return Status::OK();
 }
 
@@ -331,8 +331,8 @@ Status FeatherWriter::WriteVariables(const mxArray* variables, const mxArray* me
     auto datatype = internal::ConvertMatlabTypeStringToArrowDataType(type_str);
     auto field = std::make_shared<arrow::Field>(name_str, datatype);
 
-    ARROW_ASSIGN_OR_RAISE(auto validity_bitmap,
-        arrow::AllocateResizableBuffer(internal::BitPackedLength(num_rows_));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ResizableBuffer> validity_bitmap,
+        arrow::AllocateResizableBuffer(internal::BitPackedLength(num_rows_)));
 
     // Populate bit-packed arrow::Buffer using validity data in the mxArray*.
     internal::BitPackBuffer(valid, validity_bitmap);
@@ -348,7 +348,7 @@ Status FeatherWriter::WriteVariables(const mxArray* variables, const mxArray* me
     RETURN_NOT_OK(schema_builder.AddField(field));
 
     // Store the table column
-    table_columns.push_back(array);
+    table_columns.push_back(std::move(array));
   }
   // Create the table schema
   ARROW_ASSIGN_OR_RAISE(auto table_schema, schema_builder.Finish());

--- a/matlab/src/feather_writer.cc
+++ b/matlab/src/feather_writer.cc
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cmath>
-#include <functional> /* for std::multiplies */
-#include <numeric>    /* for std::accumulate */
+#include "feather_writer.h"
 
 #include <arrow/array.h>
 #include <arrow/buffer.h>
@@ -26,17 +24,52 @@
 #include <arrow/status.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
-#include <arrow/util/bit-util.h>
-
+#include <arrow/util/bit_util.h>
+#include <arrow/util/bitmap_generate.h>
+#include <arrow/util/key_value_metadata.h>
 #include <mex.h>
 
-#include "feather_writer.h"
+#include <cmath>
+#include <functional> /* for std::multiplies */
+#include <numeric>    /* for std::accumulate */
+
 #include "matlab_traits.h"
 #include "util/handle_status.h"
 
 namespace arrow {
 namespace matlab {
 namespace internal {
+
+// Returns the arrow::DataType that corresponds to the input type string
+std::shared_ptr<arrow::DataType> ConvertMatlabTypeStringToArrowDataType(
+    const std::string& t) {
+  if (t == "double") {
+    return arrow::float64();
+  } else if (t == "single") {
+    return arrow::float32();
+  } else if (t == "uint64") {
+    return arrow::uint64();
+  } else if (t == "uint32") {
+    return arrow::uint32();
+  } else if (t == "uint16") {
+    return arrow::uint16();
+  } else if (t == "uint8") {
+    return arrow::uint8();
+  } else if (t == "int64") {
+    return arrow::int64();
+  } else if (t == "int32") {
+    return arrow::int32();
+  } else if (t == "int16") {
+    return arrow::int16();
+  } else if (t == "int8") {
+    return arrow::int8();
+  }
+  mexErrMsgIdAndTxt("MATLAB:arrow:UnsupportedMatlabTypeString",
+                    "Unsupported MATLAB type string: '%s'", t.c_str());
+
+  // mexErrMsgIdAndTxt throws unconditionally so we should never reach this line
+  return nullptr;
+}
 
 // Utility that helps verify the input mxArray struct field name and type.
 // Returns void since any errors will throw and terminate MEX execution.
@@ -71,8 +104,7 @@ void ValidateMxStructField(const mxArray* struct_array, const char* fieldname,
                         mxGetClassName(field), fieldname);
     }
   }
-
-  // Some struct fields (like the table description) can be empty, while others 
+  // Some struct fields (like Data) can be empty, while others
   // (like NumRows) should never be empty. This conditional helps account for both cases.
   if (!can_be_empty) {
     // Ensure that individual mxStructArray fields are non-empty.
@@ -120,7 +152,7 @@ void ValidateNumRows(int64_t actual, int64_t expected) {
 }
 
 // Calculate the number of bytes required in the bit-packed validity buffer.
-constexpr int64_t BitPackedLength(int64_t num_elements) {
+int64_t BitPackedLength(int64_t num_elements) {
   // Since mxLogicalArray encodes [0, 1] in a full byte, we can compress that byte
   // down to a bit...therefore dividing the mxLogicalArray length by 8 here.
   return static_cast<int64_t>(std::ceil(num_elements / 8.0));
@@ -134,7 +166,7 @@ size_t GetNumberOfElements(const mxArray* array) {
   const size_t* dimensions = mxGetDimensions(array);
 
   // Iterate over the dimensions array and accumulate the total number of elements.
-  return std::accumulate(dimensions, dimensions + num_dimensions, 1,
+  return std::accumulate(dimensions, dimensions + num_dimensions, size_t{1},
                          std::multiplies<size_t>());
 }
 
@@ -164,7 +196,7 @@ void BitPackBuffer(const mxArray* logical_array,
 
   // Iterate over the mxLogical array and write bit-packed bools to the arrow::Buffer.
   // Call into a loop-unrolled Arrow utility for better performance when bit-packing.
-  auto generator = [&]() -> uint8_t { return *unpacked_buffer_ptr++; };
+  auto generator = [&]() -> bool { return *(unpacked_buffer_ptr++); };
   const int64_t start_offset = 0;
   arrow::internal::GenerateBitsUnrolled(packed_buffer_ptr, start_offset,
                                         unpacked_buffer_length, generator);
@@ -195,8 +227,8 @@ std::unique_ptr<Array> WriteNumericData(const mxArray* data,
                                mxGetElementSize(data) * mxGetNumberOfElements(data));
 
   // Construct arrow::NumericArray specialization using arrow::Buffer.
-  // Pass in nulls information...we could compute and provide the number of nulls here too,
-  // but passing -1 for now so that Arrow recomputes it if necessary.
+  // Pass in nulls information...we could compute and provide the number of nulls here
+  // too, but passing -1 for now so that Arrow recomputes it if necessary.
   return std::unique_ptr<Array>(new NumericArray<ArrowDataType>(
       mxGetNumberOfElements(data), buffer, validity_bitmap, -1));
 }
@@ -228,7 +260,6 @@ std::unique_ptr<Array> WriteVariableData(const mxArray* data, const std::string&
       return WriteNumericData<Int32Type>(data, validity_bitmap);
     case mxINT64_CLASS:
       return WriteNumericData<Int64Type>(data, validity_bitmap);
-
     default: {
       mexErrMsgIdAndTxt("MATLAB:arrow:UnsupportedArrowType",
                         "Unsupported arrow::Type '%s' for variable '%s'",
@@ -248,60 +279,44 @@ Status FeatherWriter::Open(const std::string& filename,
   *feather_writer = std::shared_ptr<FeatherWriter>(new FeatherWriter());
 
   // Open a FileOutputStream corresponding to the provided filename.
-  std::shared_ptr<io::OutputStream> writable_file(nullptr);
-  ARROW_RETURN_NOT_OK(io::FileOutputStream::Open(filename, &writable_file));
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> maybe_file_output_stream =
+      io::FileOutputStream::Open(filename, &((*feather_writer)->file_output_stream_));
+  RETURN_NOT_OK(maybe_file_output_stream);
+  (*feather_writer)->file_output_stream_ = maybe_file_output_stream.ValueOrDie();
 
-  // TableWriter::Open expects a shared_ptr to an OutputStream.
-  // Open the Feather file for writing with a TableWriter.
-  return ipc::feather::TableWriter::Open(writable_file,
-                                         &(*feather_writer)->table_writer_);
-}
-
-// Write table metadata to the Feather file from a mxArray*.
-void FeatherWriter::WriteMetadata(const mxArray* metadata) {
-  // Verify that all required fieldnames are provided.
-  internal::ValidateMxStructField(metadata, "Description", mxCHAR_CLASS, true);
-  internal::ValidateMxStructField(metadata, "NumRows", mxDOUBLE_CLASS, false);
-  internal::ValidateMxStructField(metadata, "NumVariables", mxDOUBLE_CLASS, false);
-
-  // Convert Description to a std::string and set on FeatherWriter and TableWriter.
-  std::string description =
-      internal::MxArrayToString(mxGetField(metadata, 0, "Description"));
-  this->description_ = description;
-  this->table_writer_->SetDescription(description);
-
-  // Get the NumRows field in the struct array and set on TableWriter.
-  this->num_rows_ = static_cast<int64_t>(mxGetScalar(mxGetField(metadata, 0, "NumRows")));
-  this->table_writer_->SetNumRows(this->num_rows_);
-
-  // Get the total number of variables. This is checked later for consistency with
-  // the provided number of columns before finishing the file write.
-  this->num_variables_ =
-      static_cast<int64_t>(mxGetScalar(mxGetField(metadata, 0, "NumVariables")));
+  return Status::OK();
 }
 
 // Write mxArrays from MATLAB into a Feather file.
-Status FeatherWriter::WriteVariables(const mxArray* variables) {
+Status FeatherWriter::WriteVariables(const mxArray* variables, const mxArray* metadata) {
   // Verify that all required fieldnames are provided.
   internal::ValidateMxStructField(variables, "Name", mxCHAR_CLASS, true);
   internal::ValidateMxStructField(variables, "Type", mxCHAR_CLASS, false);
   internal::ValidateMxStructField(variables, "Data", mxUNKNOWN_CLASS, true);
   internal::ValidateMxStructField(variables, "Valid", mxLOGICAL_CLASS, true);
 
+  // Verify that all required fieldnames are provided.
+  internal::ValidateMxStructField(metadata, "NumRows", mxDOUBLE_CLASS, false);
+  internal::ValidateMxStructField(metadata, "NumVariables", mxDOUBLE_CLASS, false);
+
   // Get the number of columns in the struct array.
   size_t num_columns = internal::GetNumberOfElements(variables);
 
+  // Get the NumRows field in the struct array and set on TableWriter.
+  num_rows_ = static_cast<int64_t>(mxGetScalar(mxGetField(metadata, 0, "NumRows")));
+  // Get the total number of variables. This is checked later for consistency with
+  // the provided number of columns before finishing the file write.
+  num_variables_ =
+      static_cast<int64_t>(mxGetScalar(mxGetField(metadata, 0, "NumVariables")));
+
   // Verify that we have all the columns required for writing
   // Currently we need all columns to be passed in together in the WriteVariables method.
-  internal::ValidateNumColumns(static_cast<int64_t>(num_columns), this->num_variables_);
+  internal::ValidateNumColumns(static_cast<int64_t>(num_columns), num_variables_);
 
-  // Allocate a packed validity bitmap for later arrow::Buffers to reference and populate.
-  // Since this is defined in the enclosing scope around any arrow::Buffer usage, this
-  // should outlive any arrow::Buffers created on this range, thus avoiding dangling
-  // references.
-  std::shared_ptr<ResizableBuffer> validity_bitmap;
-  ARROW_RETURN_NOT_OK(AllocateResizableBuffer(internal::BitPackedLength(this->num_rows_),
-                                              &validity_bitmap));
+  arrow::SchemaBuilder schema_builder;
+  std::vector<std::shared_ptr<arrow::Array>> table_columns;
+
+  const int64_t bitpacked_length = internal::BitPackedLength(num_rows_);
 
   // Iterate over the input columns and generate arrow arrays.
   for (int idx = 0; idx < num_columns; ++idx) {
@@ -316,22 +331,46 @@ Status FeatherWriter::WriteVariables(const mxArray* variables) {
     std::string name_str = internal::MxArrayToString(name);
     std::string type_str = internal::MxArrayToString(type);
 
+    std::shared_ptr<arrow::DataType> datatype =
+        internal::ConvertMatlabTypeStringToArrowDataType(type_str);
+    std::shared_ptr<arrow::Field> field =
+        std::make_shared<arrow::Field>(name_str, datatype);
+
+    arrow::Result<std::shared_ptr<ResizableBuffer>> maybe_buffer =
+        arrow::AllocateResizableBuffer(internal::BitPackedLength(num_rows_));
+    RETURN_NOT_OK(maybe_buffer);
+    std::shared_ptr<ResizableBuffer> validity_bitmap = maybe_buffer.ValueOrDie();
+
     // Populate bit-packed arrow::Buffer using validity data in the mxArray*.
     internal::BitPackBuffer(valid, validity_bitmap);
 
     // Wrap mxArray data in an arrow::Array of the equivalent type.
-    std::unique_ptr<Array> array =
+    std::shared_ptr<Array> array =
         internal::WriteVariableData(data, type_str, validity_bitmap);
 
     // Verify that the arrow::Array has the right number of elements.
-    internal::ValidateNumRows(array->length(), this->num_rows_);
+    internal::ValidateNumRows(array->length(), num_rows_);
 
-    // Write another column to the Feather file.
-    ARROW_RETURN_NOT_OK(this->table_writer_->Append(name_str, *array));
+    // Append the field to the schema builder
+    RETURN_NOT_OK(schema_builder.AddField(field));
+
+    // Store the table column
+    table_columns.push_back(array);
   }
+  // Create the table schema
+  arrow::Result<std::shared_ptr<arrow::Schema>> table_schema_result =
+      schema_builder.Finish();
+  RETURN_NOT_OK(table_schema_result);
 
+  std::shared_ptr<arrow::Schema> table_schema = table_schema_result.ValueOrDie();
+
+  // Specify the feather file format version as V1
+  arrow::ipc::feather::WriteProperties write_props;
+  write_props.version = arrow::ipc::feather::kFeatherV1Version;
+
+  std::shared_ptr<arrow::Table> table = arrow::Table::Make(table_schema, table_columns);
   // Write the Feather file metadata to the end of the file.
-  return this->table_writer_->Finalize();
+  return ipc::feather::WriteTable(*table, file_output_stream_.get(), write_props);
 }
 
 }  // namespace matlab

--- a/matlab/src/feather_writer.cc
+++ b/matlab/src/feather_writer.cc
@@ -355,9 +355,7 @@ Status FeatherWriter::WriteVariables(const mxArray* variables, const mxArray* me
     table_columns.push_back(array);
   }
   // Create the table schema
-  arrow::Result<std::shared_ptr<arrow::Schema>> maybe_table_schema =
-      schema_builder.Finish();
-  ARROW_ASSIGN_OR_RAISE(auto table_schema, maybe_table_schema);
+  ARROW_ASSIGN_OR_RAISE(auto table_schema, schema_builder.Finish());
 
   // Specify the feather file format version as V1
   arrow::ipc::feather::WriteProperties write_props;

--- a/matlab/src/feather_writer.h
+++ b/matlab/src/feather_writer.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include <arrow/ipc/feather.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
 #include <matrix.h>
-
-#include <memory>
-#include <string>
 
 namespace arrow {
 namespace matlab {

--- a/matlab/src/feather_writer.h
+++ b/matlab/src/feather_writer.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-
 #include <arrow/ipc/feather.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
-
 #include <matrix.h>
+
+#include <memory>
+#include <string>
 
 namespace arrow {
 namespace matlab {
@@ -33,24 +32,21 @@ class FeatherWriter {
  public:
   ~FeatherWriter() = default;
 
-  /// \brief Write Feather file metadata using information from an mxArray* struct.
-  ///        The input mxArray must be a scalar struct array with the following fields:
-  ///         - "Description" :: Nx1 mxChar array, table-level description
-  ///         - "NumRows" :: scalar mxDouble array, number of rows in table
-  ///         - "NumVariables" :: scalar mxDouble array, total number of variables
-  /// \param[in] metadata mxArray* scalar struct containing table-level metadata
-  void WriteMetadata(const mxArray* metadata);
-
-  /// \brief Write mxArrays to a Feather file. The input must be a N-by-1 mxStruct
-  //         array with the following fields:
+  /// \brief Write mxArrays to a Feather file. The first input must be a N-by-1 mxStruct
+  ///         array with the following fields:
   ///         - "Name" :: Nx1 mxChar array, name of the column
   ///         - "Type" :: Nx1 mxChar array, the variable's MATLAB datatype
   ///         - "Data" :: Nx1 mxArray, data for this variable
   ///         - "Valid" :: Nx1 mxLogical array, 0 represents invalid (null) values and
   ///                                           1 represents valid (non-null) values
+  ///        The second input must be a scalar mxStruct  with the following
+  ///        fields:
+  ///         - "NumRows" :: scalar mxDouble array, number of rows in table
+  ///         - "NumVariables" :: scalar mxDouble array, total number of variables
   /// \param[in] variables mxArray* struct array containing table variable data
+  /// \param[in] metadata mxArray* scalar struct containing table-level metadata
   /// \return status
-  Status WriteVariables(const mxArray* variables);
+  Status WriteVariables(const mxArray* variables, const mxArray* metadata);
 
   /// \brief Initialize a FeatherWriter object that writes to a Feather file
   /// \param[in] filename path to the new Feather file
@@ -62,12 +58,11 @@ class FeatherWriter {
  private:
   FeatherWriter() = default;
 
-  std::unique_ptr<ipc::feather::TableWriter> table_writer_;
   int64_t num_rows_;
   int64_t num_variables_;
   std::string description_;
+  std::shared_ptr<arrow::io::OutputStream> file_output_stream_;
 };
 
 }  // namespace matlab
 }  // namespace arrow
-

--- a/matlab/src/featherread.m
+++ b/matlab/src/featherread.m
@@ -83,8 +83,4 @@ if ~isempty(variableDescriptions)
     t.Properties.VariableDescriptions = cellstr(variableDescriptions);
 end
 
-% Set the Description property of the table based on the Feather file
-% description.
-t.Properties.Description = metadata.Description;
-
 end

--- a/matlab/src/featherreadmex.cc
+++ b/matlab/src/featherreadmex.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <mex.h>
-
 #include <string>
+
+#include <mex.h>
 
 #include "feather_reader.h"
 #include "util/handle_status.h"

--- a/matlab/src/featherreadmex.cc
+++ b/matlab/src/featherreadmex.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <string>
-
 #include <mex.h>
+
+#include <string>
 
 #include "feather_reader.h"
 #include "util/handle_status.h"

--- a/matlab/src/featherwritemex.cc
+++ b/matlab/src/featherwritemex.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <string>
-
 #include <mex.h>
+
+#include <string>
 
 #include "feather_writer.h"
 #include "util/handle_status.h"
@@ -32,6 +32,5 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[]) {
       arrow::matlab::FeatherWriter::Open(filename, &feather_writer));
 
   // Write the Feather file table variables and table metadata from MATLAB.
-  feather_writer->WriteMetadata(prhs[2]);
-  arrow::matlab::util::HandleStatus(feather_writer->WriteVariables(prhs[1]));
+  arrow::matlab::util::HandleStatus(feather_writer->WriteVariables(prhs[1], prhs[2]));
 }

--- a/matlab/src/featherwritemex.cc
+++ b/matlab/src/featherwritemex.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <mex.h>
-
 #include <string>
+
+#include <mex.h>
 
 #include "feather_writer.h"
 #include "util/handle_status.h"

--- a/matlab/test/tfeathermex.m
+++ b/matlab/test/tfeathermex.m
@@ -60,7 +60,7 @@ classdef tfeathermex < matlab.unittest.TestCase
             invalidVariable = mlarrow.util.createVariableStruct('double', 1, true, '@');
             validVariable = mlarrow.util.createVariableStruct('double', 1, true, 'Valid');
             variables = [invalidVariable, validVariable];
-            metadata = mlarrow.util.createMetadataStruct('', 1, 2);
+            metadata = mlarrow.util.createMetadataStruct(1, 2);
             featherwritemex(filename, variables, metadata);
             t = featherread(filename);
             

--- a/matlab/test/util/createVariablesAndMetadataStructs.m
+++ b/matlab/test/util/createVariablesAndMetadataStructs.m
@@ -90,9 +90,8 @@ variables = [uint8Variable, ...
              singleVariable, ...
              doubleVariable];
 
-description = 'test';
 numRows = 3;
 numVariables = length(variables);
 
-metadata = createMetadataStruct(description, numRows, numVariables);
+metadata = createMetadataStruct(numRows, numVariables);
 end


### PR DESCRIPTION
**Overview**
* The MEX functions ``featherreadmex`` and ``featherwritemex`` fail to build against the latest Arrow C++ APIs. These changes allow them to successfully build.
* These changes require CMake version 3.20 or later in order to access the latest functionality exposed by [FindMatlab.cmake](https://cmake.org/cmake/help/latest/module/FindMatlab.html). We noticed that some Arrow project components, such as [Gandiva](https://arrow.apache.org/docs/developers/cpp/building.html?highlight=gandiva#cmake-version-requirements), require newer versions of CMake than the core Arrow C++ libraries.  If version 3.20 is too new, we're happy to find an alternative.
* We couldn't find a way to read and write a table description for feather V1 files using the latest APIs. It looks like support for reading and writing descriptions was modified in pull request https://github.com/apache/arrow/pull/6694. For now, we've removed support for table descriptions.

**Testing**
* Built ``featherreadmex`` and ``featherwritemex`` on Windows 10 with Visual Studio 2019
* Built ``featherreadmex`` and ``featherwritemex`` on macOS Big Sur (11.2.3) with GNU Make 3.81
* Built ``featherreadmex`` and ``featherwritemex`` on Debian 10 with GNU Make GNU 4.2.1
* Ran all tests in ``tfeather`` and ``tfeathermex`` on all platforms in MATLAB R2021a

**Future Directions**
* We did not detect the build failures due to the lack of CI integration. We hope to add CI support soon and will follow up with a mailing list discussion to talk through the details. 
* These changes are temporary to allow us to have a clean slate to start developing the  [MATLAB Interface to Apache Arrow](https://github.com/apache/arrow/blob/master/matlab/doc/matlab_interface_for_apache_arrow_design.md).
* Eventually we would like to support the full ranges of data types for feather V1 and feather V2.
* In order to modernize the code, we plan to migrate to the [C++ MEX](https://www.mathworks.com/help/matlab/cpp-mex-file-applications.html) and [MATLAB Data Array](https://www.mathworks.com/help/matlab/matlab-data-array.html) APIs.
* We are going to follow up with another pull request to update the README.md to provide more detailed platform-specific development instructions. 
* The MATLAB based build system inside of the ``build_support`` folder is out of date.  We are not sure if we want to maintain a separate MATLAB based build system along side the CMake based one. We will follow up on this in the future via the mailing list or Jira. 

We acknowledge there is a lot of information in this pull request. In the future, we will work in smaller increments. We felt a bigger pull request was necessary to get back to a working state.

Thanks,
Sarah