### PR TITLE
ARROW-12903: [C++] Create new thread pool benchmark demonstrating the "scheduling" bottleneck

### DIFF
--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -288,7 +288,7 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // tasks are finished.
   Status Shutdown(bool wait = true);
 
-  // Waits for the thread pool to reach a quiet state where all workers are
+  // Wait for the thread pool to reach a quiet state where all workers are
   // idle.  Currently used for thread pool benchmarking purposes.
   void WaitForIdle();
 

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -288,6 +288,10 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // tasks are finished.
   Status Shutdown(bool wait = true);
 
+  // Waits for the thread pool to reach a quiet state where all workers are
+  // idle.  Currently used for thread pool benchmarking purposes.
+  void WaitForIdle();
+
   struct State;
 
  protected:


### PR DESCRIPTION
See JIRA for rationale (I also added a comment to the benchmark itself)

Even without any changes to the thread pools you should be able to see some speedup from ideal scheduling.  With the changes being introduced in the work stealing PRs the speedup is even more stark.
