### PR TITLE
ARROW-12835: [C++][Python][R] Implement case-insensitive match using RE2

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -43,10 +43,13 @@ struct ArithmeticOptions : public FunctionOptions {
 };
 
 struct ARROW_EXPORT MatchSubstringOptions : public FunctionOptions {
-  explicit MatchSubstringOptions(std::string pattern) : pattern(std::move(pattern)) {}
+  explicit MatchSubstringOptions(std::string pattern, bool ignore_case = false)
+      : pattern(std::move(pattern)), ignore_case(ignore_case) {}
 
   /// The exact substring (or regex, depending on kernel) to look for inside input values.
   std::string pattern;
+  /// Whether to perform a case-insensitive match.
+  bool ignore_case = false;
 };
 
 struct ARROW_EXPORT SplitOptions : public FunctionOptions {

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -657,14 +657,14 @@ cdef class _MatchSubstringOptions(FunctionOptions):
     cdef const CFunctionOptions* get_options(self) except NULL:
         return self.match_substring_options.get()
 
-    def _set_options(self, pattern):
+    def _set_options(self, pattern, bint ignore_case):
         self.match_substring_options.reset(
-            new CMatchSubstringOptions(tobytes(pattern)))
+            new CMatchSubstringOptions(tobytes(pattern), ignore_case))
 
 
 class MatchSubstringOptions(_MatchSubstringOptions):
-    def __init__(self, pattern):
-        self._set_options(pattern)
+    def __init__(self, pattern, bint ignore_case=False):
+        self._set_options(pattern, ignore_case)
 
 
 cdef class _TrimOptions(FunctionOptions):

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -308,7 +308,7 @@ def find_substring(array, pattern):
                          MatchSubstringOptions(pattern))
 
 
-def match_like(array, pattern):
+def match_like(array, pattern, *, ignore_case=False):
     """
     Test if the SQL-style LIKE pattern *pattern* matches a value of a
     string array.
@@ -321,6 +321,8 @@ def match_like(array, pattern):
         characters, '_' will match exactly one character, and all
         other characters match themselves. To match a literal percent
         sign or underscore, precede the character with a backslash.
+    ignore_case : bool, default False
+        Ignore case while searching.
 
     Returns
     -------
@@ -328,10 +330,10 @@ def match_like(array, pattern):
 
     """
     return call_function("match_like", [array],
-                         MatchSubstringOptions(pattern))
+                         MatchSubstringOptions(pattern, ignore_case))
 
 
-def match_substring(array, pattern):
+def match_substring(array, pattern, *, ignore_case=False):
     """
     Test if substring *pattern* is contained within a value of a string array.
 
@@ -340,16 +342,18 @@ def match_substring(array, pattern):
     array : pyarrow.Array or pyarrow.ChunkedArray
     pattern : str
         pattern to search for exact matches
+    ignore_case : bool, default False
+        Ignore case while searching.
 
     Returns
     -------
     result : pyarrow.Array or pyarrow.ChunkedArray
     """
     return call_function("match_substring", [array],
-                         MatchSubstringOptions(pattern))
+                         MatchSubstringOptions(pattern, ignore_case))
 
 
-def match_substring_regex(array, pattern):
+def match_substring_regex(array, pattern, *, ignore_case=False):
     """
     Test if regex *pattern* matches at any position a value of a string array.
 
@@ -358,13 +362,15 @@ def match_substring_regex(array, pattern):
     array : pyarrow.Array or pyarrow.ChunkedArray
     pattern : str
         regex pattern to search
+    ignore_case : bool, default False
+        Ignore case while searching.
 
     Returns
     -------
     result : pyarrow.Array or pyarrow.ChunkedArray
     """
     return call_function("match_substring_regex", [array],
-                         MatchSubstringOptions(pattern))
+                         MatchSubstringOptions(pattern, ignore_case))
 
 
 def sum(array):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1783,8 +1783,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CMatchSubstringOptions \
             "arrow::compute::MatchSubstringOptions"(CFunctionOptions):
-        CMatchSubstringOptions(c_string pattern)
+        CMatchSubstringOptions(c_string pattern, c_bool ignore_case)
         c_string pattern
+        c_bool ignore_case
 
     cdef cppclass CTrimOptions \
             "arrow::compute::TrimOptions"(CFunctionOptions):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -308,6 +308,14 @@ def test_match_like():
     expected = pa.array([False, True, False, True, None])
     assert expected.equals(result)
 
+    arr = pa.array(["aB", "bA%", "ba", "ca%d", None])
+    result = pc.match_like(arr, r"_a\%%", ignore_case=True)
+    expected = pa.array([False, True, False, True, None])
+    assert expected.equals(result)
+    result = pc.match_like(arr, r"_a\%%", ignore_case=False)
+    expected = pa.array([False, False, False, True, None])
+    assert expected.equals(result)
+
 
 def test_match_substring():
     arr = pa.array(["ab", "abc", "ba", None])
@@ -315,11 +323,27 @@ def test_match_substring():
     expected = pa.array([True, True, False, None])
     assert expected.equals(result)
 
+    arr = pa.array(["áB", "Ábc", "ba", None])
+    result = pc.match_substring(arr, "áb", ignore_case=True)
+    expected = pa.array([True, True, False, None])
+    assert expected.equals(result)
+    result = pc.match_substring(arr, "áb", ignore_case=False)
+    expected = pa.array([False, False, False, None])
+    assert expected.equals(result)
+
 
 def test_match_substring_regex():
     arr = pa.array(["ab", "abc", "ba", "c", None])
     result = pc.match_substring_regex(arr, "^a?b")
     expected = pa.array([True, True, True, False, None])
+    assert expected.equals(result)
+
+    arr = pa.array(["aB", "Abc", "BA", "c", None])
+    result = pc.match_substring_regex(arr, "^a?b", ignore_case=True)
+    expected = pa.array([True, True, True, False, None])
+    assert expected.equals(result)
+    result = pc.match_substring_regex(arr, "^a?b", ignore_case=False)
+    expected = pa.array([False, False, False, False, None])
     assert expected.equals(result)
 
 

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -226,11 +226,11 @@ nse_funcs$str_trim <- function(string, side = c("both", "left", "right")) {
 }
 
 nse_funcs$grepl <- function(pattern, x, ignore.case = FALSE, fixed = FALSE) {
-  arrow_fun <- ifelse(fixed && !ignore.case, "match_substring", "match_substring_regex")
+  arrow_fun <- ifelse(fixed, "match_substring", "match_substring_regex")
   Expression$create(
     arrow_fun,
     x,
-    options = list(pattern = format_string_pattern(pattern, ignore.case, fixed))
+    options = list(pattern = pattern, ignore_case = ignore.case)
   )
 }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -220,7 +220,12 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
 
   if (func_name == "match_substring" || func_name == "match_substring_regex") {
     using Options = arrow::compute::MatchSubstringOptions;
-    return std::make_shared<Options>(cpp11::as_cpp<std::string>(options["pattern"]));
+    bool ignore_case = false;
+    if (!Rf_isNull(options["ignore_case"])) {
+      ignore_case = cpp11::as_cpp<bool>(options["ignore_case"]);
+    }
+    return std::make_shared<Options>(cpp11::as_cpp<std::string>(options["pattern"]),
+                                     ignore_case);
   }
 
   if (func_name == "replace_substring" || func_name == "replace_substring_regex") {


### PR DESCRIPTION
This uses RE2 to implement a case-insensitive substring search.

Originally, I implemented this using utf8proc, but then found it was about an order of magnitude slower than RE2. (This isn't an apples-to-apples comparison; utf8proc does it more 'properly' and handles more Unicode corners.) So I switched to just doing it with RE2 instead, especially since the utf8proc approach was complicated. (You can still see it in the original commit here if you're curious.)