### PR TITLE
ARROW-12776: [Archery][Integration] Fix decimal case generation in write_js_test_json

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -396,8 +396,11 @@ def write_js_test_json(directory):
     datagen.generate_nested_case().write(
         os.path.join(directory, 'nested.json')
     )
-    datagen.generate_decimal_case().write(
+    datagen.generate_decimal128_case().write(
         os.path.join(directory, 'decimal.json')
+    )
+    datagen.generate_decimal256_case().write(
+        os.path.join(directory, 'decimal256.json')
     )
     datagen.generate_datetime_case().write(
         os.path.join(directory, 'datetime.json')


### PR DESCRIPTION
The integration build has started to fail on master: https://github.com/apache/arrow/runs/2575265526#step:9:4265

I don't entirely understand the reason why we see this error, in order to call that function we would need to pass `--write_generated_json` to the archery command, but we don't. 
The only occurrence of that option in the codebase is in the javascript [test runner](https://github.com/apache/arrow/blob/master/js/gulp/test-task.js#L97), but that seems to use the old `integration_test.py` script which have been deleted since we ported it to archery (cc @trxcllnt @domoritz).

Additionally, I'm unable to reproduce it locally since `archery integration` doesn't call `write_js_test_json` by default.

The implementation is clearly wrong though.