### PR TITLE
ARROW-13191: [Go] allow external schema in ipc readers

### DIFF
--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -85,6 +85,12 @@ func (r *Reader) Err() error { return r.err }
 func (r *Reader) Schema() *arrow.Schema { return r.schema }
 
 func (r *Reader) readSchema(schema *arrow.Schema) error {
+	// We were passed in an external schema.  Use that rather than attempting to read from the stream.
+	if schema != nil {
+		r.schema = schema
+		return nil
+	}
+
 	msg, err := r.r.Message()
 	if err != nil {
 		return xerrors.Errorf("arrow/ipc: could not read message schema: %w", err)
@@ -112,11 +118,6 @@ func (r *Reader) readSchema(schema *arrow.Schema) error {
 	r.schema, err = schemaFromFB(&schemaFB, &r.memo)
 	if err != nil {
 		return xerrors.Errorf("arrow/ipc: could not decode schema from message schema: %w", err)
-	}
-
-	// check the provided schema match the one read from stream.
-	if schema != nil && !schema.Equal(r.schema) {
-		return errInconsistentSchema
 	}
 
 	return nil


### PR DESCRIPTION
This slightly changes the newReader to accept passed in schema as
I believe is the intent.

It also removes the existing behavior where the newReader uses a passed
in schema merely for compatibility checking.

I didn't augment tests here as there doesn't appear to be any existing
reader tests, and I didn't see an obvious place to look for canonical
messages for validating message behaviors.