### PR TITLE
ARROW-12016  [C++] Implement array_sort_indices and sort_indices for BOOL type

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -42,6 +42,7 @@ namespace internal {
 
 // Visit all physical types for which sorting is implemented.
 #define VISIT_PHYSICAL_TYPES(VISIT) \
+  VISIT(BooleanType)                \
   VISIT(Int8Type)                   \
   VISIT(Int16Type)                  \
   VISIT(Int32Type)                  \
@@ -693,8 +694,6 @@ class ChunkedArraySorter : public TypeVisitor {
         ctx_(ctx) {}
 
   Status Sort() { return physical_type_->Accept(this); }
-
-  Status Visit(const BooleanType& type) override { return SortInternal<BooleanType>(); }
 
 #define VISIT(TYPE) \
   Status Visit(const TYPE& type) override { return SortInternal<TYPE>(); }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -500,9 +500,9 @@ class ArrayCountSorter<BooleanType> {
 
   // Returns where null starts.
   // `offset` is used when this is called on a chunk of a chunked array
-  static uint64_t* Sort(uint64_t* indices_begin, uint64_t* indices_end,
-                        const BooleanArray& values, int64_t offset,
-                        const ArraySortOptions& options) {
+  uint64_t* Sort(uint64_t* indices_begin, uint64_t* indices_end,
+                 const BooleanArray& values, int64_t offset,
+                 const ArraySortOptions& options) {
     // first slot reserved for prefix sum
     std::array<int64_t, 3> counts{0, 0, 0};
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -694,6 +694,8 @@ class ChunkedArraySorter : public TypeVisitor {
 
   Status Sort() { return physical_type_->Accept(this); }
 
+  Status Visit(const BooleanType& type) override { return SortInternal<BooleanType>(); }
+
 #define VISIT(TYPE) \
   Status Visit(const TYPE& type) override { return SortInternal<TYPE>(); }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -523,10 +523,10 @@ class ArrayCountSorter<BooleanType> {
 
     CounterType ones = static_cast<CounterType>(values.true_count()),
                 nulls = static_cast<CounterType>(values.null_count());
-    
+
     if (options.order == SortOrder::Ascending) {
-      counts[1] = values.length() - ones - nulls;  // 0's
-      counts[2] = values.length() - nulls;         // 0's + 1's
+      counts[1] = static_cast<CounterType>(values.length()) - ones - nulls;  // 0's
+      counts[2] = static_cast<CounterType>(values.length()) - nulls;         // 0's + 1's
       auto null_position = counts[2];
       auto nulls_begin = indices_begin + null_position;
       int64_t index = offset;
@@ -535,8 +535,8 @@ class ArrayCountSorter<BooleanType> {
           [&]() { indices_begin[null_position++] = index++; });
       return nulls_begin;
     } else {
-      counts[0] = values.length() - nulls;  // 0's + 1's
-      counts[1] = ones;                     // 1's
+      counts[0] = static_cast<CounterType>(values.length()) - nulls;  // 0's + 1's
+      counts[1] = ones;                                               // 1's
       auto null_position = counts[0];
       auto nulls_begin = indices_begin + null_position;
       int64_t index = offset;

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -543,7 +543,7 @@ class ArrayCountSorter<BooleanType> {
                          const BooleanArray& values, int64_t offset,
                          const ArraySortOptions& options) {
     // first slot reserved for prefix sum
-    std::vector<CounterType> counts(3);
+    std::array<CounterType, 3> counts{0, 0, 0};
 
     CounterType ones, nulls;
     CountBits(values, offset, &ones, &nulls);

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -521,8 +521,9 @@ class ArrayCountSorter<BooleanType> {
     // first slot reserved for prefix sum
     std::array<CounterType, 3> counts{0, 0, 0};
 
-    CounterType ones = values.true_count(), nulls = values.null_count();
-
+    CounterType ones = static_cast<CounterType>(values.true_count()),
+                nulls = static_cast<CounterType>(values.null_count());
+    
     if (options.order == SortOrder::Ascending) {
       counts[1] = values.length() - ones - nulls;  // 0's
       counts[2] = values.length() - nulls;         // 0's + 1's

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -81,6 +81,16 @@ static void ArraySortIndicesInt64Wide(benchmark::State& state) {
   ArraySortIndicesInt64Benchmark(state, min, max);
 }
 
+static void ArraySortIndicesBool(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / 8;
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto values = rand.Boolean(array_size, 0.5, args.null_proportion);
+
+  ArraySortIndicesBenchmark(state, values);
+}
+
 static void ChunkedArraySortIndicesInt64Narrow(benchmark::State& state) {
   ChunkedArraySortIndicesInt64Benchmark(state, -100, 100);
 }
@@ -230,6 +240,12 @@ BENCHMARK(ArraySortIndicesInt64Narrow)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(ArraySortIndicesInt64Wide)
+    ->Apply(RegressionSetArgs)
+    ->Args({1 << 20, 100})
+    ->Args({1 << 23, 100})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(ArraySortIndicesBool)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -84,7 +84,7 @@ static void ArraySortIndicesInt64Wide(benchmark::State& state) {
 static void ArraySortIndicesBool(benchmark::State& state) {
   RegressionArgs args(state);
 
-  const int64_t array_size = args.size / 8;
+  const int64_t array_size = args.size * 8;
   auto rand = random::RandomArrayGenerator(kSeed);
   auto values = rand.Boolean(array_size, 0.5, args.null_proportion);
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -581,7 +581,7 @@ class TestArraySortIndicesRandomCompare : public TestBase {};
 using SortIndicesableTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
                      Int32Type, Int64Type, FloatType, DoubleType, StringType,
-                     Decimal128Type>;
+                     Decimal128Type, BooleanType>;
 
 template <typename ArrayType>
 void ValidateSorted(const ArrayType& array, UInt64Array& offsets, SortOrder order) {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -181,6 +181,10 @@ class TestNthToIndicesForIntegral : public TestNthToIndices<ArrowType> {};
 TYPED_TEST_SUITE(TestNthToIndicesForIntegral, IntegralArrowTypes);
 
 template <typename ArrowType>
+class TestNthToIndicesForBool : public TestNthToIndices<ArrowType> {};
+TYPED_TEST_SUITE(TestNthToIndicesForBool, ::testing::Types<BooleanType>);
+
+template <typename ArrowType>
 class TestNthToIndicesForTemporal : public TestNthToIndices<ArrowType> {};
 TYPED_TEST_SUITE(TestNthToIndicesForTemporal, TemporalArrowTypes);
 
@@ -221,6 +225,13 @@ TYPED_TEST(TestNthToIndicesForIntegral, Integral) {
   this->AssertNthToIndicesJson("[null, 1, 3, null, 2, 5]", 2);
   this->AssertNthToIndicesJson("[null, 1, 3, null, 2, 5]", 5);
   this->AssertNthToIndicesJson("[null, 1, 3, null, 2, 5]", 6);
+}
+
+TYPED_TEST(TestNthToIndicesForBool, Bool) {
+  this->AssertNthToIndicesJson("[null, false, true, null, false, true]", 0);
+  this->AssertNthToIndicesJson("[null, false, true, null, false, true]", 2);
+  this->AssertNthToIndicesJson("[null, false, true, null, false, true]", 5);
+  this->AssertNthToIndicesJson("[null, false, true, null, false, true]", 6);
 }
 
 TYPED_TEST(TestNthToIndicesForTemporal, Temporal) {
@@ -403,6 +414,10 @@ class TestArraySortIndicesForReal : public TestArraySortIndices<ArrowType> {};
 TYPED_TEST_SUITE(TestArraySortIndicesForReal, RealArrowTypes);
 
 template <typename ArrowType>
+class TestArraySortIndicesForBool : public TestArraySortIndices<ArrowType> {};
+TYPED_TEST_SUITE(TestArraySortIndicesForBool, ::testing::Types<BooleanType>);
+
+template <typename ArrowType>
 class TestArraySortIndicesForIntegral : public TestArraySortIndices<ArrowType> {};
 TYPED_TEST_SUITE(TestArraySortIndicesForIntegral, IntegralArrowTypes);
 
@@ -462,6 +477,26 @@ TYPED_TEST(TestArraySortIndicesForIntegral, SortIntegral) {
                           "[1, 4, 2, 5, 0, 3]");
   this->AssertSortIndices("[null, 1, 3, null, 2, 5]", SortOrder::Descending,
                           "[5, 2, 4, 1, 0, 3]");
+}
+
+TYPED_TEST(TestArraySortIndicesForBool, SortBool) {
+  this->AssertSortIndices("[]", "[]");
+
+  this->AssertSortIndices("[true, true, false]", "[2, 0, 1]");
+  this->AssertSortIndices("[false, false,  false, true, true, true, true]",
+                          "[0, 1, 2, 3, 4, 5, 6]");
+  this->AssertSortIndices("[true, true, true, true, false, false, false]",
+                          "[4, 5, 6, 0, 1, 2, 3]");
+
+  this->AssertSortIndices("[false, true, false, true, true, false, false]",
+                          SortOrder::Ascending, "[0, 2, 5, 6, 1, 3, 4]");
+  this->AssertSortIndices("[false, true, false, true, true, false, false]",
+                          SortOrder::Descending, "[1, 3, 4, 0, 2, 5, 6]");
+
+  this->AssertSortIndices("[null, true, false, null, false, true]", SortOrder::Ascending,
+                          "[2, 4, 1, 5, 0, 3]");
+  this->AssertSortIndices("[null, true, false, null, false, true]", SortOrder::Descending,
+                          "[1, 5, 2, 4, 0, 3]");
 }
 
 TYPED_TEST(TestArraySortIndicesForTemporal, SortTemporal) {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1043,24 +1043,11 @@ TEST_F(TestTableSortIndices, Boolean) {
   });
   SortOptions options(
       {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
-  std::shared_ptr<Table> table;
-  table = TableFromJSON(schema, {R"([{"a": true,    "b": null},
-                                       {"a": false,   "b": null},
-                                       {"a": true,    "b": true},
-                                       {"a": false,   "b": true},
-                                       {"a": true,    "b": false},
-                                       {"a": null,    "b": false},
-                                       {"a": false,   "b": null},
-                                       {"a": null,    "b": true}
-                                       ])"});
-
-  AssertSortIndices(table, options, "[3, 1, 6, 2, 4, 0, 7, 5]");
-
-  table = TableFromJSON(schema, {R"([{"a": true,    "b": null},
+  auto table = TableFromJSON(schema, {R"([{"a": true,    "b": null},
                                        {"a": false,   "b": null},
                                        {"a": true,    "b": true},
                                        {"a": false,   "b": true}])",
-                                 R"([{"a": true,    "b": false},
+                                      R"([{"a": true,    "b": false},
                                        {"a": null,    "b": false},
                                        {"a": false,   "b": null},
                                        {"a": null,    "b": true}

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -886,26 +886,6 @@ TEST_F(TestRecordBatchSortIndices, Boolean) {
       {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
 
   auto batch = RecordBatchFromJSON(schema,
-                                   R"([{"a": true,    "b": false},
-                                       {"a": false,   "b": true},
-                                       {"a": true,    "b": false},
-                                       {"a": false,   "b": true},
-                                       {"a": true,    "b": false},
-                                       {"a": false,   "b": false},
-                                       {"a": false,   "b": true}
-                                       ])");
-  AssertSortIndices(batch, options, "[1, 3, 6, 5, 0, 2, 4]");
-}
-
-TEST_F(TestRecordBatchSortIndices, BooleanNull) {
-  auto schema = ::arrow::schema({
-      {field("a", boolean())},
-      {field("b", boolean())},
-  });
-  SortOptions options(
-      {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
-
-  auto batch = RecordBatchFromJSON(schema,
                                    R"([{"a": true,    "b": null},
                                        {"a": false,   "b": null},
                                        {"a": true,    "b": true},
@@ -1057,36 +1037,6 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
 }
 
 TEST_F(TestTableSortIndices, Boolean) {
-  auto schema = ::arrow::schema({
-      {field("a", boolean())},
-      {field("b", boolean())},
-  });
-  SortOptions options(
-      {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
-  std::shared_ptr<Table> table;
-
-  table = TableFromJSON(schema, {R"([{"a": true,    "b": false},
-                                       {"a": false,   "b": true},
-                                       {"a": true,    "b": false},
-                                       {"a": false,   "b": true},
-                                       {"a": true,    "b": false},
-                                       {"a": false,   "b": false},
-                                       {"a": false,   "b": true}
-                                       ])"});
-  AssertSortIndices(table, options, "[1, 3, 6, 5, 0, 2, 4]");
-
-  table = TableFromJSON(schema, {
-                                    R"([{"a": true,    "b": false},
-                                         {"a": false,   "b": true},
-                                         {"a": true,    "b": false},
-                                         {"a": false,   "b": true}])",
-                                    R"([{"a": true,    "b": false},
-                                      {"a": false,   "b": false},
-                                      {"a": false,   "b": true}])"});
-  AssertSortIndices(table, options, "[1, 3, 6, 5, 0, 2, 4]");
-}
-
-TEST_F(TestTableSortIndices, BooleanNull) {
   auto schema = ::arrow::schema({
       {field("a", boolean())},
       {field("b", boolean())},

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1163,21 +1163,21 @@ In these functions, nulls are considered greater than any other value
 Floating-point NaN values are considered greater than any other non-null
 value, but smaller than nulls.
 
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| Function name         | Arity      | Input types             | Output type       | Options class                  | Notes          |
-+=======================+============+=========================+===================+================================+================+
-| partition_nth_indices | Unary      | Binary- and String-like | UInt64            | :struct:`PartitionNthOptions`  | \(1) \(3)      |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| partition_nth_indices | Unary      | Numeric                 | UInt64            | :struct:`PartitionNthOptions`  | \(1)           |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| array_sort_indices    | Unary      | Binary- and String-like | UInt64            | :struct:`ArraySortOptions`     | \(2) \(3) \(4) |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| array_sort_indices    | Unary      | Numeric                 | UInt64            | :struct:`ArraySortOptions`     | \(2) \(4)      |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| sort_indices          | Unary      | Binary- and String-like | UInt64            | :struct:`SortOptions`          | \(2) \(3) \(5) |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
-| sort_indices          | Unary      | Numeric                 | UInt64            | :struct:`SortOptions`          | \(2) \(5)      |
-+-----------------------+------------+-------------------------+-------------------+--------------------------------+----------------+
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| Function name         | Arity      | Input types                 | Output type       | Options class                  | Notes          |
++=======================+============+=============================+===================+================================+================+
+| partition_nth_indices | Unary      | Binary- and String-like     | UInt64            | :struct:`PartitionNthOptions`  | \(1) \(3)      |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| partition_nth_indices | Unary      | Boolean, Numeric, Temporal  | UInt64            | :struct:`PartitionNthOptions`  | \(1)           |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| array_sort_indices    | Unary      | Binary- and String-like     | UInt64            | :struct:`ArraySortOptions`     | \(2) \(3) \(4) |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| array_sort_indices    | Unary      | Boolean, Numeric, Temporal  | UInt64            | :struct:`ArraySortOptions`     | \(2) \(4)      |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| sort_indices          | Unary      | Binary- and String-like     | UInt64            | :struct:`SortOptions`          | \(2) \(3) \(5) |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
+| sort_indices          | Unary      | Boolean, Numeric, Temporal  | UInt64            | :struct:`SortOptions`          | \(2) \(5)      |
++-----------------------+------------+-----------------------------+-------------------+--------------------------------+----------------+
 
 * \(1) The output is an array of indices into the input array, that define
   a partial non-stable sort such that the *N*'th index points to the *N*'th

--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -152,7 +152,7 @@ example_data_for_sorting <- tibble::tibble(
   int = c(-.Machine$integer.max, -101L, -100L, 0L, 0L, 1L, 100L, 1000L, .Machine$integer.max, NA_integer_),
   dbl = c(-Inf, -.Machine$double.xmax, -.Machine$double.xmin, 0, .Machine$double.xmin, pi, .Machine$double.xmax, Inf, NaN, NA_real_),
   chr = c("", "", "\"", "&", "ABC", "NULL", "a", "abc", "zzz", NA_character_),
-  lgl = c(rep(FALSE, 4L), rep(TRUE, 5L), NA), # bool is not supported (ARROW-12016)
+  lgl = c(rep(FALSE, 4L), rep(TRUE, 5L), NA),
   dttm = lubridate::ymd_hms(c(
     "0000-01-01 00:00:00",
     "1919-05-29 13:08:55",

--- a/r/tests/testthat/test-dplyr-arrange.R
+++ b/r/tests/testthat/test-dplyr-arrange.R
@@ -159,7 +159,6 @@ test_that("arrange() on datetime columns", {
 })
 
 test_that("arrange() on logical columns", {
-  skip("Sorting by bool columns is not supported (ARROW-12016)")
   expect_dplyr_equal(
     input %>%
       arrange(lgl, int) %>%


### PR DESCRIPTION
Adding `array_sort_indices` and `partition_nth_indices` for `BooleanType` using existing sort and Nth-partition utils. 
This may be rather inefficient, since the values are traversed bit-by-bit rather than working on a byte/word. 

May be we could work on it as a separate improvement? 