### PR TITLE
ARROW-12883: [R] [CI] version compatibility fails on R 4.1

### DIFF
--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -91,8 +91,8 @@ jobs:
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
       - uses: r-lib/actions/setup-r@v1
-         with:
-           r-version: {{ '${{ matrix.config.r }}' }}
+        with:
+          r-version: {{ '${{ matrix.config.r }}' }}
       - name: Install old Arrow
         run: |
           install.packages(c("remotes", "testthat"))

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -80,7 +80,6 @@ jobs:
           - "2.0.0"
           - "1.0.1"
     env:
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       ARROW_R_DEV: "TRUE"
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       OLD_ARROW_VERSION: {{ '${{ matrix.old_arrow_version }}' }}

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -92,7 +92,7 @@ jobs:
           git -C arrow submodule update --init --recursive
       - uses: r-lib/actions/setup-r@v1
          with:
-           r-version: ${{ matrix.config.r }}
+           r-version: {{ '${{ matrix.config.r }}' }}
       - name: Install old Arrow
         run: |
           install.packages(c("remotes", "testthat"))

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -68,21 +68,21 @@ jobs:
           path: arrow/r/extra-tests/files
 
   read-files:
-    name: "Read files with Arrow {{ '${{ matrix.old_arrow_version }}' }}"
+    name: "Read files with Arrow {{ '${{ matrix.config.old_arrow_version }}' }}"
     needs: [write-files]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        old_arrow_version:
-          - "4.0.0"
-          - "3.0.0"
-          - "2.0.0"
-          - "1.0.1"
+        config:
+        - { old_arrow_version: '4.0.0', r: '4.0' }
+        - { old_arrow_version: '3.0.0', r: '4.0' }
+        - { old_arrow_version: '2.0.0', r: '4.0' }
+        - { old_arrow_version: '1.0.1', r: '4.0' }
     env:
       ARROW_R_DEV: "TRUE"
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
-      OLD_ARROW_VERSION: {{ '${{ matrix.old_arrow_version }}' }}
+      OLD_ARROW_VERSION: {{ '${{ matrix.config.old_arrow_version }}' }}
     steps:
       - name: Checkout Arrow
         run: |
@@ -94,7 +94,7 @@ jobs:
       - name: Install old Arrow
         run: |
           install.packages(c("remotes", "testthat"))
-          remotes::install_version("arrow",  "{{ '${{ matrix.old_arrow_version }}' }}")
+          remotes::install_version("arrow",  "{{ '${{ matrix.config.old_arrow_version }}' }}")
         shell: Rscript {0}
       - name: Setup our testing directory, copy only the tests to it.
         run: |

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -91,6 +91,8 @@ jobs:
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
       - uses: r-lib/actions/setup-r@v1
+         with:
+           r-version: ${{ matrix.config.r }}
       - name: Install old Arrow
         run: |
           install.packages(c("remotes", "testthat"))

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -75,6 +75,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
+        # We use the R version that was released at the time of the arrow release in order
+        # to make sure we can download binaries from RSPM.
         - { old_arrow_version: '4.0.0', r: '4.0' }
         - { old_arrow_version: '3.0.0', r: '4.0' }
         - { old_arrow_version: '2.0.0', r: '4.0' }

--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -75,9 +75,13 @@ jobs:
       fail-fast: false
       matrix:
         old_arrow_version:
+          - "4.0.0"
+          - "3.0.0"
           - "2.0.0"
           - "1.0.1"
     env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      ARROW_R_DEV: "TRUE"
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       OLD_ARROW_VERSION: {{ '${{ matrix.old_arrow_version }}' }}
     steps:

--- a/r/extra-tests/test-read-files.R
+++ b/r/extra-tests/test-read-files.R
@@ -35,7 +35,9 @@ test_that("Can see the metadata (parquet)", {
   df <- read_parquet(pq_file)
   expect_s3_class(df, "tbl")
 
-  expect_equal(
+  # expect_mapequal() instead of expect_equal() because there was an order change where
+  # `class` is located in version 3.0.0 and above.
+  expect_mapequal(
     attributes(df),
     list(
       names = letters[1:4],
@@ -78,7 +80,7 @@ for (comp in c("lz4", "uncompressed", "zstd")) {
     df <- read_feather(feather_file)
     expect_s3_class(df, "tbl")
 
-    expect_equal(
+    expect_mapequal(
       attributes(df),
       list(
         names = letters[1:4],
@@ -137,7 +139,7 @@ test_that("Can see the metadata (stream)", {
 
   expect_s3_class(df, "tbl")
 
-  expect_equal(
+  expect_mapequal(
     attributes(df),
     list(
       names = letters[1:4],


### PR DESCRIPTION
Adjust the R version used to be able to install binary arrow packages from RSPM. Small adjustment to tests that doesn't require the order of attributes to be fixed (the order changed slightly in version 3.0.0) 