### PR TITLE
ARROW-13080: [Release] Generate the API docs in ubuntu 20.10

### DIFF
--- a/dev/release/post-09-docs.sh
+++ b/dev/release/post-09-docs.sh
@@ -43,10 +43,9 @@ popd
 pushd "${ARROW_DIR}"
 git checkout "${release_tag}"
 
-archery docker run \
+UBUNTU=20.10 archery docker run \
   -v "${ARROW_SITE_DIR}/docs:/build/docs" \
   -e ARROW_DOCS_VERSION="${version}" \
-  -e UBUNTU=20.10 \
   ubuntu-docs
 
 : ${PUSH:=1}


### PR DESCRIPTION
Pass ubuntu version as a docker build variable instead of a container runtime environment variable.