### PR TITLE
ARROW-11581: [Packaging][C++] Formalize distribution through vcpkg

### DIFF
--- a/dev/tasks/vcpkg-port/all.patch
+++ b/dev/tasks/vcpkg-port/all.patch
@@ -1,0 +1,162 @@
+diff --git a/cpp/cmake_modules/BuildUtils.cmake b/cpp/cmake_modules/BuildUtils.cmake
+index 2fd897b5d..b6118ad4f 100644
+--- a/cpp/cmake_modules/BuildUtils.cmake
++++ b/cpp/cmake_modules/BuildUtils.cmake
+@@ -440,7 +440,7 @@ function(ADD_ARROW_LIB LIB_NAME)
+       target_include_directories(${LIB_NAME}_static PRIVATE ${ARG_PRIVATE_INCLUDES})
+     endif()
+ 
+-    if(MSVC_TOOLCHAIN)
++    if(MSVC_TOOLCHAIN AND 0)
+       set(LIB_NAME_STATIC ${LIB_NAME}_static)
+     else()
+       set(LIB_NAME_STATIC ${LIB_NAME})
+diff --git a/cpp/cmake_modules/FindBrotli.cmake b/cpp/cmake_modules/FindBrotli.cmake
+index b46a0f1a0..3d87f5204 100644
+--- a/cpp/cmake_modules/FindBrotli.cmake
++++ b/cpp/cmake_modules/FindBrotli.cmake
+@@ -69,9 +69,9 @@ if(BROTLI_ROOT)
+             PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES}
+             NO_DEFAULT_PATH)
+ else()
+-  find_package(PkgConfig QUIET)
+-  pkg_check_modules(BROTLI_PC libbrotlicommon libbrotlienc libbrotlidec)
+-  if(BROTLI_PC_FOUND)
++  #find_package(PkgConfig QUIET)
++  #pkg_check_modules(BROTLI_PC libbrotlicommon libbrotlienc libbrotlidec)
++  if(BROTLI_PC_FOUND AND 0) # Find via pkg_check_modules disabled as incompatible with vcpkg
+     set(BROTLI_INCLUDE_DIR "${BROTLI_PC_libbrotlicommon_INCLUDEDIR}")
+ 
+     # Some systems (e.g. Fedora) don't fill Brotli_LIBRARY_DIRS, so add the other dirs here.
+diff --git a/cpp/cmake_modules/FindLz4.cmake b/cpp/cmake_modules/FindLz4.cmake
+index 14b6d93b9..1905079ee 100644
+--- a/cpp/cmake_modules/FindLz4.cmake
++++ b/cpp/cmake_modules/FindLz4.cmake
+@@ -15,10 +15,12 @@
+ # specific language governing permissions and limitations
+ # under the License.
+ 
+-if(MSVC_TOOLCHAIN AND NOT DEFINED LZ4_MSVC_LIB_PREFIX)
+-  set(LZ4_MSVC_LIB_PREFIX "lib")
++# Avoid the debug build linking to the release library by mistake.
++# In theory harmless if static linking at this point, but disastrous if done for a shared library.
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(LZ4_LIB_NAME_DEBUG_SUFFIX "d")
+ endif()
+-set(LZ4_LIB_NAME_BASE "${LZ4_MSVC_LIB_PREFIX}lz4")
++set(LZ4_LIB_NAME_BASE "lz4${LZ4_LIB_NAME_DEBUG_SUFFIX}")
+ 
+ if(ARROW_LZ4_USE_SHARED)
+   set(LZ4_LIB_NAMES)
+@@ -34,12 +36,8 @@ if(ARROW_LZ4_USE_SHARED)
+       LZ4_LIB_NAMES
+       "${CMAKE_SHARED_LIBRARY_PREFIX}${LZ4_LIB_NAME_BASE}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+ else()
+-  if(MSVC AND NOT DEFINED LZ4_MSVC_STATIC_LIB_SUFFIX)
+-    set(LZ4_MSVC_STATIC_LIB_SUFFIX "_static")
+-  endif()
+-  set(LZ4_STATIC_LIB_SUFFIX "${LZ4_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+   set(LZ4_LIB_NAMES
+-      "${CMAKE_STATIC_LIBRARY_PREFIX}${LZ4_LIB_NAME_BASE}${LZ4_STATIC_LIB_SUFFIX}")
++      "${CMAKE_STATIC_LIBRARY_PREFIX}${LZ4_LIB_NAME_BASE}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+ endif()
+ 
+ if(LZ4_ROOT)
+@@ -56,8 +54,8 @@ if(LZ4_ROOT)
+ 
+ else()
+   find_package(PkgConfig QUIET)
+-  pkg_check_modules(LZ4_PC liblz4)
+-  if(LZ4_PC_FOUND)
++  #pkg_check_modules(LZ4_PC liblz4)
++  if(0) # Do not use pkg_check_modules, doesn't seem to work correctly on some macOS versions (10.x in GitHub Actions)
+     set(LZ4_INCLUDE_DIR "${LZ4_PC_INCLUDEDIR}")
+ 
+     list(APPEND LZ4_PC_LIBRARY_DIRS "${LZ4_PC_LIBDIR}")
+diff --git a/cpp/cmake_modules/FindSnappy.cmake b/cpp/cmake_modules/FindSnappy.cmake
+index 26cccb786..8bee097af 100644
+--- a/cpp/cmake_modules/FindSnappy.cmake
++++ b/cpp/cmake_modules/FindSnappy.cmake
+@@ -15,23 +15,30 @@
+ # specific language governing permissions and limitations
+ # under the License.
+ 
++# Avoid the debug build linking to the release library by mistake.
++# In theory harmless if static linking at this point, but disastrous if done for a shared library.
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(SNAPPY_LIB_NAME_DEBUG_SUFFIX "d")
++endif()
++
++set(SNAPPY_LIB_NAME_BASE "snappy${SNAPPY_LIB_NAME_DEBUG_SUFFIX}")
++
+ if(ARROW_SNAPPY_USE_SHARED)
+   set(SNAPPY_LIB_NAMES)
+   if(CMAKE_IMPORT_LIBRARY_SUFFIX)
+     list(APPEND SNAPPY_LIB_NAMES
+-                "${CMAKE_IMPORT_LIBRARY_PREFIX}snappy${CMAKE_IMPORT_LIBRARY_SUFFIX}")
++                "${CMAKE_IMPORT_LIBRARY_PREFIX}${SNAPPY_LIB_NAME_BASE}${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+   endif()
+   list(APPEND SNAPPY_LIB_NAMES
+-              "${CMAKE_SHARED_LIBRARY_PREFIX}snappy${CMAKE_SHARED_LIBRARY_SUFFIX}")
++              "${CMAKE_SHARED_LIBRARY_PREFIX}${SNAPPY_LIB_NAME_BASE}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+ else()
+-  set(SNAPPY_STATIC_LIB_NAME_BASE "snappy")
+   if(MSVC)
+     set(SNAPPY_STATIC_LIB_NAME_BASE
+-        "${SNAPPY_STATIC_LIB_NAME_BASE}${SNAPPY_MSVC_STATIC_LIB_SUFFIX}")
++        "${SNAPPY_LIB_NAME_BASE}${SNAPPY_MSVC_STATIC_LIB_SUFFIX}")
+   endif()
+   set(
+     SNAPPY_LIB_NAMES
+-    "${CMAKE_STATIC_LIBRARY_PREFIX}${SNAPPY_STATIC_LIB_NAME_BASE}${CMAKE_STATIC_LIBRARY_SUFFIX}"
++    "${CMAKE_STATIC_LIBRARY_PREFIX}${SNAPPY_LIB_NAME_BASE}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+     )
+ endif()
+ 
+diff --git a/cpp/cmake_modules/FindThrift.cmake b/cpp/cmake_modules/FindThrift.cmake
+index 273d907ed..02a1e7fe1 100644
+--- a/cpp/cmake_modules/FindThrift.cmake
++++ b/cpp/cmake_modules/FindThrift.cmake
+@@ -39,6 +39,12 @@ function(EXTRACT_THRIFT_VERSION)
+   endif()
+ endfunction(EXTRACT_THRIFT_VERSION)
+ 
++# Avoid the debug build linking to the release library by mistake.
++# In theory harmless if static linking at this point, but disastrous if done for a shared library.
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(THRIFT_LIB_NAME_DEBUG_SUFFIX "d")
++endif()
++
+ if(MSVC_TOOLCHAIN AND NOT DEFINED THRIFT_MSVC_LIB_SUFFIX)
+   if(NOT ARROW_THRIFT_USE_SHARED)
+     if(ARROW_USE_STATIC_CRT)
+@@ -48,7 +54,7 @@ if(MSVC_TOOLCHAIN AND NOT DEFINED THRIFT_MSVC_LIB_SUFFIX)
+     endif()
+   endif()
+ endif()
+-set(THRIFT_LIB_NAME_BASE "thrift${THRIFT_MSVC_LIB_SUFFIX}")
++set(THRIFT_LIB_NAME_BASE "thrift${THRIFT_MSVC_LIB_SUFFIX}${THRIFT_LIB_NAME_DEBUG_SUFFIX}")
+ 
+ if(ARROW_THRIFT_USE_SHARED)
+   set(THRIFT_LIB_NAMES thrift)
+@@ -84,8 +90,8 @@ else()
+   # THRIFT-4760: The pkgconfig files are currently only installed when using autotools.
+   # Starting with 0.13, they are also installed for the CMake-based installations of Thrift.
+   find_package(PkgConfig QUIET)
+-  pkg_check_modules(THRIFT_PC thrift)
+-  if(THRIFT_PC_FOUND)
++  #pkg_check_modules(THRIFT_PC thrift)
++  if(0) # Do not use pkg_check_modules, as it finds the wrong location (an intermediate build dir).
+     set(THRIFT_INCLUDE_DIR "${THRIFT_PC_INCLUDEDIR}")
+ 
+     list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
+@@ -101,8 +107,7 @@ else()
+     set(THRIFT_VERSION ${THRIFT_PC_VERSION})
+   else()
+     find_library(THRIFT_LIB
+-                 NAMES ${THRIFT_LIB_NAMES}
+-                 PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib")
++                 NAMES ${THRIFT_LIB_NAMES})
+     find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h PATH_SUFFIXES "include")
+     find_program(THRIFT_COMPILER thrift PATH_SUFFIXES "bin")
+     extract_thrift_version()

--- a/dev/tasks/vcpkg-port/portfile.cmake
+++ b/dev/tasks/vcpkg-port/portfile.cmake
@@ -1,0 +1,90 @@
+vcpkg_fail_port_install(ON_ARCH "x86" "arm" "arm64")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/arrow
+    REF apache-arrow-4.0.0
+    SHA512 4697a32004d02a519b8a8e899ed3cd981ae3485e6d34071436051080d6c84e25ad0bc568b3e52effe0a9204756da3d6e560a2037df06d2730dccd19c6b4c8027
+    HEAD_REF master
+    PATCHES
+        all.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        csv         ARROW_CSV
+        dataset     ARROW_DATASET
+        filesystem  ARROW_FILESYSTEM
+        flight      ARROW_FLIGHT
+        json        ARROW_JSON
+        orc         ARROW_ORC
+        parquet     ARROW_PARQUET
+        parquet     PARQUET_REQUIRE_ENCRYPTION
+        s3          ARROW_S3
+)
+
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
+    set(MALLOC_OPTIONS -DARROW_JEMALLOC=OFF)
+elseif("jemalloc" IN_LIST FEATURES)
+    set(MALLOC_OPTIONS -DARROW_JEMALLOC=ON)
+else()
+    set(MALLOC_OPTIONS -DARROW_JEMALLOC=OFF)
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND ("mimalloc" IN_LIST FEATURES))
+    set(MALLOC_OPTIONS ${MALLOC_OPTIONS} -DARROW_MIMALLOC=ON)
+else()
+    set(MALLOC_OPTIONS ${MALLOC_OPTIONS} -DARROW_MIMALLOC=OFF)
+endif()
+
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ARROW_BUILD_STATIC)
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_DEPENDENCY_USE_SHARED)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(THRIFT_USE_SHARED OFF)
+else()
+    set(THRIFT_USE_SHARED ${ARROW_DEPENDENCY_USE_SHARED})
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/cpp
+    PREFER_NINJA
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${MALLOC_OPTIONS}
+        -DARROW_BUILD_SHARED=${ARROW_BUILD_SHARED}
+        -DARROW_BUILD_STATIC=${ARROW_BUILD_STATIC}
+        -DARROW_BUILD_TESTS=OFF
+        -DARROW_DEPENDENCY_SOURCE=SYSTEM
+        -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED}
+        -DARROW_THRIFT_USE_SHARED=${THRIFT_USE_SHARED} 
+        -DBUILD_WARNING_LEVEL=PRODUCTION
+        -DARROW_WITH_BROTLI=ON                 
+        -DARROW_WITH_BZ2=ON
+        -DARROW_WITH_LZ4=ON
+        -DARROW_WITH_SNAPPY=ON
+        -DARROW_WITH_ZLIB=ON
+        -DARROW_WITH_ZSTD=ON
+        -DZSTD_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include
+        -DZSTD_MSVC_LIB_PREFIX=
+        -DZSTD_ROOT=${CURRENT_INSTALLED_DIR}
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib)
+    message(FATAL_ERROR "Installed lib file should be named 'arrow.lib' via patching the upstream build.")
+endif()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/arrow)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/dev/tasks/vcpkg-port/vcpkg.json
+++ b/dev/tasks/vcpkg-port/vcpkg.json
@@ -1,0 +1,89 @@
+{
+  "name": "arrow",
+  "version": "4.0.0",
+  "description": "Cross-language development platform for in-memory analytics",
+  "homepage": "https://arrow.apache.org",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-multiprecision",
+    "boost-system",
+    "brotli",
+    "bzip2",
+    "gflags",
+    "glog",
+    "lz4",
+    "openssl",
+    "re2",
+    "snappy",
+    "thrift",
+    "utf8proc",
+    "zlib",
+    "zstd"
+  ],
+  "default-features": [
+    "csv",
+    "dataset",
+    "filesystem",
+    "jemalloc",
+    "json",
+    "mimalloc",
+    "parquet"
+  ],
+  "features": {
+    "csv": {
+      "description": "CSV support"
+    },
+    "dataset": {
+      "description": "Dataset support"
+    },
+    "filesystem": {
+      "description": "Filesystem support"
+    },
+    "flight": {
+      "description": "Arrow Flight RPC support",
+      "dependencies": [
+        "abseil",
+        "c-ares",
+        "grpc",
+        "protobuf"
+      ]
+    },
+    "jemalloc": {
+      "description": "jemalloc allocator"
+    },
+    "json": {
+      "description": "JSON support",
+      "dependencies": [
+        "rapidjson"
+      ]
+    },
+    "mimalloc": {
+      "description": "mimalloc allocator"
+    },
+    "orc": {
+      "description": "ORC support",
+      "dependencies": [
+        "orc"
+      ]
+    },
+    "parquet": {
+      "description": "Parquet support"
+    },
+    "s3": {
+      "description": "S3 support",
+      "dependencies": [
+        {
+          "name": "aws-sdk-cpp",
+          "features": [
+            "cognito-identity",
+            "config",
+            "identity-management",
+            "s3",
+            "sts",
+            "transfer"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The actual work is done in https://github.com/microsoft/vcpkg/pull/17975; this PR just adds a copy of the arrow version 4.0.0 vcpkg port files under `dev/tasks/vcpkg-port`.