### PR TITLE
ARROW-12877: [C++] Create implementation of chase-lev deque

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -220,6 +220,7 @@ set(ARROW_SRCS
     util/uri.cc
     util/utf8.cc
     util/value_parsing.cc
+    util/ws_thread_pool.cc
     vendored/base64.cpp
     vendored/datetime/tz.cpp
     vendored/double-conversion/bignum.cc

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -74,7 +74,8 @@ add_arrow_test(threading-utility-test
                cancel_test.cc
                future_test.cc
                task_group_test.cc
-               thread_pool_test.cc)
+               thread_pool_test.cc
+               ws_thread_pool_test.cc)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
 add_arrow_benchmark(bit_util_benchmark)

--- a/cpp/src/arrow/util/ws_thread_pool.cc
+++ b/cpp/src/arrow/util/ws_thread_pool.cc
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/ws_thread_pool.h"
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+
+#include "arrow/util/atomic_shared_ptr.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace internal {
+
+ResizableRingBuffer::ResizableRingBuffer(std::size_t size)
+    : size_(size), mask_(size - 1), arr_(size) {
+  // Confirm size is a power of 2
+  DCHECK_EQ(size & (size - 1), 0);
+}
+
+std::size_t ResizableRingBuffer::size() const { return size_; }
+
+Task* ResizableRingBuffer::Get(std::size_t i) {
+  return arr_[i & mask_].load(std::memory_order_relaxed);
+}
+
+void ResizableRingBuffer::Put(std::size_t i, Task* task) {
+  arr_[i & mask_].store(task, std::memory_order_relaxed);
+}
+
+ResizableRingBuffer ResizableRingBuffer::Resize(std::size_t top, std::size_t bottom) {
+  std::size_t new_size = size_ << 1;
+  ResizableRingBuffer new_buf(new_size);
+  for (std::size_t i = top; i < bottom; i++) {
+    new_buf.Put(i, Get(i));
+  }
+  return new_buf;
+}
+
+WorkQueue::WorkQueue(std::size_t initial_capacity)
+    : top_(0),
+      bottom_(0),
+      tasks_(new ResizableRingBuffer(initial_capacity)),
+      to_delete_(32) {}
+
+WorkQueue::~WorkQueue() {
+  for (auto& item : to_delete_) {
+    delete item;
+  }
+  delete tasks_.load();
+}
+
+bool WorkQueue::Empty() const {
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+  return bottom <= top;
+}
+
+std::size_t WorkQueue::Size() const {
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+  return std::max(bottom - top, static_cast<std::size_t>(0));
+}
+
+std::size_t WorkQueue::Capacity() const {
+  return tasks_.load(std::memory_order_relaxed)->size();
+}
+
+void WorkQueue::Push(Task* task) {
+  DCHECK(task->callable);
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_acquire);
+  ResizableRingBuffer* tasks = tasks_.load(std::memory_order_relaxed);
+  std::size_t count_existing = bottom - top;
+
+  // The queue is full so we need to resize.  There is only one producer so only one
+  // thread can be in resize at once.  Other threads will only see the new queue once it
+  // is fully initialized
+  if (tasks->size() < count_existing + 1) {
+    ResizableRingBuffer* bigger = new ResizableRingBuffer(tasks->Resize(top, bottom));
+    // Collect to delete later
+    to_delete_.push_back(tasks);
+    tasks = bigger;
+    // FIXME - Should be relaxed
+    tasks_.store(tasks, std::memory_order_relaxed);
+  }
+
+  tasks->Put(bottom, std::move(task));
+  std::atomic_thread_fence(std::memory_order_release);
+  bottom_.store(bottom + 1, std::memory_order_relaxed);
+}
+
+Task* WorkQueue::Pop() {
+  std::size_t new_bottom = bottom_.load(std::memory_order_relaxed) - 1;
+  ResizableRingBuffer* tasks = tasks_.load(std::memory_order_relaxed);
+
+  bottom_.store(new_bottom, std::memory_order_relaxed);
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+
+  Task* task = nullptr;
+  if (top <= new_bottom) {
+    task = tasks->Get(new_bottom);
+    if (top == new_bottom) {
+      // If we are removing the last item we need to do a double-check to handle the
+      // case where a stealing thread comes in and steals the item at the same time we are
+      // trying to grab it.
+      if (!top_.compare_exchange_strong(top, top + 1, std::memory_order_seq_cst,
+                                        std::memory_order_relaxed)) {
+        task = nullptr;
+      }
+      bottom_.store(new_bottom + 1, std::memory_order_relaxed);
+    }
+  } else {
+    // Empty, return null and put the bottom back
+    bottom_.store(new_bottom + 1, std::memory_order_relaxed);
+  }
+
+  DCHECK(!task || task->callable);
+
+  return task;
+}
+
+Task* WorkQueue::Steal() {
+  std::size_t top = top_.load(std::memory_order_acquire);
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+  std::size_t bottom = bottom_.load(std::memory_order_acquire);
+
+  Task* task = nullptr;
+
+  if (top < bottom) {
+    ResizableRingBuffer* tasks = tasks_.load(std::memory_order_consume);
+    task = tasks->Get(top);
+
+    // Need to check and see if the owning thread grabbed the item before we could
+    // mark it claimed.
+    if (!top_.compare_exchange_strong(top, top + 1, std::memory_order_seq_cst,
+                                      std::memory_order_relaxed)) {
+      return nullptr;
+    }
+  }
+
+  return task;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/ws_thread_pool.h
+++ b/cpp/src/arrow/util/ws_thread_pool.h
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstddef>
+
+#include "arrow/util/cancel.h"
+#include "arrow/util/functional.h"
+#include "arrow/util/thread_pool.h"
+
+namespace arrow {
+namespace internal {
+
+struct Task {
+  FnOnce<void()> callable;
+  StopToken stop_token;
+  Executor::StopCallback stop_callback;
+};
+
+/// An implementation of a Chase-Lev deque as described in
+/// https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf
+///
+/// Implementations to look at:
+///  * https://github.com/taskflow/taskflow/blob/master/taskflow/core/tsq.hpp
+///
+/// It is lock-free and supports multiple consumers with a single producer
+///
+/// The owning thread pushes tasks to the bottom of the stack
+/// The owning thread pulls tasks from the bottom of the stack (LIFO)
+///
+/// Thieving threads pull tasks from the top of the stack (FIFO)
+///
+/// The memory ordering is designed such that the hot path (owning thread pulls its own
+/// items) is fastest.  It is based on a paper "Correct and Efficient Work-Stealing for
+/// Weak Memory Models" here: https://fzn.fr/readings/ppopp13.pdf
+///
+/// Potential future optimizations
+/// * The original paper (see above) describes how to shrink the array to help conserve
+///   memory after a burst  of tasks.
+/// * When the buffer resizes the original buffer is destroyed immediately.  The taskflow
+///   implementation throws it in a garbage buffer to be destroyed later at destruction
+///   time
+
+class ResizableRingBuffer {
+ public:
+  /// Creates a ring buffer with a fixed capacity
+  /// NB: size must be a power of 2
+  ResizableRingBuffer(std::size_t size);
+  /// Size of the buffer
+  std::size_t size() const;
+  /// Gets an item from the buffer
+  Task* Get(std::size_t i);
+  /// Inserts an item into the buffer
+  void Put(std::size_t i, Task* task);
+  /// Creates a new buffer with 2x the capacity, needs to know where top and
+  /// bottom are to copy into the new buffer in the correct order.
+  ResizableRingBuffer Resize(std::size_t bottom, std::size_t top);
+
+ private:
+  std::size_t size_;
+  // The original paper has to regularly do (i % size).  Since size is always a power
+  // of 2 we can do this more efficiently with (i & (size - 1)).   mask_ is size_ - 1
+  std::size_t mask_;
+  std::vector<std::atomic<Task*>> arr_;
+};
+
+class WorkQueue {
+ public:
+  /// Creates a work queue with a given initial capacity, the queue can grow beyond this
+  /// capacity if needed
+  WorkQueue(std::size_t initial_capacity);
+  ~WorkQueue();
+
+  bool Empty() const;
+  std::size_t Size() const;
+  std::size_t Capacity() const;
+
+  /// Adds an item to the bottom of the stack
+  /// NB: Must only be called by the owning thread
+  void Push(Task* task);
+  /// Pulls an item off the bottom of the stack
+  /// NB: Must only be called by the owning thread
+  Task* Pop();
+  /// Steals an item off the top of the stack
+  Task* Steal();
+
+ private:
+  std::atomic<std::size_t> top_;
+  std::atomic<std::size_t> bottom_;
+  std::atomic<ResizableRingBuffer*> tasks_;
+  // We can't delete a buffer immediately when we resize it because there may be threads
+  // in the middle of a steal operation.  So instead we just keep track of all the buffers
+  // here and delete them at the end.  Each resize doubles the queue so this shouldn't
+  // happen all that often.
+  std::vector<ResizableRingBuffer*> to_delete_;
+};
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/ws_thread_pool_test.cc
+++ b/cpp/src/arrow/util/ws_thread_pool_test.cc
@@ -1,0 +1,329 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Task queue tests
+
+#include <iostream>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/ws_thread_pool.h"
+
+namespace arrow {
+namespace internal {
+
+class WorkStealingTest : public ::testing::Test {
+ protected:
+  template <int Size>
+  struct Tasks {
+    Tasks() { Reset(); }
+
+    Task* GetTask(int i) { return tasks[i].get(); }
+
+    // Used when the task finish order is known, verifies the correct task finished
+    void VerifyTask(Task* task, int expected_index) {
+      ASSERT_FALSE(finished[expected_index])
+          << " expected task " << expected_index
+          << " just finished now but it was finished already";
+      std::move(task->callable)();
+      ASSERT_TRUE(finished[expected_index])
+          << " expected task " << expected_index
+          << " to finish but some other task was given instead";
+    }
+
+    // FinishTask + VerifyAllTasksFinished is used when the task finish order is
+    // not known
+    void FinishTask(Task* task) { std::move(task->callable)(); }
+
+    void VerifyAllTasksFinished(int expected_num_tasks) {
+      for (int i = 0; i < expected_num_tasks; i++) {
+        ASSERT_TRUE(finished[i])
+            << "Expected task " << i << " to be finished but it was not";
+      }
+    }
+
+    void Reset() {
+      for (int i = 0; i < Size; i++) {
+        finished[i] = false;
+        tasks[i] = std::make_shared<Task>(MakeTask(i));
+      }
+    }
+
+    Task MakeTask(int index) {
+      bool* finished_flag = finished.data() + index;
+      FnOnce<void()> cb = [finished_flag, index] { *finished_flag = true; };
+      return Task{std::move(cb), StopToken::Unstoppable(), {}};
+    }
+
+    std::array<bool, Size> finished;
+    std::array<std::shared_ptr<Task>, Size> tasks;
+  };
+};
+
+class ResizableRingBufferTest : public WorkStealingTest {};
+
+TEST_F(ResizableRingBufferTest, Basic) {
+  Tasks<18> tasks;
+  ResizableRingBuffer buffer(8);
+  ASSERT_EQ(8, buffer.size());
+
+  for (int i = 0; i < 6; i++) {
+    buffer.Put(i, tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(buffer.Get(i), i);
+  }
+
+  auto resized = buffer.Resize(2, 6);
+  ASSERT_EQ(16, resized.size());
+
+  for (int i = 6; i < 18; i++) {
+    resized.Put(i, tasks.GetTask(i));
+  }
+
+  for (int i = 2; i < 16; i++) {
+    tasks.VerifyTask(resized.Get(i), i);
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(resized.Get(i), 16 + i);
+  }
+}
+
+class WorkQueueTest : public WorkStealingTest {};
+
+TEST_F(WorkQueueTest, PushThenPop) {
+  Tasks<18> tasks;
+  WorkQueue work_queue(8);
+
+  for (int i = 0; i < 6; i++) {
+    // Add 0-5
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    // Pop 4,5
+    tasks.VerifyTask(work_queue.Pop(), 5 - i);
+  }
+
+  for (int i = 6; i < 18; i++) {
+    // Add 6-17
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 12; i++) {
+    // Pop 17-6
+    tasks.VerifyTask(work_queue.Pop(), 17 - i);
+  }
+
+  for (int i = 0; i < 4; i++) {
+    // Pop 0-3
+    tasks.VerifyTask(work_queue.Pop(), 3 - i);
+  }
+}
+
+TEST_F(WorkQueueTest, PushThenSteal) {
+  Tasks<18> tasks;
+  WorkQueue work_queue(8);
+
+  for (int i = 0; i < 6; i++) {
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(work_queue.Steal(), i);
+  }
+
+  for (int i = 6; i < 18; i++) {
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 2; i < 18; i++) {
+    tasks.VerifyTask(work_queue.Steal(), i);
+  }
+}
+
+class WorkQueueStressTest : public WorkStealingTest,
+                            public ::testing::WithParamInterface<bool> {};
+
+TEST_P(WorkQueueStressTest, StressSteal) {
+  // Tests stealing from the queue while the producer adds tasks
+  bool slow_consumer = GetParam();
+  constexpr int MAX_NTASKS = 10000;
+  int ntasks = MAX_NTASKS;
+  if (slow_consumer) {
+    ntasks = 100;
+  }
+  int iterations = 100;
+  if (slow_consumer) {
+    iterations = 10;
+  }
+  Tasks<MAX_NTASKS> tasks;
+
+  for (int i = 0; i < iterations; i++) {
+    // The slow_consumer test case should cover steal while resizing
+    WorkQueue work_queue(2);
+    std::thread producer([&work_queue, &tasks, ntasks] {
+      for (int i = 0; i < ntasks; i++) {
+        work_queue.Push(tasks.GetTask(i));
+      }
+    });
+
+    std::thread consumer([&work_queue, &tasks, ntasks, slow_consumer] {
+      int tasks_consumed = 0;
+      while (tasks_consumed < ntasks) {
+        auto next_task = work_queue.Steal();
+        if (next_task) {
+          tasks.FinishTask(next_task);
+          tasks_consumed++;
+          if (slow_consumer) {
+            SleepABit();
+          }
+        }
+      }
+    });
+
+    producer.join();
+    consumer.join();
+    tasks.VerifyAllTasksFinished(ntasks);
+    tasks.Reset();
+  }
+}
+
+TEST_P(WorkQueueStressTest, PopSteal) {
+  // Builds up a queue of tasks and then tests the owning producer
+  // working through the queue at the same time another thread steal
+  constexpr int NTASKS = 10000;
+  constexpr int ITERATIONS = 100;
+
+  bool multiple_theives = GetParam();
+  int num_thieves = (multiple_theives) ? 8 : 1;
+
+  Tasks<NTASKS> tasks;
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    WorkQueue work_queue(32);
+    for (int i = 0; i < NTASKS; i++) {
+      work_queue.Push(tasks.GetTask(i));
+    }
+
+    std::function<Task*()> pop = [&work_queue] { return work_queue.Pop(); };
+    std::function<Task*()> steal = [&work_queue] { return work_queue.Steal(); };
+
+    std::atomic<int> tasks_consumed(0);
+    // The logic for the consumers is the same. The only difference is if they call
+    // pop or steal.
+    auto consume_factory = [&work_queue, &tasks,
+                            &tasks_consumed](std::function<Task*()> consume_fn) {
+      return [&work_queue, &tasks, &tasks_consumed, consume_fn] {
+        while (true) {
+          auto next_task = consume_fn();
+          if (next_task) {
+            tasks.FinishTask(next_task);
+            tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+          } else {
+            int consumed = tasks_consumed.load(std::memory_order_acquire);
+            if (consumed >= NTASKS) {
+              break;
+            }
+          }
+        }
+      };
+    };
+
+    std::vector<std::thread> threads;
+    threads.emplace_back(consume_factory(pop));
+    for (int i = 0; i < num_thieves; i++) {
+      threads.emplace_back(consume_factory(steal));
+    }
+
+    for (auto& thread : threads) {
+      thread.join();
+    }
+
+    tasks.VerifyAllTasksFinished(NTASKS);
+    tasks.Reset();
+  }
+}
+
+TEST_P(WorkQueueStressTest, PopAddSteal) {
+  // Producer alternates between adding and popping a task while other
+  // threads compete to steal tasks.  The pop may fail (because it was
+  // already stolen) and that's ok.
+  constexpr int NTASKS = 10000;
+  constexpr int ITERATIONS = 100;
+
+  bool multiple_theives = GetParam();
+  int num_thieves = (multiple_theives) ? 8 : 1;
+
+  Tasks<NTASKS> tasks;
+  std::atomic<int> tasks_consumed(0);
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    WorkQueue work_queue(32);
+
+    auto producer_fn = [&tasks, &work_queue, &tasks_consumed] {
+      for (int i = 0; i < NTASKS; i++) {
+        work_queue.Push(tasks.GetTask(i));
+        auto task = work_queue.Pop();
+        if (task) {
+          tasks.FinishTask(task);
+          tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    };
+
+    auto consumer_fn = [&tasks, &work_queue, &tasks_consumed] {
+      while (true) {
+        auto next_task = work_queue.Steal();
+        if (next_task) {
+          tasks.FinishTask(next_task);
+          tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          int consumed = tasks_consumed.load(std::memory_order_acquire);
+          if (consumed >= NTASKS) {
+            break;
+          }
+        }
+      }
+    };
+
+    std::vector<std::thread> threads;
+    threads.emplace_back(producer_fn);
+    for (int i = 0; i < num_thieves; i++) {
+      threads.emplace_back(consumer_fn);
+    }
+
+    for (auto& thread : threads) {
+      thread.join();
+    }
+
+    tasks.VerifyAllTasksFinished(NTASKS);
+    tasks.Reset();
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestWorkQueueStress, WorkQueueStressTest,
+                         ::testing::Values(false, true));
+
+}  // namespace internal
+}  // namespace arrow
+
+/// Thread pool tests


### PR DESCRIPTION
The Chase-Lev deque allows for a pop operation and a steal operation.  It is commonly implemented using lock-free methods.  The following is a fairly literal implementation of the ppopp13 paper using simple pointers.  I also have a shared_ptr version but it is not lock free because it uses std::shared_ptr atomic methods which are not lockfree (at least on my GCC version).  When I add benchmarks (soon, in a later PR) I will share some comparisons of the two.  Until then I will leave this in draft state.

## Original paper:

https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf

 
## Follow-up describing best way to implement lock-free:

https://fzn.fr/readings/ppopp13.pdf

 
## Example implementation:

https://github.com/taskflow/taskflow/blob/master/taskflow/core/tsq.hpp

