### PR TITLE
ARROW-13158: [Python] Fix StructScalar contains and repr with duplicate field names

### DIFF
--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1726,7 +1726,7 @@ def test_struct_from_list_of_pairs():
         [('a', 6), ('a', 'bar'), ('b', False)],
     ]
     arr = pa.array(data, type=ty)
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         # TODO(kszucs): ARROW-9997
         arr.to_pylist()
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -500,6 +500,7 @@ def test_struct():
     assert 'x' in s
     assert 'y' in s
     assert 'z' not in s
+    assert 0 not in s
 
     assert s.as_py() == v
     assert repr(s) != repr(v)
@@ -514,7 +515,7 @@ def test_struct():
         s['non-existent']
 
     s = pa.scalar(None, type=ty)
-    assert list(s) == []
+    assert list(s) == list(s.keys()) == ['x', 'y']
     assert s.as_py() is None
     assert 'x' in s
     assert 'y' in s
@@ -524,6 +525,49 @@ def test_struct():
     assert s['y'].is_valid is False
     assert s['x'].as_py() is None
     assert s['y'].as_py() is None
+
+
+def test_struct_duplicate_fields():
+    ty = pa.struct([
+        pa.field('x', pa.int16()),
+        pa.field('y', pa.float32()),
+        pa.field('x', pa.int64()),
+    ])
+    s = pa.scalar([('x', 1), ('y', 2.0), ('x', 3)], type=ty)
+
+    assert list(s) == list(s.keys()) == ['x', 'y', 'x']
+    assert len(s) == 3
+    assert s == s
+    assert list(s.items()) == [
+        ('x', pa.scalar(1, pa.int16())),
+        ('y', pa.scalar(2.0, pa.float32())),
+        ('x', pa.scalar(3, pa.int64()))
+    ]
+
+    assert 'x' in s
+    assert 'y' in s
+    assert 'z' not in s
+    assert 0 not in s
+
+    # getitem with field names fails for duplicate fields, works for others
+    with pytest.raises(KeyError):
+        s['x']
+
+    assert isinstance(s['y'], pa.FloatScalar)
+    assert s['y'].as_py() == 2.0
+
+    # getitem with integer index works for all fields
+    assert isinstance(s[0], pa.Int16Scalar)
+    assert s[0].as_py() == 1
+    assert isinstance(s[1], pa.FloatScalar)
+    assert s[1].as_py() == 2.0
+    assert isinstance(s[2], pa.Int64Scalar)
+    assert s[2].as_py() == 3
+
+    assert "pyarrow.StructScalar" in repr(s)
+
+    with pytest.raises(ValueError, match="duplicate field names"):
+        s.as_py()
 
 
 def test_map():


### PR DESCRIPTION
This PR does several small things:

- Fix `__contains__` to not check the actual keys (and not rely on `__getitem__` since that also supports integers)
- Add tests for the case of StructScalar with duplicate field names, and ensure some behaviours that already worked (`__getitem__` with integers, `__iter__`, `keys()`)
- Changed `list(scalar)` (`__iter__`) to also return the keys for a "null" scalar (since we do allow `s["key"]` in that case, that seems most consistent?)
- Changed the `repr` to use a tuple instead of dict representation. I know this just postpones a bit the `as_py()` discussion (should it return dict vs tuple?), but at least this ensures that the `repr` doesn't fail on the short term, and so you can inspect the object.
- I added an explicit `items()` method (overriding the ones from Mapping), because the return value of this can in theory support duplicate fields, and this can be a way to get a list of tuples already. But, this doesn't fully follows the Mapping API as the return value is different (not a `dict_items` object).
