### PR TITLE
ARROW-13125: [R] Throw error when 2+ args passed to desc() in arrange()

### DIFF
--- a/r/R/dplyr-arrange.R
+++ b/r/R/dplyr-arrange.R
@@ -77,7 +77,8 @@ find_and_remove_desc <- function(quosure) {
       # remove enclosing parentheses
       expr <- expr[[2]]
     } else if (identical(expr[[1]], quote(desc))) {
-      # ensure desc() has only one argument
+      # ensure desc() has only one argument (when an R expression is a function
+      # call, length == 2 means it has exactly one argument)
       if (length(expr) > 2) {
         stop("desc() expects only one argument", call. = FALSE)
       }

--- a/r/R/dplyr-arrange.R
+++ b/r/R/dplyr-arrange.R
@@ -77,6 +77,10 @@ find_and_remove_desc <- function(quosure) {
       # remove enclosing parentheses
       expr <- expr[[2]]
     } else if (identical(expr[[1]], quote(desc))) {
+      # ensure desc() has only one argument
+      if (length(expr) > 2) {
+        stop("desc() expects only one argument", call. = FALSE)
+      }
       # remove desc() and toggle descending
       expr <- expr[[2]]
       descending <- !descending

--- a/r/tests/testthat/test-dplyr-arrange.R
+++ b/r/tests/testthat/test-dplyr-arrange.R
@@ -210,4 +210,11 @@ test_that("arrange() with bad inputs", {
     "not found",
     fixed = TRUE
   )
+  expect_error(
+    tbl %>%
+      Table$create() %>%
+      arrange(desc(int, chr)),
+    "expects only one argument",
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
This throws an error if the user passes two or more arguments to `desc()` in `arrange()`. Previously the second argument was silently ignored. The zero-arguments case is already handled.