### PR TITLE
ARROW-12800: [JS] Remove text encoder and decoder polyfills

### DIFF
--- a/js/gulp/closure-task.js
+++ b/js/gulp/closure-task.js
@@ -72,8 +72,6 @@ const closureTask = ((cache) => memoizeTask(cache, async function closure(target
                 /* external libs first */
                 `node_modules/flatbuffers/package.json`,
                 `node_modules/flatbuffers/js/flatbuffers.mjs`,
-                `node_modules/text-encoding-utf-8/package.json`,
-                `node_modules/text-encoding-utf-8/src/encoding.js`,
                 `${src}/**/*.js` /* <-- then source globs */
             ], { base: `./` }),
             sourcemaps.init(),

--- a/js/package.json
+++ b/js/package.json
@@ -55,13 +55,11 @@
   "dependencies": {
     "@types/flatbuffers": "^1.10.0",
     "@types/node": "^15.0.2",
-    "@types/text-encoding-utf-8": "^1.0.1",
     "command-line-args": "5.1.1",
     "command-line-usage": "6.1.1",
     "flatbuffers": "1.12.0",
     "json-bignum": "^0.0.3",
     "pad-left": "^2.1.0",
-    "text-encoding-utf-8": "^1.0.2",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/js/src/util/utf8.ts
+++ b/js/src/util/utf8.ts
@@ -15,15 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import {
-    TextDecoder as TextDecoderPolyfill,
-    TextEncoder as TextEncoderPolyfill,
-} from 'text-encoding-utf-8';
-
-const decoder = new (typeof TextDecoder !== 'undefined' ? TextDecoder : TextDecoderPolyfill)('utf-8');
+const decoder = new TextDecoder('utf-8');
 /** @ignore */
-export const decodeUtf8 = (buffer?: ArrayBuffer | ArrayBufferView) => decoder.decode(buffer);
+export const decodeUtf8 = (buffer?: BufferSource) => decoder.decode(buffer);
 
-const encoder = new (typeof TextEncoder !== 'undefined' ? TextEncoder : TextEncoderPolyfill)();
+const encoder = new TextEncoder();
 /** @ignore */
 export const encodeUtf8 = (value?: string) => encoder.encode(value);

--- a/js/test/generate-test-data.ts
+++ b/js/test/generate-test-data.ts
@@ -16,7 +16,6 @@
 // under the License.
 
 const randomatic = require('randomatic');
-import { TextEncoder } from 'text-encoding-utf-8';
 import { VectorType as V } from '../src/interfaces';
 
 import {
@@ -589,7 +588,7 @@ const memoize = (fn: () => any) => ((x?: any) => () => x || (x = fn()))();
 
 const encodeUtf8 = ((encoder) =>
     encoder.encode.bind(encoder) as (input?: string, options?: { stream?: boolean }) => Uint8Array
-)(new TextEncoder('utf-8'));
+)(new TextEncoder());
 
 function fillRandom<T extends TypedArrayConstructor>(ArrayType: T, length: number) {
     const BPE = ArrayType.BYTES_PER_ELEMENT;

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1683,11 +1683,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/text-encoding-utf-8@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.1.tgz#908d884af1114e5d8df47597b1e04f833383d23d"
-  integrity sha512-GpIEYaS+yNfYqpowLLziiY42pyaL+lThd/wMh6tTubaKuG4IRkXqqyxK7Nddn3BvpUg2+go3Gv/jbXvAFMRjiQ==
-
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -9227,11 +9222,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-text-encoding-utf-8@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
-  integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
 
 text-extensions@^1.0.0:
   version "1.9.0"


### PR DESCRIPTION
This drops IE support as well. 