### PR TITLE
ARROW-13090: [Python] Fix create_dir() implementation in FSSpecHandler

### DIFF
--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -263,7 +263,10 @@ class FSSpecHandler(FileSystemHandler):
 
     def create_dir(self, path, recursive):
         # mkdir also raises FileNotFoundError when base directory is not found
-        self.fs.mkdir(path, create_parents=recursive)
+        try:
+            self.fs.mkdir(path, create_parents=recursive)
+        except FileExistsError:
+            pass
 
     def delete_dir(self, path):
         self.fs.rm(path, recursive=True)


### PR DESCRIPTION
Recent fsspec version have started raising FileExistsError if the target directory already exists.  Ignore the error, as create_dir() is supposed to succeed in that case.