### PR TITLE
ARROW-12972: [CI] Fix centos-8 cmake error

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -128,6 +128,7 @@ ${install_command} \
   ${cmake_package} \
   gcc-c++ \
   git \
+  libarchive \
   make
 mkdir -p build
 cp -a /arrow/cpp/examples/minimal_build build

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
@@ -40,6 +40,7 @@ RUN \
     glog-devel \
     gobject-introspection-devel \
     gtk-doc \
+    libarchive \
     libzstd-devel \
     llvm-devel \
     llvm-static \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
@@ -40,7 +40,6 @@ RUN \
     glog-devel \
     gobject-introspection-devel \
     gtk-doc \
-    libarchive \
     libzstd-devel \
     llvm-devel \
     llvm-static \


### PR DESCRIPTION
Install libarchive to fix cmake error on centos-8.

cmake: undefined symbol: archive_write_add_filter_zstd