### PR TITLE
ARROW-13190: [C++] [Gandiva] Change behavior of INITCAP function

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -426,8 +426,8 @@ CAST_VARLEN_TYPE_FROM_NUMERIC(VARBINARY)
 #undef GDV_FN_CAST_VARCHAR_INTEGER
 #undef GDV_FN_CAST_VARCHAR_REAL
 
-FORCE_INLINE
-inline int32_t gdv_fn_utf8_char_length(char c) {
+GDV_FORCE_INLINE
+int32_t gdv_fn_utf8_char_length(char c) {
   if ((signed char)c >= 0) {  // 1-byte char (0x00 ~ 0x7F)
     return 1;
   } else if ((c & 0xE0) == 0xC0) {  // 2-byte char
@@ -441,8 +441,8 @@ inline int32_t gdv_fn_utf8_char_length(char c) {
   return 0;
 }
 
-FORCE_INLINE
-inline void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
+GDV_FORCE_INLINE
+void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
@@ -602,8 +602,8 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
 // The Unicode characters also are divided between categories. This link
 // https://www.compart.com/en/unicode/category shows
 // more information about characters categories.
-FORCE_INLINE
-inline bool gdv_fn_is_codepoint_for_space(uint32_t val) {
+GDV_FORCE_INLINE
+bool gdv_fn_is_codepoint_for_space(uint32_t val) {
   auto category = utf8proc_category(val);
 
   return category != utf8proc_category_t::UTF8PROC_CATEGORY_LU &&

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -427,7 +427,8 @@ CAST_VARLEN_TYPE_FROM_NUMERIC(VARBINARY)
 #undef GDV_FN_CAST_VARCHAR_REAL
 
 GANDIVA_EXPORT
-int32_t gdv_fn_utf8_char_length(char c) {
+FORCE_INLINE
+inline int32_t gdv_fn_utf8_char_length(char c) {
   if ((signed char)c >= 0) {  // 1-byte char (0x00 ~ 0x7F)
     return 1;
   } else if ((c & 0xE0) == 0xC0) {  // 2-byte char
@@ -442,7 +443,8 @@ int32_t gdv_fn_utf8_char_length(char c) {
 }
 
 GANDIVA_EXPORT
-void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
+FORCE_INLINE
+inline void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
@@ -603,7 +605,8 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
 // https://www.compart.com/en/unicode/category shows
 // more information about characters categories.
 GANDIVA_EXPORT
-bool gdv_fn_is_codepoint_for_space(uint32_t val) {
+FORCE_INLINE
+inline bool gdv_fn_is_codepoint_for_space(uint32_t val) {
   auto category = utf8proc_category(val);
 
   return category != utf8proc_category_t::UTF8PROC_CATEGORY_LU &&

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -643,9 +643,9 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
   bool last_char_was_space = true;
 
   for (int32_t i = 0; i < data_len; i += char_len) {
-    char_len = gdv_fn_utf8_char_length(data[i]);
     // An optimization for single byte characters:
-    if (char_len == 1) {
+    if (static_cast<signed char>(data[i]) >= 0) {  // 1-byte char (0x00 ~ 0x7F)
+      char_len = 1;
       char cur = data[i];
 
       if (cur >= 0x61 && cur <= 0x7a && last_char_was_space) {
@@ -667,6 +667,8 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
       }
       continue;
     }
+
+    char_len = gdv_fn_utf8_char_length(data[i]);
 
     // Control reaches here when we encounter a multibyte character
     const auto* in_char = (const uint8_t*)(data + i);

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -595,8 +595,9 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
   return out;
 }
 
-// Any codepoint, except the ones for lowercase letters, uppercase letters and decimal
-// digits will be considered as word separators.
+// Any codepoint, except the ones for lowercase letters category,
+// uppercase letters category and decimal digits category will be
+// considered as word separators.
 //
 // The Unicode characters also are divided between categories. This link
 // https://en.wikipedia.org/wiki/Unicode_character_property#General_Category shows

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -426,7 +426,6 @@ CAST_VARLEN_TYPE_FROM_NUMERIC(VARBINARY)
 #undef GDV_FN_CAST_VARCHAR_INTEGER
 #undef GDV_FN_CAST_VARCHAR_REAL
 
-GANDIVA_EXPORT
 FORCE_INLINE
 inline int32_t gdv_fn_utf8_char_length(char c) {
   if ((signed char)c >= 0) {  // 1-byte char (0x00 ~ 0x7F)
@@ -442,7 +441,6 @@ inline int32_t gdv_fn_utf8_char_length(char c) {
   return 0;
 }
 
-GANDIVA_EXPORT
 FORCE_INLINE
 inline void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
@@ -604,7 +602,6 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
 // The Unicode characters also are divided between categories. This link
 // https://www.compart.com/en/unicode/category shows
 // more information about characters categories.
-GANDIVA_EXPORT
 FORCE_INLINE
 inline bool gdv_fn_is_codepoint_for_space(uint32_t val) {
   auto category = utf8proc_category(val);

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -595,12 +595,12 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
   return out;
 }
 
-// Any codepoint, except the ones for lowercase letters category,
-// uppercase letters category and decimal digits category will be
+// Any codepoint, except the ones for lowercase letters, uppercase letters,
+// titlecase letters, decimal digits and letter numbers categories will be
 // considered as word separators.
 //
 // The Unicode characters also are divided between categories. This link
-// https://en.wikipedia.org/wiki/Unicode_character_property#General_Category shows
+// https://www.compart.com/en/unicode/category shows
 // more information about characters categories.
 GANDIVA_EXPORT
 bool gdv_fn_is_codepoint_for_space(uint32_t val) {
@@ -608,10 +608,12 @@ bool gdv_fn_is_codepoint_for_space(uint32_t val) {
 
   return category != utf8proc_category_t::UTF8PROC_CATEGORY_LU &&
          category != utf8proc_category_t::UTF8PROC_CATEGORY_LL &&
+         category != utf8proc_category_t::UTF8PROC_CATEGORY_LT &&
+         category != utf8proc_category_t::UTF8PROC_CATEGORY_NL &&
          category != utf8proc_category_t ::UTF8PROC_CATEGORY_ND;
 }
 
-// For a given text, initialize the first letter of each word and lowercase
+// For a given text, initialize the first letter after a word-separator and lowercase
 // the others e.g:
 //     - "IT is a tEXt str" -> "It Is A Text Str"
 GANDIVA_EXPORT

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -43,6 +43,17 @@ using gdv_utf8 = char*;
 using gdv_binary = char*;
 using gdv_day_time_interval = int64_t;
 
+#ifdef GANDIVA_UNIT_TEST
+// unit tests may be compiled without O2, so inlining may not happen.
+#define GDV_FORCE_INLINE
+#else
+#ifdef _MSC_VER
+#define GDV_FORCE_INLINE __forceinline
+#else
+#define GDV_FORCE_INLINE inline __attribute__((always_inline))
+#endif
+#endif
+
 bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
                            const char* pattern, int pattern_len);
 

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -128,18 +128,12 @@ GANDIVA_EXPORT
 int32_t gdv_fn_utf8_char_length(char c);
 
 GANDIVA_EXPORT
-void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val);
-
-GANDIVA_EXPORT
 const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_len,
                               int32_t* out_len);
 
 GANDIVA_EXPORT
 const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_len,
                               int32_t* out_len);
-
-GANDIVA_EXPORT
-bool gdv_fn_is_codepoint_for_space(uint32_t val);
 
 GANDIVA_EXPORT
 const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_len,

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -517,6 +517,26 @@ TEST(TestGdvFnStubs, TestInitCap) {
   EXPECT_EQ(std::string(out_str, out_len), "{Õhp,Pqśv}Ń+");
   EXPECT_FALSE(ctx.has_error());
 
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "sɦasasdsɦsd\"sdsdɦ", 19, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Sɦasasdsɦsd\"Sdsdɦ");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "mysuperscipt@number²isfine", 27, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Mysuperscipt@Number²Isfine");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "Ő<tŵas̓老ƕɱ¢vIYwށ", 25, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Ő<Tŵas̓老Ƕɱ¢Viywށ");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "ↆcheckↆnumberisspace", 24, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "ↆcheckↆnumberisspace");
+  EXPECT_FALSE(ctx.has_error());
+
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "testing ᾌTitleᾌcase", 23, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "Testing ᾌtitleᾄcase");
+  EXPECT_FALSE(ctx.has_error());
+
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_FALSE(ctx.has_error());

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -537,6 +537,10 @@ TEST(TestGdvFnStubs, TestInitCap) {
   EXPECT_EQ(std::string(out_str, out_len), "Testing ᾌtitleᾄcase");
   EXPECT_FALSE(ctx.has_error());
 
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "ʳTesting mʳodified", 20, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "ʳTesting MʳOdified");
+  EXPECT_FALSE(ctx.has_error());
+
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_FALSE(ctx.has_error());

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -488,20 +488,20 @@ TEST(TestGdvFnStubs, TestInitCap) {
   EXPECT_EQ(std::string(out_str, out_len), "Asdfj\nHlqf");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "s;DCgs,Jo!L", 11, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), "S;DCgs,Jo!L");
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "s;DCgs,Jo!l", 11, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "S;Dcgs,Jo!L");
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, " mÜNCHEN", 9, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), " MÜNCHEN");
+  EXPECT_EQ(std::string(out_str, out_len), " München");
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "citroën CaR", 12, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), "Citroën CaR");
+  EXPECT_EQ(std::string(out_str, out_len), "Citroën Car");
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "ÂbĆDËFgh\néll", 16, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), "ÂbĆDËFgh\nÉll");
+  EXPECT_EQ(std::string(out_str, out_len), "Âbćdëfgh\nÉll");
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "  øhpqršvñ  \n\n", 17, &out_len);
@@ -514,7 +514,7 @@ TEST(TestGdvFnStubs, TestInitCap) {
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "{ÕHP,pqśv}Ń+", 15, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), "{ÕHP,pqśv}Ń+");
+  EXPECT_EQ(std::string(out_str, out_len), "{Õhp,Pqśv}Ń+");
   EXPECT_FALSE(ctx.has_error());
 
   out_str = gdv_fn_initcap_utf8(ctx_ptr, "", 0, &out_len);

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -2310,7 +2310,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     byte[] validity = new byte[]{(byte) 15, 0};
     String[] valuesX = new String[]{
         "  øhpqršvñ  \n\n",
-        "möbelträgerfüße   \nmöbelträgerfüße",
+        "möbelträger1füße   \nmöbelträge'rfüße",
         "ÂbĆDËFgh\néll",
         "citroën CaR",
         "kjk"
@@ -2318,9 +2318,9 @@ public class ProjectorTest extends BaseEvaluatorTest {
 
     String[] expected = new String[]{
         "  Øhpqršvñ  \n\n",
-        "Möbelträgerfüße   \nMöbelträgerfüße",
-        "ÂbĆDËFgh\nÉll",
-        "Citroën CaR",
+        "Möbelträger1füße   \nMöbelträge'Rfüße",
+        "Âbćdëfgh\nÉll",
+        "Citroën Car",
         null
     };
 


### PR DESCRIPTION
The current behavior of the INITCAP function is to turn the first character of each word uppercase and remains the other as is.

The desired behavior is to turn the first letter uppercase and the other lowercase. Any character except the [lowercase letters](https://www.compart.com/en/unicode/category/Ll), [uppercase letters](https://www.compart.com/en/unicode/category/Lu) and [decimal numbers](https://www.compart.com/en/unicode/category/Nd) ones should be considered as a word separator. 

That behavior is based on these database systems:
    - [Oracle](https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions065.htm)
    - [Postgres](https://w3resource.com/PostgreSQL/initcap-function.php)
    - [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_INITCAP.html)
    - [Splice Machine](https://doc.splicemachine.com/sqlref_builtinfcns_initcap.html)