### PR TITLE
ARROW-12975: [C++][Python] if_else kernel doesn't support upcasting 

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -552,6 +552,11 @@ struct IfElseFunction : ScalarFunction {
     using arrow::compute::detail::DispatchExactImpl;
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
 
+    // if 0th descriptor is null, replace with bool
+    if (values->at(0).type->id() == Type::NA) {
+      values->at(0).type = boolean();
+    }
+
     // if-else 0'th descriptor is bool, so skip it
     std::vector<ValueDescr> values_copy(values->begin() + 1, values->end());
     internal::EnsureDictionaryDecoded(&values_copy);

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -543,7 +543,37 @@ struct ResolveIfElseExec {
   }
 };
 
-void AddPrimitiveIfElseKernels(const std::shared_ptr<ScalarFunction>& scalar_function,
+struct IfElseFunction : ScalarFunction {
+  using ScalarFunction::ScalarFunction;
+
+  Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
+    RETURN_NOT_OK(CheckArity(*values));
+
+    // if-else 0'th descriptor is bool
+    std::vector<ValueDescr> left_right{(*values)[1], (*values)[2]};
+
+    using arrow::compute::detail::DispatchExactImpl;
+    if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
+
+    //    internal::EnsureDictionaryDecoded(values);
+
+    if (values->size() == 3) {
+      internal::ReplaceNullWithOtherType(&left_right);
+
+      if (auto type = internal::CommonNumeric(left_right)) {
+        internal::ReplaceTypes(type, &left_right);
+      }
+    }
+
+    if (auto kernel =
+            DispatchExactImpl(this, {(*values)[0], left_right[0], left_right[1]})) {
+      return kernel;
+    }
+    return arrow::compute::detail::NoMatchingKernel(this, *values);
+  }
+};
+
+void AddPrimitiveIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_function,
                                const std::vector<std::shared_ptr<DataType>>& types) {
   for (auto&& type : types) {
     auto exec = internal::GenerateTypeAgnosticPrimitive<ResolveIfElseExec>(*type);
@@ -572,7 +602,7 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
   scalar_kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
   scalar_kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
 
-  auto func = std::make_shared<ScalarFunction>("if_else", Arity::Ternary(), &if_else_doc);
+  auto func = std::make_shared<IfElseFunction>("if_else", Arity::Ternary(), &if_else_doc);
 
   AddPrimitiveIfElseKernels(func, NumericTypes());
   AddPrimitiveIfElseKernels(func, TemporalTypes());

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -561,7 +561,7 @@ struct IfElseFunction : ScalarFunction {
       internal::ReplaceTypes(type, &values_copy);
     }
 
-    std::copy(values_copy.begin(), values_copy.end(), values->begin() + 1);
+    std::move(values_copy.begin(), values_copy.end(), values->begin() + 1);
 
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -549,12 +549,11 @@ struct IfElseFunction : ScalarFunction {
   Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
     RETURN_NOT_OK(CheckArity(*values));
 
-    // if-else 0'th descriptor is bool, so skip it
-    std::vector<ValueDescr> values_copy(values->begin() + 1, values->end());
-
     using arrow::compute::detail::DispatchExactImpl;
     if (auto kernel = DispatchExactImpl(this, *values)) return kernel;
 
+    // if-else 0'th descriptor is bool, so skip it
+    std::vector<ValueDescr> values_copy(values->begin() + 1, values->end());
     internal::EnsureDictionaryDecoded(&values_copy);
     internal::ReplaceNullWithOtherType(&values_copy);
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -278,5 +278,33 @@ TEST_F(TestIfElseKernel, IfElseMultiType) {
                            ArrayFromJSON(float32(), "[1, 2, 3, 8]"));
 }
 
+TEST_F(TestIfElseKernel, IfElseDispatchBest) {
+  std::string name = "if_else";
+  CheckDispatchBest(name, {boolean(), int32(), int32()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), null()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), null(), int32()}, {boolean(), int32(), int32()});
+
+  CheckDispatchBest(name, {boolean(), int32(), int8()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), int16()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), int32()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), int64()}, {boolean(), int64(), int64()});
+
+  CheckDispatchBest(name, {boolean(), int32(), uint8()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), uint16()}, {boolean(), int32(), int32()});
+  CheckDispatchBest(name, {boolean(), int32(), uint32()}, {boolean(), int64(), int64()});
+  CheckDispatchBest(name, {boolean(), int32(), uint64()}, {boolean(), int64(), int64()});
+
+  CheckDispatchBest(name, {boolean(), uint8(), uint8()}, {boolean(), uint8(), uint8()});
+  CheckDispatchBest(name, {boolean(), uint8(), uint16()},
+                    {boolean(), uint16(), uint16()});
+
+  CheckDispatchBest(name, {boolean(), int32(), float32()},
+                    {boolean(), float32(), float32()});
+  CheckDispatchBest(name, {boolean(), float32(), int64()},
+                    {boolean(), float32(), float32()});
+  CheckDispatchBest(name, {boolean(), float64(), int32()},
+                    {boolean(), float64(), float64()});
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -271,5 +271,12 @@ TEST_F(TestIfElseKernel, IfElseNull) {
                     ArrayFromJSON(null(), "[null, null, null, null]"));
 }
 
+TEST_F(TestIfElseKernel, IfElseMultiType) {
+  CheckWithDifferentShapes(ArrayFromJSON(boolean(), "[true, true, true, false]"),
+                           ArrayFromJSON(int32(), "[1, 2, 3, 4]"),
+                           ArrayFromJSON(float32(), "[5, 6, 7, 8]"),
+                           ArrayFromJSON(float32(), "[1, 2, 3, 8]"));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -304,6 +304,8 @@ TEST_F(TestIfElseKernel, IfElseDispatchBest) {
                     {boolean(), float32(), float32()});
   CheckDispatchBest(name, {boolean(), float64(), int32()},
                     {boolean(), float64(), float64()});
+
+  CheckDispatchBest(name, {null(), uint8(), int8()}, {boolean(), int16(), int16()});
 }
 
 }  // namespace compute


### PR DESCRIPTION
Allowing if-else operation for following use cases
```python
>>> pc.if_else([True], [1], [3.5])
```