### PR TITLE
ARROW-12834: [Python] Expose pre_buffer for IPC fragments

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -37,6 +37,7 @@ from pyarrow._dataset import (  # noqa
     HivePartitioning,
     IpcFileFormat,
     IpcFileWriteOptions,
+    IpcFragmentScanOptions,
     InMemoryDataset,
     ParquetDatasetFactory,
     ParquetFactoryOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1385,6 +1385,12 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         void set_memcopy_blocksize(int64_t blocksize)
         void set_memcopy_threshold(int64_t threshold)
 
+    cdef cppclass CCacheOptions" arrow::io::CacheOptions":
+        CCacheOptions(CCacheOptions)
+
+        @staticmethod
+        CCacheOptions LazyDefaults()
+
 
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     enum MessageType" arrow::ipc::MessageType":

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -311,6 +311,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             CFileFormat):
         pass
 
+    cdef cppclass CIpcFragmentScanOptions \
+            "arrow::dataset::IpcFragmentScanOptions"(CFragmentScanOptions):
+        shared_ptr[CCacheOptions] cache_options
+
     cdef cppclass CCsvFileWriteOptions \
             "arrow::dataset::CsvFileWriteOptions"(CFileWriteOptions):
         shared_ptr[CCSVWriteOptions] write_options

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -694,6 +694,8 @@ def test_fragment_scan_options_pickling():
             convert_options=pa.csv.ConvertOptions(strings_can_be_null=True)),
         ds.CsvFragmentScanOptions(
             read_options=pa.csv.ReadOptions(block_size=2**16)),
+        ds.IpcFragmentScanOptions(),
+        ds.IpcFragmentScanOptions(pre_buffer=True),
         ds.ParquetFragmentScanOptions(buffer_size=4096),
         ds.ParquetFragmentScanOptions(pre_buffer=True),
     ]
@@ -2699,6 +2701,15 @@ def test_feather_format(tempdir, dataset_reader):
     assert result.column_names == ["b", "a"]
     result = dataset_reader.to_table(dataset, columns=["a", "a"])
     assert result.column_names == ["a", "a"]
+
+    dataset = ds.dataset(basedir, format="feather")
+    options = ds.IpcFragmentScanOptions(pre_buffer=True)
+    result = dataset.to_table(fragment_scan_options=options)
+    assert result.equals(table)
+
+    dataset = ds.dataset(basedir, format=ds.IpcFileFormat(pre_buffer=True))
+    result = dataset.to_table()
+    assert result.equals(table)
 
     # error with Feather v1 files
     write_feather(table, str(basedir / "data1.feather"), version=1)


### PR DESCRIPTION
This exposes the same API as for Parquet fragments.