### PR TITLE
ARROW-12865: [C++][FlightRPC] Link gRPC with RE2

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2548,6 +2548,7 @@ macro(build_grpc)
       gRPC::upb
       gRPC::address_sorting
       ${ABSL_LIBRARIES}
+      re2::re2
       c-ares::cares
       ZLIB::ZLIB
       Threads::Threads)


### PR DESCRIPTION
This fixes undefined symbol error if build flight with vendored re2.