### PR TITLE
ARROW-13220: [C++] Implement 'choose' function

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -47,6 +47,7 @@ std::vector<std::shared_ptr<DataType>> g_floating_types;
 std::vector<std::shared_ptr<DataType>> g_numeric_types;
 std::vector<std::shared_ptr<DataType>> g_base_binary_types;
 std::vector<std::shared_ptr<DataType>> g_temporal_types;
+std::vector<std::shared_ptr<DataType>> g_interval_types;
 std::vector<std::shared_ptr<DataType>> g_primitive_types;
 std::vector<Type::type> g_decimal_type_ids;
 static std::once_flag codegen_static_initialized;
@@ -90,6 +91,9 @@ static void InitStaticData() {
                       timestamp(TimeUnit::MILLI),
                       timestamp(TimeUnit::MICRO),
                       timestamp(TimeUnit::NANO)};
+
+  // Interval types
+  g_interval_types = {day_time_interval(), month_interval()};
 
   // Base binary types (without FixedSizeBinary)
   g_base_binary_types = {binary(), utf8(), large_binary(), large_utf8()};
@@ -155,6 +159,11 @@ const std::vector<std::shared_ptr<DataType>>& NumericTypes() {
 const std::vector<std::shared_ptr<DataType>>& TemporalTypes() {
   std::call_once(codegen_static_initialized, InitStaticData);
   return g_temporal_types;
+}
+
+const std::vector<std::shared_ptr<DataType>>& IntervalTypes() {
+  std::call_once(codegen_static_initialized, InitStaticData);
+  return g_interval_types;
 }
 
 const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes() {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -442,6 +442,9 @@ const std::vector<std::shared_ptr<DataType>>& NumericTypes();
 // Temporal types including time and timestamps for each unit
 const std::vector<std::shared_ptr<DataType>>& TemporalTypes();
 
+// Interval types
+const std::vector<std::shared_ptr<DataType>>& IntervalTypes();
+
 // Integer, floating point, base binary, and temporal
 const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes();
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1182,6 +1182,20 @@ void CopyOneArrayValue(const DataType& type, const uint8_t* in_valid,
                                   out_offset);
 }
 
+template <typename Type>
+void CopyOneValue(const Datum& in_values, const int64_t in_offset, uint8_t* out_valid,
+                  uint8_t* out_values, const int64_t out_offset) {
+  if (in_values.is_array()) {
+    const ArrayData& array = *in_values.array();
+    CopyOneArrayValue<Type>(*array.type, array.GetValues<uint8_t>(0, 0),
+                            array.GetValues<uint8_t>(1, 0), array.offset + in_offset,
+                            out_valid, out_values, out_offset);
+  } else {
+    CopyValues<Type>(in_values, in_offset, /*length=*/1, out_valid, out_values,
+                     out_offset);
+  }
+}
+
 struct CaseWhenFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
@@ -1606,6 +1620,203 @@ struct CoalesceFunctor<Type, enable_if_base_binary<Type>> {
   }
 };
 
+template <typename Type>
+Status ExecScalarChoose(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+  const auto& index_scalar = *batch[0].scalar();
+  if (!index_scalar.is_valid) {
+    if (out->is_array()) {
+      auto source = MakeNullScalar(out->type());
+      ArrayData* output = out->mutable_array();
+      CopyValues<Type>(source, /*row=*/0, batch.length,
+                       output->GetMutableValues<uint8_t>(0, /*absolute_offset=*/0),
+                       output->GetMutableValues<uint8_t>(1, /*absolute_offset=*/0),
+                       output->offset);
+    }
+    return Status::OK();
+  }
+  auto index = UnboxScalar<Int64Type>::Unbox(index_scalar);
+  if (index < 0 || static_cast<size_t>(index + 1) >= batch.values.size()) {
+    return Status::IndexError("choose: index ", index, " out of range");
+  }
+  auto source = batch.values[index + 1];
+  if (out->is_scalar()) {
+    *out = source;
+  } else {
+    ArrayData* output = out->mutable_array();
+    CopyValues<Type>(source, /*row=*/0, batch.length,
+                     output->GetMutableValues<uint8_t>(0, /*absolute_offset=*/0),
+                     output->GetMutableValues<uint8_t>(1, /*absolute_offset=*/0),
+                     output->offset);
+  }
+  return Status::OK();
+}
+
+template <typename Type>
+Status ExecArrayChoose(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+  ArrayData* output = out->mutable_array();
+  const int64_t out_offset = output->offset;
+  // Need a null bitmap if any input has nulls
+  uint8_t* out_valid = nullptr;
+  if (std::any_of(batch.values.begin(), batch.values.end(),
+                  [](const Datum& d) { return d.null_count() > 0; })) {
+    out_valid = output->buffers[0]->mutable_data();
+  } else {
+    BitUtil::SetBitsTo(output->buffers[0]->mutable_data(), out_offset, batch.length,
+                       true);
+  }
+  uint8_t* out_values = output->buffers[1]->mutable_data();
+  int64_t row = 0;
+  return VisitArrayValuesInline<Int64Type>(
+      *batch[0].array(),
+      [&](int64_t index) {
+        if (index < 0 || static_cast<size_t>(index + 1) >= batch.values.size()) {
+          return Status::IndexError("choose: index ", index, " out of range");
+        }
+        const auto& source = batch.values[index + 1];
+        CopyOneValue<Type>(source, row, out_valid, out_values, out_offset + row);
+        row++;
+        return Status::OK();
+      },
+      [&]() {
+        // Index is null, but we should still initialize the output with some value
+        const auto& source = batch.values[1];
+        CopyOneValue<Type>(source, row, out_valid, out_values, out_offset + row);
+        BitUtil::ClearBit(out_valid, out_offset + row);
+        row++;
+        return Status::OK();
+      });
+}
+
+template <typename Type, typename Enable = void>
+struct ChooseFunctor {
+  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    if (batch.values[0].is_scalar()) {
+      return ExecScalarChoose<Type>(ctx, batch, out);
+    }
+    return ExecArrayChoose<Type>(ctx, batch, out);
+  }
+};
+
+template <>
+struct ChooseFunctor<NullType> {
+  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    return Status::OK();
+  }
+};
+
+template <typename Type>
+struct ChooseFunctor<Type, enable_if_base_binary<Type>> {
+  using offset_type = typename Type::offset_type;
+  using BuilderType = typename TypeTraits<Type>::BuilderType;
+
+  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    if (batch.values[0].is_scalar()) {
+      const auto& index_scalar = *batch[0].scalar();
+      if (!index_scalar.is_valid) {
+        if (out->is_array()) {
+          auto null_scalar = MakeNullScalar(out->type());
+          ARROW_ASSIGN_OR_RAISE(
+              auto temp_array,
+              MakeArrayFromScalar(*null_scalar, batch.length, ctx->memory_pool()));
+          *out->mutable_array() = *temp_array->data();
+        }
+        return Status::OK();
+      }
+      auto index = UnboxScalar<Int64Type>::Unbox(index_scalar);
+      if (index < 0 || static_cast<size_t>(index + 1) >= batch.values.size()) {
+        return Status::IndexError("choose: index ", index, " out of range");
+      }
+      auto source = batch.values[index + 1];
+      if (source.is_scalar() && out->is_array()) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto temp_array,
+            MakeArrayFromScalar(*source.scalar(), batch.length, ctx->memory_pool()));
+        *out->mutable_array() = *temp_array->data();
+      } else {
+        *out = source;
+      }
+      return Status::OK();
+    }
+
+    // Row-wise implementation
+    BuilderType builder(out->type(), ctx->memory_pool());
+    RETURN_NOT_OK(builder.Reserve(batch.length));
+    int64_t reserve_data = 0;
+    for (const auto& value : batch.values) {
+      if (value.is_scalar()) {
+        if (!value.scalar()->is_valid) continue;
+        const auto row_length =
+            checked_cast<const BaseBinaryScalar&>(*value.scalar()).value->size();
+        reserve_data = std::max<int64_t>(reserve_data, batch.length * row_length);
+      }
+      const ArrayData& arr = *value.array();
+      const offset_type* offsets = arr.GetValues<offset_type>(1);
+      const offset_type values_length = offsets[arr.length] - offsets[0];
+      reserve_data = std::max<int64_t>(reserve_data, values_length);
+    }
+    RETURN_NOT_OK(builder.ReserveData(reserve_data));
+    int64_t row = 0;
+    RETURN_NOT_OK(VisitArrayValuesInline<Int64Type>(
+        *batch[0].array(),
+        [&](int64_t index) {
+          if (index < 0 || static_cast<size_t>(index + 1) >= batch.values.size()) {
+            return Status::IndexError("choose: index ", index, " out of range");
+          }
+          const auto& source = batch.values[index + 1];
+          return CopyValue(source, &builder, row++);
+        },
+        [&]() {
+          row++;
+          return builder.AppendNull();
+        }));
+    auto actual_type = out->type();
+    std::shared_ptr<Array> temp_output;
+    RETURN_NOT_OK(builder.Finish(&temp_output));
+    ArrayData* output = out->mutable_array();
+    *output = *temp_output->data();
+    // Builder type != logical type due to GenerateTypeAgnosticVarBinaryBase
+    output->type = std::move(actual_type);
+    return Status::OK();
+  }
+
+  static Status CopyValue(const Datum& datum, BuilderType* builder, int64_t row) {
+    if (datum.is_scalar()) {
+      return builder->AppendScalar(*datum.scalar());
+    }
+    const ArrayData& source = *datum.array();
+    if (!source.MayHaveNulls() ||
+        BitUtil::GetBit(source.buffers[0]->data(), source.offset + row)) {
+      const uint8_t* data = source.buffers[2]->data();
+      const offset_type* offsets = source.GetValues<offset_type>(1);
+      const offset_type offset0 = offsets[row];
+      const offset_type offset1 = offsets[row + 1];
+      return builder->Append(data + offset0, offset1 - offset0);
+    }
+    return builder->AppendNull();
+  }
+};
+
+struct ChooseFunction : ScalarFunction {
+  using ScalarFunction::ScalarFunction;
+
+  Result<const Kernel*> DispatchBest(std::vector<ValueDescr>* values) const override {
+    // The first argument is always int64 or promoted to it. The kernel is dispatched
+    // based on the type of the rest of the arguments.
+    RETURN_NOT_OK(CheckArity(*values));
+    EnsureDictionaryDecoded(values);
+    if (values->front().type->id() != Type::INT64) {
+      values->front().type = int64();
+    }
+    if (auto type = CommonNumeric(values->data() + 1, values->size() - 1)) {
+      for (auto it = values->begin() + 1; it != values->end(); it++) {
+        it->type = type;
+      }
+    }
+    if (auto kernel = DispatchExactImpl(this, {values->back()})) return kernel;
+    return arrow::compute::detail::NoMatchingKernel(this, *values);
+  }
+};
+
 Result<ValueDescr> LastType(KernelContext*, const std::vector<ValueDescr>& descrs) {
   ValueDescr result = descrs.back();
   result.shape = GetBroadcastShape(descrs);
@@ -1652,6 +1863,26 @@ void AddPrimitiveCoalesceKernels(const std::shared_ptr<ScalarFunction>& scalar_f
   }
 }
 
+void AddChooseKernel(const std::shared_ptr<ScalarFunction>& scalar_function,
+                     detail::GetTypeId get_id, ArrayKernelExec exec) {
+  ScalarKernel kernel(
+      KernelSignature::Make({Type::INT64, InputType(get_id.id)}, OutputType(LastType),
+                            /*is_varargs=*/true),
+      exec);
+  kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
+  kernel.mem_allocation = MemAllocation::PREALLOCATE;
+  kernel.can_write_into_slices = is_fixed_width(get_id.id);
+  DCHECK_OK(scalar_function->AddKernel(std::move(kernel)));
+}
+
+void AddPrimitiveChooseKernels(const std::shared_ptr<ScalarFunction>& scalar_function,
+                               const std::vector<std::shared_ptr<DataType>>& types) {
+  for (auto&& type : types) {
+    auto exec = GenerateTypeAgnosticPrimitive<ChooseFunctor>(*type);
+    AddChooseKernel(scalar_function, type, std::move(exec));
+  }
+}
+
 const FunctionDoc if_else_doc{"Choose values based on a condition",
                               ("`cond` must be a Boolean scalar/ array. \n`left` or "
                                "`right` must be of the same type scalar/ array.\n"
@@ -1679,6 +1910,15 @@ const FunctionDoc coalesce_doc{
      "for which the value is not null. If all inputs are null in a row, the output "
      "will be null."),
     {"*values"}};
+
+const FunctionDoc choose_doc{
+    "Given indices and arrays, choose the value from the corresponding array for each "
+    "index",
+    ("For each row, the value of the first argument is used as a 0-based index into the "
+     "rest of the arguments (i.e. index 0 selects the second argument). The output value "
+     "is the corresponding value of the selected argument.\n"
+     "If an index is null, the output will be null."),
+    {"indices", "*values"}};
 }  // namespace
 
 void RegisterScalarIfElse(FunctionRegistry* registry) {
@@ -1720,6 +1960,22 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddCoalesceKernel(func, Type::DECIMAL256, CoalesceFunctor<Decimal256Type>::Exec);
     for (const auto& ty : BaseBinaryTypes()) {
       AddCoalesceKernel(func, ty, GenerateTypeAgnosticVarBinaryBase<CoalesceFunctor>(ty));
+    }
+    DCHECK_OK(registry->AddFunction(std::move(func)));
+  }
+  {
+    auto func = std::make_shared<ChooseFunction>("choose", Arity::VarArgs(/*min_args=*/2),
+                                                 &choose_doc);
+    AddPrimitiveChooseKernels(func, NumericTypes());
+    AddPrimitiveChooseKernels(func, TemporalTypes());
+    AddPrimitiveChooseKernels(func,
+                              {boolean(), null(), day_time_interval(), month_interval()});
+    AddChooseKernel(func, Type::FIXED_SIZE_BINARY,
+                    ChooseFunctor<FixedSizeBinaryType>::Exec);
+    AddChooseKernel(func, Type::DECIMAL128, ChooseFunctor<Decimal128Type>::Exec);
+    AddChooseKernel(func, Type::DECIMAL256, ChooseFunctor<Decimal256Type>::Exec);
+    for (const auto& ty : BaseBinaryTypes()) {
+      AddChooseKernel(func, ty, GenerateTypeAgnosticVarBinaryBase<ChooseFunctor>(ty));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1791,7 +1791,8 @@ struct ChooseFunctor<Type, enable_if_base_binary<Type>> {
     if (datum.is_scalar()) {
       const auto& scalar = checked_cast<const BaseBinaryScalar&>(*datum.scalar());
       if (!scalar.value) return builder->AppendNull();
-      return builder->Append(scalar.value->data(), scalar.value->size());
+      return builder->Append(scalar.value->data(),
+                             static_cast<offset_type>(scalar.value->size()));
     }
     const ArrayData& source = *datum.array();
     if (!source.MayHaveNulls() ||

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -26,7 +26,7 @@
 namespace arrow {
 namespace compute {
 
-const int64_t elems = 1024 * 1024;
+const int64_t kNumItems = 1024 * 1024;
 
 template <typename Type, typename Enable = void>
 struct SetBytesProcessed {};
@@ -313,38 +313,38 @@ static void ChooseBench64(benchmark::State& state) {
   return ChooseBench<Int64Type>(state);
 }
 
-BENCHMARK(IfElseBench32)->Args({elems, 0});
-BENCHMARK(IfElseBench64)->Args({elems, 0});
+BENCHMARK(IfElseBench32)->Args({kNumItems, 0});
+BENCHMARK(IfElseBench64)->Args({kNumItems, 0});
 
-BENCHMARK(IfElseBench32)->Args({elems, 99});
-BENCHMARK(IfElseBench64)->Args({elems, 99});
+BENCHMARK(IfElseBench32)->Args({kNumItems, 99});
+BENCHMARK(IfElseBench64)->Args({kNumItems, 99});
 
-BENCHMARK(IfElseBench32Contiguous)->Args({elems, 0});
-BENCHMARK(IfElseBench64Contiguous)->Args({elems, 0});
+BENCHMARK(IfElseBench32Contiguous)->Args({kNumItems, 0});
+BENCHMARK(IfElseBench64Contiguous)->Args({kNumItems, 0});
 
-BENCHMARK(IfElseBench32Contiguous)->Args({elems, 99});
-BENCHMARK(IfElseBench64Contiguous)->Args({elems, 99});
+BENCHMARK(IfElseBench32Contiguous)->Args({kNumItems, 99});
+BENCHMARK(IfElseBench64Contiguous)->Args({kNumItems, 99});
 
-BENCHMARK(IfElseBenchString32)->Args({elems, 0});
-BENCHMARK(IfElseBenchString64)->Args({elems, 0});
+BENCHMARK(IfElseBenchString32)->Args({kNumItems, 0});
+BENCHMARK(IfElseBenchString64)->Args({kNumItems, 0});
 
-BENCHMARK(IfElseBenchString32Contiguous)->Args({elems, 99});
-BENCHMARK(IfElseBenchString64Contiguous)->Args({elems, 99});
+BENCHMARK(IfElseBenchString32Contiguous)->Args({kNumItems, 99});
+BENCHMARK(IfElseBenchString64Contiguous)->Args({kNumItems, 99});
 
-BENCHMARK(CaseWhenBench64)->Args({elems, 0});
-BENCHMARK(CaseWhenBench64)->Args({elems, 99});
+BENCHMARK(CaseWhenBench64)->Args({kNumItems, 0});
+BENCHMARK(CaseWhenBench64)->Args({kNumItems, 99});
 
-BENCHMARK(CaseWhenBench64Contiguous)->Args({elems, 0});
-BENCHMARK(CaseWhenBench64Contiguous)->Args({elems, 99});
+BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 0});
+BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 99});
 
-BENCHMARK(CoalesceBench64)->Args({elems, 0});
-BENCHMARK(CoalesceBench64)->Args({elems, 99});
+BENCHMARK(CoalesceBench64)->Args({kNumItems, 0});
+BENCHMARK(CoalesceBench64)->Args({kNumItems, 99});
 
-BENCHMARK(CoalesceNonNullBench64)->Args({elems, 0});
-BENCHMARK(CoalesceNonNullBench64)->Args({elems, 99});
+BENCHMARK(CoalesceNonNullBench64)->Args({kNumItems, 0});
+BENCHMARK(CoalesceNonNullBench64)->Args({kNumItems, 99});
 
-BENCHMARK(ChooseBench64)->Args({elems, 0});
-BENCHMARK(ChooseBench64)->Args({elems, 99});
+BENCHMARK(ChooseBench64)->Args({kNumItems, 0});
+BENCHMARK(ChooseBench64)->Args({kNumItems, 99});
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -1056,6 +1056,8 @@ TYPED_TEST(TestChooseNumeric, FixedSize) {
   auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
   CheckScalar("choose", {indices1, values1, values2},
               ArrayFromJSON(type, "[10, 21, null, null, null]"));
+  CheckScalar("choose", {indices1, ScalarFromJSON(type, "1"), values1},
+              ArrayFromJSON(type, "[1, 11, 1, null, null]"));
   // Mixed scalar and array (note CheckScalar checks all-scalar cases for us)
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
@@ -1078,6 +1080,8 @@ TYPED_TEST(TestChooseBinary, Basics) {
   auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
   CheckScalar("choose", {indices1, values1, values2},
               ArrayFromJSON(type, R"(["a", "klmno", null, null, null])"));
+  CheckScalar("choose", {indices1, ScalarFromJSON(type, R"("foo")"), values1},
+              ArrayFromJSON(type, R"(["foo", "bc", "foo", null, null])"));
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
   CheckScalar("choose", {ScalarFromJSON(int64(), "null"), values1, values2}, nulls);
@@ -1096,6 +1100,7 @@ TEST(TestChoose, Null) {
   auto indices1 = ArrayFromJSON(int64(), "[0, 1, 0, 1, null]");
   auto nulls = *MakeArrayOfNull(type, 5);
   CheckScalar("choose", {indices1, nulls, nulls}, nulls);
+  CheckScalar("choose", {indices1, MakeNullScalar(type), nulls}, nulls);
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), nulls, nulls}, nulls);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), nulls, nulls}, nulls);
   CheckScalar("choose", {ScalarFromJSON(int64(), "null"), nulls, nulls}, nulls);
@@ -1113,6 +1118,8 @@ TEST(TestChoose, Boolean) {
   auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
   CheckScalar("choose", {indices1, values1, values2},
               ArrayFromJSON(type, "[true, false, null, null, null]"));
+  CheckScalar("choose", {indices1, ScalarFromJSON(type, "false"), values1},
+              ArrayFromJSON(type, "[false, true, false, null, null]"));
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
   CheckScalar("choose", {ScalarFromJSON(int64(), "null"), values1, values2}, nulls);
@@ -1134,6 +1141,8 @@ TEST(TestChoose, DayTimeInterval) {
   auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
   CheckScalar("choose", {indices1, values1, values2},
               ArrayFromJSON(type, "[[10, 1], [2, 20], null, null, null]"));
+  CheckScalar("choose", {indices1, ScalarFromJSON(type, "[1, 2]"), values1},
+              ArrayFromJSON(type, "[[1, 2], [10, 1], [1, 2], null, null]"));
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
   CheckScalar("choose", {ScalarFromJSON(int64(), "null"), values1, values2}, nulls);
@@ -1155,6 +1164,8 @@ TEST(TestChoose, Decimal) {
     auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
     CheckScalar("choose", {indices1, values1, values2},
                 ArrayFromJSON(type, R"(["1.23", "4.57", null, null, null])"));
+    CheckScalar("choose", {indices1, ScalarFromJSON(type, R"("2.34")"), values1},
+                ArrayFromJSON(type, R"(["2.34", "1.24", "2.34", null, null])"));
     CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
     CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
     CheckScalar("choose", {ScalarFromJSON(int64(), "null"), values1, values2}, nulls);
@@ -1177,6 +1188,8 @@ TEST(TestChoose, FixedSizeBinary) {
   auto nulls = ArrayFromJSON(type, "[null, null, null, null, null]");
   CheckScalar("choose", {indices1, values1, values2},
               ArrayFromJSON(type, R"(["abc", "deg", null, null, null])"));
+  CheckScalar("choose", {indices1, ScalarFromJSON(type, R"("xyz")"), values1},
+              ArrayFromJSON(type, R"(["xyz", "abd", "xyz", null, null])"));
   CheckScalar("choose", {ScalarFromJSON(int64(), "0"), values1, values2}, values1);
   CheckScalar("choose", {ScalarFromJSON(int64(), "1"), values1, values2}, values2);
   CheckScalar("choose", {ScalarFromJSON(int64(), "null"), values1, values2}, nulls);

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -520,10 +520,11 @@ void RegisterVectorReplace(FunctionRegistry* registry) {
   for (const auto& ty : TemporalTypes()) {
     add_primitive_kernel(ty);
   }
+  for (const auto& ty : IntervalTypes()) {
+    add_primitive_kernel(ty);
+  }
   add_primitive_kernel(null());
   add_primitive_kernel(boolean());
-  add_primitive_kernel(day_time_interval());
-  add_primitive_kernel(month_interval());
   add_kernel(Type::FIXED_SIZE_BINARY, ReplaceWithMaskFunctor<FixedSizeBinaryType>::Exec);
   add_kernel(Type::DECIMAL128, ReplaceWithMaskFunctor<Decimal128Type>::Exec);
   add_kernel(Type::DECIMAL256, ReplaceWithMaskFunctor<Decimal256Type>::Exec);

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -891,25 +891,27 @@ Structural transforms
 +==========================+============+===================================================+=====================+=========+
 | case_when                | Varargs    | Struct of Boolean (Arg 0), Any fixed-width (rest) | Input type          | \(1)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| coalesce                 | Varargs    | Any                                               | Input type          | \(2)    |
+| choose                   | Varargs    | Integral (Arg 0); Fixed-width/Binary-like (rest)  | Input type          | \(2)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like     | Input type          | \(3)    |
+| coalesce                 | Varargs    | Any                                               | Input type          | \(3)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal                  | Input type          | \(4)    |
+| fill_null                | Binary     | Boolean, Null, Numeric, Temporal, String-like     | Input type          | \(4)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| is_finite                | Unary      | Float, Double                                     | Boolean             | \(5)    |
+| if_else                  | Ternary    | Boolean, Null, Numeric, Temporal                  | Input type          | \(5)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| is_inf                   | Unary      | Float, Double                                     | Boolean             | \(6)    |
+| is_finite                | Unary      | Float, Double                                     | Boolean             | \(6)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| is_nan                   | Unary      | Float, Double                                     | Boolean             | \(7)    |
+| is_inf                   | Unary      | Float, Double                                     | Boolean             | \(7)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| is_null                  | Unary      | Any                                               | Boolean             | \(8)    |
+| is_nan                   | Unary      | Float, Double                                     | Boolean             | \(8)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| is_valid                 | Unary      | Any                                               | Boolean             | \(9)    |
+| is_null                  | Unary      | Any                                               | Boolean             | \(9)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| list_value_length        | Unary      | List-like                                         | Int32 or Int64      | \(10)   |
+| is_valid                 | Unary      | Any                                               | Boolean             | \(10)   |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
-| make_struct              | Varargs    | Any                                               | Struct              | \(11)   |
+| list_value_length        | Unary      | List-like                                         | Int32 or Int64      | \(11)   |
++--------------------------+------------+---------------------------------------------------+---------------------+---------+
+| make_struct              | Varargs    | Any                                               | Struct              | \(12)   |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
 
 * \(1) This function acts like a SQL 'case when' statement or switch-case. The
@@ -921,14 +923,21 @@ Structural transforms
   the first value datum for which the corresponding Boolean is true, or the
   corresponding value from the 'default' input, or null otherwise.
 
-* \(2) Each row of the output will be the corresponding value of the first
+* \(2) The first input must be an integral type. The rest of the arguments can be
+  any type, but must all be the same type or promotable to a common type. Each
+  value of the first input (the 'index') is used as a zero-based index into the
+  remaining arguments (i.e. index 0 is the second argument, index 1 is the third
+  argument, etc.), and the value of the output for that row will be the
+  corresponding value of the selected input at that row.
+
+* \(3) Each row of the output will be the corresponding value of the first
   input which is non-null for that row, otherwise null.
 
-* \(3) First input must be an array, second input a scalar of the same type.
+* \(4) First input must be an array, second input a scalar of the same type.
   Output is an array of the same type as the inputs, and with the same values
   as the first input, except for nulls replaced with the second input value.
 
-* \(4) First input must be a Boolean scalar or array. Second and third inputs
+* \(5) First input must be a Boolean scalar or array. Second and third inputs
   could be scalars or arrays and must be of the same type. Output is an array
   (or scalar if all inputs are scalar) of the same type as the second/ third
   input. If the nulls present on the first input, they will be promoted to the
@@ -936,21 +945,21 @@ Structural transforms
 
   Also see: :ref:`replace_with_mask <cpp-compute-vector-structural-transforms>`.
 
-* \(5) Output is true iff the corresponding input element is finite (not Infinity,
+* \(6) Output is true iff the corresponding input element is finite (not Infinity,
   -Infinity, or NaN).
 
-* \(6) Output is true iff the corresponding input element is Infinity/-Infinity.
+* \(7) Output is true iff the corresponding input element is Infinity/-Infinity.
 
-* \(7) Output is true iff the corresponding input element is NaN.
+* \(8) Output is true iff the corresponding input element is NaN.
 
-* \(8) Output is true iff the corresponding input element is null.
+* \(9) Output is true iff the corresponding input element is null.
 
-* \(9) Output is true iff the corresponding input element is non-null.
+* \(10) Output is true iff the corresponding input element is non-null.
 
-* \(10) Each output element is the length of the corresponding input element
+* \(11) Each output element is the length of the corresponding input element
   (null if input is null).  Output type is Int32 for List, Int64 for LargeList.
 
-* \(11) The output struct's field types are the types of its arguments. The
+* \(12) The output struct's field types are the types of its arguments. The
   field names are specified using an instance of :struct:`MakeStructOptions`.
   The output shape will be scalar if all inputs are scalar, otherwise any
   scalars will be broadcast to arrays.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -928,7 +928,8 @@ Structural transforms
   value of the first input (the 'index') is used as a zero-based index into the
   remaining arguments (i.e. index 0 is the second argument, index 1 is the third
   argument, etc.), and the value of the output for that row will be the
-  corresponding value of the selected input at that row.
+  corresponding value of the selected input at that row. If the index is null,
+  then the output will also be null.
 
 * \(3) Each row of the output will be the corresponding value of the first
   input which is non-null for that row, otherwise null.

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -352,6 +352,7 @@ Structural Transforms
 
    binary_length
    case_when
+   choose
    coalesce
    fill_null
    if_else


### PR DESCRIPTION
Also makes two changes:
- MakeArrayFromScalar now works with Decimal256 and FixedSizeBinaryType
- VarArgs(min_args=N) for N>1 now works (before different assertions/runtime checks would trigger). Though, might it make sense to update KernelSignature to reflect min_args?