### PR TITLE
ARROW-12827: [C++] Improve error message for dataset discovery failure

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -230,7 +230,8 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "': ", result.status().message());
+          "': ", result.status().message(), ". Is this a '", format_->type_name(),
+          "' file?");
     }
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -230,8 +230,7 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "': ", result.status().message(), ". Is this a '", format_->type_name(),
-          "' file?");
+          "': ", result.status().message());
     }
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -229,7 +229,7 @@ N/A
 }
 
 TEST_P(TestCsvFileFormat, InspectFailureWithRelevantError) {
-  TestInspectFailureWithRelevantError(StatusCode::Invalid);
+  TestInspectFailureWithRelevantError(StatusCode::Invalid, "CSV");
 }
 
 TEST_P(TestCsvFileFormat, Inspect) {

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -85,7 +85,7 @@ TEST_F(TestIpcFileFormat, WriteRecordBatchReaderCustomOptions) {
 }
 
 TEST_F(TestIpcFileFormat, InspectFailureWithRelevantError) {
-  TestInspectFailureWithRelevantError(StatusCode::Invalid);
+  TestInspectFailureWithRelevantError(StatusCode::Invalid, "IPC");
 }
 TEST_F(TestIpcFileFormat, Inspect) { TestInspect(); }
 TEST_F(TestIpcFileFormat, IsSupported) { TestIsSupported(); }

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -283,7 +283,7 @@ Result<bool> ParquetFileFormat::IsSupported(const FileSource& source) const {
     ARROW_UNUSED(e);
     return false;
   } catch (const ::parquet::ParquetException& e) {
-    return Status::IOError("Could not open Parquet input source '", source.path(),
+    return Status::IOError("Could not open parquet input source '", source.path(),
                            "': ", e.what());
   }
 
@@ -311,7 +311,7 @@ Result<std::unique_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   try {
     reader = parquet::ParquetFileReader::Open(std::move(input), std::move(properties));
   } catch (const ::parquet::ParquetException& e) {
-    return Status::IOError("Could not open Parquet input source '", source.path(),
+    return Status::IOError("Could not open parquet input source '", source.path(),
                            "': ", e.what());
   }
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -283,7 +283,7 @@ Result<bool> ParquetFileFormat::IsSupported(const FileSource& source) const {
     ARROW_UNUSED(e);
     return false;
   } catch (const ::parquet::ParquetException& e) {
-    return Status::IOError("Could not open parquet input source '", source.path(),
+    return Status::IOError("Could not open Parquet input source '", source.path(),
                            "': ", e.what());
   }
 
@@ -311,7 +311,7 @@ Result<std::unique_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   try {
     reader = parquet::ParquetFileReader::Open(std::move(input), std::move(properties));
   } catch (const ::parquet::ParquetException& e) {
-    return Status::IOError("Could not open parquet input source '", source.path(),
+    return Status::IOError("Could not open Parquet input source '", source.path(),
                            "': ", e.what());
   }
 

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -176,7 +176,7 @@ class TestParquetFileFormat : public FileFormatFixtureMixin<ParquetFormatHelper>
 };
 
 TEST_F(TestParquetFileFormat, InspectFailureWithRelevantError) {
-  TestInspectFailureWithRelevantError(StatusCode::IOError, "Parquet");
+  TestInspectFailureWithRelevantError(StatusCode::IOError, "parquet");
 }
 TEST_F(TestParquetFileFormat, Inspect) { TestInspect(); }
 

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -176,7 +176,7 @@ class TestParquetFileFormat : public FileFormatFixtureMixin<ParquetFormatHelper>
 };
 
 TEST_F(TestParquetFileFormat, InspectFailureWithRelevantError) {
-  TestInspectFailureWithRelevantError(StatusCode::IOError);
+  TestInspectFailureWithRelevantError(StatusCode::IOError, "Parquet");
 }
 TEST_F(TestParquetFileFormat, Inspect) { TestInspect(); }
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -442,7 +442,8 @@ class FileFormatFixtureMixin : public ::testing::Test {
         ::testing::AllOf(
             ::testing::HasSubstr(make_error_message("/herp/derp")),
             ::testing::HasSubstr(
-                "Error creating dataset. Could not read schema from '/herp/derp':")));
+                "Error creating dataset. Could not read schema from '/herp/derp':"),
+            ::testing::HasSubstr("Is this a '" + format_->type_name() + "' file?")));
   }
   void TestInspectFailureWithRelevantError(StatusCode code,
                                            const std::string format_name) {

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -442,8 +442,7 @@ class FileFormatFixtureMixin : public ::testing::Test {
         ::testing::AllOf(
             ::testing::HasSubstr(make_error_message("/herp/derp")),
             ::testing::HasSubstr(
-                "Error creating dataset. Could not read schema from '/herp/derp':"),
-            ::testing::HasSubstr("Is this a '" + format_->type_name() + "' file?")));
+                "Error creating dataset. Could not read schema from '/herp/derp':")));
   }
   void TestInspectFailureWithRelevantError(StatusCode code,
                                            const std::string format_name) {


### PR DESCRIPTION
This adds a bit more context to the error messages, though maybe this is a bit wordy?

```
>>> ds.dataset('dataset4', format="ipc")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lidavidm/Code/upstream/arrow-12827/python/pyarrow/dataset.py", line 655, in dataset
    return _filesystem_dataset(source, **kwargs)
  File "/home/lidavidm/Code/upstream/arrow-12827/python/pyarrow/dataset.py", line 410, in _filesystem_dataset
    return factory.finish(schema)
  File "pyarrow/_dataset.pyx", line 2262, in pyarrow._dataset.DatasetFactory.finish
    return Dataset.wrap(GetResultValue(result))
  File "pyarrow/error.pxi", line 141, in pyarrow.lib.pyarrow_internal_check_status
    return check_status(status)
  File "pyarrow/error.pxi", line 97, in pyarrow.lib.check_status
    raise ArrowInvalid(message)
pyarrow.lib.ArrowInvalid: Error creating dataset. Could not read schema from 'dataset4/foo.parquet': Could not open IPC input source 'dataset4/foo.parquet': File is too small: 9. Is this a 'ipc' file?
>>> ds.dataset('dataset5', format="parquet")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lidavidm/Code/upstream/arrow-12827/python/pyarrow/dataset.py", line 655, in dataset
    return _filesystem_dataset(source, **kwargs)
  File "/home/lidavidm/Code/upstream/arrow-12827/python/pyarrow/dataset.py", line 410, in _filesystem_dataset
    return factory.finish(schema)
  File "pyarrow/_dataset.pyx", line 2262, in pyarrow._dataset.DatasetFactory.finish
    return Dataset.wrap(GetResultValue(result))
  File "pyarrow/error.pxi", line 141, in pyarrow.lib.pyarrow_internal_check_status
    return check_status(status)
  File "pyarrow/error.pxi", line 112, in pyarrow.lib.check_status
    raise IOError(message)
OSError: Error creating dataset. Could not read schema from 'dataset5/foo.parquet': Could not open Parquet input source 'dataset5/foo.parquet': Invalid: Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file.. Is this a 'parquet' file?
```