### PR TITLE
ARROW-13085: [Python] Document compatible toolchains for python bindings

### DIFF
--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -467,12 +467,13 @@ installed. This function will attempt to create symlinks like
    pip install pyarrow
    python -c "import pyarrow; pyarrow.create_library_symlinks()"
 
-Toolchain Compatibility
-~~~~~~~~~~~~~~~~~~~~~~~
+Toolchain Compatibility (Linux)
+"""""""""""""""""""""""""""""""
 
-The Python wheels are built using the [quay.io manylinux
-images](https://quay.io/organization/pypa) which use `devtoolset-8` or
-`devtoolset-9` depending on which manylinux wheel version (2010 or 2014) is
-being used. In addition to the other notes above, if you are compiling C++
-using these shared libraries, you will need to make sure you use a compatible
-toolchain as well or you might see a segfault during runtime.
+The Python wheels for Linux are built using the
+`PyPA manylinux images <https://quay.io/organization/pypa>`_ which use
+the CentOS `devtoolset-8` or `devtoolset-9` depending on which manylinux
+wheel version (2010 or 2014) is being used. In addition to the other notes
+above, if you are compiling C++ using these shared libraries, you will need
+to make sure you use a compatible toolchain as well or you might see a
+segfault during runtime.

--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -466,3 +466,13 @@ installed. This function will attempt to create symlinks like
 
    pip install pyarrow
    python -c "import pyarrow; pyarrow.create_library_symlinks()"
+
+Toolchain Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Python wheels are built using the [quay.io manylinux
+images](https://quay.io/organization/pypa) which use `devtoolset-8` or
+`devtoolset-9` depending on which manylinux wheel version (2010 or 2014) is
+being used. In addition to the other notes above, if you are compiling C++
+using these shared libraries, you will need to make sure you use a compatible
+toolchain as well or you might see a segfault during runtime.


### PR DESCRIPTION
This is a documentation-only PR that adds an additional note for users compibiling C++ extensions using the shared libraries bundled with the python package. Adding this note on the toolchain will help resolve (confusing?) segfaults that occur.

Before (toolchain) change:

- segfault when running the minimal cpp example

After (toolchain) change:

- no segfault when running the minimal cpp example

Please see the linked JIRA for more details.
