### PR TITLE
ARROW-12756: [C++] MSVC build fails with latest gtest from vcpkg

### DIFF
--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version-string": "5.0.0-SNAPSHOT",
-  "builtin-baseline": "",
+  "builtin-baseline": "6a274ad4b370b3b729d3af6227f57257ec708b43",
   "dependencies": [
     "abseil",
     {

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -36,5 +36,8 @@
     "utf8proc",
     "zlib",
     "zstd"
+  ],
+  "overrides": [
+    { "name": "gtest", "version": "1.10.0" }
   ]
 }

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "arrow",
   "version-string": "5.0.0-SNAPSHOT",
-  "builtin-baseline": "6a274ad4b370b3b729d3af6227f57257ec708b43",
   "dependencies": [
     "abseil",
     {
@@ -40,5 +39,6 @@
   ],
   "overrides": [
     { "name": "gtest", "version": "1.10.0" }
-  ]
+  ],
+  "builtin-baseline": "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
 }

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -38,7 +38,7 @@
     "zstd"
   ],
   "overrides": [
-    { "name": "gtest", "version": "1.10.0#4" }
+    { "name": "gtest", "version": "1.10.0", "port-version": 4 }
   ],
   "builtin-baseline": "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
 }

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -38,7 +38,7 @@
     "zstd"
   ],
   "overrides": [
-    { "name": "gtest", "version": "1.10.0" }
+    { "name": "gtest", "version": "1.10.0#4" }
   ],
   "builtin-baseline": "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
 }

--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrow",
   "version-string": "5.0.0-SNAPSHOT",
+  "builtin-baseline": "",
   "dependencies": [
     "abseil",
     {

--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -29,6 +29,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Too
 vcpkg install ^
     --triplet x64-windows ^
     --x-manifest-root cpp  ^
+    --feature-flags=versions ^
     --clean-after-build ^
     || exit /B 1
 

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -77,6 +77,7 @@ With `vcpkg <https://github.com/Microsoft/vcpkg>`_:
    cd arrow
    vcpkg install \
      --x-manifest-root cpp \
+     --feature-flags=versions \
      --clean-after-build
 
 On MSYS2:
@@ -294,7 +295,7 @@ the build system how to resolve each dependency. There are a few options:
   have this feature
 * ``CONDA``: Use ``$CONDA_PREFIX`` as alternative ``SYSTEM`` PATH
 * ``VCPKG``: Find dependencies installed by vcpkg, and if not found, run
-  ``vpckg install`` to install them
+  ``vcpkg install`` to install them
 * ``BREW``: Use Homebrew default paths as an alternative ``SYSTEM`` path
 
 The default method is ``AUTO`` unless you are developing within an active conda

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -134,6 +134,7 @@ of Arrow and run the command:
    vcpkg install ^
      --triplet x64-windows ^
      --x-manifest-root cpp  ^
+     --feature-flags=versions ^
      --clean-after-build
 
 On Windows, vcpkg builds dynamic link libraries by default. Use the triplet


### PR DESCRIPTION
This pins gtest to version 1.10.0 in the vcpkg manifest