### PR TITLE
ARROW-12998: [C++] Add dataset->toolchain dependency

### DIFF
--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -53,6 +53,8 @@ add_arrow_lib(arrow_dataset
               ${ARROW_DATASET_SRCS}
               PRECOMPILED_HEADERS
               "$<$<COMPILE_LANGUAGE:CXX>:arrow/dataset/pch.h>"
+              DEPENDENCIES
+              toolchain
               PRIVATE_INCLUDES
               ${ARROW_DATASET_PRIVATE_INCLUDES}
               SHARED_LINK_LIBS


### PR DESCRIPTION
This is rather coarse-grained, but in principle if datasets needs any headers that are built as part of the build process or depends on headers that do, then this is the right thing (and it saves us from maintaining a separate target for datasets - though I could do that if preferred).