### PR TITLE
ARROW-12142: [Python][Doc] Mention the CXX ABI flag in the docs

### DIFF
--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -477,3 +477,7 @@ wheel version (2010 or 2014) is being used. In addition to the other notes
 above, if you are compiling C++ using these shared libraries, you will need
 to make sure you use a compatible toolchain as well or you might see a
 segfault during runtime.
+
+Also, if you enconter errors when linking or loading the library, consider
+setting the ``_GLIBCXX_USE_CXX11_ABI`` preprocessor macro to ``0``
+(for example by adding ``-D_GLIBCXX_USE_CXX11_ABI=0`` to ``CFLAGS``).

--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -478,6 +478,6 @@ above, if you are compiling C++ using these shared libraries, you will need
 to make sure you use a compatible toolchain as well or you might see a
 segfault during runtime.
 
-Also, if you enconter errors when linking or loading the library, consider
+Also, if you encounter errors when linking or loading the library, consider
 setting the ``_GLIBCXX_USE_CXX11_ABI`` preprocessor macro to ``0``
 (for example by adding ``-D_GLIBCXX_USE_CXX11_ABI=0`` to ``CFLAGS``).


### PR DESCRIPTION
Getting weird linker errors when trying to compile C++ code against the manylinux-provided Arrow shared library is common.  Give the solution explicitly in the docs.