### PR TITLE
ARROW-12993: [Python] Avoid half-initialized FeatherReader object

### DIFF
--- a/python/pyarrow/_feather.pyx
+++ b/python/pyarrow/_feather.pyx
@@ -69,13 +69,9 @@ cdef class FeatherReader(_Weakrefable):
     cdef:
         shared_ptr[CFeatherReader] reader
 
-    def __cinit__(self):
-        pass
-
-    def open(self, source, c_bool use_memory_map=True):
+    def __cinit__(self, source, c_bool use_memory_map):
         cdef shared_ptr[CRandomAccessFile] reader
         get_reader(source, use_memory_map, &reader)
-
         with nogil:
             self.reader = GetResultValue(CFeatherReader.Open(reader))
 

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -236,8 +236,7 @@ def read_table(source, columns=None, memory_map=True):
     -------
     table : pyarrow.Table
     """
-    reader = _feather.FeatherReader()
-    reader.open(source, use_memory_map=memory_map)
+    reader = _feather.FeatherReader(source, use_memory_map=memory_map)
 
     if columns is None:
         return reader.read()


### PR DESCRIPTION
When trying to read an invalid Feather file, the `stackprinter` project
would crash when walking the stack and attempting to print detailed information
about captured local variables.

Specifically, the crash would occur when looking up the `version` attribute
on the half-initialized FeatherReader object.