### PR TITLE
ARROW-12364: [Python] [Dataset] Add metadata_collector option to ds.write_dataset()

### DIFF
--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -544,7 +544,8 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
   for (const auto& part_queue : state.queues) {
     task_group->Append([&] {
       RETURN_NOT_OK(write_options.writer_pre_finish(part_queue.second->writer().get()));
-      return part_queue.second->writer()->Finish();
+      RETURN_NOT_OK(part_queue.second->writer()->Finish());
+      return write_options.writer_post_finish(part_queue.second->writer().get());
     });
   }
   return task_group->Finish();

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -360,6 +360,12 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
     return Status::OK();
   };
 
+  /// Callback to be invoked against all FileWriters after they have
+  /// called FileWriter::Finish().
+  std::function<Status(FileWriter*)> writer_post_finish = [](FileWriter*) {
+    return Status::OK();
+  };
+
   const std::shared_ptr<FileFormat>& format() const {
     return file_write_options->format();
   }

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -3124,6 +3124,8 @@ def _filesystemdataset_write(
     if file_visitor is not None:
         visit_args = {'base_dir': c_options.base_dir,
                       'file_visitor': file_visitor}
+        # Need to use post_finish because parquet metadata is not available
+        # until after Finish has been called
         c_options.writer_post_finish = BindFunction[cb_writer_finish_internal](
             &_filesystemdataset_write_visitor, visit_args)
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -3063,7 +3063,11 @@ cdef class WrittenFile(_Weakrefable):
 
     """The full path to the created file"""
     cdef public str path
-    """If the file is a parquet file this will contain the parquet metadata"""
+    """
+    If the file is a parquet file this will contain the parquet metadata.
+    This metadata will have the file path attribute set to the path of
+    the written file.
+    """
     cdef public object metadata
 
     def __init__(self, path, metadata):

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -733,7 +733,10 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
         Maximum number of partitions any batch may be written into.
     file_visitor : Function
         If set, this function will be called with a WrittenFile instance
-        for each file created during the call.
+        for each file created during the call.  This object will contain
+        the path and (if the dataset is a parquet dataset) the parquet
+        metadata.  This can be used to collect the paths or metadata of
+        all written files.
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -690,7 +690,7 @@ def _ensure_write_partitioning(scheme):
 def write_dataset(data, base_dir, basename_template=None, format=None,
                   partitioning=None, schema=None,
                   filesystem=None, file_options=None, use_threads=True,
-                  use_async=False, max_partitions=None):
+                  use_async=False, max_partitions=None, file_visitor=None):
     """
     Write a dataset to a given format and partitioning.
 
@@ -731,6 +731,9 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
         (e.g. S3)
     max_partitions : int, default 1024
         Maximum number of partitions any batch may be written into.
+    file_visitor : Function
+        If set, this function will be called with a WrittenFile instance
+        for each file created during the call.
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 
@@ -784,5 +787,5 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
 
     _filesystemdataset_write(
         scanner, base_dir, basename_template, filesystem, partitioning,
-        file_options, max_partitions
+        file_options, max_partitions, file_visitor
     )

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -736,7 +736,7 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
         for each file created during the call.  This object will have both
         a path attribute and a metadata attribute.
 
-        The path attribute will a str containing the absolute path to
+        The path attribute will be a string containing the path to
         the created file.
 
         The metadata attribute will be the parquet metadata of the file.

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -744,11 +744,12 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
         to build a _metadata file.  The metadata attribute will be None if
         the format is not parquet.
 
-        # Example visitor which simple collects the filenames created
-        visited_paths = []
+        Example visitor which simple collects the filenames created::
 
-        def file_visitor(written_file):
-            visited_paths.append(written_file.path)
+            visited_paths = []
+
+            def file_visitor(written_file):
+                visited_paths.append(written_file.path)
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -733,10 +733,22 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
         Maximum number of partitions any batch may be written into.
     file_visitor : Function
         If set, this function will be called with a WrittenFile instance
-        for each file created during the call.  This object will contain
-        the path and (if the dataset is a parquet dataset) the parquet
-        metadata.  This can be used to collect the paths or metadata of
-        all written files.
+        for each file created during the call.  This object will have both
+        a path attribute and a metadata attribute.
+
+        The path attribute will a str containing the absolute path to
+        the created file.
+
+        The metadata attribute will be the parquet metadata of the file.
+        This metadata will have the file path attribute set and can be used
+        to build a _metadata file.  The metadata attribute will be None if
+        the format is not parquet.
+
+        # Example visitor which simple collects the filenames created
+        visited_paths = []
+
+        def file_visitor(written_file):
+            visited_paths.append(written_file.path)
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -81,6 +81,8 @@ cdef extern from "arrow/compute/exec/expression.h" \
         CExtractKnownFieldValues "arrow::compute::ExtractKnownFieldValues"(
             const CExpression& partition_expression)
 
+ctypedef CStatus cb_writer_finish_internal(CFileWriter*)
+ctypedef void cb_writer_finish(dict, CFileWriter*)
 
 cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
@@ -223,6 +225,17 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         const shared_ptr[CFileFormat]& format() const
         c_string type_name() const
 
+    cdef cppclass CFileWriter \
+            "arrow::dataset::FileWriter":
+        const shared_ptr[CFileFormat]& format() const
+        const shared_ptr[CSchema]& schema() const
+        const shared_ptr[CFileWriteOptions]& options() const
+        const CFileLocator& destination() const
+
+    cdef cppclass CParquetFileWriter \
+            "arrow::dataset::ParquetFileWriter"(CFileWriter):
+        const shared_ptr[FileWriter]& parquet_writer() const
+
     cdef cppclass CFileFormat "arrow::dataset::FileFormat":
         shared_ptr[CFragmentScanOptions] default_fragment_scan_options
         c_string type_name() const
@@ -263,6 +276,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         shared_ptr[CPartitioning] partitioning
         int max_partitions
         c_string basename_template
+        function[cb_writer_finish_internal] writer_pre_finish
+        function[cb_writer_finish_internal] writer_post_finish
 
     cdef cppclass CFileSystemDataset \
             "arrow::dataset::FileSystemDataset"(CDataset):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -52,6 +52,10 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_bool allow_not_found
         c_bool recursive
 
+    cdef cppclass CFileLocator "arrow::fs::FileLocator":
+        shared_ptr[CFileSystem] filesystem
+        c_string path
+
     cdef cppclass CFileSystem "arrow::fs::FileSystem":
         shared_ptr[CFileSystem] shared_from_this()
         c_string type_name() const

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1961,8 +1961,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         file_visitor = None
         if metadata_collector is not None:
             def file_visitor(written_file):
-                if written_file.metadata:
-                    metadata_collector.append(written_file.metadata)
+                metadata_collector.append(written_file.metadata)
         if partition_filename_cb is not None:
             raise ValueError(msg.format("partition_filename_cb"))
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1958,8 +1958,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
             "implementation."
         )
         metadata_collector = kwargs.pop('metadata_collector', None)
+        file_visitor = None
         if metadata_collector is not None:
-            raise ValueError(msg.format("metadata_collector"))
+            def file_visitor(written_file):
+                if written_file.metadata:
+                    metadata_collector.append(written_file.metadata)
         if partition_filename_cb is not None:
             raise ValueError(msg.format("partition_filename_cb"))
 
@@ -1979,7 +1982,8 @@ def write_to_dataset(table, root_path, partition_cols=None,
         ds.write_dataset(
             table, root_path, filesystem=filesystem,
             format=parquet_format, file_options=write_options, schema=schema,
-            partitioning=partitioning, use_threads=use_threads)
+            partitioning=partitioning, use_threads=use_threads,
+            file_visitor=file_visitor)
         return
 
     fs, root_path = legacyfs.resolve_filesystem_and_path(root_path, filesystem)


### PR DESCRIPTION
Created writer_post_finish (similar to writer_pre_finish) to visit dataset-created files after Finish.  Added a similar file_visitor concept to pyarrow which maps to writer_post_finish.  Connected the legacy metadata_collector to the file_visitor so that parquet datasets created with use_legacy_dataset=True can support metadata_collector.