### PR TITLE
ARROW-12096: [C++] Allows users to define arrow timestamp unit for Parquet INT96 timestamp 

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1672,7 +1672,7 @@ TEST(TestArrowReadWrite, UseDeprecatedInt96) {
 }
 
 // Test for added functionality in ARROW-12096
-TEST(TestArrowReadWrite, DowncastDeprecatedInt96) {
+TEST(TestArrowReadWrite, DownsampleDeprecatedInt96) {
   using ::arrow::ArrayFromVector;
   using ::arrow::field;
   using ::arrow::schema;
@@ -1684,6 +1684,7 @@ TEST(TestArrowReadWrite, DowncastDeprecatedInt96) {
   auto t_us = ::arrow::timestamp(TimeUnit::MICRO);
   auto t_ns = ::arrow::timestamp(TimeUnit::NANO);
 
+  // Values demonstrate loss of resolution when "down sampling" INT96 to units that are not NS
   std::vector<int64_t> s_values = {1489269, 1489269, 1489269, 1489269};
   std::vector<int64_t> ms_values = {1489269000, 1489269000,
                                     1489269000, 1489269001};

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -561,24 +561,24 @@ void ReadSingleColumnFileStatistics(std::unique_ptr<FileReader> file_reader,
 void DownsampleInt96RoundTrip(std::shared_ptr<Array> arrow_vector_in,
                               std::shared_ptr<Array> arrow_vector_out,
                               ::arrow::TimeUnit::type unit) {
-
   // Create single input table of NS to be written to parquet with INT96
-  auto input_schema = ::arrow::schema({::arrow::field("f", ::arrow::timestamp(TimeUnit::NANO))});
+  auto input_schema =
+      ::arrow::schema({::arrow::field("f", ::arrow::timestamp(TimeUnit::NANO))});
   auto input = Table::Make(input_schema, {arrow_vector_in});
 
   // Create an expected schema for each resulting table (one for each "downsampled" ts)
   auto ex_schema = ::arrow::schema({::arrow::field("f", ::arrow::timestamp(unit))});
   auto ex_result = Table::Make(ex_schema, {arrow_vector_out});
-  
+
   std::shared_ptr<Table> result;
 
   ArrowReaderProperties arrow_reader_prop;
   arrow_reader_prop.set_coerce_int96_timestamp_unit(unit);
 
   ASSERT_NO_FATAL_FAILURE(DoRoundtrip(
-    input, input->num_rows(), &result, default_writer_properties(),
-    ArrowWriterProperties::Builder().enable_deprecated_int96_timestamps()->build(),
-    arrow_reader_prop));
+      input, input->num_rows(), &result, default_writer_properties(),
+      ArrowWriterProperties::Builder().enable_deprecated_int96_timestamps()->build(),
+      arrow_reader_prop));
 
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertSchemaEqual(*ex_result->schema(),
                                                      *result->schema(),
@@ -1705,15 +1705,21 @@ TEST(TestArrowReadWrite, DownsampleDeprecatedInt96) {
   using ::arrow::field;
   using ::arrow::schema;
 
-  // timestamp values at 2000-01-01 00:00:00 then with increment unit of 1ns, 1us, 1ms and 1s
-  auto a_nano = ArrayFromJSON(timestamp(TimeUnit::NANO),
-                           "[946684800000000000, 946684800000000001, 946684800000001000, 946684800001000000, 946684801000000000]");
+  // Timestamp values at 2000-01-01 00:00:00,
+  // then with increment unit of 1ns, 1us, 1ms and 1s.
+  auto a_nano =
+      ArrayFromJSON(timestamp(TimeUnit::NANO),
+                    "[946684800000000000, 946684800000000001, 946684800000001000, "
+                    "946684800001000000, 946684801000000000]");
   auto a_micro = ArrayFromJSON(timestamp(TimeUnit::MICRO),
-                           "[946684800000000, 946684800000000, 946684800000001, 946684800001000, 946684801000000]");
-  auto a_milli = ArrayFromJSON(timestamp(TimeUnit::MILLI),
-                           "[946684800000, 946684800000, 946684800000, 946684800001, 946684801000]");
-  auto a_second = ArrayFromJSON(timestamp(TimeUnit::SECOND),
-                           "[946684800, 946684800, 946684800, 946684800, 946684801]");
+                               "[946684800000000, 946684800000000, 946684800000001, "
+                               "946684800001000, 946684801000000]");
+  auto a_milli = ArrayFromJSON(
+      timestamp(TimeUnit::MILLI),
+      "[946684800000, 946684800000, 946684800000, 946684800001, 946684801000]");
+  auto a_second =
+      ArrayFromJSON(timestamp(TimeUnit::SECOND),
+                    "[946684800, 946684800, 946684800, 946684800, 946684801]");
 
   ASSERT_NO_FATAL_FAILURE(DownsampleInt96RoundTrip(a_nano, a_nano, TimeUnit::NANO));
   ASSERT_NO_FATAL_FAILURE(DownsampleInt96RoundTrip(a_nano, a_micro, TimeUnit::MICRO));

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1671,6 +1671,89 @@ TEST(TestArrowReadWrite, UseDeprecatedInt96) {
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*ex_result, *result));
 }
 
+TEST(TestArrowReadWrite, DowncastDeprecatedInt96) {
+  using ::arrow::ArrayFromVector;
+  using ::arrow::field;
+  using ::arrow::schema;
+
+  std::vector<bool> is_valid = {true, true, true, true};
+
+  auto t_s = ::arrow::timestamp(TimeUnit::SECOND);
+  auto t_ms = ::arrow::timestamp(TimeUnit::MILLI);
+  auto t_us = ::arrow::timestamp(TimeUnit::MICRO);
+  auto t_ns = ::arrow::timestamp(TimeUnit::NANO);
+
+  std::vector<int64_t> s_values = {1489269, 1489269, 1489269, 1489269};
+  std::vector<int64_t> ms_values = {1489269000, 1489269000,
+                                    1489269000, 1489269001};
+  std::vector<int64_t> us_values = {1489269000000, 1489269000000,
+                                    1489269000001, 1489269001000};
+  std::vector<int64_t> ns_values = {1489269000000000LL, 1489269000000001LL,
+                                    1489269000001000LL, 1489269001000000LL};
+
+  std::shared_ptr<Array> a_s, a_ms, a_us, a_ns;
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, is_valid, s_values, &a_s);
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_ms, is_valid, ms_values, &a_ms);
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_us, is_valid, us_values, &a_us);
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_ns, is_valid, ns_values, &a_ns);
+
+  // Create single input table of NS to be written to parquet with INT96
+  auto input_schema = schema({field("f", t_ns)});
+  auto input = Table::Make(input_schema, {a_ns});
+
+  // Create an expected schema for each resulting table (one for each "down sampled" ts)
+  auto ex_schema_s = schema({field("f", t_s)});
+  auto ex_schema_ms = schema({field("f", t_ms)});
+  auto ex_schema_us = schema({field("f", t_us)});
+  
+  // Create tables
+  auto ex_result_s = Table::Make(ex_schema_s, {a_s});
+  auto ex_result_ms = Table::Make(ex_schema_ms, {a_ms});
+  auto ex_result_us = Table::Make(ex_schema_us, {a_us});
+
+  std::shared_ptr<Table> result_s;
+  std::shared_ptr<Table> result_ms;
+  std::shared_ptr<Table> result_us;
+
+  ArrowReaderProperties arrow_reader_prop_s, arrow_reader_prop_ms, arrow_reader_prop_us;
+  arrow_reader_prop_s.set_coerce_int96_timestamp_unit(::arrow::TimeUnit::SECOND);
+  arrow_reader_prop_ms.set_coerce_int96_timestamp_unit(::arrow::TimeUnit::MILLI);
+  arrow_reader_prop_us.set_coerce_int96_timestamp_unit(::arrow::TimeUnit::MICRO);
+
+// SECOND
+  ASSERT_NO_FATAL_FAILURE(DoRoundtrip(
+    input, input->num_rows(), &result_s, default_writer_properties(),
+    ArrowWriterProperties::Builder().enable_deprecated_int96_timestamps()->build(),
+    arrow_reader_prop_s));
+
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertSchemaEqual(*ex_result_s->schema(),
+                                                     *result_s->schema(),
+                                                     /*check_metadata=*/false));
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*ex_result_s, *result_s));
+
+// MILLI
+  ASSERT_NO_FATAL_FAILURE(DoRoundtrip(
+    input, input->num_rows(), &result_ms, default_writer_properties(),
+    ArrowWriterProperties::Builder().enable_deprecated_int96_timestamps()->build(),
+    arrow_reader_prop_ms));
+
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertSchemaEqual(*ex_result_ms->schema(),
+                                                     *result_ms->schema(),
+                                                     /*check_metadata=*/false));
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*ex_result_ms, *result_ms));
+
+  // MICRO
+  ASSERT_NO_FATAL_FAILURE(DoRoundtrip(
+    input, input->num_rows(), &result_us, default_writer_properties(),
+    ArrowWriterProperties::Builder().enable_deprecated_int96_timestamps()->build(),
+    arrow_reader_prop_us));
+
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertSchemaEqual(*ex_result_us->schema(),
+                                                     *result_us->schema(),
+                                                     /*check_metadata=*/false));
+  ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*ex_result_us, *result_us));
+}
+
 TEST(TestArrowReadWrite, CoerceTimestamps) {
   using ::arrow::ArrayFromVector;
   using ::arrow::field;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1671,6 +1671,7 @@ TEST(TestArrowReadWrite, UseDeprecatedInt96) {
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*ex_result, *result));
 }
 
+// Test for added functionality in ARROW-12096
 TEST(TestArrowReadWrite, DowncastDeprecatedInt96) {
   using ::arrow::ArrayFromVector;
   using ::arrow::field;

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -366,15 +366,19 @@ Status TransferInt96(RecordReader* reader, MemoryPool* pool,
       // isn't representable as a 64-bit Unix timestamp.
       *data_ptr++ = 0;
     } else {
-      switch (int96_arrow_time_unit){
+      switch (int96_arrow_time_unit) {
         case ::arrow::TimeUnit::NANO:
-          *data_ptr++ = Int96GetNanoSeconds(values[i]); break;
+          *data_ptr++ = Int96GetNanoSeconds(values[i]);
+          break;
         case ::arrow::TimeUnit::MICRO:
-          *data_ptr++ = Int96GetMicroSeconds(values[i]); break;
+          *data_ptr++ = Int96GetMicroSeconds(values[i]);
+          break;
         case ::arrow::TimeUnit::MILLI:
-          *data_ptr++ = Int96GetMilliSeconds(values[i]); break;
+          *data_ptr++ = Int96GetMilliSeconds(values[i]);
+          break;
         case ::arrow::TimeUnit::SECOND:
-          *data_ptr++ = Int96GetSeconds(values[i]); break;
+          *data_ptr++ = Int96GetSeconds(values[i]);
+          break;
       }
     }
   }
@@ -753,15 +757,17 @@ Status TransferColumnData(RecordReader* reader, std::shared_ptr<DataType> value_
       const ::arrow::TimestampType& timestamp_type =
           checked_cast<::arrow::TimestampType&>(*value_type);
       if (descr->physical_type() == ::parquet::Type::INT96) {
-            RETURN_NOT_OK(TransferInt96(reader, pool, value_type, &result, timestamp_type.unit()));
-        }
-      else {
+        RETURN_NOT_OK(
+            TransferInt96(reader, pool, value_type, &result, timestamp_type.unit()));
+      } else {
         switch (timestamp_type.unit()) {
           case ::arrow::TimeUnit::MILLI:
           case ::arrow::TimeUnit::MICRO:
-          case ::arrow::TimeUnit::NANO: {
+          case ::arrow::TimeUnit::NANO:
             result = TransferZeroCopy(reader, value_type);
-          } break;
+            break;
+          default:
+            return Status::NotImplemented("TimeUnit not supported");
         }
       }
     } break;

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -354,7 +354,7 @@ Status TransferBool(RecordReader* reader, MemoryPool* pool, Datum* out) {
 
 Status TransferInt96(RecordReader* reader, MemoryPool* pool,
                      const std::shared_ptr<DataType>& type, Datum* out,
-                     const ::arrow::TimeUnit::type& int96_arrow_time_unit) {
+                     const ::arrow::TimeUnit::type int96_arrow_time_unit) {
   int64_t length = reader->values_written();
   auto values = reinterpret_cast<const Int96*>(reader->values());
   ARROW_ASSIGN_OR_RAISE(auto data,
@@ -757,14 +757,11 @@ Status TransferColumnData(RecordReader* reader, std::shared_ptr<DataType> value_
         }
       else {
         switch (timestamp_type.unit()) {
-          case ::arrow::TimeUnit::SECOND:
           case ::arrow::TimeUnit::MILLI:
           case ::arrow::TimeUnit::MICRO:
           case ::arrow::TimeUnit::NANO: {
             result = TransferZeroCopy(reader, value_type);
           } break;
-          default:
-            return Status::NotImplemented("TimeUnit not supported");
         }
       }
     } break;

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -376,6 +376,7 @@ Status TransferInt96(RecordReader* reader, MemoryPool* pool,
         case ::arrow::TimeUnit::SECOND:
           *data_ptr++ = Int96GetSeconds(values[i]); break;
       }
+    }
   }
   *out = std::make_shared<TimestampArray>(type, length, std::move(data),
                                           reader->ReleaseIsValid(), reader->null_count());

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -353,7 +353,8 @@ Status TransferBool(RecordReader* reader, MemoryPool* pool, Datum* out) {
 }
 
 Status TransferInt96(RecordReader* reader, MemoryPool* pool,
-                     const std::shared_ptr<DataType>& type, Datum* out) {
+                     const std::shared_ptr<DataType>& type, Datum* out,
+                     const ::arrow::TimeUnit::type& int96_arrow_time_unit) {
   int64_t length = reader->values_written();
   auto values = reinterpret_cast<const Int96*>(reader->values());
   ARROW_ASSIGN_OR_RAISE(auto data,
@@ -365,8 +366,16 @@ Status TransferInt96(RecordReader* reader, MemoryPool* pool,
       // isn't representable as a 64-bit Unix timestamp.
       *data_ptr++ = 0;
     } else {
-      *data_ptr++ = Int96GetNanoSeconds(values[i]);
-    }
+      switch (int96_arrow_time_unit){
+        case ::arrow::TimeUnit::NANO:
+          *data_ptr++ = Int96GetNanoSeconds(values[i]); break;
+        case ::arrow::TimeUnit::MICRO:
+          *data_ptr++ = Int96GetMicroSeconds(values[i]); break;
+        case ::arrow::TimeUnit::MILLI:
+          *data_ptr++ = Int96GetMilliSeconds(values[i]); break;
+        case ::arrow::TimeUnit::SECOND:
+          *data_ptr++ = Int96GetSeconds(values[i]); break;
+      }
   }
   *out = std::make_shared<TimestampArray>(type, length, std::move(data),
                                           reader->ReleaseIsValid(), reader->null_count());
@@ -742,20 +751,20 @@ Status TransferColumnData(RecordReader* reader, std::shared_ptr<DataType> value_
     case ::arrow::Type::TIMESTAMP: {
       const ::arrow::TimestampType& timestamp_type =
           checked_cast<::arrow::TimestampType&>(*value_type);
-      switch (timestamp_type.unit()) {
-        case ::arrow::TimeUnit::MILLI:
-        case ::arrow::TimeUnit::MICRO: {
-          result = TransferZeroCopy(reader, value_type);
-        } break;
-        case ::arrow::TimeUnit::NANO: {
-          if (descr->physical_type() == ::parquet::Type::INT96) {
-            RETURN_NOT_OK(TransferInt96(reader, pool, value_type, &result));
-          } else {
+      if (descr->physical_type() == ::parquet::Type::INT96) {
+            RETURN_NOT_OK(TransferInt96(reader, pool, value_type, &result, timestamp_type.unit()));
+        }
+      else {
+        switch (timestamp_type.unit()) {
+          case ::arrow::TimeUnit::SECOND:
+          case ::arrow::TimeUnit::MILLI:
+          case ::arrow::TimeUnit::MICRO:
+          case ::arrow::TimeUnit::NANO: {
             result = TransferZeroCopy(reader, value_type);
-          }
-        } break;
-        default:
-          return Status::NotImplemented("TimeUnit not supported");
+          } break;
+          default:
+            return Status::NotImplemented("TimeUnit not supported");
+        }
       }
     } break;
     default:

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -454,7 +454,7 @@ bool IsDictionaryReadSupported(const ArrowType& type) {
 ::arrow::Result<std::shared_ptr<ArrowType>> GetTypeForNode(
     int column_index, const schema::PrimitiveNode& primitive_node,
     SchemaTreeContext* ctx) {
-  ASSIGN_OR_RAISE(std::shared_ptr<ArrowType> storage_type, GetArrowType(primitive_node));
+  ASSIGN_OR_RAISE(std::shared_ptr<ArrowType> storage_type, GetArrowType(primitive_node, ctx->properties.coerce_int96_timestamp_unit()));
   if (ctx->properties.read_dictionary(column_index) &&
       IsDictionaryReadSupported(*storage_type)) {
     return ::arrow::dictionary(::arrow::int32(), storage_type);

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -454,7 +454,9 @@ bool IsDictionaryReadSupported(const ArrowType& type) {
 ::arrow::Result<std::shared_ptr<ArrowType>> GetTypeForNode(
     int column_index, const schema::PrimitiveNode& primitive_node,
     SchemaTreeContext* ctx) {
-  ASSIGN_OR_RAISE(std::shared_ptr<ArrowType> storage_type, GetArrowType(primitive_node, ctx->properties.coerce_int96_timestamp_unit()));
+  ASSIGN_OR_RAISE(
+      std::shared_ptr<ArrowType> storage_type,
+      GetArrowType(primitive_node, ctx->properties.coerce_int96_timestamp_unit()));
   if (ctx->properties.read_dictionary(column_index) &&
       IsDictionaryReadSupported(*storage_type)) {
     return ::arrow::dictionary(::arrow::int32(), storage_type);

--- a/cpp/src/parquet/arrow/schema_internal.cc
+++ b/cpp/src/parquet/arrow/schema_internal.cc
@@ -182,7 +182,7 @@ Result<std::shared_ptr<ArrowType>> FromInt64(const LogicalType& logical_type) {
 Result<std::shared_ptr<ArrowType>> GetArrowType(Type::type physical_type,
                                                 const LogicalType& logical_type,
                                                 int type_length,
-                                                const ::arrow::TimeUnit::type& int96_arrow_time_unit) {
+                                                const ::arrow::TimeUnit::type int96_arrow_time_unit) {
   if (logical_type.is_invalid() || logical_type.is_null()) {
     return ::arrow::null();
   }
@@ -212,7 +212,6 @@ Result<std::shared_ptr<ArrowType>> GetArrowType(Type::type physical_type,
   }
 }
 
-// ARROW-12096 -- Overloading functions with new input (setting default as NANO)
 Result<std::shared_ptr<ArrowType>> GetArrowType(const schema::PrimitiveNode& primitive) {
   return GetArrowType(primitive.physical_type(), *primitive.logical_type(),
                       primitive.type_length(), ::arrow::TimeUnit::NANO);
@@ -223,9 +222,8 @@ Result<std::shared_ptr<ArrowType>> GetArrowType(const ColumnDescriptor& descript
                       descriptor.type_length(), ::arrow::TimeUnit::NANO);
 }
 
-// ARROW-12096 -- Exposing INT96 arrow type definition fromm parquet reader
 Result<std::shared_ptr<ArrowType>> GetArrowType(const schema::PrimitiveNode& primitive,
-                                                const ::arrow::TimeUnit::type& int96_arrow_time_unit) {
+                                                const ::arrow::TimeUnit::type int96_arrow_time_unit) {
   return GetArrowType(primitive.physical_type(), *primitive.logical_type(),
                       primitive.type_length(), int96_arrow_time_unit);
 }

--- a/cpp/src/parquet/arrow/schema_internal.cc
+++ b/cpp/src/parquet/arrow/schema_internal.cc
@@ -179,10 +179,9 @@ Result<std::shared_ptr<ArrowType>> FromInt64(const LogicalType& logical_type) {
   }
 }
 
-Result<std::shared_ptr<ArrowType>> GetArrowType(Type::type physical_type,
-                                                const LogicalType& logical_type,
-                                                int type_length,
-                                                const ::arrow::TimeUnit::type int96_arrow_time_unit) {
+Result<std::shared_ptr<ArrowType>> GetArrowType(
+    Type::type physical_type, const LogicalType& logical_type, int type_length,
+    const ::arrow::TimeUnit::type int96_arrow_time_unit) {
   if (logical_type.is_invalid() || logical_type.is_null()) {
     return ::arrow::null();
   }
@@ -212,18 +211,9 @@ Result<std::shared_ptr<ArrowType>> GetArrowType(Type::type physical_type,
   }
 }
 
-Result<std::shared_ptr<ArrowType>> GetArrowType(const schema::PrimitiveNode& primitive) {
-  return GetArrowType(primitive.physical_type(), *primitive.logical_type(),
-                      primitive.type_length(), ::arrow::TimeUnit::NANO);
-}
-
-Result<std::shared_ptr<ArrowType>> GetArrowType(const ColumnDescriptor& descriptor) {
-  return GetArrowType(descriptor.physical_type(), *descriptor.logical_type(),
-                      descriptor.type_length(), ::arrow::TimeUnit::NANO);
-}
-
-Result<std::shared_ptr<ArrowType>> GetArrowType(const schema::PrimitiveNode& primitive,
-                                                const ::arrow::TimeUnit::type int96_arrow_time_unit) {
+Result<std::shared_ptr<ArrowType>> GetArrowType(
+    const schema::PrimitiveNode& primitive,
+    const ::arrow::TimeUnit::type int96_arrow_time_unit) {
   return GetArrowType(primitive.physical_type(), *primitive.logical_type(),
                       primitive.type_length(), int96_arrow_time_unit);
 }

--- a/cpp/src/parquet/arrow/schema_internal.h
+++ b/cpp/src/parquet/arrow/schema_internal.h
@@ -39,21 +39,13 @@ Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type
                                                         const LogicalType& logical_type,
                                                         int type_length);
 
-// ARROW-12096 Exposing int96 arrow timestamp unit definition
-Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type,
-                                                        const LogicalType& logical_type,
-                                                        int type_length,
-                                                        const ::arrow::TimeUnit::type int96_arrow_time_unit);
-
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
-    const schema::PrimitiveNode& primitive);
+    Type::type physical_type, const LogicalType& logical_type, int type_length,
+    ::arrow::TimeUnit::type int96_arrow_time_unit = ::arrow::TimeUnit::NANO);
 
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const schema::PrimitiveNode& primitive,
-    const ::arrow::TimeUnit::type int96_arrow_time_unit);
-
-Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
-    const ColumnDescriptor& descriptor);
+    ::arrow::TimeUnit::type int96_arrow_time_unit = ::arrow::TimeUnit::NANO);
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/schema_internal.h
+++ b/cpp/src/parquet/arrow/schema_internal.h
@@ -39,8 +39,20 @@ Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type
                                                         const LogicalType& logical_type,
                                                         int type_length);
 
+// ARROW-12096 Exposing int96 arrow timestamp unit definition
+Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type,
+                                                        const LogicalType& logical_type,
+                                                        int type_length,
+                                                        const ::arrow::TimeUnit::type& int96_arrow_time_unit);
+
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const schema::PrimitiveNode& primitive);
+
+// ARROW-12096 Exposing int96 arrow timestamp unit definition
+Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
+    const schema::PrimitiveNode& primitive,
+    const ::arrow::TimeUnit::type& int96_arrow_time_unit);
+
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const ColumnDescriptor& descriptor);
 

--- a/cpp/src/parquet/arrow/schema_internal.h
+++ b/cpp/src/parquet/arrow/schema_internal.h
@@ -43,15 +43,14 @@ Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type,
                                                         const LogicalType& logical_type,
                                                         int type_length,
-                                                        const ::arrow::TimeUnit::type& int96_arrow_time_unit);
+                                                        const ::arrow::TimeUnit::type int96_arrow_time_unit);
 
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const schema::PrimitiveNode& primitive);
 
-// ARROW-12096 Exposing int96 arrow timestamp unit definition
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const schema::PrimitiveNode& primitive,
-    const ::arrow::TimeUnit::type& int96_arrow_time_unit);
+    const ::arrow::TimeUnit::type int96_arrow_time_unit);
 
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     const ColumnDescriptor& descriptor);

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -621,10 +621,15 @@ class PARQUET_EXPORT ArrowReaderProperties {
 
   const ::arrow::io::IOContext& io_context() const { return io_context_; }
 
-  /// Set output Arrow format for parquet reader ARROW-12096
-  void set_coerce_int96_timestamp_unit(::arrow::TimeUnit::type unit) { coerce_int96_timestamp_unit_ = unit; }
+  /// Set timestamp unit to use for deprecated INT96-encoded timestamps
+  /// (default is NANO).
+  void set_coerce_int96_timestamp_unit(::arrow::TimeUnit::type unit) {
+    coerce_int96_timestamp_unit_ = unit;
+  }
 
-  ::arrow::TimeUnit::type coerce_int96_timestamp_unit() const { return coerce_int96_timestamp_unit_; }
+  ::arrow::TimeUnit::type coerce_int96_timestamp_unit() const {
+    return coerce_int96_timestamp_unit_;
+  }
 
  private:
   bool use_threads_;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -575,7 +575,8 @@ class PARQUET_EXPORT ArrowReaderProperties {
         read_dict_indices_(),
         batch_size_(kArrowDefaultBatchSize),
         pre_buffer_(false),
-        cache_options_(::arrow::io::CacheOptions::Defaults()) {}
+        cache_options_(::arrow::io::CacheOptions::Defaults()),
+        coerce_int96_timestamp_unit_(::arrow::TimeUnit::NANO) {}
 
   void set_use_threads(bool use_threads) { use_threads_ = use_threads; }
 
@@ -620,6 +621,11 @@ class PARQUET_EXPORT ArrowReaderProperties {
 
   const ::arrow::io::IOContext& io_context() const { return io_context_; }
 
+  /// Set output Arrow format for parquet reader ARROW-12096
+  void set_coerce_int96_timestamp_unit(::arrow::TimeUnit::type unit) { coerce_int96_timestamp_unit_ = unit; }
+
+  ::arrow::TimeUnit::type coerce_int96_timestamp_unit() const { return coerce_int96_timestamp_unit_; }
+
  private:
   bool use_threads_;
   std::unordered_set<int> read_dict_indices_;
@@ -627,6 +633,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
   bool pre_buffer_;
   ::arrow::io::IOContext io_context_;
   ::arrow::io::CacheOptions cache_options_;
+  ::arrow::TimeUnit::type coerce_int96_timestamp_unit_;
 };
 
 /// EXPERIMENTAL: Constructs the default ArrowReaderProperties

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -602,6 +602,49 @@ static inline int64_t Int96GetNanoSeconds(const parquet::Int96& i96) {
   return static_cast<int64_t>(days_since_epoch * kNanosecondsPerDay + nanoseconds);
 }
 
+// ARROW-12096
+static inline int64_t Int96GetMicroSeconds(const parquet::Int96& i96) {
+  // We do the computations in the unsigned domain to avoid unsigned behaviour
+  // on overflow.
+  uint64_t days_since_epoch =
+      i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);
+  uint64_t nanoseconds = 0;
+  memcpy(&nanoseconds, &i96.value, sizeof(uint64_t));
+
+  uint64_t microseconds = nanoseconds/static_cast<uint64_t>(1000);
+
+  return static_cast<int64_t>(days_since_epoch * kMicrosecondsPerDay + microseconds);
+}
+
+// ARROW-12096
+static inline int64_t Int96GetMilliSeconds(const parquet::Int96& i96) {
+  // We do the computations in the unsigned domain to avoid unsigned behaviour
+  // on overflow.
+  uint64_t days_since_epoch =
+      i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);
+  uint64_t nanoseconds = 0;
+  memcpy(&nanoseconds, &i96.value, sizeof(uint64_t));
+
+  uint64_t milliseconds = nanoseconds/static_cast<uint64_t>(1000000);
+
+  return static_cast<int64_t>(days_since_epoch * kMillisecondsPerDay + milliseconds);
+}
+
+// ARROW-12096
+static inline int64_t Int96GetSeconds(const parquet::Int96& i96) {
+  // We do the computations in the unsigned domain to avoid unsigned behaviour
+  // on overflow.
+  uint64_t days_since_epoch =
+      i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);
+  
+  uint64_t nanoseconds = 0;
+  memcpy(&nanoseconds, &i96.value, sizeof(uint64_t));
+
+  uint64_t seconds = nanoseconds/(static_cast<uint64_t>(1000000000));
+
+  return static_cast<int64_t>(days_since_epoch * kSecondsPerDay + seconds);
+}
+
 static inline std::string Int96ToString(const Int96& a) {
   std::ostringstream result;
   std::copy(a.value, a.value + 3, std::ostream_iterator<uint32_t>(result, " "));

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -632,7 +632,7 @@ static inline int64_t Int96GetMilliSeconds(const parquet::Int96& i96) {
 
 // ARROW-12096
 static inline int64_t Int96GetSeconds(const parquet::Int96& i96) {
-  // We do the computations in the unsigned domain to avoid unsigned behaviour
+  // We do the computations in the unsigned domain to avoid undefined behaviour
   // on overflow.
   uint64_t days_since_epoch =
       i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -591,7 +591,6 @@ static inline void Int96SetNanoSeconds(parquet::Int96& i96, int64_t nanoseconds)
   std::memcpy(&i96.value, &nanoseconds, sizeof(nanoseconds));
 }
 
-// ARROW-12096 - Update INT96 conversion to allow users to define arrow timestamp unit
 struct DecodedInt96 {
   uint64_t days_since_epoch;
   uint64_t nanoseconds;
@@ -603,31 +602,34 @@ static inline DecodedInt96 DecodeInt96Timestamp(const parquet::Int96& i96) {
   DecodedInt96 result;
   result.days_since_epoch = i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);
   result.nanoseconds = 0;
-  
+
   memcpy(&result.nanoseconds, &i96.value, sizeof(uint64_t));
   return result;
 }
 
 static inline int64_t Int96GetNanoSeconds(const parquet::Int96& i96) {
   const auto decoded = DecodeInt96Timestamp(i96);
-  return static_cast<int64_t>(decoded.days_since_epoch * kNanosecondsPerDay + decoded.nanoseconds);
+  return static_cast<int64_t>(decoded.days_since_epoch * kNanosecondsPerDay +
+                              decoded.nanoseconds);
 }
 
 static inline int64_t Int96GetMicroSeconds(const parquet::Int96& i96) {
   const auto decoded = DecodeInt96Timestamp(i96);
-  uint64_t microseconds = decoded.nanoseconds/static_cast<uint64_t>(1000);
-  return static_cast<int64_t>(decoded.days_since_epoch * kMicrosecondsPerDay + microseconds);
+  uint64_t microseconds = decoded.nanoseconds / static_cast<uint64_t>(1000);
+  return static_cast<int64_t>(decoded.days_since_epoch * kMicrosecondsPerDay +
+                              microseconds);
 }
 
 static inline int64_t Int96GetMilliSeconds(const parquet::Int96& i96) {
   const auto decoded = DecodeInt96Timestamp(i96);
-  uint64_t milliseconds = decoded.nanoseconds/static_cast<uint64_t>(1000000);
-  return static_cast<int64_t>(decoded.days_since_epoch * kMillisecondsPerDay + milliseconds);
+  uint64_t milliseconds = decoded.nanoseconds / static_cast<uint64_t>(1000000);
+  return static_cast<int64_t>(decoded.days_since_epoch * kMillisecondsPerDay +
+                              milliseconds);
 }
 
 static inline int64_t Int96GetSeconds(const parquet::Int96& i96) {
   const auto decoded = DecodeInt96Timestamp(i96);
-  uint64_t seconds = decoded.nanoseconds/static_cast<uint64_t>(1000000000);
+  uint64_t seconds = decoded.nanoseconds / static_cast<uint64_t>(1000000000);
   return static_cast<int64_t>(decoded.days_since_epoch * kSecondsPerDay + seconds);
 }
 


### PR DESCRIPTION
Have added functionality in C++ code to allow users to define the arrow timestamp unit when reading parquet INT96 types. This avoids the overflow bug when trying to convert INT96 values which have dates which are out of bounds for Arrow NS Timestamp. 

See added test: `TestArrowReadWrite.DownsampleDeprecatedInt96` which demonstrates use and expected results.

Main discussion of changes in [JIRA Issue ARROW-12096](https://issues.apache.org/jira/browse/ARROW-12096).

