### PR TITLE
ARROW-13065: [Packaging][RPM] Add missing required LZ4 version information

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -35,6 +35,11 @@
     echo 3; \
   fi)
 
+%define lz4_requirement %( \
+  if [ %{_amzn} -eq 0 ]; then \
+    echo ">= 1.8.0"; \
+  fi)
+
 %define use_boost (!%{is_amazon_linux})
 %define use_flight (%{rhel} >= 8)
 %define use_gandiva (%{rhel} >= 8 && %{_arch} != "aarch64")
@@ -82,7 +87,7 @@ BuildRequires:	gflags-devel
 BuildRequires:	git
 BuildRequires:	glog-devel
 BuildRequires:	libzstd-devel
-BuildRequires:	lz4-devel
+BuildRequires:	lz4-devel %{lz4_requirement}
 BuildRequires:	ninja-build
 BuildRequires:	openssl-devel
 BuildRequires:	pkgconfig
@@ -198,7 +203,7 @@ Requires:	gflags
 %endif
 Requires:	glog
 Requires:	libzstd
-Requires:	lz4
+Requires:	lz4 %{lz4_requirement}
 %if %{have_re2}
 Requires:	re2
 %endif
@@ -227,7 +232,7 @@ Requires:	bzip2-devel
 Requires:	c-ares-devel
 %endif
 Requires:	libzstd-devel
-Requires:	lz4-devel
+Requires:	lz4-devel %{lz4_requirement}
 Requires:	openssl-devel
 %if %{have_rapidjson}
 Requires:	rapidjson-devel


### PR DESCRIPTION
If we use old LZ4 (< 1.8.0, that is installed on old CentOS
installation), the following error is occurred:

    /lib64/libarrow.so.400: undefined symbol: LZ4F_resetDecompressionContext