### PR TITLE
ARROW-13172: [Java] Make TYPE_WIDTH publicly accessible

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.util.TransferPair;
  */
 public final class DateDayVector extends BaseFixedWidthVector {
 
-  private static final byte TYPE_WIDTH = 4;
+  public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -39,7 +39,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * maintained to track which elements in the vector are null.
  */
 public final class DateMilliVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -42,7 +42,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * vector are null.
  */
 public final class DurationVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
   private final TimeUnit unit;

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * (bit vector) is maintained to track which elements in the vector are null.
  */
 public final class IntervalYearVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 4;
+  public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * vector are null.
  */
 public final class TimeMicroVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -39,7 +39,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * (bit vector) is maintained to track which elements in the vector are null.
  */
 public final class TimeMilliVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 4;
+  public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * (bit vector) is maintained to track which elements in the vector are null.
  */
 public final class TimeNanoVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * maintained to track which elements in the vector are null.
  */
 public final class TimeSecVector extends BaseFixedWidthVector {
-  private static final byte TYPE_WIDTH = 4;
+  public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
@@ -31,7 +31,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * maintained to track which elements in the vector are null.
  */
 public abstract class TimeStampVector extends BaseFixedWidthVector {
-  protected static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
 
   /**
    * Instantiate a TimeStampVector. This doesn't allocate any memory for

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -46,7 +46,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
    */
   public static final byte MAX_UINT1 = (byte) 0XFF;
 
-  private static final byte TYPE_WIDTH = 1;
+  public static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
   public UInt1Vector(String name, BufferAllocator allocator) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -42,7 +42,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
    */
   public static final char MAX_UINT2 = (char) 0XFFFF;
 
-  private static final byte TYPE_WIDTH = 2;
+  public static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
   public UInt2Vector(String name, BufferAllocator allocator) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -47,7 +47,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
    */
   public static final int MAX_UINT4 = 0XFFFFFFFF;
 
-  private static final byte TYPE_WIDTH = 4;
+  public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
   public UInt4Vector(String name, BufferAllocator allocator) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -44,7 +44,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
    */
   public static final long MAX_UINT8 = 0XFFFFFFFFFFFFFFFFL;
 
-  private static final byte TYPE_WIDTH = 8;
+  public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
   public UInt8Vector(String name, BufferAllocator allocator) {


### PR DESCRIPTION
Some Vector class were already making `TYPE_WIDTH` publicly accessible.
This PR just makes sure that this is done across all Vector classes.