### PR TITLE
ARROW-13097: [C++] Provide simple reflection utility

### DIFF
--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -57,6 +57,7 @@ add_arrow_test(utility-test
                logging_test.cc
                queue_test.cc
                range_test.cc
+               reflection_test.cc
                rle_encoding_test.cc
                stl_util_test.cc
                string_test.cc

--- a/cpp/src/arrow/util/reflection_internal.h
+++ b/cpp/src/arrow/util/reflection_internal.h
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <array>
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace arrow {
+namespace internal {
+
+namespace detail {
+
+#ifdef _MSC_VER
+#define ARROW_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define ARROW_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+template <typename T>
+const char* raw() {
+  return ARROW_PRETTY_FUNCTION;
+}
+
+template <typename T>
+size_t raw_sizeof() {
+  return sizeof(ARROW_PRETTY_FUNCTION);
+}
+
+#undef ARROW_PRETTY_FUNCTION
+
+constexpr bool starts_with(char const* haystack, char const* needle) {
+  return needle[0] == '\0' ||
+         (haystack[0] == needle[0] && starts_with(haystack + 1, needle + 1));
+}
+
+constexpr size_t search(char const* haystack, char const* needle) {
+  return haystack[0] == '\0' || starts_with(haystack, needle)
+             ? 0
+             : search(haystack + 1, needle) + 1;
+}
+
+const size_t typename_prefix = search(raw<double>(), "double");
+
+template <typename T>
+size_t struct_class_prefix() {
+#ifdef _MSC_VER
+  return starts_with(raw<T>() + typename_prefix, "struct ")
+             ? 7
+             : starts_with(raw<T>() + typename_prefix, "class ") ? 6 : 0;
+#else
+  return 0;
+#endif
+}
+
+template <typename T>
+size_t typename_length() {
+  // raw_sizeof<T>() - raw_sizeof<double>() ==
+  //     (length of T's name) - strlen("double")
+  // (length of T's name) ==
+  //     raw_sizeof<T>() - raw_sizeof<double>() + strlen("double")
+  return raw_sizeof<T>() - struct_class_prefix<T>() - raw_sizeof<double>() + 6;
+}
+
+template <typename T>
+const char* typename_begin() {
+  return raw<T>() + struct_class_prefix<T>() + typename_prefix;
+}
+
+template <class Class, typename Type, Type Class::*Ptr>
+struct member_pointer_constant {
+  static constexpr auto value = Ptr;
+};
+
+struct HasCrib {
+  double crib;
+  using crib_constant = member_pointer_constant<HasCrib, double, &HasCrib::crib>;
+};
+
+const size_t membername_boilerplate = search(raw<HasCrib::crib_constant>(), "crib") -
+                                      typename_length<HasCrib>() * 2 -
+                                      typename_length<double>();
+
+template <class Class, typename Type, Type Class::*Ptr>
+size_t membername_prefix() {
+  return membername_boilerplate + typename_length<Class>() * 2 + typename_length<Type>();
+}
+
+const size_t membername_suffix = raw_sizeof<HasCrib::crib_constant>() -
+                                 membername_prefix<HasCrib, double, &HasCrib::crib>() -
+                                 4;  //  == strlen("crib")
+
+template <class Class, typename Type, Type Class::*Ptr>
+const char* membername_begin() {
+  return raw<member_pointer_constant<Class, Type, Ptr>>() +
+         membername_prefix<Class, Type, Ptr>();
+}
+
+template <class Class, typename Type, Type Class::*Ptr>
+size_t membername_length() {
+  return raw_sizeof<member_pointer_constant<Class, Type, Ptr>>() -
+         membername_prefix<Class, Type, Ptr>() - membername_suffix;
+}
+
+}  // namespace detail
+
+template <typename T>
+std::string nameof(bool strip_namespace = false) {
+  std::string name{detail::typename_begin<T>(), detail::typename_length<T>()};
+  if (strip_namespace) {
+    auto i = name.find_last_of("::");
+    if (i != std::string::npos) {
+      name = name.substr(i + 1);
+    }
+  }
+  return name;
+}
+
+template <size_t...>
+struct index_sequence {};
+
+template <size_t N, size_t Head = N, size_t... Tail>
+struct make_index_sequence_impl;
+
+template <size_t N>
+using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
+template <typename... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+template <size_t N, size_t... I>
+struct make_index_sequence_impl<N, 0, I...> {
+  using type = index_sequence<I...>;
+};
+
+template <size_t N, size_t H, size_t... I>
+struct make_index_sequence_impl : make_index_sequence_impl<N, H - 1, H - 1, I...> {};
+
+static_assert(std::is_base_of<index_sequence<>, make_index_sequence<0>>::value, "");
+static_assert(std::is_base_of<index_sequence<0, 1, 2>, make_index_sequence<3>>::value,
+              "");
+
+template <typename Props, typename Fn, size_t... I>
+void ForEachPropertyImpl(Fn&& fn, const index_sequence<I...>&) {
+  struct {
+  } dummy;
+  std::make_tuple((std::forward<Fn>(fn)(std::get<I>(Props{}), I), dummy)...);
+}
+
+template <typename Props, typename Fn>
+void ForEachProperty(Fn&& fn) {
+  ForEachPropertyImpl<Props>(std::forward<Fn>(fn),
+                             make_index_sequence<std::tuple_size<Props>::value>{});
+}
+
+template <typename Class, typename Type, Type Class::*Ptr>
+struct DataMember {
+  using type = Type;
+
+  static constexpr auto ptr = Ptr;
+
+  static constexpr const type& get(const Class& obj) { return obj.*ptr; }
+
+  static void set(Class* obj, type value) { (*obj).*ptr = std::move(value); }
+
+  static std::string name() {
+    return std::string(detail::membername_begin<Class, Type, Ptr>(),
+                       detail::membername_length<Class, Type, Ptr>());
+  }
+};
+
+template <typename Class>
+struct ReflectionTraits {};
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/reflection_internal.h
+++ b/cpp/src/arrow/util/reflection_internal.h
@@ -83,8 +83,6 @@ struct TupleImpl<> {};
 template <size_t I0, size_t... I, typename T0, typename... T>
 struct TupleImpl<TupleMember<I0, T0>, TupleMember<I, T>...>
     : TupleMember<I0, T0>, TupleImpl<TupleMember<I, T>...> {
-  constexpr static size_t size() { return sizeof...(T); }
-
   constexpr explicit TupleImpl(T0 value0, T... values)
       : TupleMember<I0, T0>{value0}, TupleImpl<TupleMember<I, T>...>{values...} {}
 };
@@ -99,6 +97,8 @@ using TupleImplFor =
 template <typename... T>
 struct Tuple : TupleImplFor<T...> {
   using TupleImplFor<T...>::TupleImplFor;
+
+  constexpr static size_t size() { return sizeof...(T); }
 };
 
 template <typename... T>

--- a/cpp/src/arrow/util/reflection_internal.h
+++ b/cpp/src/arrow/util/reflection_internal.h
@@ -67,7 +67,9 @@ struct all_same<One, Other, Rest...> : std::false_type {};
 
 template <size_t I, typename T>
 struct TupleMember {
-  constexpr const T& operator[](index_constant<I>) const { return value_; }
+  friend constexpr const T& GetTupleMember(const TupleMember& member, index_constant<I>) {
+    return member.value_;
+  }
 
   T value_;
 };
@@ -101,7 +103,8 @@ constexpr Tuple<T...> MakeTuple(T... values) {
 
 template <size_t... I, typename... T, typename Fn>
 void ForEachTupleMember(const TupleImpl<TupleMember<I, T>...>& tup, Fn&& fn) {
-  (void)MakeTuple((fn(tup[index_constant<I>()], I), std::ignore)...);
+  (void)MakeTuple((fn(GetTupleMember(tup, index_constant<I>()), index_constant<I>()),
+                   std::ignore)...);
 }
 
 template <typename C, typename T>

--- a/cpp/src/arrow/util/reflection_internal.h
+++ b/cpp/src/arrow/util/reflection_internal.h
@@ -46,9 +46,8 @@ struct make_index_sequence_impl<N, 0, I...> {
 template <size_t N, size_t H, size_t... I>
 struct make_index_sequence_impl : make_index_sequence_impl<N, H - 1, H - 1, I...> {};
 
-static_assert(std::is_base_of<index_sequence<>, make_index_sequence<0>>::value, "");
-static_assert(std::is_base_of<index_sequence<0, 1, 2>, make_index_sequence<3>>::value,
-              "");
+static_assert(std::is_same<index_sequence<>, make_index_sequence<0>>::value, "");
+static_assert(std::is_same<index_sequence<0, 1, 2>, make_index_sequence<3>>::value, "");
 
 template <typename...>
 struct all_same : std::true_type {};

--- a/cpp/src/arrow/util/reflection_test.cc
+++ b/cpp/src/arrow/util/reflection_test.cc
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <sstream>
+
 #include <gtest/gtest.h>
 
 #include "arrow/util/reflection_internal.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 namespace internal {
@@ -61,60 +64,133 @@ bool operator!=(const Class& l, const Class& r) {
   return !(l == r);
 }
 
-const std::string& GenericToString(const std::string& str) { return str; }
-std::string GenericToString(int i) { return std::to_string(i); }
-
-template <typename Class, int NumProperties>
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
 struct ToStringImpl {
+  explicit ToStringImpl(const Class& obj)
+      : obj_(obj), members_(std::tuple_size<Properties>::value) {}
+
   template <typename Property>
   void operator()(const Property& prop, size_t i) {
-    members[i] = prop.name() + ": " + GenericToString(prop.get(obj));
+    std::stringstream ss;
+    ss << prop.name() << ":" << prop.get(obj_);
+    members_[i] = ss.str();
   }
 
   std::string Finish() {
-    std::string out = nameof<Person>(/*strip_namespace=*/true) + "{";
-    for (auto&& member : members) {
-      out += member + ", ";
-    }
-    out.resize(out.size() - 1);
-    out.back() = '}';
-    return out;
+    auto members = JoinStrings(members_, ",");
+    return nameof<Class>(/*strip_namespace=*/true) + "{" + members + "}";
   }
 
-  const Class& obj;
-  std::array<std::string, NumProperties> members;
+  const Class& obj_;
+  std::vector<std::string> members_;
 };
 
 template <typename Class,
           typename Properties = typename ReflectionTraits<Class>::Properties>
 std::string ToString(const Class& obj) {
-  ToStringImpl<Class, std::tuple_size<Properties>::value> impl{obj, {}};
+  ToStringImpl<Class> impl{obj};
   ForEachProperty<Properties>(impl);
   return impl.Finish();
 }
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
+struct FromStringImpl {
+  void Fail() { *obj_ = util::nullopt; }
+
+  template <typename Property>
+  void operator()(const Property& prop, size_t i) {
+    if (!obj_->has_value()) return;
+
+    auto first_colon = members_[i].find_first_of(':');
+    if (first_colon == util::string_view::npos) return Fail();
+
+    auto name = members_[i].substr(0, first_colon);
+    if (name != prop.name()) return Fail();
+
+    auto value_repr = members_[i].substr(first_colon + 1);
+    typename Property::type value;
+    try {
+      std::stringstream ss(value_repr.to_string());
+      ss >> value;
+      if (!ss.eof()) return Fail();
+    } catch (...) {
+      return Fail();
+    }
+    prop.set(&obj_->value(), value);
+  }
+
+  util::optional<Class>* obj_;
+  std::vector<util::string_view> members_;
+};
+
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
+util::optional<Class> FromString(util::string_view repr) {
+  auto first_brace = repr.find_first_of('{');
+  if (first_brace == util::string_view::npos) return util::nullopt;
+
+  auto name = repr.substr(0, first_brace);
+  if (name != nameof<Class>(/*strip_namespace=*/true)) return util::nullopt;
+
+  repr = repr.substr(first_brace + 1);
+  if (repr.empty()) return util::nullopt;
+  if (repr.back() != '}') return util::nullopt;
+  repr = repr.substr(0, repr.size() - 1);
+
+  auto members = SplitString(repr, ',');
+  if (members.size() != std::tuple_size<Properties>::value) return util::nullopt;
+
+  util::optional<Class> obj = Class{};
+  FromStringImpl<Class> impl{&obj, members};
+  ForEachProperty<Properties>(impl);
+  return obj;
+}
 
 TEST(Reflection, Nameof) {
-  ASSERT_EQ(nameof<Person>(), "arrow::internal::Person");
-  ASSERT_EQ(nameof<Person>(/*strip_namespace=*/true), "Person");
+  EXPECT_EQ(nameof<Person>(), "arrow::internal::Person");
+  EXPECT_EQ(nameof<Person>(/*strip_namespace=*/true), "Person");
 }
 
 TEST(Reflection, EqualityWithDataMembers) {
   Person genos{"Genos", 19};
   Person kuseno{"Kuseno", 45};
 
-  ASSERT_EQ(genos, genos);
-  ASSERT_EQ(kuseno, kuseno);
+  EXPECT_EQ(genos, genos);
+  EXPECT_EQ(kuseno, kuseno);
 
-  ASSERT_NE(genos, kuseno);
-  ASSERT_NE(kuseno, genos);
+  EXPECT_NE(genos, kuseno);
+  EXPECT_NE(kuseno, genos);
 }
 
 TEST(Reflection, ToStringFromDataMembers) {
   Person genos{"Genos", 19};
   Person kuseno{"Kuseno", 45};
 
-  ASSERT_EQ(ToString(genos), "Person{age: 19, name: Genos}");
-  ASSERT_EQ(ToString(kuseno), "Person{age: 45, name: Kuseno}");
+  EXPECT_EQ(ToString(genos), "Person{age:19,name:Genos}");
+  EXPECT_EQ(ToString(kuseno), "Person{age:45,name:Kuseno}");
+}
+
+TEST(Reflection, FromStringToDataMembers) {
+  Person genos{"Genos", 19};
+
+  EXPECT_EQ(FromString<Person>(ToString(genos)), genos);
+
+  EXPECT_EQ(FromString<Person>(""), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Per"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{age:19,name:Genos"), util::nullopt);
+
+  EXPECT_EQ(FromString<Person>("Person{name:Genos"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{age:19,name:Genos,extra:Cyborg}"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{name:Genos,age:19"), util::nullopt);
+
+  EXPECT_EQ(FromString<Person>("Fake{age:19,name:Genos}"), util::nullopt);
+
+  EXPECT_EQ(FromString<Person>("Person{age,name:Genos}"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{age:nineteen,name:Genos}"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{age:19 ,name:Genos}"), util::nullopt);
+  EXPECT_EQ(FromString<Person>("Person{age:19,moniker:Genos}"), util::nullopt);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/reflection_test.cc
+++ b/cpp/src/arrow/util/reflection_test.cc
@@ -31,7 +31,7 @@ struct EqualsImpl {
   template <typename Properties>
   EqualsImpl(const Class& l, const Class& r, const Properties& props)
       : left_(l), right_(r) {
-    ForEachTupleMember(props, *this);
+    props.ForEach(*this);
   }
 
   template <typename Property>
@@ -50,7 +50,7 @@ struct ToStringImpl {
   template <typename Properties>
   ToStringImpl(util::string_view class_name, const Class& obj, const Properties& props)
       : class_name_(class_name), obj_(obj), members_(props.size()) {
-    ForEachTupleMember(props, *this);
+    props.ForEach(*this);
   }
 
   template <typename Property>
@@ -76,7 +76,7 @@ struct FromStringImpl {
   FromStringImpl(util::string_view class_name, util::string_view repr,
                  const Properties& props) {
     Init(class_name, repr, props.size());
-    ForEachTupleMember(props, *this);
+    props.ForEach(*this);
   }
 
   void Fail() { obj_ = util::nullopt; }
@@ -130,7 +130,7 @@ struct Person {
 // NB: no references to Person::age or Person::name after this
 // NB: ordering of properties follows this enum, regardless of
 //     order of declaration in `struct Person`
-constexpr auto kPersonProperties =
+static auto kPersonProperties =
     MakeProperties(DataMember("age", &Person::age), DataMember("name", &Person::name));
 
 // use generic facilities to define equality, serialization and deserialization

--- a/cpp/src/arrow/util/reflection_test.cc
+++ b/cpp/src/arrow/util/reflection_test.cc
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/util/reflection_internal.h"
+
+namespace arrow {
+namespace internal {
+
+// unmodified structure which we wish to reflect on:
+struct Person {
+  std::string name;
+  int age;
+};
+
+// enumeration of properties:
+template <>
+struct ReflectionTraits<Person> {
+  using Properties = std::tuple<DataMember<Person, int, &Person::age>,
+                                DataMember<Person, std::string, &Person::name>>;
+};
+
+// generic property-based equality comparison
+template <typename Class>
+struct EqualsImpl {
+  template <typename Property>
+  void operator()(const Property& prop, size_t i) const {
+    *out &= prop.get(l) == prop.get(r);
+  }
+  const Class& l;
+  const Class& r;
+  bool* out;
+};
+
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
+bool operator==(const Class& l, const Class& r) {
+  bool out = true;
+  ForEachProperty<Properties>(EqualsImpl<Person>{l, r, &out});
+  return out;
+}
+
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
+bool operator!=(const Class& l, const Class& r) {
+  return !(l == r);
+}
+
+const std::string& GenericToString(const std::string& str) { return str; }
+std::string GenericToString(int i) { return std::to_string(i); }
+
+template <typename Class, int NumProperties>
+struct ToStringImpl {
+  template <typename Property>
+  void operator()(const Property& prop, size_t i) {
+    members[i] = prop.name() + ": " + GenericToString(prop.get(obj));
+  }
+
+  std::string Finish() {
+    std::string out = nameof<Person>(/*strip_namespace=*/true) + "{";
+    for (auto&& member : members) {
+      out += member + ", ";
+    }
+    out.resize(out.size() - 1);
+    out.back() = '}';
+    return out;
+  }
+
+  const Class& obj;
+  std::array<std::string, NumProperties> members;
+};
+
+template <typename Class,
+          typename Properties = typename ReflectionTraits<Class>::Properties>
+std::string ToString(const Class& obj) {
+  ToStringImpl<Class, std::tuple_size<Properties>::value> impl{obj, {}};
+  ForEachProperty<Properties>(impl);
+  return impl.Finish();
+}
+
+TEST(Reflection, Nameof) {
+  ASSERT_EQ(nameof<Person>(), "arrow::internal::Person");
+  ASSERT_EQ(nameof<Person>(/*strip_namespace=*/true), "Person");
+}
+
+TEST(Reflection, EqualityWithDataMembers) {
+  Person genos{"Genos", 19};
+  Person kuseno{"Kuseno", 45};
+
+  ASSERT_EQ(genos, genos);
+  ASSERT_EQ(kuseno, kuseno);
+
+  ASSERT_NE(genos, kuseno);
+  ASSERT_NE(kuseno, genos);
+}
+
+TEST(Reflection, ToStringFromDataMembers) {
+  Person genos{"Genos", 19};
+  Person kuseno{"Kuseno", 45};
+
+  ASSERT_EQ(ToString(genos), "Person{age: 19, name: Genos}");
+  ASSERT_EQ(ToString(kuseno), "Person{age: 45, name: Kuseno}");
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/reflection_test.cc
+++ b/cpp/src/arrow/util/reflection_test.cc
@@ -27,8 +27,8 @@ namespace internal {
 
 // unmodified structure which we wish to reflect on:
 struct Person {
-  std::string name;
   int age;
+  std::string name;
 };
 
 // enumeration of properties:
@@ -153,8 +153,8 @@ TEST(Reflection, Nameof) {
 }
 
 TEST(Reflection, EqualityWithDataMembers) {
-  Person genos{"Genos", 19};
-  Person kuseno{"Kuseno", 45};
+  Person genos{19, "Genos"};
+  Person kuseno{45, "Kuseno"};
 
   EXPECT_EQ(genos, genos);
   EXPECT_EQ(kuseno, kuseno);
@@ -164,15 +164,15 @@ TEST(Reflection, EqualityWithDataMembers) {
 }
 
 TEST(Reflection, ToStringFromDataMembers) {
-  Person genos{"Genos", 19};
-  Person kuseno{"Kuseno", 45};
+  Person genos{19, "Genos"};
+  Person kuseno{45, "Kuseno"};
 
   EXPECT_EQ(ToString(genos), "Person{age:19,name:Genos}");
   EXPECT_EQ(ToString(kuseno), "Person{age:45,name:Kuseno}");
 }
 
 TEST(Reflection, FromStringToDataMembers) {
-  Person genos{"Genos", 19};
+  Person genos{19, "Genos"};
 
   EXPECT_EQ(FromString<Person>(ToString(genos)), genos);
 

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<arrow::csv::ConvertOptions> csv___ConvertOptions__initialize(
   if (!Rf_isNull(op_timestamp_parsers)) {
     std::vector<std::shared_ptr<arrow::TimestampParser>> timestamp_parsers;
 
-    // if we have a character vector, convert to arrow::TimestampParser
+    // if we have a character vector, convert to arrow::StrptimeTimestampParser
     if (TYPEOF(op_timestamp_parsers) == STRSXP) {
       cpp11::strings s_timestamp_parsers(op_timestamp_parsers);
       for (cpp11::r_string s : s_timestamp_parsers) {


### PR DESCRIPTION
Provides functions for enumerating struct's data members, which enables reduction of boilerplate since many operations (equality comparison, serialization, ...) can be reduced to a generic loop over this enumeration of members.

```c++
struct Person { int age; std::string name; };

static auto kPersonProperties =
    MakeProperties(DataMember("age", &Person::age), DataMember("name", &Person::name));

bool operator==(const Person& l, const Person& r) { return EqualsImpl<Person>{l, r, kPersonProperties}.equal_; }
```