### PR TITLE
ARROW-13044: [Java] Change UnionVector and DenseUnionVector to extend AbstractContainerVector

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -85,9 +85,6 @@ import static org.apache.arrow.vector.types.UnionMode.Dense;
  * Source code generated using FreeMarker template ${.template_name}
  */
 public class DenseUnionVector extends AbstractContainerVector implements FieldVector {
-
-  private String name;
-  private BufferAllocator allocator;
   int valueCount;
 
   NonNullableStructVector internalStruct;
@@ -109,13 +106,12 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
   private byte[] typeMapFields = new byte[Byte.MAX_VALUE + 1];
 
   /**
-   * The next typd id to allocate.
+   * The next type id to allocate.
    */
   private byte nextTypeId = 0;
 
   private FieldReader reader;
 
-  private final CallBack callBack;
   private long typeBufferAllocationSizeInBytes;
   private long offsetBufferAllocationSizeInBytes;
 
@@ -135,8 +131,6 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
 
   public DenseUnionVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, callBack);
-    this.name = name;
-    this.allocator = allocator;
     this.fieldType = fieldType;
     this.internalStruct = new NonNullableStructVector(
         "internal",
@@ -146,7 +140,6 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
         AbstractStructVector.ConflictPolicy.CONFLICT_REPLACE,
         false);
     this.typeBuffer = allocator.getEmpty();
-    this.callBack = callBack;
     this.typeBufferAllocationSizeInBytes = BaseValueVector.INITIAL_VALUE_ALLOCATION * TYPE_WIDTH;
     this.offsetBuffer = allocator.getEmpty();
     this.offsetBufferAllocationSizeInBytes = BaseValueVector.INITIAL_VALUE_ALLOCATION * OFFSET_WIDTH;

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -85,9 +85,6 @@ import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
  * Source code generated using FreeMarker template ${.template_name}
  */
 public class UnionVector extends AbstractContainerVector implements FieldVector {
-
-  private String name;
-  private BufferAllocator allocator;
   int valueCount;
 
   NonNullableStructVector internalStruct;
@@ -102,7 +99,6 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
   private int singleType = 0;
   private ValueVector singleVector;
 
-  private final CallBack callBack;
   private int typeBufferAllocationSizeInBytes;
 
   private final FieldType fieldType;
@@ -125,8 +121,6 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
 
   public UnionVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, callBack);
-    this.name = name;
-    this.allocator = allocator;
     this.fieldType = fieldType;
     this.internalStruct = new NonNullableStructVector(
         "internal",
@@ -136,7 +130,6 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
         AbstractStructVector.ConflictPolicy.CONFLICT_REPLACE,
         false);
     this.typeBuffer = allocator.getEmpty();
-    this.callBack = callBack;
     this.typeBufferAllocationSizeInBytes = BaseValueVector.INITIAL_VALUE_ALLOCATION * TYPE_WIDTH;
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
@@ -77,7 +77,7 @@ public class TestDenseUnionVector {
       unionVector.allocateNew();
 
       // write some data
-      byte uint4TypeId = unionVector.registerNewTypeId(Field.nullable("uint4", MinorType.UINT4.getType()));
+      byte uint4TypeId = unionVector.registerNewTypeId(Field.nullable("", MinorType.UINT4.getType()));
       unionVector.setTypeId(0, uint4TypeId);
       unionVector.setSafe(0, uInt4Holder);
       unionVector.setTypeId(2, uint4TypeId);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
@@ -31,6 +31,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.VectorWithOrdinal;
 import org.apache.arrow.vector.holders.NullableBigIntHolder;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
@@ -76,7 +77,7 @@ public class TestDenseUnionVector {
       unionVector.allocateNew();
 
       // write some data
-      byte uint4TypeId = unionVector.registerNewTypeId(Field.nullable("", MinorType.UINT4.getType()));
+      byte uint4TypeId = unionVector.registerNewTypeId(Field.nullable("uint4", MinorType.UINT4.getType()));
       unionVector.setTypeId(0, uint4TypeId);
       unionVector.setSafe(0, uInt4Holder);
       unionVector.setTypeId(2, uint4TypeId);
@@ -346,6 +347,19 @@ public class TestDenseUnionVector {
     vector.initializeChildrenFromFields(children);
 
     assertEquals(vector.getField(), field);
+
+    // Union has 2 child vectors
+    assertEquals(vector.size(), 2);
+
+    // Check child field 0
+    VectorWithOrdinal intChild = vector.getChildVectorWithOrdinal("int");
+    assertEquals(intChild.ordinal, 0);
+    assertEquals(intChild.vector.getField(), children.get(0));
+
+    // Check child field 1
+    VectorWithOrdinal varcharChild = vector.getChildVectorWithOrdinal("varchar");
+    assertEquals(varcharChild.ordinal, 1);
+    assertEquals(varcharChild.vector.getField(), children.get(1));
   }
 
   @Test
@@ -406,8 +420,8 @@ public class TestDenseUnionVector {
   @Test
   public void testMultipleStructs() {
     FieldType type = new FieldType(true, ArrowType.Struct.INSTANCE, null, null);
-    try (StructVector structVector1 = new StructVector("struct", allocator, type, null);
-         StructVector structVector2 = new StructVector("struct", allocator, type, null);
+    try (StructVector structVector1 = new StructVector("struct1", allocator, type, null);
+         StructVector structVector2 = new StructVector("struct2", allocator, type, null);
          DenseUnionVector unionVector = DenseUnionVector.empty("union", allocator)) {
 
       // prepare sub vectors

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -31,6 +31,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.complex.VectorWithOrdinal;
 import org.apache.arrow.vector.complex.impl.UnionWriter;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
@@ -392,6 +393,19 @@ public class TestUnionVector {
     vector.initializeChildrenFromFields(children);
 
     assertTrue(vector.getField().equals(field));
+
+    // Union has 2 child vectors
+    assertEquals(vector.size(), 2);
+
+    // Check child field 0
+    VectorWithOrdinal intChild = vector.getChildVectorWithOrdinal("int");
+    assertEquals(intChild.ordinal, 0);
+    assertEquals(intChild.vector.getField(), children.get(0));
+
+    // Check child field 1
+    VectorWithOrdinal varcharChild = vector.getChildVectorWithOrdinal("varchar");
+    assertEquals(varcharChild.ordinal, 1);
+    assertEquals(varcharChild.vector.getField(), children.get(1));
   }
 
   @Test


### PR DESCRIPTION
Currently UnionVector and DenseUnionVector do not extend any base class, only implement the FieldVector interface. This change makes these vectors extend AbstractContainerVector, which is a subclass of BaseValueVector. This allows a the union vectors to be used in extension types as the underlying vector storage. 

The current naming of child fields in the union vector ignores the original name and generates a new name based on type (and typeid). This has been changed to respect the original Field name if given, and only if the name is empty it will generate a new name as before. Some current tests add child Fields with empty names, so this preserves the original behavior.

Included tests to verify the added methods from AbstractContainerVector.