### PR TITLE
ARROW-13253: [FlightRPC][C++] Fix segfault with large messages

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -689,7 +689,7 @@ class GrpcStreamWriter : public FlightStreamWriter {
     FlightPayload payload{};
     payload.app_metadata = app_metadata;
     auto status = internal::WritePayload(payload, writer_->stream().get());
-    if (!status.ok() && status.IsIOError()) {
+    if (status.IsIOError()) {
       return writer_->Finish(MakeFlightError(FlightStatusCode::Internal,
                                              "Could not write metadata to stream"));
     }
@@ -810,7 +810,7 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
     }
 
     auto status = internal::WritePayload(payload, writer_->stream().get());
-    if (!status.ok() && status.IsIOError()) {
+    if (status.IsIOError()) {
       return writer_->Finish(MakeFlightError(FlightStatusCode::Internal,
                                              "Could not write record batch to stream"));
     }
@@ -853,7 +853,7 @@ Status GrpcStreamWriter<ProtoReadT, FlightReadT>::Open(
     FlightPayload payload{};
     RETURN_NOT_OK(internal::ToPayload(descriptor, &payload.descriptor));
     auto status = internal::WritePayload(payload, instance->writer_->stream().get());
-    if (!status.ok() && status.IsIOError()) {
+    if (status.IsIOError()) {
       return writer->Finish(MakeFlightError(FlightStatusCode::Internal,
                                             "Could not write descriptor to stream"));
     }

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -688,11 +688,12 @@ class GrpcStreamWriter : public FlightStreamWriter {
   Status WriteMetadata(std::shared_ptr<Buffer> app_metadata) override {
     FlightPayload payload{};
     payload.app_metadata = app_metadata;
-    if (!internal::WritePayload(payload, writer_->stream().get())) {
+    auto status = internal::WritePayload(payload, writer_->stream().get());
+    if (!status.ok() && status.IsIOError()) {
       return writer_->Finish(MakeFlightError(FlightStatusCode::Internal,
                                              "Could not write metadata to stream"));
     }
-    return Status::OK();
+    return status;
   }
 
   Status WriteWithMetadata(const RecordBatch& batch,
@@ -808,11 +809,12 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
       }
     }
 
-    if (!internal::WritePayload(payload, writer_->stream().get())) {
+    auto status = internal::WritePayload(payload, writer_->stream().get());
+    if (!status.ok() && status.IsIOError()) {
       return writer_->Finish(MakeFlightError(FlightStatusCode::Internal,
                                              "Could not write record batch to stream"));
     }
-    return Status::OK();
+    return status;
   }
 
   Status Close() override {
@@ -850,10 +852,12 @@ Status GrpcStreamWriter<ProtoReadT, FlightReadT>::Open(
     // calls Begin() to send data, we'll send a redundant descriptor.
     FlightPayload payload{};
     RETURN_NOT_OK(internal::ToPayload(descriptor, &payload.descriptor));
-    if (!internal::WritePayload(payload, instance->writer_->stream().get())) {
+    auto status = internal::WritePayload(payload, instance->writer_->stream().get());
+    if (!status.ok() && status.IsIOError()) {
       return writer->Finish(MakeFlightError(FlightStatusCode::Internal,
                                             "Could not write descriptor to stream"));
     }
+    RETURN_NOT_OK(status);
   }
   *out = std::move(instance);
   return Status::OK();

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1491,9 +1491,10 @@ TEST_F(TestFlightClient, FlightDataOverflow) {
         Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
         stream->Next(&chunk));
   }
-  std::string large_str(static_cast<size_t>(1) << 29, ' ');
-  auto large_descr =
-      FlightDescriptor::Path({large_str, large_str, large_str, large_str, "pad"});
+  std::string large_str(static_cast<size_t>(1) << 27, ' ');
+  std::vector<std::string> path_parts(16, large_str);
+  path_parts.push_back("pad");
+  auto large_descr = FlightDescriptor::Path(path_parts);
   {
     // DoPut: check for overflow on large descriptor
     std::unique_ptr<FlightStreamWriter> stream;

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1518,7 +1518,7 @@ TEST_F(TestFlightClient, FlightDataOverflow) {
     EXPECT_THAT(st.message(),
                 ::testing::HasSubstr("Failed to serialize Flight descriptor"));
   }
-  constexpr int64_t nbytes_overflow = (1L << 31) + 8;
+  constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
   ASSERT_OK_AND_ASSIGN(auto batch, VeryLargeBatch());
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> metadata, AllocateBuffer(nbytes_overflow));
   std::memset(metadata->mutable_data(), 0x00, metadata->capacity());

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1478,9 +1478,9 @@ TEST_F(TestFlightClient, DoGetLargeBatch) {
   CheckDoGet(ticket, expected_batches);
 }
 
-TEST_F(TestFlightClient, FlightDataOverflow) {
+TEST_F(TestFlightClient, FlightDataOverflowServerBatch) {
   // Regression test for ARROW-13253
-  // N.B. this is rather a slow test
+  // N.B. this is rather a slow and memory-hungry test
   {
     // DoGet: check for overflow on large batch
     Ticket ticket{"ARROW-13253-DoGet-Batch"};
@@ -1490,65 +1490,6 @@ TEST_F(TestFlightClient, FlightDataOverflow) {
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
         stream->Next(&chunk));
-  }
-  std::string large_str(static_cast<size_t>(1) << 27, ' ');
-  std::vector<std::string> path_parts(16, large_str);
-  path_parts.push_back("pad");
-  auto large_descr = FlightDescriptor::Path(path_parts);
-  {
-    // DoPut: check for overflow on large descriptor
-    std::unique_ptr<FlightStreamWriter> stream;
-    std::unique_ptr<FlightMetadataReader> reader;
-    auto st = client_->DoPut(large_descr, schema({}), &stream, &reader);
-    // Initial write may not actually write the data, if so close the stream to force a
-    // write
-    if (st.ok()) st = stream->Close();
-    // The error code we get here can vary (IOError or CapacityError), since we might get
-    // the server error or the client error
-    EXPECT_FALSE(st.ok());
-    EXPECT_THAT(st.message(),
-                ::testing::HasSubstr("Failed to serialize Flight descriptor"));
-  }
-  // constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
-  ASSERT_OK_AND_ASSIGN(auto batch, VeryLargeBatch());
-  {
-    // DoPut: check for overflow on large batch
-    std::unique_ptr<FlightStreamWriter> stream;
-    std::unique_ptr<FlightMetadataReader> reader;
-    auto descr = FlightDescriptor::Path({""});
-    ASSERT_OK(client_->DoPut(descr, batch->schema(), &stream, &reader));
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
-        stream->WriteRecordBatch(*batch));
-    // // DoPut: check for overflow on large metadata
-    // EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
-    //                                 ::testing::HasSubstr("app_metadata size overflow"),
-    //                                 stream->WriteMetadata(metadata));
-    ASSERT_OK(stream->Close());
-  }
-  {
-    // DoExchange: check for overflow on large descriptor
-    std::unique_ptr<FlightStreamReader> reader;
-    std::unique_ptr<FlightStreamWriter> writer;
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        UnknownError, ::testing::HasSubstr("Failed to serialize Flight descriptor"),
-        client_->DoExchange(large_descr, &writer, &reader));
-  }
-  {
-    // DoExchange: check for overflow on large batch from client
-    auto descr = FlightDescriptor::Command("counter");
-    std::unique_ptr<FlightStreamReader> reader;
-    std::unique_ptr<FlightStreamWriter> writer;
-    ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
-    ASSERT_OK(writer->Begin(batch->schema()));
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
-        writer->WriteRecordBatch(*batch));
-    // // DoExchange: check for overflow on large metadata from client
-    // EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
-    //                                 ::testing::HasSubstr("app_metadata size overflow"),
-    //                                 writer->WriteMetadata(metadata));
-    ASSERT_OK(writer->Close());
   }
   {
     // DoExchange: check for overflow on large batch from server
@@ -1560,6 +1501,88 @@ TEST_F(TestFlightClient, FlightDataOverflow) {
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
         reader->ReadAll(&batches));
+  }
+}
+
+TEST_F(TestFlightClient, FlightDataOverflowServerMetadata) {
+  // Test split up to reduce memory pressure
+  {
+    // DoGet: check for overflow on large metadata
+    Ticket ticket{"ARROW-13253-DoGet-Metadata"};
+    std::unique_ptr<FlightStreamReader> stream;
+    ASSERT_OK(client_->DoGet(ticket, &stream));
+    FlightStreamChunk chunk;
+    EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
+                                    ::testing::HasSubstr("app_metadata size overflow"),
+                                    stream->Next(&chunk));
+  }
+  {
+    // DoExchange: check for overflow on large metadata from server
+    auto descr = FlightDescriptor::Command("large_metadata");
+    std::unique_ptr<FlightStreamReader> reader;
+    std::unique_ptr<FlightStreamWriter> writer;
+    ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
+    BatchVector batches;
+    EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
+                                    ::testing::HasSubstr("app_metadata size overflow"),
+                                    reader->ReadAll(&batches));
+  }
+}
+
+TEST_F(TestFlightClient, FlightDataOverflowClientBatch) {
+  ASSERT_OK_AND_ASSIGN(auto batch, VeryLargeBatch());
+  {
+    // DoPut: check for overflow on large batch
+    std::unique_ptr<FlightStreamWriter> stream;
+    std::unique_ptr<FlightMetadataReader> reader;
+    auto descr = FlightDescriptor::Path({""});
+    ASSERT_OK(client_->DoPut(descr, batch->schema(), &stream, &reader));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
+        stream->WriteRecordBatch(*batch));
+    ASSERT_OK(stream->Close());
+  }
+  {
+    // DoExchange: check for overflow on large batch from client
+    auto descr = FlightDescriptor::Command("counter");
+    std::unique_ptr<FlightStreamReader> reader;
+    std::unique_ptr<FlightStreamWriter> writer;
+    ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
+    ASSERT_OK(writer->Begin(batch->schema()));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("Cannot send record batches exceeding 2GiB yet"),
+        writer->WriteRecordBatch(*batch));
+    ASSERT_OK(writer->Close());
+  }
+}
+
+TEST_F(TestFlightClient, FlightDataOverflowClientMetadata) {
+  constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> metadata, AllocateBuffer(nbytes_overflow));
+  std::memset(metadata->mutable_data(), 0x00, metadata->capacity());
+  auto descr = FlightDescriptor::Path({""});
+  {
+    // DoPut: check for overflow on large metadata
+    std::unique_ptr<FlightStreamWriter> stream;
+    std::unique_ptr<FlightMetadataReader> reader;
+    ASSERT_OK(client_->DoPut(descr, schema({}), &stream, &reader));
+    // DoPut: check for overflow on large metadata
+    EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
+                                    ::testing::HasSubstr("app_metadata size overflow"),
+                                    stream->WriteMetadata(metadata));
+    ASSERT_OK(stream->Close());
+  }
+  {
+    // DoExchange: check for overflow on large metadata from client
+    auto descr = FlightDescriptor::Command("counter");
+    std::unique_ptr<FlightStreamReader> reader;
+    std::unique_ptr<FlightStreamWriter> writer;
+    ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
+    // DoExchange: check for overflow on large metadata from client
+    EXPECT_RAISES_WITH_MESSAGE_THAT(CapacityError,
+                                    ::testing::HasSubstr("app_metadata size overflow"),
+                                    writer->WriteMetadata(metadata));
+    ASSERT_OK(writer->Close());
   }
 }
 

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -165,7 +165,7 @@ static const uint8_t kPaddingBytes[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 // Update the sizes of our Protobuf fields based on the given IPC payload.
 grpc::Status IpcMessageHeaderSize(const arrow::ipc::IpcPayload& ipc_msg, bool has_body,
                                   size_t* header_size, int32_t* metadata_size) {
-  DCHECK_LT(ipc_msg.metadata->size(), kInt32Max);
+  DCHECK_LE(ipc_msg.metadata->size(), kInt32Max);
   *metadata_size = static_cast<int32_t>(ipc_msg.metadata->size());
 
   // 1 byte for metadata tag
@@ -193,7 +193,7 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
   // Write the descriptor if present
   int32_t descriptor_size = 0;
   if (msg.descriptor != nullptr) {
-    DCHECK_LT(msg.descriptor->size(), kInt32Max);
+    DCHECK_LE(msg.descriptor->size(), kInt32Max);
     descriptor_size = static_cast<int32_t>(msg.descriptor->size());
     header_size += 1 + WireFormatLite::LengthDelimitedSize(descriptor_size);
   }
@@ -201,7 +201,7 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
   // App metadata tag if appropriate
   int32_t app_metadata_size = 0;
   if (msg.app_metadata && msg.app_metadata->size() > 0) {
-    DCHECK_LT(msg.app_metadata->size(), kInt32Max);
+    DCHECK_LE(msg.app_metadata->size(), kInt32Max);
     app_metadata_size = static_cast<int32_t>(msg.app_metadata->size());
     header_size += 1 + WireFormatLite::LengthDelimitedSize(app_metadata_size);
   }

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -164,26 +164,18 @@ static const uint8_t kPaddingBytes[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
 // Update the sizes of our Protobuf fields based on the given IPC payload.
 grpc::Status IpcMessageHeaderSize(const arrow::ipc::IpcPayload& ipc_msg, bool has_body,
-                                  size_t* body_size, size_t* header_size,
-                                  int32_t* metadata_size) {
+                                  size_t* header_size, int32_t* metadata_size) {
   DCHECK_LT(ipc_msg.metadata->size(), kInt32Max);
   *metadata_size = static_cast<int32_t>(ipc_msg.metadata->size());
 
   // 1 byte for metadata tag
   *header_size += 1 + WireFormatLite::LengthDelimitedSize(*metadata_size);
 
-  for (const auto& buffer : ipc_msg.body_buffers) {
-    // Buffer may be null when the row length is zero, or when all
-    // entries are invalid.
-    if (!buffer) continue;
-
-    *body_size += static_cast<size_t>(BitUtil::RoundUpToMultipleOf8(buffer->size()));
-  }
-
   // 2 bytes for body tag
   if (has_body) {
     // We write the body tag in the header but not the actual body data
-    *header_size += 2 + WireFormatLite::LengthDelimitedSize(*body_size) - *body_size;
+    *header_size += 2 + WireFormatLite::LengthDelimitedSize(ipc_msg.body_length) -
+                    ipc_msg.body_length;
   }
 
   return grpc::Status::OK;
@@ -201,9 +193,7 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
   // Write the descriptor if present
   int32_t descriptor_size = 0;
   if (msg.descriptor != nullptr) {
-    if (msg.descriptor->size() > kInt32Max) {
-      return ToGrpcStatus(Status::CapacityError("Descriptor size overflow (>= 2**31)"));
-    }
+    DCHECK_LT(msg.descriptor->size(), kInt32Max);
     descriptor_size = static_cast<int32_t>(msg.descriptor->size());
     header_size += 1 + WireFormatLite::LengthDelimitedSize(descriptor_size);
   }
@@ -223,15 +213,14 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
 
   if (has_ipc) {
     DCHECK(has_body || ipc_msg.body_length == 0);
-    GRPC_RETURN_NOT_GRPC_OK(IpcMessageHeaderSize(ipc_msg, has_body, &body_size,
-                                                 &header_size, &metadata_size));
+    GRPC_RETURN_NOT_GRPC_OK(
+        IpcMessageHeaderSize(ipc_msg, has_body, &header_size, &metadata_size));
+    body_size = static_cast<size_t>(ipc_msg.body_length);
   }
 
   // TODO(wesm): messages over 2GB unlikely to be yet supported
-  if (body_size > kInt32Max) {
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                        "Cannot send record batches exceeding 2GB yet");
-  }
+  // Validated in WritePayload since returning error here causes gRPC to fail an assertion
+  DCHECK_LE(body_size, kInt32Max);
 
   // Allocate and initialize slices
   std::vector<grpc::Slice> slices;
@@ -404,32 +393,48 @@ grpc::Status FlightDataDeserialize(ByteBuffer* buffer, FlightData* out) {
 // pointer argument whichever way we want, including cast it back to the original type.
 // (see customize_protobuf.h).
 
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ClientReaderWriter<pb::FlightData, pb::PutResult>* writer) {
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ClientReaderWriter<pb::FlightData, pb::PutResult>* writer) {
+  RETURN_NOT_OK(payload.Validate());
   // Pretend to be pb::FlightData and intercept in SerializationTraits
-  return writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
-                       grpc::WriteOptions());
+  if (!writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
+                     grpc::WriteOptions())) {
+    return Status::IOError("Could not write payload to stream");
+  }
+  return Status::OK();
 }
 
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ClientReaderWriter<pb::FlightData, pb::FlightData>* writer) {
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ClientReaderWriter<pb::FlightData, pb::FlightData>* writer) {
+  RETURN_NOT_OK(payload.Validate());
   // Pretend to be pb::FlightData and intercept in SerializationTraits
-  return writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
-                       grpc::WriteOptions());
+  if (!writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
+                     grpc::WriteOptions())) {
+    return Status::IOError("Could not write payload to stream");
+  }
+  return Status::OK();
 }
 
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* writer) {
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* writer) {
+  RETURN_NOT_OK(payload.Validate());
   // Pretend to be pb::FlightData and intercept in SerializationTraits
-  return writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
-                       grpc::WriteOptions());
+  if (!writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
+                     grpc::WriteOptions())) {
+    return Status::IOError("Could not write payload to stream");
+  }
+  return Status::OK();
 }
 
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ServerWriter<pb::FlightData>* writer) {
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ServerWriter<pb::FlightData>* writer) {
+  RETURN_NOT_OK(payload.Validate());
   // Pretend to be pb::FlightData and intercept in SerializationTraits
-  return writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
-                       grpc::WriteOptions());
+  if (!writer->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
+                     grpc::WriteOptions())) {
+    return Status::IOError("Could not write payload to stream");
+  }
+  return Status::OK();
 }
 
 bool ReadPayload(grpc::ClientReader<pb::FlightData>* reader, FlightData* data) {

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -54,15 +54,17 @@ struct FlightData {
 };
 
 /// Write Flight message on gRPC stream with zero-copy optimizations.
-/// True is returned on success, false if some error occurred (connection closed?).
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ClientReaderWriter<pb::FlightData, pb::PutResult>* writer);
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ClientReaderWriter<pb::FlightData, pb::FlightData>* writer);
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* writer);
-bool WritePayload(const FlightPayload& payload,
-                  grpc::ServerWriter<pb::FlightData>* writer);
+// Returns Invalid if the payload is ill-formed
+// Returns IOError if gRPC did not write the message (note this is not
+// necessarily an error - the client may simply have gone away)
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ClientReaderWriter<pb::FlightData, pb::PutResult>* writer);
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ClientReaderWriter<pb::FlightData, pb::FlightData>* writer);
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* writer);
+Status WritePayload(const FlightPayload& payload,
+                    grpc::ServerWriter<pb::FlightData>* writer);
 
 /// Read Flight message from gRPC stream with zero-copy optimizations.
 /// True is returned on success, false if stream ended.

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -656,7 +656,7 @@ class FlightServiceImpl : public FlightService::Service {
     FlightPayload schema_payload;
     SERVICE_RETURN_NOT_OK(flight_context, data_stream->GetSchemaPayload(&schema_payload));
     auto status = internal::WritePayload(schema_payload, writer);
-    if (!status.ok() && status.IsIOError()) {
+    if (status.IsIOError()) {
       // gRPC doesn't give any way for us to know why the message
       // could not be written.
       RETURN_WITH_MIDDLEWARE(flight_context, grpc::Status::OK);
@@ -671,7 +671,7 @@ class FlightServiceImpl : public FlightService::Service {
       if (payload.ipc_message.metadata == nullptr) break;
       auto status = internal::WritePayload(payload, writer);
       // Connection terminated
-      if (!status.ok() && status.IsIOError()) break;
+      if (status.IsIOError()) break;
       SERVICE_RETURN_NOT_OK(flight_context, status);
     }
     RETURN_WITH_MIDDLEWARE(flight_context, grpc::Status::OK);

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -336,10 +336,7 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
 
  private:
   Status WritePayload(const FlightPayload& payload) {
-    if (!internal::WritePayload(payload, stream_)) {
-      // gRPC doesn't give us any way to find what the error was (if any).
-      return Status::IOError("Could not write payload to stream");
-    }
+    RETURN_NOT_OK(internal::WritePayload(payload, stream_));
     ++stats_.num_messages;
     return Status::OK();
   }
@@ -658,21 +655,24 @@ class FlightServiceImpl : public FlightService::Service {
     // Write the schema as the first message in the stream
     FlightPayload schema_payload;
     SERVICE_RETURN_NOT_OK(flight_context, data_stream->GetSchemaPayload(&schema_payload));
-    if (!internal::WritePayload(schema_payload, writer)) {
+    auto status = internal::WritePayload(schema_payload, writer);
+    if (!status.ok() && status.IsIOError()) {
       // gRPC doesn't give any way for us to know why the message
       // could not be written.
       RETURN_WITH_MIDDLEWARE(flight_context, grpc::Status::OK);
     }
+    SERVICE_RETURN_NOT_OK(flight_context, status);
 
     // Consume data stream and write out payloads
     while (true) {
       FlightPayload payload;
       SERVICE_RETURN_NOT_OK(flight_context, data_stream->Next(&payload));
-      if (payload.ipc_message.metadata == nullptr ||
-          !internal::WritePayload(payload, writer))
-        // No more messages to write, or connection terminated for some other
-        // reason
-        break;
+      // End of stream
+      if (payload.ipc_message.metadata == nullptr) break;
+      auto status = internal::WritePayload(payload, writer);
+      // Connection terminated
+      if (!status.ok() && status.IsIOError()) break;
+      SERVICE_RETURN_NOT_OK(flight_context, status);
     }
     RETURN_WITH_MIDDLEWARE(flight_context, grpc::Status::OK);
   }

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -238,7 +238,7 @@ class FlightTestServer : public FlightServerBase {
     }
     if (request.ticket == "ARROW-13253-DoGet-Metadata") {
       // Make metadata > 2GiB in size
-      constexpr int64_t nbytes_overflow = (1L << 31) + 8;
+      constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
       ARROW_ASSIGN_OR_RAISE(auto metadata, AllocateBuffer(nbytes_overflow));
       std::memset(metadata->mutable_data(), 0x00, metadata->capacity());
       BatchVector batches;
@@ -458,7 +458,7 @@ class FlightTestServer : public FlightServerBase {
   // Regression test for ARROW-13253
   Status RunExchangeLargeMetadata(std::unique_ptr<FlightMessageReader>,
                                   std::unique_ptr<FlightMessageWriter> writer) {
-    constexpr int64_t nbytes_overflow = (1L << 31) + 8;
+    constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> metadata,
                           AllocateBuffer(nbytes_overflow));
     std::memset(metadata->mutable_data(), 0x00, metadata->capacity());
@@ -681,7 +681,7 @@ Status ExampleLargeBatches(BatchVector* out) {
 }
 
 arrow::Result<std::shared_ptr<RecordBatch>> VeryLargeBatch() {
-  constexpr int64_t nbytes_overflow = (1L << 31) + 8;
+  constexpr int64_t nbytes_overflow = (1ul << 31ul) + 8ul;
   ARROW_ASSIGN_OR_RAISE(auto values, AllocateBuffer(nbytes_overflow));
   std::memset(values->mutable_data(), 0x00, values->capacity());
   std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, std::move(values)};

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -683,9 +683,9 @@ Status ExampleLargeBatches(BatchVector* out) {
 arrow::Result<std::shared_ptr<RecordBatch>> VeryLargeBatch() {
   // In CI, some platforms don't let us allocate one very large
   // buffer, so allocate a smaller buffer and repeat it a few times
-  constexpr int64_t nbytes = (1ul << 28ul) + 8ul;
+  constexpr int64_t nbytes = (1ul << 27ul) + 8ul;
   constexpr int64_t nrows = nbytes / 8;
-  constexpr int64_t ncols = 8;
+  constexpr int64_t ncols = 16;
   ARROW_ASSIGN_OR_RAISE(auto values, AllocateBuffer(nbytes));
   std::memset(values->mutable_data(), 0x00, values->capacity());
   std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, std::move(values)};

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -164,6 +164,9 @@ ARROW_FLIGHT_EXPORT
 Status ExampleLargeBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
+arrow::Result<std::shared_ptr<RecordBatch>> VeryLargeBatch();
+
+ARROW_FLIGHT_EXPORT
 std::vector<FlightInfo> ExampleFlightInfo();
 
 ARROW_FLIGHT_EXPORT

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <utility>
 
+#include "arrow/buffer.h"
 #include "arrow/flight/serialization_internal.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/dictionary.h"
@@ -124,6 +125,20 @@ std::string FlightDescriptor::ToString() const {
   }
   ss << ">";
   return ss.str();
+}
+
+Status FlightPayload::Validate() const {
+  static constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+  if (descriptor && descriptor->size() > kInt32Max) {
+    return Status::CapacityError("Descriptor size overflow (>= 2**31)");
+  }
+  if (app_metadata && app_metadata->size() > kInt32Max) {
+    return Status::CapacityError("app_metadata size overflow (>= 2**31)");
+  }
+  if (ipc_message.body_length > kInt32Max) {
+    return Status::Invalid("Cannot send record batches exceeding 2GiB yet");
+  }
+  return Status::OK();
 }
 
 Status SchemaResult::GetSchema(ipc::DictionaryMemo* dictionary_memo,

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -341,6 +341,9 @@ struct ARROW_FLIGHT_EXPORT FlightPayload {
   std::shared_ptr<Buffer> descriptor;
   std::shared_ptr<Buffer> app_metadata;
   ipc::IpcPayload ipc_message;
+
+  /// \brief Check that the payload can be written to the wire.
+  Status Validate() const;
 };
 
 /// \brief Schema result returned after a schema request RPC


### PR DESCRIPTION
We can't report errors during serialization - gRPC will just trip an assert. Instead, move these checks into the layer above so we can report them to the client or server as appropriate.