### PR TITLE
ARROW-13468: [Release] Fix binary download/upload failures

### DIFF
--- a/dev/release/04-binary-download.sh
+++ b/dev/release/04-binary-download.sh
@@ -36,4 +36,4 @@ crossbow_job_prefix="release-${version_with_rc}"
 : ${CROSSBOW_JOB_NUMBER:="0"}
 : ${CROSSBOW_JOB_ID:="${crossbow_job_prefix}-${CROSSBOW_JOB_NUMBER}"}
 
-archery crossbow download-artifacts ${CROSSBOW_JOB_ID}
+archery crossbow download-artifacts ${CROSSBOW_JOB_ID} --no-fetch

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -128,8 +128,8 @@ docker_run \
   ./runner.sh \
   rake \
     "${rake_tasks[@]}" \
-    ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     APT_TARGETS=$(IFS=,; echo "${apt_targets[*]}") \
+    ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \
     VERSION=${version} \

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -128,6 +128,7 @@ docker_run \
   ./runner.sh \
   rake \
     "${rake_tasks[@]}" \
+    ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     APT_TARGETS=$(IFS=,; echo "${apt_targets[*]}") \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \


### PR DESCRIPTION
These are two minor fixes to the release script.

1. Made git not fetch the 15k tags on crossbow and instead. This was causing timeouts
2. pass the `ARTIFACTORY_API_KEY` to the docker image so that it can use it in pushing artifacts

