### PR TITLE
PARQUET-2056: [C++] Add ability for retrieving dictionary and indices separately for ColumnReader

### DIFF
--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -128,6 +128,19 @@ class PARQUET_EXPORT ColumnReader {
   virtual Type::type type() const = 0;
 
   virtual const ColumnDescriptor* descr() const = 0;
+
+  // Get the encoding that can be exposed by this reader. If it returns
+  // dictionary encoding, then ReadBatchWithDictionary can be used to read data.
+  //
+  // \note API EXPERIMENTAL
+  virtual ExposedEncodingType GetExposedEncoding() = 0;
+
+ protected:
+  friend class RowGroupReader;
+  // Set the encoding that can be exposed by this reader.
+  //
+  // \note API EXPERIMENTAL
+  virtual void SetExposedEncoding(ExposedEncodingType encoding) = 0;
 };
 
 // API to read values from a single column. This is a main client facing API.
@@ -201,6 +214,36 @@ class TypedColumnReader : public ColumnReader {
   // Skip reading levels
   // Returns the number of levels skipped
   virtual int64_t Skip(int64_t num_rows_to_skip) = 0;
+
+  // Read a batch of repetition levels, definition levels, and indices from the
+  // column. And read the dictionary if a dictionary page is encountered during
+  // reading pages. This API is similar to ReadBatch(), with ability to read
+  // dictionary and indices. It's only valid when the reader can expose
+  // dictionary encoding. (i.e., the reader's GetExposedEncoding() returns
+  // DICTIONARY).
+  //
+  // Since a column chunk can only have one dictinoary page followed by all data
+  // pages, the dictionary page is read only once for each column chunk (upon
+  // reading the 1st batch).
+  //
+  // @param batch_size The batch size to read
+  // @param[out] def_levels The Parquet definition levels.
+  // @param[out] rep_levels The Parquet repetition levels.
+  // @param[out] indices The dictionary indices.
+  // @param[out] indices_read The number of indices read.
+  // @param[out] dict The pointer to dictionary values. It's set only if the
+  // reader encounters a new dictionary page (which only occurs once per column
+  // chunk). Dictionary is owned by the reader, so the caller is responsible for
+  // copying the dictionary values before the reader gets destroyed.
+  // @param[out] dict_len The dictionary length.
+  // @returns: actual number of levels read (see indices_read for number of
+  // indices read
+  //
+  // \note API EXPERIMENTAL
+  virtual int64_t ReadBatchWithDictionary(int64_t batch_size, int16_t* def_levels,
+                                          int16_t* rep_levels, int32_t* indices,
+                                          int64_t* indices_read, const T** dict,
+                                          int32_t* dict_len) = 0;
 };
 
 namespace internal {

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -133,14 +133,14 @@ class PARQUET_EXPORT ColumnReader {
   // dictionary encoding, then ReadBatchWithDictionary can be used to read data.
   //
   // \note API EXPERIMENTAL
-  virtual ExposedEncodingType GetExposedEncoding() = 0;
+  virtual ExposedEncoding GetExposedEncoding() = 0;
 
  protected:
   friend class RowGroupReader;
   // Set the encoding that can be exposed by this reader.
   //
   // \note API EXPERIMENTAL
-  virtual void SetExposedEncoding(ExposedEncodingType encoding) = 0;
+  virtual void SetExposedEncoding(ExposedEncoding encoding) = 0;
 };
 
 // API to read values from a single column. This is a main client facing API.
@@ -218,24 +218,24 @@ class TypedColumnReader : public ColumnReader {
   // Read a batch of repetition levels, definition levels, and indices from the
   // column. And read the dictionary if a dictionary page is encountered during
   // reading pages. This API is similar to ReadBatch(), with ability to read
-  // dictionary and indices. It's only valid when the reader can expose
-  // dictionary encoding. (i.e., the reader's GetExposedEncoding() returns
+  // dictionary and indices. It is only valid to call this method  when the reader can
+  // expose dictionary encoding. (i.e., the reader's GetExposedEncoding() returns
   // DICTIONARY).
   //
-  // Since a column chunk can only have one dictinoary page followed by all data
-  // pages, the dictionary page is read only once for each column chunk (upon
-  // reading the 1st batch).
+  // The dictionary is read along with the data page. When there's no data page,
+  // the dictionary won't be read.
   //
   // @param batch_size The batch size to read
   // @param[out] def_levels The Parquet definition levels.
   // @param[out] rep_levels The Parquet repetition levels.
   // @param[out] indices The dictionary indices.
   // @param[out] indices_read The number of indices read.
-  // @param[out] dict The pointer to dictionary values. It's set only if the
-  // reader encounters a new dictionary page (which only occurs once per column
-  // chunk). Dictionary is owned by the reader, so the caller is responsible for
-  // copying the dictionary values before the reader gets destroyed.
-  // @param[out] dict_len The dictionary length.
+  // @param[out] dict The pointer to dictionary values. It will return nullptr if
+  // there's no data page. Each column chunk only has one dictionary page. The dictionary
+  // is owned by the reader, so the caller is responsible for copying the dictionary
+  // values before the reader gets destroyed.
+  // @param[out] dict_len The dictionary length. It will return 0 if there's no data
+  // page.
   // @returns: actual number of levels read (see indices_read for number of
   // indices read
   //

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -223,7 +223,7 @@ class TypedColumnReader : public ColumnReader {
   // DICTIONARY).
   //
   // The dictionary is read along with the data page. When there's no data page,
-  // the dictionary won't be read.
+  // the dictionary won't be returned.
   //
   // @param batch_size The batch size to read
   // @param[out] def_levels The Parquet definition levels.

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -392,26 +392,25 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
   max_rep_level_ = 0;
   int levels_per_page = 100;
   int num_pages = 5;
-  const ByteArray* dict = nullptr;
-  int32_t dict_len = 0;
-  int64_t total_indices = 0;
-  int64_t indices_read = 0;
   std::vector<int16_t> def_levels;
   std::vector<int16_t> rep_levels;
   std::vector<ByteArray> values;
   std::vector<uint8_t> buffer;
-  ByteArrayReader* reader = nullptr;
   NodePtr type = schema::ByteArray("a", Repetition::REQUIRED);
   const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
 
   // Fully dictionary encoded
   MakePages<ByteArrayType>(&descr, num_pages, levels_per_page, def_levels, rep_levels,
                            values, buffer, pages_, Encoding::RLE_DICTIONARY);
+  InitReader(&descr);
+
+  auto reader = static_cast<ByteArrayReader*>(reader_.get());
+  const ByteArray* dict = nullptr;
+  int32_t dict_len = 0;
+  int64_t total_indices = 0;
+  int64_t indices_read = 0;
   int64_t value_size = values.size();
   auto indices = ::arrow::internal::make_unique<int32_t[]>(value_size);
-
-  InitReader(&descr);
-  reader = static_cast<ByteArrayReader*>(reader_.get());
   while (total_indices < value_size && reader->HasNext()) {
     const ByteArray* tmp_dict = nullptr;
     int32_t tmp_dict_len = 0;
@@ -419,16 +418,14 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
         value_size, /*def_levels=*/nullptr,
         /*rep_levels=*/nullptr, indices.get() + total_indices, &indices_read, &tmp_dict,
         &tmp_dict_len));
-    if (tmp_dict) {
-      // Only reading the 1st batch will return the dictionary
-      EXPECT_EQ(total_indices, 0);
-      EXPECT_GT(tmp_dict_len, 0);
+    if (tmp_dict != nullptr) {
+      // Dictionary is read along with data
+      EXPECT_GT(indices_read, 0);
       dict = tmp_dict;
       dict_len = tmp_dict_len;
     } else {
-      // Reading following batches won't return the dictionary
-      EXPECT_GT(total_indices, 0);
-      EXPECT_EQ(tmp_dict_len, 0);
+      // Dictionary is not read when there's no data
+      EXPECT_EQ(indices_read, 0);
     }
     total_indices += indices_read;
   }
@@ -440,17 +437,33 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
     EXPECT_EQ(memcmp(dict[indices[i]].ptr, values[i].ptr, values[i].len), 0);
   }
   pages_.clear();
+}
+
+TEST_F(TestPrimitiveReader, TestNonDictionaryEncodedPagesWithExposeEncoding) {
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  int64_t value_size = 100;
+  std::vector<int32_t> values(value_size, 0);
+  NodePtr type = schema::Int32("a", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
 
   // The data page falls back to plain encoding
   std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
   std::shared_ptr<DictionaryPage> dict_page =
       std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
-  std::shared_ptr<DataPageV1> data_page = MakeDataPage<ByteArrayType>(
-      &descr, values, value_size, Encoding::PLAIN, {}, 0, {}, 0, {}, 0);
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+      &descr, values, static_cast<int>(value_size), Encoding::PLAIN, /*indices=*/{},
+      /*indices_size=*/0, /*def_levels=*/{}, /*max_def_level=*/0, /*rep_levels=*/{},
+      /*max_rep_level=*/0);
   pages_.push_back(dict_page);
   pages_.push_back(data_page);
   InitReader(&descr);
-  reader = static_cast<ByteArrayReader*>(reader_.get());
+
+  auto reader = static_cast<ByteArrayReader*>(reader_.get());
+  const ByteArray* dict = nullptr;
+  int32_t dict_len = 0;
+  int64_t indices_read = 0;
+  auto indices = ::arrow::internal::make_unique<int32_t[]>(value_size);
   // Dictionary cannot be exposed when it's not fully dictionary encoded
   EXPECT_THROW(reader->ReadBatchWithDictionary(value_size, /*def_levels=*/nullptr,
                                                /*rep_levels=*/nullptr, indices.get(),

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1569,6 +1569,19 @@ class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
     return num_values;
   }
 
+  int DecodeIndices(int num_values, int32_t* indices) override {
+    if (num_values != idx_decoder_.GetBatch(indices, num_values)) {
+      ParquetException::EofException();
+    }
+    num_values_ -= num_values;
+    return num_values;
+  }
+
+  void GetDictionary(const T** dictionary, int32_t* dictionary_length) override {
+    *dictionary_length = dictionary_length_;
+    *dictionary = reinterpret_cast<T*>(dictionary_->mutable_data());
+  }
+
  protected:
   Status IndexInBounds(int32_t index) {
     if (ARROW_PREDICT_TRUE(0 <= index && index < dictionary_length_)) {

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -350,6 +350,8 @@ class TypedDecoder : virtual public Decoder {
 template <typename DType>
 class DictDecoder : virtual public TypedDecoder<DType> {
  public:
+  using T = typename DType::c_type;
+
   virtual void SetDict(TypedDecoder<DType>* dictionary) = 0;
 
   /// \brief Insert dictionary values into the Arrow dictionary builder's memo,
@@ -371,6 +373,22 @@ class DictDecoder : virtual public TypedDecoder<DType> {
   /// \warning Remember to reset the builder each time the dict decoder is initialized
   /// with a new dictionary page
   virtual int DecodeIndices(int num_values, ::arrow::ArrayBuilder* builder) = 0;
+
+  /// \brief Decode only dictionary indices (no nulls). Same as above
+  /// DecodeIndices but target is an array instead of a builder.
+  ///
+  /// \note API EXPERIMENTAL
+  virtual int DecodeIndices(int num_values, int32_t* indices) = 0;
+
+  /// \brief Get dictionary. The reader will call this API when it encounters a
+  /// new dictionary.
+  ///
+  /// @param[out] dict The pointer to dictionary values. Dictionary is owned by
+  /// the decoder and is destroyed when the decoder is destroyed.
+  /// @param[out] dict_len The dictionary length.
+  ///
+  /// \note API EXPERIMENTAL
+  virtual void GetDictionary(const T** dictionary, int32_t* dictionary_length) = 0;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -383,9 +383,9 @@ class DictDecoder : virtual public TypedDecoder<DType> {
   /// \brief Get dictionary. The reader will call this API when it encounters a
   /// new dictionary.
   ///
-  /// @param[out] dict The pointer to dictionary values. Dictionary is owned by
+  /// @param[out] dictionary The pointer to dictionary values. Dictionary is owned by
   /// the decoder and is destroyed when the decoder is destroyed.
-  /// @param[out] dict_len The dictionary length.
+  /// @param[out] dictionary_length The dictionary length.
   ///
   /// \note API EXPERIMENTAL
   virtual void GetDictionary(const T** dictionary, int32_t* dictionary_length) = 0;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -75,7 +75,7 @@ std::shared_ptr<ColumnReader> RowGroupReader::Column(int i) {
 }
 
 std::shared_ptr<ColumnReader> RowGroupReader::ColumnWithExposeEncoding(
-    int i, ExposedEncodingType encoding_to_expose) {
+    int i, ExposedEncoding encoding_to_expose) {
   auto encoding_stats = metadata()->ColumnChunk(i)->encoding_stats();
   auto reader = Column(i);
 
@@ -83,7 +83,7 @@ std::shared_ptr<ColumnReader> RowGroupReader::ColumnWithExposeEncoding(
     return reader;
   }
 
-  if (encoding_to_expose == ExposedEncodingType::DICTIONARY) {
+  if (encoding_to_expose == ExposedEncoding::DICTIONARY) {
     // The 1st page should be the dictionary page.
     if (encoding_stats[0].page_type != PageType::DICTIONARY_PAGE ||
         (encoding_stats[0].encoding != Encoding::PLAIN &&

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -62,7 +62,7 @@ class PARQUET_EXPORT RowGroupReader {
   // same encoding. For dictionary encoding, currently we only support column
   // chunks that are fully dictionary encoded, i.e., all data pages in the
   // column chunk are dictionary encoded. If a column chunk uses dictionary
-  // encoding but then falls back to plain encoding, the encoding cannot be
+  // encoding but then falls back to plain encoding, the encoding will not be
   // exposed.
   //
   // The returned column reader provides an API GetExposedEncoding() for the
@@ -70,7 +70,7 @@ class PARQUET_EXPORT RowGroupReader {
   //
   // \note API EXPERIMENTAL
   std::shared_ptr<ColumnReader> ColumnWithExposeEncoding(
-      int i, ExposedEncodingType encoding_to_expose);
+      int i, ExposedEncoding encoding_to_expose);
 
   std::unique_ptr<PageReader> GetColumnPageReader(int i);
 

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -56,6 +56,22 @@ class PARQUET_EXPORT RowGroupReader {
   // column. Ownership is shared with the RowGroupReader.
   std::shared_ptr<ColumnReader> Column(int i);
 
+  // Construct a ColumnReader, trying to enable exposed encoding.
+  //
+  // The encoding can only be exposed if the column chunk is encoded with the
+  // same encoding. For dictionary encoding, currently we only support column
+  // chunks that are fully dictionary encoded, i.e., all data pages in the
+  // column chunk are dictionary encoded. If a column chunk uses dictionary
+  // encoding but then falls back to plain encoding, the encoding cannot be
+  // exposed.
+  //
+  // The returned column reader provides an API GetExposedEncoding() for the
+  // users to check the exposed encoding and determine how to read the batches.
+  //
+  // \note API EXPERIMENTAL
+  std::shared_ptr<ColumnReader> ColumnWithExposeEncoding(
+      int i, ExposedEncodingType encoding_to_expose);
+
   std::unique_ptr<PageReader> GetColumnPageReader(int i);
 
  private:

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -58,12 +58,10 @@ class PARQUET_EXPORT RowGroupReader {
 
   // Construct a ColumnReader, trying to enable exposed encoding.
   //
-  // The encoding can only be exposed if the column chunk is encoded with the
-  // same encoding. For dictionary encoding, currently we only support column
-  // chunks that are fully dictionary encoded, i.e., all data pages in the
-  // column chunk are dictionary encoded. If a column chunk uses dictionary
-  // encoding but then falls back to plain encoding, the encoding will not be
-  // exposed.
+  // For dictionary encoding, currently we only support column chunks that are fully
+  // dictionary encoded, i.e., all data pages in the column chunk are dictionary encoded.
+  // If a column chunk uses dictionary encoding but then falls back to plain encoding, the
+  // encoding will not be exposed.
   //
   // The returned column reader provides an API GetExposedEncoding() for the
   // users to check the exposed encoding and determine how to read the batches.

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -519,8 +519,8 @@ TEST(TestFileReader, BufferedReadsWithDictionary) {
 
   auto row_group = file_reader->RowGroup(0);
   auto col_reader = std::static_pointer_cast<DoubleReader>(
-      row_group->ColumnWithExposeEncoding(0, ExposedEncodingType::DICTIONARY));
-  EXPECT_EQ(col_reader->GetExposedEncoding(), ExposedEncodingType::DICTIONARY);
+      row_group->ColumnWithExposeEncoding(0, ExposedEncoding::DICTIONARY));
+  EXPECT_EQ(col_reader->GetExposedEncoding(), ExposedEncoding::DICTIONARY);
 
   auto indices = ::arrow::internal::make_unique<int32_t[]>(num_rows);
   const double* dict = nullptr;
@@ -530,15 +530,15 @@ TEST(TestFileReader, BufferedReadsWithDictionary) {
     int32_t tmp_dict_len = 0;
     int64_t values_read = 0;
     int64_t levels_read = col_reader->ReadBatchWithDictionary(
-        1, nullptr, nullptr, indices.get() + row_index, &values_read, &tmp_dict,
-        &tmp_dict_len);
+        /*batch_size=*/1, /*def_levels=*/nullptr, /*rep_levels=*/nullptr,
+        indices.get() + row_index, &values_read, &tmp_dict, &tmp_dict_len);
 
-    if (tmp_dict) {
-      EXPECT_EQ(row_index, 0);
+    if (tmp_dict != nullptr) {
+      EXPECT_EQ(values_read, 1);
       dict = tmp_dict;
       dict_len = tmp_dict_len;
     } else {
-      EXPECT_GT(row_index, 0);
+      EXPECT_EQ(values_read, 0);
     }
 
     ASSERT_EQ(1, levels_read);

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -29,6 +29,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/make_unique.h"
 
 #include "parquet/column_reader.h"
 #include "parquet/column_scanner.h"
@@ -472,6 +473,83 @@ TEST(TestJSONWithLocalFile, JSONOutput) {
   printer.JSONPrint(ss, columns, "alltypes_plain.parquet");
 
   ASSERT_EQ(json_output, ss.str());
+}
+
+TEST(TestFileReader, BufferedReadsWithDictionary) {
+  const int num_rows = 1000;
+
+  // Make schema
+  schema::NodeVector fields;
+  fields.push_back(PrimitiveNode::Make("field", Repetition::REQUIRED, Type::DOUBLE,
+                                       ConvertedType::NONE));
+  auto schema = std::static_pointer_cast<GroupNode>(
+      GroupNode::Make("schema", Repetition::REQUIRED, fields));
+
+  // Write small batches and small data pages
+  std::shared_ptr<WriterProperties> writer_props = WriterProperties::Builder()
+                                                       .write_batch_size(64)
+                                                       ->data_pagesize(128)
+                                                       ->enable_dictionary()
+                                                       ->build();
+
+  ASSERT_OK_AND_ASSIGN(auto out_file, ::arrow::io::BufferOutputStream::Create());
+  std::shared_ptr<ParquetFileWriter> file_writer =
+      ParquetFileWriter::Open(out_file, schema, writer_props);
+
+  RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
+
+  // write one column
+  ::arrow::random::RandomArrayGenerator rag(0);
+  DoubleWriter* writer = static_cast<DoubleWriter*>(rg_writer->NextColumn());
+  std::shared_ptr<::arrow::Array> col = rag.Float64(num_rows, 0, 100);
+  const auto& col_typed = static_cast<const ::arrow::DoubleArray&>(*col);
+  writer->WriteBatch(num_rows, nullptr, nullptr, col_typed.raw_values());
+  rg_writer->Close();
+  file_writer->Close();
+
+  // Open the reader
+  ASSERT_OK_AND_ASSIGN(auto file_buf, out_file->Finish());
+  auto in_file = std::make_shared<::arrow::io::BufferReader>(file_buf);
+
+  ReaderProperties reader_props;
+  reader_props.enable_buffered_stream();
+  reader_props.set_buffer_size(64);
+  std::unique_ptr<ParquetFileReader> file_reader =
+      ParquetFileReader::Open(in_file, reader_props);
+
+  auto row_group = file_reader->RowGroup(0);
+  auto col_reader = std::static_pointer_cast<DoubleReader>(
+      row_group->ColumnWithExposeEncoding(0, ExposedEncodingType::DICTIONARY));
+  EXPECT_EQ(col_reader->GetExposedEncoding(), ExposedEncodingType::DICTIONARY);
+
+  auto indices = ::arrow::internal::make_unique<int32_t[]>(num_rows);
+  const double* dict = nullptr;
+  int32_t dict_len = 0;
+  for (int row_index = 0; row_index < num_rows; ++row_index) {
+    const double* tmp_dict = nullptr;
+    int32_t tmp_dict_len = 0;
+    int64_t values_read = 0;
+    int64_t levels_read = col_reader->ReadBatchWithDictionary(
+        1, nullptr, nullptr, indices.get() + row_index, &values_read, &tmp_dict,
+        &tmp_dict_len);
+
+    if (tmp_dict) {
+      EXPECT_EQ(row_index, 0);
+      dict = tmp_dict;
+      dict_len = tmp_dict_len;
+    } else {
+      EXPECT_GT(row_index, 0);
+    }
+
+    ASSERT_EQ(1, levels_read);
+    ASSERT_EQ(1, values_read);
+  }
+
+  // Check the results
+  for (int row_index = 0; row_index < num_rows; ++row_index) {
+    EXPECT_LT(indices[row_index], dict_len);
+    EXPECT_EQ(dict[indices[row_index]], col_typed.Value(row_index));
+  }
 }
 
 TEST(TestFileReader, BufferedReads) {

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -481,7 +481,7 @@ struct Encoding {
 
 // Exposed data encodings. It is the encoding of the data read from the file,
 // rather than the encoding of the data in the file. E.g., the data encoded as
-// RLW_DICTIONARY in the file can be read as dictionary indices by RLE
+// RLE_DICTIONARY in the file can be read as dictionary indices by RLE
 // decoding, in which case the data read from the file is DICTIONARY encoded.
 enum class ExposedEncoding {
   NO_ENCODING = 0,  // data is not encoded, i.e. already decoded during reading

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -479,8 +479,14 @@ struct Encoding {
   };
 };
 
-// Exposed data encodings.
-enum class ExposedEncodingType { NO_ENCODING = 0, DICTIONARY = 1 };
+// Exposed data encodings. It is the encoding of the data read from the file,
+// rather than the encoding of the data in the file. E.g., the data encoded as
+// RLW_DICTIONARY in the file can be read as dictionary indices by RLE
+// decoding, in which case the data read from the file is DICTIONARY encoded.
+enum class ExposedEncoding {
+  NO_ENCODING = 0,  // data is not encoded, i.e. already decoded during reading
+  DICTIONARY = 1
+};
 
 /// \brief Return true if Parquet supports indicated compression type
 PARQUET_EXPORT

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -479,6 +479,9 @@ struct Encoding {
   };
 };
 
+// Exposed data encodings.
+enum class ExposedEncodingType { NO_ENCODING = 0, DICTIONARY = 1 };
+
 /// \brief Return true if Parquet supports indicated compression type
 PARQUET_EXPORT
 bool IsCodecSupported(Compression::type codec);


### PR DESCRIPTION
In some contexts it is useful to be able to retrieve encoding information separately instead of decoding. This introduces new apis in RowGroupReader, ColumnReader, TypedColumnReader, and DictDecoder to support reading batches of dictionary indices. Given that a column chunk only has one dictionary page, the dictionary is read along with the 1st batch.



Thanks.
 