### PR TITLE
ARROW-13173: [C++] TestAsyncUtil.ReadaheadFailed asserts occasionally 

### DIFF
--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -696,30 +696,38 @@ class ReadaheadGenerator {
   ReadaheadGenerator(AsyncGenerator<T> source_generator, int max_readahead)
       : state_(std::make_shared<State>(std::move(source_generator), max_readahead)) {}
 
-  Future<T> operator()() {
-    // Copy so we can capture into lambdas
+  Future<T> AddMarkFinishedContinuation(Future<T> fut) {
     auto state = state_;
-    if (state->readahead_queue.empty()) {
+    return fut.Then(
+        [state](const T& result) -> Result<T> {
+          state->MarkFinishedIfDone(result);
+          return result;
+        },
+        [state](const Status& err) -> Result<T> {
+          state->finished.store(true);
+          return err;
+        });
+  }
+
+  Future<T> operator()() {
+    if (state_->readahead_queue.empty()) {
       // This is the first request, let's pump the underlying queue
-      for (int i = 0; i < state->max_readahead; i++) {
-        auto next = state->source_generator();
-        auto state = state_;
-        next.AddCallback(
-            [state](const Result<T>& result) { state->MarkFinishedIfDone(result); });
-        state->readahead_queue.push(std::move(next));
+      for (int i = 0; i < state_->max_readahead; i++) {
+        auto next = state_->source_generator();
+        auto next_after_check = AddMarkFinishedContinuation(std::move(next));
+        state_->readahead_queue.push(std::move(next_after_check));
       }
     }
     // Pop one and add one
-    auto result = state->readahead_queue.front();
-    state->readahead_queue.pop();
-    if (state->finished.load()) {
-      state->readahead_queue.push(AsyncGeneratorEnd<T>());
+    auto result = state_->readahead_queue.front();
+    state_->readahead_queue.pop();
+    if (state_->finished.load()) {
+      state_->readahead_queue.push(AsyncGeneratorEnd<T>());
     } else {
-      auto back_of_queue = state->source_generator();
-      auto state = state_;
-      back_of_queue.AddCallback(
-          [state](const Result<T>& result) { state->MarkFinishedIfDone(result); });
-      state->readahead_queue.push(std::move(back_of_queue));
+      auto back_of_queue = state_->source_generator();
+      auto back_of_queue_after_check =
+          AddMarkFinishedContinuation(std::move(back_of_queue));
+      state_->readahead_queue.push(std::move(back_of_queue_after_check));
     }
     return result;
   }
@@ -731,13 +739,9 @@ class ReadaheadGenerator {
       finished.store(false);
     }
 
-    void MarkFinishedIfDone(const Result<T>& next_result) {
-      if (!next_result.ok()) {
+    void MarkFinishedIfDone(const T& next_result) {
+      if (IsIterationEnd(next_result)) {
         finished.store(true);
-      } else {
-        if (IsIterationEnd(*next_result)) {
-          finished.store(true);
-        }
       }
     }
 

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -1123,7 +1123,7 @@ TEST(TestAsyncUtil, ReadaheadFailed) {
   ASSERT_FINISHES_OK_AND_ASSIGN(auto remaining_results, CollectAsyncGenerator(readahead));
   // Don't need to know the exact number of successful tasks (and it may vary)
   for (std::size_t i = 0; i < remaining_results.size(); i++) {
-    ASSERT_EQ(TestInt(i + 1), remaining_results[i]);
+    ASSERT_EQ(TestInt(static_cast<int>(i) + 1), remaining_results[i]);
   }
 }
 

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -1136,8 +1136,8 @@ TEST(TestAsyncUtil, ReadaheadFailed) {
     ASSERT_EQ(TestInt(i + 1), next_val);
   }
 
-  // The error should have put the readahead into a failure state so
-  // no future reads should have occurred
+  // The error should have put the readahead into a failure state.  However, it does so
+  // with AddCallback and not Then so there is no guarantee when that will happen.
   ASSERT_FINISHES_OK_AND_ASSIGN(auto after, readahead());
   ASSERT_TRUE(IsIterationEnd(after));
   ASSERT_EQ(11, counter.load());

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -20,7 +20,6 @@
 #include <cassert>
 #include <functional>
 #include <memory>
-#include <queue>
 #include <tuple>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
As @cyb70289 pointed out the test was dependent on timing and when running on a slow CI machine it could lead to failure.  I changed the test to use condition variables instead of sleeps so that it should be fully deterministic now.