### PR TITLE
ARROW-13147: [Java] Respect the rounding policy when allocating vector buffers

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -715,6 +715,11 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     return ImmutableConfig.builder();
   }
 
+  @Override
+  public RoundingPolicy getRoundingPolicy() {
+    return roundingPolicy;
+  }
+
   /**
    * Config class of {@link BaseAllocator}.
    */

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -19,6 +19,9 @@ package org.apache.arrow.memory;
 
 import java.util.Collection;
 
+import org.apache.arrow.memory.rounding.DefaultRoundingPolicy;
+import org.apache.arrow.memory.rounding.RoundingPolicy;
+
 /**
  * Wrapper class to deal with byte buffer allocation. Ensures users only use designated methods.
  */
@@ -225,4 +228,11 @@ public interface BufferAllocator extends AutoCloseable {
    * a no-op.
    */
   void assertOpen();
+
+  /**
+   * Gets the rounding policy of the allocator.
+   */
+  default RoundingPolicy getRoundingPolicy() {
+    return DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY;
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
-import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.util.DataSizeRoundingUtil;
 import org.apache.arrow.vector.util.TransferPair;
@@ -141,7 +140,7 @@ public abstract class BaseValueVector implements ValueVector {
     } else {
       bufferSize += DataSizeRoundingUtil.roundUpTo8Multiple((long) valueCount * typeWidth);
     }
-    return CommonUtil.nextPowerOfTwo(bufferSize);
+    return allocator.getRoundingPolicy().getRoundedSize(bufferSize);
   }
 
   /**
@@ -174,7 +173,7 @@ public abstract class BaseValueVector implements ValueVector {
     if (typeWidth == 0) {
       validityBufferSize = dataBufferSize = bufferSize / 2;
     } else {
-      // Due to roundup to power-of-2 allocation, the bufferSize could be greater than the
+      // Due to the rounding policy, the bufferSize could be greater than the
       // requested size. Utilize the allocated buffer fully.;
       long actualCount = (long) ((bufferSize * 8.0) / (8 * typeWidth + 1));
       do {


### PR DESCRIPTION
According to the current implementation, the default "next power of two" rounding policy is assumed when allocating buffers for a vector.

In particular, for fixed width vectors, this policy is applied for the validity and data buffers, and for variable width vectors, this policy is applied for the validity and offset buffers.

However, this default policy is not always used for the allocator. When an alternative policy is in use, the buffers allocated assuming the default policy will have inappropriate capacities, which may lead to waste of memory spaces.

