### PR TITLE
ARROW-12744: [C++][Compute] Add rounding kernel

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -53,6 +53,7 @@ struct EnumTraits<compute::JoinOptions::NullHandlingBehavior>
     return "<INVALID>";
   }
 };
+
 template <>
 struct EnumTraits<TimeUnit::type>
     : BasicEnumTraits<TimeUnit::type, TimeUnit::type::SECOND, TimeUnit::type::MILLI,
@@ -72,6 +73,7 @@ struct EnumTraits<TimeUnit::type>
     return "<INVALID>";
   }
 };
+
 template <>
 struct EnumTraits<compute::CompareOperator>
     : BasicEnumTraits<
@@ -136,6 +138,42 @@ struct EnumTraits<compute::AssumeTimezoneOptions::Nonexistent>
     return "<INVALID>";
   }
 };
+
+template <>
+struct EnumTraits<compute::RoundMode>
+    : BasicEnumTraits<compute::RoundMode, compute::RoundMode::DOWN,
+                      compute::RoundMode::UP, compute::RoundMode::TOWARDS_ZERO,
+                      compute::RoundMode::TOWARDS_INFINITY, compute::RoundMode::HALF_DOWN,
+                      compute::RoundMode::HALF_UP, compute::RoundMode::HALF_TOWARDS_ZERO,
+                      compute::RoundMode::HALF_TOWARDS_INFINITY,
+                      compute::RoundMode::HALF_TO_EVEN, compute::RoundMode::HALF_TO_ODD> {
+  static std::string name() { return "compute::RoundMode"; }
+  static std::string value_name(compute::RoundMode value) {
+    switch (value) {
+      case compute::RoundMode::DOWN:
+        return "DOWN";
+      case compute::RoundMode::UP:
+        return "UP";
+      case compute::RoundMode::TOWARDS_ZERO:
+        return "TOWARDS_ZERO";
+      case compute::RoundMode::TOWARDS_INFINITY:
+        return "TOWARDS_INFINITY";
+      case compute::RoundMode::HALF_DOWN:
+        return "HALF_DOWN";
+      case compute::RoundMode::HALF_UP:
+        return "HALF_UP";
+      case compute::RoundMode::HALF_TOWARDS_ZERO:
+        return "HALF_TOWARDS_ZERO";
+      case compute::RoundMode::HALF_TOWARDS_INFINITY:
+        return "HALF_TOWARDS_INFINITY";
+      case compute::RoundMode::HALF_TO_EVEN:
+        return "HALF_TO_EVEN";
+      case compute::RoundMode::HALF_TO_ODD:
+        return "HALF_TO_ODD";
+    }
+    return "<INVALID>";
+  }
+};
 }  // namespace internal
 
 namespace compute {
@@ -153,6 +191,12 @@ static auto kArithmeticOptionsType = GetFunctionOptionsType<ArithmeticOptions>(
 static auto kElementWiseAggregateOptionsType =
     GetFunctionOptionsType<ElementWiseAggregateOptions>(
         DataMember("skip_nulls", &ElementWiseAggregateOptions::skip_nulls));
+static auto kRoundOptionsType = GetFunctionOptionsType<RoundOptions>(
+    DataMember("ndigits", &RoundOptions::ndigits),
+    DataMember("round_mode", &RoundOptions::round_mode));
+static auto kRoundToMultipleOptionsType = GetFunctionOptionsType<RoundToMultipleOptions>(
+    DataMember("multiple", &RoundToMultipleOptions::multiple),
+    DataMember("round_mode", &RoundToMultipleOptions::round_mode));
 static auto kJoinOptionsType = GetFunctionOptionsType<JoinOptions>(
     DataMember("null_handling", &JoinOptions::null_handling),
     DataMember("null_replacement", &JoinOptions::null_replacement));
@@ -216,6 +260,30 @@ ElementWiseAggregateOptions::ElementWiseAggregateOptions(bool skip_nulls)
     : FunctionOptions(internal::kElementWiseAggregateOptionsType),
       skip_nulls(skip_nulls) {}
 constexpr char ElementWiseAggregateOptions::kTypeName[];
+
+RoundOptions::RoundOptions(int64_t ndigits, RoundMode round_mode)
+    : FunctionOptions(internal::kRoundOptionsType),
+      ndigits(ndigits),
+      round_mode(round_mode) {
+  static_assert(RoundMode::HALF_DOWN > RoundMode::DOWN &&
+                    RoundMode::HALF_DOWN > RoundMode::UP &&
+                    RoundMode::HALF_DOWN > RoundMode::TOWARDS_ZERO &&
+                    RoundMode::HALF_DOWN > RoundMode::TOWARDS_INFINITY &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_UP &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TOWARDS_ZERO &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TOWARDS_INFINITY &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TO_EVEN &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TO_ODD,
+                "Invalid order of round modes. Modes prefixed with HALF need to be "
+                "enumerated last with HALF_DOWN being the first among them.");
+}
+constexpr char RoundOptions::kTypeName[];
+
+RoundToMultipleOptions::RoundToMultipleOptions(double multiple, RoundMode round_mode)
+    : FunctionOptions(internal::kRoundToMultipleOptionsType),
+      multiple(multiple),
+      round_mode(round_mode) {}
+constexpr char RoundToMultipleOptions::kTypeName[];
 
 JoinOptions::JoinOptions(NullHandlingBehavior null_handling, std::string null_replacement)
     : FunctionOptions(internal::kJoinOptionsType),
@@ -352,6 +420,8 @@ namespace internal {
 void RegisterScalarOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kArithmeticOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kElementWiseAggregateOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kRoundOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kRoundToMultipleOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kJoinOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kMatchSubstringOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kSplitOptionsType));
@@ -404,6 +474,15 @@ SCALAR_ARITHMETIC_UNARY(Ln, "ln", "ln_checked")
 SCALAR_ARITHMETIC_UNARY(Log10, "log10", "log10_checked")
 SCALAR_ARITHMETIC_UNARY(Log2, "log2", "log2_checked")
 SCALAR_ARITHMETIC_UNARY(Log1p, "log1p", "log1p_checked")
+
+Result<Datum> Round(const Datum& arg, RoundOptions options, ExecContext* ctx) {
+  return CallFunction("round", {arg}, &options, ctx);
+}
+
+Result<Datum> RoundToMultiple(const Datum& arg, RoundToMultipleOptions options,
+                              ExecContext* ctx) {
+  return CallFunction("round_to_multiple", {arg}, &options, ctx);
+}
 
 #define SCALAR_ARITHMETIC_BINARY(NAME, REGISTRY_NAME, REGISTRY_CHECKED_NAME)           \
   Result<Datum> NAME(const Datum& left, const Datum& right, ArithmeticOptions options, \

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -50,8 +50,56 @@ class ARROW_EXPORT ElementWiseAggregateOptions : public FunctionOptions {
   explicit ElementWiseAggregateOptions(bool skip_nulls = true);
   constexpr static char const kTypeName[] = "ElementWiseAggregateOptions";
   static ElementWiseAggregateOptions Defaults() { return ElementWiseAggregateOptions{}; }
-
   bool skip_nulls;
+};
+
+/// Rounding and tie-breaking modes for round compute functions.
+/// Additional details and examples are provided in compute.rst.
+enum class RoundMode : int8_t {
+  /// Round to nearest integer less than or equal in magnitude (aka "floor")
+  DOWN,
+  /// Round to nearest integer greater than or equal in magnitude (aka "ceil")
+  UP,
+  /// Get the integral part without fractional digits (aka "trunc")
+  TOWARDS_ZERO,
+  /// Round negative values with DOWN rule and positive values with UP rule
+  TOWARDS_INFINITY,
+  /// Round ties with DOWN rule
+  HALF_DOWN,
+  /// Round ties with UP rule
+  HALF_UP,
+  /// Round ties with TOWARDS_ZERO rule
+  HALF_TOWARDS_ZERO,
+  /// Round ties with TOWARDS_INFINITY rule
+  HALF_TOWARDS_INFINITY,
+  /// Round ties to nearest even integer
+  HALF_TO_EVEN,
+  /// Round ties to nearest odd integer
+  HALF_TO_ODD,
+};
+
+class ARROW_EXPORT RoundOptions : public FunctionOptions {
+ public:
+  explicit RoundOptions(int64_t ndigits = 0,
+                        RoundMode round_mode = RoundMode::HALF_TO_EVEN);
+  constexpr static char const kTypeName[] = "RoundOptions";
+  static RoundOptions Defaults() { return RoundOptions(); }
+  /// Rounding precision (number of digits to round to)
+  int64_t ndigits;
+  /// Rounding and tie-breaking mode
+  RoundMode round_mode;
+};
+
+class ARROW_EXPORT RoundToMultipleOptions : public FunctionOptions {
+ public:
+  explicit RoundToMultipleOptions(double multiple = 1.0,
+                                  RoundMode round_mode = RoundMode::HALF_TO_EVEN);
+  constexpr static char const kTypeName[] = "RoundToMultipleOptions";
+  static RoundToMultipleOptions Defaults() { return RoundToMultipleOptions(); }
+  /// Rounding scale (multiple to round to)
+  double multiple;
+  /// Rounding and tie-breaking mode
+  RoundMode round_mode;
 };
 
 /// Options for var_args_join.
@@ -559,8 +607,9 @@ Result<Datum> Logb(const Datum& arg, const Datum& base,
                    ExecContext* ctx = NULLPTR);
 
 /// \brief Round to the nearest integer less than or equal in magnitude to the
-/// argument. Array values can be of arbitrary length. If argument is null the
-/// result will be null.
+/// argument.
+///
+/// If argument is null the result will be null.
 ///
 /// \param[in] arg the value to round
 /// \param[in] ctx the function execution context, optional
@@ -569,8 +618,9 @@ ARROW_EXPORT
 Result<Datum> Floor(const Datum& arg, ExecContext* ctx = NULLPTR);
 
 /// \brief Round to the nearest integer greater than or equal in magnitude to the
-/// argument. Array values can be of arbitrary length. If argument is null the
-/// result will be null.
+/// argument.
+///
+/// If argument is null the result will be null.
 ///
 /// \param[in] arg the value to round
 /// \param[in] ctx the function execution context, optional
@@ -578,8 +628,9 @@ Result<Datum> Floor(const Datum& arg, ExecContext* ctx = NULLPTR);
 ARROW_EXPORT
 Result<Datum> Ceil(const Datum& arg, ExecContext* ctx = NULLPTR);
 
-/// \brief Get the integral part without fractional digits. Array values can be
-/// of arbitrary length. If argument is null the result will be null.
+/// \brief Get the integral part without fractional digits.
+///
+/// If argument is null the result will be null.
 ///
 /// \param[in] arg the value to truncate
 /// \param[in] ctx the function execution context, optional
@@ -618,9 +669,34 @@ Result<Datum> MinElementWise(
 ///
 /// \param[in] arg the value to extract sign from
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise sign function
+/// \return the element-wise sign function
 ARROW_EXPORT
 Result<Datum> Sign(const Datum& arg, ExecContext* ctx = NULLPTR);
+
+/// \brief Round a value to a given precision.
+///
+/// If argument is null the result will be null.
+///
+/// \param[in] arg the value rounded
+/// \param[in] options rounding options (rounding mode and number of digits), optional
+/// \param[in] ctx the function execution context, optional
+/// \return the element-wise rounded value
+ARROW_EXPORT
+Result<Datum> Round(const Datum& arg, RoundOptions options = RoundOptions::Defaults(),
+                    ExecContext* ctx = NULLPTR);
+
+/// \brief Round a value to a given multiple.
+///
+/// If argument is null the result will be null.
+///
+/// \param[in] arg the value to round
+/// \param[in] options rounding options (rounding mode and multiple), optional
+/// \param[in] ctx the function execution context, optional
+/// \return the element-wise rounded value
+ARROW_EXPORT
+Result<Datum> RoundToMultiple(
+    const Datum& arg, RoundToMultipleOptions options = RoundToMultipleOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
 
 /// \brief Compare a numeric array with a scalar.
 ///

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -227,7 +227,7 @@ class ARROW_EXPORT Function {
   virtual Result<Datum> Execute(const std::vector<Datum>& args,
                                 const FunctionOptions* options, ExecContext* ctx) const;
 
-  /// \brief Returns a the default options for this function.
+  /// \brief Returns the default options for this function.
   ///
   /// Whatever option semantics a Function has, implementations must guarantee
   /// that default_options() is valid to pass to Execute as options.

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -58,6 +58,12 @@ TEST(FunctionOptions, Equality) {
   options.emplace_back(new IndexOptions(ScalarFromJSON(boolean(), "null")));
   options.emplace_back(new ArithmeticOptions());
   options.emplace_back(new ArithmeticOptions(/*check_overflow=*/true));
+  options.emplace_back(new RoundOptions());
+  options.emplace_back(
+      new RoundOptions(/*ndigits=*/2, /*round_mode=*/RoundMode::TOWARDS_INFINITY));
+  options.emplace_back(new RoundToMultipleOptions());
+  options.emplace_back(new RoundToMultipleOptions(
+      /*multiple=*/100, /*round_mode=*/RoundMode::TOWARDS_INFINITY));
   options.emplace_back(new ElementWiseAggregateOptions());
   options.emplace_back(new ElementWiseAggregateOptions(/*skip_nulls=*/false));
   options.emplace_back(new JoinOptions());

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -94,8 +94,8 @@ struct OptionsWrapper : public KernelState {
 /// KernelContext and the FunctionOptions as argument
 template <typename StateType, typename OptionsType>
 struct KernelStateFromFunctionOptions : public KernelState {
-  explicit KernelStateFromFunctionOptions(KernelContext* ctx, OptionsType state)
-      : state(StateType(ctx, std::move(state))) {}
+  explicit KernelStateFromFunctionOptions(KernelContext* ctx, OptionsType options)
+      : state(StateType(ctx, std::move(options))) {}
 
   static Result<std::unique_ptr<KernelState>> Init(KernelContext* ctx,
                                                    const KernelInitArgs& args) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -20,7 +20,6 @@
 #include <cmath>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -43,8 +42,19 @@
 namespace arrow {
 namespace compute {
 
-template <typename T>
-class TestUnaryArithmetic : public TestBase {
+using IntegralTypes = testing::Types<Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type,
+                                     UInt16Type, UInt32Type, UInt64Type>;
+
+using SignedIntegerTypes = testing::Types<Int8Type, Int16Type, Int32Type, Int64Type>;
+
+using UnsignedIntegerTypes =
+    testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type>;
+
+// TODO(kszucs): add half-float
+using FloatingTypes = testing::Types<FloatType, DoubleType>;
+
+template <typename T, typename OptionsType>
+class TestBaseUnaryArithmetic : public TestBase {
  protected:
   using ArrowType = T;
   using CType = typename ArrowType::c_type;
@@ -54,9 +64,7 @@ class TestUnaryArithmetic : public TestBase {
   }
 
   using UnaryFunction =
-      std::function<Result<Datum>(const Datum&, ArithmeticOptions, ExecContext*)>;
-
-  void SetUp() override { options_.check_overflow = false; }
+      std::function<Result<Datum>(const Datum&, OptionsType, ExecContext*)>;
 
   std::shared_ptr<Scalar> MakeNullScalar() {
     return arrow::MakeNullScalar(type_singleton());
@@ -65,6 +73,8 @@ class TestUnaryArithmetic : public TestBase {
   std::shared_ptr<Scalar> MakeScalar(CType value) {
     return *arrow::MakeScalar(type_singleton(), value);
   }
+
+  void SetUp() override {}
 
   // (CScalar, CScalar)
   void AssertUnaryOp(UnaryFunction func, CType argument, CType expected) {
@@ -150,14 +160,21 @@ class TestUnaryArithmetic : public TestBase {
     AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
   }
 
-  void SetOverflowCheck(bool value = true) { options_.check_overflow = value; }
-
   void SetNansEqual(bool value = true) {
-    this->equal_options_ = equal_options_.nans_equal(value);
+    equal_options_ = equal_options_.nans_equal(value);
   }
 
-  ArithmeticOptions options_ = ArithmeticOptions();
+  OptionsType options_ = OptionsType();
   EqualOptions equal_options_ = EqualOptions::Defaults();
+};
+
+// Subclasses of TestBaseUnaryArithmetic for different FunctionOptions.
+template <typename T>
+class TestUnaryArithmetic : public TestBaseUnaryArithmetic<T, ArithmeticOptions> {
+ protected:
+  using Base = TestBaseUnaryArithmetic<T, ArithmeticOptions>;
+  using Base::options_;
+  void SetOverflowCheck(bool value) { options_.check_overflow = value; }
 };
 
 template <typename T>
@@ -171,6 +188,49 @@ class TestUnaryArithmeticUnsigned : public TestUnaryArithmeticIntegral<T> {};
 
 template <typename T>
 class TestUnaryArithmeticFloating : public TestUnaryArithmetic<T> {};
+
+template <typename T>
+class TestUnaryRound : public TestBaseUnaryArithmetic<T, RoundOptions> {
+ protected:
+  using Base = TestBaseUnaryArithmetic<T, RoundOptions>;
+  using Base::options_;
+  void SetRoundMode(RoundMode value) { options_.round_mode = value; }
+  void SetRoundNdigits(int64_t value) { options_.ndigits = value; }
+};
+
+template <typename T>
+class TestUnaryRoundIntegral : public TestUnaryRound<T> {};
+
+template <typename T>
+class TestUnaryRoundSigned : public TestUnaryRoundIntegral<T> {};
+
+template <typename T>
+class TestUnaryRoundUnsigned : public TestUnaryRoundIntegral<T> {};
+
+template <typename T>
+class TestUnaryRoundFloating : public TestUnaryRound<T> {};
+
+template <typename T>
+class TestUnaryRoundToMultiple
+    : public TestBaseUnaryArithmetic<T, RoundToMultipleOptions> {
+ protected:
+  using Base = TestBaseUnaryArithmetic<T, RoundToMultipleOptions>;
+  using Base::options_;
+  void SetRoundMode(RoundMode value) { options_.round_mode = value; }
+  void SetRoundMultiple(double value) { options_.multiple = value; }
+};
+
+template <typename T>
+class TestUnaryRoundToMultipleIntegral : public TestUnaryRoundToMultiple<T> {};
+
+template <typename T>
+class TestUnaryRoundToMultipleSigned : public TestUnaryRoundToMultipleIntegral<T> {};
+
+template <typename T>
+class TestUnaryRoundToMultipleUnsigned : public TestUnaryRoundToMultipleIntegral<T> {};
+
+template <typename T>
+class TestUnaryRoundToMultipleFloating : public TestUnaryRoundToMultiple<T> {};
 
 template <typename T>
 class TestBinaryArithmetic : public TestBase {
@@ -404,18 +464,6 @@ class TestBitWiseArithmetic : public TestBase {
     AssertArraysEqual(*expected, *actual, /*verbose=*/true);
   }
 };
-
-// InputType - OutputType pairs
-using IntegralTypes = testing::Types<Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type,
-                                     UInt16Type, UInt32Type, UInt64Type>;
-
-using SignedIntegerTypes = testing::Types<Int8Type, Int16Type, Int32Type, Int64Type>;
-
-using UnsignedIntegerTypes =
-    testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type>;
-
-// TODO(kszucs): add half-float
-using FloatingTypes = testing::Types<FloatType, DoubleType>;
 
 TYPED_TEST_SUITE(TestUnaryArithmeticIntegral, IntegralTypes);
 TYPED_TEST_SUITE(TestUnaryArithmeticSigned, SignedIntegerTypes);
@@ -1089,7 +1137,8 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Fail on null type
-  for (std::string name : {"atan", "sign", "floor", "ceil", "trunc"}) {
+  for (std::string name :
+       {"atan", "sign", "floor", "ceil", "trunc", "round", "round_to_multiple"}) {
     CheckDispatchFails(name, {null()});
   }
 
@@ -1114,7 +1163,8 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Float types
-  for (std::string name : {"atan", "floor", "ceil", "trunc"}) {
+  for (std::string name :
+       {"atan", "sign", "floor", "ceil", "trunc", "round", "round_to_multiple"}) {
     for (const auto& ty : {float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});
       CheckDispatchBest(name, {dictionary(int8(), ty)}, {ty});
@@ -1135,7 +1185,8 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Integer -> Float64
-  for (std::string name : {"atan", "floor", "ceil", "trunc"}) {
+  for (std::string name :
+       {"atan", "floor", "ceil", "trunc", "round", "round_to_multiple"}) {
     for (const auto& ty :
          {int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(), uint64()}) {
       CheckDispatchBest(name, {ty}, {float64()});
@@ -1350,6 +1401,213 @@ TYPED_TEST(TestUnaryArithmeticFloating, AbsoluteValue) {
     this->AssertUnaryOp(AbsoluteValue, min, max);
     this->AssertUnaryOp(AbsoluteValue, max, max);
   }
+}
+
+TYPED_TEST_SUITE(TestUnaryRoundIntegral, IntegralTypes);
+TYPED_TEST_SUITE(TestUnaryRoundSigned, SignedIntegerTypes);
+TYPED_TEST_SUITE(TestUnaryRoundUnsigned, UnsignedIntegerTypes);
+TYPED_TEST_SUITE(TestUnaryRoundFloating, FloatingTypes);
+
+const std::vector<RoundMode> kRoundModes{
+    RoundMode::DOWN,
+    RoundMode::UP,
+    RoundMode::TOWARDS_ZERO,
+    RoundMode::TOWARDS_INFINITY,
+    RoundMode::HALF_DOWN,
+    RoundMode::HALF_UP,
+    RoundMode::HALF_TOWARDS_ZERO,
+    RoundMode::HALF_TOWARDS_INFINITY,
+    RoundMode::HALF_TO_EVEN,
+    RoundMode::HALF_TO_ODD,
+};
+
+TYPED_TEST(TestUnaryRoundSigned, Round) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, -13, -50, 115]");
+  this->SetRoundNdigits(0);
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  std::vector<std::pair<int64_t, std::string>> ndigits_and_expected{{
+      {-2, "[0, 0, -0, -100, 100]"},
+      {-1, "[0, 0, -10, -50, 120]"},
+      {0, values},
+      {1, values},
+      {2, values},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->SetRoundNdigits(pair.first);
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestUnaryRoundUnsigned, Round) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, 13, 50, 115]");
+  this->SetRoundNdigits(0);
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  std::vector<std::pair<int64_t, std::string>> ndigits_and_expected{{
+      {-2, "[0, 0, 0, 100, 100]"},
+      {-1, "[0, 0, 10, 50, 120]"},
+      {0, values},
+      {1, values},
+      {2, values},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->SetRoundNdigits(pair.first);
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestUnaryRoundFloating, Round) {
+  this->SetNansEqual(true);
+
+  // Test different rounding modes
+  std::string values("[3.2, 3.5, 3.7, 4.5, -3.2, -3.5, -3.7]");
+  std::vector<std::pair<RoundMode, std::string>> rmode_and_expected{{
+      {RoundMode::DOWN, "[3, 3, 3, 4, -4, -4, -4]"},
+      {RoundMode::UP, "[4, 4, 4, 5, -3, -3, -3]"},
+      {RoundMode::TOWARDS_ZERO, "[3, 3, 3, 4, -3, -3, -3]"},
+      {RoundMode::TOWARDS_INFINITY, "[4, 4, 4, 5, -4, -4, -4]"},
+      {RoundMode::HALF_DOWN, "[3, 3, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_UP, "[3, 4, 4, 5, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_ZERO, "[3, 3, 4, 4, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_INFINITY, "[3, 4, 4, 5, -3, -4, -4]"},
+      {RoundMode::HALF_TO_EVEN, "[3, 4, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_TO_ODD, "[3, 3, 4, 5, -3, -3, -4]"},
+  }};
+  this->SetRoundNdigits(0);
+  for (const auto& pair : rmode_and_expected) {
+    this->SetRoundMode(pair.first);
+    this->AssertUnaryOp(Round, "[]", "[]");
+    this->AssertUnaryOp(Round, "[null, 0, Inf, -Inf, NaN, -NaN]",
+                        "[null, 0, Inf, -Inf, NaN, -NaN]");
+    this->AssertUnaryOp(Round, values, pair.second);
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  values = "[320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045]";
+  std::vector<std::pair<int64_t, std::string>> ndigits_and_expected{{
+      {-2, "[300, 0, 0, 0, -0, -0, -0]"},
+      {-1, "[320, 0, 0, 0, -0, -40, -0]"},
+      {0, "[320, 4, 3, 5, -3, -35, -3]"},
+      {1, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3]"},
+      {2, "[320, 3.5, 3.08, 4.5, -3.21, -35.12, -3.05]"},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->SetRoundNdigits(pair.first);
+    this->AssertUnaryOp(Round, values, pair.second);
+  }
+}
+
+TYPED_TEST_SUITE(TestUnaryRoundToMultipleIntegral, IntegralTypes);
+TYPED_TEST_SUITE(TestUnaryRoundToMultipleSigned, SignedIntegerTypes);
+TYPED_TEST_SUITE(TestUnaryRoundToMultipleUnsigned, UnsignedIntegerTypes);
+TYPED_TEST_SUITE(TestUnaryRoundToMultipleFloating, FloatingTypes);
+
+TYPED_TEST(TestUnaryRoundToMultipleSigned, RoundToMultiple) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, -13, -50, 115]");
+  this->SetRoundMultiple(1);
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round multiples for nearest rounding mode
+  std::vector<std::pair<double, std::string>> multiple_and_expected{{
+      {2, "[0, 2, -14, -50, 116]"},
+      {0.05, "[0, 1, -13, -50, 115]"},
+      {0.1, values},
+      {10, "[0, 0, -10, -50, 120]"},
+      {100, "[0, 0, -0, -100, 100]"},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : multiple_and_expected) {
+    this->SetRoundMultiple(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestUnaryRoundToMultipleUnsigned, RoundToMultiple) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, 13, 50, 115]");
+  this->SetRoundMultiple(1);
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round multiples for nearest rounding mode
+  std::vector<std::pair<double, std::string>> multiple_and_expected{{
+      {2, "[0, 2, 14, 50, 116]"},
+      {0.05, "[0, 1, 13, 50, 115]"},
+      {0.1, values},
+      {10, "[0, 0, 10, 50, 120]"},
+      {100, "[0, 0, 0, 100, 100]"},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : multiple_and_expected) {
+    this->SetRoundMultiple(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
+  this->SetNansEqual(true);
+
+  // Test different rounding modes for integer rounding
+  std::string values("[3.2, 3.5, 3.7, 4.5, -3.2, -3.5, -3.7]");
+  std::vector<std::pair<RoundMode, std::string>> rmode_and_expected{{
+      {RoundMode::DOWN, "[3, 3, 3, 4, -4, -4, -4]"},
+      {RoundMode::UP, "[4, 4, 4, 5, -3, -3, -3]"},
+      {RoundMode::TOWARDS_ZERO, "[3, 3, 3, 4, -3, -3, -3]"},
+      {RoundMode::TOWARDS_INFINITY, "[4, 4, 4, 5, -4, -4, -4]"},
+      {RoundMode::HALF_DOWN, "[3, 3, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_UP, "[3, 4, 4, 5, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_ZERO, "[3, 3, 4, 4, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_INFINITY, "[3, 4, 4, 5, -3, -4, -4]"},
+      {RoundMode::HALF_TO_EVEN, "[3, 4, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_TO_ODD, "[3, 3, 4, 5, -3, -3, -4]"},
+  }};
+  this->SetRoundMultiple(1);
+  for (const auto& pair : rmode_and_expected) {
+    this->SetRoundMode(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, "[]", "[]");
+    this->AssertUnaryOp(RoundToMultiple, "[null, 0, Inf, -Inf, NaN, -NaN]",
+                        "[null, 0, Inf, -Inf, NaN, -NaN]");
+    this->AssertUnaryOp(RoundToMultiple, values, pair.second);
+  }
+
+  // Test different round multiples for nearest rounding mode
+  values = "[320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045]";
+  std::vector<std::pair<double, std::string>> multiple_and_expected{{
+      {2, "[320, 4, 4, 4, -4, -36, -4]"},
+      {0.05, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3.05]"},
+      {0.1, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3]"},
+      {10, "[320, 0, 0, 0, -0, -40, -0]"},
+      {100, "[300, 0, 0, 0, -0, -0, -0]"},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : multiple_and_expected) {
+    this->SetRoundMultiple(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, values, pair.second);
+  }
+
+  this->SetRoundMultiple(-2);
+  this->AssertUnaryOpRaises(RoundToMultiple, values,
+                            "multiple has to be a positive value");
 }
 
 TEST(TestBinaryDecimalArithmetic, DispatchBest) {

--- a/cpp/src/arrow/python/python_test.cc
+++ b/cpp/src/arrow/python/python_test.cc
@@ -222,7 +222,7 @@ TEST(PyBuffer, NumpyArray) {
 }
 
 TEST(NumPyBuffer, NumpyArray) {
-  const npy_intp dims[1] = {10};
+  npy_intp dims[1] = {10};
 
   OwnedRef arr_ref(PyArray_SimpleNew(1, dims, NPY_FLOAT));
   PyObject* arr = arr_ref.obj();

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -78,14 +78,16 @@ Bit-wise operations do not offer (or need) a checked variant.
 Rounding Functions
 ------------------
 
-Rounding functions convert a numeric input into an approximate value with a
-simpler representation based on the rounding strategy.
+Rounding functions displace numeric inputs to an approximate value with a simpler
+representation based on the rounding criterion.
 
 .. autosummary::
    :toctree: ../generated/
 
    ceil
    floor
+   round
+   round_to_multiple
    trunc
 
 Logarithmic Functions

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -699,6 +699,57 @@ class ElementWiseAggregateOptions(_ElementWiseAggregateOptions):
         self._set_options(skip_nulls)
 
 
+cdef CRoundMode unwrap_round_mode(round_mode) except *:
+    if round_mode == 'down':
+        return CRoundMode_DOWN
+    elif round_mode == 'up':
+        return CRoundMode_UP
+    elif round_mode == 'towards_zero':
+        return CRoundMode_TOWARDS_ZERO
+    elif round_mode == 'towards_infinity':
+        return CRoundMode_TOWARDS_INFINITY
+    elif round_mode == 'half_down':
+        return CRoundMode_HALF_DOWN
+    elif round_mode == 'half_up':
+        return CRoundMode_HALF_UP
+    elif round_mode == 'half_towards_zero':
+        return CRoundMode_HALF_TOWARDS_ZERO
+    elif round_mode == 'half_towards_infinity':
+        return CRoundMode_HALF_TOWARDS_INFINITY
+    elif round_mode == 'half_to_even':
+        return CRoundMode_HALF_TO_EVEN
+    elif round_mode == 'half_to_odd':
+        return CRoundMode_HALF_TO_ODD
+    else:
+        raise ValueError('"{}" is not a valid round mode'.format(round_mode))
+
+
+cdef class _RoundOptions(FunctionOptions):
+    def _set_options(self, int64_t ndigits, round_mode):
+        cdef:
+            CRoundMode c_round_mode = CRoundMode_HALF_TO_EVEN
+        c_round_mode = unwrap_round_mode(round_mode)
+        self.wrapped.reset(new CRoundOptions(ndigits, c_round_mode))
+
+
+class RoundOptions(_RoundOptions):
+    def __init__(self, ndigits=0, round_mode='half_to_even'):
+        self._set_options(ndigits, round_mode)
+
+
+cdef class _RoundToMultipleOptions(FunctionOptions):
+    def _set_options(self, double multiple, round_mode):
+        cdef:
+            CRoundMode c_round_mode = CRoundMode_HALF_TO_EVEN
+        c_round_mode = unwrap_round_mode(round_mode)
+        self.wrapped.reset(new CRoundToMultipleOptions(multiple, c_round_mode))
+
+
+class RoundToMultipleOptions(_RoundToMultipleOptions):
+    def __init__(self, multiple=1.0, round_mode='half_to_even'):
+        self._set_options(multiple, round_mode)
+
+
 cdef class _JoinOptions(FunctionOptions):
     def _set_options(self, null_handling, null_replacement):
         cdef:

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -49,6 +49,8 @@ from pyarrow._compute import (  # noqa
     QuantileOptions,
     ReplaceSliceOptions,
     ReplaceSubstringOptions,
+    RoundOptions,
+    RoundToMultipleOptions,
     ScalarAggregateOptions,
     SetLookupOptions,
     SliceOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1827,6 +1827,41 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CElementWiseAggregateOptions(c_bool skip_nulls)
         c_bool skip_nulls
 
+    ctypedef enum CRoundMode \
+            "arrow::compute::RoundMode":
+        CRoundMode_DOWN \
+            "arrow::compute::RoundMode::DOWN"
+        CRoundMode_UP \
+            "arrow::compute::RoundMode::UP"
+        CRoundMode_TOWARDS_ZERO \
+            "arrow::compute::RoundMode::TOWARDS_ZERO"
+        CRoundMode_TOWARDS_INFINITY \
+            "arrow::compute::RoundMode::TOWARDS_INFINITY"
+        CRoundMode_HALF_DOWN \
+            "arrow::compute::RoundMode::HALF_DOWN"
+        CRoundMode_HALF_UP \
+            "arrow::compute::RoundMode::HALF_UP"
+        CRoundMode_HALF_TOWARDS_ZERO \
+            "arrow::compute::RoundMode::HALF_TOWARDS_ZERO"
+        CRoundMode_HALF_TOWARDS_INFINITY \
+            "arrow::compute::RoundMode::HALF_TOWARDS_INFINITY"
+        CRoundMode_HALF_TO_EVEN \
+            "arrow::compute::RoundMode::HALF_TO_EVEN"
+        CRoundMode_HALF_TO_ODD \
+            "arrow::compute::RoundMode::HALF_TO_ODD"
+
+    cdef cppclass CRoundOptions \
+            "arrow::compute::RoundOptions"(CFunctionOptions):
+        CRoundOptions(int64_t ndigits, CRoundMode round_mode)
+        int64_t ndigits
+        CRoundMode round_mode
+
+    cdef cppclass CRoundToMultipleOptions \
+            "arrow::compute::RoundToMultipleOptions"(CFunctionOptions):
+        CRoundToMultipleOptions(double multiple, CRoundMode round_mode)
+        double multiple
+        CRoundMode round_mode
+
     enum CJoinNullHandlingBehavior \
             "arrow::compute::JoinOptions::NullHandlingBehavior":
         CJoinNullHandlingBehavior_EMIT_NULL \


### PR DESCRIPTION
This PR adds rounding compute functions, namely "round" and "round_to_multiple".
* `round(x, RoundOptions(ndigits, round_mode))` - round `x` to the precision indicated by `ndigits`
* `round_to_multiple(x, RoundToMultipleOptions(multiple, round_mode))` - round `x` to scale of `multiple`

Rounding modes supported are: DOWN, UP, TOWARDS_ZERO, TOWARDS_INFINITY, HALF_DOWN, HALF_UP, HALF_TOWARDS_ZERO, HALF_TOWARDS_INFINITY, HALF_TO_EVEN, HALF_TO_ODD.
By default tie-breaking modes round to the nearest integer and resolve ties with HALF_TO_EVEN.

The rounding functions expect floating-point inputs and return output of the same type. Integral inputs are implicitly type-casted and output is float64.