### PR TITLE
ARROW-12619: [Python] pyarrow sdist should not require git

### DIFF
--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -42,10 +42,16 @@ export PYARROW_WITH_DATASET=${ARROW_DATASET:-OFF}
 # unset ARROW_HOME
 # apt purge -y pkg-config
 
+# ARROW-12619
+if [ command -v COMMAND &> /dev/null ]; then
+  echo "Git exists, remove it from PATH before executing this script."
+  exit 1
+fi
+
 if [ -n "${PYARROW_VERSION:-}" ]; then
   sdist="${arrow_dir}/python/dist/pyarrow-${PYARROW_VERSION}.tar.gz"
 else
-  sdist=$(ls "${arrow_dir}/python/dist/pyarrow-*.tar.gz" | sort -r | head -n1)
+  sdist=$(ls ${arrow_dir}/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)
 fi
 ${PYTHON:-python} -m pip install ${sdist}
 

--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -43,7 +43,7 @@ export PYARROW_WITH_DATASET=${ARROW_DATASET:-OFF}
 # apt purge -y pkg-config
 
 # ARROW-12619
-if [ command -v COMMAND &> /dev/null ]; then
+if command -v git &> /dev/null; then
   echo "Git exists, remove it from PATH before executing this script."
   exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -713,6 +713,7 @@ services:
     volumes: *ubuntu-volumes
     command: >
       /bin/bash -c "
+        apt remove -y git &&
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_sdist_test.sh /arrow"
 
@@ -814,9 +815,9 @@ services:
         source: .
         target: "C:/arrow"
     command: arrow\\ci\\scripts\\python_wheel_windows_test.bat
-  
+
   java-bundled-jars:
-    # Docker image 
+    # Docker image
     image: ${REPO}:${ARCH}-java-bundled-jars-vcpkg-${VCPKG}
     build:
       args:
@@ -831,7 +832,7 @@ services:
     volumes:
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux2014-ccache:/ccache:delegated
-    command: 
+    command:
       [/arrow/ci/scripts/java_bundled_jars_manylinux_build.sh /arrow /build /arrow/dist]
 
   ##############################  Integration #################################

--- a/python/setup.py
+++ b/python/setup.py
@@ -525,12 +525,8 @@ def _move_shared_libs_unix(build_prefix, build_lib, lib_name):
 default_version = '5.0.0-SNAPSHOT'
 if (not os.path.exists('../.git') and
         not os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')):
-    if os.path.exists('PKG-INFO'):
-        # We're probably in a Python sdist, setuptools_scm will handle fine
-        pass
-    else:
-        os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
-            default_version.replace('-SNAPSHOT', 'a0')
+    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
+        default_version.replace('-SNAPSHOT', 'a0')
 
 
 # See https://github.com/pypa/setuptools_scm#configuration-parameters


### PR DESCRIPTION
There is a fallback_version configuration option for setuptools_scm which we don't use: https://github.com/pypa/setuptools_scm#configuration-parameters

Although this setting seems to have issues according to https://github.com/pypa/setuptools_scm/issues/549
We already have a workaround in setup.py for the functionality of the fallback_version option, but it is disabled for the case of sdist: https://github.com/apache/arrow/blob/master/python/setup.py#L529