### PR TITLE
ARROW-13074: [Python] Deprecate ParquetDataset custom properties (eg pieces, partitions)

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1476,7 +1476,13 @@ pre_buffer : bool, default True
             DeprecationWarning, stacklevel=2)
         return self._metadata.buffer_size
 
-    fs = property(operator.attrgetter('_metadata.fs'))
+    @property
+    def fs(self):
+        warnings.warn(
+            "ParquetDataset.fs attribute is deprecated",
+            DeprecationWarning, stacklevel=2)
+        return self._metadata.fs
+
     common_metadata = property(
         operator.attrgetter('_metadata.common_metadata')
     )
@@ -1697,8 +1703,23 @@ class _ParquetDatasetV2:
 
     @property
     def pieces(self):
-        # TODO raise deprecation warning
+        warnings.warn(
+            "ParquetDataset.pieces attribute is deprecated, use the .fragments"
+            " attribute instead",
+            DeprecationWarning, stacklevel=2)
         return list(self._dataset.get_fragments())
+
+    @property
+    def fragments(self):
+        return list(self._dataset.get_fragments())
+
+    @property
+    def files(self):
+        return self._dataset.files
+
+    @property
+    def filesystem(self):
+        return self._dataset.filesystem
 
 
 _read_table_docstring = """

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1171,6 +1171,12 @@ def _open_dataset_file(dataset, path, meta=None):
     )
 
 
+_DEPR_MSG = (
+    "'{}' attribute is deprecated as of pyarrow 5.0.0 and will be removed "
+    "in a future version.{}"
+)
+
+
 _read_docstring_common = """\
 read_dictionary : list, default None
     List of names or column paths (for nested types) to read directly
@@ -1461,35 +1467,39 @@ pre_buffer : bool, default True
     @property
     def pieces(self):
         warnings.warn(
-            "ParquetDataset.pieces attribute is deprecated",
+            _DEPR_MSG.format(
+                "ParquetDataset.pieces",
+                " Specify 'use_legacy_dataset=False' while constructing the "
+                "ParquetDataset, and then use the '.fragments' attribute "
+                "instead."),
             DeprecationWarning, stacklevel=2)
         return self._pieces
 
     @property
     def partitions(self):
         warnings.warn(
-            "ParquetDataset.partitions attribute is deprecated",
+            _DEPR_MSG.format("ParquetDataset.partitions", ""),
             DeprecationWarning, stacklevel=2)
         return self._partitions
 
     @property
     def memory_map(self):
         warnings.warn(
-            "ParquetDataset.memory_map attribute is deprecated",
+            _DEPR_MSG.format("ParquetDataset.memory_map", ""),
             DeprecationWarning, stacklevel=2)
         return self._metadata.memory_map
 
     @property
     def read_dictionary(self):
         warnings.warn(
-            "ParquetDataset.read_dictionary attribute is deprecated",
+            _DEPR_MSG.format("ParquetDataset.read_dictionary", ""),
             DeprecationWarning, stacklevel=2)
         return self._metadata.read_dictionary
 
     @property
     def buffer_size(self):
         warnings.warn(
-            "ParquetDataset.buffer_size attribute is deprecated",
+            _DEPR_MSG.format("ParquetDataset.buffer_size", ""),
             DeprecationWarning, stacklevel=2)
         return self._metadata.buffer_size
 
@@ -1500,7 +1510,11 @@ pre_buffer : bool, default True
     @property
     def fs(self):
         warnings.warn(
-            "ParquetDataset.fs attribute is deprecated",
+            _DEPR_MSG.format(
+                "ParquetDataset.fs",
+                " Specify 'use_legacy_dataset=False' while constructing the "
+                "ParquetDataset, and then use the '.filesystem' attribute "
+                "instead."),
             DeprecationWarning, stacklevel=2)
         return self._metadata.fs
 
@@ -1726,8 +1740,8 @@ class _ParquetDatasetV2:
     @property
     def pieces(self):
         warnings.warn(
-            "ParquetDataset.pieces attribute is deprecated, use the .fragments"
-            " attribute instead",
+            _DEPR_MSG.format("ParquetDataset.pieces",
+                             " Use the '.fragments' attribute instead"),
             DeprecationWarning, stacklevel=2)
         return list(self._dataset.get_fragments())
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1510,8 +1510,8 @@ pre_buffer : bool, default True
         return self._metadata.buffer_size
 
     _fs = property(
-            operator.attrgetter('_metadata.fs')
-        )
+        operator.attrgetter('_metadata.fs')
+    )
 
     @property
     def fs(self):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -706,10 +706,16 @@ def _get_pandas_index_columns(keyvalues):
 
 class ParquetDatasetPiece:
     """
-    A single chunk of a potentially larger Parquet dataset to read.
+    DEPRECATED: A single chunk of a potentially larger Parquet dataset to read.
 
     The arguments will indicate to read either a single row group or all row
     groups, and whether to add partition keys to the resulting pyarrow.Table.
+
+    .. deprecated:: 5.0
+        Directly constructing a ``ParquetDatasetPiece`` is deprecated, as well
+        as accessing the pieces of a ``ParquetDataset`` object. Specify
+        ``use_legacy_dataset=False`` when constructing the ``ParquetDataset``
+        and use the ``ParquetDataset.fragments`` attribute instead.
 
     Parameters
     ----------

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1323,11 +1323,14 @@ pre_buffer : bool, default True
 
         if self.fs.__class__ != other.fs.__class__:
             return False
-        for prop in ('paths', 'memory_map', '_pieces', '_partitions',
+        for prop in ('paths', '_pieces', '_partitions',
                      'common_metadata_path', 'metadata_path',
                      'common_metadata', 'metadata', 'schema',
-                     'buffer_size', 'split_row_groups'):
+                     'split_row_groups'):
             if getattr(self, prop) != getattr(other, prop):
+                return False
+        for prop in ('memory_map', 'buffer_size'):
+            if getattr(self._metadata, prop) != getattr(other._metadata, prop):
                 return False
 
         return True
@@ -1452,15 +1455,31 @@ pre_buffer : bool, default True
             DeprecationWarning, stacklevel=2)
         return self._partitions
 
+    @property
+    def memory_map(self):
+        warnings.warn(
+            "ParquetDataset.memory_map attribute is deprecated",
+            DeprecationWarning, stacklevel=2)
+        return self._metadata.memory_map
+
+    @property
+    def read_dictionary(self):
+        warnings.warn(
+            "ParquetDataset.read_dictionary attribute is deprecated",
+            DeprecationWarning, stacklevel=2)
+        return self._metadata.read_dictionary
+
+    @property
+    def buffer_size(self):
+        warnings.warn(
+            "ParquetDataset.buffer_size attribute is deprecated",
+            DeprecationWarning, stacklevel=2)
+        return self._metadata.buffer_size
+
     fs = property(operator.attrgetter('_metadata.fs'))
-    memory_map = property(operator.attrgetter('_metadata.memory_map'))
-    read_dictionary = property(
-        operator.attrgetter('_metadata.read_dictionary')
-    )
     common_metadata = property(
         operator.attrgetter('_metadata.common_metadata')
     )
-    buffer_size = property(operator.attrgetter('_metadata.buffer_size'))
 
 
 def _make_manifest(path_or_paths, fs, pathsep='/', metadata_nthreads=1,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1634,3 +1634,11 @@ def test_parquet_dataset_deprecated_properties(tempdir):
 
     with pytest.warns(DeprecationWarning, match="ParquetDataset.buffer_size"):
         dataset.buffer_size
+
+    with pytest.warns(DeprecationWarning, match="ParquetDataset.fs"):
+        dataset.fs
+
+    dataset2 = pq.ParquetDataset(path, use_legacy_dataset=False)
+
+    with pytest.warns(DeprecationWarning, match="ParquetDataset.pieces"):
+        dataset2.pieces

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -57,7 +57,8 @@ def test_parquet_piece_read(tempdir):
     path = tempdir / 'parquet_piece_read.parquet'
     _write_table(table, path, version='2.0')
 
-    piece1 = pq.ParquetDatasetPiece(path)
+    with pytest.warns(DeprecationWarning):
+        piece1 = pq.ParquetDatasetPiece(path)
 
     result = piece1.read()
     assert result.equals(table)
@@ -71,7 +72,8 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     path = tempdir / 'parquet_piece_read.parquet'
     _write_table(table, path, version='2.0')
 
-    piece = pq.ParquetDatasetPiece(path)
+    with pytest.warns(DeprecationWarning):
+        piece = pq.ParquetDatasetPiece(path)
     table1 = piece.read()
     assert isinstance(table1, pa.Table)
     meta1 = piece.get_metadata()
@@ -80,6 +82,7 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     assert table.equals(table1)
 
 
+@pytest.mark.filterwarnings("ignore:ParquetDatasetPiece:DeprecationWarning")
 def test_parquet_piece_basics():
     path = '/baz.parq'
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1625,3 +1625,12 @@ def test_parquet_dataset_deprecated_properties(tempdir):
 
     with pytest.warns(DeprecationWarning, match="ParquetDataset.partitions"):
         dataset.partitions
+
+    with pytest.warns(DeprecationWarning, match="ParquetDataset.memory_map"):
+        dataset.memory_map
+
+    with pytest.warns(DeprecationWarning, match="ParquetDataset.read_diction"):
+        dataset.read_dictionary
+
+    with pytest.warns(DeprecationWarning, match="ParquetDataset.buffer_size"):
+        dataset.buffer_size

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -142,7 +142,7 @@ def test_read_partitioned_directory(tempdir, use_legacy_dataset):
     _partition_test_for_filesystem(fs, tempdir, use_legacy_dataset)
 
 
-@pytest.mark.filterwarnings("ignore:ParquetDataset:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:'ParquetDataset:DeprecationWarning")
 @pytest.mark.pandas
 def test_create_parquet_dataset_multi_threaded(tempdir):
     fs = LocalFileSystem._get_instance()
@@ -983,7 +983,7 @@ def test_dataset_read_pandas(tempdir, use_legacy_dataset):
     tm.assert_frame_equal(result.reindex(columns=expected.columns), expected)
 
 
-@pytest.mark.filterwarnings("ignore:ParquetDataset:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:'ParquetDataset:DeprecationWarning")
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_dataset_memory_map(tempdir, use_legacy_dataset):
@@ -1373,7 +1373,7 @@ def test_write_to_dataset_no_partitions_s3fs(
         path, use_legacy_dataset, filesystem=fs)
 
 
-@pytest.mark.filterwarnings("ignore:ParquetDataset:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:'ParquetDataset:DeprecationWarning")
 @pytest.mark.pandas
 @parametrize_legacy_dataset_not_supported
 def test_write_to_dataset_with_partitions_and_custom_filenames(
@@ -1600,7 +1600,7 @@ def test_parquet_dataset_new_filesystem(tempdir):
     assert result.equals(table)
 
 
-@pytest.mark.filterwarnings("ignore:ParquetDataset:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:'ParquetDataset:DeprecationWarning")
 def test_parquet_dataset_partitions_piece_path_with_fsspec(tempdir):
     # ARROW-10462 ensure that on Windows we properly use posix-style paths
     # as used by fsspec
@@ -1623,25 +1623,25 @@ def test_parquet_dataset_deprecated_properties(tempdir):
     pq.write_table(table, path)
     dataset = pq.ParquetDataset(path)
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.pieces"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.pieces"):
         dataset.pieces
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.partitions"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.partitions"):
         dataset.partitions
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.memory_map"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.memory_map"):
         dataset.memory_map
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.read_diction"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.read_dictio"):
         dataset.read_dictionary
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.buffer_size"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.buffer_size"):
         dataset.buffer_size
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.fs"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.fs"):
         dataset.fs
 
     dataset2 = pq.ParquetDataset(path, use_legacy_dataset=False)
 
-    with pytest.warns(DeprecationWarning, match="ParquetDataset.pieces"):
+    with pytest.warns(DeprecationWarning, match="'ParquetDataset.pieces"):
         dataset2.pieces

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -138,8 +138,8 @@ def test_parquet_metadata_lifetime(tempdir):
     # ARROW-6642 - ensure that chained access keeps parent objects alive
     table = pa.table({'a': [1, 2, 3]})
     pq.write_table(table, tempdir / 'test_metadata_segfault.parquet')
-    dataset = pq.ParquetDataset(tempdir / 'test_metadata_segfault.parquet')
-    dataset.pieces[0].get_metadata().row_group(0).column(0).statistics
+    parquet_file = pq.ParquetFile(tempdir / 'test_metadata_segfault.parquet')
+    parquet_file.metadata.row_group(0).column(0).statistics
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
The idea is that before fully deprecating/removing the legacy implementation of `ParquetDataset`, we can already deprecate its custom attributes (which is AFAIK the main/only reason to still use the legacy version).