### PR TITLE
ARROW-13252: [C++] Add offset to CSV error reporting

### DIFF
--- a/cpp/src/arrow/csv/invalid_row.h
+++ b/cpp/src/arrow/csv/invalid_row.h
@@ -35,6 +35,8 @@ struct InvalidRow {
   /// This number is one-based and also accounts for non-data rows (such as
   /// CSV header rows).
   int64_t number;
+  /// \brief The byte offset in the csv data where this row starts
+  int64_t offset;
   /// \brief View of the entire row. Memory will be freed after callback returns
   const util::string_view text;
 };

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -67,7 +67,7 @@ Result<std::unordered_set<std::string>> GetColumnNames(
   uint32_t parsed_size = 0;
   int32_t max_num_rows = read_options.skip_rows + 1;
   csv::BlockParser parser(pool, parse_options, /*num_cols=*/-1, /*first_row=*/1,
-                          max_num_rows);
+                          /*offset=*/0, max_num_rows);
 
   RETURN_NOT_OK(parser.Parse(util::string_view{first_block}, &parsed_size));
 


### PR DESCRIPTION
Add the offset of the start of a row to parsing and decoding errors.

In order to know the row offset during decoding a new array of offsets was added to DataBatch which indicate the offset of the row relative to the offset of the batch. This adds an overhead of an additional vector and an array of ints with one int per row