### PR TITLE
ARROW-12608: [C++][Python][R] Add split_pattern_regex kernel

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1319,7 +1319,7 @@ struct SplitRegexTransform : SplitBaseTransform<Type, ListType, SplitPatternOpti
     // RE2 does *not* give you the full match! Must wrap the regex in a capture group
     // There is FindAndConsume, but it would give only the end of the separator
     std::string pattern = "(";
-    pattern.reserve(options.pattern.size() + 1);
+    pattern.reserve(options.pattern.size() + 2);
     pattern += options.pattern;
     pattern += ')';
     return pattern;

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -472,6 +472,34 @@ TYPED_TEST(TestStringKernels, SplitWhitespaceUTF8Reverse) {
                    &options_max);
 }
 
+#ifdef ARROW_WITH_RE2
+TYPED_TEST(TestStringKernels, SplitRegex) {
+  SplitPatternOptions options{"a+|b"};
+
+  this->CheckUnary(
+      "split_pattern_regex", R"(["aaaab", "foob", "foo bar", "foo", "AaaaBaaaC", null])",
+      list(this->type()),
+      R"([["", "", ""], ["foo", ""], ["foo ", "", "r"], ["foo"], ["A", "B", "C"], null])",
+      &options);
+
+  options.max_splits = 1;
+  this->CheckUnary(
+      "split_pattern_regex", R"(["aaaab", "foob", "foo bar", "foo", "AaaaBaaaC", null])",
+      list(this->type()),
+      R"([["", "b"], ["foo", ""], ["foo ", "ar"], ["foo"], ["A", "BaaaC"], null])",
+      &options);
+}
+
+TYPED_TEST(TestStringKernels, SplitRegexReverse) {
+  SplitPatternOptions options{"a+|b", /*max_splits=*/1, /*reverse=*/true};
+  Datum input = ArrayFromJSON(this->type(), R"(["a"])");
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      NotImplemented, ::testing::HasSubstr("Cannot split in reverse with regex"),
+      CallFunction("split_pattern_regex", {input}, &options));
+}
+#endif
+
 TYPED_TEST(TestStringKernels, ReplaceSubstring) {
   ReplaceSubstringOptions options{"foo", "bazz"};
   this->CheckUnary("replace_substring", R"(["foo", "this foo that foo", null])",

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -578,7 +578,7 @@ when a positive ``max_splits`` is given.
 * \(1) The string is split when an exact pattern is found (the pattern itself
   is not included in the output).
 
-* \(1) The string is split when a regex match is found (the matched
+* \(2) The string is split when a regex match is found (the matched
   substring itself is not included in the output).
 
 * \(3) A non-zero length sequence of Unicode defined whitespace codepoints

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -568,18 +568,23 @@ when a positive ``max_splits`` is given.
 +==========================+============+=========================+===================+==================================+=========+
 | split_pattern            | Unary      | String-like             | List-like         | :struct:`SplitPatternOptions`    | \(1)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
-| utf8_split_whitespace    | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(2)    |
+| split_pattern_regex      | Unary      | String-like             | List-like         | :struct:`SplitPatternOptions`    | \(2)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
-| ascii_split_whitespace   | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(3)    |
+| utf8_split_whitespace    | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(3)    |
++--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
+| ascii_split_whitespace   | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(4)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
 
 * \(1) The string is split when an exact pattern is found (the pattern itself
   is not included in the output).
 
-* \(2) A non-zero length sequence of Unicode defined whitespace codepoints
+* \(1) The string is split when a regex match is found (the matched
+  substring itself is not included in the output).
+
+* \(3) A non-zero length sequence of Unicode defined whitespace codepoints
   is seen as separator.
 
-* \(3) A non-zero length sequence of ASCII defined whitespace bytes
+* \(4) A non-zero length sequence of ASCII defined whitespace bytes
   (``'\t'``, ``'\n'``, ``'\v'``, ``'\f'``, ``'\r'``  and ``' '``) is seen
   as separator.
 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -137,6 +137,17 @@ a byte-by-byte basis.
 
    string_is_ascii
 
+String Splitting
+----------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   split_pattern
+   split_pattern_regex
+   ascii_split_whitespace
+   utf8_split_whitespace
+
 String Transforms
 -----------------
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -349,6 +349,22 @@ def test_split_whitespace_ascii():
     assert expected.equals(result)
 
 
+def test_split_pattern_regex():
+    arr = pa.array(["-foo---bar--", "---foo---b"])
+    result = pc.split_pattern_regex(arr, pattern="-+")
+    expected = pa.array([["", "foo", "bar", ""], ["", "foo", "b"]])
+    assert expected.equals(result)
+
+    result = pc.split_pattern_regex(arr, pattern="-+", max_splits=1)
+    expected = pa.array([["", "foo---bar--"], ["", "foo---b"]])
+    assert expected.equals(result)
+
+    with pytest.raises(NotImplementedError,
+                       match="Cannot split in reverse with regex"):
+        result = pc.split_pattern_regex(
+            arr, pattern="---", max_splits=1, reverse=True)
+
+
 def test_min_max():
     # An example generated function wrapper with possible options
     data = [4, 5, 6, None, 1]

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
                                      max_replacements);
   }
 
-  if (func_name == "split_pattern") {
+  if (func_name == "split_pattern" || func_name == "split_pattern_regex") {
     using Options = arrow::compute::SplitPatternOptions;
     int64_t max_splits = -1;
     if (!Rf_isNull(options["max_splits"])) {

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -273,6 +273,12 @@ test_that("strsplit and str_split", {
   )
   expect_dplyr_equal(
     input %>%
+      mutate(x = strsplit(x, " +and +")) %>%
+      collect(),
+    df
+  )
+  expect_dplyr_equal(
+    input %>%
       mutate(x = str_split(x, "and")) %>%
       collect(),
     df
@@ -295,7 +301,12 @@ test_that("strsplit and str_split", {
       collect(),
     df
   )
-
+  expect_dplyr_equal(
+    input %>%
+      mutate(x = str_split(x, "Foo|bar", n = 2)) %>%
+      collect(),
+    df
+  )
 })
 
 test_that("arrow_*_split_whitespace functions", {
@@ -352,21 +363,6 @@ test_that("errors and warnings in string splitting", {
   # so here we can just call the functions directly
 
   x <- Expression$field_ref("x")
-  expect_error(
-    nse_funcs$strsplit(x, "and.*", fixed = FALSE),
-    'Regular expression matching in strsplit() not supported by Arrow',
-    fixed = TRUE
-  )
-  expect_error(
-    nse_funcs$str_split(x, "and.?"),
-    'Regular expression matching in str_split() not supported by Arrow',
-    fixed = TRUE
-  )
-  expect_error(
-    nse_funcs$str_split(x, regex("and.*")),
-    'Regular expression matching in str_split() not supported by Arrow',
-    fixed = TRUE
-  )
   expect_error(
     nse_funcs$str_split(x, fixed("and", ignore_case = TRUE)),
     "Case-insensitive string splitting not supported by Arrow"


### PR DESCRIPTION
This adds a split_pattern_regex kernel using RE2.

Caveats:
- RE2 requires us to wrap the user's regex in a capture group in order to actually get the matched delimiter.
- Reverse splitting is not implemented - there's not a good way to do this with RE2.
- In R, strsplit behaves differently - trailing empty splits are no longer dropped:

```
> df <- tibble(x = c("foo bar"))
> (df %>% mutate(x = strsplit(x, "bar")) %>% collect())$x
[[1]]
[1] "foo "

> (record_batch(df) %>% mutate(x = strsplit(x, "bar")) %>% collect())$x
<list<character>[1]>
[[1]]
[1] "foo " ""   
```

So the behavior here does not exactly match R. Though this was already the case:

```
> (df %>% mutate(x = strsplit(x, "bar", fixed = TRUE)) %>% collect())$x
[[1]]
[1] "foo "

> (record_batch(df) %>% mutate(x = strsplit(x, "bar", fixed = TRUE)) %>% collect())$x
<list<character>[1]>
[[1]]
[1] "foo " ""    
```