### PR TITLE
ARROW-12876: [R] Fix build flags on Raspberry Pi

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -44,8 +44,7 @@ NOT_CRAN=`echo $NOT_CRAN | tr '[:upper:]' '[:lower:]'`
 
 VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
-DISTID=`lsb_release -i`
-echo "$DISTID"
+DISTID=`lsb_release -i -s`
 
 # generate code
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then

--- a/r/configure
+++ b/r/configure
@@ -45,6 +45,7 @@ NOT_CRAN=`echo $NOT_CRAN | tr '[:upper:]' '[:lower:]'`
 VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
 DISTID=`lsb_release -i`
+echo "$DISTID"
 
 # generate code
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then

--- a/r/configure
+++ b/r/configure
@@ -44,7 +44,7 @@ NOT_CRAN=`echo $NOT_CRAN | tr '[:upper:]' '[:lower:]'`
 
 VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
-DISTID=`lsb_release -i -s`
+DISTID=`grep ^ID\= /etc/os-release | awk -F= '{print $2}' | sed 's/\"//g'`
 
 # generate code
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then

--- a/r/configure
+++ b/r/configure
@@ -44,6 +44,7 @@ NOT_CRAN=`echo $NOT_CRAN | tr '[:upper:]' '[:lower:]'`
 
 VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
+DISTID=`lsb_release -i`
 
 # generate code
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then
@@ -184,6 +185,11 @@ else
       fi
     fi
   fi
+fi
+
+# If on Raspberry Pi, need to manually link against latomic
+if [ "$DISTID" = "Raspbian" ]; then
+  PKG_CFLAGS="$PKG_CFLAGS -DARROW_CXXFLAGS=-latomic"
 fi
 
 # If libarrow uses the old GLIBCXX ABI, so we have to use it too

--- a/r/configure
+++ b/r/configure
@@ -188,7 +188,7 @@ else
 fi
 
 # If on Raspberry Pi, need to manually link against latomic
-if [ "$DISTID" = "raspbian" ]; then
+if grep raspbian /etc/os-release >/dev/null 2>&1; then
   PKG_CFLAGS="$PKG_CFLAGS -DARROW_CXXFLAGS=-latomic"
 fi
 

--- a/r/configure
+++ b/r/configure
@@ -44,7 +44,6 @@ NOT_CRAN=`echo $NOT_CRAN | tr '[:upper:]' '[:lower:]'`
 
 VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
-DISTID=`grep ^ID\= /etc/os-release | awk -F= '{print $2}' | sed 's/\"//g'`
 
 # generate code
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then

--- a/r/configure
+++ b/r/configure
@@ -187,6 +187,7 @@ else
 fi
 
 # If on Raspberry Pi, need to manually link against latomic
+# See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358 for similar example
 if grep raspbian /etc/os-release >/dev/null 2>&1; then
   PKG_CFLAGS="$PKG_CFLAGS -DARROW_CXXFLAGS=-latomic"
 fi

--- a/r/configure
+++ b/r/configure
@@ -188,7 +188,7 @@ else
 fi
 
 # If on Raspberry Pi, need to manually link against latomic
-if [ "$DISTID" = "Raspbian" ]; then
+if [ "$DISTID" = "raspbian" ]; then
   PKG_CFLAGS="$PKG_CFLAGS -DARROW_CXXFLAGS=-latomic"
 fi
 


### PR DESCRIPTION
Checks if installing on Raspberry PI OS, and if so, adds an additional build flag so that the compiler can link to one of the necessary libraries.