### PR TITLE
ARROW-12988: [CI][Python] Revert skip of failing test in kartothek nightly integration build

### DIFF
--- a/ci/scripts/integration_kartothek.sh
+++ b/ci/scripts/integration_kartothek.sh
@@ -28,4 +28,4 @@ python -c "import kartothek"
 
 pushd /kartothek
 # See ARROW-12314, test_load_dataframes_columns_raises_missing skipped because of changed error message
-pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing and not test_update_dataset_from_ddf_empty"
+pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing"


### PR DESCRIPTION
Revert of #10466