### PR TITLE
ARROW-12831: [CI][macOS] Remove needless Homebrew workaround

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -222,7 +222,6 @@ jobs:
         run: |
           rm -f /usr/local/bin/2to3
           brew update --preinstall
-          brew unlink gcc@8 gcc@9
           brew bundle --file=cpp/Brewfile
       - name: Build
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -140,7 +140,6 @@ jobs:
         run: |
           rm -f /usr/local/bin/2to3
           brew update --preinstall
-          brew unlink gcc@8 gcc@9
           brew bundle --file=cpp/Brewfile
           brew install coreutils
           python3 -mpip install \

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -132,7 +132,6 @@ jobs:
         run: |
           rm -f /usr/local/bin/2to3
           brew update --preinstall
-          brew unlink gcc@8 gcc@9
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
       - name: Install Ruby Dependencies


### PR DESCRIPTION
This was introduced by #9119 (ARROW-1152) but this is no longer
needed.