### PR TITLE
ARROW-12773: [Docs] Clarify Java support for ORC and Parquet via JNI bindings

### DIFF
--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -221,9 +221,9 @@ Third-Party Data Formats
 +-----------------------------+---------+---------+-------+------------+-------+---------+-------+
 | CSV                         | R       |         | R/W   |            |       | R/W     | R/W   |
 +-----------------------------+---------+---------+-------+------------+-------+---------+-------+
-| ORC                         | R/W     |         |       |            |       |         |       |
+| ORC                         | R/W     | R (2)   |       |            |       |         |       |
 +-----------------------------+---------+---------+-------+------------+-------+---------+-------+
-| Parquet                     | R/W     | R (2)   |       |            |       | R/W (1) |       |
+| Parquet                     | R/W     | R (3)   |       |            |       | R/W (1) |       |
 +-----------------------------+---------+---------+-------+------------+-------+---------+-------+
 
 Notes:
@@ -232,6 +232,8 @@ Notes:
 
 * *W* = Write supported
 
-* \(1) Nested read/write not supported
+* \(1) Nested read/write not supported.
 
-* \(2) Through JNI bindings to datasets.
+* \(2) Through JNI bindings. (Provided by ``org.apache.arrow.orc:arrow-orc``)
+
+* \(3) Through JNI bindings to Arrow C++ Datasets. (Provided by ``org.apache.arrow:arrow-dataset``)


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARROW-12773 for further details.