### PR TITLE
ARROW-12983: [C++][Python][R] Properly overflow to chunked array in Python-to-Arrow conversion

### DIFF
--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -379,12 +379,13 @@ class TypeInferrer {
   // Infer value type from a sequence of values
   Status VisitSequence(PyObject* obj, PyObject* mask = nullptr) {
     if (mask == nullptr || mask == Py_None) {
-      return internal::VisitSequence(obj, [this](PyObject* value, bool* keep_going) {
-        return Visit(value, keep_going);
-      });
+      return internal::VisitSequence(
+          obj, /*offset=*/0,
+          [this](PyObject* value, bool* keep_going) { return Visit(value, keep_going); });
     } else {
       return internal::VisitSequenceMasked(
-          obj, mask, [this](PyObject* value, uint8_t masked, bool* keep_going) {
+          obj, mask, /*offset=*/0,
+          [this](PyObject* value, uint8_t masked, bool* keep_going) {
             if (!masked) {
               return Visit(value, keep_going);
             } else {

--- a/cpp/src/arrow/python/iterators.h
+++ b/cpp/src/arrow/python/iterators.h
@@ -84,16 +84,6 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
   return Status::OK();
 }
 
-// Visit sequence with no null mask or offset
-template <class VisitorFunc>
-inline Status VisitSequence(PyObject* obj, VisitorFunc&& func) {
-  return VisitSequenceGeneric(
-      obj, /*offset=*/0,
-      [&func](PyObject* value, int64_t i /* unused */, bool* keep_going) {
-        return func(value, keep_going);
-      });
-}
-
 // Visit sequence with offset but no null mask
 template <class VisitorFunc>
 inline Status VisitSequence(PyObject* obj, int64_t offset, VisitorFunc&& func) {
@@ -134,12 +124,6 @@ inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, int64_t offset,
   }
 }
 
-/// Visit sequence with null mask but no offset
-template <class VisitorFunc>
-inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, VisitorFunc&& func) {
-  return VisitSequenceMasked(obj, mo, /*offset=*/0, func);
-}
-
 // Like IterateSequence, but accepts any generic iterable (including
 // non-restartable iterators, e.g. generators).
 //
@@ -149,7 +133,7 @@ template <class VisitorFunc>
 inline Status VisitIterable(PyObject* obj, VisitorFunc&& func) {
   if (PySequence_Check(obj)) {
     // Numpy arrays fall here as well
-    return VisitSequence(obj, std::forward<VisitorFunc>(func));
+    return VisitSequence(obj, /*offset=*/0, std::forward<VisitorFunc>(func));
   }
   // Fall back on the iterator protocol
   OwnedRef iter_ref(PyObject_GetIter(obj));

--- a/cpp/src/arrow/python/iterators.h
+++ b/cpp/src/arrow/python/iterators.h
@@ -36,7 +36,7 @@ namespace internal {
 //
 // If keep_going is set to false, the iteration terminates
 template <class VisitorFunc>
-inline Status VisitSequenceGeneric(PyObject* obj, VisitorFunc&& func) {
+inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& func) {
   // VisitorFunc may set to false to terminate iteration
   bool keep_going = true;
 
@@ -49,7 +49,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, VisitorFunc&& func) {
     if (PyArray_DESCR(arr_obj)->type_num == NPY_OBJECT) {
       // It's an array object, we can fetch object pointers directly
       const Ndarray1DIndexer<PyObject*> objects(arr_obj);
-      for (int64_t i = 0; keep_going && i < objects.size(); ++i) {
+      for (int64_t i = offset; keep_going && i < objects.size(); ++i) {
         RETURN_NOT_OK(func(objects[i], i, &keep_going));
       }
       return Status::OK();
@@ -64,7 +64,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, VisitorFunc&& func) {
     if (PyList_Check(obj) || PyTuple_Check(obj)) {
       // Use fast item access
       const Py_ssize_t size = PySequence_Fast_GET_SIZE(obj);
-      for (Py_ssize_t i = 0; keep_going && i < size; ++i) {
+      for (Py_ssize_t i = offset; keep_going && i < size; ++i) {
         PyObject* value = PySequence_Fast_GET_ITEM(obj, i);
         RETURN_NOT_OK(func(value, static_cast<int64_t>(i), &keep_going));
       }
@@ -72,7 +72,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, VisitorFunc&& func) {
       // Regular sequence: avoid making a potentially large copy
       const Py_ssize_t size = PySequence_Size(obj);
       RETURN_IF_PYERROR();
-      for (Py_ssize_t i = 0; keep_going && i < size; ++i) {
+      for (Py_ssize_t i = offset; keep_going && i < size; ++i) {
         OwnedRef value_ref(PySequence_ITEM(obj, i));
         RETURN_IF_PYERROR();
         RETURN_NOT_OK(func(value_ref.obj(), static_cast<int64_t>(i), &keep_going));
@@ -84,18 +84,29 @@ inline Status VisitSequenceGeneric(PyObject* obj, VisitorFunc&& func) {
   return Status::OK();
 }
 
-// Visit sequence with no null mask
+// Visit sequence with no null mask or offset
 template <class VisitorFunc>
 inline Status VisitSequence(PyObject* obj, VisitorFunc&& func) {
   return VisitSequenceGeneric(
-      obj, [&func](PyObject* value, int64_t i /* unused */, bool* keep_going) {
+      obj, /*offset=*/0,
+      [&func](PyObject* value, int64_t i /* unused */, bool* keep_going) {
         return func(value, keep_going);
       });
 }
 
-/// Visit sequence with null mask
+// Visit sequence with offset but no null mask
 template <class VisitorFunc>
-inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, VisitorFunc&& func) {
+inline Status VisitSequence(PyObject* obj, int64_t offset, VisitorFunc&& func) {
+  return VisitSequenceGeneric(
+      obj, offset, [&func](PyObject* value, int64_t i /* unused */, bool* keep_going) {
+        return func(value, keep_going);
+      });
+}
+
+/// Visit sequence with null mask and offset
+template <class VisitorFunc>
+inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, int64_t offset,
+                                  VisitorFunc&& func) {
   if (mo == nullptr || !PyArray_Check(mo)) {
     return Status::Invalid("Null mask must be NumPy array");
   }
@@ -115,12 +126,18 @@ inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, VisitorFunc&& fun
     Ndarray1DIndexer<uint8_t> mask_values(mask);
 
     return VisitSequenceGeneric(
-        obj, [&func, &mask_values](PyObject* value, int64_t i, bool* keep_going) {
+        obj, offset, [&func, &mask_values](PyObject* value, int64_t i, bool* keep_going) {
           return func(value, mask_values[i], keep_going);
         });
   } else {
     return Status::Invalid("Mask must be boolean dtype");
   }
+}
+
+/// Visit sequence with null mask but no offset
+template <class VisitorFunc>
+inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, VisitorFunc&& func) {
+  return VisitSequenceMasked(obj, mo, /*offset=*/0, func);
 }
 
 // Like IterateSequence, but accepts any generic iterable (including

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -543,13 +543,9 @@ class PyPrimitiveConverter<T, enable_if_binary<T>>
                                          int64_t offset) override {
     DCHECK_GE(size, offset);
     // See BaseBinaryBuilder::Resize - avoid error in Reserve()
-    ARROW_LOG(WARNING) << "size=" << size << " offset=" << offset
-                       << " limit=" << BaseBinaryBuilder<T>::memory_limit();
     if (size - offset >= BaseBinaryBuilder<T>::memory_limit()) {
       size = offset + BaseBinaryBuilder<T>::memory_limit() - 1;
     }
-    ARROW_LOG(WARNING) << "size=" << size << " offset=" << offset
-                       << " limit=" << BaseBinaryBuilder<T>::memory_limit();
     const auto status = this->Extend(values, size, offset);
     const auto num_converted = this->builder()->length();
     if (ARROW_PREDICT_TRUE(status.ok() ||

--- a/cpp/src/arrow/util/converter.h
+++ b/cpp/src/arrow/util/converter.h
@@ -25,6 +25,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
 #include "arrow/visitor_inline.h"
 
@@ -71,7 +72,7 @@ class Converter {
   /// \param[in] offset The offset to start at.
   virtual Result<int64_t> ExtendAsMuchAsPossible(InputType values, int64_t size,
                                                  int64_t offset) {
-    DCHECK_GE(size, offset);
+    ARROW_DCHECK_GE(size, offset);
     ARROW_RETURN_NOT_OK(Extend(values, size, offset));
     return builder()->length();
   }
@@ -83,7 +84,7 @@ class Converter {
 
   virtual Result<int64_t> ExtendMaskedAsMuchAsPossible(InputType values, InputType mask,
                                                        int64_t size, int64_t offset) {
-    DCHECK_GE(size, offset);
+    ARROW_DCHECK_GE(size, offset);
     ARROW_RETURN_NOT_OK(ExtendMasked(values, mask, size, offset));
     return builder()->length();
   }

--- a/cpp/src/arrow/util/converter.h
+++ b/cpp/src/arrow/util/converter.h
@@ -72,7 +72,7 @@ class Converter {
   virtual Result<int64_t> ExtendAsMuchAsPossible(InputType values, int64_t size,
                                                  int64_t offset) {
     DCHECK_GE(size, offset);
-    RETURN_NOT_OK(Extend(values, size, offset));
+    ARROW_RETURN_NOT_OK(Extend(values, size, offset));
     return builder()->length();
   }
 
@@ -84,7 +84,7 @@ class Converter {
   virtual Result<int64_t> ExtendMaskedAsMuchAsPossible(InputType values, InputType mask,
                                                        int64_t size, int64_t offset) {
     DCHECK_GE(size, offset);
-    RETURN_NOT_OK(ExtendMasked(values, mask, size, offset));
+    ARROW_RETURN_NOT_OK(ExtendMasked(values, mask, size, offset));
     return builder()->length();
   }
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -17,6 +17,7 @@ Testing/
 *.cpp
 pyarrow/*_api.h
 pyarrow/_generated_version.py
+cython_debug/
 
 # Bundled headers
 pyarrow/include

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2875,3 +2875,50 @@ def test_to_pandas_timezone():
     arr = pa.chunked_array([arr])
     s = arr.to_pandas()
     assert s.dt.tz is not None
+
+
+@pytest.mark.slow
+@pytest.mark.large_memory
+def test_array_from_pylist_data_overflow():
+    # Regression test for ARROW-12983
+    # Data buffer overflow - should result in chunked array
+    items = [b'a' * 4096] * (2 ** 19)
+    arr = pa.array(items, type=pa.string())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**19
+    assert len(arr.chunks) > 1
+
+    mask = np.zeros(2**19, bool)
+    arr = pa.array(items, mask=mask, type=pa.string())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**19
+    assert len(arr.chunks) > 1
+
+    arr = pa.array(items, type=pa.binary())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**19
+    assert len(arr.chunks) > 1
+
+
+@pytest.mark.slow
+@pytest.mark.large_memory
+def test_array_from_pylist_offset_overflow():
+    # Regression test for ARROW-12983
+    # Offset buffer overflow - should result in chunked array
+    # Note this doesn't apply to primitive arrays
+    items = [b'a'] * (2 ** 31)
+    arr = pa.array(items, type=pa.string())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**31
+    assert len(arr.chunks) > 1
+
+    mask = np.zeros(2**31, bool)
+    arr = pa.array(items, mask=mask, type=pa.string())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**31
+    assert len(arr.chunks) > 1
+
+    arr = pa.array(items, type=pa.binary())
+    assert isinstance(arr, pa.ChunkedArray)
+    assert len(arr) == 2**31
+    assert len(arr.chunks) > 1


### PR DESCRIPTION
This fixes an error from when this was last refactored/improved. Now, when building a chunked array, we properly build multiple chunks. 

This also fixes a case Weston pointed out, such that an array of 2**31 strings (which won't fit in the offsets buffer) will also get chunked instead of just saying OOM.

Unfortunately the test is rather slow so I've marked it such that it doesn't run in CI.

I've updated R but note that R never builds a chunked array hence there should be no effect.