### PR TITLE
ARROW-12798: [JS] Use == null Comparison

### DIFF
--- a/js/src/ipc/writer.ts
+++ b/js/src/ipc/writer.ts
@@ -163,7 +163,7 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
 
         if (!this._sink) {
             throw new Error(`RecordBatchWriter is closed`);
-        } else if (payload === null || payload === undefined) {
+        } else if (payload == null) {
             return this.finish() && undefined;
         } else if (payload instanceof Table && !(schema = payload.schema)) {
             return this.finish() && undefined;

--- a/js/src/vector/index.ts
+++ b/js/src/vector/index.ts
@@ -191,7 +191,7 @@ function wrapNullableGet<T extends DataType, V extends Vector<T>, F extends (i: 
 /** @ignore */
 function wrapNullableSet<T extends DataType, V extends BaseVector<T>, F extends (i: number, a: any) => void>(fn: F): (...args: Parameters<F>) => void {
     return function(this: V, i: number, a: any) {
-        if (setBool(this.nullBitmap, this.offset + i, !(a === null || a === undefined))) {
+        if (setBool(this.nullBitmap, this.offset + i, !((a == null)))) {
             fn.call(this, i, a);
         }
     };

--- a/js/src/vector/row.ts
+++ b/js/src/vector/row.ts
@@ -54,7 +54,7 @@ abstract class Row<K extends PropertyKey = any, V = any> implements Map<K, V> {
 
     public get(key: K) {
         let val = undefined;
-        if (key !== null && key !== undefined) {
+        if (key != null) {
             const ktoi = this[kKeyToIdx] || (this[kKeyToIdx] = new Map());
             let idx = ktoi.get(key);
             if (idx !== undefined) {
@@ -70,7 +70,7 @@ abstract class Row<K extends PropertyKey = any, V = any> implements Map<K, V> {
     }
 
     public set(key: K, val: V) {
-        if (key !== null && key !== undefined) {
+        if (key != null) {
             const ktoi = this[kKeyToIdx] || (this[kKeyToIdx] = new Map());
             let idx = ktoi.get(key);
             if (idx === undefined) {


### PR DESCRIPTION
The `== null` check is a concise expression to identify nullish values (`null` and `undefined`).

This refactoring replaces the following combinations of longer strict equality checks with the shorter `null` comparison:

* `a === null || a === undefined` becomes `a == null`
* `b !== null && b !== undefined` becomes `b != null`
* `x.f(1, 2) === null || x.f(1, 2) === undefined` becomes `x.f(1, 2) == null`

Learn More: [Equality comparisons and sameness (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness), [Equality table](https://dorey.github.io/JavaScript-Equality-Table/)

When two similar-looking function calls have a side effect, this refactoring can change the behavior of the code.

For example, the refactoring changes:

```javascript
let a = f(1) === null || f(1) === undefined;
```

into

```javascript
let a = f(1) == null;
```

If `f(1)` has a side effect, it would have been called once or twice before the refactoring, and once after the refactoring.
This means that the side effect would have been called a different number of times, potentially changing the behavior.