### PR TITLE
ARROW-12984: [C++][Compute] Passing options parameter of Count/Index aggregation by reference

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -25,7 +25,7 @@ namespace compute {
 // ----------------------------------------------------------------------
 // Scalar aggregates
 
-Result<Datum> Count(const Datum& value, ScalarAggregateOptions options,
+Result<Datum> Count(const Datum& value, const ScalarAggregateOptions& options,
                     ExecContext* ctx) {
   return CallFunction("count", {value}, &options, ctx);
 }

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -77,7 +77,7 @@ Result<Datum> TDigest(const Datum& value, const TDigestOptions& options,
   return CallFunction("tdigest", {value}, &options, ctx);
 }
 
-Result<Datum> Index(const Datum& value, IndexOptions options, ExecContext* ctx) {
+Result<Datum> Index(const Datum& value, const IndexOptions& options, ExecContext* ctx) {
   return CallFunction("index", {value}, &options, ctx);
 }
 

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -145,9 +145,10 @@ struct ARROW_EXPORT IndexOptions : public FunctionOptions {
 /// \since 1.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> Count(const Datum& datum,
-                    ScalarAggregateOptions options = ScalarAggregateOptions::Defaults(),
-                    ExecContext* ctx = NULLPTR);
+Result<Datum> Count(
+    const Datum& datum,
+    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
 
 /// \brief Compute the mean of a numeric array.
 ///

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -311,7 +311,8 @@ Result<Datum> TDigest(const Datum& value,
 /// \since 5.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> Index(const Datum& value, IndexOptions options, ExecContext* ctx = NULLPTR);
+Result<Datum> Index(const Datum& value, const IndexOptions& options,
+                    ExecContext* ctx = NULLPTR);
 
 namespace internal {
 


### PR DESCRIPTION
The options parameter of `Count` function is passed by value, it's better to be passed by reference like other aggregation functions.