### PR TITLE
ARROW-6513: [CI] Rename conda requirements files to have txt extension instead of yml

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1842,7 +1842,7 @@ if(ARROW_BUILD_BENCHMARKS)
     # archive. So the benchmark package on conda-forge isn't report
     # the real version. We accept all the benchmark package with
     # conda. Conda users should install benchmark 1.5.2 or later by
-    # ci/conda_env_cpp.yml.
+    # ci/conda_env_cpp.txt.
     set(BENCHMARK_REQUIRED_VERSION 0.0.0)
   endif()
   resolve_dependency(benchmark

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -42,8 +42,8 @@ set PYTHON=3.6
 @rem Using call with conda.bat seems necessary to avoid terminating the batch
 @rem script execution
 call conda create --no-shortcuts -c conda-forge -f -q -y -p %_VERIFICATION_CONDA_ENV% ^
-    --file=ci\conda_env_cpp.yml ^
-    --file=ci\conda_env_python.yml ^
+    --file=ci\conda_env_cpp.txt ^
+    --file=ci\conda_env_python.txt ^
     git ^
     python=%PYTHON% ^
     || exit /B 1

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -81,7 +81,7 @@ Arrow codebase):
 
 .. code-block:: shell
 
-   conda create -y -n arrow-dev --file=ci\conda_env_cpp.yml
+   conda create -y -n arrow-dev --file=ci\conda_env_cpp.txt
 
 Then "activate" this conda environment with:
 
@@ -138,7 +138,7 @@ of Arrow and run the command:
      --clean-after-build
 
 On Windows, vcpkg builds dynamic link libraries by default. Use the triplet
-``x64-windows-static`` to build static libraries. vcpkg downloads source 
+``x64-windows-static`` to build static libraries. vcpkg downloads source
 packages and compiles them locally, so installing dependencies with vcpkg is
 more time-consuming than with conda.
 
@@ -150,12 +150,12 @@ Then in your ``cmake`` command, to use dependencies installed by vcpkg, set:
 
 You can optionally set other variables to override the default CMake
 configurations for vcpkg, including:
-   
+
 * ``-DCMAKE_TOOLCHAIN_FILE``: by default, the CMake scripts automatically find
   the location of the vcpkg CMake toolchain file ``vcpkg.cmake``; use this to
   instead specify its location
 * ``-DVCPKG_TARGET_TRIPLET``: by default, the CMake scripts attempt to infer the
-  vcpkg 
+  vcpkg
   `triplet <https://github.com/microsoft/vcpkg/blob/master/docs/users/triplets.md>`_;
   use this to instead specify the triplet
 * ``-DARROW_DEPENDENCY_USE_SHARED``: default is ``ON``; set to ``OFF`` for
@@ -408,7 +408,7 @@ tests can be made with there individual make targets).
 
 .. code-block:: shell
 
-   conda install -c conda-forge --file .\ci\conda_env_cpp.yml
+   conda install -c conda-forge --file .\ci\conda_env_cpp.txt
    .\ci\appveyor-cpp-setup.bat
    @rem this might fail but at this point most unit tests should be buildable by there individual targets
    @rem see next line for example.

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -30,7 +30,7 @@ If you're using Conda, the required software can be installed in a single line:
 
 .. code-block:: shell
 
-   conda install -c conda-forge --file=ci/conda_env_sphinx.yml
+   conda install -c conda-forge --file=ci/conda_env_sphinx.txt
 
 Otherwise, you'll first need to install `Doxygen <http://www.doxygen.nl/>`_
 yourself (for example from your distribution's official repositories, if

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -173,10 +173,10 @@ On Linux and macOS:
 .. code-block:: shell
 
     conda create -y -n pyarrow-dev -c conda-forge \
-        --file arrow/ci/conda_env_unix.yml \
-        --file arrow/ci/conda_env_cpp.yml \
-        --file arrow/ci/conda_env_python.yml \
-        --file arrow/ci/conda_env_gandiva.yml \
+        --file arrow/ci/conda_env_unix.txt \
+        --file arrow/ci/conda_env_cpp.txt \
+        --file arrow/ci/conda_env_python.txt \
+        --file arrow/ci/conda_env_gandiva.txt \
         compilers \
         python=3.7 \
         pandas
@@ -431,9 +431,9 @@ First, starting from fresh clones of Apache Arrow:
 .. code-block:: shell
 
    conda create -y -n pyarrow-dev -c conda-forge ^
-       --file arrow\ci\conda_env_cpp.yml ^
-       --file arrow\ci\conda_env_python.yml ^
-       --file arrow\ci\conda_env_gandiva.yml ^
+       --file arrow\ci\conda_env_cpp.txt ^
+       --file arrow\ci\conda_env_python.txt ^
+       --file arrow\ci\conda_env_gandiva.txt ^
        python=3.7
    conda activate pyarrow-dev
 

--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -50,9 +50,9 @@ function setup_miniconda() {
   conda config --add channels conda-forge
 
   conda create -y -n pyarrow-$PYTHON -c conda-forge \
-        --file arrow/ci/conda_env_unix.yml \
-        --file arrow/ci/conda_env_cpp.yml \
-        --file arrow/ci/conda_env_python.yml \
+        --file arrow/ci/conda_env_unix.txt \
+        --file arrow/ci/conda_env_cpp.txt \
+        --file arrow/ci/conda_env_python.txt \
         compilers \
         python=3.7 \
         pandas


### PR DESCRIPTION
Missing renames from #10572