### PR TITLE
ARROW-13016: [C++][Compute] Support Null type in Sum/Mean aggregation

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -961,6 +961,14 @@ class ScalarAggExecutor : public KernelExecutorImpl<ScalarAggregateKernel> {
     return outputs[0];
   }
 
+  Status CheckResultType(const Datum& out, const char* function_name) override {
+    if (strcmp(function_name, "sum") == 0 && output_descr_.type->Equals(null())) {
+      // Skip CheckResultType for sum of null type, as it may return various types
+      return Status::OK();
+    }
+    return KernelExecutorImpl::CheckResultType(out, function_name);
+  }
+
  private:
   Status Consume(const ExecBatch& batch) {
     // FIXME(ARROW-11840) don't merge *any* aggegates for every batch

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -961,14 +961,6 @@ class ScalarAggExecutor : public KernelExecutorImpl<ScalarAggregateKernel> {
     return outputs[0];
   }
 
-  Status CheckResultType(const Datum& out, const char* function_name) override {
-    if (strcmp(function_name, "sum") == 0 && output_descr_.type->Equals(null())) {
-      // Skip CheckResultType for sum of null type, as it may return various types
-      return Status::OK();
-    }
-    return KernelExecutorImpl::CheckResultType(out, function_name);
-  }
-
  private:
   Status Consume(const ExecBatch& batch) {
     // FIXME(ARROW-11840) don't merge *any* aggegates for every batch

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -259,7 +259,7 @@ Result<std::unique_ptr<KernelState>> SumInit(KernelContext* ctx,
 
 Result<std::unique_ptr<KernelState>> MeanInit(KernelContext* ctx,
                                               const KernelInitArgs& args) {
-  SumLikeInit<MeanImplDefault> visitor(
+  MeanKernelInit<MeanImplDefault> visitor(
       ctx, args.inputs[0].type,
       static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
@@ -929,6 +929,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddArrayScalarAggKernels(SumInit, SignedIntTypes(), int64(), func.get());
   AddArrayScalarAggKernels(SumInit, UnsignedIntTypes(), uint64(), func.get());
   AddArrayScalarAggKernels(SumInit, FloatingPointTypes(), float64(), func.get());
+  AddArrayScalarAggKernels(SumInit, {null()}, null(), func.get());
   // Add the SIMD variants for sum
 #if defined(ARROW_HAVE_RUNTIME_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX512)
   auto cpu_info = arrow::internal::CpuInfo::GetInstance();
@@ -955,6 +956,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddAggKernel(
       KernelSignature::Make({InputType(Type::DECIMAL256)}, OutputType(ScalarFirstType)),
       MeanInit, func.get(), SimdLevel::NONE);
+  AddArrayScalarAggKernels(MeanInit, {null()}, float64(), func.get());
   // Add the SIMD variants for mean
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
   if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX2)) {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -929,7 +929,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddArrayScalarAggKernels(SumInit, SignedIntTypes(), int64(), func.get());
   AddArrayScalarAggKernels(SumInit, UnsignedIntTypes(), uint64(), func.get());
   AddArrayScalarAggKernels(SumInit, FloatingPointTypes(), float64(), func.get());
-  AddArrayScalarAggKernels(SumInit, {null()}, null(), func.get());
+  AddArrayScalarAggKernels(SumInit, {null()}, int64(), func.get());
   // Add the SIMD variants for sum
 #if defined(ARROW_HAVE_RUNTIME_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX512)
   auto cpu_info = arrow::internal::CpuInfo::GetInstance();

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -121,6 +121,37 @@ struct SumImpl : public ScalarAggregator {
   ScalarAggregateOptions options;
 };
 
+struct NullSumImpl : public ScalarAggregator {
+  NullSumImpl(const ScalarAggregateOptions& options_) : options(options_) {}
+
+  Status Consume(KernelContext*, const ExecBatch& batch) override {
+    if (batch[0].is_scalar() || batch[0].array()->GetNullCount() > 0) {
+      // If the batch is a scalar or an array with elements, set is_empty to false
+      is_empty = false;
+    }
+    return Status::OK();
+  }
+
+  Status MergeFrom(KernelContext*, KernelState&& src) override {
+    const auto& other = checked_cast<const NullSumImpl&>(src);
+    this->is_empty &= other.is_empty;
+    return Status::OK();
+  }
+
+  Status Finalize(KernelContext*, Datum* out) override {
+    if ((options.skip_nulls || this->is_empty) && options.min_count == 0) {
+      // Return 0 if the remaining data is empty
+      out->value = std::make_shared<Int64Scalar>(0);
+    } else {
+      out->value = MakeNullScalar(null());
+    }
+    return Status::OK();
+  }
+
+  bool is_empty = true;
+  ScalarAggregateOptions options;
+};
+
 template <typename ArrowType, SimdLevel::type SimdLevel>
 struct MeanImpl : public SumImpl<ArrowType, SimdLevel> {
   using SumImpl<ArrowType, SimdLevel>::SumImpl;
@@ -164,6 +195,20 @@ struct MeanImpl : public SumImpl<ArrowType, SimdLevel> {
   using SumImpl<ArrowType, SimdLevel>::options;
 };
 
+struct NullMeanImpl : public NullSumImpl {
+  NullMeanImpl(const ScalarAggregateOptions& options_) : NullSumImpl(options_) {}
+
+  Status Finalize(KernelContext*, Datum* out) override {
+    if ((options.skip_nulls || this->is_empty) && options.min_count == 0) {
+      // Return 0 if the remaining data is empty
+      out->value = std::make_shared<DoubleScalar>(0);
+    } else {
+      out->value = MakeNullScalar(float64());
+    }
+    return Status::OK();
+  }
+};
+
 template <template <typename> class KernelClass>
 struct SumLikeInit {
   std::unique_ptr<KernelState> state;
@@ -200,9 +245,26 @@ struct SumLikeInit {
     return Status::OK();
   }
 
+  virtual Status Visit(const NullType&) {
+    state.reset(new NullSumImpl(options));
+    return Status::OK();
+  }
+
   Result<std::unique_ptr<KernelState>> Create() {
     RETURN_NOT_OK(VisitTypeInline(*type, this));
     return std::move(state);
+  }
+};
+
+template <template <typename> class KernelClass>
+struct MeanKernelInit : public SumLikeInit<KernelClass> {
+  MeanKernelInit(KernelContext* ctx, const std::shared_ptr<DataType>& type,
+                 const ScalarAggregateOptions& options)
+      : SumLikeInit<KernelClass>(ctx, type, options) {}
+
+  Status Visit(const NullType&) override {
+    this->state.reset(new NullMeanImpl(this->options));
+    return Status::OK();
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -122,7 +122,7 @@ struct SumImpl : public ScalarAggregator {
 };
 
 struct NullSumImpl : public ScalarAggregator {
-  NullSumImpl(const ScalarAggregateOptions& options_) : options(options_) {}
+  explicit NullSumImpl(const ScalarAggregateOptions& options_) : options(options_) {}
 
   Status Consume(KernelContext*, const ExecBatch& batch) override {
     if (batch[0].is_scalar() || batch[0].array()->GetNullCount() > 0) {
@@ -196,7 +196,7 @@ struct MeanImpl : public SumImpl<ArrowType, SimdLevel> {
 };
 
 struct NullMeanImpl : public NullSumImpl {
-  NullMeanImpl(const ScalarAggregateOptions& options_) : NullSumImpl(options_) {}
+  explicit NullMeanImpl(const ScalarAggregateOptions& options_) : NullSumImpl(options_) {}
 
   Status Finalize(KernelContext*, Datum* out) override {
     if ((options.skip_nulls || this->is_empty) && options.min_count == 0) {

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -591,9 +591,9 @@ TEST(TestDecimalSumKernel, ScalarAggregateOptions) {
   }
 }
 
-TEST(TestSumKernel, Null) {
+TEST(TestNullSumKernel, Basics) {
   auto ty = null();
-  Datum null_result = std::make_shared<NullScalar>();
+  Datum null_result = std::make_shared<Int64Scalar>();
   Datum zero_result = std::make_shared<Int64Scalar>(0);
 
   EXPECT_THAT(Sum(ScalarFromJSON(ty, "null")), ResultWith(null_result));
@@ -1380,7 +1380,7 @@ TEST(TestDecimalMeanKernel, ScalarAggregateOptions) {
   }
 }
 
-TEST(TestMeanKernel, Null) {
+TEST(TestNullMeanKernel, Basics) {
   auto ty = null();
   Datum null_result = std::make_shared<DoubleScalar>();
   Datum zero_result = std::make_shared<DoubleScalar>(0);

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -591,6 +591,32 @@ TEST(TestDecimalSumKernel, ScalarAggregateOptions) {
   }
 }
 
+TEST(TestSumKernel, Null) {
+  auto ty = null();
+  Datum null_result = std::make_shared<NullScalar>();
+  Datum zero_result = std::make_shared<Int64Scalar>(0);
+
+  EXPECT_THAT(Sum(ScalarFromJSON(ty, "null")), ResultWith(null_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[]")), ResultWith(null_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[null]")), ResultWith(null_result));
+  EXPECT_THAT(Sum(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"})),
+              ResultWith(null_result));
+
+  ScalarAggregateOptions options(/*skip_nulls=*/true, /*min_count=*/0);
+  EXPECT_THAT(Sum(ScalarFromJSON(ty, "null"), options), ResultWith(zero_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[null]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Sum(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"}), options),
+              ResultWith(zero_result));
+
+  options = ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0);
+  EXPECT_THAT(Sum(ScalarFromJSON(ty, "null"), options), ResultWith(null_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Sum(ArrayFromJSON(ty, "[null]"), options), ResultWith(null_result));
+  EXPECT_THAT(Sum(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"}), options),
+              ResultWith(null_result));
+}
+
 //
 // Product
 //
@@ -1352,6 +1378,32 @@ TEST(TestDecimalMeanKernel, ScalarAggregateOptions) {
     EXPECT_THAT(Mean(null, ScalarAggregateOptions(/*skip_nulls=*/false)),
                 ResultWith(null));
   }
+}
+
+TEST(TestMeanKernel, Null) {
+  auto ty = null();
+  Datum null_result = std::make_shared<DoubleScalar>();
+  Datum zero_result = std::make_shared<DoubleScalar>(0);
+
+  EXPECT_THAT(Mean(ScalarFromJSON(ty, "null")), ResultWith(null_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[]")), ResultWith(null_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[null]")), ResultWith(null_result));
+  EXPECT_THAT(Mean(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"})),
+              ResultWith(null_result));
+
+  ScalarAggregateOptions options(/*skip_nulls=*/true, /*min_count=*/0);
+  EXPECT_THAT(Mean(ScalarFromJSON(ty, "null"), options), ResultWith(zero_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[null]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Mean(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"}), options),
+              ResultWith(zero_result));
+
+  options = ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0);
+  EXPECT_THAT(Mean(ScalarFromJSON(ty, "null"), options), ResultWith(null_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[]"), options), ResultWith(zero_result));
+  EXPECT_THAT(Mean(ArrayFromJSON(ty, "[null]"), options), ResultWith(null_result));
+  EXPECT_THAT(Mean(ChunkedArrayFromJSON(ty, {"[null]", "[]", "[null, null]"}), options),
+              ResultWith(null_result));
 }
 
 //


### PR DESCRIPTION
The Sum/Mean of a Null type array is a Null type scalar.