### PR TITLE
ARROW-12578: [JS] Remove Buffer in favor of TextEncoder API to support bundlers such as Rollup

### DIFF
--- a/js/src/util/utf8.ts
+++ b/js/src/util/utf8.ts
@@ -15,34 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { toUint8Array } from './buffer';
 import {
     TextDecoder as TextDecoderPolyfill,
     TextEncoder as TextEncoderPolyfill,
 } from 'text-encoding-utf-8';
 
-/** @ignore @suppress {missingRequire} */
-const _Buffer = eval("typeof Buffer === 'function' ? Buffer : null");
-/** @ignore */
-const useNativeEncoders = typeof TextDecoder === 'function' && typeof TextEncoder === 'function';
-
 /** @ignore */
 export const decodeUtf8 = ((TextDecoder) => {
-    if (useNativeEncoders || !_Buffer) {
-        const decoder = new TextDecoder('utf-8');
-        return (buffer?: ArrayBuffer | ArrayBufferView) => decoder.decode(buffer);
-    }
-    return (input: ArrayBufferLike | ArrayBufferView) => {
-        const { buffer, byteOffset, length } = toUint8Array(input);
-        return _Buffer.from(buffer, byteOffset, length).toString();
-    };
+    const decoder = new TextDecoder('utf-8');
+    return (buffer?: ArrayBuffer | ArrayBufferView) => decoder.decode(buffer);
 })(typeof TextDecoder !== 'undefined' ? TextDecoder : TextDecoderPolyfill);
 
 /** @ignore */
 export const encodeUtf8 = ((TextEncoder) => {
-    if (useNativeEncoders || !_Buffer) {
-        const encoder = new TextEncoder();
-        return (value?: string) => encoder.encode(value);
-    }
-    return (input = '') => toUint8Array(_Buffer.from(input, 'utf8'));
+    const encoder = new TextEncoder();
+    return (value?: string) => encoder.encode(value);
 })(typeof TextEncoder !== 'undefined' ? TextEncoder : TextEncoderPolyfill);

--- a/js/src/util/utf8.ts
+++ b/js/src/util/utf8.ts
@@ -20,14 +20,10 @@ import {
     TextEncoder as TextEncoderPolyfill,
 } from 'text-encoding-utf-8';
 
+const decoder = new (typeof TextDecoder !== 'undefined' ? TextDecoder : TextDecoderPolyfill)('utf-8');
 /** @ignore */
-export const decodeUtf8 = ((TextDecoder) => {
-    const decoder = new TextDecoder('utf-8');
-    return (buffer?: ArrayBuffer | ArrayBufferView) => decoder.decode(buffer);
-})(typeof TextDecoder !== 'undefined' ? TextDecoder : TextDecoderPolyfill);
+export const decodeUtf8 = (buffer?: ArrayBuffer | ArrayBufferView) => decoder.decode(buffer);
 
+const encoder = new (typeof TextEncoder !== 'undefined' ? TextEncoder : TextEncoderPolyfill)();
 /** @ignore */
-export const encodeUtf8 = ((TextEncoder) => {
-    const encoder = new TextEncoder();
-    return (value?: string) => encoder.encode(value);
-})(typeof TextEncoder !== 'undefined' ? TextEncoder : TextEncoderPolyfill);
+export const encodeUtf8 = (value?: string) => encoder.encode(value);


### PR DESCRIPTION
Bundlers such as Rollup do not recognize the `_Buffer` import, which breaks their builds. This change resolves this issue by removing Buffer in favor of `TextEncoder`. Note that change incurs a performance penalty on Node as `Buffer` is often faster.

Co-authored-by: Adam Lippai <adam@rigo.sk>
Co-authored-by: Paul Taylor <paul.e.taylor@me.com>
