### PR TITLE
ARROW-13064: [C++] Implement select ('case when') function for fixed-width types

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -466,6 +466,10 @@ Result<Datum> IfElse(const Datum& cond, const Datum& if_true, const Datum& if_fa
   return CallFunction("if_else", {cond, if_true, if_false}, ctx);
 }
 
+Result<Datum> CaseWhen(const std::vector<Datum>& cases, ExecContext* ctx) {
+  return CallFunction("case_when", cases, ctx);
+}
+
 // ----------------------------------------------------------------------
 // Temporal functions
 

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -466,8 +466,12 @@ Result<Datum> IfElse(const Datum& cond, const Datum& if_true, const Datum& if_fa
   return CallFunction("if_else", {cond, if_true, if_false}, ctx);
 }
 
-Result<Datum> CaseWhen(const std::vector<Datum>& cases, ExecContext* ctx) {
-  return CallFunction("case_when", cases, ctx);
+Result<Datum> CaseWhen(const Datum& cond, const std::vector<Datum>& cases,
+                       ExecContext* ctx) {
+  std::vector<Datum> args = {cond};
+  args.reserve(cases.size() + 1);
+  args.insert(args.end(), cases.begin(), cases.end());
+  return CallFunction("case_when", args, ctx);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -741,6 +741,22 @@ ARROW_EXPORT
 Result<Datum> IfElse(const Datum& cond, const Datum& left, const Datum& right,
                      ExecContext* ctx = NULLPTR);
 
+/// \brief CaseWhen behaves like a switch/case or if-else if-else statement: for
+/// each row, select the first value for which the corresponding condition is
+/// true, or (if given) select the 'else' value, else emit null. Note that a
+/// null condition is the same as false.
+///
+/// \param[in] cases Zero or more pairs of conditions (Boolean) & values (any
+/// type), along with an optional 'else' value.
+/// \param[in] ctx the function execution context, optional
+///
+/// \return the resulting datum
+///
+/// \since 5.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> CaseWhen(const std::vector<Datum>& cases, ExecContext* ctx = NULLPTR);
+
 /// \brief Year returns year for each element of `values`
 ///
 /// \param[in] values input to extract year from

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -746,8 +746,8 @@ Result<Datum> IfElse(const Datum& cond, const Datum& left, const Datum& right,
 /// true, or (if given) select the 'else' value, else emit null. Note that a
 /// null condition is the same as false.
 ///
-/// \param[in] cases Zero or more pairs of conditions (Boolean) & values (any
-/// type), along with an optional 'else' value.
+/// \param[in] cond Conditions (Boolean)
+/// \param[in] cases Values (any type), along with an optional 'else' value.
 /// \param[in] ctx the function execution context, optional
 ///
 /// \return the resulting datum
@@ -755,7 +755,8 @@ Result<Datum> IfElse(const Datum& cond, const Datum& left, const Datum& right,
 /// \since 5.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> CaseWhen(const std::vector<Datum>& cases, ExecContext* ctx = NULLPTR);
+Result<Datum> CaseWhen(const Datum& cond, const std::vector<Datum>& cases,
+                       ExecContext* ctx = NULLPTR);
 
 /// \brief Year returns year for each element of `values`
 ///

--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -402,8 +402,7 @@ KernelSignature::KernelSignature(std::vector<InputType> in_types, OutputType out
       out_type_(std::move(out_type)),
       is_varargs_(is_varargs),
       hash_code_(0) {
-  // VarArgs sigs must have only a single input type to use for argument validation
-  DCHECK(!is_varargs || (is_varargs && (in_types_.size() == 1)));
+  DCHECK(!is_varargs || (is_varargs && (in_types_.size() >= 1)));
 }
 
 std::shared_ptr<KernelSignature> KernelSignature::Make(std::vector<InputType> in_types,
@@ -430,8 +429,8 @@ bool KernelSignature::Equals(const KernelSignature& other) const {
 
 bool KernelSignature::MatchesInputs(const std::vector<ValueDescr>& args) const {
   if (is_varargs_) {
-    for (const auto& arg : args) {
-      if (!in_types_[0].Matches(arg)) {
+    for (size_t i = 0; i < args.size(); ++i) {
+      if (!in_types_[std::min(i, in_types_.size() - 1)].Matches(args[i])) {
         return false;
       }
     }
@@ -464,15 +463,19 @@ std::string KernelSignature::ToString() const {
   std::stringstream ss;
 
   if (is_varargs_) {
-    ss << "varargs[" << in_types_[0].ToString() << "]";
+    ss << "varargs[";
   } else {
     ss << "(";
-    for (size_t i = 0; i < in_types_.size(); ++i) {
-      if (i > 0) {
-        ss << ", ";
-      }
-      ss << in_types_[i].ToString();
+  }
+  for (size_t i = 0; i < in_types_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
     }
+    ss << in_types_[i].ToString();
+  }
+  if (is_varargs_) {
+    ss << "]";
+  } else {
     ss << ")";
   }
   ss << " -> " << out_type_.ToString();

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -366,8 +366,10 @@ class ARROW_EXPORT OutputType {
 
 /// \brief Holds the input types and output type of the kernel.
 ///
-/// VarArgs functions should pass a single input type to be used to validate
-/// the input types of a function invocation.
+/// VarArgs functions with minimum N arguments should pass up to N input types to be
+/// used to validate the input types of a function invocation. The first N-1 types
+/// will be matched against the first N-1 arguments, and the last type will be
+/// matched against the remaining arguments.
 class ARROW_EXPORT KernelSignature {
  public:
   KernelSignature(std::vector<InputType> in_types, OutputType out_type,

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -468,15 +468,28 @@ TEST(KernelSignature, MatchesInputs) {
 }
 
 TEST(KernelSignature, VarArgsMatchesInputs) {
-  KernelSignature sig({int8()}, utf8(), /*is_varargs=*/true);
+  {
+    KernelSignature sig({int8()}, utf8(), /*is_varargs=*/true);
 
-  std::vector<ValueDescr> args = {int8()};
-  ASSERT_TRUE(sig.MatchesInputs(args));
-  args.push_back(ValueDescr::Scalar(int8()));
-  args.push_back(ValueDescr::Array(int8()));
-  ASSERT_TRUE(sig.MatchesInputs(args));
-  args.push_back(int32());
-  ASSERT_FALSE(sig.MatchesInputs(args));
+    std::vector<ValueDescr> args = {int8()};
+    ASSERT_TRUE(sig.MatchesInputs(args));
+    args.push_back(ValueDescr::Scalar(int8()));
+    args.push_back(ValueDescr::Array(int8()));
+    ASSERT_TRUE(sig.MatchesInputs(args));
+    args.push_back(int32());
+    ASSERT_FALSE(sig.MatchesInputs(args));
+  }
+  {
+    KernelSignature sig({int8(), utf8()}, utf8(), /*is_varargs=*/true);
+
+    std::vector<ValueDescr> args = {int8()};
+    ASSERT_TRUE(sig.MatchesInputs(args));
+    args.push_back(ValueDescr::Scalar(utf8()));
+    args.push_back(ValueDescr::Array(utf8()));
+    ASSERT_TRUE(sig.MatchesInputs(args));
+    args.push_back(int32());
+    ASSERT_FALSE(sig.MatchesInputs(args));
+  }
 }
 
 TEST(KernelSignature, ToString) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -218,9 +218,14 @@ void ReplaceTypes(const std::shared_ptr<DataType>& type,
 }
 
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
-  DCHECK(!descrs.empty()) << "tried to find CommonNumeric type of an empty set";
+  return CommonNumeric(descrs.data(), descrs.size());
+}
 
-  for (const auto& descr : descrs) {
+std::shared_ptr<DataType> CommonNumeric(const ValueDescr* begin, size_t count) {
+  DCHECK_GT(count, 0) << "tried to find CommonNumeric type of an empty set";
+
+  for (size_t i = 0; i < count; i++) {
+    const auto& descr = *(begin + i);
     auto id = descr.type->id();
     if (!is_floating(id) && !is_integer(id)) {
       // a common numeric type is only possible if all types are numeric
@@ -232,17 +237,20 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
     }
   }
 
-  for (const auto& descr : descrs) {
+  for (size_t i = 0; i < count; i++) {
+    const auto& descr = *(begin + i);
     if (descr.type->id() == Type::DOUBLE) return float64();
   }
 
-  for (const auto& descr : descrs) {
+  for (size_t i = 0; i < count; i++) {
+    const auto& descr = *(begin + i);
     if (descr.type->id() == Type::FLOAT) return float32();
   }
 
   int max_width_signed = 0, max_width_unsigned = 0;
 
-  for (const auto& descr : descrs) {
+  for (size_t i = 0; i < count; i++) {
+    const auto& descr = *(begin + i);
     auto id = descr.type->id();
     auto max_width = &(is_signed_integer(id) ? max_width_signed : max_width_unsigned);
     *max_width = std::max(bit_width(id), *max_width);

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -253,7 +253,7 @@ std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs) {
     if (max_width_unsigned == 32) return uint32();
     if (max_width_unsigned == 16) return uint16();
     DCHECK_EQ(max_width_unsigned, 8);
-    return int8();
+    return uint8();
   }
 
   if (max_width_signed <= max_width_unsigned) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1368,6 +1368,9 @@ ARROW_EXPORT
 std::shared_ptr<DataType> CommonNumeric(const std::vector<ValueDescr>& descrs);
 
 ARROW_EXPORT
+std::shared_ptr<DataType> CommonNumeric(const ValueDescr* begin, size_t count);
+
+ARROW_EXPORT
 std::shared_ptr<DataType> CommonTimestamp(const std::vector<ValueDescr>& descrs);
 
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -869,7 +869,7 @@ template <typename Type>
 Status ExecArrayCaseWhen(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   const auto& conds_array = *batch.values[0].array();
   if (conds_array.GetNullCount() > 0) {
-    return Status::Invalid("cond struct must not have nulls");
+    return Status::Invalid("cond struct must not have top-level nulls");
   }
   ArrayData* output = out->mutable_array();
   const int64_t out_offset = output->offset;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1024,16 +1024,17 @@ const FunctionDoc if_else_doc{"Choose values based on a condition",
 
 const FunctionDoc case_when_doc{
     "Choose values based on multiple conditions",
-    ("`cond` must be a sequence of alternating Boolean condition data "
-     "and value data (of any type, but all must be the same type or "
-     "castable to a common type), along with an optional datum of "
-     "\"else\" values. At least one datum must be given.\n"
+    ("`cond` must be a struct of Boolean values. `cases` can be a mix "
+     "of scalar and array arguments (of any type, but all must be the "
+     "same type or castable to a common type), with either exactly one "
+     "datum per child of `cond`, or one more `cases` than children of "
+     "`cond` (in which case we have an \"else\" value).\n"
      "Each row of the output will be the corresponding value of the "
-     "first value datum for which the corresponding condition datum "
+     "first datum in `cases` for which the corresponding child of `cond` "
      "is true, or otherwise the \"else\" value (if given), or null. "
-     "Essentially, this implements a switch-case or if-else if-else "
+     "Essentially, this implements a switch-case or if-else, if-else... "
      "statement."),
-    {"*cond"}};
+    {"cond", "*cases"}};
 }  // namespace
 
 void RegisterScalarIfElse(FunctionRegistry* registry) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -99,7 +99,7 @@ static void IfElseBench32Contiguous(benchmark::State& state) {
   return IfElseBenchContiguous<UInt32Type>(state);
 }
 
-template <typename Type, bool outer_nulls = false>
+template <typename Type>
 static void CaseWhenBench(benchmark::State& state) {
   using CType = typename Type::c_type;
   auto type = TypeTraits<Type>::type_singleton();
@@ -118,10 +118,9 @@ static void CaseWhenBench(benchmark::State& state) {
       rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
   auto cond_field =
       field("cond", boolean(), key_value_metadata({{"null_probability", "0.01"}}));
-  auto cond = rand.ArrayOf(
-      *field("", struct_({cond_field, cond_field, cond_field}),
-             key_value_metadata({{"null_probability", outer_nulls ? "0.01" : "0.0"}})),
-      len);
+  auto cond = rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),
+                                  key_value_metadata({{"null_probability", "0.0"}})),
+                           len);
   auto val1 = std::static_pointer_cast<ArrayType>(
       rand.ArrayOf(type, len, /*null_probability=*/0.01));
   auto val2 = std::static_pointer_cast<ArrayType>(
@@ -179,11 +178,6 @@ static void CaseWhenBench64(benchmark::State& state) {
   return CaseWhenBench<UInt64Type>(state);
 }
 
-static void CaseWhenBench64OuterNulls(benchmark::State& state) {
-  // Benchmark where both children of cond have nulls and cond itself has nulls
-  return CaseWhenBench<UInt64Type, /*outer_nulls=*/true>(state);
-}
-
 static void CaseWhenBench64Contiguous(benchmark::State& state) {
   return CaseWhenBenchContiguous<UInt64Type>(state);
 }
@@ -202,9 +196,6 @@ BENCHMARK(IfElseBench64Contiguous)->Args({elems, 99});
 
 BENCHMARK(CaseWhenBench64)->Args({elems, 0});
 BENCHMARK(CaseWhenBench64)->Args({elems, 99});
-
-BENCHMARK(CaseWhenBench64OuterNulls)->Args({elems, 0});
-BENCHMARK(CaseWhenBench64OuterNulls)->Args({elems, 99});
 
 BENCHMARK(CaseWhenBench64Contiguous)->Args({elems, 0});
 BENCHMARK(CaseWhenBench64Contiguous)->Args({elems, 99});

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -122,12 +122,15 @@ static void CaseWhenBench(benchmark::State& state) {
       rand.ArrayOf(type, len, /*null_probability=*/0.01));
   auto val4 = std::static_pointer_cast<ArrayType>(
       rand.ArrayOf(type, len, /*null_probability=*/0.01));
+  ASSERT_OK_AND_ASSIGN(
+      auto cond,
+      StructArray::Make({cond1, cond2, cond3}, std::vector<std::string>{"a", "b", "c"},
+                        nullptr, /*null_count=*/0));
 
   for (auto _ : state) {
     ABORT_NOT_OK(
-        CaseWhen({cond1->Slice(offset), val1->Slice(offset), cond2->Slice(offset),
-                  val2->Slice(offset), cond3->Slice(offset), val3->Slice(offset),
-                  val4->Slice(offset)}));
+        CaseWhen(cond->Slice(offset), {val1->Slice(offset), val2->Slice(offset),
+                                       val3->Slice(offset), val4->Slice(offset)}));
   }
 
   state.SetBytesProcessed(state.iterations() *
@@ -160,11 +163,13 @@ static void CaseWhenBenchContiguous(benchmark::State& state) {
       rand.ArrayOf(type, len, /*null_probability=*/0.01));
   auto val3 = std::static_pointer_cast<ArrayType>(
       rand.ArrayOf(type, len, /*null_probability=*/0.01));
+  ASSERT_OK_AND_ASSIGN(
+      auto cond, StructArray::Make({cond1, cond2}, std::vector<std::string>{"a", "b"},
+                                   nullptr, /*null_count=*/0));
 
   for (auto _ : state) {
-    ABORT_NOT_OK(
-        CaseWhen({cond1->Slice(offset), val1->Slice(offset), cond2->Slice(offset),
-                  val2->Slice(offset), val3->Slice(offset)}));
+    ABORT_NOT_OK(CaseWhen(cond->Slice(offset), {val1->Slice(offset), val2->Slice(offset),
+                                                val3->Slice(offset)}));
   }
 
   state.SetBytesProcessed(state.iterations() *

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -133,8 +133,7 @@ static void CaseWhenBench(benchmark::State& state) {
                                        val3->Slice(offset), val4->Slice(offset)}));
   }
 
-  state.SetBytesProcessed(state.iterations() *
-                          ((len - offset) / 8 + 4 * (len - offset) * sizeof(CType)));
+  state.SetBytesProcessed(state.iterations() * (len - offset) * sizeof(CType));
 }
 
 template <typename Type>
@@ -172,8 +171,7 @@ static void CaseWhenBenchContiguous(benchmark::State& state) {
                                                 val3->Slice(offset)}));
   }
 
-  state.SetBytesProcessed(state.iterations() *
-                          ((len - offset) / 8 + 3 * (len - offset) * sizeof(CType)));
+  state.SetBytesProcessed(state.iterations() * (len - offset) * sizeof(CType));
 }
 
 static void CaseWhenBench64(benchmark::State& state) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -408,6 +408,19 @@ TYPED_TEST(TestCaseWhenNumeric, FixedSize) {
        ArrayFromJSON(type, "[20, 21, 22, 23, 24, 25, 26, 27, 28]"),
        ArrayFromJSON(type, "[30, 31, 32, 33, 34, null, 36, 37, null]")},
       ArrayFromJSON(type, "[10, 11, 12, 23, 34, null, 26, 37, null]"));
+
+  // Error cases
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("cond struct must not be null"),
+      CallFunction(
+          "case_when",
+          {Datum(std::make_shared<StructScalar>(struct_({field("", boolean())}))),
+           Datum(scalar1)}));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("cond struct must not have nulls"),
+      CallFunction(
+          "case_when",
+          {Datum(*MakeArrayOfNull(struct_({field("", boolean())}), 4)), Datum(values1)}));
 }
 
 TEST(TestCaseWhen, Null) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -417,7 +417,7 @@ TYPED_TEST(TestCaseWhenNumeric, FixedSize) {
           {Datum(std::make_shared<StructScalar>(struct_({field("", boolean())}))),
            Datum(scalar1)}));
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, ::testing::HasSubstr("cond struct must not have nulls"),
+      Invalid, ::testing::HasSubstr("cond struct must not have top-level nulls"),
       CallFunction(
           "case_when",
           {Datum(*MakeArrayOfNull(struct_({field("", boolean())}), 4)), Datum(values1)}));

--- a/cpp/src/arrow/compute/kernels/test_util.h
+++ b/cpp/src/arrow/compute/kernels/test_util.h
@@ -95,8 +95,7 @@ void CheckScalar(std::string func_name, const ScalarVector& inputs,
                  std::shared_ptr<Scalar> expected,
                  const FunctionOptions* options = nullptr);
 
-void CheckScalar(std::string func_name, const DatumVector& inputs,
-                 std::shared_ptr<Array> expected,
+void CheckScalar(std::string func_name, const DatumVector& inputs, Datum expected,
                  const FunctionOptions* options = nullptr);
 
 void CheckScalarUnary(std::string func_name, std::shared_ptr<DataType> in_ty,

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -863,30 +863,40 @@ Structural transforms
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
 | Function name            | Arity      | Input types                                    | Output type         | Notes   |
 +==========================+============+================================================+=====================+=========+
-| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like  | Input type          | \(1)    |
+| case_when                | Varargs    | Boolean, Any fixed-width                       | Input type          | \(1)   |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal               | Input type          | \(2)    |
+| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like  | Input type          | \(2)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_finite                | Unary      | Float, Double                                  | Boolean             | \(3)    |
+| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal               | Input type          | \(3)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_inf                   | Unary      | Float, Double                                  | Boolean             | \(4)    |
+| is_finite                | Unary      | Float, Double                                  | Boolean             | \(4)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_nan                   | Unary      | Float, Double                                  | Boolean             | \(5)    |
+| is_inf                   | Unary      | Float, Double                                  | Boolean             | \(5)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_null                  | Unary      | Any                                            | Boolean             | \(6)    |
+| is_nan                   | Unary      | Float, Double                                  | Boolean             | \(6)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_valid                 | Unary      | Any                                            | Boolean             | \(7)    |
+| is_null                  | Unary      | Any                                            | Boolean             | \(7)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| list_value_length        | Unary      | List-like                                      | Int32 or Int64      | \(8)    |
+| is_valid                 | Unary      | Any                                            | Boolean             | \(8)    |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
-| project                  | Varargs    | Any                                            | Struct              | \(9)    |
+| list_value_length        | Unary      | List-like                                      | Int32 or Int64      | \(9)    |
++--------------------------+------------+------------------------------------------------+---------------------+---------+
+| project                  | Varargs    | Any                                            | Struct              | \(10)   |
 +--------------------------+------------+------------------------------------------------+---------------------+---------+
 
-* \(1) First input must be an array, second input a scalar of the same type.
+* \(1) This function acts like a SQL 'case when' statement or switch-case. The
+  input is any number of alternating Boolean and value data, followed by an
+  optional value datum to represent the 'else' or 'default' case. At least one
+  input must be provided. The output is of the same type as the value inputs;
+  each row will be the corresponding value from the first value datum for which
+  the corresponding Boolean is true, or the corresponding value from the
+  'default' input, or null otherwise.
+
+* \(2) First input must be an array, second input a scalar of the same type.
   Output is an array of the same type as the inputs, and with the same values
   as the first input, except for nulls replaced with the second input value.
 
-* \(2) First input must be a Boolean scalar or array. Second and third inputs
+* \(3) First input must be a Boolean scalar or array. Second and third inputs
   could be scalars or arrays and must be of the same type. Output is an array
   (or scalar if all inputs are scalar) of the same type as the second/ third
   input. If the nulls present on the first input, they will be promoted to the
@@ -894,21 +904,21 @@ Structural transforms
 
   Also see: :ref:`replace_with_mask <cpp-compute-vector-structural-transforms>`.
 
-* \(3) Output is true iff the corresponding input element is finite (not Infinity,
+* \(4) Output is true iff the corresponding input element is finite (not Infinity,
   -Infinity, or NaN).
 
-* \(4) Output is true iff the corresponding input element is Infinity/-Infinity.
+* \(5) Output is true iff the corresponding input element is Infinity/-Infinity.
 
-* \(5) Output is true iff the corresponding input element is NaN.
+* \(6) Output is true iff the corresponding input element is NaN.
 
-* \(6) Output is true iff the corresponding input element is null.
+* \(7) Output is true iff the corresponding input element is null.
 
-* \(7) Output is true iff the corresponding input element is non-null.
+* \(8) Output is true iff the corresponding input element is non-null.
 
-* \(8) Each output element is the length of the corresponding input element
+* \(9) Each output element is the length of the corresponding input element
   (null if input is null).  Output type is Int32 for List, Int64 for LargeList.
 
-* \(9) The output struct's field types are the types of its arguments. The
+* \(10) The output struct's field types are the types of its arguments. The
   field names are specified using an instance of :struct:`ProjectOptions`.
   The output shape will be scalar if all inputs are scalar, otherwise any
   scalars will be broadcast to arrays.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -860,37 +860,38 @@ Structural transforms
 
 .. XXX (this category is a bit of a hodgepodge)
 
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| Function name            | Arity      | Input types                                    | Output type         | Notes   |
-+==========================+============+================================================+=====================+=========+
-| case_when                | Varargs    | Boolean, Any fixed-width                       | Input type          | \(1)   |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like  | Input type          | \(2)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal               | Input type          | \(3)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_finite                | Unary      | Float, Double                                  | Boolean             | \(4)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_inf                   | Unary      | Float, Double                                  | Boolean             | \(5)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_nan                   | Unary      | Float, Double                                  | Boolean             | \(6)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_null                  | Unary      | Any                                            | Boolean             | \(7)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| is_valid                 | Unary      | Any                                            | Boolean             | \(8)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| list_value_length        | Unary      | List-like                                      | Int32 or Int64      | \(9)    |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
-| project                  | Varargs    | Any                                            | Struct              | \(10)   |
-+--------------------------+------------+------------------------------------------------+---------------------+---------+
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| Function name            | Arity      | Input types                                       | Output type         | Notes   |
++==========================+============+===================================================+=====================+=========+
+| case_when                | Varargs    | Struct of Boolean (Arg 0), Any fixed-width (rest) | Input type          | \(1)   |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like     | Input type          | \(2)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal                  | Input type          | \(3)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| is_finite                | Unary      | Float, Double                                     | Boolean             | \(4)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| is_inf                   | Unary      | Float, Double                                     | Boolean             | \(5)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| is_nan                   | Unary      | Float, Double                                     | Boolean             | \(6)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| is_null                  | Unary      | Any                                               | Boolean             | \(7)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| is_valid                 | Unary      | Any                                               | Boolean             | \(8)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| list_value_length        | Unary      | List-like                                         | Int32 or Int64      | \(9)    |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| project                  | Varargs    | Any                                               | Struct              | \(10)   |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
 
 * \(1) This function acts like a SQL 'case when' statement or switch-case. The
-  input is any number of alternating Boolean and value data, followed by an
-  optional value datum to represent the 'else' or 'default' case. At least one
-  input must be provided. The output is of the same type as the value inputs;
-  each row will be the corresponding value from the first value datum for which
-  the corresponding Boolean is true, or the corresponding value from the
-  'default' input, or null otherwise.
+  input is a "condition" value, which is a struct of Booleans, followed by the
+  values for each "branch". There must be either exactly one value argument for
+  each child of the condition struct, or one more value argument than children
+  (in which case we have an 'else' or 'default' value). The output is of the
+  same type as the value inputs; each row will be the corresponding value from
+  the first value datum for which the corresponding Boolean is true, or the
+  corresponding value from the 'default' input, or null otherwise.
 
 * \(2) First input must be an array, second input a scalar of the same type.
   Output is an array of the same type as the inputs, and with the same values

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -335,6 +335,7 @@ Structural Transforms
    :toctree: ../generated/
 
    binary_length
+   case_when
    fill_null
    if_else
    is_finite


### PR DESCRIPTION
This doesn't support variable-width types (e.g. strings) as the implementation here is columnwise. I will work on those separately (they require a rowwise implementation).

Also fixes a small bug in the CommonNumericType implementation (I noticed uint8 was getting promoted to int8).