### PR TITLE
ARROW-12996: Add bytes_read() to StreamingReader

### DIFF
--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -145,6 +145,7 @@ struct CSVBlock {
   std::shared_ptr<Buffer> buffer;
   int64_t block_index;
   bool is_final;
+  int64_t bytes_skipped;
   std::function<Status(int64_t)> consume_bytes;
 };
 
@@ -153,7 +154,7 @@ struct CSVBlock {
 
 template <>
 struct IterationTraits<csv::CSVBlock> {
-  static csv::CSVBlock End() { return csv::CSVBlock{{}, {}, {}, -1, true, {}}; }
+  static csv::CSVBlock End() { return csv::CSVBlock{{}, {}, {}, -1, true, 0, {}}; }
   static bool IsEnd(const csv::CSVBlock& val) { return val.block_index < 0; }
 };
 
@@ -222,16 +223,20 @@ class SerialBlockReader : public BlockReader {
     }
 
     bool is_final = (next_buffer == nullptr);
+    int64_t bytes_skipped = 0;
 
     if (skip_rows_) {
+      bytes_skipped += partial_->size();
+      auto orig_size = buffer_->size();
       RETURN_NOT_OK(
           chunker_->ProcessSkip(partial_, buffer_, is_final, &skip_rows_, &buffer_));
+      bytes_skipped += orig_size - buffer_->size();
       partial_ = SliceBuffer(buffer_, 0, 0);
       if (skip_rows_) {
         // Still have rows beyond this buffer to skip return empty block
         buffer_ = next_buffer;
         return TransformYield<CSVBlock>(CSVBlock{partial_, partial_, partial_,
-                                                 block_index_++, is_final,
+                                                 block_index_++, is_final, bytes_skipped,
                                                  [](int64_t) { return Status::OK(); }});
       }
     }
@@ -262,7 +267,7 @@ class SerialBlockReader : public BlockReader {
     };
 
     return TransformYield<CSVBlock>(CSVBlock{partial_, completion, buffer_,
-                                             block_index_++, is_final,
+                                             block_index_++, is_final, bytes_skipped,
                                              std::move(consume_bytes)});
   }
 };
@@ -294,10 +299,14 @@ class ThreadedBlockReader : public BlockReader {
 
     auto current_partial = std::move(partial_);
     auto current_buffer = std::move(buffer_);
+    int64_t bytes_skipped = 0;
 
     if (skip_rows_) {
+      auto orig_size = current_buffer->size();
+      bytes_skipped = current_partial->size();
       RETURN_NOT_OK(chunker_->ProcessSkip(current_partial, current_buffer, is_final,
                                           &skip_rows_, &current_buffer));
+      bytes_skipped += orig_size - current_buffer->size();
       current_partial = SliceBuffer(current_buffer, 0, 0);
       if (skip_rows_) {
         partial_ = std::move(current_buffer);
@@ -307,6 +316,7 @@ class ThreadedBlockReader : public BlockReader {
                                                  current_partial,
                                                  block_index_++,
                                                  is_final,
+                                                 bytes_skipped,
                                                  {}});
       }
     }
@@ -332,8 +342,8 @@ class ThreadedBlockReader : public BlockReader {
     partial_ = std::move(next_partial);
     buffer_ = std::move(next_buffer);
 
-    return TransformYield<CSVBlock>(
-        CSVBlock{current_partial, completion, whole, block_index_++, is_final, {}});
+    return TransformYield<CSVBlock>(CSVBlock{
+        current_partial, completion, whole, block_index_++, is_final, bytes_skipped, {}});
   }
 };
 
@@ -761,12 +771,13 @@ class SerialStreamingReader : public BaseStreamingReader,
 
     auto self = shared_from_this();
     // Read schema from first batch
-    return ReadNextAsync().Then([self](const std::shared_ptr<RecordBatch>& first_batch)
-                                    -> Result<std::shared_ptr<csv::StreamingReader>> {
-      self->pending_batch_ = first_batch;
-      DCHECK_NE(self->schema_, nullptr);
-      return self;
-    });
+    return ReadNextAsync(true).Then(
+        [self](const std::shared_ptr<RecordBatch>& first_batch)
+            -> Result<std::shared_ptr<csv::StreamingReader>> {
+          self->pending_batch_ = first_batch;
+          DCHECK_NE(self->schema_, nullptr);
+          return self;
+        });
   }
 
   Result<std::shared_ptr<RecordBatch>> DecodeBatchAndUpdateSchema() {
@@ -788,6 +799,7 @@ class SerialStreamingReader : public BaseStreamingReader,
       return block_generator_()
           .Then([self](const CSVBlock& maybe_block) -> Status {
             if (!IsIterationEnd(maybe_block)) {
+              self->bytes_parsed_ += maybe_block.bytes_skipped;
               self->last_block_index_ = maybe_block.block_index;
               auto maybe_parsed = self->ParseAndInsert(
                   maybe_block.partial, maybe_block.completion, maybe_block.buffer,
@@ -797,6 +809,7 @@ class SerialStreamingReader : public BaseStreamingReader,
                 self->eof_ = true;
                 return maybe_parsed.status();
               }
+              self->bytes_parsed_ += *maybe_parsed;
               RETURN_NOT_OK(maybe_block.consume_bytes(*maybe_parsed));
             } else {
               self->source_eof_ = true;
@@ -815,16 +828,46 @@ class SerialStreamingReader : public BaseStreamingReader,
   }
 
   Future<std::shared_ptr<RecordBatch>> ReadNextSkippingEmpty(
-      std::shared_ptr<SerialStreamingReader> self) {
-    return DoReadNext(self).Then([self](const std::shared_ptr<RecordBatch>& batch) {
-      if (batch != nullptr && batch->num_rows() == 0) {
-        return self->ReadNextSkippingEmpty(self);
-      }
-      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
-    });
+      std::shared_ptr<SerialStreamingReader> self, bool internal_read) {
+    return DoReadNext(self).Then(
+        [self, internal_read](const std::shared_ptr<RecordBatch>& batch) {
+          if (batch != nullptr && batch->num_rows() == 0) {
+            return self->ReadNextSkippingEmpty(self, internal_read);
+          }
+          if (!internal_read) {
+            self->bytes_decoded_ += self->bytes_parsed_;
+            self->bytes_parsed_ = 0;
+          }
+          return Future<std::shared_ptr<RecordBatch>>::MakeFinished(batch);
+        });
   }
 
   Future<std::shared_ptr<RecordBatch>> ReadNextAsync() override {
+    return ReadNextAsync(false);
+  };
+
+  int64_t bytes_read() const override { return bytes_decoded_; }
+
+ protected:
+  Future<> SetupReader(std::shared_ptr<SerialStreamingReader> self) {
+    return buffer_generator_().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
+      if (first_buffer == nullptr) {
+        return Status::Invalid("Empty CSV file");
+      }
+      auto own_first_buffer = first_buffer;
+      auto start = own_first_buffer->data();
+      RETURN_NOT_OK(self->ProcessHeader(own_first_buffer, &own_first_buffer));
+      self->bytes_decoded_ = own_first_buffer->data() - start;
+      RETURN_NOT_OK(self->MakeColumnDecoders());
+
+      self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
+          std::move(self->buffer_generator_), MakeChunker(self->parse_options_),
+          std::move(own_first_buffer), self->read_options_.skip_rows_after_names);
+      return Status::OK();
+    });
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextAsync(bool internal_read) {
     if (eof_) {
       return Future<std::shared_ptr<RecordBatch>>::MakeFinished(nullptr);
     }
@@ -835,38 +878,25 @@ class SerialStreamingReader : public BaseStreamingReader,
     auto self = shared_from_this();
     if (!block_generator_) {
       return SetupReader(self).Then(
-          [self]() -> Future<std::shared_ptr<RecordBatch>> {
-            return self->ReadNextSkippingEmpty(self);
+          [self, internal_read]() -> Future<std::shared_ptr<RecordBatch>> {
+            return self->ReadNextSkippingEmpty(self, internal_read);
           },
           [self](const Status& err) -> Result<std::shared_ptr<RecordBatch>> {
             self->eof_ = true;
             return err;
           });
     } else {
-      return self->ReadNextSkippingEmpty(self);
+      return self->ReadNextSkippingEmpty(self, internal_read);
     }
-  };
-
- protected:
-  Future<> SetupReader(std::shared_ptr<SerialStreamingReader> self) {
-    return buffer_generator_().Then([self](const std::shared_ptr<Buffer>& first_buffer) {
-      if (first_buffer == nullptr) {
-        return Status::Invalid("Empty CSV file");
-      }
-      auto own_first_buffer = first_buffer;
-      RETURN_NOT_OK(self->ProcessHeader(own_first_buffer, &own_first_buffer));
-      RETURN_NOT_OK(self->MakeColumnDecoders());
-
-      self->block_generator_ = SerialBlockReader::MakeAsyncIterator(
-          std::move(self->buffer_generator_), MakeChunker(self->parse_options_),
-          std::move(own_first_buffer), self->read_options_.skip_rows_after_names);
-      return Status::OK();
-    });
   }
 
   bool source_eof_ = false;
   int64_t last_block_index_ = 0;
   AsyncGenerator<CSVBlock> block_generator_;
+  // bytes of data parsed but not yet decoded
+  int64_t bytes_parsed_ = 0;
+  // bytes which have been decoded for caller
+  int64_t bytes_decoded_ = 0;
 };
 
 /////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -73,6 +73,17 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
 
   virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
 
+  /// - bytes skipped by `ReadOptions.skip_rows` will be counted as being read before
+  /// any records are returned.
+  /// - bytes read while parsing the header will be counted as being read before any
+  /// records are returned.
+  /// - bytes skipped by `ReadOptions.skip_rows_after_names` will be counted after the
+  /// first batch is returned.
+  ///
+  /// \return the number of bytes which have been read from the CSV stream and returned to
+  /// caller
+  virtual int64_t bytes_read() const = 0;
+
   /// Create a StreamingReader instance
   ///
   /// This involves some I/O as the first batch must be loaded during the creation process

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -73,15 +73,19 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
 
   virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
 
-  /// - bytes skipped by `ReadOptions.skip_rows` will be counted as being read before
-  /// any records are returned.
-  /// - bytes read while parsing the header will be counted as being read before any
-  /// records are returned.
-  /// - bytes skipped by `ReadOptions.skip_rows_after_names` will be counted after the
-  /// first batch is returned.
+  /// \brief Return the number of bytes which have been read and processed
   ///
-  /// \return the number of bytes which have been read from the CSV stream and returned to
-  /// caller
+  /// The returned number includes CSV bytes which the StreamingReader has
+  /// finished processing, but not bytes for which some processing (e.g.
+  /// CSV parsing or conversion to Arrow layout) is still ongoing.
+  ///
+  /// Furthermore, the following rules apply:
+  /// - bytes skipped by `ReadOptions.skip_rows` are counted as being read before
+  /// any records are returned.
+  /// - bytes read while parsing the header are counted as being read before any
+  /// records are returned.
+  /// - bytes skipped by `ReadOptions.skip_rows_after_names` are counted after the
+  /// first batch is returned.
   virtual int64_t bytes_read() const = 0;
 
   /// Create a StreamingReader instance


### PR DESCRIPTION
Add a bytes_read() to the StreamingReader interface so the progress of the stream can be determined easily and accurately by a user.