### PR TITLE
ARROW-12861: [C++][Compute] Add sign function kernels

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -330,6 +330,7 @@ void RegisterScalarOptions(FunctionRegistry* registry) {
 
 SCALAR_ARITHMETIC_UNARY(AbsoluteValue, "abs", "abs_checked")
 SCALAR_ARITHMETIC_UNARY(Negate, "negate", "negate_checked")
+SCALAR_EAGER_UNARY(Sign, "sign")
 SCALAR_ARITHMETIC_UNARY(Sin, "sin", "sin_checked")
 SCALAR_ARITHMETIC_UNARY(Cos, "cos", "cos_checked")
 SCALAR_ARITHMETIC_UNARY(Asin, "asin", "asin_checked")

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -41,7 +41,6 @@ class ARROW_EXPORT ArithmeticOptions : public FunctionOptions {
  public:
   explicit ArithmeticOptions(bool check_overflow = false);
   constexpr static char const kTypeName[] = "ArithmeticOptions";
-  bool check_overflow;
 };
 
 class ARROW_EXPORT ElementWiseAggregateOptions : public FunctionOptions {
@@ -517,6 +516,7 @@ Result<Datum> MinElementWise(
 /// is null the result will be null.
 ///
 /// \param[in] arg the value to extract sign from
+/// \param[in] options arithmetic options (signed zero handling), optional
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise sign function
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -41,6 +41,7 @@ class ARROW_EXPORT ArithmeticOptions : public FunctionOptions {
  public:
   explicit ArithmeticOptions(bool check_overflow = false);
   constexpr static char const kTypeName[] = "ArithmeticOptions";
+  bool check_overflow;
 };
 
 class ARROW_EXPORT ElementWiseAggregateOptions : public FunctionOptions {
@@ -516,12 +517,10 @@ Result<Datum> MinElementWise(
 /// is null the result will be null.
 ///
 /// \param[in] arg the value to extract sign from
-/// \param[in] options options for handling signed zero, optional
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise sign function
 ARROW_EXPORT
-Result<Datum> Sign(const Datum& arg, SignOptions options = SignOptions(),
-                   ExecContext* ctx = NULLPTR);
+Result<Datum> Sign(const Datum& arg, ExecContext* ctx = NULLPTR);
 
 /// \brief Compare a numeric array with a scalar.
 ///

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -513,6 +513,16 @@ Result<Datum> MinElementWise(
     ElementWiseAggregateOptions options = ElementWiseAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
+/// \brief Get the sign of a value. Array values can be of arbitrary length. If argument
+/// is null the result will be null.
+///
+/// \param[in] arg the value to extract sign from
+/// \param[in] ctx the function execution context, optional
+/// \return the elementwise sign function
+ARROW_EXPORT
+Result<Datum> Sign(const Datum& arg, ArithmeticOptions options = ArithmeticOptions(),
+                   ExecContext* ctx = NULLPTR);
+
 /// \brief Compare a numeric array with a scalar.
 ///
 /// \param[in] left datum to compare, must be an Array

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -516,11 +516,11 @@ Result<Datum> MinElementWise(
 /// is null the result will be null.
 ///
 /// \param[in] arg the value to extract sign from
-/// \param[in] options arithmetic options (signed zero handling), optional
+/// \param[in] options options for handling signed zero, optional
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise sign function
 ARROW_EXPORT
-Result<Datum> Sign(const Datum& arg, ArithmeticOptions options = ArithmeticOptions(),
+Result<Datum> Sign(const Datum& arg, SignOptions options = SignOptions(),
                    ExecContext* ctx = NULLPTR);
 
 /// \brief Compare a numeric array with a scalar.

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -474,28 +474,7 @@ struct Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
   static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return (arg == 0) ? 0 : 1;
-  }
-
-  template <typename T, typename Arg,
-            enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
-                        bool> = true>
-  static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return (arg > 0) ? 1 : ((arg == 0) ? 0 : -1);
-  }
-};
-
-struct SignWithSignedZero {
-  template <typename T, typename Arg,
-            enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
-  static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return std::signbit(arg) ? -1 : 1;
-  }
-
-  template <typename T, typename Arg,
-            enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
-  static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return (arg == 0) ? 0 : 1;
+    return arg > 0;
   }
 
   template <typename T, typename Arg,

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1312,12 +1312,11 @@ const FunctionDoc absolute_value_checked_doc{
      "doesn't fail on overflow, use function \"abs\"."),
     {"x"}};
 
-const FunctionDoc add_doc{
-    "Add the arguments element-wise",
-    ("Results will wrap around on integer overflow.\n"
-     "Use function \"add_checked\" if you want overflow\n"
-     "to return an error."),
-    {"x", "y"}};
+const FunctionDoc add_doc{"Add the arguments element-wise",
+                          ("Results will wrap around on integer overflow.\n"
+                           "Use function \"add_checked\" if you want overflow\n"
+                           "to return an error."),
+                          {"x", "y"}};
 
 const FunctionDoc add_checked_doc{
     "Add the arguments element-wise",
@@ -1325,12 +1324,11 @@ const FunctionDoc add_checked_doc{
      "doesn't fail on overflow, use function \"add\"."),
     {"x", "y"}};
 
-const FunctionDoc sub_doc{
-    "Subtract the arguments element-wise",
-    ("Results will wrap around on integer overflow.\n"
-     "Use function \"subtract_checked\" if you want overflow\n"
-     "to return an error."),
-    {"x", "y"}};
+const FunctionDoc sub_doc{"Subtract the arguments element-wise",
+                          ("Results will wrap around on integer overflow.\n"
+                           "Use function \"subtract_checked\" if you want overflow\n"
+                           "to return an error."),
+                          {"x", "y"}};
 
 const FunctionDoc sub_checked_doc{
     "Subtract the arguments element-wise",
@@ -1338,12 +1336,11 @@ const FunctionDoc sub_checked_doc{
      "doesn't fail on overflow, use function \"subtract\"."),
     {"x", "y"}};
 
-const FunctionDoc mul_doc{
-    "Multiply the arguments element-wise",
-    ("Results will wrap around on integer overflow.\n"
-     "Use function \"multiply_checked\" if you want overflow\n"
-     "to return an error."),
-    {"x", "y"}};
+const FunctionDoc mul_doc{"Multiply the arguments element-wise",
+                          ("Results will wrap around on integer overflow.\n"
+                           "Use function \"multiply_checked\" if you want overflow\n"
+                           "to return an error."),
+                          {"x", "y"}};
 
 const FunctionDoc mul_checked_doc{
     "Multiply the arguments element-wise",
@@ -1365,12 +1362,11 @@ const FunctionDoc div_checked_doc{
      "integer overflow is encountered."),
     {"dividend", "divisor"}};
 
-const FunctionDoc negate_doc{
-    "Negate the argument element-wise",
-    ("Results will wrap around on integer overflow.\n"
-     "Use function \"negate_checked\" if you want overflow\n"
-     "to return an error."),
-    {"x"}};
+const FunctionDoc negate_doc{"Negate the argument element-wise",
+                             ("Results will wrap around on integer overflow.\n"
+                              "Use function \"negate_checked\" if you want overflow\n"
+                              "to return an error."),
+                             {"x"}};
 
 const FunctionDoc negate_checked_doc{
     "Negate the arguments element-wise",
@@ -1396,24 +1392,16 @@ const FunctionDoc sign_doc{
     {"x"}};
 
 const FunctionDoc bit_wise_not_doc{
-    "Bit-wise negate the arguments element-wise",
-    ("Null values return null."),
-    {"x"}};
+    "Bit-wise negate the arguments element-wise", ("Null values return null."), {"x"}};
 
 const FunctionDoc bit_wise_and_doc{
-    "Bit-wise AND the arguments element-wise",
-    ("Null values return null."),
-    {"x", "y"}};
+    "Bit-wise AND the arguments element-wise", ("Null values return null."), {"x", "y"}};
 
 const FunctionDoc bit_wise_or_doc{
-    "Bit-wise OR the arguments element-wise",
-    ("Null values return null."),
-    {"x", "y"}};
+    "Bit-wise OR the arguments element-wise", ("Null values return null."), {"x", "y"}};
 
 const FunctionDoc bit_wise_xor_doc{
-    "Bit-wise XOR the arguments element-wise",
-    ("Null values return null."),
-    {"x", "y"}};
+    "Bit-wise XOR the arguments element-wise", ("Null values return null."), {"x", "y"}};
 
 const FunctionDoc shift_left_doc{
     "Left shift `x` by `y`",
@@ -1453,12 +1441,11 @@ const FunctionDoc shift_right_checked_doc{
      "See \"shift_right\" for a variant that doesn't fail for an invalid shift amount"),
     {"x", "y"}};
 
-const FunctionDoc sin_doc{
-    "Compute the sine of the elements argument-wise",
-    ("Integer arguments return double values. "
-     "This function returns NaN on values outside its domain. "
-     "To raise an error instead, see \"sin_checked\"."),
-    {"x"}};
+const FunctionDoc sin_doc{"Compute the sine of the elements argument-wise",
+                          ("Integer arguments return double values. "
+                           "This function returns NaN on values outside its domain. "
+                           "To raise an error instead, see \"sin_checked\"."),
+                          {"x"}};
 
 const FunctionDoc sin_checked_doc{
     "Compute the sine of the elements argument-wise",
@@ -1467,12 +1454,11 @@ const FunctionDoc sin_checked_doc{
      "To return NaN instead, see \"sin\"."),
     {"x"}};
 
-const FunctionDoc cos_doc{
-    "Compute the cosine of the elements argument-wise",
-    ("Integer arguments return double values. "
-     "This function returns NaN on values outside its domain. "
-     "To raise an error instead, see \"cos_checked\"."),
-    {"x"}};
+const FunctionDoc cos_doc{"Compute the cosine of the elements argument-wise",
+                          ("Integer arguments return double values. "
+                           "This function returns NaN on values outside its domain. "
+                           "To raise an error instead, see \"cos_checked\"."),
+                          {"x"}};
 
 const FunctionDoc cos_checked_doc{
     "Compute the cosine of the elements argument-wise",
@@ -1481,12 +1467,11 @@ const FunctionDoc cos_checked_doc{
      "To return NaN instead, see \"cos\"."),
     {"x"}};
 
-const FunctionDoc tan_doc{
-    "Compute the tangent of the elements argument-wise",
-    ("Integer arguments return double values. "
-     "This function returns NaN on values outside its domain. "
-     "To raise an error instead, see \"tan_checked\"."),
-    {"x"}};
+const FunctionDoc tan_doc{"Compute the tangent of the elements argument-wise",
+                          ("Integer arguments return double values. "
+                           "This function returns NaN on values outside its domain. "
+                           "To raise an error instead, see \"tan_checked\"."),
+                          {"x"}};
 
 const FunctionDoc tan_checked_doc{
     "Compute the tangent of the elements argument-wise",
@@ -1495,12 +1480,11 @@ const FunctionDoc tan_checked_doc{
      "To return NaN instead, see \"tan\"."),
     {"x"}};
 
-const FunctionDoc asin_doc{
-    "Compute the inverse sine of the elements argument-wise",
-    ("Integer arguments return double values. "
-     "This function returns NaN on values outside its domain. "
-     "To raise an error instead, see \"asin_checked\"."),
-    {"x"}};
+const FunctionDoc asin_doc{"Compute the inverse sine of the elements argument-wise",
+                           ("Integer arguments return double values. "
+                            "This function returns NaN on values outside its domain. "
+                            "To raise an error instead, see \"asin_checked\"."),
+                           {"x"}};
 
 const FunctionDoc asin_checked_doc{
     "Compute the inverse sine of the elements argument-wise",
@@ -1509,12 +1493,11 @@ const FunctionDoc asin_checked_doc{
      "To return NaN instead, see \"asin\"."),
     {"x"}};
 
-const FunctionDoc acos_doc{
-    "Compute the inverse cosine of the elements argument-wise",
-    ("Integer arguments return double values. "
-     "This function returns NaN on values outside its domain. "
-     "To raise an error instead, see \"acos_checked\"."),
-    {"x"}};
+const FunctionDoc acos_doc{"Compute the inverse cosine of the elements argument-wise",
+                           ("Integer arguments return double values. "
+                            "This function returns NaN on values outside its domain. "
+                            "To raise an error instead, see \"acos_checked\"."),
+                           {"x"}};
 
 const FunctionDoc acos_checked_doc{
     "Compute the inverse cosine of the elements argument-wise",
@@ -1523,10 +1506,9 @@ const FunctionDoc acos_checked_doc{
      "To return NaN instead, see \"acos\"."),
     {"x"}};
 
-const FunctionDoc atan_doc{
-    "Compute the principal value of the inverse tangent",
-    ("Integer arguments return double values."),
-    {"x"}};
+const FunctionDoc atan_doc{"Compute the principal value of the inverse tangent",
+                           ("Integer arguments return double values."),
+                           {"x"}};
 
 const FunctionDoc atan2_doc{
     "Compute the inverse tangent using argument signs to determine the quadrant",

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1384,8 +1384,10 @@ const FunctionDoc pow_checked_doc{
     {"base", "exponent"}};
 
 const FunctionDoc sign_doc{
-    "Get the sign value of the argument element-wise",
-    ("For nonzero inputs, output is any of (-1,1) and 0 for zero input."),
+    "Get the signedness of the arguments element-wise",
+    ("Output is any of (-1,1) for nonzero inputs and 0 for zero input.\n"
+     "NaN values return NaN.  Integral values return signedness as Int8 and\n"
+     "floating-point values return it with the same type as the input values."),
     {"x"}};
 
 const FunctionDoc bit_wise_not_doc{

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -468,6 +468,27 @@ struct Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+    return (arg == 0) ? 0 : (std::signbit(arg) ? -1 : 1);
+  }
+
+  template <typename T, typename Arg,
+            enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
+  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+    return arg ? 1 : 0;
+  }
+
+  template <typename T, typename Arg,
+            enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
+                        bool> = true>
+  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+    return (arg > 0) ? 1 : ((arg < 0) ? -1 : 0);
+  }
+};
+
+struct SignWithSignedZero : Sign {
+  template <typename T, typename Arg,
+            enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
+  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
     return std::signbit(arg) ? -1 : 1;
   }
 
@@ -480,10 +501,8 @@ struct Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
-  static int8_t Call(KernelContext*, Arg arg, Status*) {
-    if (arg > 0) return 1;
-    if (arg < 0) return -1;
-    return 0;
+  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+    return (arg > 0) ? 1 : ((arg < 0) ? -1 : 0);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -495,14 +495,14 @@ struct SignWithSignedZero {
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
   static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return 1;
+    return (arg == 0) ? 0 : 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
   static constexpr T Call(KernelContext*, Arg arg, Status*) {
-    return (arg >= 0) ? 1 : -1;
+    return (arg > 0) ? 1 : ((arg == 0) ? 0 : -1);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -474,18 +474,18 @@ struct Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
-    return arg ? 1 : 0;
+    return (arg == 0) ? 0 : 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
-    return (arg > 0) ? 1 : ((arg < 0) ? -1 : 0);
+    return (arg > 0) ? 1 : ((arg == 0) ? 0 : -1);
   }
 };
 
-struct SignWithSignedZero : Sign {
+struct SignWithSignedZero {
   template <typename T, typename Arg,
             enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
@@ -495,14 +495,14 @@ struct SignWithSignedZero : Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
-    return arg ? 1 : 0;
+    return (arg == 0) ? 0 : 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
   static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
-    return (arg > 0) ? 1 : ((arg < 0) ? -1 : 0);
+    return (arg >= 0) ? 1 : -1;
   }
 };
 
@@ -1078,31 +1078,31 @@ void AddDecimalBinaryKernels(const std::string& name,
 }
 
 // Generate a kernel given an arithmetic functor
-template <template <typename... Args> class KernelGenerator, typename Type0,
+template <template <typename... Args> class KernelGenerator, typename OutType,
           typename... Args>
 ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:
-      return KernelGenerator<Type0, Int8Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int8Type, Args...>::Exec;
     case Type::UINT8:
-      return KernelGenerator<Type0, UInt8Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt8Type, Args...>::Exec;
     case Type::INT16:
-      return KernelGenerator<Type0, Int16Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int16Type, Args...>::Exec;
     case Type::UINT16:
-      return KernelGenerator<Type0, UInt16Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt16Type, Args...>::Exec;
     case Type::INT32:
-      return KernelGenerator<Type0, Int32Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int32Type, Args...>::Exec;
     case Type::UINT32:
-      return KernelGenerator<Type0, UInt32Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt32Type, Args...>::Exec;
     case Type::INT64:
     case Type::TIMESTAMP:
-      return KernelGenerator<Type0, Int64Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int64Type, Args...>::Exec;
     case Type::UINT64:
-      return KernelGenerator<Type0, UInt64Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt64Type, Args...>::Exec;
     case Type::FLOAT:
-      return KernelGenerator<Type0, FloatType, Args...>::Exec;
+      return KernelGenerator<OutType, FloatType, Args...>::Exec;
     case Type::DOUBLE:
-      return KernelGenerator<Type0, DoubleType, Args...>::Exec;
+      return KernelGenerator<OutType, DoubleType, Args...>::Exec;
     default:
       DCHECK(false);
       return ExecFail;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1079,30 +1079,30 @@ void AddDecimalBinaryKernels(const std::string& name,
 
 // Generate a kernel given an arithmetic functor
 template <template <typename...> class KernelGenerator, typename OutType,
-          typename... Args>
+          typename Op>
 ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:
-      return KernelGenerator<OutType, Int8Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int8Type, Op>::Exec;
     case Type::UINT8:
-      return KernelGenerator<OutType, UInt8Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt8Type, Op>::Exec;
     case Type::INT16:
-      return KernelGenerator<OutType, Int16Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int16Type, Op>::Exec;
     case Type::UINT16:
-      return KernelGenerator<OutType, UInt16Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt16Type, Op>::Exec;
     case Type::INT32:
-      return KernelGenerator<OutType, Int32Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int32Type, Op>::Exec;
     case Type::UINT32:
-      return KernelGenerator<OutType, UInt32Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt32Type, Op>::Exec;
     case Type::INT64:
     case Type::TIMESTAMP:
-      return KernelGenerator<OutType, Int64Type, Args...>::Exec;
+      return KernelGenerator<OutType, Int64Type, Op>::Exec;
     case Type::UINT64:
-      return KernelGenerator<OutType, UInt64Type, Args...>::Exec;
+      return KernelGenerator<OutType, UInt64Type, Op>::Exec;
     case Type::FLOAT:
-      return KernelGenerator<OutType, FloatType, Args...>::Exec;
+      return KernelGenerator<OutType, FloatType, Op>::Exec;
     case Type::DOUBLE:
-      return KernelGenerator<OutType, DoubleType, Args...>::Exec;
+      return KernelGenerator<OutType, DoubleType, Op>::Exec;
     default:
       DCHECK(false);
       return ExecFail;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1078,8 +1078,7 @@ void AddDecimalBinaryKernels(const std::string& name,
 }
 
 // Generate a kernel given an arithmetic functor
-template <template <typename...> class KernelGenerator, typename OutType,
-          typename Op>
+template <template <typename...> class KernelGenerator, typename OutType, typename Op>
 ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -467,20 +467,20 @@ struct PowerChecked {
 struct Sign {
   template <typename T, typename Arg,
             enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg == 0) ? 0 : (std::signbit(arg) ? -1 : 1);
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg == 0) ? 0 : 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg > 0) ? 1 : ((arg == 0) ? 0 : -1);
   }
 };
@@ -488,20 +488,20 @@ struct Sign {
 struct SignWithSignedZero {
   template <typename T, typename Arg,
             enable_if_t<std::is_floating_point<Arg>::value, bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return std::signbit(arg) ? -1 : 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_unsigned<Arg>::value, bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
-    return (arg == 0) ? 0 : 1;
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
+    return 1;
   }
 
   template <typename T, typename Arg,
             enable_if_t<std::is_integral<Arg>::value && std::is_signed<Arg>::value,
                         bool> = true>
-  static constexpr int8_t Call(KernelContext*, Arg arg, Status*) {
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg >= 0) ? 1 : -1;
   }
 };
@@ -1078,7 +1078,7 @@ void AddDecimalBinaryKernels(const std::string& name,
 }
 
 // Generate a kernel given an arithmetic functor
-template <template <typename... Args> class KernelGenerator, typename OutType,
+template <template <typename...> class KernelGenerator, typename OutType,
           typename... Args>
 ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
   switch (get_id.id) {
@@ -1218,7 +1218,8 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunction(std::string name,
   return func;
 }
 
-// Like MakeUnaryArithmeticFunction, but with a fixed output type.
+// Like MakeUnaryArithmeticFunction, but for unary arithmetic ops with a fixed
+// output type.
 template <typename Op, typename OutType>
 std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionFixedOutType(
     std::string name, const FunctionDoc* doc) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1079,7 +1079,7 @@ void AddDecimalBinaryKernels(const std::string& name,
 
 // Generate a kernel given an arithmetic functor
 template <template <typename...> class KernelGenerator, typename OutType, typename Op>
-ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
+ArrayKernelExec GenerateArithmeticWithFixedOutType(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:
       return KernelGenerator<OutType, Int8Type, Op>::Exec;
@@ -1220,12 +1220,12 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunction(std::string name,
 // Like MakeUnaryArithmeticFunction, but for unary arithmetic ops with a fixed
 // output type.
 template <typename Op, typename OutType>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionFixedOutType(
+std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionWithFixedOutType(
     std::string name, const FunctionDoc* doc) {
   auto out_ty = TypeTraits<OutType>::type_singleton();
   auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : NumericTypes()) {
-    auto exec = GenerateArithmeticFixedOutType<ScalarUnary, OutType, Op>(ty);
+    auto exec = GenerateArithmeticWithFixedOutType<ScalarUnary, OutType, Op>(ty);
     DCHECK_OK(func->AddKernel({ty}, out_ty, exec));
   }
   return func;
@@ -1692,7 +1692,8 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(power_checked)));
 
   // ----------------------------------------------------------------------
-  auto sign = MakeUnaryArithmeticFunctionFixedOutType<Sign, Int8Type>("sign", &sign_doc);
+  auto sign =
+      MakeUnaryArithmeticFunctionWithFixedOutType<Sign, Int8Type>("sign", &sign_doc);
   DCHECK_OK(registry->AddFunction(std::move(sign)));
 
   // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1311,11 +1311,12 @@ const FunctionDoc absolute_value_checked_doc{
      "doesn't fail on overflow, use function \"abs\"."),
     {"x"}};
 
-const FunctionDoc add_doc{"Add the arguments element-wise",
-                          ("Results will wrap around on integer overflow.\n"
-                           "Use function \"add_checked\" if you want overflow\n"
-                           "to return an error."),
-                          {"x", "y"}};
+const FunctionDoc add_doc{
+    "Add the arguments element-wise",
+    ("Results will wrap around on integer overflow.\n"
+     "Use function \"add_checked\" if you want overflow\n"
+     "to return an error."),
+    {"x", "y"}};
 
 const FunctionDoc add_checked_doc{
     "Add the arguments element-wise",
@@ -1323,11 +1324,12 @@ const FunctionDoc add_checked_doc{
      "doesn't fail on overflow, use function \"add\"."),
     {"x", "y"}};
 
-const FunctionDoc sub_doc{"Subtract the arguments element-wise",
-                          ("Results will wrap around on integer overflow.\n"
-                           "Use function \"subtract_checked\" if you want overflow\n"
-                           "to return an error."),
-                          {"x", "y"}};
+const FunctionDoc sub_doc{
+    "Subtract the arguments element-wise",
+    ("Results will wrap around on integer overflow.\n"
+     "Use function \"subtract_checked\" if you want overflow\n"
+     "to return an error."),
+    {"x", "y"}};
 
 const FunctionDoc sub_checked_doc{
     "Subtract the arguments element-wise",
@@ -1335,11 +1337,12 @@ const FunctionDoc sub_checked_doc{
      "doesn't fail on overflow, use function \"subtract\"."),
     {"x", "y"}};
 
-const FunctionDoc mul_doc{"Multiply the arguments element-wise",
-                          ("Results will wrap around on integer overflow.\n"
-                           "Use function \"multiply_checked\" if you want overflow\n"
-                           "to return an error."),
-                          {"x", "y"}};
+const FunctionDoc mul_doc{
+    "Multiply the arguments element-wise",
+    ("Results will wrap around on integer overflow.\n"
+     "Use function \"multiply_checked\" if you want overflow\n"
+     "to return an error."),
+    {"x", "y"}};
 
 const FunctionDoc mul_checked_doc{
     "Multiply the arguments element-wise",
@@ -1361,11 +1364,12 @@ const FunctionDoc div_checked_doc{
      "integer overflow is encountered."),
     {"dividend", "divisor"}};
 
-const FunctionDoc negate_doc{"Negate the argument element-wise",
-                             ("Results will wrap around on integer overflow.\n"
-                              "Use function \"negate_checked\" if you want overflow\n"
-                              "to return an error."),
-                             {"x"}};
+const FunctionDoc negate_doc{
+    "Negate the argument element-wise",
+    ("Results will wrap around on integer overflow.\n"
+     "Use function \"negate_checked\" if you want overflow\n"
+     "to return an error."),
+    {"x"}};
 
 const FunctionDoc negate_checked_doc{
     "Negate the arguments element-wise",
@@ -1385,22 +1389,30 @@ const FunctionDoc pow_checked_doc{
      "or integer overflow is encountered."),
     {"base", "exponent"}};
 
-const FunctionDoc sign_doc{"Get the sign value of the argument element-wise",
-                           ("Floating-point variants always return (-1,1).\n"
-                            "Integral variants can result in any of (-1,0,1).\n"),
-                           {"x"}};
+const FunctionDoc sign_doc{
+    "Get the sign value of the argument element-wise",
+    ("For nonzero inputs, output is any of (-1,1) and 0 for zero input."),
+    {"x"}};
 
 const FunctionDoc bit_wise_not_doc{
-    "Bit-wise negate the arguments element-wise", ("Null values return null."), {"x"}};
+    "Bit-wise negate the arguments element-wise",
+    ("Null values return null."),
+    {"x"}};
 
 const FunctionDoc bit_wise_and_doc{
-    "Bit-wise AND the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise AND the arguments element-wise",
+    ("Null values return null."),
+    {"x", "y"}};
 
 const FunctionDoc bit_wise_or_doc{
-    "Bit-wise OR the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise OR the arguments element-wise",
+    ("Null values return null."),
+    {"x", "y"}};
 
 const FunctionDoc bit_wise_xor_doc{
-    "Bit-wise XOR the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise XOR the arguments element-wise",
+    ("Null values return null."),
+    {"x", "y"}};
 
 const FunctionDoc shift_left_doc{
     "Left shift `x` by `y`",
@@ -1440,11 +1452,12 @@ const FunctionDoc shift_right_checked_doc{
      "See \"shift_right\" for a variant that doesn't fail for an invalid shift amount"),
     {"x", "y"}};
 
-const FunctionDoc sin_doc{"Compute the sine of the elements argument-wise",
-                          ("Integer arguments return double values. "
-                           "This function returns NaN on values outside its domain. "
-                           "To raise an error instead, see \"sin_checked\"."),
-                          {"x"}};
+const FunctionDoc sin_doc{
+    "Compute the sine of the elements argument-wise",
+    ("Integer arguments return double values. "
+     "This function returns NaN on values outside its domain. "
+     "To raise an error instead, see \"sin_checked\"."),
+    {"x"}};
 
 const FunctionDoc sin_checked_doc{
     "Compute the sine of the elements argument-wise",
@@ -1453,11 +1466,12 @@ const FunctionDoc sin_checked_doc{
      "To return NaN instead, see \"sin\"."),
     {"x"}};
 
-const FunctionDoc cos_doc{"Compute the cosine of the elements argument-wise",
-                          ("Integer arguments return double values. "
-                           "This function returns NaN on values outside its domain. "
-                           "To raise an error instead, see \"cos_checked\"."),
-                          {"x"}};
+const FunctionDoc cos_doc{
+    "Compute the cosine of the elements argument-wise",
+    ("Integer arguments return double values. "
+     "This function returns NaN on values outside its domain. "
+     "To raise an error instead, see \"cos_checked\"."),
+    {"x"}};
 
 const FunctionDoc cos_checked_doc{
     "Compute the cosine of the elements argument-wise",
@@ -1466,11 +1480,12 @@ const FunctionDoc cos_checked_doc{
      "To return NaN instead, see \"cos\"."),
     {"x"}};
 
-const FunctionDoc tan_doc{"Compute the tangent of the elements argument-wise",
-                          ("Integer arguments return double values. "
-                           "This function returns NaN on values outside its domain. "
-                           "To raise an error instead, see \"tan_checked\"."),
-                          {"x"}};
+const FunctionDoc tan_doc{
+    "Compute the tangent of the elements argument-wise",
+    ("Integer arguments return double values. "
+     "This function returns NaN on values outside its domain. "
+     "To raise an error instead, see \"tan_checked\"."),
+    {"x"}};
 
 const FunctionDoc tan_checked_doc{
     "Compute the tangent of the elements argument-wise",
@@ -1479,11 +1494,12 @@ const FunctionDoc tan_checked_doc{
      "To return NaN instead, see \"tan\"."),
     {"x"}};
 
-const FunctionDoc asin_doc{"Compute the inverse sine of the elements argument-wise",
-                           ("Integer arguments return double values. "
-                            "This function returns NaN on values outside its domain. "
-                            "To raise an error instead, see \"asin_checked\"."),
-                           {"x"}};
+const FunctionDoc asin_doc{
+    "Compute the inverse sine of the elements argument-wise",
+    ("Integer arguments return double values. "
+     "This function returns NaN on values outside its domain. "
+     "To raise an error instead, see \"asin_checked\"."),
+    {"x"}};
 
 const FunctionDoc asin_checked_doc{
     "Compute the inverse sine of the elements argument-wise",
@@ -1492,11 +1508,12 @@ const FunctionDoc asin_checked_doc{
      "To return NaN instead, see \"asin\"."),
     {"x"}};
 
-const FunctionDoc acos_doc{"Compute the inverse cosine of the elements argument-wise",
-                           ("Integer arguments return double values. "
-                            "This function returns NaN on values outside its domain. "
-                            "To raise an error instead, see \"acos_checked\"."),
-                           {"x"}};
+const FunctionDoc acos_doc{
+    "Compute the inverse cosine of the elements argument-wise",
+    ("Integer arguments return double values. "
+     "This function returns NaN on values outside its domain. "
+     "To raise an error instead, see \"acos_checked\"."),
+    {"x"}};
 
 const FunctionDoc acos_checked_doc{
     "Compute the inverse cosine of the elements argument-wise",
@@ -1505,9 +1522,10 @@ const FunctionDoc acos_checked_doc{
      "To return NaN instead, see \"acos\"."),
     {"x"}};
 
-const FunctionDoc atan_doc{"Compute the principal value of the inverse tangent",
-                           ("Integer arguments return double values."),
-                           {"x"}};
+const FunctionDoc atan_doc{
+    "Compute the principal value of the inverse tangent",
+    ("Integer arguments return double values."),
+    {"x"}};
 
 const FunctionDoc atan2_doc{
     "Compute the inverse tangent using argument signs to determine the quadrant",

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1108,6 +1108,7 @@ ArrayKernelExec GenerateArithmeticFixedOutType(detail::GetTypeId get_id) {
       return ExecFail;
   }
 }
+
 struct ArithmeticFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1096,7 +1096,8 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Null input
-  for (std::string name : {"negate", "negate_checked", "abs", "abs_checked", "sign", "sign_with_signed_zero"}) {
+  for (std::string name : {"negate", "negate_checked", "abs", "abs_checked", "sign",
+                           "sign_with_signed_zero"}) {
     CheckDispatchFails(name, {null()});
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2088,7 +2088,8 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   // NaN
   this->AssertUnaryOp(Sign, "[NaN]", ArrayFromJSON(int8(), "[1]"));
   // Min/max
-  this->AssertUnaryOp(Sign, MakeArray(min, max), ArrayFromJSON(int8(), "[-1, 1]"));
+  this->AssertUnaryOp(Sign, MakeScalar(min), *arrow::MakeScalar(int8(), -1));
+  this->AssertUnaryOp(Sign, MakeScalar(max), *arrow::MakeScalar(int8(), 1));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2038,8 +2038,7 @@ TYPED_TEST(TestUnaryArithmeticSigned, Sign) {
     // Negative inputs
     this->AssertUnaryOp(Sign, "[-1, -10, -127]", ArrayFromJSON(int8(), "[-1, -1, -1]"));
     // Min/max
-    this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
-                        ArrayFromJSON(int8(), "[-1, 1]"));
+    this->AssertUnaryOp(Sign, MakeArray(min, max), ArrayFromJSON(int8(), "[-1, 1]"));
   }
 }
 
@@ -2061,8 +2060,7 @@ TYPED_TEST(TestUnaryArithmeticUnsigned, Sign) {
     // Positive inputs
     this->AssertUnaryOp(Sign, "[1, 10, 127]", ArrayFromJSON(int8(), "[1, 1, 1]"));
     // Min/max
-    this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
-                        ArrayFromJSON(int8(), "[0, 1]"));
+    this->AssertUnaryOp(Sign, MakeArray(min, max), ArrayFromJSON(int8(), "[0, 1]"));
   }
 }
 
@@ -2090,8 +2088,7 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   // NaN
   this->AssertUnaryOp(Sign, "[NaN]", ArrayFromJSON(int8(), "[1]"));
   // Min/max
-  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
-                      ArrayFromJSON(int8(), "[-1, 1]"));
+  this->AssertUnaryOp(Sign, MakeArray(min, max), ArrayFromJSON(int8(), "[-1, 1]"));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2001,7 +2001,8 @@ TYPED_TEST(TestUnaryArithmeticSigned, Sign) {
   this->AssertUnaryOp(sign, "[0]", ArrayFromJSON(int8(), "[0]"));
   this->AssertUnaryOp(sign, "[1, 10, 127]", ArrayFromJSON(int8(), "[1, 1, 1]"));
   this->AssertUnaryOp(sign, "[-1, -10, -127]", ArrayFromJSON(int8(), "[-1, -1, -1]"));
-  this->AssertUnaryOp(sign, MakeArray(min, max), ArrayFromJSON(int8(), "[-1, 1]"));
+  this->AssertUnaryOp(sign, this->MakeScalar(min), *arrow::MakeScalar(int8(), -1));
+  this->AssertUnaryOp(sign, this->MakeScalar(max), *arrow::MakeScalar(int8(), 1));
 }
 
 TYPED_TEST(TestUnaryArithmeticUnsigned, Sign) {
@@ -2020,7 +2021,8 @@ TYPED_TEST(TestUnaryArithmeticUnsigned, Sign) {
   this->AssertUnaryOp(sign, "[1, null, 10]", ArrayFromJSON(int8(), "[1, null, 1]"));
   this->AssertUnaryOp(sign, "[0]", ArrayFromJSON(int8(), "[0]"));
   this->AssertUnaryOp(sign, "[1, 10, 127]", ArrayFromJSON(int8(), "[1, 1, 1]"));
-  this->AssertUnaryOp(sign, MakeArray(min, max), ArrayFromJSON(int8(), "[0, 1]"));
+  this->AssertUnaryOp(sign, this->MakeScalar(min), *arrow::MakeScalar(int8(), 0));
+  this->AssertUnaryOp(sign, this->MakeScalar(max), *arrow::MakeScalar(int8(), 1));
 }
 
 TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
@@ -2044,7 +2046,8 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   this->AssertUnaryOp(sign, "[-1.3, -10.80, -12748.001]", "[-1, -1, -1]");
   this->AssertUnaryOp(sign, "[Inf, -Inf]", "[1, -1]");
   this->AssertUnaryOp(sign, "[NaN]", "[NaN]");
-  this->AssertUnaryOp(sign, MakeArray(min, max), "[-1, 1]");
+  this->AssertUnaryOp(sign, this->MakeScalar(min), this->MakeScalar(-1));
+  this->AssertUnaryOp(sign, this->MakeScalar(max), this->MakeScalar(1));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2066,13 +2066,13 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   // Arrays with NaNs
   this->AssertUnaryOp(Sign, "[NaN]", ArrayFromJSON(int8(), "[1]"));
   // Min/max
-  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
-                      ArrayFromJSON(int8(), "[-1, 1]"));
+  // this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
+  //                     ArrayFromJSON(int8(), "[-1, 1]"));
 
-  auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(-1, min, max, 1));
-  arg = TweakValidityBit(arg, 1, false);
-  arg = TweakValidityBit(arg, 2, false);
-  this->AssertUnaryOp(Sign, arg, ArrayFromJSON(int8(), "[-1, null, null, 1]"));
+  // auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(-1, min, max, 1));
+  // arg = TweakValidityBit(arg, 1, false);
+  // arg = TweakValidityBit(arg, 2, false);
+  // this->AssertUnaryOp(Sign, arg, ArrayFromJSON(int8(), "[-1, null, null, 1]"));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2028,25 +2028,23 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   auto min = std::numeric_limits<CType>::lowest();
   auto max = std::numeric_limits<CType>::max();
 
+  this->SetNansEqual(true);
+
   // XXX TestUnaryArithmetic expects a function with ArithmeticOptions as its
   // second parameter
   auto sign = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
     return Sign(arg, ctx);
   };
 
-  this->AssertUnaryOp(sign, "[]", ArrayFromJSON(int8(), "[]"));
-  this->AssertUnaryOp(sign, "[null]", ArrayFromJSON(int8(), "[null]"));
-  this->AssertUnaryOp(sign, "[1.3, null, -10.80]",
-                      ArrayFromJSON(int8(), "[1, null, -1]"));
-  this->AssertUnaryOp(sign, "[0.0, -0.0]", ArrayFromJSON(int8(), "[0, 0]"));
-  this->AssertUnaryOp(sign, "[1.3, 10.80, 12748.001]",
-                      ArrayFromJSON(int8(), "[1, 1, 1]"));
-  this->AssertUnaryOp(sign, "[-1.3, -10.80, -12748.001]",
-                      ArrayFromJSON(int8(), "[-1, -1, -1]"));
-  this->AssertUnaryOp(sign, "[Inf, -Inf]", ArrayFromJSON(int8(), "[1, -1]"));
-  this->AssertUnaryOp(sign, "[NaN]", ArrayFromJSON(int8(), "[1]"));
-  this->AssertUnaryOp(sign, MakeScalar(min), *arrow::MakeScalar(int8(), -1));
-  this->AssertUnaryOp(sign, MakeScalar(max), *arrow::MakeScalar(int8(), 1));
+  this->AssertUnaryOp(sign, "[]", "[]");
+  this->AssertUnaryOp(sign, "[null]", "[null]");
+  this->AssertUnaryOp(sign, "[1.3, null, -10.80]", "[1, null, -1]");
+  this->AssertUnaryOp(sign, "[0.0, -0.0]", "[0, 0]");
+  this->AssertUnaryOp(sign, "[1.3, 10.80, 12748.001]", "[1, 1, 1]");
+  this->AssertUnaryOp(sign, "[-1.3, -10.80, -12748.001]", "[-1, -1, -1]");
+  this->AssertUnaryOp(sign, "[Inf, -Inf]", "[1, -1]");
+  this->AssertUnaryOp(sign, "[NaN]", "[NaN]");
+  this->AssertUnaryOp(sign, MakeArray(min, max), "[-1, 1]");
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1989,7 +1989,7 @@ TYPED_TEST(TestUnaryArithmeticSigned, Sign) {
   auto min = std::numeric_limits<CType>::min();
   auto max = std::numeric_limits<CType>::max();
 
-  // XXX TestUnaryArithmetic expects a function with ArithmeticOptions as its
+  // N.B. TestUnaryArithmetic expects a function with ArithmeticOptions as its
   // second parameter
   auto sign = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
     return Sign(arg, ctx);
@@ -2010,7 +2010,7 @@ TYPED_TEST(TestUnaryArithmeticUnsigned, Sign) {
   auto min = std::numeric_limits<CType>::min();
   auto max = std::numeric_limits<CType>::max();
 
-  // XXX TestUnaryArithmetic expects a function with ArithmeticOptions as its
+  // N.B. TestUnaryArithmetic expects a function with ArithmeticOptions as its
   // second parameter
   auto sign = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
     return Sign(arg, ctx);
@@ -2032,7 +2032,7 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
 
   this->SetNansEqual(true);
 
-  // XXX TestUnaryArithmetic expects a function with ArithmeticOptions as its
+  // N.B. TestUnaryArithmetic expects a function with ArithmeticOptions as its
   // second parameter
   auto sign = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
     return Sign(arg, ctx);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2066,8 +2066,8 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   // Arrays with NaNs
   this->AssertUnaryOp(Sign, "[NaN]", ArrayFromJSON(int8(), "[1]"));
   // Min/max
-  // this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
-  //                     ArrayFromJSON(int8(), "[-1, 1]"));
+  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
+                      ArrayFromJSON(int8(), "[-1, 1]"));
 
   // auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(-1, min, max, 1));
   // arg = TweakValidityBit(arg, 1, false);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -66,7 +66,7 @@ class TestUnaryArithmetic : public TestBase {
     return *arrow::MakeScalar(type_singleton(), value);
   }
 
-  // (Scalar)
+  // (Scalar, Scalar)
   void AssertUnaryOp(UnaryFunction func, CType argument, CType expected) {
     auto arg = MakeScalar(argument);
     auto exp = MakeScalar(expected);
@@ -74,34 +74,42 @@ class TestUnaryArithmetic : public TestBase {
     AssertScalarsApproxEqual(*exp, *actual.scalar(), /*verbose=*/true);
   }
 
-  // (Scalar)
+  // (Scalar, Scalar)
   void AssertUnaryOp(UnaryFunction func, const std::shared_ptr<Scalar>& arg,
                      const std::shared_ptr<Scalar>& expected) {
     ASSERT_OK_AND_ASSIGN(auto actual, func(arg, options_, nullptr));
     AssertScalarsApproxEqual(*expected, *actual.scalar(), /*verbose=*/true);
   }
 
-  // (Array)
-  void AssertUnaryOp(UnaryFunction func, const std::string& argument,
-                     const std::string& expected) {
-    auto arg = ArrayFromJSON(type_singleton(), argument);
+  // (JSON, JSON)
+  void AssertUnaryOp(UnaryFunction func, const std::string& arg_json,
+                     const std::string& expected_json) {
+    auto arg = ArrayFromJSON(type_singleton(), arg_json);
+    auto expected = ArrayFromJSON(type_singleton(), expected_json);
     AssertUnaryOp(func, arg, expected);
   }
 
-  // (Array)
+  // (Array, JSON)
   void AssertUnaryOp(UnaryFunction func, const std::shared_ptr<Array>& arg,
                      const std::string& expected_json) {
     const auto expected = ArrayFromJSON(type_singleton(), expected_json);
-    return AssertUnaryOp(func, arg, expected);
+    AssertUnaryOp(func, arg, expected);
   }
 
-  // (Array)
+  // (JSON, Array)
+  void AssertUnaryOp(UnaryFunction func, const std::string& arg_json,
+                     const std::shared_ptr<Array>& expected) {
+    auto arg = ArrayFromJSON(type_singleton(), arg_json);
+    AssertUnaryOp(func, arg, expected);
+  }
+
+  // (Array, Array)
   void AssertUnaryOp(UnaryFunction func, const std::shared_ptr<Array>& arg,
                      const std::shared_ptr<Array>& expected) {
     ASSERT_OK_AND_ASSIGN(Datum actual, func(arg, options_, nullptr));
     ValidateAndAssertApproxEqual(actual.make_array(), expected);
 
-    // Also check (Scalar) operations
+    // Also check (Scalar, Scalar) operations
     const int64_t length = expected->length();
     for (int64_t i = 0; i < length; ++i) {
       const auto expected_scalar = *expected->GetScalar(i);
@@ -1024,7 +1032,8 @@ TEST(TestBinaryArithmetic, AddWithImplicitCastsUint64EdgeCase) {
 }
 
 TEST(TestUnaryArithmetic, DispatchBest) {
-  for (std::string name : {"negate", "abs", "abs_checked"}) {
+  // All arithmetic
+  for (std::string name : {"negate", "abs", "abs_checked", "sign"}) {
     for (const auto& ty : {int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(),
                            uint64(), float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});
@@ -1032,6 +1041,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
     }
   }
 
+  // Signed arithmetic
   for (std::string name : {"negate_checked"}) {
     for (const auto& ty : {int8(), int16(), int32(), int64(), float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});
@@ -1039,7 +1049,8 @@ TEST(TestUnaryArithmetic, DispatchBest) {
     }
   }
 
-  for (std::string name : {"negate", "negate_checked", "abs", "abs_checked"}) {
+  // Null input
+  for (std::string name : {"negate", "negate_checked", "abs", "abs_checked", "sign"}) {
     CheckDispatchFails(name, {null()});
   }
 
@@ -1973,5 +1984,88 @@ TYPED_TEST(TestUnaryArithmeticSigned, Log) {
   this->AssertUnaryOpRaises(Log1p, "[-2]", "logarithm of negative number");
 }
 
+TYPED_TEST(TestUnaryArithmeticSigned, Sign) {
+  using CType = typename TestFixture::CType;
+
+  auto min = std::numeric_limits<CType>::min();
+  auto max = std::numeric_limits<CType>::max();
+
+  // Empty array
+  this->AssertUnaryOp(Sign, "[]", ArrayFromJSON(int8(), "[]"));
+  // Scalar/arrays with nulls
+  this->AssertUnaryOp(Sign, "[null]", ArrayFromJSON(int8(), "[null]"));
+  this->AssertUnaryOp(Sign, "[1, null, -10]", ArrayFromJSON(int8(), "[1, null, -1]"));
+  // Scalar/arrays with zeros
+  this->AssertUnaryOp(Sign, "[0]", ArrayFromJSON(int8(), "[0]"));
+  // Ordinary scalar/arrays (positive inputs)
+  this->AssertUnaryOp(Sign, "[1, 10, 127]", ArrayFromJSON(int8(), "[1, 1, 1]"));
+  // Ordinary scalar/arrays (negative inputs)
+  this->AssertUnaryOp(Sign, "[-1, -10, -127]", ArrayFromJSON(int8(), "[-1, -1, -1]"));
+  // Min/max
+  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
+                      ArrayFromJSON(int8(), "[-1, 1]"));
+
+  auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(-1, min, max, 1));
+  arg = TweakValidityBit(arg, 1, false);
+  arg = TweakValidityBit(arg, 2, false);
+  this->AssertUnaryOp(Sign, arg, ArrayFromJSON(int8(), "[-1, null, null, 1]"));
+}
+
+TYPED_TEST(TestUnaryArithmeticUnsigned, Sign) {
+  using CType = typename TestFixture::CType;
+
+  auto min = std::numeric_limits<CType>::min();
+  auto max = std::numeric_limits<CType>::max();
+
+  // Empty arrays
+  this->AssertUnaryOp(Sign, "[]", ArrayFromJSON(int8(), "[]"));
+  // Array with nulls
+  this->AssertUnaryOp(Sign, "[null]", ArrayFromJSON(int8(), "[null]"));
+  // Ordinary arrays
+  this->AssertUnaryOp(Sign, "[0, 1, 10, 127]", ArrayFromJSON(int8(), "[0, 1, 1, 1]"));
+  // Min/max
+  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
+                      ArrayFromJSON(int8(), "[0, 1]"));
+
+  auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(0, min, max, 1));
+  arg = TweakValidityBit(arg, 1, false);
+  arg = TweakValidityBit(arg, 2, false);
+  this->AssertUnaryOp(Sign, arg, ArrayFromJSON(int8(), "[0, null, null, 1]"));
+}
+
+TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
+  using CType = typename TestFixture::CType;
+
+  auto min = std::numeric_limits<CType>::lowest();
+  auto max = std::numeric_limits<CType>::max();
+
+  // Empty array
+  this->AssertUnaryOp(Sign, "[]", ArrayFromJSON(int8(), "[]"));
+  // Scalar/arrays with nulls
+  this->AssertUnaryOp(Sign, "[null]", ArrayFromJSON(int8(), "[null]"));
+  this->AssertUnaryOp(Sign, "[1.3, null, -10.80]",
+                      ArrayFromJSON(int8(), "[1, null, -1]"));
+  // Scalars/arrays with zeros
+  this->AssertUnaryOp(Sign, "[0.0, -0.0]", ArrayFromJSON(int8(), "[1, -1]"));
+  // Ordinary scalars/arrays (positive inputs)
+  this->AssertUnaryOp(Sign, "[1.3, 10.80, 12748.001]",
+                      ArrayFromJSON(int8(), "[1, 1, 1]"));
+  // Ordinary scalars/arrays (negative inputs)
+  this->AssertUnaryOp(Sign, "[-1.3, -10.80, -12748.001]",
+                      ArrayFromJSON(int8(), "[-1, -1, -1]"));
+  // Arrays with infinites
+  this->AssertUnaryOp(Sign, "[Inf, -Inf]", ArrayFromJSON(int8(), "[1, -1]"));
+  // Arrays with NaNs
+  // NOTE[EPM] NaNs do no work, why?
+  // this->AssertUnaryOp(Sign, "[NaN, -NaN]", ArrayFromJSON(int8(), "[1, -1]"));
+  // Min/max
+  this->AssertUnaryOp(Sign, ArrayFromJSON(this->type_singleton(), MakeArray(min, max)),
+                      ArrayFromJSON(int8(), "[-1, 1]"));
+
+  auto arg = ArrayFromJSON(this->type_singleton(), MakeArray(-1, min, max, 1));
+  arg = TweakValidityBit(arg, 1, false);
+  arg = TweakValidityBit(arg, 2, false);
+  this->AssertUnaryOp(Sign, arg, ArrayFromJSON(int8(), "[-1, null, null, 1]"));
+}
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -262,39 +262,39 @@ then typically wraps around).  Most functions are also available in an
 overflow-checking variant, suffixed ``_checked``, which returns
 an ``Invalid`` :class:`Status` when overflow is detected.
 
-+------------------+--------+----------------+----------------+-------+
-| Function name    | Arity  | Input types    | Output type    | Notes |
-+==================+========+================+================+=======+
-| abs              | Unary  | Numeric        | Numeric        |       |
-+------------------+--------+----------------+----------------+-------+
-| abs_checked      | Unary  | Numeric        | Numeric        |       |
-+------------------+--------+----------------+----------------+-------+
-| add              | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| add_checked      | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| divide           | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| divide_checked   | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| multiply         | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| multiply_checked | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| negate           | Unary  | Numeric        | Numeric        |       |
-+------------------+--------+----------------+----------------+-------+
-| negate_checked   | Unary  | Signed Numeric | Signed Numeric |       |
-+------------------+--------+----------------+----------------+-------+
-| power            | Binary | Numeric        | Numeric        |       |
-+------------------+--------+----------------+----------------+-------+
-| power_checked    | Binary | Numeric        | Numeric        |       |
-+------------------+--------+----------------+----------------+-------+
-| sign             | Unary  | Numeric        | Int8           | \(2)  |
-+------------------+--------+----------------+----------------+-------+
-| subtract         | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
-| subtract_checked | Binary | Numeric        | Numeric        | \(1)  |
-+------------------+--------+----------------+----------------+-------+
++------------------+--------+----------------+----------------------+-------+
+| Function name    | Arity  | Input types    | Output type          | Notes |
++==================+========+================+======================+=======+
+| abs              | Unary  | Numeric        | Numeric              |       |
++------------------+--------+----------------+----------------------+-------+
+| abs_checked      | Unary  | Numeric        | Numeric              |       |
++------------------+--------+----------------+----------------------+-------+
+| add              | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| add_checked      | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| divide           | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| divide_checked   | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| multiply         | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| multiply_checked | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| negate           | Unary  | Numeric        | Numeric              |       |
++------------------+--------+----------------+----------------------+-------+
+| negate_checked   | Unary  | Signed Numeric | Signed Numeric       |       |
++------------------+--------+----------------+----------------------+-------+
+| power            | Binary | Numeric        | Numeric              |       |
++------------------+--------+----------------+----------------------+-------+
+| power_checked    | Binary | Numeric        | Numeric              |       |
++------------------+--------+----------------+----------------------+-------+
+| sign             | Unary  | Numeric        | Int8/Float32/Float64 | \(2)  |
++------------------+--------+----------------+----------------------+-------+
+| subtract         | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
+| subtract_checked | Binary | Numeric        | Numeric              | \(1)  |
++------------------+--------+----------------+----------------------+-------+
 
 * \(1) Precision and scale of computed DECIMAL results
 
@@ -317,8 +317,9 @@ an ``Invalid`` :class:`Status` when overflow is detected.
   enough scale kept. Error is returned if the result precision is beyond the
   decimal value range.
 
-* \(2) Output is an integral representing the signedness of the input.
-  For nonzero inputs, output is any of (-1,1) and 0 for zero input.
+* \(2) Output is any of (-1,1) for nonzero inputs and 0 for zero input.
+  NaN values return NaN.  Integral values return signedness as Int8 and
+  floating-point values return it with the same type as the input values.
 
 Bit-wise functions
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -258,7 +258,7 @@ Input(s) will be cast to the :ref:`common numeric type <common-numeric-type>`
 (and dictionary decoded, if applicable) before the operation is applied.
 
 The default variant of these functions does not detect overflow (the result
-then typically wraps around).  Each function is also available in an
+then typically wraps around).  Most functions are also available in an
 overflow-checking variant, suffixed ``_checked``, which returns
 an ``Invalid`` :class:`Status` when overflow is detected.
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -289,6 +289,8 @@ an ``Invalid`` :class:`Status` when overflow is detected.
 +------------------+--------+----------------+----------------+-------+
 | power_checked    | Binary | Numeric        | Numeric        |       |
 +------------------+--------+----------------+----------------+-------+
+| sign             | Unary  | Numeric        | Int8           | \(2)  |
++------------------+--------+----------------+----------------+-------+
 | subtract         | Binary | Numeric        | Numeric        | \(1)  |
 +------------------+--------+----------------+----------------+-------+
 | subtract_checked | Binary | Numeric        | Numeric        | \(1)  |
@@ -314,6 +316,9 @@ an ``Invalid`` :class:`Status` when overflow is detected.
   precision of `divide` is at least the sum of precisions of both operands with
   enough scale kept. Error is returned if the result precision is beyond the
   decimal value range.
+
+* \(2) Output is an integral representing the signedness of the input.
+  For nonzero inputs, output is any of (-1,1) and 0 for zero input.
 
 Bit-wise functions
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -54,14 +54,15 @@ throws an ``ArrowInvalid`` exception when overflow is detected.
    divide_checked
    multiply
    multiply_checked
-   subtract
-   subtract_checked
    power
    power_checked
    shift_left
    shift_left_checked
    shift_right
    shift_right_checked
+   sign
+   subtract
+   subtract_checked
 
 Bit-wise operations do not offer (or need) a checked variant.
 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -39,7 +39,7 @@ Aggregations
 Arithmetic Functions
 --------------------
 
-By default these functions do not detect overflow. Each function is also
+By default these functions do not detect overflow. Most functions are also
 available in an overflow-checking variant, suffixed ``_checked``, which
 throws an ``ArrowInvalid`` exception when overflow is detected.
 


### PR DESCRIPTION
This PR adds the sign function to the compute layer as a unary scalar function.
* Numeric inputs result in any of (-1,0,1)
* +/-0 input returns 0
* Infinity is treated as a signed number
* NaN input returns NaN