### PR TITLE
ARROW-13033: [C++] Kernel to localize naive timestamps to a timezone (preserving clock-time)

### DIFF
--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -15,17 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/compute/function.h"
+
+#include <gtest/gtest.h>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/function.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/datum.h"
 #include "arrow/status.h"
@@ -80,6 +81,11 @@ TEST(FunctionOptions, Equality) {
   options.emplace_back(new StrptimeOptions("%Y", TimeUnit::type::MILLI));
   options.emplace_back(new StrptimeOptions("%Y", TimeUnit::type::NANO));
   options.emplace_back(new StrftimeOptions("%Y-%m-%dT%H:%M:%SZ", "C"));
+#ifndef _WIN32
+  options.emplace_back(new AssumeTimezoneOptions(
+      "Europe/Amsterdam", AssumeTimezoneOptions::Ambiguous::AMBIGUOUS_RAISE,
+      AssumeTimezoneOptions::Nonexistent::NONEXISTENT_RAISE));
+#endif
   options.emplace_back(new PadOptions(5, " "));
   options.emplace_back(new PadOptions(10, "A"));
   options.emplace_back(new TrimOptions(" "));

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -290,9 +290,11 @@ class ARROW_EXPORT OutputType {
   enum ResolveKind { FIXED, COMPUTED };
 
   /// Type resolution function. Given input types and shapes, return output
-  /// type and shape. This function SHOULD _not_ be used to check for arity,
-  /// that is to be performed one or more layers above. May make use of kernel
-  /// state to know what type to output in some cases.
+  /// type and shape.  This function MAY may use the kernel state to decide
+  /// the output type based on the functionoptions.
+  ///
+  /// This function SHOULD _not_ be used to check for arity, that is to be
+  /// performed one or more layers above.
   using Resolver =
       std::function<Result<ValueDescr>(KernelContext*, const std::vector<ValueDescr>&)>;
 
@@ -304,7 +306,8 @@ class ARROW_EXPORT OutputType {
   /// \brief Output the exact type and shape provided by a ValueDescr
   OutputType(ValueDescr descr);  // NOLINT implicit construction
 
-  explicit OutputType(Resolver resolver)
+  /// \brief Output a computed type depending on actual input types
+  OutputType(Resolver resolver)  // NOLINT implicit construction
       : kind_(COMPUTED), resolver_(std::move(resolver)) {}
 
   OutputType(const OutputType& other) {

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1263,6 +1263,30 @@ For timestamps inputs with non-empty timezone, localized timestamp components wi
 
 .. _ISO 8601 week date definition: https://en.wikipedia.org/wiki/ISO_week_date#First_week
 
+Timezone handling
+~~~~~~~~~~~~~~~~~
+
+This function is meant to be used when an external system produces
+"timezone-naive" timestamps which need to be converted to "timezone-aware"
+timestamps (see for example the `definition
+<https://docs.python.org/3/library/datetime.html#aware-and-naive-objects>`__
+in the Python documentation).
+
+Input timestamps are assumed to be relative to the timezone given in
+:member:`AssumeTimezoneOptions::timezone`. They are converted to
+UTC-relative timestamps with the timezone metadata set to the above value.
+An error is returned if the timestamps already have the timezone metadata set.
+
++--------------------+------------+-------------------+---------------+----------------------------------+-------+
+| Function name      | Arity      | Input types       | Output type   | Options class                    | Notes |
++====================+============+===================+===============+==================================+=======+
+| assume_timezone    | Unary      | Timestamp         | Timestamp     | :struct:`AssumeTimezoneOptions`  | \(1)  |
++--------------------+------------+-------------------+---------------+----------------------------------+-------+
+
+* \(1) In addition to the timezone value, :struct:`AssumeTimezoneOptions`
+  allows choosing the behaviour when a timestamp is ambiguous or nonexistent
+  in the given timezone (because of DST shifts).
+
 
 Array-wise ("vector") functions
 -------------------------------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1005,6 +1005,41 @@ class DayOfWeekOptions(_DayOfWeekOptions):
         self._set_options(one_based_numbering, week_start)
 
 
+cdef class _AssumeTimezoneOptions(FunctionOptions):
+    def _set_options(self, timezone, ambiguous, nonexistent):
+        ambiguous_dict = {
+            'raise': CAssumeTimezoneAmbiguous_AMBIGUOUS_RAISE,
+            'earliest': CAssumeTimezoneAmbiguous_AMBIGUOUS_EARLIEST,
+            'latest': CAssumeTimezoneAmbiguous_AMBIGUOUS_LATEST,
+        }
+        nonexistent_dict = {
+            'raise': CAssumeTimezoneNonexistent_NONEXISTENT_RAISE,
+            'earliest': CAssumeTimezoneNonexistent_NONEXISTENT_EARLIEST,
+            'latest': CAssumeTimezoneNonexistent_NONEXISTENT_LATEST,
+        }
+
+        if ambiguous not in ambiguous_dict:
+            raise ValueError(
+                "{!r} is not a valid 'ambiguous' keyword".format(ambiguous)
+            )
+        if nonexistent not in nonexistent_dict:
+            raise ValueError(
+                "{!r} is not a valid 'nonexistent' keyword".format(
+                    nonexistent)
+            )
+        self.wrapped.reset(
+            new CAssumeTimezoneOptions(
+                tobytes(timezone),
+                ambiguous_dict[ambiguous],
+                nonexistent_dict[nonexistent])
+        )
+
+
+class AssumeTimezoneOptions(_AssumeTimezoneOptions):
+    def __init__(self, timezone, *, ambiguous="raise", nonexistent="raise"):
+        self._set_options(timezone, ambiguous, nonexistent)
+
+
 cdef class _NullOptions(FunctionOptions):
     def _set_options(self, nan_is_null):
         self.wrapped.reset(

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -30,6 +30,7 @@ from pyarrow._compute import (  # noqa
     VectorKernel,
     # Option classes
     ArraySortOptions,
+    AssumeTimezoneOptions,
     CastOptions,
     CountOptions,
     DayOfWeekOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1964,6 +1964,30 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         c_bool one_based_numbering
         uint32_t week_start
 
+    enum CAssumeTimezoneAmbiguous \
+            "arrow::compute::AssumeTimezoneOptions::Ambiguous":
+        CAssumeTimezoneAmbiguous_AMBIGUOUS_RAISE \
+            "arrow::compute::AssumeTimezoneOptions::AMBIGUOUS_RAISE"
+        CAssumeTimezoneAmbiguous_AMBIGUOUS_EARLIEST \
+            "arrow::compute::AssumeTimezoneOptions::AMBIGUOUS_EARLIEST"
+        CAssumeTimezoneAmbiguous_AMBIGUOUS_LATEST \
+            "arrow::compute::AssumeTimezoneOptions::AMBIGUOUS_LATEST"
+
+    enum CAssumeTimezoneNonexistent \
+            "arrow::compute::AssumeTimezoneOptions::Nonexistent":
+        CAssumeTimezoneNonexistent_NONEXISTENT_RAISE \
+            "arrow::compute::AssumeTimezoneOptions::NONEXISTENT_RAISE"
+        CAssumeTimezoneNonexistent_NONEXISTENT_EARLIEST \
+            "arrow::compute::AssumeTimezoneOptions::NONEXISTENT_EARLIEST"
+        CAssumeTimezoneNonexistent_NONEXISTENT_LATEST \
+            "arrow::compute::AssumeTimezoneOptions::NONEXISTENT_LATEST"
+
+    cdef cppclass CAssumeTimezoneOptions \
+            "arrow::compute::AssumeTimezoneOptions"(CFunctionOptions):
+        CAssumeTimezoneOptions(
+            c_string timezone, CAssumeTimezoneAmbiguous ambiguous,
+            CAssumeTimezoneNonexistent nonexistent)
+
     cdef cppclass CNullOptions \
             "arrow::compute::NullOptions"(CFunctionOptions):
         CNullOptions(c_bool nan_is_null)

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -325,6 +325,22 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
         cpp11::as_cpp<arrow::TimeUnit::type>(options["unit"]));
   }
 
+  if (func_name == "assume_timezone") {
+    using Options = arrow::compute::AssumeTimezoneOptions;
+    enum Options::Ambiguous ambiguous;
+    enum Options::Nonexistent nonexistent;
+
+    if (!Rf_isNull(options["ambiguous"])) {
+      ambiguous = cpp11::as_cpp<enum Options::Ambiguous>(options["ambiguous"]);
+    }
+    if (!Rf_isNull(options["nonexistent"])) {
+      nonexistent = cpp11::as_cpp<enum Options::Nonexistent>(options["nonexistent"]);
+    }
+
+    return std::make_shared<Options>(cpp11::as_cpp<std::string>(options["timezone"]),
+                                     ambiguous, nonexistent);
+  }
+
   if (func_name == "split_pattern" || func_name == "split_pattern_regex") {
     using Options = arrow::compute::SplitPatternOptions;
     int64_t max_splits = -1;


### PR DESCRIPTION
This is to resolve [ARROW-13033](https://issues.apache.org/jira/browse/ARROW-13033).