### PR TITLE
[C++] Create work stealing implementation of generalized ThreadPool

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -220,6 +220,7 @@ set(ARROW_SRCS
     util/uri.cc
     util/utf8.cc
     util/value_parsing.cc
+    util/ws_thread_pool.cc
     vendored/base64.cpp
     vendored/datetime/tz.cpp
     vendored/double-conversion/bignum.cc

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -285,7 +285,7 @@ static Result<RecordBatchGenerator> MakeSlowRecordBatchGenerator(
 class TestExecPlanExecution : public ::testing::Test {
  public:
   void SetUp() override {
-    ASSERT_OK_AND_ASSIGN(io_executor_, internal::ThreadPool::Make(8));
+    ASSERT_OK_AND_ASSIGN(io_executor_, internal::SimpleThreadPool::Make(8));
   }
 
   RecordBatchVector MakeRandomBatches(const std::shared_ptr<Schema>& schema,

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -154,14 +154,14 @@ TableReaderFactory MakeSerialFactory() {
 TEST(SerialReaderTests, Stress) { StressTableReader(MakeSerialFactory()); }
 TEST(SerialReaderTests, StressInvalid) { StressInvalidTableReader(MakeSerialFactory()); }
 TEST(SerialReaderTests, NestedParallelism) {
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(1));
   TestNestedParallelism(thread_pool, MakeSerialFactory());
 }
 
 Result<TableReaderFactory> MakeAsyncFactory(
     std::shared_ptr<internal::ThreadPool> thread_pool = nullptr) {
   if (!thread_pool) {
-    ARROW_ASSIGN_OR_RAISE(thread_pool, internal::ThreadPool::Make(1));
+    ARROW_ASSIGN_OR_RAISE(thread_pool, internal::SimpleThreadPool::Make(1));
   }
   return [thread_pool](std::shared_ptr<io::InputStream> input_stream)
              -> Result<std::shared_ptr<TableReader>> {
@@ -184,7 +184,7 @@ TEST(AsyncReaderTests, StressInvalid) {
   StressInvalidTableReader(table_factory);
 }
 TEST(AsyncReaderTests, NestedParallelism) {
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(1));
   ASSERT_OK_AND_ASSIGN(auto table_factory, MakeAsyncFactory(thread_pool));
   TestNestedParallelism(thread_pool, table_factory);
 }
@@ -211,7 +211,7 @@ TEST(StreamingReaderTests, StressInvalid) {
   StressInvalidTableReader(table_factory);
 }
 TEST(StreamingReaderTests, NestedParallelism) {
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(1));
   ASSERT_OK_AND_ASSIGN(auto table_factory, MakeStreamingFactory());
   TestNestedParallelism(thread_pool, table_factory);
 }

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -41,6 +41,7 @@
 namespace arrow {
 
 using internal::Executor;
+using internal::SimpleThreadPool;
 using internal::TaskHints;
 using internal::ThreadPool;
 
@@ -331,7 +332,7 @@ void SharedExclusiveChecker::UnlockExclusive() {}
 #endif
 
 static std::shared_ptr<ThreadPool> MakeIOThreadPool() {
-  auto maybe_pool = ThreadPool::MakeEternal(/*threads=*/8);
+  auto maybe_pool = SimpleThreadPool::MakeEternal(/*threads=*/8);
   if (!maybe_pool.ok()) {
     maybe_pool.status().Abort("Failed to create global IO thread pool");
   }

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -74,7 +74,8 @@ add_arrow_test(threading-utility-test
                cancel_test.cc
                future_test.cc
                task_group_test.cc
-               thread_pool_test.cc)
+               thread_pool_test.cc
+               ws_thread_pool_test.cc)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
 add_arrow_benchmark(bit_util_benchmark)

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1491,7 +1491,7 @@ Result<Iterator<T>> MakeGeneratorIterator(AsyncGenerator<T> source) {
 /// MakeGeneratorIterator.
 template <typename T>
 Result<Iterator<T>> MakeReadaheadIterator(Iterator<T> it, int readahead_queue_size) {
-  ARROW_ASSIGN_OR_RAISE(auto io_executor, internal::ThreadPool::Make(1));
+  ARROW_ASSIGN_OR_RAISE(auto io_executor, internal::SimpleThreadPool::Make(1));
   auto max_q = readahead_queue_size;
   auto q_restart = std::max(1, max_q / 2);
   ARROW_ASSIGN_OR_RAISE(

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -630,7 +630,7 @@ TEST(TestAsyncUtil, MakeTransferredGenerator) {
   std::condition_variable cv;
   std::atomic<bool> finished(false);
 
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(1));
 
   // Needs to be a slow source to ensure we don't call Then on a completed
   AsyncGenerator<TestInt> slow_generator = [&]() {
@@ -753,7 +753,7 @@ TEST_P(BackgroundGeneratorTestFixture, InvalidExecutor) {
   // Case 1: waiting future
   auto slow = GetParam();
   auto it = PossiblySlowVectorIt(expected, slow);
-  ASSERT_OK_AND_ASSIGN(auto invalid_executor, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto invalid_executor, internal::SimpleThreadPool::Make(1));
   ASSERT_OK(invalid_executor->Shutdown());
   ASSERT_OK_AND_ASSIGN(auto background, MakeBackgroundGenerator(
                                             std::move(it), invalid_executor.get(), 4, 2));
@@ -761,7 +761,7 @@ TEST_P(BackgroundGeneratorTestFixture, InvalidExecutor) {
 
   // Case 2: Queue bad result
   it = PossiblySlowVectorIt(expected, slow);
-  ASSERT_OK_AND_ASSIGN(invalid_executor, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(invalid_executor, internal::SimpleThreadPool::Make(1));
   ASSERT_OK_AND_ASSIGN(
       background, MakeBackgroundGenerator(std::move(it), invalid_executor.get(), 4, 2));
   ASSERT_FINISHES_OK_AND_EQ(TestInt(1), background());
@@ -855,7 +855,7 @@ TEST_P(BackgroundGeneratorTestFixture, AbortReading) {
 
 TEST_P(BackgroundGeneratorTestFixture, AbortOnIdleBackground) {
   // Tests what happens when the downstream aborts while the background thread is idle
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(1));
 
   auto source = PossiblySlowVectorIt(RangeVector(100), IsSlow());
   std::shared_ptr<AsyncGenerator<TestInt>> generator;
@@ -867,7 +867,7 @@ TEST_P(BackgroundGeneratorTestFixture, AbortOnIdleBackground) {
   ASSERT_FINISHES_OK_AND_EQ(TestInt(0), (*generator)());
 
   // The generator should pretty quickly fill up the queue and idle
-  BusyWait(10, [&thread_pool] { return thread_pool->GetNumTasks() == 0; });
+  BusyWait(10, [&thread_pool] { return thread_pool->NumTasksRunningOrQueued() == 0; });
 
   // Now delete the generator and hope we don't deadlock
   generator.reset();
@@ -889,7 +889,7 @@ struct SlowEmptyIterator {
 TEST_P(BackgroundGeneratorTestFixture, BackgroundRepeatEnd) {
   // Ensure that the background generator properly fulfills the asyncgenerator contract
   // and can be called after it ends.
-  ASSERT_OK_AND_ASSIGN(auto io_pool, internal::ThreadPool::Make(1));
+  ASSERT_OK_AND_ASSIGN(auto io_pool, internal::SimpleThreadPool::Make(1));
 
   bool slow = GetParam();
   Iterator<TestInt> iterator;
@@ -1061,7 +1061,7 @@ TEST(TestAsyncUtil, Readahead) {
 }
 
 TEST(TestAsyncUtil, ReadaheadFailed) {
-  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(4));
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::SimpleThreadPool::Make(4));
   std::atomic<int32_t> counter(0);
   // All tasks are a little slow.  The first task fails.
   // The readahead will have spawned 9 more tasks and they

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -39,6 +39,7 @@
 
 namespace arrow {
 
+using internal::SimpleThreadPool;
 using internal::ThreadPool;
 
 int ToInt(int x) { return x; }
@@ -104,7 +105,7 @@ template <typename T>
 class SimpleExecutor {
  public:
   explicit SimpleExecutor(int nfutures)
-      : pool_(ThreadPool::Make(/*threads=*/4).ValueOrDie()) {
+      : pool_(SimpleThreadPool::Make(/*threads=*/4).ValueOrDie()) {
     for (int i = 0; i < nfutures; ++i) {
       futures_.push_back(Future<T>::Make());
     }

--- a/cpp/src/arrow/util/task_group_test.cc
+++ b/cpp/src/arrow/util/task_group_test.cc
@@ -380,14 +380,14 @@ TEST(ThreadedTaskGroup, Errors) {
   // Limit parallelism to ensure some tasks don't get started
   // after the first failing ones
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(4));
 
   TestTaskGroupErrors(TaskGroup::MakeThreaded(thread_pool.get()));
 }
 
 TEST(ThreadedTaskGroup, Cancel) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(4));
 
   StopSource stop_source;
   TestTaskGroupCancel(TaskGroup::MakeThreaded(thread_pool.get(), stop_source.token()),
@@ -401,20 +401,20 @@ TEST(ThreadedTaskGroup, TasksSpawnTasks) {
 
 TEST(ThreadedTaskGroup, NoCopyTask) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(4));
   TestNoCopyTask(TaskGroup::MakeThreaded(thread_pool.get()));
 }
 
 TEST(ThreadedTaskGroup, StressTaskGroupLifetime) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(16));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(16));
 
   StressTaskGroupLifetime([&] { return TaskGroup::MakeThreaded(thread_pool.get()); });
 }
 
 TEST(ThreadedTaskGroup, StressFailingTaskGroupLifetime) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(16));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(16));
 
   StressFailingTaskGroupLifetime(
       [&] { return TaskGroup::MakeThreaded(thread_pool.get()); });
@@ -422,20 +422,20 @@ TEST(ThreadedTaskGroup, StressFailingTaskGroupLifetime) {
 
 TEST(ThreadedTaskGroup, FinishNotSticky) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(16));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(16));
 
   TestFinishNotSticky([&] { return TaskGroup::MakeThreaded(thread_pool.get()); });
 }
 
 TEST(ThreadedTaskGroup, FinishNeverStarted) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(4));
   TestFinishNeverStarted(TaskGroup::MakeThreaded(thread_pool.get()));
 }
 
 TEST(ThreadedTaskGroup, FinishAlreadyCompleted) {
   std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(16));
+  ASSERT_OK_AND_ASSIGN(thread_pool, SimpleThreadPool::Make(16));
 
   TestFinishAlreadyCompleted([&] { return TaskGroup::MakeThreaded(thread_pool.get()); });
 }

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -34,18 +34,8 @@ namespace internal {
 
 Executor::~Executor() = default;
 
-namespace {
-
-struct Task {
-  FnOnce<void()> callable;
-  StopToken stop_token;
-  Executor::StopCallback stop_callback;
-};
-
-}  // namespace
-
 struct SerialExecutor::State {
-  std::deque<Task> task_queue;
+  std::deque<ThreadPool::Task> task_queue;
   std::mutex mutex;
   std::condition_variable wait_for_tasks;
   bool finished{false};
@@ -67,8 +57,8 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
   auto state = state_;
   {
     std::lock_guard<std::mutex> lk(state->mutex);
-    state->task_queue.push_back(
-        Task{std::move(task), std::move(stop_token), std::move(stop_callback)});
+    state->task_queue.push_back(ThreadPool::Task{std::move(task), std::move(stop_token),
+                                                 std::move(stop_callback)});
   }
   state->wait_for_tasks.notify_one();
   return Status::OK();
@@ -91,7 +81,7 @@ void SerialExecutor::RunLoop() {
 
   while (!state_->finished) {
     while (!state_->task_queue.empty()) {
-      Task task = std::move(state_->task_queue.front());
+      ThreadPool::Task task = std::move(state_->task_queue.front());
       state_->task_queue.pop_front();
       lk.unlock();
       if (!task.stop_token.IsStopRequested()) {
@@ -112,64 +102,91 @@ void SerialExecutor::RunLoop() {
   }
 }
 
-struct ThreadPool::State {
-  State() = default;
-
-  // NOTE: in case locking becomes too expensive, we can investigate lock-free FIFOs
-  // such as https://github.com/cameron314/concurrentqueue
-
-  std::mutex mutex_;
-  std::condition_variable cv_;
-  std::condition_variable cv_shutdown_;
-
-  std::list<std::thread> workers_;
-  // Trashcan for finished threads
-  std::vector<std::thread> finished_workers_;
-  std::deque<Task> pending_tasks_;
-
-  // Desired number of threads
-  int desired_capacity_ = 0;
-
-  // Total number of tasks that are either queued or running
-  int tasks_queued_or_running_ = 0;
-
-  // Are we shutting down?
-  bool please_shutdown_ = false;
-  bool quick_shutdown_ = false;
+struct ThreadPool::Control {
+  std::mutex mx;
+  // Condition variable that workers wait on when there is no work to do.  This should be
+  // signalled whenever new work arrives or when threads need to shut down
+  std::condition_variable cv_idle_workers;
+  // Condition variable that the thread pool waits on when it is waiting for all worker
+  // threads to finish while shutting down
+  std::condition_variable cv_shutdown;
 };
 
-// The worker loop is an independent function so that it can keep running
-// after the ThreadPool is destroyed.
-static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
-                       std::list<std::thread>::iterator it) {
-  std::unique_lock<std::mutex> lock(state->mutex_);
+void ThreadPool::ResetAfterFork() {
+  for (auto worker : workers_) {
+    worker->ResetAfterFork();
+  }
+  workers_.clear();
+  finished_workers_.clear();
+  num_tasks_running_.store(0);
+  total_tasks_.store(0);
+  max_tasks_.store(0);
+  desired_capacity_ = 0;
+  // We need to reinitialize the control block because any threads holding a mutex when
+  // the fork happened will never release those mutexes (this is true of all other mutexes
+  // too.  See ARROW-12879 for follow-up)
+  //
+  // The proper way to do this is to use pthread_atfork to obtain the mutex before
+  // forking.  Improvements welcome, this approach leaks memory because we do not delete
+  // the old instance.  We cannot delete the old instance because mutexes cannot be delete
+  // while locked (and they will never be unlocked).
+  control_ = new Control();
+}
 
-  // Since we hold the lock, `it` now points to the correct thread object
-  // (LaunchWorkersUnlocked has exited)
-  DCHECK_EQ(std::this_thread::get_id(), it->get_id());
+void ThreadPool::RecordTaskSubmitted() {
+  uint64_t num_tasks_running =
+      num_tasks_running_.fetch_add(1, std::memory_order_release) + 1;
+  // This is incorrect if multiple threads are submitting tasks at the same time
+  // but correctness is not worth introducing the cost of cross-thread
+  // synchronization
+  if (num_tasks_running > max_tasks_.load(std::memory_order_relaxed)) {
+    max_tasks_.store(num_tasks_running_, std::memory_order_relaxed);
+  }
+  total_tasks_.fetch_add(1, std::memory_order_relaxed);
+}
 
-  // If too many threads, we should secede from the pool
-  const auto should_secede = [&]() -> bool {
-    return state->workers_.size() > static_cast<size_t>(state->desired_capacity_);
-  };
+void ThreadPool::RecordFinishedTask() {
+  num_tasks_running_.fetch_sub(1, std::memory_order_relaxed);
+}
+
+uint64_t ThreadPool::NumTasksRunningOrQueued() const {
+  return num_tasks_running_.load(std::memory_order_acquire);
+}
+uint64_t ThreadPool::MaxTasksQueued() const {
+  return max_tasks_.load(std::memory_order_relaxed);
+}
+uint64_t ThreadPool::TotalTasksQueued() const {
+  // This may lag behind the actual value a bit
+  return total_tasks_.load(std::memory_order_relaxed);
+}
+
+// The worker loop must be capable of running after all other references to `thread_pool`
+// have been lost so we capture a shared_ptr
+void SimpleThreadPool::WorkerLoop(std::shared_ptr<SimpleThreadPool> thread_pool,
+                                  Control* control, ThreadIt thread_it) {
+  // We could use a dedicated mutex for the simple thread pool's task queue but
+  // the existing one isn't used that much so it should be ok.
+  std::unique_lock<std::mutex> lock(control->mx);
+
+  // thread_it is our reference to the thread object's position in the worker list, needed
+  // for notifying the pool when finished
+  DCHECK((*thread_it)->IsCurrentThread());
 
   while (true) {
     // By the time this thread is started, some tasks may have been pushed
     // or shutdown could even have been requested.  So we only wait on the
     // condition variable at the end of the loop.
 
+    bool stopped = false;
     // Execute pending tasks if any
-    while (!state->pending_tasks_.empty() && !state->quick_shutdown_) {
-      // We check this opportunistically at each loop iteration since
-      // it releases the lock below.
-      if (should_secede()) {
-        break;
-      }
-
-      DCHECK_GE(state->tasks_queued_or_running_, 0);
+    while (!thread_pool->pending_tasks_.empty() &&
+           // We check this opportunistically at each loop iteration since
+           // it releases the lock below.
+           !thread_pool->ShouldWorkerQuitNowUnlocked(thread_it, &stopped)) {
+      DCHECK_GE(thread_pool->NumTasksRunningOrQueued(), 0);
       {
-        Task task = std::move(state->pending_tasks_.front());
-        state->pending_tasks_.pop_front();
+        Task task = std::move(thread_pool->pending_tasks_.front());
+        thread_pool->pending_tasks_.pop_front();
         StopToken* stop_token = &task.stop_token;
         lock.unlock();
         if (!stop_token->IsStopRequested()) {
@@ -182,16 +199,20 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
         ARROW_UNUSED(std::move(task));  // release resources before waiting for lock
         lock.lock();
       }
-      state->tasks_queued_or_running_--;
+      thread_pool->RecordFinishedTask();
+    }
+
+    if (stopped) {
+      break;
     }
     // Now either the queue is empty *or* a quick shutdown was requested
-    if (state->please_shutdown_ || should_secede()) {
+    if (thread_pool->ShouldWorkerQuitUnlocked(thread_it)) {
       break;
     }
     // Wait for next wakeup
-    state->cv_.wait(lock);
+    control->cv_idle_workers.wait(lock);
   }
-  DCHECK_GE(state->tasks_queued_or_running_, 0);
+  DCHECK_GE(thread_pool->NumTasksRunningOrQueued(), 0);
 
   // We're done.  Move our thread object to the trashcan of finished
   // workers.  This has two motivations:
@@ -200,19 +221,18 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
   // 2) we can explicitly join() the trashcan threads to make sure all OS threads
   //    are exited before the ThreadPool is destroyed.  Otherwise subtle
   //    timing conditions can lead to false positives with Valgrind.
-  DCHECK_EQ(std::this_thread::get_id(), it->get_id());
-  state->finished_workers_.push_back(std::move(*it));
-  state->workers_.erase(it);
-  if (state->please_shutdown_) {
+  if (thread_pool->please_shutdown_) {
     // Notify the function waiting in Shutdown().
-    state->cv_shutdown_.notify_one();
+    control->cv_shutdown.notify_one();
   }
 }
 
 ThreadPool::ThreadPool()
-    : sp_state_(std::make_shared<ThreadPool::State>()),
-      state_(sp_state_.get()),
-      shutdown_on_destroy_(true) {
+    : num_tasks_running_(0),
+      total_tasks_(0),
+      max_tasks_(0),
+      shutdown_on_destroy_(true),
+      control_(new Control()) {
 #ifndef _WIN32
   pid_ = getpid();
 #endif
@@ -222,6 +242,7 @@ ThreadPool::~ThreadPool() {
   if (shutdown_on_destroy_) {
     ARROW_UNUSED(Shutdown(false /* wait */));
   }
+  delete control_;
 }
 
 void ThreadPool::ProtectAgainstFork() {
@@ -232,134 +253,156 @@ void ThreadPool::ProtectAgainstFork() {
     // Ideally we would use pthread_at_fork(), but that doesn't allow
     // storing an argument, hence we'd need to maintain a list of all
     // existing ThreadPools.
-    int capacity = state_->desired_capacity_;
+    int capacity = desired_capacity_;
 
-    auto new_state = std::make_shared<ThreadPool::State>();
-    new_state->please_shutdown_ = state_->please_shutdown_;
-    new_state->quick_shutdown_ = state_->quick_shutdown_;
+    ResetAfterFork();
 
     pid_ = current_pid;
-    sp_state_ = new_state;
-    state_ = sp_state_.get();
 
     // Launch worker threads anew
-    if (!state_->please_shutdown_) {
+    if (!please_shutdown_) {
       ARROW_UNUSED(SetCapacity(capacity));
     }
   }
 #endif
 }
 
-Status ThreadPool::SetCapacity(int threads) {
+Status ThreadPool::SetCapacity(int desired_capacity) {
   ProtectAgainstFork();
-  std::unique_lock<std::mutex> lock(state_->mutex_);
-  if (state_->please_shutdown_) {
+  std::lock_guard<std::mutex> lock(control_->mx);
+  if (please_shutdown_) {
     return Status::Invalid("operation forbidden during or after shutdown");
   }
-  if (threads <= 0) {
+  if (desired_capacity <= 0) {
     return Status::Invalid("ThreadPool capacity must be > 0");
   }
   CollectFinishedWorkersUnlocked();
 
-  state_->desired_capacity_ = threads;
-  // See if we need to increase or decrease the number of running threads
-  const int required = std::min(static_cast<int>(state_->pending_tasks_.size()),
-                                threads - static_cast<int>(state_->workers_.size()));
+  desired_capacity_ = desired_capacity;
+  // See if we need to increase or decrease the number of running threads.  There is a bit
+  // of finesse here.  NumTasksRunningOrQueued can change outside the mutex.
+  //
+  // It's possible we spawn workers when we didn't strictly need to (i.e.
+  // NumTasksRunningOrQueued goes down after we check).  However, that should be ok.
+  //
+  // It should not be possible we fail to spawn tasks when needed.  Any call to increase
+  // NumTasksRunningOrQueued will have its own accompanying call to launch workers.
+  const int required = GetAdditionalThreadsNeeded();
+
   if (required > 0) {
     // Some tasks are pending, spawn the number of needed threads immediately
     LaunchWorkersUnlocked(required);
   } else if (required < 0) {
     // Excess threads are running, wake them so that they stop
-    state_->cv_.notify_all();
+    control_->cv_idle_workers.notify_all();
   }
   return Status::OK();
 }
 
 int ThreadPool::GetCapacity() {
   ProtectAgainstFork();
-  std::unique_lock<std::mutex> lock(state_->mutex_);
-  return state_->desired_capacity_;
+  return desired_capacity_;
 }
 
-int ThreadPool::GetNumTasks() {
-  ProtectAgainstFork();
-  std::unique_lock<std::mutex> lock(state_->mutex_);
-  return state_->tasks_queued_or_running_;
-}
-
-int ThreadPool::GetActualCapacity() {
-  ProtectAgainstFork();
-  std::unique_lock<std::mutex> lock(state_->mutex_);
-  return static_cast<int>(state_->workers_.size());
-}
+int ThreadPool::GetActualCapacity() { return static_cast<int>(workers_.size()); }
 
 Status ThreadPool::Shutdown(bool wait) {
   ProtectAgainstFork();
-  std::unique_lock<std::mutex> lock(state_->mutex_);
+  std::unique_lock<std::mutex> lock(control_->mx);
 
-  if (state_->please_shutdown_) {
+  if (please_shutdown_) {
     return Status::Invalid("Shutdown() already called");
   }
-  state_->please_shutdown_ = true;
-  state_->quick_shutdown_ = !wait;
-  state_->cv_.notify_all();
-  state_->cv_shutdown_.wait(lock, [this] { return state_->workers_.empty(); });
-  if (!state_->quick_shutdown_) {
-    DCHECK_EQ(state_->pending_tasks_.size(), 0);
-  } else {
-    state_->pending_tasks_.clear();
+  please_shutdown_ = true;
+  quick_shutdown_ = !wait;
+  control_->cv_idle_workers.notify_all();
+  control_->cv_shutdown.wait(lock, [this] { return workers_.empty(); });
+  DCHECK(workers_.empty());
+  if (!quick_shutdown_) {
+    DCHECK_EQ(NumTasksRunningOrQueued(), 0);
   }
   CollectFinishedWorkersUnlocked();
   return Status::OK();
 }
 
 void ThreadPool::CollectFinishedWorkersUnlocked() {
-  for (auto& thread : state_->finished_workers_) {
-    // Make sure OS thread has exited
-    thread.join();
+  for (auto& thread : finished_workers_) {
+    // Allow thread to do any neccesary cleanup (e.g. OS-level join)
+    thread->Join();
   }
-  state_->finished_workers_.clear();
+  finished_workers_.clear();
+}
+
+bool ThreadPool::ShouldWorkerQuitUnlocked(const ThreadIt& thread_it) {
+  if (please_shutdown_) {
+    finished_workers_.push_back(std::move(*thread_it));
+    workers_.erase(thread_it);
+    return true;
+  }
+  return false;
+}
+
+bool ThreadPool::ShouldWorkerQuitNowUnlocked(const ThreadIt& thread_it, bool* stopped) {
+  if (quick_shutdown_ || desired_capacity_ < static_cast<int>(workers_.size())) {
+    finished_workers_.push_back(std::move(*thread_it));
+    workers_.erase(thread_it);
+    *stopped = true;
+    return true;
+  }
+  return false;
 }
 
 void ThreadPool::LaunchWorkersUnlocked(int threads) {
-  std::shared_ptr<State> state = sp_state_;
-
   for (int i = 0; i < threads; i++) {
-    state_->workers_.emplace_back();
-    auto it = --(state_->workers_.end());
-    *it = std::thread([state, it] { WorkerLoop(state, it); });
+    workers_.emplace_back();
+    auto it = --(workers_.end());
+    *it = LaunchWorker(control_, it);
   }
+}
+
+int ThreadPool::GetAdditionalThreadsNeeded() const {
+  int unallocated_tasks =
+      static_cast<int>(NumTasksRunningOrQueued()) - static_cast<int>(workers_.size());
+  int unused_capacity = desired_capacity_ - static_cast<int>(workers_.size());
+  return std::min(unallocated_tasks, unused_capacity);
 }
 
 Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken stop_token,
                              StopCallback&& stop_callback) {
   {
     ProtectAgainstFork();
-    std::lock_guard<std::mutex> lock(state_->mutex_);
-    if (state_->please_shutdown_) {
+    if (please_shutdown_) {
       return Status::Invalid("operation forbidden during or after shutdown");
     }
-    CollectFinishedWorkersUnlocked();
-    state_->tasks_queued_or_running_++;
-    if (static_cast<int>(state_->workers_.size()) < state_->tasks_queued_or_running_ &&
-        state_->desired_capacity_ > static_cast<int>(state_->workers_.size())) {
-      // We can still spin up more workers so spin up a new worker
-      LaunchWorkersUnlocked(/*threads=*/1);
+    if (!finished_workers_.empty()) {
+      std::lock_guard<std::mutex> lock(control_->mx);
+      // Maybe someone snuck in and cleared this out while we were grabbing the lock
+      // but it should be harmless to do it again.
+      CollectFinishedWorkersUnlocked();
     }
-    state_->pending_tasks_.push_back(
-        {std::move(task), std::move(stop_token), std::move(stop_callback)});
+    RecordTaskSubmitted();
+    if (GetAdditionalThreadsNeeded() > 0) {
+      std::lock_guard<std::mutex> lock(control_->mx);
+      // We avoided locking on the hot path unless we needed to so we have to double
+      // check to ensure we still have spare capacity
+      if (GetAdditionalThreadsNeeded() > 0) {
+        // We can still spin up more workers so spin up a new worker
+        LaunchWorkersUnlocked(/*threads=*/1);
+      }
+    }
+    Task task_wrapper{std::move(task), std::move(stop_token), std::move(stop_callback)};
+    DoSubmitTask(std::move(hints), std::move(task_wrapper));
   }
-  state_->cv_.notify_one();
   return Status::OK();
 }
 
-Result<std::shared_ptr<ThreadPool>> ThreadPool::Make(int threads) {
-  auto pool = std::shared_ptr<ThreadPool>(new ThreadPool());
+Result<std::shared_ptr<ThreadPool>> SimpleThreadPool::Make(int threads) {
+  auto pool = std::shared_ptr<ThreadPool>(new SimpleThreadPool());
   RETURN_NOT_OK(pool->SetCapacity(threads));
   return pool;
 }
 
-Result<std::shared_ptr<ThreadPool>> ThreadPool::MakeEternal(int threads) {
+Result<std::shared_ptr<ThreadPool>> SimpleThreadPool::MakeEternal(int threads) {
   ARROW_ASSIGN_OR_RAISE(auto pool, Make(threads));
   // On Windows, the ThreadPool destructor may be called after non-main threads
   // have been killed by the OS, and hang in a condition variable.
@@ -368,6 +411,46 @@ Result<std::shared_ptr<ThreadPool>> ThreadPool::MakeEternal(int threads) {
   pool->shutdown_on_destroy_ = false;
 #endif
   return pool;
+}
+
+SimpleThreadPool::~SimpleThreadPool() = default;
+SimpleThreadPool::SimpleThreadPool() = default;
+
+void SimpleThreadPool::ResetAfterFork() {
+  ThreadPool::ResetAfterFork();
+  pending_tasks_.clear();
+}
+
+void SimpleThreadPool::DoSubmitTask(TaskHints hints, Task task) {
+  std::unique_lock<std::mutex> lock(control_->mx);
+  pending_tasks_.push_back(std::move(task));
+  lock.unlock();
+  control_->cv_idle_workers.notify_one();
+}
+
+struct StlThread : public Thread {
+  StlThread(std::thread* thread) : thread(thread) {}
+  ~StlThread() {
+    if (thread) {
+      delete thread;
+    }
+  }
+  void Join() { thread->join(); }
+  bool IsCurrentThread() const { return std::this_thread::get_id() == thread->get_id(); }
+  // This is called on the child process.  The actual pthread is no longer valid.  We
+  // cannot delete it any longer.  Simply drop the reference.  This is a bit of a leak
+  // so feel free to replace with something more clever.
+  void ResetAfterFork() { thread = nullptr; }
+  std::thread* thread = nullptr;
+};
+
+std::shared_ptr<Thread> SimpleThreadPool::LaunchWorker(Control* control,
+                                                       ThreadIt thread_it) {
+  auto self = shared_from_this();
+  std::thread* thread = new std::thread([self, control, thread_it] {
+    SimpleThreadPool::WorkerLoop(self, control, thread_it);
+  });
+  return std::make_shared<StlThread>(thread);
 }
 
 // ----------------------------------------------------------------------
@@ -412,7 +495,7 @@ int ThreadPool::DefaultCapacity() {
 
 // Helper for the singleton pattern
 std::shared_ptr<ThreadPool> ThreadPool::MakeCpuThreadPool() {
-  auto maybe_pool = ThreadPool::MakeEternal(ThreadPool::DefaultCapacity());
+  auto maybe_pool = SimpleThreadPool::MakeEternal(ThreadPool::DefaultCapacity());
   if (!maybe_pool.ok()) {
     maybe_pool.status().Abort("Failed to create global CPU thread pool");
   }

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -22,10 +22,12 @@
 #endif
 
 #include <cstdint>
+#include <deque>
+#include <list>
 #include <memory>
-#include <queue>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -242,31 +244,40 @@ class ARROW_EXPORT SerialExecutor : public Executor {
   void MarkFinished();
 };
 
-/// An Executor implementation spawning tasks in FIFO manner on a fixed-size
-/// pool of worker threads.
+/// In order to avoid ThreadPool from depending directly on std::thread (mainly to reduce
+/// compile times) we create a base interface for a thread object.
+class Thread {
+ public:
+  virtual void Join() = 0;
+  virtual bool IsCurrentThread() const = 0;
+  virtual void ResetAfterFork() = 0;
+};
+
+/// An executor implementation which spawns tasks across a fixed-size pool of worker
+/// threads.
 ///
 /// Note: Any sort of nested parallelism will deadlock this executor.  Blocking waits are
 /// fine but if one task needs to wait for another task it must be expressed as an
 /// asynchronous continuation.
 class ARROW_EXPORT ThreadPool : public Executor {
  public:
-  // Construct a thread pool with the given number of worker threads
-  static Result<std::shared_ptr<ThreadPool>> Make(int threads);
+  struct Task {
+    FnOnce<void()> callable;
+    StopToken stop_token;
+    Executor::StopCallback stop_callback;
+  };
 
-  // Like Make(), but takes care that the returned ThreadPool is compatible
-  // with destruction late at process exit.
-  static Result<std::shared_ptr<ThreadPool>> MakeEternal(int threads);
+  using ThreadIt = std::list<std::shared_ptr<Thread>>::iterator;
 
-  // Destroy thread pool; the pool will first be shut down
-  ~ThreadPool() override;
+  virtual ~ThreadPool();
+
+  // -------------- Management API -------------
+  // These methods must all be guarded with ProtectAgainstFork
 
   // Return the desired number of worker threads.
   // The actual number of workers may lag a bit before being adjusted to
   // match this value.
   int GetCapacity() override;
-
-  // Return the number of tasks either running or in the queue.
-  int GetNumTasks();
 
   // Dynamically change the number of worker threads.
   //
@@ -288,9 +299,41 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // tasks are finished.
   Status Shutdown(bool wait = true);
 
-  struct State;
+  // ------------- Statistics API ---------------
+
+  /// The current number of tasks either currently running or in the queue to run
+  uint64_t NumTasksRunningOrQueued() const;
+  /// A guess at the maximum number of tasks running or queued at any one point
+  uint64_t MaxTasksQueued() const;
+  /// The total number of tasks that have been submitted over the lifetime of the pool
+  uint64_t TotalTasksQueued() const;
+
+  // ------------- Children API -----------------
+
+  /// Called by children when a worker thread completes a task
+  void RecordFinishedTask();
+  /// True if the thread pool is shutting down, should only be checked if a thread has
+  /// no tasks to work on.  This allows us to ensure we drain the task queue before
+  /// shutting down the pool.
+  ///
+  /// If this function returns true then the thread will have been removed from the
+  /// workers queue.
+  bool ShouldWorkerQuitUnlocked(const ThreadIt& thread_it);
+  /// True if the thread is no longer needed (e.g. excess capacity) or if a quick shutdown
+  /// has been requested.  Should be checked frequently as threads can quit with remaining
+  /// work if this is true
+  ///
+  /// If this function returns true then `stopped` will also be set to true.  The caller
+  /// should use this to ensure they don't later call ShouldWorkerQuitUnlocked
+  ///
+  /// If this function returns true then the thread will have been removed from the
+  /// workers queue.
+  bool ShouldWorkerQuitNowUnlocked(const ThreadIt& thread_it, bool* stopped);
+
+  struct Control;
 
  protected:
+  FRIEND_TEST(TestThreadPool, DestroyWithoutShutdown);
   FRIEND_TEST(TestThreadPool, SetCapacity);
   FRIEND_TEST(TestGlobalThreadPool, Capacity);
   friend ARROW_EXPORT ThreadPool* GetCpuThreadPool();
@@ -300,23 +343,81 @@ class ARROW_EXPORT ThreadPool : public Executor {
   Status SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken,
                    StopCallback&&) override;
 
+  /// Called on the child process after a fork.  After a fork all threads will have ceased
+  /// running in the child process.  This method should clean up the thread pool state and
+  /// restart any previously running threads.
+  ///
+  /// The behavior is somewhat ill-defined if tasks are running when the fork happened.
+  /// For more details see ARROW-12879
+  virtual void ResetAfterFork();
+
+  /// Launches a worker thread
+  virtual std::shared_ptr<Thread> LaunchWorker(Control* control, ThreadIt thread_it) = 0;
+  /// Adds a task to the task queue(s)
+  virtual void DoSubmitTask(TaskHints hints, Task task) = 0;
+
   // Collect finished worker threads, making sure the OS threads have exited
   void CollectFinishedWorkersUnlocked();
   // Launch a given number of additional workers
   void LaunchWorkersUnlocked(int threads);
   // Get the current actual capacity
   int GetActualCapacity();
+  // Get the amount of threads we could still launch based on capacity and # of tasks
+  int GetAdditionalThreadsNeeded() const;
   // Reinitialize the thread pool if the pid changed
   void ProtectAgainstFork();
+  void RecordTaskSubmitted();
 
   static std::shared_ptr<ThreadPool> MakeCpuThreadPool();
 
-  std::shared_ptr<State> sp_state_;
-  State* state_;
+  std::atomic<uint64_t> num_tasks_running_;
+  std::atomic<uint64_t> total_tasks_;
+  std::atomic<uint64_t> max_tasks_;
+
+  std::list<std::shared_ptr<Thread>> workers_;
+  // Trashcan for finished threads
+  std::vector<std::shared_ptr<Thread>> finished_workers_;
+  // Desired number of threads
+  int desired_capacity_ = 0;
+
+  // Are we shutting down?
+  bool please_shutdown_ = false;
+  bool quick_shutdown_ = false;
+
   bool shutdown_on_destroy_;
+  // Contains mutexes and condition variables which cannot be in the header
+  Control* control_;
 #ifndef _WIN32
   pid_t pid_;
 #endif
+};
+
+/// A ThreadPool implementation which uses one lock-protected task queue which
+/// the workers all share.
+class ARROW_EXPORT SimpleThreadPool
+    : public ThreadPool,
+      public std::enable_shared_from_this<SimpleThreadPool> {
+ public:
+  // Construct a thread pool with the given number of worker threads
+  static Result<std::shared_ptr<ThreadPool>> Make(int threads);
+
+  // Like Make(), but takes care that the returned ThreadPool is compatible
+  // with destruction late at process exit.
+  static Result<std::shared_ptr<ThreadPool>> MakeEternal(int threads);
+
+  // Destroy thread pool; the pool will first be shut down
+  ~SimpleThreadPool() override;
+
+ protected:
+  SimpleThreadPool();
+  void ResetAfterFork() override;
+  std::shared_ptr<Thread> LaunchWorker(Control* control, ThreadIt thread_it) override;
+  static void WorkerLoop(std::shared_ptr<SimpleThreadPool> thread_pool, Control* control,
+                         ThreadIt thread_it);
+
+  void DoSubmitTask(TaskHints hints, Task task);
+
+  std::deque<Task> pending_tasks_;
 };
 
 // Return the process-global thread pool for CPU-bound tasks.

--- a/cpp/src/arrow/util/thread_pool_benchmark.cc
+++ b/cpp/src/arrow/util/thread_pool_benchmark.cc
@@ -31,6 +31,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
+#include "arrow/util/ws_thread_pool.h"
 
 namespace arrow {
 namespace internal {
@@ -73,10 +74,37 @@ struct Task {
   Workload workload_;
 };
 
+using ThreadPoolFactory = std::function<std::shared_ptr<ThreadPool>(int)>;
+
+static const int32_t SIMPLE_THREAD_POOL = 1;
+static const int32_t WORK_STEALING_THREAD_POOL = 2;
+static const std::vector<int32_t> kThreadPoolImpls = {SIMPLE_THREAD_POOL,
+                                                      WORK_STEALING_THREAD_POOL};
+
+ThreadPoolFactory MakeSimple() {
+  return [](int nthreads) { return *SimpleThreadPool::Make(nthreads); };
+}
+
+ThreadPoolFactory MakeWorkStealing() {
+  return [](int nthreads) { return *WorkStealingThreadPool::Make(nthreads); };
+}
+
+static ThreadPoolFactory FactoryFromArg(int32_t arg) {
+  switch (arg) {
+    case SIMPLE_THREAD_POOL:
+      return MakeSimple();
+    case WORK_STEALING_THREAD_POOL:
+      return MakeWorkStealing();
+    default:
+      assert(false);
+  }
+}
+
 // Benchmark ThreadPool::Spawn
 static void ThreadPoolSpawn(benchmark::State& state) {  // NOLINT non-const reference
-  const auto nthreads = static_cast<int>(state.range(0));
-  const auto workload_size = static_cast<int32_t>(state.range(1));
+  const auto thread_pool_factory = FactoryFromArg(state.range(0));
+  const auto nthreads = static_cast<int>(state.range(1));
+  const auto workload_size = static_cast<int32_t>(state.range(2));
 
   Workload workload(workload_size);
 
@@ -86,7 +114,7 @@ static void ThreadPoolSpawn(benchmark::State& state) {  // NOLINT non-const refe
   for (auto _ : state) {
     state.PauseTiming();
     std::shared_ptr<ThreadPool> pool;
-    pool = *SimpleThreadPool::Make(nthreads);
+    pool = thread_pool_factory(nthreads);
     state.ResumeTiming();
 
     for (int32_t i = 0; i < nspawns; ++i) {
@@ -101,6 +129,43 @@ static void ThreadPoolSpawn(benchmark::State& state) {  // NOLINT non-const refe
     state.ResumeTiming();
   }
   state.SetItemsProcessed(state.iterations() * nspawns);
+}
+
+// Benchmark ThreadPool::Spawn when the spawning happens withing the thread pool
+static void ThreadPoolNestedSpawn(
+    benchmark::State& state) {  // NOLINT non-const reference
+  const auto thread_pool_factory = FactoryFromArg(state.range(0));
+  const auto nthreads = static_cast<int>(state.range(1));
+  const auto workload_size = static_cast<int32_t>(state.range(2));
+
+  Workload workload(workload_size);
+
+  // Spawn enough tasks to make the pool start up overhead negligible
+  const int32_t nspawns = 200000000 / workload_size + 1;
+  const int32_t spawns_per_thread = nspawns / nthreads;
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::shared_ptr<ThreadPool> pool;
+    pool = thread_pool_factory(nthreads);
+    state.ResumeTiming();
+
+    for (int32_t i = 0; i < nthreads; ++i) {
+      // Pass the task by reference to avoid copying it around
+      ABORT_NOT_OK(pool->Spawn([&workload, &pool, spawns_per_thread] {
+        for (int32_t j = 0; j < spawns_per_thread; j++) {
+          pool->Spawn(std::ref(workload));
+        }
+      }));
+    }
+
+    // Wait for all tasks to finish
+    ABORT_NOT_OK(pool->Shutdown(true /* wait */));
+    state.PauseTiming();
+    pool.reset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(state.iterations() * spawns_per_thread * nthreads);
 }
 
 // Benchmark SerialExecutor::RunInSerialExecutor
@@ -121,8 +186,9 @@ static void RunInSerialExecutor(benchmark::State& state) {  // NOLINT non-const 
 
 // Benchmark ThreadPool::Submit
 static void ThreadPoolSubmit(benchmark::State& state) {  // NOLINT non-const reference
-  const auto nthreads = static_cast<int>(state.range(0));
-  const auto workload_size = static_cast<int32_t>(state.range(1));
+  const auto thread_pool_factory = FactoryFromArg(state.range(0));
+  const auto nthreads = static_cast<int>(state.range(1));
+  const auto workload_size = static_cast<int32_t>(state.range(2));
 
   Workload workload(workload_size);
 
@@ -130,7 +196,7 @@ static void ThreadPoolSubmit(benchmark::State& state) {  // NOLINT non-const ref
 
   for (auto _ : state) {
     state.PauseTiming();
-    auto pool = *SimpleThreadPool::Make(nthreads);
+    auto pool = thread_pool_factory(nthreads);
     std::atomic<int32_t> n_finished{0};
     state.ResumeTiming();
 
@@ -172,10 +238,12 @@ static void SerialTaskGroup(benchmark::State& state) {  // NOLINT non-const refe
 
 // Benchmark threaded TaskGroup
 static void ThreadedTaskGroup(benchmark::State& state) {  // NOLINT non-const reference
-  const auto nthreads = static_cast<int>(state.range(0));
-  const auto workload_size = static_cast<int32_t>(state.range(1));
+  const auto thread_pool_factory = FactoryFromArg(state.range(0));
+  const auto nthreads = static_cast<int>(state.range(1));
+  const auto workload_size = static_cast<int32_t>(state.range(2));
 
   std::shared_ptr<ThreadPool> pool;
+  // FIXME: Add support for work-stealing
   pool = *SimpleThreadPool::Make(nthreads);
 
   Task task(workload_size);
@@ -209,12 +277,14 @@ static void WorkloadCost_Customize(benchmark::internal::Benchmark* b) {
 }
 
 static void ThreadPoolSpawn_Customize(benchmark::internal::Benchmark* b) {
-  for (const int32_t w : kWorkloadSizes) {
-    for (const int nthreads : {1, 2, 4, 8}) {
-      b->Args({nthreads, w});
+  for (const int32_t thread_pool_type : kThreadPoolImpls) {
+    for (const int32_t w : kWorkloadSizes) {
+      for (const int nthreads : {1, 2, 4, 8}) {
+        b->Args({thread_pool_type, nthreads, w});
+      }
     }
   }
-  b->ArgNames({"threads", "task_cost"});
+  b->ArgNames({"impl", "threads", "task_cost"});
   b->UseRealTime();
 }
 
@@ -241,6 +311,7 @@ BENCHMARK(ReferenceWorkloadCost)->Apply(WorkloadCost_Customize);
 BENCHMARK(SerialTaskGroup)->Apply(WorkloadCost_Customize);
 BENCHMARK(RunInSerialExecutor)->Apply(WorkloadCost_Customize);
 BENCHMARK(ThreadPoolSpawn)->Apply(ThreadPoolSpawn_Customize);
+BENCHMARK(ThreadPoolNestedSpawn)->Apply(ThreadPoolSpawn_Customize);
 BENCHMARK(ThreadedTaskGroup)->Apply(ThreadPoolSpawn_Customize);
 BENCHMARK(ThreadPoolSubmit)->Apply(ThreadPoolSpawn_Customize);
 

--- a/cpp/src/arrow/util/thread_pool_benchmark.cc
+++ b/cpp/src/arrow/util/thread_pool_benchmark.cc
@@ -86,7 +86,7 @@ static void ThreadPoolSpawn(benchmark::State& state) {  // NOLINT non-const refe
   for (auto _ : state) {
     state.PauseTiming();
     std::shared_ptr<ThreadPool> pool;
-    pool = *ThreadPool::Make(nthreads);
+    pool = *SimpleThreadPool::Make(nthreads);
     state.ResumeTiming();
 
     for (int32_t i = 0; i < nspawns; ++i) {
@@ -130,7 +130,7 @@ static void ThreadPoolSubmit(benchmark::State& state) {  // NOLINT non-const ref
 
   for (auto _ : state) {
     state.PauseTiming();
-    auto pool = *ThreadPool::Make(nthreads);
+    auto pool = *SimpleThreadPool::Make(nthreads);
     std::atomic<int32_t> n_finished{0};
     state.ResumeTiming();
 
@@ -176,7 +176,7 @@ static void ThreadedTaskGroup(benchmark::State& state) {  // NOLINT non-const re
   const auto workload_size = static_cast<int32_t>(state.range(1));
 
   std::shared_ptr<ThreadPool> pool;
-  pool = *ThreadPool::Make(nthreads);
+  pool = *SimpleThreadPool::Make(nthreads);
 
   Task task(workload_size);
 

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -21,10 +21,12 @@
 #endif
 
 #include <algorithm>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -138,7 +140,7 @@ class TestRunSynchronously : public testing::TestWithParam<bool> {
 
   void TestContinueAfterExternal(bool transfer_to_main_thread) {
     bool continuation_ran = false;
-    EXPECT_OK_AND_ASSIGN(auto external_pool, ThreadPool::Make(1));
+    EXPECT_OK_AND_ASSIGN(auto external_pool, SimpleThreadPool::Make(1));
     auto top_level_task = [&](Executor* executor) {
       struct Callback {
         Status operator()() {
@@ -266,7 +268,7 @@ class TestThreadPool : public ::testing::Test {
   std::shared_ptr<ThreadPool> MakeThreadPool() { return MakeThreadPool(4); }
 
   std::shared_ptr<ThreadPool> MakeThreadPool(int threads) {
-    return *ThreadPool::Make(threads);
+    return *SimpleThreadPool::Make(threads);
   }
 
   void DoSpawnAdds(ThreadPool* pool, int nadds, AddTaskFunc add_func,
@@ -411,6 +413,42 @@ TEST_F(TestThreadPool, QuickShutdown) {
     add_tester.CheckNotAllComputed();
   }
   add_tester.CheckNotAllComputed();
+}
+
+TEST_F(TestThreadPool, DestroyWithoutShutdown) {
+  std::mutex mx;
+  std::condition_variable cv;
+  std::weak_ptr<ThreadPool> weak_pool;
+  bool ready = false;
+  bool completed = false;
+  {
+    auto pool = this->MakeThreadPool(1);
+    weak_pool = pool;
+    // Simulate Windows
+    pool->shutdown_on_destroy_ = false;
+
+    ASSERT_OK(pool->Spawn([&mx, &cv, &completed, &ready] {
+      std::unique_lock<std::mutex> lock(mx);
+      ready = true;
+      cv.notify_one();
+      cv.wait(lock);
+      completed = true;
+    }));
+  }
+
+  std::unique_lock<std::mutex> lock(mx);
+  cv.wait(lock, [&ready] { return ready; });
+  // Thread pool has shut down, now we unblock the task
+  cv.notify_one();
+  lock.unlock();
+
+  // The worker thread should be able to keep the thread pool alive by itself
+  ASSERT_FALSE(weak_pool.expired());
+  // Need to shutdown for test purposes to ensure the thread is joined and that the worker
+  // finishes
+  weak_pool.lock()->Shutdown(false);
+
+  ASSERT_TRUE(completed);
 }
 
 TEST_F(TestThreadPool, SetCapacity) {

--- a/cpp/src/arrow/util/ws_thread_pool.cc
+++ b/cpp/src/arrow/util/ws_thread_pool.cc
@@ -19,10 +19,17 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <iostream>
+#include <mutex>
+#include <sstream>
+#include <thread>
 
 #include "arrow/util/atomic_shared_ptr.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/thread_pool.h"
+
+constexpr bool PRINT_DEBUG = false;
 
 namespace arrow {
 namespace internal {
@@ -35,11 +42,11 @@ ResizableRingBuffer::ResizableRingBuffer(std::size_t size)
 
 std::size_t ResizableRingBuffer::size() const { return size_; }
 
-Task* ResizableRingBuffer::Get(std::size_t i) {
+ThreadPool::Task* ResizableRingBuffer::Get(std::size_t i) {
   return arr_[i & mask_].load(std::memory_order_relaxed);
 }
 
-void ResizableRingBuffer::Put(std::size_t i, Task* task) {
+void ResizableRingBuffer::Put(std::size_t i, ThreadPool::Task* task) {
   arr_[i & mask_].store(task, std::memory_order_relaxed);
 }
 
@@ -81,7 +88,7 @@ std::size_t WorkQueue::Capacity() const {
   return tasks_.load(std::memory_order_relaxed)->size();
 }
 
-void WorkQueue::Push(Task* task) {
+void WorkQueue::Push(ThreadPool::Task* task) {
   DCHECK(task->callable);
   std::size_t bottom = bottom_.load(std::memory_order_relaxed);
   std::size_t top = top_.load(std::memory_order_acquire);
@@ -105,7 +112,7 @@ void WorkQueue::Push(Task* task) {
   bottom_.store(bottom + 1, std::memory_order_relaxed);
 }
 
-Task* WorkQueue::Pop() {
+ThreadPool::Task* WorkQueue::Pop() {
   std::size_t new_bottom = bottom_.load(std::memory_order_relaxed) - 1;
   ResizableRingBuffer* tasks = tasks_.load(std::memory_order_relaxed);
 
@@ -113,7 +120,7 @@ Task* WorkQueue::Pop() {
   std::atomic_thread_fence(std::memory_order_seq_cst);
   std::size_t top = top_.load(std::memory_order_relaxed);
 
-  Task* task = nullptr;
+  ThreadPool::Task* task = nullptr;
   if (top <= new_bottom) {
     task = tasks->Get(new_bottom);
     if (top == new_bottom) {
@@ -136,12 +143,12 @@ Task* WorkQueue::Pop() {
   return task;
 }
 
-Task* WorkQueue::Steal() {
+ThreadPool::Task* WorkQueue::Steal() {
   std::size_t top = top_.load(std::memory_order_acquire);
   std::atomic_thread_fence(std::memory_order_seq_cst);
   std::size_t bottom = bottom_.load(std::memory_order_acquire);
 
-  Task* task = nullptr;
+  ThreadPool::Task* task = nullptr;
 
   if (top < bottom) {
     ResizableRingBuffer* tasks = tasks_.load(std::memory_order_consume);
@@ -156,6 +163,210 @@ Task* WorkQueue::Steal() {
   }
 
   return task;
+}
+
+void WorkQueue::Clear() {
+  for (auto& item : to_delete_) {
+    delete item;
+  }
+  bottom_.store(0);
+  top_.store(0);
+}
+
+Result<std::shared_ptr<ThreadPool>> WorkStealingThreadPool::Make(int threads) {
+  auto pool = std::shared_ptr<ThreadPool>(new WorkStealingThreadPool(threads));
+  RETURN_NOT_OK(pool->SetCapacity(threads));
+  return pool;
+}
+
+Result<std::shared_ptr<ThreadPool>> WorkStealingThreadPool::MakeEternal(int threads) {
+  ARROW_ASSIGN_OR_RAISE(auto pool, Make(threads));
+  // On Windows, the ThreadPool destructor may be called after non-main threads
+  // have been killed by the OS, and hang in a condition variable.
+  // On Unix, we want to avoid leak reports by Valgrind.
+#ifdef _WIN32
+  pool->shutdown_on_destroy_ = false;
+#endif
+  return pool;
+}
+
+WorkStealingThreadPool::WorkStealingThreadPool(int capacity)
+    : task_queues_(capacity), next_thread_index_(0), searching_(0){};
+
+WorkStealingThreadPool::~WorkStealingThreadPool() {
+  // In the event of a quick shutdown we may have extra tasks lying around
+  while (!unaffiliated_queue_.Empty()) {
+    delete unaffiliated_queue_.Pop();
+  }
+  for (auto& thread_q : task_queues_) {
+    while (!thread_q.Empty()) {
+      delete thread_q.Pop();
+    }
+  }
+}
+
+void WorkStealingThreadPool::ResetAfterFork() {
+  unaffiliated_queue_.Clear();
+  for (auto& task_queue : task_queues_) {
+    task_queue.Clear();
+  }
+}
+
+constexpr std::size_t NOT_IN_POOL = -1;
+thread_local std::size_t tls_thread_index = NOT_IN_POOL;
+
+struct StlThread : public Thread {
+  StlThread(std::thread* thread) : thread(thread) {}
+  ~StlThread() {
+    if (thread) {
+      delete thread;
+    }
+  }
+  void Join() { thread->join(); }
+  bool IsCurrentThread() const { return std::this_thread::get_id() == thread->get_id(); }
+  // This is called on the child process.  The actual pthread is no longer valid.  We
+  // cannot delete it any longer.  Simply drop the reference.  This is a bit of a leak
+  // so feel free to replace with something more clever.
+  void ResetAfterFork() { thread = nullptr; }
+  std::thread* thread = nullptr;
+};
+
+std::shared_ptr<Thread> WorkStealingThreadPool::LaunchWorker(ThreadPool::Control* control,
+                                                             ThreadIt thread_it) {
+  // FIXME: Not safe for capacity resize
+  std::size_t worker_index = next_thread_index_.fetch_add(1, std::memory_order_relaxed);
+  auto self = shared_from_this();
+  std::thread* thread = new std::thread([self, control, thread_it, worker_index] {
+    WorkStealingThreadPool::WorkerLoop(self, control, thread_it, worker_index);
+  });
+  return std::make_shared<StlThread>(thread);
+}
+
+void WorkStealingThreadPool::DoSubmitTask(TaskHints hints, ThreadPool::Task task) {
+  auto task_ptr = new ThreadPool::Task(std::move(task));
+  if (tls_thread_index == NOT_IN_POOL) {
+    // FIXME: Not safe as multiple threads may be pushing to the unaffiliated queue
+    unaffiliated_queue_.Push(task_ptr);
+  } else {
+    DCHECK_LT(tls_thread_index, task_queues_.size());
+    task_queues_[tls_thread_index].Push(task_ptr);
+  }
+  // If we are already searching then the searcher will notify when done
+  if (!searching_.load()) {
+    NotifyIdleWorker();
+  }
+}
+
+namespace {
+
+void RunTask(ThreadPool::Task* task, const std::shared_ptr<ThreadPool>& thread_pool) {
+  StopToken* stop_token = &task->stop_token;
+  if (!stop_token->IsStopRequested()) {
+    std::move(task->callable)();
+  } else {
+    if (task->stop_callback) {
+      std::move(task->stop_callback)(stop_token->Poll());
+    }
+  }
+  ARROW_UNUSED(std::move(task));  // release resources before waiting for lock
+  delete task;
+  thread_pool->RecordFinishedTask();
+}
+
+}  // namespace
+
+bool WorkStealingThreadPool::Empty() { return unaffiliated_queue_.Empty(); }
+
+void WorkStealingThreadPool::WorkerLoop(
+    std::shared_ptr<WorkStealingThreadPool> thread_pool, Control* tp_control,
+    ThreadIt thread_it, int thread_index) {
+  thread_pool->NotifyWorkerStarted();
+  tls_thread_index = thread_index;
+  DCHECK_NE(tls_thread_index, NOT_IN_POOL);
+  DCHECK_LT(tls_thread_index, thread_pool->task_queues_.size());
+  DCHECK((*thread_it)->IsCurrentThread());
+
+  auto& my_queue = thread_pool->task_queues_[thread_index];
+
+  while (true) {
+    bool stopped = false;
+    // First, execute tasks belonging to this thread
+    if (PRINT_DEBUG) {
+      std::cout << tls_thread_index << ": Loop start" << std::endl;
+    }
+    while (!my_queue.Empty() && !thread_pool->ShouldWorkerQuitNow(thread_it, &stopped)) {
+      {
+        ThreadPool::Task* task = my_queue.Pop();
+        // Need to check since task may have been stolen
+        if (task) {
+          if (PRINT_DEBUG) {
+            std::cout << tls_thread_index << ": Found my task" << std::endl;
+          }
+          RunTask(task, thread_pool);
+        }
+      }
+    }
+
+    if (!stopped) {
+      thread_pool->ShouldWorkerQuitNow(thread_it, &stopped);
+    }
+    if (stopped) {
+      break;
+    }
+
+    // Second, try and grab a task from the unaffiliated queue
+    ThreadPool::Task* unassigned_task = thread_pool->unaffiliated_queue_.Steal();
+    if (unassigned_task) {
+      if (PRINT_DEBUG) {
+        std::cout << tls_thread_index << ": Stole unassigned task" << std::endl;
+      }
+      RunTask(unassigned_task, thread_pool);
+      // Since we ran a task lets jump back to the start and see if we ended up with any
+      // child tasks
+      continue;
+    }
+
+    auto task_stolen = false;
+    // Try and steal if no one else is
+    auto was_searching = thread_pool->searching_.fetch_or(1);
+    if (!was_searching) {
+      // FIXME: Should pick a random starting point
+      ThreadPool::Task* stolen_task = nullptr;
+      for (auto& task_queue : thread_pool->task_queues_) {
+        stolen_task = task_queue.Steal();
+        if (stolen_task) {
+          break;
+        }
+      }
+      thread_pool->searching_.store(0);
+      // If we were able to find a task it seems likely there is work to do so wake up
+      // sibling
+      if (stolen_task) {
+        if (PRINT_DEBUG) {
+          std::cout << tls_thread_index << ": Running stolen task" << std::endl;
+        }
+        thread_pool->NotifyIdleWorker();
+        RunTask(stolen_task, thread_pool);
+      }
+    }
+
+    // If we stole a task then we can go through the loop again before we go idle
+    if (!task_stolen) {
+      // Now either the queue is empty *or* a quick shutdown was requested
+      if (thread_pool->ShouldWorkerQuit(thread_it)) {
+        if (PRINT_DEBUG) {
+          std::cout << tls_thread_index << ": Quitting" << std::endl;
+        }
+        break;
+      }
+
+      // Wait for next wakeup
+      thread_pool->WaitForWork();
+    }
+  }
+
+  // FIXME: Do I need to worry about this?
+  tls_thread_index = NOT_IN_POOL;
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/ws_thread_pool.cc
+++ b/cpp/src/arrow/util/ws_thread_pool.cc
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/ws_thread_pool.h"
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+
+#include "arrow/util/atomic_shared_ptr.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace internal {
+
+ResizableRingBuffer::ResizableRingBuffer(std::size_t size)
+    : size_(size), mask_(size - 1), arr_(size) {
+  // Confirm size is a power of 2
+  DCHECK_EQ(size & (size - 1), 0);
+}
+
+std::size_t ResizableRingBuffer::size() const { return size_; }
+
+Task* ResizableRingBuffer::Get(std::size_t i) {
+  return arr_[i & mask_].load(std::memory_order_relaxed);
+}
+
+void ResizableRingBuffer::Put(std::size_t i, Task* task) {
+  arr_[i & mask_].store(task, std::memory_order_relaxed);
+}
+
+ResizableRingBuffer ResizableRingBuffer::Resize(std::size_t top, std::size_t bottom) {
+  std::size_t new_size = size_ << 1;
+  ResizableRingBuffer new_buf(new_size);
+  for (std::size_t i = top; i < bottom; i++) {
+    new_buf.Put(i, Get(i));
+  }
+  return new_buf;
+}
+
+WorkQueue::WorkQueue(std::size_t initial_capacity)
+    : top_(0),
+      bottom_(0),
+      tasks_(new ResizableRingBuffer(initial_capacity)),
+      to_delete_(32) {}
+
+WorkQueue::~WorkQueue() {
+  for (auto& item : to_delete_) {
+    delete item;
+  }
+  delete tasks_.load();
+}
+
+bool WorkQueue::Empty() const {
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+  return bottom <= top;
+}
+
+std::size_t WorkQueue::Size() const {
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+  return std::max(bottom - top, static_cast<std::size_t>(0));
+}
+
+std::size_t WorkQueue::Capacity() const {
+  return tasks_.load(std::memory_order_relaxed)->size();
+}
+
+void WorkQueue::Push(Task* task) {
+  DCHECK(task->callable);
+  std::size_t bottom = bottom_.load(std::memory_order_relaxed);
+  std::size_t top = top_.load(std::memory_order_acquire);
+  ResizableRingBuffer* tasks = tasks_.load(std::memory_order_relaxed);
+  std::size_t count_existing = bottom - top;
+
+  // The queue is full so we need to resize.  There is only one producer so only one
+  // thread can be in resize at once.  Other threads will only see the new queue once it
+  // is fully initialized
+  if (tasks->size() < count_existing + 1) {
+    ResizableRingBuffer* bigger = new ResizableRingBuffer(tasks->Resize(top, bottom));
+    // Collect to delete later
+    to_delete_.push_back(tasks);
+    tasks = bigger;
+    // FIXME - Should be relaxed
+    tasks_.store(tasks, std::memory_order_relaxed);
+  }
+
+  tasks->Put(bottom, std::move(task));
+  std::atomic_thread_fence(std::memory_order_release);
+  bottom_.store(bottom + 1, std::memory_order_relaxed);
+}
+
+Task* WorkQueue::Pop() {
+  std::size_t new_bottom = bottom_.load(std::memory_order_relaxed) - 1;
+  ResizableRingBuffer* tasks = tasks_.load(std::memory_order_relaxed);
+
+  bottom_.store(new_bottom, std::memory_order_relaxed);
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+  std::size_t top = top_.load(std::memory_order_relaxed);
+
+  Task* task = nullptr;
+  if (top <= new_bottom) {
+    task = tasks->Get(new_bottom);
+    if (top == new_bottom) {
+      // If we are removing the last item we need to do a double-check to handle the
+      // case where a stealing thread comes in and steals the item at the same time we are
+      // trying to grab it.
+      if (!top_.compare_exchange_strong(top, top + 1, std::memory_order_seq_cst,
+                                        std::memory_order_relaxed)) {
+        task = nullptr;
+      }
+      bottom_.store(new_bottom + 1, std::memory_order_relaxed);
+    }
+  } else {
+    // Empty, return null and put the bottom back
+    bottom_.store(new_bottom + 1, std::memory_order_relaxed);
+  }
+
+  DCHECK(!task || task->callable);
+
+  return task;
+}
+
+Task* WorkQueue::Steal() {
+  std::size_t top = top_.load(std::memory_order_acquire);
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+  std::size_t bottom = bottom_.load(std::memory_order_acquire);
+
+  Task* task = nullptr;
+
+  if (top < bottom) {
+    ResizableRingBuffer* tasks = tasks_.load(std::memory_order_consume);
+    task = tasks->Get(top);
+
+    // Need to check and see if the owning thread grabbed the item before we could
+    // mark it claimed.
+    if (!top_.compare_exchange_strong(top, top + 1, std::memory_order_seq_cst,
+                                      std::memory_order_relaxed)) {
+      return nullptr;
+    }
+  }
+
+  return task;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/ws_thread_pool.h
+++ b/cpp/src/arrow/util/ws_thread_pool.h
@@ -24,11 +24,7 @@
 namespace arrow {
 namespace internal {
 
-struct Task {
-  FnOnce<void()> callable;
-  StopToken stop_token;
-  Executor::StopCallback stop_callback;
-};
+using Task = ThreadPool::Task;
 
 /// An implementation of a Chase-Lev deque as described in
 /// https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf

--- a/cpp/src/arrow/util/ws_thread_pool.h
+++ b/cpp/src/arrow/util/ws_thread_pool.h
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstddef>
+
+#include "arrow/util/cancel.h"
+#include "arrow/util/functional.h"
+#include "arrow/util/thread_pool.h"
+
+namespace arrow {
+namespace internal {
+
+struct Task {
+  FnOnce<void()> callable;
+  StopToken stop_token;
+  Executor::StopCallback stop_callback;
+};
+
+/// An implementation of a Chase-Lev deque as described in
+/// https://www.dre.vanderbilt.edu/~schmidt/PDF/work-stealing-dequeue.pdf
+///
+/// Implementations to look at:
+///  * https://github.com/taskflow/taskflow/blob/master/taskflow/core/tsq.hpp
+///
+/// It is lock-free and supports multiple consumers with a single producer
+///
+/// The owning thread pushes tasks to the bottom of the stack
+/// The owning thread pulls tasks from the bottom of the stack (LIFO)
+///
+/// Thieving threads pull tasks from the top of the stack (FIFO)
+///
+/// The memory ordering is designed such that the hot path (owning thread pulls its own
+/// items) is fastest.  It is based on a paper "Correct and Efficient Work-Stealing for
+/// Weak Memory Models" here: https://fzn.fr/readings/ppopp13.pdf
+///
+/// Potential future optimizations
+/// * The original paper (see above) describes how to shrink the array to help conserve
+///   memory after a burst  of tasks.
+/// * When the buffer resizes the original buffer is destroyed immediately.  The taskflow
+///   implementation throws it in a garbage buffer to be destroyed later at destruction
+///   time
+
+class ResizableRingBuffer {
+ public:
+  /// Creates a ring buffer with a fixed capacity
+  /// NB: size must be a power of 2
+  ResizableRingBuffer(std::size_t size);
+  /// Size of the buffer
+  std::size_t size() const;
+  /// Gets an item from the buffer
+  Task* Get(std::size_t i);
+  /// Inserts an item into the buffer
+  void Put(std::size_t i, Task* task);
+  /// Creates a new buffer with 2x the capacity, needs to know where top and
+  /// bottom are to copy into the new buffer in the correct order.
+  ResizableRingBuffer Resize(std::size_t bottom, std::size_t top);
+
+ private:
+  std::size_t size_;
+  // The original paper has to regularly do (i % size).  Since size is always a power
+  // of 2 we can do this more efficiently with (i & (size - 1)).   mask_ is size_ - 1
+  std::size_t mask_;
+  std::vector<std::atomic<Task*>> arr_;
+};
+
+class WorkQueue {
+ public:
+  /// Creates a work queue with a given initial capacity, the queue can grow beyond this
+  /// capacity if needed
+  WorkQueue(std::size_t initial_capacity);
+  ~WorkQueue();
+
+  bool Empty() const;
+  std::size_t Size() const;
+  std::size_t Capacity() const;
+
+  /// Adds an item to the bottom of the stack
+  /// NB: Must only be called by the owning thread
+  void Push(Task* task);
+  /// Pulls an item off the bottom of the stack
+  /// NB: Must only be called by the owning thread
+  Task* Pop();
+  /// Steals an item off the top of the stack
+  Task* Steal();
+
+ private:
+  std::atomic<std::size_t> top_;
+  std::atomic<std::size_t> bottom_;
+  std::atomic<ResizableRingBuffer*> tasks_;
+  // We can't delete a buffer immediately when we resize it because there may be threads
+  // in the middle of a steal operation.  So instead we just keep track of all the buffers
+  // here and delete them at the end.  Each resize doubles the queue so this shouldn't
+  // happen all that often.
+  std::vector<ResizableRingBuffer*> to_delete_;
+};
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/ws_thread_pool_test.cc
+++ b/cpp/src/arrow/util/ws_thread_pool_test.cc
@@ -1,0 +1,329 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Task queue tests
+
+#include <iostream>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/ws_thread_pool.h"
+
+namespace arrow {
+namespace internal {
+
+class WorkStealingTest : public ::testing::Test {
+ protected:
+  template <int Size>
+  struct Tasks {
+    Tasks() { Reset(); }
+
+    Task* GetTask(int i) { return tasks[i].get(); }
+
+    // Used when the task finish order is known, verifies the correct task finished
+    void VerifyTask(Task* task, int expected_index) {
+      ASSERT_FALSE(finished[expected_index])
+          << " expected task " << expected_index
+          << " just finished now but it was finished already";
+      std::move(task->callable)();
+      ASSERT_TRUE(finished[expected_index])
+          << " expected task " << expected_index
+          << " to finish but some other task was given instead";
+    }
+
+    // FinishTask + VerifyAllTasksFinished is used when the task finish order is
+    // not known
+    void FinishTask(Task* task) { std::move(task->callable)(); }
+
+    void VerifyAllTasksFinished(int expected_num_tasks) {
+      for (int i = 0; i < expected_num_tasks; i++) {
+        ASSERT_TRUE(finished[i])
+            << "Expected task " << i << " to be finished but it was not";
+      }
+    }
+
+    void Reset() {
+      for (int i = 0; i < Size; i++) {
+        finished[i] = false;
+        tasks[i] = std::make_shared<Task>(MakeTask(i));
+      }
+    }
+
+    Task MakeTask(int index) {
+      bool* finished_flag = finished.data() + index;
+      FnOnce<void()> cb = [finished_flag, index] { *finished_flag = true; };
+      return Task{std::move(cb), StopToken::Unstoppable(), {}};
+    }
+
+    std::array<bool, Size> finished;
+    std::array<std::shared_ptr<Task>, Size> tasks;
+  };
+};
+
+class ResizableRingBufferTest : public WorkStealingTest {};
+
+TEST_F(ResizableRingBufferTest, Basic) {
+  Tasks<18> tasks;
+  ResizableRingBuffer buffer(8);
+  ASSERT_EQ(8, buffer.size());
+
+  for (int i = 0; i < 6; i++) {
+    buffer.Put(i, tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(buffer.Get(i), i);
+  }
+
+  auto resized = buffer.Resize(2, 6);
+  ASSERT_EQ(16, resized.size());
+
+  for (int i = 6; i < 18; i++) {
+    resized.Put(i, tasks.GetTask(i));
+  }
+
+  for (int i = 2; i < 16; i++) {
+    tasks.VerifyTask(resized.Get(i), i);
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(resized.Get(i), 16 + i);
+  }
+}
+
+class WorkQueueTest : public WorkStealingTest {};
+
+TEST_F(WorkQueueTest, PushThenPop) {
+  Tasks<18> tasks;
+  WorkQueue work_queue(8);
+
+  for (int i = 0; i < 6; i++) {
+    // Add 0-5
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    // Pop 4,5
+    tasks.VerifyTask(work_queue.Pop(), 5 - i);
+  }
+
+  for (int i = 6; i < 18; i++) {
+    // Add 6-17
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 12; i++) {
+    // Pop 17-6
+    tasks.VerifyTask(work_queue.Pop(), 17 - i);
+  }
+
+  for (int i = 0; i < 4; i++) {
+    // Pop 0-3
+    tasks.VerifyTask(work_queue.Pop(), 3 - i);
+  }
+}
+
+TEST_F(WorkQueueTest, PushThenSteal) {
+  Tasks<18> tasks;
+  WorkQueue work_queue(8);
+
+  for (int i = 0; i < 6; i++) {
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 0; i < 2; i++) {
+    tasks.VerifyTask(work_queue.Steal(), i);
+  }
+
+  for (int i = 6; i < 18; i++) {
+    work_queue.Push(tasks.GetTask(i));
+  }
+
+  for (int i = 2; i < 18; i++) {
+    tasks.VerifyTask(work_queue.Steal(), i);
+  }
+}
+
+class WorkQueueStressTest : public WorkStealingTest,
+                            public ::testing::WithParamInterface<bool> {};
+
+TEST_P(WorkQueueStressTest, StressSteal) {
+  // Tests stealing from the queue while the producer adds tasks
+  bool slow_consumer = GetParam();
+  constexpr int MAX_NTASKS = 10000;
+  int ntasks = MAX_NTASKS;
+  if (slow_consumer) {
+    ntasks = 100;
+  }
+  int iterations = 100;
+  if (slow_consumer) {
+    iterations = 10;
+  }
+  Tasks<MAX_NTASKS> tasks;
+
+  for (int i = 0; i < iterations; i++) {
+    // The slow_consumer test case should cover steal while resizing
+    WorkQueue work_queue(2);
+    std::thread producer([&work_queue, &tasks, ntasks] {
+      for (int i = 0; i < ntasks; i++) {
+        work_queue.Push(tasks.GetTask(i));
+      }
+    });
+
+    std::thread consumer([&work_queue, &tasks, ntasks, slow_consumer] {
+      int tasks_consumed = 0;
+      while (tasks_consumed < ntasks) {
+        auto next_task = work_queue.Steal();
+        if (next_task) {
+          tasks.FinishTask(next_task);
+          tasks_consumed++;
+          if (slow_consumer) {
+            SleepABit();
+          }
+        }
+      }
+    });
+
+    producer.join();
+    consumer.join();
+    tasks.VerifyAllTasksFinished(ntasks);
+    tasks.Reset();
+  }
+}
+
+TEST_P(WorkQueueStressTest, PopSteal) {
+  // Builds up a queue of tasks and then tests the owning producer
+  // working through the queue at the same time another thread steal
+  constexpr int NTASKS = 10000;
+  constexpr int ITERATIONS = 100;
+
+  bool multiple_theives = GetParam();
+  int num_thieves = (multiple_theives) ? 8 : 1;
+
+  Tasks<NTASKS> tasks;
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    WorkQueue work_queue(32);
+    for (int i = 0; i < NTASKS; i++) {
+      work_queue.Push(tasks.GetTask(i));
+    }
+
+    std::function<Task*()> pop = [&work_queue] { return work_queue.Pop(); };
+    std::function<Task*()> steal = [&work_queue] { return work_queue.Steal(); };
+
+    std::atomic<int> tasks_consumed(0);
+    // The logic for the consumers is the same. The only difference is if they call
+    // pop or steal.
+    auto consume_factory = [&work_queue, &tasks,
+                            &tasks_consumed](std::function<Task*()> consume_fn) {
+      return [&work_queue, &tasks, &tasks_consumed, consume_fn] {
+        while (true) {
+          auto next_task = consume_fn();
+          if (next_task) {
+            tasks.FinishTask(next_task);
+            tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+          } else {
+            int consumed = tasks_consumed.load(std::memory_order_acquire);
+            if (consumed >= NTASKS) {
+              break;
+            }
+          }
+        }
+      };
+    };
+
+    std::vector<std::thread> threads;
+    threads.emplace_back(consume_factory(pop));
+    for (int i = 0; i < num_thieves; i++) {
+      threads.emplace_back(consume_factory(steal));
+    }
+
+    for (auto& thread : threads) {
+      thread.join();
+    }
+
+    tasks.VerifyAllTasksFinished(NTASKS);
+    tasks.Reset();
+  }
+}
+
+TEST_P(WorkQueueStressTest, PopAddSteal) {
+  // Producer alternates between adding and popping a task while other
+  // threads compete to steal tasks.  The pop may fail (because it was
+  // already stolen) and that's ok.
+  constexpr int NTASKS = 10000;
+  constexpr int ITERATIONS = 100;
+
+  bool multiple_theives = GetParam();
+  int num_thieves = (multiple_theives) ? 8 : 1;
+
+  Tasks<NTASKS> tasks;
+  std::atomic<int> tasks_consumed(0);
+
+  for (int i = 0; i < ITERATIONS; i++) {
+    WorkQueue work_queue(32);
+
+    auto producer_fn = [&tasks, &work_queue, &tasks_consumed] {
+      for (int i = 0; i < NTASKS; i++) {
+        work_queue.Push(tasks.GetTask(i));
+        auto task = work_queue.Pop();
+        if (task) {
+          tasks.FinishTask(task);
+          tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    };
+
+    auto consumer_fn = [&tasks, &work_queue, &tasks_consumed] {
+      while (true) {
+        auto next_task = work_queue.Steal();
+        if (next_task) {
+          tasks.FinishTask(next_task);
+          tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          int consumed = tasks_consumed.load(std::memory_order_acquire);
+          if (consumed >= NTASKS) {
+            break;
+          }
+        }
+      }
+    };
+
+    std::vector<std::thread> threads;
+    threads.emplace_back(producer_fn);
+    for (int i = 0; i < num_thieves; i++) {
+      threads.emplace_back(consumer_fn);
+    }
+
+    for (auto& thread : threads) {
+      thread.join();
+    }
+
+    tasks.VerifyAllTasksFinished(NTASKS);
+    tasks.Reset();
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestWorkQueueStress, WorkQueueStressTest,
+                         ::testing::Values(false, true));
+
+}  // namespace internal
+}  // namespace arrow
+
+/// Thread pool tests


### PR DESCRIPTION
Following the spirit of the literature I've done my best to keep things lock free.  Most management tasks (resizing, launching new workers, shutting down, etc.) still require locking.  In addition, when a thread runs out of work it must lock so it can safely sleep.

Finally, we will probably require locking when requests come in from outside the thread pool. (at the moment we are naively assuming these requests will come from a single external thread).

However, the hot path of working through tasks submitted by tasks should be able to be done with a minimal amount of synchronization (although I'm not entirely convinced this benefit is worth the complexity at the moment, see upcoming discussion in ARROW-10117).  Very early benchmarking shows ~2x speedup on this hot path.

Of course, the more interesting case, is the case where work stealing saves us from losing cache locality.  I haven't gotten around to benchmarking that yet.

Keeping in draft at the moment:

* In addition to the above work still needing to be done the current implementation does not support incoming requests from multiple outside threads.
* Also, resize is not currently supported.

Mostly I'm just submitting this now to help inform some of the upstream PRs.