### PR TITLE
ARROW-12569: [R] [CI]  Run revdep in CI

### DIFF
--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -51,9 +51,14 @@ SCRIPT="
     # We can't use RSPM binaries because we need source packages
     options('repos' = c(CRAN = 'https://packagemanager.rstudio.com/all/latest'))
     remotes::install_github('r-lib/revdepcheck')
+
+    # zoo is needed by RcisTarget tests, though only listed in enhances so not installed by revdepcheck
+    install.packages('zoo')
+
+    # actually run revdepcheck
     revdepcheck::revdep_check(
     quiet = FALSE,
-    timeout = as.difftime(90, units = 'mins'),
+    timeout = as.difftime(120, units = 'mins'),
     num_workers = 4,
     env = c(
         ARROW_R_DEV = '$ARROW_R_DEV',

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -47,6 +47,9 @@ export TEST_R_WITH_ARROW=$TEST_R_WITH_ARROW
 # to retrieve metadata. Disable this so that S3FileSystem tests run faster.
 export AWS_EC2_METADATA_DISABLED=TRUE
 
+# Set crancache dir so we can cache it
+export CRANCACHE_DIR="/arrow/.crancache"
+
 SCRIPT="
     # We can't use RSPM binaries because we need source packages
     options('repos' = c(CRAN = 'https://packagemanager.rstudio.com/all/latest'))

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -64,7 +64,7 @@ SCRIPT="
     revdepcheck::revdep_check(
     quiet = FALSE,
     timeout = as.difftime(120, units = 'mins'),
-    num_workers = 2,
+    num_workers = 1,
     env = c(
         ARROW_R_DEV = '$ARROW_R_DEV',
         LIBARROW_DOWNLOAD = TRUE,

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -67,6 +67,16 @@ SCRIPT="
         revdepcheck::revdep_env_vars()
     ))
     revdepcheck::revdep_report(all = TRUE)
+
+    # Go through the summary and fail if any of the statuses include `-`
+    summary <- revdepcheck::revdep_summary()
+    failed <- lapply(summary, function(check) {
+      grepl('-', check$status)
+    })
+
+    if (any(unlist(failed))) {
+      quit(status = 1)
+    }
     "
 
 echo "$SCRIPT" | ${R_BIN} --no-save

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -70,7 +70,7 @@ SCRIPT="
 
     # Go through the summary and fail if any of the statuses include -
     summary <- revdepcheck::revdep_summary()
-    failed <- lapply(summary, function(check) grepl('-', check$status))
+    failed <- lapply(summary, function(check) grepl('-', check[['status']]))
 
     if (any(unlist(failed))) {
       quit(status = 1)

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -22,24 +22,26 @@ set -ex
 
 source_dir=${1}/r
 
+# cpp building dependencies
+apt install -y cmake
+
+# system dependencies needed for arrow's reverse dependencies
+apt install -y libxml2-dev \
+  libfontconfig1-dev \
+  libcairo2-dev \
+  libglpk-dev \
+  libmariadb-dev \
+  unixodbc-dev \
+  libpq-dev \
+  coinor-libsymphony-dev \
+  coinor-libcgl-dev \
+  coinor-symphony \
+  libzmq3-dev
+
 pushd ${source_dir}
 
 printenv
 
-# This is problematic?
-# TODO: why?
-# if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
-#   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
-#   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
-# fi
-
-export _R_CHECK_COMPILATION_FLAGS_KNOWN_=${ARROW_R_CXXFLAGS}
-if [ "$ARROW_R_DEV" = "TRUE" ]; then
-  # These are used in the Arrow C++ build and are not a problem
-  export _R_CHECK_COMPILATION_FLAGS_KNOWN_="${_R_CHECK_COMPILATION_FLAGS_KNOWN_} -Wno-attributes -msse4.2"
-  # Note that NOT_CRAN=true means (among other things) that optional dependencies are built
-  export NOT_CRAN=true
-fi
 : ${TEST_R_WITH_ARROW:=TRUE}
 export TEST_R_WITH_ARROW=$TEST_R_WITH_ARROW
 

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -47,7 +47,10 @@ export TEST_R_WITH_ARROW=$TEST_R_WITH_ARROW
 # to retrieve metadata. Disable this so that S3FileSystem tests run faster.
 export AWS_EC2_METADATA_DISABLED=TRUE
 
-SCRIPT="remotes::install_github('r-lib/revdepcheck')
+SCRIPT="
+    # We can't use RSPM binaries because we need source packages
+    options('repos' = 'https://packagemanager.rstudio.com/all/latest')
+    remotes::install_github('r-lib/revdepcheck')
     revdepcheck::revdep_check(
     quiet = FALSE,
     timeout = as.difftime(90, units = 'mins'),
@@ -57,8 +60,9 @@ SCRIPT="remotes::install_github('r-lib/revdepcheck')
         LIBARROW_DOWNLOAD = TRUE,
         LIBARROW_MINIMAL = FALSE,
         revdepcheck::revdep_env_vars()
-    )
-    )"
+    ))
+    revdepcheck::revdep_report(all = TRUE)
+    "
 
 echo "$SCRIPT" | ${R_BIN} --no-save
 

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -49,7 +49,7 @@ export AWS_EC2_METADATA_DISABLED=TRUE
 
 SCRIPT="
     # We can't use RSPM binaries because we need source packages
-    options('repos' = 'https://packagemanager.rstudio.com/all/latest')
+    options('repos' = c(CRAN = 'https://packagemanager.rstudio.com/all/latest'))
     remotes::install_github('r-lib/revdepcheck')
     revdepcheck::revdep_check(
     quiet = FALSE,

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -64,7 +64,7 @@ SCRIPT="
     revdepcheck::revdep_check(
     quiet = FALSE,
     timeout = as.difftime(120, units = 'mins'),
-    num_workers = 1,
+    num_workers = 2,
     env = c(
         ARROW_R_DEV = '$ARROW_R_DEV',
         LIBARROW_DOWNLOAD = TRUE,

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -68,11 +68,9 @@ SCRIPT="
     ))
     revdepcheck::revdep_report(all = TRUE)
 
-    # Go through the summary and fail if any of the statuses include `-`
+    # Go through the summary and fail if any of the statuses include -
     summary <- revdepcheck::revdep_summary()
-    failed <- lapply(summary, function(check) {
-      grepl('-', check$status)
-    })
+    failed <- lapply(summary, function(check) grepl('-', check$status))
 
     if (any(unlist(failed))) {
       quit(status = 1)

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+: ${R_BIN:=R}
+
+source_dir=${1}/r
+
+pushd ${source_dir}
+
+printenv
+
+# This is problematic?
+# TODO: why?
+# if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
+#   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
+#   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+# fi
+
+export _R_CHECK_COMPILATION_FLAGS_KNOWN_=${ARROW_R_CXXFLAGS}
+if [ "$ARROW_R_DEV" = "TRUE" ]; then
+  # These are used in the Arrow C++ build and are not a problem
+  export _R_CHECK_COMPILATION_FLAGS_KNOWN_="${_R_CHECK_COMPILATION_FLAGS_KNOWN_} -Wno-attributes -msse4.2"
+  # Note that NOT_CRAN=true means (among other things) that optional dependencies are built
+  export NOT_CRAN=true
+fi
+: ${TEST_R_WITH_ARROW:=TRUE}
+export TEST_R_WITH_ARROW=$TEST_R_WITH_ARROW
+
+# By default, aws-sdk tries to contact a non-existing local ip host
+# to retrieve metadata. Disable this so that S3FileSystem tests run faster.
+export AWS_EC2_METADATA_DISABLED=TRUE
+
+SCRIPT="remotes::install_github('r-lib/revdepcheck')
+    revdepcheck::revdep_check(
+    quiet = FALSE,
+    timeout = as.difftime(90, units = 'mins'),
+    num_workers = 4,
+    env = c(
+        ARROW_R_DEV = '$ARROW_R_DEV',
+        LIBARROW_DOWNLOAD = TRUE,
+        LIBARROW_MINIMAL = FALSE,
+        revdepcheck::revdep_env_vars()
+    )
+    )"
+
+echo "$SCRIPT" | ${R_BIN} --no-save
+
+popd

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -59,7 +59,7 @@ SCRIPT="
     revdepcheck::revdep_check(
     quiet = FALSE,
     timeout = as.difftime(120, units = 'mins'),
-    num_workers = 4,
+    num_workers = 1,
     env = c(
         ARROW_R_DEV = '$ARROW_R_DEV',
         LIBARROW_DOWNLOAD = TRUE,

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             /arrow/r/revdep
             /arrow/.crancache
-        key: {{ "${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
+          key: {{ "${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -48,11 +48,12 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: cd arrow && ci/scripts/util_checkout.sh
+      # The cache will not be found unless there is a run that was cached
+      # on the main branch first.
       - name: Cache crancache and revdeps directory
         uses: actions/cache@v2
         with:
-          key: {{ "cache-${{ hashFiles('arrow/cpp/vcpkg.json') }}" }}
-          restore-keys: "cache-"
+          key: {{ "r-revdep-cache-${{ hashFiles('arrow/cpp/vcpkg.json') }}" }}
           path: |
             arrow/r/revdep
             arrow/.crancache

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             /arrow/r/revdep
             /arrow/.crancache
-        key: {{ "${{ hashFiles('cpp/vcpkg.json') }}" }}
+        key: {{ "${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Cache crancache and revdeps directory
         uses: actions/cache@v2
         with:
+          key: {{ "cache-${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
           path: |
             /arrow/r/revdep
             /arrow/.crancache
-          key: {{ "${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Cache crancache and revdeps directory
         uses: actions/cache@v2
         with:
-          key: {{ "cache-${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
+          key: {{ "cache-${{ hashFiles('arrow/cpp/vcpkg.json') }}" }}
           path: |
             arrow/r/revdep
             arrow/.crancache

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           key: {{ "cache-${{ hashFiles('/arrow/cpp/vcpkg.json') }}" }}
           path: |
-            /arrow/r/revdep
-            /arrow/.crancache
+            arrow/r/revdep
+            arrow/.crancache
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -48,15 +48,6 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: cd arrow && ci/scripts/util_checkout.sh
-      # The cache will not be found unless there is a run that was cached
-      # on the main branch first.
-      - name: Cache crancache and revdeps directory
-        uses: actions/cache@v2
-        with:
-          key: {{ "r-revdep-cache-${{ hashFiles('arrow/cpp/vcpkg.json') }}" }}
-          path: |
-            arrow/r/revdep
-            arrow/.crancache
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -54,6 +54,7 @@ jobs:
           path: |
             /arrow/r/revdep
             /arrow/.crancache
+        key: ${{ hashFiles('cpp/vcpkg.json') }}
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             /arrow/r/revdep
             /arrow/.crancache
-        key: ${{ hashFiles('cpp/vcpkg.json') }}
+        key: {{ "${{ hashFiles('cpp/vcpkg.json') }}" }}
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           key: {{ "cache-${{ hashFiles('arrow/cpp/vcpkg.json') }}" }}
+          restore-keys: "cache-"
           path: |
             arrow/r/revdep
             arrow/.crancache

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE: must set "Crossbow" as name to have the badge links working in the
+# github comment reports!
+name: Crossbow
+
+on:
+  push:
+    branches:
+      - "*-github-*"
+
+jobs:
+  r-versions:
+    name: "rstudio/r-base:latest-focal"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      R_ORG: "rstudio"
+      R_IMAGE: "r-base"
+      R_TAG: "latest-focal"
+      ARROW_R_DEV: "TRUE"
+    steps:
+      - name: Checkout Arrow
+        run: |
+          git clone --no-checkout {{ arrow.remote }} arrow
+          git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
+          git -C arrow checkout FETCH_HEAD
+          git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: cd arrow && ci/scripts/util_checkout.sh
+      - name: Docker Pull
+        shell: bash
+        run: cd arrow && docker-compose pull --ignore-pull-failures r
+      - name: Docker Build
+        shell: bash
+        run: cd arrow && docker-compose build r-revdepcheck
+      - name: Docker Run
+        shell: bash
+        run: cd arrow && docker-compose run r-revdepcheck
+      - name: Save the revdep output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: revdepcheck-folder
+          path: arrow/r/revdep

--- a/dev/tasks/r/github.linux.revdepcheck.yml
+++ b/dev/tasks/r/github.linux.revdepcheck.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: cd arrow && ci/scripts/util_checkout.sh
+      - name: Cache crancache and revdeps directory
+        uses: actions/cache@v2
+        with:
+          path: |
+            /arrow/r/revdep
+            /arrow/.crancache
       - name: Docker Pull
         shell: bash
         run: cd arrow && docker-compose pull --ignore-pull-failures r
@@ -57,6 +63,18 @@ jobs:
       - name: Docker Run
         shell: bash
         run: cd arrow && docker-compose run r-revdepcheck
+      - name: revdepcheck CRAN report
+        if: always()
+        shell: bash
+        run: cat arrow/r/revdep/cran.md
+      - name: revdepcheck failures
+        if: always()
+        shell: bash
+        run: cat arrow/r/revdep/failures.md
+      - name: revdepcheck problems
+        if: always()
+        shell: bash
+        run: cat arrow/r/revdep/problems.md
       - name: Save the revdep output
         if: always()
         uses: actions/upload-artifact@v2

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -919,6 +919,10 @@ tasks:
         UBUNTU: 18.04
       run: ubuntu-r-sanitizer
 
+  revdep-r-check:
+    ci: github
+    template: r/github.linux.revdepcheck.yml
+
   test-debian-10-go-1.15:
     ci: azure
     template: docker-tests/azure.linux.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1096,6 +1096,46 @@ services:
       /bin/bash -c "
         /arrow/ci/scripts/r_valgrind.sh /arrow"
 
+  r-revdepcheck:
+    # Usage:
+    #   docker-compose build r-revdepcheck
+    #   docker-compose run r-revdepcheck
+    image: ${REPO}:r-rstudio-r-base-4.0-focal-revdepcheck
+    build:
+      context: .
+      dockerfile: ci/docker/linux-r.dockerfile
+      cache_from:
+        - ${REPO}:r-rstudio-r-base-4.0-focal-revdepcheck
+      args:
+        base: rstudio/r-base:4.0-focal
+        r_dev: ${ARROW_R_DEV}
+    shm_size: *shm-size
+    environment:
+      LIBARROW_DOWNLOAD: "true"
+      LIBARROW_MINIMAL: "false"
+      ARROW_SOURCE_HOME: "/arrow"
+      ARROW_R_DEV: "true"
+    volumes: *ubuntu-volumes
+    command: >
+      /bin/bash -c "
+        # cpp building dependencies
+        apt install -y cmake ninja-build pkg-config
+
+        # system dependencies needed for arrow's reverse dependencies
+        apt install -y libxml2-dev \
+          libfontconfig1-dev \
+          libcairo2-dev \
+          libglpk-dev \
+          libmariadb-dev \
+          unixodbc-dev \
+          libpq-dev \
+          coinor-libsymphony-dev \
+          coinor-libcgl-dev \
+          coinor-symphony
+        /arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/r_revdepcheck.sh /arrow"
+
+
 
   ################################# Go ########################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1118,23 +1118,7 @@ services:
       ARROW_R_DEV: "true"
     volumes: *ubuntu-volumes
     command: >
-      /bin/bash -c "
-        # cpp building dependencies
-        apt install -y cmake
-
-        # system dependencies needed for arrow's reverse dependencies
-        apt install -y libxml2-dev \
-          libfontconfig1-dev \
-          libcairo2-dev \
-          libglpk-dev \
-          libmariadb-dev \
-          unixodbc-dev \
-          libpq-dev \
-          coinor-libsymphony-dev \
-          coinor-libcgl-dev \
-          coinor-symphony \
-          libzmq3-dev
-        /arrow/ci/scripts/r_revdepcheck.sh /arrow"
+      /bin/bash -c "/arrow/ci/scripts/r_revdepcheck.sh /arrow"
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1119,7 +1119,7 @@ services:
     command: >
       /bin/bash -c "
         # cpp building dependencies
-        apt install -y cmake ninja-build pkg-config
+        apt install -y cmake
 
         # system dependencies needed for arrow's reverse dependencies
         apt install -y libxml2-dev \
@@ -1131,8 +1131,8 @@ services:
           libpq-dev \
           coinor-libsymphony-dev \
           coinor-libcgl-dev \
-          coinor-symphony
-        /arrow/ci/scripts/cpp_build.sh /arrow /build &&
+          coinor-symphony \
+          libzmq3-dev
         /arrow/ci/scripts/r_revdepcheck.sh /arrow"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ x-hierarchy:
   - ubuntu-r-valgrind
   - python-sdist
   - r
+  - r-revdepcheck
   # helper services
   - impala
   - postgres


### PR DESCRIPTION
This runs reverse dependency checks using {revdepchecks}. The way that works is by installing a release version of arrow and the current development version (i.e. from the git checkout), and then runs checks on each of the reverse dependencies first with the release (called "old" in {revdepcheck}'s terms) and with the development version ("new" in {revdepcheck}'s terms). Then it compares the outputs and will only fail if there is a failure in the new check that is not in the old check. 

I've customized the output a bit so that it prints any errors that come up in either (in the revdepcheck problems step) so we can more easily diagnose, but it will only fail if there are new errors.

One thing that I tried and was unable to do is to find a way to cache packages+info across runs. The github cache action will create a cache, but because of how they are run on crossbow (i.e. on different branches) the caches are never accessible in different runs. I've kept the cacheing step in for now, if we could find a way to (manually?) run this on the main branch like https://github.com/ursacomputing/crossbow/blob/master/.github/workflows/cache_vcpkg.yml before we use this heavily (i.e. likely only around a release) that would create a cache that could be used to speed up some of the jobs.