### PR TITLE
ARROW-13026: [CI] Use LLVM 10 for s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,9 @@ jobs:
           -e Protobuf_SOURCE=BUNDLED
           -e gRPC_SOURCE=BUNDLED
           "
+        # The LLVM's APT repository causes download error for s390x binary
+        # We should use the LLVM provided by the default APT repository
+        LLVM: "10"
         UBUNTU: "20.04"
 
     - name: "Go on s390x"


### PR DESCRIPTION
[Recent TravisCI for s390x C](https://travis-ci.com/github/apache/arrow/jobs/512489573#L586) causes the following error. The file should be downloaded `...20210605...`. To fix this issue, this PR tries to download LLVM from the default apt repository instead of the LLVM apt repository.

```
Err:8 https://apt.llvm.org/focal llvm-toolchain-focal-12/main s390x libllvm12 s390x 1:12.0.1~++20210604112550+6279fd114acb-1~exp1~20210604213327.98

  404  Not Found [IP: 199.232.38.49 443]
```
