### PR TITLE
ARROW-12709: [C++] Add binary_join_element_wise

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -63,14 +63,14 @@ SCALAR_ARITHMETIC_BINARY(Multiply, "multiply", "multiply_checked")
 SCALAR_ARITHMETIC_BINARY(Divide, "divide", "divide_checked")
 SCALAR_ARITHMETIC_BINARY(Power, "power", "power_checked")
 
-Result<Datum> ElementWiseMax(const std::vector<Datum>& args,
+Result<Datum> MaxElementWise(const std::vector<Datum>& args,
                              ElementWiseAggregateOptions options, ExecContext* ctx) {
-  return CallFunction("element_wise_max", args, &options, ctx);
+  return CallFunction("max_element_wise", args, &options, ctx);
 }
 
-Result<Datum> ElementWiseMin(const std::vector<Datum>& args,
+Result<Datum> MinElementWise(const std::vector<Datum>& args,
                              ElementWiseAggregateOptions options, ExecContext* ctx) {
-  return CallFunction("element_wise_min", args, &options, ctx);
+  return CallFunction("min_element_wise", args, &options, ctx);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -306,7 +306,7 @@ Result<Datum> Power(const Datum& left, const Datum& right,
 /// \param[in] ctx the function execution context, optional
 /// \return the element-wise maximum
 ARROW_EXPORT
-Result<Datum> ElementWiseMax(
+Result<Datum> MaxElementWise(
     const std::vector<Datum>& args,
     ElementWiseAggregateOptions options = ElementWiseAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
@@ -319,7 +319,7 @@ Result<Datum> ElementWiseMax(
 /// \param[in] ctx the function execution context, optional
 /// \return the element-wise minimum
 ARROW_EXPORT
-Result<Datum> ElementWiseMin(
+Result<Datum> MinElementWise(
     const std::vector<Datum>& args,
     ElementWiseAggregateOptions options = ElementWiseAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -48,6 +48,25 @@ struct ARROW_EXPORT ElementWiseAggregateOptions : public FunctionOptions {
   bool skip_nulls;
 };
 
+/// Options for var_args_join.
+struct ARROW_EXPORT JoinOptions : public FunctionOptions {
+  /// How to handle null values. (A null separator always results in a null output.)
+  enum NullHandlingBehavior {
+    /// A null in any input results in a null in the output.
+    EMIT_NULL,
+    /// Nulls in inputs are skipped.
+    SKIP,
+    /// Nulls in inputs are replaced with the replacement string.
+    REPLACE,
+  };
+  explicit JoinOptions(NullHandlingBehavior null_handling = EMIT_NULL,
+                       std::string null_replacement = "")
+      : null_handling(null_handling), null_replacement(std::move(null_replacement)) {}
+  static JoinOptions Defaults() { return JoinOptions(); }
+  NullHandlingBehavior null_handling;
+  std::string null_replacement;
+};
+
 struct ARROW_EXPORT MatchSubstringOptions : public FunctionOptions {
   explicit MatchSubstringOptions(std::string pattern, bool ignore_case = false)
       : pattern(std::move(pattern)), ignore_case(ignore_case) {}

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -467,14 +467,14 @@ const FunctionDoc less_equal_doc{
     ("A null on either side emits a null comparison result."),
     {"x", "y"}};
 
-const FunctionDoc element_wise_min_doc{
+const FunctionDoc min_element_wise_doc{
     "Find the element-wise minimum value",
     ("Nulls will be ignored (default) or propagated. "
      "NaN will be taken over null, but not over any valid float."),
     {"*args"},
     "ElementWiseAggregateOptions"};
 
-const FunctionDoc element_wise_max_doc{
+const FunctionDoc max_element_wise_doc{
     "Find the element-wise maximum value",
     ("Nulls will be ignored (default) or propagated. "
      "NaN will be taken over null, but not over any valid float."),
@@ -501,13 +501,13 @@ void RegisterScalarComparison(FunctionRegistry* registry) {
   // ----------------------------------------------------------------------
   // Variadic element-wise functions
 
-  auto element_wise_min =
-      MakeScalarMinMax<Minimum>("element_wise_min", &element_wise_min_doc);
-  DCHECK_OK(registry->AddFunction(std::move(element_wise_min)));
+  auto min_element_wise =
+      MakeScalarMinMax<Minimum>("min_element_wise", &min_element_wise_doc);
+  DCHECK_OK(registry->AddFunction(std::move(min_element_wise)));
 
-  auto element_wise_max =
-      MakeScalarMinMax<Maximum>("element_wise_max", &element_wise_max_doc);
-  DCHECK_OK(registry->AddFunction(std::move(element_wise_max)));
+  auto max_element_wise =
+      MakeScalarMinMax<Maximum>("max_element_wise", &max_element_wise_doc);
+  DCHECK_OK(registry->AddFunction(std::move(max_element_wise)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -729,90 +729,90 @@ TYPED_TEST_SUITE(TestVarArgsCompareNumeric, NumericBasedTypes);
 TYPED_TEST_SUITE(TestVarArgsCompareFloating, RealArrowTypes);
 TYPED_TEST_SUITE(TestVarArgsCompareParametricTemporal, ParametricTemporalTypes);
 
-TYPED_TEST(TestVarArgsCompareNumeric, ElementWiseMin) {
-  this->AssertNullScalar(ElementWiseMin, {});
-  this->AssertNullScalar(ElementWiseMin, {this->scalar("null"), this->scalar("null")});
+TYPED_TEST(TestVarArgsCompareNumeric, MinElementWise) {
+  this->AssertNullScalar(MinElementWise, {});
+  this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(ElementWiseMin, this->scalar("0"), {this->scalar("0")});
-  this->Assert(ElementWiseMin, this->scalar("0"),
+  this->Assert(MinElementWise, this->scalar("0"), {this->scalar("0")});
+  this->Assert(MinElementWise, this->scalar("0"),
                {this->scalar("2"), this->scalar("0"), this->scalar("1")});
   this->Assert(
-      ElementWiseMin, this->scalar("0"),
+      MinElementWise, this->scalar("0"),
       {this->scalar("2"), this->scalar("0"), this->scalar("1"), this->scalar("null")});
-  this->Assert(ElementWiseMin, this->scalar("1"),
+  this->Assert(MinElementWise, this->scalar("1"),
                {this->scalar("null"), this->scalar("null"), this->scalar("1"),
                 this->scalar("null")});
 
-  this->Assert(ElementWiseMin, (this->array("[]")), {this->array("[]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 3, null]"),
+  this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
+  this->Assert(MinElementWise, this->array("[1, 2, 3, null]"),
                {this->array("[1, 2, 3, null]")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, 2, 3, 4]"), this->scalar("2")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2"), this->scalar("4")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, 2, 2, 2]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, null, 2, 2]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->array("[2, 2, 2, 2]")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 2, null, 6]"),
+  this->Assert(MinElementWise, this->array("[1, 2, null, 6]"),
                {this->array("[1, 2, null, null]"), this->array("[4, null, null, 6]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, null, 6]"),
+  this->Assert(MinElementWise, this->array("[1, 2, null, 6]"),
                {this->array("[4, null, null, 6]"), this->array("[1, 2, null, null]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 3, 4]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 3, 4]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 3, 4]"),
                {this->array("[null, null, null, null]"), this->array("[1, 2, 3, 4]")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 1, 1, 1]"),
+  this->Assert(MinElementWise, this->array("[1, 1, 1, 1]"),
                {this->scalar("1"), this->array("[1, 2, 3, 4]")});
-  this->Assert(ElementWiseMin, this->array("[1, 1, 1, 1]"),
+  this->Assert(MinElementWise, this->array("[1, 1, 1, 1]"),
                {this->scalar("1"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMin, this->array("[1, 1, 1, 1]"),
+  this->Assert(MinElementWise, this->array("[1, 1, 1, 1]"),
                {this->scalar("null"), this->array("[1, 1, 1, 1]")});
-  this->Assert(ElementWiseMin, this->array("[null, null, null, null]"),
+  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[null, null, null, null]")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(ElementWiseMin, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(ElementWiseMin, {this->scalar("0"), this->scalar("null")});
+  this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
+  this->AssertNullScalar(MinElementWise, {this->scalar("0"), this->scalar("null")});
 
-  this->Assert(ElementWiseMin, this->array("[1, null, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, null, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2"), this->scalar("4")});
-  this->Assert(ElementWiseMin, this->array("[null, null, null, null]"),
+  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
-  this->Assert(ElementWiseMin, this->array("[1, null, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, null, 2, 2]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, null, 2, 2]")});
 
-  this->Assert(ElementWiseMin, this->array("[null, null, null, null]"),
+  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->scalar("1"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMin, this->array("[null, null, null, null]"),
+  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[1, 1, 1, 1]")});
 }
 
-TYPED_TEST(TestVarArgsCompareFloating, ElementWiseMin) {
+TYPED_TEST(TestVarArgsCompareFloating, MinElementWise) {
   auto Check = [this](const std::string& expected,
                       const std::vector<std::string>& inputs) {
     std::vector<Datum> args;
     for (const auto& input : inputs) {
       args.emplace_back(this->scalar(input));
     }
-    this->Assert(ElementWiseMin, this->scalar(expected), args);
+    this->Assert(MinElementWise, this->scalar(expected), args);
 
     args.clear();
     for (const auto& input : inputs) {
       args.emplace_back(this->array("[" + input + "]"));
     }
-    this->Assert(ElementWiseMin, this->array("[" + expected + "]"), args);
+    this->Assert(MinElementWise, this->array("[" + expected + "]"), args);
   };
   Check("-0.0", {"0.0", "-0.0"});
   Check("-0.0", {"1.0", "-0.0", "0.0"});
@@ -828,111 +828,111 @@ TYPED_TEST(TestVarArgsCompareFloating, ElementWiseMin) {
   Check("-Inf", {"0", "-Inf"});
 }
 
-TYPED_TEST(TestVarArgsCompareParametricTemporal, ElementWiseMin) {
+TYPED_TEST(TestVarArgsCompareParametricTemporal, MinElementWise) {
   // Temporal kernel is implemented with numeric kernel underneath
-  this->AssertNullScalar(ElementWiseMin, {});
-  this->AssertNullScalar(ElementWiseMin, {this->scalar("null"), this->scalar("null")});
+  this->AssertNullScalar(MinElementWise, {});
+  this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(ElementWiseMin, this->scalar("0"), {this->scalar("0")});
-  this->Assert(ElementWiseMin, this->scalar("0"), {this->scalar("2"), this->scalar("0")});
-  this->Assert(ElementWiseMin, this->scalar("0"),
+  this->Assert(MinElementWise, this->scalar("0"), {this->scalar("0")});
+  this->Assert(MinElementWise, this->scalar("0"), {this->scalar("2"), this->scalar("0")});
+  this->Assert(MinElementWise, this->scalar("0"),
                {this->scalar("0"), this->scalar("null")});
 
-  this->Assert(ElementWiseMin, (this->array("[]")), {this->array("[]")});
-  this->Assert(ElementWiseMin, this->array("[1, 2, 3, null]"),
+  this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
+  this->Assert(MinElementWise, this->array("[1, 2, 3, null]"),
                {this->array("[1, 2, 3, null]")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 2, 2, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 2, 2]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
 
-  this->Assert(ElementWiseMin, this->array("[1, 2, 3, 2]"),
+  this->Assert(MinElementWise, this->array("[1, 2, 3, 2]"),
                {this->array("[1, null, 3, 4]"), this->array("[2, 2, null, 2]")});
 }
 
-TYPED_TEST(TestVarArgsCompareNumeric, ElementWiseMax) {
-  this->AssertNullScalar(ElementWiseMax, {});
-  this->AssertNullScalar(ElementWiseMax, {this->scalar("null"), this->scalar("null")});
+TYPED_TEST(TestVarArgsCompareNumeric, MaxElementWise) {
+  this->AssertNullScalar(MaxElementWise, {});
+  this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(ElementWiseMax, this->scalar("0"), {this->scalar("0")});
-  this->Assert(ElementWiseMax, this->scalar("2"),
+  this->Assert(MaxElementWise, this->scalar("0"), {this->scalar("0")});
+  this->Assert(MaxElementWise, this->scalar("2"),
                {this->scalar("2"), this->scalar("0"), this->scalar("1")});
   this->Assert(
-      ElementWiseMax, this->scalar("2"),
+      MaxElementWise, this->scalar("2"),
       {this->scalar("2"), this->scalar("0"), this->scalar("1"), this->scalar("null")});
-  this->Assert(ElementWiseMax, this->scalar("1"),
+  this->Assert(MaxElementWise, this->scalar("1"),
                {this->scalar("null"), this->scalar("null"), this->scalar("1"),
                 this->scalar("null")});
 
-  this->Assert(ElementWiseMax, (this->array("[]")), {this->array("[]")});
-  this->Assert(ElementWiseMax, this->array("[1, 2, 3, null]"),
+  this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
+  this->Assert(MaxElementWise, this->array("[1, 2, 3, null]"),
                {this->array("[1, 2, 3, null]")});
 
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->scalar("2")});
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2")});
-  this->Assert(ElementWiseMax, this->array("[4, 4, 4, 4]"),
+  this->Assert(MaxElementWise, this->array("[4, 4, 4, 4]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2"), this->scalar("4")});
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
 
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, 2, 2, 2]")});
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, null, 2, 2]")});
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, null, 3, 4]"), this->array("[2, 2, 2, 2]")});
 
-  this->Assert(ElementWiseMax, this->array("[4, 2, null, 6]"),
+  this->Assert(MaxElementWise, this->array("[4, 2, null, 6]"),
                {this->array("[1, 2, null, null]"), this->array("[4, null, null, 6]")});
-  this->Assert(ElementWiseMax, this->array("[4, 2, null, 6]"),
+  this->Assert(MaxElementWise, this->array("[4, 2, null, 6]"),
                {this->array("[4, null, null, 6]"), this->array("[1, 2, null, null]")});
-  this->Assert(ElementWiseMax, this->array("[1, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[1, 2, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMax, this->array("[1, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[1, 2, 3, 4]"),
                {this->array("[null, null, null, null]"), this->array("[1, 2, 3, 4]")});
 
-  this->Assert(ElementWiseMax, this->array("[1, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[1, 2, 3, 4]"),
                {this->scalar("1"), this->array("[1, 2, 3, 4]")});
-  this->Assert(ElementWiseMax, this->array("[1, 1, 1, 1]"),
+  this->Assert(MaxElementWise, this->array("[1, 1, 1, 1]"),
                {this->scalar("1"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMax, this->array("[1, 1, 1, 1]"),
+  this->Assert(MaxElementWise, this->array("[1, 1, 1, 1]"),
                {this->scalar("null"), this->array("[1, 1, 1, 1]")});
-  this->Assert(ElementWiseMax, this->array("[null, null, null, null]"),
+  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[null, null, null, null]")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(ElementWiseMax, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(ElementWiseMax, {this->scalar("0"), this->scalar("null")});
+  this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
+  this->AssertNullScalar(MaxElementWise, {this->scalar("0"), this->scalar("null")});
 
-  this->Assert(ElementWiseMax, this->array("[4, null, 4, 4]"),
+  this->Assert(MaxElementWise, this->array("[4, null, 4, 4]"),
                {this->array("[1, null, 3, 4]"), this->scalar("2"), this->scalar("4")});
-  this->Assert(ElementWiseMax, this->array("[null, null, null, null]"),
+  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
-  this->Assert(ElementWiseMax, this->array("[2, null, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, null, 3, 4]"),
                {this->array("[1, 2, 3, 4]"), this->array("[2, null, 2, 2]")});
 
-  this->Assert(ElementWiseMax, this->array("[null, null, null, null]"),
+  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->scalar("1"), this->array("[null, null, null, null]")});
-  this->Assert(ElementWiseMax, this->array("[null, null, null, null]"),
+  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[1, 1, 1, 1]")});
 }
 
-TYPED_TEST(TestVarArgsCompareFloating, ElementWiseMax) {
+TYPED_TEST(TestVarArgsCompareFloating, MaxElementWise) {
   auto Check = [this](const std::string& expected,
                       const std::vector<std::string>& inputs) {
     std::vector<Datum> args;
     for (const auto& input : inputs) {
       args.emplace_back(this->scalar(input));
     }
-    this->Assert(ElementWiseMax, this->scalar(expected), args);
+    this->Assert(MaxElementWise, this->scalar(expected), args);
 
     args.clear();
     for (const auto& input : inputs) {
       args.emplace_back(this->array("[" + input + "]"));
     }
-    this->Assert(ElementWiseMax, this->array("[" + expected + "]"), args);
+    this->Assert(MaxElementWise, this->array("[" + expected + "]"), args);
   };
   Check("0.0", {"0.0", "-0.0"});
   Check("1.0", {"1.0", "-0.0", "0.0"});
@@ -948,34 +948,34 @@ TYPED_TEST(TestVarArgsCompareFloating, ElementWiseMax) {
   Check("0", {"0", "-Inf"});
 }
 
-TYPED_TEST(TestVarArgsCompareParametricTemporal, ElementWiseMax) {
+TYPED_TEST(TestVarArgsCompareParametricTemporal, MaxElementWise) {
   // Temporal kernel is implemented with numeric kernel underneath
-  this->AssertNullScalar(ElementWiseMax, {});
-  this->AssertNullScalar(ElementWiseMax, {this->scalar("null"), this->scalar("null")});
+  this->AssertNullScalar(MaxElementWise, {});
+  this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(ElementWiseMax, this->scalar("0"), {this->scalar("0")});
-  this->Assert(ElementWiseMax, this->scalar("2"), {this->scalar("2"), this->scalar("0")});
-  this->Assert(ElementWiseMax, this->scalar("0"),
+  this->Assert(MaxElementWise, this->scalar("0"), {this->scalar("0")});
+  this->Assert(MaxElementWise, this->scalar("2"), {this->scalar("2"), this->scalar("0")});
+  this->Assert(MaxElementWise, this->scalar("0"),
                {this->scalar("0"), this->scalar("null")});
 
-  this->Assert(ElementWiseMax, (this->array("[]")), {this->array("[]")});
-  this->Assert(ElementWiseMax, this->array("[1, 2, 3, null]"),
+  this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
+  this->Assert(MaxElementWise, this->array("[1, 2, 3, null]"),
                {this->array("[1, 2, 3, null]")});
 
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, null, 3, 4]"), this->scalar("null"), this->scalar("2")});
 
-  this->Assert(ElementWiseMax, this->array("[2, 2, 3, 4]"),
+  this->Assert(MaxElementWise, this->array("[2, 2, 3, 4]"),
                {this->array("[1, null, 3, 4]"), this->array("[2, 2, null, 2]")});
 }
 
-TEST(TestElementWiseMaxElementWiseMin, CommonTimestamp) {
+TEST(TestMaxElementWiseMinElementWise, CommonTimestamp) {
   {
     auto t1 = std::make_shared<TimestampType>(TimeUnit::SECOND);
     auto t2 = std::make_shared<TimestampType>(TimeUnit::MILLI);
     auto expected = MakeScalar(t2, 1000).ValueOrDie();
     ASSERT_OK_AND_ASSIGN(auto actual,
-                         ElementWiseMin({Datum(MakeScalar(t1, 1).ValueOrDie()),
+                         MinElementWise({Datum(MakeScalar(t1, 1).ValueOrDie()),
                                          Datum(MakeScalar(t2, 12000).ValueOrDie())}));
     AssertScalarsEqual(*expected, *actual.scalar(), /*verbose=*/true);
   }
@@ -984,7 +984,7 @@ TEST(TestElementWiseMaxElementWiseMin, CommonTimestamp) {
     auto t2 = std::make_shared<TimestampType>(TimeUnit::SECOND);
     auto expected = MakeScalar(t2, 86401).ValueOrDie();
     ASSERT_OK_AND_ASSIGN(auto actual,
-                         ElementWiseMax({Datum(MakeScalar(t1, 1).ValueOrDie()),
+                         MaxElementWise({Datum(MakeScalar(t1, 1).ValueOrDie()),
                                          Datum(MakeScalar(t2, 86401).ValueOrDie())}));
     AssertScalarsEqual(*expected, *actual.scalar(), /*verbose=*/true);
   }
@@ -994,7 +994,7 @@ TEST(TestElementWiseMaxElementWiseMin, CommonTimestamp) {
     auto t3 = std::make_shared<TimestampType>(TimeUnit::SECOND);
     auto expected = MakeScalar(t3, 86400).ValueOrDie();
     ASSERT_OK_AND_ASSIGN(
-        auto actual, ElementWiseMin({Datum(MakeScalar(t1, 1).ValueOrDie()),
+        auto actual, MinElementWise({Datum(MakeScalar(t1, 1).ValueOrDie()),
                                      Datum(MakeScalar(t2, 2 * 86400000).ValueOrDie())}));
     AssertScalarsEqual(*expected, *actual.scalar(), /*verbose=*/true);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -3408,6 +3408,7 @@ struct BinaryJoinElementWise {
       buf = std::copy(s.begin(), s.end(), buf);
     }
     output->is_valid = true;
+    DCHECK_EQ(final_size, buf - output->value->mutable_data());
     return Status::OK();
   }
 
@@ -3492,6 +3493,8 @@ struct BinaryJoinElementWise {
     *out = *string_array->data();
     out->mutable_array()->type = batch[0].type();
     DCHECK_EQ(batch.length, out->array()->length);
+    DCHECK_EQ(final_size,
+              checked_cast<const ArrayType&>(*string_array).total_values_length());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -174,7 +174,7 @@ static void BinaryJoinElementWise(benchmark::State& state,
   // Unfortunately benchmark is not 1:1 with BinaryJoin since BinaryJoin can join a
   // varying number of inputs per output
   const int64_t n_strings = 1000;
-  const int64_t n_lists = 10;
+  const int64_t n_lists = state.range(0);
   const double null_probability = 0.02;
 
   random::RandomArrayGenerator rng(kSeed);
@@ -234,8 +234,8 @@ BENCHMARK(TrimManyUtf8);
 
 BENCHMARK(BinaryJoinArrayScalar);
 BENCHMARK(BinaryJoinArrayArray);
-BENCHMARK(BinaryJoinElementWiseArrayScalar);
-BENCHMARK(BinaryJoinElementWiseArrayArray);
+BENCHMARK(BinaryJoinElementWiseArrayScalar)->RangeMultiplier(8)->Range(2, 128);
+BENCHMARK(BinaryJoinElementWiseArrayArray)->RangeMultiplier(8)->Range(2, 128);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -173,8 +173,8 @@ static void BinaryJoinElementWise(benchmark::State& state,
                                   SeparatorFactory make_separator) {
   // Unfortunately benchmark is not 1:1 with BinaryJoin since BinaryJoin can join a
   // varying number of inputs per output
-  const int64_t n_strings = 65536;
-  const int64_t n_lists = state.range(0);
+  const int64_t n_rows = 10000;
+  const int64_t n_cols = state.range(0);
   const double null_probability = 0.02;
 
   random::RandomArrayGenerator rng(kSeed);
@@ -182,14 +182,13 @@ static void BinaryJoinElementWise(benchmark::State& state,
   DatumVector args;
   ArrayVector strings;
   int64_t total_values_length = 0;
-  for (int i = 0; i < n_lists; i++) {
-    auto arr =
-        rng.String(n_strings, /*min_length=*/5, /*max_length=*/20, null_probability);
+  for (int i = 0; i < n_cols; i++) {
+    auto arr = rng.String(n_rows, /*min_length=*/5, /*max_length=*/20, null_probability);
     strings.push_back(arr);
     args.emplace_back(arr);
     total_values_length += checked_cast<const StringArray&>(*arr).total_values_length();
   }
-  auto separator = make_separator(n_strings, null_probability);
+  auto separator = make_separator(n_rows, null_probability);
   args.emplace_back(separator);
 
   for (auto _ : state) {

--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -173,7 +173,7 @@ static void BinaryJoinElementWise(benchmark::State& state,
                                   SeparatorFactory make_separator) {
   // Unfortunately benchmark is not 1:1 with BinaryJoin since BinaryJoin can join a
   // varying number of inputs per output
-  const int64_t n_strings = 1000;
+  const int64_t n_strings = 65536;
   const int64_t n_lists = state.range(0);
   const double null_probability = 0.02;
 

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -249,23 +249,25 @@ TYPED_TEST(TestBinaryKernels, CountSubstringIgnoreCase) {
 }
 #endif
 
-TYPED_TEST(TestBinaryKernels, VarArgsJoin) {
+TYPED_TEST(TestBinaryKernels, BinaryJoinElementWise) {
   const auto ty = this->type();
   JoinOptions options;
   JoinOptions options_skip(JoinOptions::SKIP);
   JoinOptions options_replace(JoinOptions::REPLACE, "X");
   // Scalar args, Scalar separator
-  this->CheckVarArgsScalar("var_args_join", R"([null])", ty, R"(null)", &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["-"])", ty, R"("")", &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", "-"])", ty, R"("a")", &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", "b", "-"])", ty, R"("a-b")",
+  this->CheckVarArgsScalar("binary_join_element_wise", R"([null])", ty, R"(null)",
                            &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", "b", null])", ty, R"(null)",
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["-"])", ty, R"("")", &options);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", "-"])", ty, R"("a")",
                            &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "-"])", ty, R"(null)",
-                           &options);
-  this->CheckVarArgsScalar("var_args_join", R"(["foo", "bar", "baz", "++"])", ty,
-                           R"("foo++bar++baz")", &options);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", "b", "-"])", ty,
+                           R"("a-b")", &options);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", "b", null])", ty,
+                           R"(null)", &options);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", null, "-"])", ty,
+                           R"(null)", &options);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["foo", "bar", "baz", "++"])",
+                           ty, R"("foo++bar++baz")", &options);
 
   // Scalar args, Array separator
   const auto sep = ArrayFromJSON(ty, R"([null, "-", "--"])");
@@ -273,14 +275,15 @@ TYPED_TEST(TestBinaryKernels, VarArgsJoin) {
   const auto scalar2 = ScalarFromJSON(ty, R"("bar")");
   const auto scalar3 = ScalarFromJSON(ty, R"("")");
   const auto scalar_null = ScalarFromJSON(ty, R"(null)");
-  this->CheckVarArgs("var_args_join", {sep}, ty, R"([null, "", ""])", &options);
-  this->CheckVarArgs("var_args_join", {scalar1, sep}, ty, R"([null, "foo", "foo"])",
+  this->CheckVarArgs("binary_join_element_wise", {sep}, ty, R"([null, "", ""])",
                      &options);
-  this->CheckVarArgs("var_args_join", {scalar1, scalar2, sep}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {scalar1, sep}, ty,
+                     R"([null, "foo", "foo"])", &options);
+  this->CheckVarArgs("binary_join_element_wise", {scalar1, scalar2, sep}, ty,
                      R"([null, "foo-bar", "foo--bar"])", &options);
-  this->CheckVarArgs("var_args_join", {scalar1, scalar_null, sep}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {scalar1, scalar_null, sep}, ty,
                      R"([null, null, null])", &options);
-  this->CheckVarArgs("var_args_join", {scalar1, scalar2, scalar3, sep}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {scalar1, scalar2, scalar3, sep}, ty,
                      R"([null, "foo-bar-", "foo--bar--"])", &options);
 
   // Array args, Scalar separator
@@ -289,60 +292,60 @@ TYPED_TEST(TestBinaryKernels, VarArgsJoin) {
   const auto arr1 = ArrayFromJSON(ty, R"([null, "a", "bb", "ccc"])");
   const auto arr2 = ArrayFromJSON(ty, R"(["d", null, "e", ""])");
   const auto arr3 = ArrayFromJSON(ty, R"(["gg", null, "h", "iii"])");
-  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, scalar_null}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, arr3, scalar_null}, ty,
                      R"([null, null, null, null])", &options);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep1}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, arr3, sep1}, ty,
                      R"([null, null, "bb-e-h", "ccc--iii"])", &options);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep2}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, arr3, sep2}, ty,
                      R"([null, null, "bb--e--h", "ccc----iii"])", &options);
 
   // Array args, Array separator
   const auto sep3 = ArrayFromJSON(ty, R"(["-", "--", null, "---"])");
-  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep3}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, arr3, sep3}, ty,
                      R"([null, null, null, "ccc------iii"])", &options);
 
   // Mixed
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep3}, ty,
                      R"([null, null, null, "ccc------bar"])", &options);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, sep3}, ty,
                      R"([null, null, null, null])", &options);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep1}, ty,
                      R"([null, null, "bb-e-bar", "ccc--bar"])", &options);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
-                     R"([null, null, null, null])", &options);
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, scalar_null},
+                     ty, R"([null, null, null, null])", &options);
 
   // Skip
-  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", "-"])", ty, R"("a-b")",
-                           &options_skip);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", null])", ty, R"(null)",
-                           &options_skip);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", null, "b", "-"])", ty,
+                           R"("a-b")", &options_skip);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", null, "b", null])", ty,
+                           R"(null)", &options_skip);
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep3}, ty,
                      R"(["d-bar", "a--bar", null, "ccc------bar"])", &options_skip);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, sep3}, ty,
                      R"(["d", "a", null, "ccc---"])", &options_skip);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep1}, ty,
                      R"(["d-bar", "a-bar", "bb-e-bar", "ccc--bar"])", &options_skip);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
-                     R"([null, null, null, null])", &options_skip);
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, scalar_null},
+                     ty, R"([null, null, null, null])", &options_skip);
 
   // Replace
-  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", "-"])", ty, R"("a-X-b")",
-                           &options_replace);
-  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", null])", ty, R"(null)",
-                           &options_replace);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", null, "b", "-"])", ty,
+                           R"("a-X-b")", &options_replace);
+  this->CheckVarArgsScalar("binary_join_element_wise", R"(["a", null, "b", null])", ty,
+                           R"(null)", &options_replace);
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep3}, ty,
                      R"(["X-d-bar", "a--X--bar", null, "ccc------bar"])",
                      &options_replace);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, sep3}, ty,
                      R"(["X-d-X", "a--X--X", null, "ccc------X"])", &options_replace);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar2, sep1}, ty,
                      R"(["X-d-bar", "a-X-bar", "bb-e-bar", "ccc--bar"])",
                      &options_replace);
-  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
-                     R"([null, null, null, null])", &options_replace);
+  this->CheckVarArgs("binary_join_element_wise", {arr1, arr2, scalar_null, scalar_null},
+                     ty, R"([null, null, null, null])", &options_replace);
 
   // Error cases
-  ASSERT_RAISES(Invalid, CallFunction("var_args_join", {}, &options));
+  ASSERT_RAISES(Invalid, CallFunction("binary_join_element_wise", {}, &options));
 }
 
 template <typename TestType>

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -58,6 +58,26 @@ class BaseTestStringKernels : public ::testing::Test {
                             json_expected, options);
   }
 
+  void CheckVarArgsScalar(std::string func_name, std::string json_input,
+                          std::shared_ptr<DataType> out_ty, std::string json_expected,
+                          const FunctionOptions* options = nullptr) {
+    // CheckScalar (on arrays) checks scalar arguments individually,
+    // but this lets us test the all-scalar case explicitly
+    ScalarVector inputs;
+    std::shared_ptr<Array> args = ArrayFromJSON(type(), json_input);
+    for (int64_t i = 0; i < args->length(); i++) {
+      ASSERT_OK_AND_ASSIGN(auto scalar, args->GetScalar(i));
+      inputs.push_back(std::move(scalar));
+    }
+    CheckScalar(func_name, inputs, ScalarFromJSON(out_ty, json_expected), options);
+  }
+
+  void CheckVarArgs(std::string func_name, const std::vector<Datum>& inputs,
+                    std::shared_ptr<DataType> out_ty, std::string json_expected,
+                    const FunctionOptions* options = nullptr) {
+    CheckScalar(func_name, inputs, ArrayFromJSON(out_ty, json_expected), options);
+  }
+
   std::shared_ptr<DataType> type() { return TypeTraits<TestType>::type_singleton(); }
 
   template <typename CType>
@@ -228,6 +248,102 @@ TYPED_TEST(TestBinaryKernels, CountSubstringIgnoreCase) {
                                   CallFunction("count_substring", {input}, &options));
 }
 #endif
+
+TYPED_TEST(TestBinaryKernels, VarArgsJoin) {
+  const auto ty = this->type();
+  JoinOptions options;
+  JoinOptions options_skip(JoinOptions::SKIP);
+  JoinOptions options_replace(JoinOptions::REPLACE, "X");
+  // Scalar args, Scalar separator
+  this->CheckVarArgsScalar("var_args_join", R"([null])", ty, R"(null)", &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["-"])", ty, R"("")", &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", "-"])", ty, R"("a")", &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", "b", "-"])", ty, R"("a-b")",
+                           &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", "b", null])", ty, R"(null)",
+                           &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "-"])", ty, R"(null)",
+                           &options);
+  this->CheckVarArgsScalar("var_args_join", R"(["foo", "bar", "baz", "++"])", ty,
+                           R"("foo++bar++baz")", &options);
+
+  // Scalar args, Array separator
+  const auto sep = ArrayFromJSON(ty, R"([null, "-", "--"])");
+  const auto scalar1 = ScalarFromJSON(ty, R"("foo")");
+  const auto scalar2 = ScalarFromJSON(ty, R"("bar")");
+  const auto scalar3 = ScalarFromJSON(ty, R"("")");
+  const auto scalar_null = ScalarFromJSON(ty, R"(null)");
+  this->CheckVarArgs("var_args_join", {sep}, ty, R"([null, "", ""])", &options);
+  this->CheckVarArgs("var_args_join", {scalar1, sep}, ty, R"([null, "foo", "foo"])",
+                     &options);
+  this->CheckVarArgs("var_args_join", {scalar1, scalar2, sep}, ty,
+                     R"([null, "foo-bar", "foo--bar"])", &options);
+  this->CheckVarArgs("var_args_join", {scalar1, scalar_null, sep}, ty,
+                     R"([null, null, null])", &options);
+  this->CheckVarArgs("var_args_join", {scalar1, scalar2, scalar3, sep}, ty,
+                     R"([null, "foo-bar-", "foo--bar--"])", &options);
+
+  // Array args, Scalar separator
+  const auto sep1 = ScalarFromJSON(ty, R"("-")");
+  const auto sep2 = ScalarFromJSON(ty, R"("--")");
+  const auto arr1 = ArrayFromJSON(ty, R"([null, "a", "bb", "ccc"])");
+  const auto arr2 = ArrayFromJSON(ty, R"(["d", null, "e", ""])");
+  const auto arr3 = ArrayFromJSON(ty, R"(["gg", null, "h", "iii"])");
+  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, scalar_null}, ty,
+                     R"([null, null, null, null])", &options);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep1}, ty,
+                     R"([null, null, "bb-e-h", "ccc--iii"])", &options);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep2}, ty,
+                     R"([null, null, "bb--e--h", "ccc----iii"])", &options);
+
+  // Array args, Array separator
+  const auto sep3 = ArrayFromJSON(ty, R"(["-", "--", null, "---"])");
+  this->CheckVarArgs("var_args_join", {arr1, arr2, arr3, sep3}, ty,
+                     R"([null, null, null, "ccc------iii"])", &options);
+
+  // Mixed
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+                     R"([null, null, null, "ccc------bar"])", &options);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+                     R"([null, null, null, null])", &options);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+                     R"([null, null, "bb-e-bar", "ccc--bar"])", &options);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
+                     R"([null, null, null, null])", &options);
+
+  // Skip
+  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", "-"])", ty, R"("a-b")",
+                           &options_skip);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", null])", ty, R"(null)",
+                           &options_skip);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+                     R"(["d-bar", "a--bar", null, "ccc------bar"])", &options_skip);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+                     R"(["d", "a", null, "ccc---"])", &options_skip);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+                     R"(["d-bar", "a-bar", "bb-e-bar", "ccc--bar"])", &options_skip);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
+                     R"([null, null, null, null])", &options_skip);
+
+  // Replace
+  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", "-"])", ty, R"("a-X-b")",
+                           &options_replace);
+  this->CheckVarArgsScalar("var_args_join", R"(["a", null, "b", null])", ty, R"(null)",
+                           &options_replace);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep3}, ty,
+                     R"(["X-d-bar", "a--X--bar", null, "ccc------bar"])",
+                     &options_replace);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, sep3}, ty,
+                     R"(["X-d-X", "a--X--X", null, "ccc------X"])", &options_replace);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar2, sep1}, ty,
+                     R"(["X-d-bar", "a-X-bar", "bb-e-bar", "ccc--bar"])",
+                     &options_replace);
+  this->CheckVarArgs("var_args_join", {arr1, arr2, scalar_null, scalar_null}, ty,
+                     R"([null, null, null, null])", &options_replace);
+
+  // Error cases
+  ASSERT_RAISES(Invalid, CallFunction("var_args_join", {}, &options));
+}
 
 template <typename TestType>
 class TestStringKernels : public BaseTestStringKernels<TestType> {};

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -680,15 +680,15 @@ String component extraction
 String joining
 ~~~~~~~~~~~~~~
 
-This function does the inverse of string splitting.
+These functions do the inverse of string splitting.
 
-+-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
-| Function name   | Arity     | Input type 1          | Input type 2   | Output type       | Options class         | Notes   |
-+=================+===========+=======================+================+===================+=======================+=========+
-| binary_join     | Binary    | List of string-like   | String-like    | String-like       |                       | \(1)    |
-+-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
-| var_args_join   | Varargs   | String-like (varargs) | String-like    | String-like       | :struct:`JoinOptions` | \(2)    |
-+-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
++--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
+| Function name            | Arity     | Input type 1          | Input type 2   | Output type       | Options class         | Notes   |
++==========================+===========+=======================+================+===================+=======================+=========+
+| binary_join              | Binary    | List of string-like   | String-like    | String-like       |                       | \(1)    |
++--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
+| binary_join_element_wise | Varargs   | String-like (varargs) | String-like    | String-like       | :struct:`JoinOptions` | \(2)    |
++--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
 
 * \(1) The first input must be an array, while the second can be a scalar or array.
   Each list of values in the first input is joined using each second input

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -682,17 +682,23 @@ String joining
 
 This function does the inverse of string splitting.
 
-+-----------------+-----------+----------------------+----------------+-------------------+---------+
-| Function name   | Arity     | Input type 1         | Input type 2   | Output type       | Notes   |
-+=================+===========+======================+================+===================+=========+
-| binary_join     | Binary    | List of string-like  | String-like    | String-like       | \(1)    |
-+-----------------+-----------+----------------------+----------------+-------------------+---------+
++-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
+| Function name   | Arity     | Input type 1         | Input type 2   | Output type       | Options class         | Notes   |
++=================+===========+======================+================+===================+=======================+=========+
+| binary_join     | Binary    | List of string-like  | String-like    | String-like       |                       | \(1)    |
++-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
+| var_args_join   | Varargs   | List of string-like  | (NA)           | String-like       | :struct:`JoinOptions` | \(2)    |
++-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
 
 * \(1) The first input must be an array, while the second can be a scalar or array.
   Each list of values in the first input is joined using each second input
   as separator.  If any input list is null or contains a null, the corresponding
   output will be null.
 
+* \(2) All arguments are concatenated element-wise, with the last argument treated
+  as the separator (scalars are recycled in either case).  Null separators emit
+  null. If any other argument is null, by default the corresponding output will be
+  null, but it can instead either be skipped or replaced with a given string.
 
 Slicing
 ~~~~~~~

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -318,8 +318,8 @@ expanded for the purposes of comparison.
 +--------------------------+------------+---------------------------------------------+---------------------+---------------------------------------+-------+
 | Function names           | Arity      | Input types                                 | Output type         | Options class                         | Notes |
 +==========================+============+=============================================+=====================+=======================================+=======+
-| element_wise_max,        | Varargs    | Numeric and Temporal                        | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
-| element_wise_min         |            |                                             |                     |                                       |       |
+| max_element_wise,        | Varargs    | Numeric and Temporal                        | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
+| min_element_wise         |            |                                             |                     |                                       |       |
 +--------------------------+------------+---------------------------------------------+---------------------+---------------------------------------+-------+
 
 * \(1) By default, nulls are skipped (but the kernel can be configured to propagate nulls).

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -682,13 +682,13 @@ String joining
 
 This function does the inverse of string splitting.
 
-+-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
-| Function name   | Arity     | Input type 1         | Input type 2   | Output type       | Options class         | Notes   |
-+=================+===========+======================+================+===================+=======================+=========+
-| binary_join     | Binary    | List of string-like  | String-like    | String-like       |                       | \(1)    |
-+-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
-| var_args_join   | Varargs   | List of string-like  | (NA)           | String-like       | :struct:`JoinOptions` | \(2)    |
-+-----------------+-----------+----------------------+----------------+-------------------+-----------------------+---------+
++-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
+| Function name   | Arity     | Input type 1          | Input type 2   | Output type       | Options class         | Notes   |
++=================+===========+=======================+================+===================+=======================+=========+
+| binary_join     | Binary    | List of string-like   | String-like    | String-like       |                       | \(1)    |
++-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
+| var_args_join   | Varargs   | String-like (varargs) | String-like    | String-like       | :struct:`JoinOptions` | \(2)    |
++-----------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
 
 * \(1) The first input must be an array, while the second can be a scalar or array.
   Each list of values in the first input is joined using each second input
@@ -696,7 +696,7 @@ This function does the inverse of string splitting.
   output will be null.
 
 * \(2) All arguments are concatenated element-wise, with the last argument treated
-  as the separator (scalars are recycled in either case).  Null separators emit
+  as the separator (scalars are recycled in either case). Null separators emit
   null. If any other argument is null, by default the corresponding output will be
   null, but it can instead either be skipped or replaced with a given string.
 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -174,7 +174,7 @@ String Joining
    :toctree: ../generated/
 
    binary_join
-   var_args_join
+   binary_join_element_wise
 
 String Transforms
 -----------------

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -80,8 +80,8 @@ These functions take any number of arguments of a numeric or temporal type.
 .. autosummary::
    :toctree: ../generated/
 
-   element_wise_max
-   element_wise_min
+   max_element_wise
+   min_element_wise
 
 Logical Functions
 -----------------

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -159,6 +159,23 @@ String Splitting
    ascii_split_whitespace
    utf8_split_whitespace
 
+String Component Extraction
+---------------------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   extract_regex
+
+String Joining
+--------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   binary_join
+   var_args_join
+
 String Transforms
 -----------------
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -667,6 +667,37 @@ class ElementWiseAggregateOptions(_ElementWiseAggregateOptions):
         self._set_options(skip_nulls)
 
 
+cdef class _JoinOptions(FunctionOptions):
+    cdef:
+        unique_ptr[CJoinOptions] join_options
+
+    cdef const CFunctionOptions* get_options(self) except NULL:
+        return self.join_options.get()
+
+    def _set_options(self, null_handling, null_replacement):
+        cdef:
+            CJoinNullHandlingBehavior c_null_handling = \
+                CJoinNullHandlingBehavior_EMIT_NULL
+            c_string c_null_replacement = tobytes(null_replacement)
+        if null_handling == 'emit_null':
+            c_null_handling = CJoinNullHandlingBehavior_EMIT_NULL
+        elif null_handling == 'skip':
+            c_null_handling = CJoinNullHandlingBehavior_SKIP
+        elif null_handling == 'replace':
+            c_null_handling = CJoinNullHandlingBehavior_REPLACE
+        else:
+            raise ValueError(
+                '"{}" is not a valid null_handling'
+                .format(null_handling))
+        self.join_options.reset(
+            new CJoinOptions(c_null_handling, c_null_replacement))
+
+
+class JoinOptions(_JoinOptions):
+    def __init__(self, null_handling='emit_null', null_replacement=''):
+        self._set_options(null_handling, null_replacement)
+
+
 cdef class _MatchSubstringOptions(FunctionOptions):
     cdef:
         unique_ptr[CMatchSubstringOptions] match_substring_options

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -36,6 +36,7 @@ from pyarrow._compute import (  # noqa
     ExtractRegexOptions,
     FilterOptions,
     IndexOptions,
+    JoinOptions,
     MatchSubstringOptions,
     ModeOptions,
     PartitionNthOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1787,6 +1787,22 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CElementWiseAggregateOptions(c_bool skip_nulls)
         c_bool skip_nulls
 
+    enum CJoinNullHandlingBehavior \
+            "arrow::compute::JoinOptions::NullHandlingBehavior":
+        CJoinNullHandlingBehavior_EMIT_NULL \
+            "arrow::compute::JoinOptions::EMIT_NULL"
+        CJoinNullHandlingBehavior_SKIP \
+            "arrow::compute::JoinOptions::SKIP"
+        CJoinNullHandlingBehavior_REPLACE \
+            "arrow::compute::JoinOptions::REPLACE"
+
+    cdef cppclass CJoinOptions \
+            "arrow::compute::JoinOptions"(CFunctionOptions):
+        CJoinOptions(CJoinNullHandlingBehavior null_handling,
+                     c_string null_replacement)
+        CJoinNullHandlingBehavior null_handling
+        c_string null_replacement
+
     cdef cppclass CMatchSubstringOptions \
             "arrow::compute::MatchSubstringOptions"(CFunctionOptions):
         CMatchSubstringOptions(c_string pattern, c_bool ignore_case)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -766,29 +766,34 @@ def test_binary_join():
     assert pc.binary_join(ar_list, separator_array).equals(expected)
 
 
-def test_var_args_join():
+def test_binary_join_element_wise():
     null = pa.scalar(None, type=pa.string())
     arrs = [[None, 'a', 'b'], ['c', None, 'd'], [None, '-', '--']]
-    assert pc.var_args_join(*arrs).to_pylist() == \
+    assert pc.binary_join_element_wise(*arrs).to_pylist() == \
         [None, None, 'b--d']
-    assert pc.var_args_join('a', 'b', '-').as_py() == 'a-b'
-    assert pc.var_args_join('a', null, '-').as_py() is None
-    assert pc.var_args_join('a', 'b', null).as_py() is None
+    assert pc.binary_join_element_wise('a', 'b', '-').as_py() == 'a-b'
+    assert pc.binary_join_element_wise('a', null, '-').as_py() is None
+    assert pc.binary_join_element_wise('a', 'b', null).as_py() is None
 
     skip = pc.JoinOptions('skip')
-    assert pc.var_args_join(*arrs, options=skip).to_pylist() == \
+    assert pc.binary_join_element_wise(*arrs, options=skip).to_pylist() == \
         [None, 'a', 'b--d']
-    assert pc.var_args_join('a', 'b', '-', options=skip).as_py() == 'a-b'
-    assert pc.var_args_join('a', null, '-', options=skip).as_py() == 'a'
-    assert pc.var_args_join('a', 'b', null, options=skip).as_py() is None
+    assert pc.binary_join_element_wise(
+        'a', 'b', '-', options=skip).as_py() == 'a-b'
+    assert pc.binary_join_element_wise(
+        'a', null, '-', options=skip).as_py() == 'a'
+    assert pc.binary_join_element_wise(
+        'a', 'b', null, options=skip).as_py() is None
 
     replace = pc.JoinOptions('replace', null_replacement='spam')
-    assert pc.var_args_join(*arrs, options=replace).to_pylist() == \
+    assert pc.binary_join_element_wise(*arrs, options=replace).to_pylist() == \
         [None, 'a-spam', 'b--d']
-    assert pc.var_args_join('a', 'b', '-', options=replace).as_py() == 'a-b'
-    assert pc.var_args_join(
+    assert pc.binary_join_element_wise(
+        'a', 'b', '-', options=replace).as_py() == 'a-b'
+    assert pc.binary_join_element_wise(
         'a', null, '-', options=replace).as_py() == 'a-spam'
-    assert pc.var_args_join('a', 'b', null, options=replace).as_py() is None
+    assert pc.binary_join_element_wise(
+        'a', 'b', null, options=replace).as_py() is None
 
 
 @pytest.mark.parametrize(('ty', 'values'), all_array_types)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1467,35 +1467,35 @@ def test_fill_null_segfault():
     assert result == pa.array([0], pa.int8())
 
 
-def test_elementwise_min_max():
+def test_min_max_element_wise():
     arr1 = pa.array([1, 2, 3])
     arr2 = pa.array([3, 1, 2])
     arr3 = pa.array([2, 3, None])
 
-    result = pc.element_wise_max(arr1, arr2)
+    result = pc.max_element_wise(arr1, arr2)
     assert result == pa.array([3, 2, 3])
-    result = pc.element_wise_min(arr1, arr2)
+    result = pc.min_element_wise(arr1, arr2)
     assert result == pa.array([1, 1, 2])
 
-    result = pc.element_wise_max(arr1, arr2, arr3)
+    result = pc.max_element_wise(arr1, arr2, arr3)
     assert result == pa.array([3, 3, 3])
-    result = pc.element_wise_min(arr1, arr2, arr3)
+    result = pc.min_element_wise(arr1, arr2, arr3)
     assert result == pa.array([1, 1, 2])
 
     # with specifying the option
-    result = pc.element_wise_max(arr1, arr3, skip_nulls=True)
+    result = pc.max_element_wise(arr1, arr3, skip_nulls=True)
     assert result == pa.array([2, 3, 3])
-    result = pc.element_wise_min(arr1, arr3, skip_nulls=True)
+    result = pc.min_element_wise(arr1, arr3, skip_nulls=True)
     assert result == pa.array([1, 2, 3])
-    result = pc.element_wise_max(
+    result = pc.max_element_wise(
         arr1, arr3, options=pc.ElementWiseAggregateOptions())
     assert result == pa.array([2, 3, 3])
-    result = pc.element_wise_min(
+    result = pc.min_element_wise(
         arr1, arr3, options=pc.ElementWiseAggregateOptions())
     assert result == pa.array([1, 2, 3])
 
     # not skipping nulls
-    result = pc.element_wise_max(arr1, arr3, skip_nulls=False)
+    result = pc.max_element_wise(arr1, arr3, skip_nulls=False)
     assert result == pa.array([2, 3, None])
-    result = pc.element_wise_min(arr1, arr3, skip_nulls=False)
+    result = pc.min_element_wise(arr1, arr3, skip_nulls=False)
     assert result == pa.array([1, 2, None])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -766,6 +766,31 @@ def test_binary_join():
     assert pc.binary_join(ar_list, separator_array).equals(expected)
 
 
+def test_var_args_join():
+    null = pa.scalar(None, type=pa.string())
+    arrs = [[None, 'a', 'b'], ['c', None, 'd'], [None, '-', '--']]
+    assert pc.var_args_join(*arrs).to_pylist() == \
+        [None, None, 'b--d']
+    assert pc.var_args_join('a', 'b', '-').as_py() == 'a-b'
+    assert pc.var_args_join('a', null, '-').as_py() is None
+    assert pc.var_args_join('a', 'b', null).as_py() is None
+
+    skip = pc.JoinOptions('skip')
+    assert pc.var_args_join(*arrs, options=skip).to_pylist() == \
+        [None, 'a', 'b--d']
+    assert pc.var_args_join('a', 'b', '-', options=skip).as_py() == 'a-b'
+    assert pc.var_args_join('a', null, '-', options=skip).as_py() == 'a'
+    assert pc.var_args_join('a', 'b', null, options=skip).as_py() is None
+
+    replace = pc.JoinOptions('replace', null_replacement='spam')
+    assert pc.var_args_join(*arrs, options=replace).to_pylist() == \
+        [None, 'a-spam', 'b--d']
+    assert pc.var_args_join('a', 'b', '-', options=replace).as_py() == 'a-b'
+    assert pc.var_args_join(
+        'a', null, '-', options=replace).as_py() == 'a-spam'
+    assert pc.var_args_join('a', 'b', null, options=replace).as_py() is None
+
+
 @pytest.mark.parametrize(('ty', 'values'), all_array_types)
 def test_take(ty, values):
     arr = pa.array(values, type=ty)


### PR DESCRIPTION
This adds a variadic scalar string join kernel, using the last argument (min 1 argument) as the separator. An options class allows emitting null (the default), skipping null non-separator arguments, or replacing null non-separator arguments with another string (mimicking libcudf).