### PR TITLE
ARROW-12741: [CI] Configure Crossbow GitHub Token for Nightly Builds

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -789,9 +789,7 @@ def integration(with_all=False, random_seed=12345, **args):
               default='-', required=True)
 @click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
               help='OAuth token for responding comment in the arrow repo')
-@click.option('--crossbow-token', '-ct', envvar='CROSSBOW_GITHUB_TOKEN',
-              help='OAuth token for pushing to the crossow repository')
-def trigger_bot(event_name, event_payload, arrow_token, crossbow_token):
+def trigger_bot(event_name, event_payload, arrow_token):
     from .bot import CommentBot, actions
 
     event_payload = json.loads(event_payload.read())

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -789,7 +789,9 @@ def integration(with_all=False, random_seed=12345, **args):
               default='-', required=True)
 @click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
               help='OAuth token for responding comment in the arrow repo')
-def trigger_bot(event_name, event_payload, arrow_token):
+@click.option('--crossbow-token', '-ct', envvar='CROSSBOW_GITHUB_TOKEN',
+              help='OAuth token for pushing to the crossow repository')
+def trigger_bot(event_name, event_payload, arrow_token, crossbow_token):
     from .bot import CommentBot, actions
 
     event_payload = json.loads(event_payload.read())

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -87,7 +87,7 @@ on:
       {% endfor %}
     {% endif %}
     env:
-      CROSSBOW_GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+      CROSSBOW_GITHUB_TOKEN: {{ '${{ secrets.CROSSBOW_GITHUB_TOKEN }}' }}
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -87,7 +87,7 @@ on:
       {% endfor %}
     {% endif %}
     env:
-      CROSSBOW_GITHUB_TOKEN: {{ '${{ secrets.CROSSBOW_GITHUB_TOKEN }}' }}
+      CROSSBOW_GITHUB_TOKEN: {{ '${{ secrets.CROSSBOW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}' }}
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}


### PR DESCRIPTION
This partially reverts commit dae3fcccca9bba114913b2b09564127bc0ee779e.