### PR TITLE
ARROW-10316: [Python] Improve introspection of compute function options

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -537,8 +537,8 @@ def test_min_max():
 
     # Missing argument
     with pytest.raises(
-            TypeError,
-            match=r"min_max\(\) missing 1 required positional argument"):
+            ValueError,
+            match=r"Function min_max accepts 1 argument"):
         s = pc.min_max()
 
 
@@ -614,6 +614,22 @@ def test_generated_docstrings():
         memory_pool : pyarrow.MemoryPool, optional
             If not passed, will allocate memory from the default memory pool.
         """)
+
+
+def test_generated_signatures():
+    # The self-documentation provided by signatures should show acceptable
+    # options and their default values.
+    sig = inspect.signature(pc.add)
+    assert str(sig) == "(x, y, *, memory_pool=None)"
+    sig = inspect.signature(pc.min_max)
+    assert str(sig) == ("(array, *, memory_pool=None, "
+                        "options=None, skip_nulls=True, min_count=1)")
+    sig = inspect.signature(pc.quantile)
+    assert str(sig) == ("(array, *, memory_pool=None, "
+                        "options=None, q=0.5, interpolation='linear')")
+    sig = inspect.signature(pc.binary_join_element_wise)
+    assert str(sig) == ("(*strings, memory_pool=None, options=None, "
+                        "null_handling='emit_null', null_replacement='')")
 
 
 # We use isprintable to find about codepoints that Python doesn't know, but


### PR DESCRIPTION
Generate a signature for compute functions that better reflects the accepted arguments.

Example before:
```python
>>> pc.sum?
Signature: pc.sum(array, *, options=None, memory_pool=None, **kwargs)
Docstring:
Compute the sum of a numeric array.
[...]
```

Same example after:
```python
>>> ?pc.sum
Signature:
pc.sum(
    array,
    *,
    memory_pool=None,
    options=None,
    skip_nulls=True,
    min_count=1,
)
Docstring:
Compute the sum of a numeric array.
[...]
```

One caveat is that the individual options are not explicitly documented (yet):
```
Parameters
----------
array : Array-like
    Argument to compute function
memory_pool : pyarrow.MemoryPool, optional
    If not passed, will allocate memory from the default memory pool.
options : pyarrow.compute.ScalarAggregateOptions, optional
    Parameters altering compute function semantics
**kwargs : optional
    Parameters for ScalarAggregateOptions constructor. Either `options`
    or `**kwargs` can be passed, but not both at the same time.
```