### PR TITLE
MINOR: [C#] Fixing example to use WriteEndAsync instead of WriteFooterAsync

### DIFF
--- a/csharp/examples/FluentBuilderExample/Program.cs
+++ b/csharp/examples/FluentBuilderExample/Program.cs
@@ -51,7 +51,7 @@ namespace FluentBuilderExample
             using (var writer = new ArrowFileWriter(stream, recordBatch.Schema))
             {
                 await writer.WriteRecordBatchAsync(recordBatch);
-                await writer.WriteFooterAsync();
+                await writer.WriteEndAsync();
             }
 
             Console.WriteLine("Done");


### PR DESCRIPTION
WriteFooterAsync is private, so the example doesn't compile. 
This method was probably public in an earlier version of the library.
WriteEndAsync seems to be the proper replacement.