### PR TITLE
ARROW-13238: [C++][Compute][Dataset] Use an ExecPlan for dataset scans

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -987,8 +987,9 @@ std::unique_ptr<KernelExecutor> KernelExecutor::MakeScalarAggregate() {
 
 }  // namespace detail
 
-ExecContext::ExecContext(MemoryPool* pool, FunctionRegistry* func_registry)
-    : pool_(pool) {
+ExecContext::ExecContext(MemoryPool* pool, ::arrow::internal::Executor* executor,
+                         FunctionRegistry* func_registry)
+    : pool_(pool), executor_(executor) {
   this->func_registry_ = func_registry == nullptr ? GetFunctionRegistry() : func_registry;
 }
 

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -34,6 +34,7 @@
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -60,6 +61,7 @@ class ARROW_EXPORT ExecContext {
  public:
   // If no function registry passed, the default is used.
   explicit ExecContext(MemoryPool* pool = default_memory_pool(),
+                       ::arrow::internal::Executor* executor = NULLPTR,
                        FunctionRegistry* func_registry = NULLPTR);
 
   /// \brief The MemoryPool used for allocations, default is
@@ -67,6 +69,9 @@ class ARROW_EXPORT ExecContext {
   MemoryPool* memory_pool() const { return pool_; }
 
   ::arrow::internal::CpuInfo* cpu_info() const;
+
+  /// \brief An Executor which may be used to parallelize execution.
+  ::arrow::internal::Executor* executor() const { return executor_; }
 
   /// \brief The FunctionRegistry for looking up functions by name and
   /// selecting kernels for execution. Defaults to the library-global function
@@ -114,6 +119,7 @@ class ARROW_EXPORT ExecContext {
 
  private:
   MemoryPool* pool_;
+  ::arrow::internal::Executor* executor_;
   FunctionRegistry* func_registry_;
   int64_t exec_chunksize_ = std::numeric_limits<int64_t>::max();
   bool preallocate_contiguous_ = true;

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -39,7 +39,7 @@ namespace compute {
 namespace {
 
 struct ExecPlanImpl : public ExecPlan {
-  using ExecPlan::ExecPlan;
+  explicit ExecPlanImpl(ExecContext* exec_context) : ExecPlan(exec_context) {}
 
   ~ExecPlanImpl() override {
     if (started_ && !finished_.is_finished()) {

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -41,8 +41,6 @@ namespace {
 struct ExecPlanImpl : public ExecPlan {
   using ExecPlan::ExecPlan;
 
-  // FIXME decouple finishing a plan/node from calling StopProducing.
-  // Then we can call that and wait on `finished` here (which we *do* expect to happen).
   ~ExecPlanImpl() override {
     if (started_ && !finished_.is_finished()) {
       ARROW_LOG(WARNING) << "Plan was destroyed before finishing";

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -272,7 +272,7 @@ struct SourceNode : ExecNode {
                   return generator_().Then(
                       [=](const util::optional<ExecBatch>& batch) -> ControlFlow<int> {
                         std::unique_lock<std::mutex> lock(mutex_);
-                        if (!batch || stop_requested_) {
+                        if (IsIterationEnd(batch) || stop_requested_) {
                           stop_requested_ = true;
                           return Break(seq);
                         }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -39,11 +39,15 @@ namespace compute {
 namespace {
 
 struct ExecPlanImpl : public ExecPlan {
-  ExecPlanImpl() = default;
+  using ExecPlan::ExecPlan;
 
+  // FIXME decouple finishing a plan/node from calling StopProducing.
+  // Then we can call that and wait on `finished` here (which we *do* expect to happen).
   ~ExecPlanImpl() override {
-    if (started_ && !stopped_) {
+    if (started_ && !finished_.is_finished()) {
+      ARROW_LOG(WARNING) << "Plan was destroyed before finishing";
       StopProducing();
+      finished().Wait();
     }
   }
 
@@ -77,25 +81,40 @@ struct ExecPlanImpl : public ExecPlan {
     // producers precede consumers
     sorted_nodes_ = TopoSort();
 
-    for (size_t i = 0, rev_i = sorted_nodes_.size() - 1; i < sorted_nodes_.size();
-         ++i, --rev_i) {
-      auto st = sorted_nodes_[rev_i]->StartProducing();
-      if (st.ok()) continue;
+    std::vector<Future<>> futures;
 
-      // Stop nodes that successfully started, in reverse order
-      for (; rev_i < sorted_nodes_.size(); ++rev_i) {
-        sorted_nodes_[rev_i]->StopProducing();
+    Status st = Status::OK();
+
+    using rev_it = std::reverse_iterator<NodeVector::iterator>;
+    for (rev_it it(sorted_nodes_.end()), end(sorted_nodes_.begin()); it != end; ++it) {
+      auto node = *it;
+
+      st = node->StartProducing();
+      if (!st.ok()) {
+        // Stop nodes that successfully started, in reverse order
+        stopped_ = true;
+        StopProducingImpl(it.base(), sorted_nodes_.end());
+        break;
       }
-      return st;
+
+      futures.push_back(node->finished());
     }
-    return Status::OK();
+
+    finished_ = AllComplete(std::move(futures));
+    return st;
   }
 
   void StopProducing() {
     DCHECK(started_) << "stopped an ExecPlan which never started";
     stopped_ = true;
 
-    for (const auto& node : sorted_nodes_) {
+    StopProducingImpl(sorted_nodes_.begin(), sorted_nodes_.end());
+  }
+
+  template <typename It>
+  void StopProducingImpl(It begin, It end) {
+    for (auto it = begin; it != end; ++it) {
+      auto node = *it;
       node->StopProducing();
     }
   }
@@ -133,10 +152,11 @@ struct ExecPlanImpl : public ExecPlan {
     return std::move(Impl{nodes_}.sorted);
   }
 
+  Future<> finished_ = Future<>::MakeFinished();
   bool started_ = false, stopped_ = false;
   std::vector<std::unique_ptr<ExecNode>> nodes_;
-  NodeVector sorted_nodes_;
   NodeVector sources_, sinks_;
+  NodeVector sorted_nodes_;
 };
 
 ExecPlanImpl* ToDerived(ExecPlan* ptr) { return checked_cast<ExecPlanImpl*>(ptr); }
@@ -155,8 +175,8 @@ util::optional<int> GetNodeIndex(const std::vector<ExecNode*>& nodes,
 
 }  // namespace
 
-Result<std::shared_ptr<ExecPlan>> ExecPlan::Make() {
-  return std::make_shared<ExecPlanImpl>();
+Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(ExecContext* ctx) {
+  return std::shared_ptr<ExecPlan>(new ExecPlanImpl{ctx});
 }
 
 ExecNode* ExecPlan::AddNode(std::unique_ptr<ExecNode> node) {
@@ -174,6 +194,8 @@ Status ExecPlan::Validate() { return ToDerived(this)->Validate(); }
 Status ExecPlan::StartProducing() { return ToDerived(this)->StartProducing(); }
 
 void ExecPlan::StopProducing() { ToDerived(this)->StopProducing(); }
+
+Future<> ExecPlan::finished() { return ToDerived(this)->finished_; }
 
 ExecNode::ExecNode(ExecPlan* plan, std::string label, NodeVector inputs,
                    std::vector<std::string> input_labels,
@@ -220,58 +242,61 @@ struct SourceNode : ExecNode {
 
   const char* kind_name() override { return "SourceNode"; }
 
-  static void NoInputs() { DCHECK(false) << "no inputs; this should never be called"; }
-  void InputReceived(ExecNode*, int, ExecBatch) override { NoInputs(); }
-  void ErrorReceived(ExecNode*, Status) override { NoInputs(); }
-  void InputFinished(ExecNode*, int) override { NoInputs(); }
+  [[noreturn]] static void NoInputs() {
+    DCHECK(false) << "no inputs; this should never be called";
+    std::abort();
+  }
+  [[noreturn]] void InputReceived(ExecNode*, int, ExecBatch) override { NoInputs(); }
+  [[noreturn]] void ErrorReceived(ExecNode*, Status) override { NoInputs(); }
+  [[noreturn]] void InputFinished(ExecNode*, int) override { NoInputs(); }
 
   Status StartProducing() override {
-    if (finished_) {
-      return Status::Invalid("Restarted SourceNode '", label(), "'");
+    DCHECK(!stop_requested_) << "Restarted SourceNode";
+
+    CallbackOptions options;
+    if (auto executor = plan()->exec_context()->executor()) {
+      // These options will transfer execution to the desired Executor if necessary.
+      // This can happen for in-memory scans where batches didn't require
+      // any CPU work to decode. Otherwise, parsing etc should have already
+      // been placed us on the desired Executor and no queues will be pushed to.
+      options.executor = executor;
+      options.should_schedule = ShouldSchedule::IfDifferentExecutor;
     }
 
-    finished_fut_ =
-        Loop([this] {
-          std::unique_lock<std::mutex> lock(mutex_);
-          int seq = next_batch_index_++;
-          if (finished_) {
-            return Future<ControlFlow<int>>::MakeFinished(Break(seq));
-          }
-          lock.unlock();
-
-          return generator_().Then(
-              [=](const util::optional<ExecBatch>& batch) -> ControlFlow<int> {
-                std::unique_lock<std::mutex> lock(mutex_);
-                if (!batch || finished_) {
-                  finished_ = true;
-                  return Break(seq);
-                }
-                lock.unlock();
-
-                // TODO check if we are on the desired Executor and transfer if not.
-                // This can happen for in-memory scans where batches didn't require
-                // any CPU work to decode. Otherwise, parsing etc should have already
-                // been placed us on the thread pool
-                outputs_[0]->InputReceived(this, seq, *batch);
-                return Continue();
-              },
-              [=](const Status& error) -> ControlFlow<int> {
-                std::unique_lock<std::mutex> lock(mutex_);
-                if (!finished_) {
-                  finished_ = true;
+    finished_ = Loop([this, options] {
+                  std::unique_lock<std::mutex> lock(mutex_);
+                  int seq = batch_count_++;
+                  if (stop_requested_) {
+                    return Future<ControlFlow<int>>::MakeFinished(Break(seq));
+                  }
                   lock.unlock();
-                  // unless we were already finished, push the error to our output
-                  // XXX is this correct? Is it reasonable for a consumer to
-                  // ignore errors from a finished producer?
-                  outputs_[0]->ErrorReceived(this, error);
-                }
-                return Break(seq);
-              });
-        }).Then([&](int seq) {
-          /// XXX this is probably redundant: do we always call InputFinished after
-          /// ErrorReceived or will ErrorRecieved be sufficient?
-          outputs_[0]->InputFinished(this, seq);
-        });
+
+                  return generator_().Then(
+                      [=](const util::optional<ExecBatch>& batch) -> ControlFlow<int> {
+                        std::unique_lock<std::mutex> lock(mutex_);
+                        if (!batch || stop_requested_) {
+                          stop_requested_ = true;
+                          return Break(seq);
+                        }
+                        lock.unlock();
+
+                        outputs_[0]->InputReceived(this, seq, *batch);
+                        return Continue();
+                      },
+                      [=](const Status& error) -> ControlFlow<int> {
+                        // NB: ErrorReceived is independent of InputFinished, but
+                        // ErrorReceived will usually prompt StopProducing which will
+                        // prompt InputFinished. ErrorReceived may still be called from a
+                        // node which was requested to stop (indeed, the request to stop
+                        // may prompt an error).
+                        std::unique_lock<std::mutex> lock(mutex_);
+                        stop_requested_ = true;
+                        lock.unlock();
+                        outputs_[0]->ErrorReceived(this, error);
+                        return Break(seq);
+                      },
+                      options);
+                }).Then([&](int seq) { outputs_[0]->InputFinished(this, seq); });
 
     return Status::OK();
   }
@@ -282,20 +307,21 @@ struct SourceNode : ExecNode {
 
   void StopProducing(ExecNode* output) override {
     DCHECK_EQ(output, outputs_[0]);
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      finished_ = true;
-    }
-    finished_fut_.Wait();
+    StopProducing();
   }
 
-  void StopProducing() override { StopProducing(outputs_[0]); }
+  void StopProducing() override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    stop_requested_ = true;
+  }
+
+  Future<> finished() override { return finished_; }
 
  private:
   std::mutex mutex_;
-  bool finished_{false};
-  int next_batch_index_{0};
-  Future<> finished_fut_ = Future<>::MakeFinished();
+  bool stop_requested_{false};
+  int batch_count_{0};
+  Future<> finished_ = Future<>::MakeFinished();
   AsyncGenerator<util::optional<ExecBatch>> generator_;
 };
 
@@ -319,8 +345,8 @@ struct FilterNode : ExecNode {
     ARROW_ASSIGN_OR_RAISE(Expression simplified_filter,
                           SimplifyWithGuarantee(filter_, target.guarantee));
 
-    // XXX get a non-default exec context
-    ARROW_ASSIGN_OR_RAISE(Datum mask, ExecuteScalarExpression(simplified_filter, target));
+    ARROW_ASSIGN_OR_RAISE(Datum mask, ExecuteScalarExpression(simplified_filter, target,
+                                                              plan()->exec_context()));
 
     if (mask.is_scalar()) {
       const auto& mask_scalar = mask.scalar_as<BooleanScalar>();
@@ -330,6 +356,10 @@ struct FilterNode : ExecNode {
 
       return target.Slice(0, 0);
     }
+
+    // if the values are all scalar then the mask must also be
+    DCHECK(!std::all_of(target.values.begin(), target.values.end(),
+                        [](const Datum& value) { return value.is_scalar(); }));
 
     auto values = target.values;
     for (auto& value : values) {
@@ -345,7 +375,6 @@ struct FilterNode : ExecNode {
     auto maybe_filtered = DoFilter(std::move(batch));
     if (!maybe_filtered.ok()) {
       outputs_[0]->ErrorReceived(this, maybe_filtered.status());
-      inputs_[0]->StopProducing(this);
       return;
     }
 
@@ -356,7 +385,6 @@ struct FilterNode : ExecNode {
   void ErrorReceived(ExecNode* input, Status error) override {
     DCHECK_EQ(input, inputs_[0]);
     outputs_[0]->ErrorReceived(this, std::move(error));
-    inputs_[0]->StopProducing(this);
   }
 
   void InputFinished(ExecNode* input, int seq) override {
@@ -372,10 +400,12 @@ struct FilterNode : ExecNode {
 
   void StopProducing(ExecNode* output) override {
     DCHECK_EQ(output, outputs_[0]);
-    inputs_[0]->StopProducing(this);
+    StopProducing();
   }
 
-  void StopProducing() override { StopProducing(outputs_[0]); }
+  void StopProducing() override { inputs_[0]->StopProducing(this); }
+
+  Future<> finished() override { return inputs_[0]->finished(); }
 
  private:
   Expression filter_;
@@ -407,15 +437,15 @@ struct ProjectNode : ExecNode {
   const char* kind_name() override { return "ProjectNode"; }
 
   Result<ExecBatch> DoProject(const ExecBatch& target) {
-    // XXX get a non-default exec context
     std::vector<Datum> values{exprs_.size()};
     for (size_t i = 0; i < exprs_.size(); ++i) {
       ARROW_ASSIGN_OR_RAISE(Expression simplified_expr,
                             SimplifyWithGuarantee(exprs_[i], target.guarantee));
 
-      ARROW_ASSIGN_OR_RAISE(values[i], ExecuteScalarExpression(simplified_expr, target));
+      ARROW_ASSIGN_OR_RAISE(values[i], ExecuteScalarExpression(simplified_expr, target,
+                                                               plan()->exec_context()));
     }
-    return ExecBatch::Make(std::move(values));
+    return ExecBatch{std::move(values), target.length};
   }
 
   void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
@@ -424,7 +454,6 @@ struct ProjectNode : ExecNode {
     auto maybe_projected = DoProject(std::move(batch));
     if (!maybe_projected.ok()) {
       outputs_[0]->ErrorReceived(this, maybe_projected.status());
-      inputs_[0]->StopProducing(this);
       return;
     }
 
@@ -435,7 +464,6 @@ struct ProjectNode : ExecNode {
   void ErrorReceived(ExecNode* input, Status error) override {
     DCHECK_EQ(input, inputs_[0]);
     outputs_[0]->ErrorReceived(this, std::move(error));
-    inputs_[0]->StopProducing(this);
   }
 
   void InputFinished(ExecNode* input, int seq) override {
@@ -451,10 +479,12 @@ struct ProjectNode : ExecNode {
 
   void StopProducing(ExecNode* output) override {
     DCHECK_EQ(output, outputs_[0]);
-    inputs_[0]->StopProducing(this);
+    StopProducing();
   }
 
-  void StopProducing() override { StopProducing(outputs_[0]); }
+  void StopProducing() override { inputs_[0]->StopProducing(this); }
+
+  Future<> finished() override { return inputs_[0]->finished(); }
 
  private:
   std::vector<Expression> exprs_;
@@ -494,28 +524,38 @@ struct SinkNode : ExecNode {
 
   const char* kind_name() override { return "SinkNode"; }
 
-  Status StartProducing() override { return Status::OK(); }
+  Status StartProducing() override {
+    finished_ = Future<>::Make();
+    return Status::OK();
+  }
 
   // sink nodes have no outputs from which to feel backpressure
-  static void NoOutputs() { DCHECK(false) << "no outputs; this should never be called"; }
-  void ResumeProducing(ExecNode* output) override { NoOutputs(); }
-  void PauseProducing(ExecNode* output) override { NoOutputs(); }
-  void StopProducing(ExecNode* output) override { NoOutputs(); }
+  [[noreturn]] static void NoOutputs() {
+    DCHECK(false) << "no outputs; this should never be called";
+    std::abort();
+  }
+  [[noreturn]] void ResumeProducing(ExecNode* output) override { NoOutputs(); }
+  [[noreturn]] void PauseProducing(ExecNode* output) override { NoOutputs(); }
+  [[noreturn]] void StopProducing(ExecNode* output) override { NoOutputs(); }
 
   void StopProducing() override {
-    std::unique_lock<std::mutex> lock(mutex_);
-    InputFinishedUnlocked();
+    Finish();
+    inputs_[0]->StopProducing(this);
   }
+
+  Future<> finished() override { return finished_; }
 
   void InputReceived(ExecNode* input, int seq_num, ExecBatch batch) override {
     DCHECK_EQ(input, inputs_[0]);
 
     std::unique_lock<std::mutex> lock(mutex_);
-    if (stopped_) return;
+    if (finished_.is_finished()) return;
 
     ++num_received_;
     if (num_received_ == emit_stop_) {
-      InputFinishedUnlocked();
+      lock.unlock();
+      Finish();
+      lock.lock();
     }
 
     if (emit_stop_ != -1) {
@@ -529,23 +569,21 @@ struct SinkNode : ExecNode {
   void ErrorReceived(ExecNode* input, Status error) override {
     DCHECK_EQ(input, inputs_[0]);
     producer_.Push(std::move(error));
-    std::unique_lock<std::mutex> lock(mutex_);
-    InputFinishedUnlocked();
+    Finish();
+    inputs_[0]->StopProducing(this);
   }
 
   void InputFinished(ExecNode* input, int seq_stop) override {
     std::unique_lock<std::mutex> lock(mutex_);
     emit_stop_ = seq_stop;
-    if (emit_stop_ == num_received_) {
-      InputFinishedUnlocked();
-    }
+    lock.unlock();
+    Finish();
   }
 
  private:
-  void InputFinishedUnlocked() {
-    if (!stopped_) {
-      stopped_ = true;
-      producer_.Close();
+  void Finish() {
+    if (producer_.Close()) {
+      finished_.MarkFinished();
     }
   }
 
@@ -553,7 +591,7 @@ struct SinkNode : ExecNode {
 
   int num_received_ = 0;
   int emit_stop_ = -1;
-  bool stopped_ = false;
+  Future<> finished_ = Future<>::MakeFinished();
 
   PushGenerator<util::optional<ExecBatch>>::Producer producer_;
 };

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -69,7 +69,7 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
 
   /// \brief Stop producing on all nodes
   ///
-  /// Nodes are stopped topological order, such that any node
+  /// Nodes are stopped in topological order, such that any node
   /// is stopped before all of its outputs.
   void StopProducing();
 

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -234,10 +234,10 @@ class ARROW_EXPORT ExecNode {
 
 /// \brief Adapt an AsyncGenerator<ExecBatch> as a source node
 ///
-/// TODO this should accept an Executor and explicitly handle batches
-/// as they are generated on each of the Executor's threads.
+/// plan->exec_context()->executor() is used to parallelize pushing to
+/// outputs, if provided.
 ARROW_EXPORT
-ExecNode* MakeSourceNode(ExecPlan*, std::string label,
+ExecNode* MakeSourceNode(ExecPlan* plan, std::string label,
                          std::shared_ptr<Schema> output_schema,
                          std::function<Future<util::optional<ExecBatch>>()>);
 

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -22,21 +22,15 @@
 #include <string>
 #include <vector>
 
+#include "arrow/compute/exec.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/optional.h"
 #include "arrow/util/visibility.h"
 
-// NOTES:
-// - ExecBatches only have arrays or scalars
-// - data streams may be ordered, so add input number?
-// - node to combine input needs to reorder
-
 namespace arrow {
 namespace compute {
-
-class ExecNode;
 
 class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
  public:
@@ -44,14 +38,16 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
 
   virtual ~ExecPlan() = default;
 
+  ExecContext* exec_context() const { return exec_context_; }
+
   /// Make an empty exec plan
-  static Result<std::shared_ptr<ExecPlan>> Make();
+  static Result<std::shared_ptr<ExecPlan>> Make(ExecContext* = default_exec_context());
 
   ExecNode* AddNode(std::unique_ptr<ExecNode> node);
 
   template <typename Node, typename... Args>
   Node* EmplaceNode(Args&&... args) {
-    auto node = std::unique_ptr<Node>(new Node{std::forward<Args>(args)...});
+    std::unique_ptr<Node> node{new Node{std::forward<Args>(args)...}};
     auto out = node.get();
     AddNode(std::move(node));
     return out;
@@ -65,16 +61,24 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
 
   Status Validate();
 
-  /// Start producing on all nodes
+  /// \brief Start producing on all nodes
   ///
   /// Nodes are started in reverse topological order, such that any node
   /// is started before all of its inputs.
   Status StartProducing();
 
+  /// \brief Stop producing on all nodes
+  ///
+  /// Nodes are stopped topological order, such that any node
+  /// is stopped before all of its outputs.
   void StopProducing();
 
+  /// \brief A future which will be marked finished when all nodes have stopped producing.
+  Future<> finished();
+
  protected:
-  ExecPlan() = default;
+  ExecContext* exec_context_;
+  explicit ExecPlan(ExecContext* exec_context) : exec_context_(exec_context) {}
 };
 
 class ARROW_EXPORT ExecNode {
@@ -203,13 +207,14 @@ class ARROW_EXPORT ExecNode {
   /// \brief Stop producing definitively to a single output
   ///
   /// This call is a hint that an output node has completed and is not willing
-  /// to not receive any further data.
+  /// to receive any further data.
   virtual void StopProducing(ExecNode* output) = 0;
 
-  /// \brief Stop producing definitively
-  ///
-  /// XXX maybe this should return a Future<>?
+  /// \brief Stop producing definitively to all outputs
   virtual void StopProducing() = 0;
+
+  /// \brief A future which will be marked finished when this node has stopped producing.
+  virtual Future<> finished() = 0;
 
  protected:
   ExecNode(ExecPlan* plan, std::string label, NodeVector inputs,

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -148,6 +148,7 @@ TEST(ExecPlan, DummyStartProducing) {
 
   plan->StopProducing();
   ASSERT_THAT(plan->finished(), Finishes(Ok()));
+  // Note that any correct topological order may do
   ASSERT_THAT(t.stopped, ElementsAre("source1", "source2", "process1", "process2",
                                      "process3", "sink"));
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -357,14 +357,16 @@ TEST(ExecPlanExecution, StressSourceSinkStopped) {
                                                            random_data, parallel, slow));
 
       auto sink_gen = MakeSinkNode(source, "sink");
-      auto first_batch_fut = sink_gen();
 
       ASSERT_OK(plan->Validate());
       ASSERT_OK(plan->StartProducing());
+
+      auto maybe_first_batch = sink_gen().result();
+
       plan->StopProducing();
       plan->finished().Wait();
 
-      EXPECT_THAT(first_batch_fut, ResultWith(random_data.batches[0]));
+      EXPECT_THAT(maybe_first_batch, ResultWith(random_data.batches[0]));
     }
   }
 }

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -88,14 +89,12 @@ struct DummyNode : ExecNode {
   }
 
   void StopProducing(ExecNode* output) override {
-    ASSERT_GE(num_outputs(), 0) << "Sink nodes should not experience backpressure";
+    EXPECT_GE(num_outputs(), 0) << "Sink nodes should not experience backpressure";
     AssertIsOutput(output);
-    StopProducing();
   }
 
   void StopProducing() override {
     if (started_) {
-      started_ = false;
       for (const auto& input : inputs_) {
         input->StopProducing(this);
       }
@@ -105,9 +104,12 @@ struct DummyNode : ExecNode {
     }
   }
 
+  Future<> finished() override { return Future<>::MakeFinished(); }
+
  private:
   void AssertIsOutput(ExecNode* output) {
-    ASSERT_NE(std::find(outputs_.begin(), outputs_.end(), output), outputs_.end());
+    auto it = std::find(outputs_.begin(), outputs_.end(), output);
+    ASSERT_NE(it, outputs_.end());
   }
 
   std::shared_ptr<Schema> dummy_schema() const {
@@ -116,6 +118,7 @@ struct DummyNode : ExecNode {
 
   StartProducingFunc start_producing_;
   StopProducingFunc stop_producing_;
+  std::unordered_set<ExecNode*> requested_stop_;
   bool started_ = false;
 };
 

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -69,7 +69,7 @@ TEST(ExecContext, BasicWorkings) {
   // Now, let's customize all the things
   LoggingMemoryPool my_pool(default_memory_pool());
   std::unique_ptr<FunctionRegistry> custom_reg = FunctionRegistry::Make();
-  ExecContext ctx(&my_pool, custom_reg.get());
+  ExecContext ctx(&my_pool, /*executor=*/nullptr, custom_reg.get());
 
   ASSERT_EQ(custom_reg.get(), ctx.func_registry());
   ASSERT_EQ(&my_pool, ctx.memory_pool());

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -653,7 +653,7 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   std::shared_ptr<void> stop_producing{
       nullptr, [plan, exec_context](...) {
         bool not_finished_yet = plan->finished().TryAddCallback([&] {
-          auto keepalive_until_finish = [plan, exec_context](const Status&) {};
+          auto keepalive_until_finish = [plan, exec_context](const Status&) { return; };
           return keepalive_until_finish;
         });
 

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -652,10 +652,8 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   // If the generator is destroyed before being completely drained, inform plan
   std::shared_ptr<void> stop_producing{
       nullptr, [plan, exec_context](...) {
-        bool not_finished_yet = plan->finished().TryAddCallback([&] {
-          auto keepalive_until_finish = [plan, exec_context](const Status&) { return; };
-          return keepalive_until_finish;
-        });
+        bool not_finished_yet = plan->finished().TryAddCallback(
+            [&plan, &exec_context] { return [plan, exec_context](const Status&) {}; });
 
         if (not_finished_yet) {
           plan->StopProducing();

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -466,11 +466,8 @@ Result<compute::ExecNode*> MakeScanNode(compute::ExecPlan* plan,
   ARROW_ASSIGN_OR_RAISE(auto batch_gen_gen,
                         FragmentsToBatches(std::move(fragment_gen), options));
 
-  auto batch_gen_gen_readahead =
-      MakeSerialReadaheadGenerator(std::move(batch_gen_gen), options->fragment_readahead);
-
-  auto merged_batch_gen = MakeMergedGenerator(std::move(batch_gen_gen_readahead),
-                                              options->fragment_readahead);
+  auto merged_batch_gen =
+      MakeMergedGenerator(std::move(batch_gen_gen), options->fragment_readahead);
 
   auto batch_gen =
       MakeReadaheadGenerator(std::move(merged_batch_gen), options->fragment_readahead);

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -653,8 +653,8 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   std::shared_ptr<void> stop_producing{
       nullptr, [plan, exec_context](...) {
         bool not_finished_yet = plan->finished().TryAddCallback([&] {
-          // keep plan alive until it finishes
-          return [plan, exec_context](const Status&) {};
+          auto keepalive_until_finish = [plan, exec_context](const Status&) {};
+          return keepalive_until_finish;
         });
 
         if (not_finished_yet) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1262,6 +1262,7 @@ TEST(ScanNode, DeferredFilterOnPhysicalColumn) {
 }
 
 TEST(ScanNode, DISABLED_ProjectionPushdown) {
+  // ARROW-13263
   ASSERT_OK_AND_ASSIGN(auto plan, compute::ExecPlan::Make());
 
   auto basic = MakeBasicDataset();

--- a/cpp/src/arrow/testing/future_util.h
+++ b/cpp/src/arrow/testing/future_util.h
@@ -21,21 +21,21 @@
 #include "arrow/util/future.h"
 
 // This macro should be called by futures that are expected to
-// complete pretty quickly.  2 seconds is the default max wait
-// here.  Anything longer than that and it's a questionable
-// unit test anyways.
-#define ASSERT_FINISHES_IMPL(fut)                            \
-  do {                                                       \
-    ASSERT_TRUE(fut.Wait(300));                              \
-    if (!fut.is_finished()) {                                \
-      FAIL() << "Future did not finish in a timely fashion"; \
-    }                                                        \
+// complete pretty quickly.  arrow::kDefaultAssertFinishesWaitSeconds is the
+// default max wait here.  Anything longer than that and it's a questionable unit test
+// anyways.
+#define ASSERT_FINISHES_IMPL(fut)                                      \
+  do {                                                                 \
+    ASSERT_TRUE(fut.Wait(::arrow::kDefaultAssertFinishesWaitSeconds)); \
+    if (!fut.is_finished()) {                                          \
+      FAIL() << "Future did not finish in a timely fashion";           \
+    }                                                                  \
   } while (false)
 
 #define ASSERT_FINISHES_OK(expr)                                              \
   do {                                                                        \
     auto&& _fut = (expr);                                                     \
-    ASSERT_TRUE(_fut.Wait(300));                                              \
+    ASSERT_TRUE(_fut.Wait(::arrow::kDefaultAssertFinishesWaitSeconds));       \
     if (!_fut.is_finished()) {                                                \
       FAIL() << "Future did not finish in a timely fashion";                  \
     }                                                                         \
@@ -74,12 +74,12 @@
     ASSERT_EQ(expected, _actual);                        \
   } while (0)
 
-#define EXPECT_FINISHES_IMPL(fut)                                   \
-  do {                                                              \
-    EXPECT_TRUE(fut.Wait(300));                                     \
-    if (!fut.is_finished()) {                                       \
-      ADD_FAILURE() << "Future did not finish in a timely fashion"; \
-    }                                                               \
+#define EXPECT_FINISHES_IMPL(fut)                                      \
+  do {                                                                 \
+    EXPECT_TRUE(fut.Wait(::arrow::kDefaultAssertFinishesWaitSeconds)); \
+    if (!fut.is_finished()) {                                          \
+      ADD_FAILURE() << "Future did not finish in a timely fashion";    \
+    }                                                                  \
   } while (false)
 
 #define ON_FINISH_ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, future_name, lhs, rexpr) \
@@ -104,6 +104,8 @@
   } while (0)
 
 namespace arrow {
+
+constexpr double kDefaultAssertFinishesWaitSeconds = 10;
 
 template <typename T>
 void AssertNotFinished(const Future<T>& fut) {

--- a/cpp/src/arrow/testing/future_util.h
+++ b/cpp/src/arrow/testing/future_util.h
@@ -105,7 +105,7 @@
 
 namespace arrow {
 
-constexpr double kDefaultAssertFinishesWaitSeconds = 10;
+constexpr double kDefaultAssertFinishesWaitSeconds = 64;
 
 template <typename T>
 void AssertNotFinished(const Future<T>& fut) {

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -21,8 +21,59 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/testing/future_util.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/future.h"
 
 namespace arrow {
+
+template <typename ResultMatcher>
+class FutureMatcher {
+ public:
+  explicit FutureMatcher(ResultMatcher result_matcher, double wait_seconds)
+      : result_matcher_(std::move(result_matcher)), wait_seconds_(wait_seconds) {}
+
+  template <typename Fut,
+            typename ValueType = typename std::decay<Fut>::type::ValueType>
+  operator testing::Matcher<Fut>() const {  // NOLINT runtime/explicit
+    struct Impl : testing::MatcherInterface<const Fut&> {
+      explicit Impl(const ResultMatcher& result_matcher, double wait_seconds)
+          : result_matcher_(testing::MatcherCast<Result<ValueType>>(result_matcher)),
+            wait_seconds_(wait_seconds) {}
+
+      void DescribeTo(::std::ostream* os) const override {
+        *os << "value ";
+        result_matcher_.DescribeTo(os);
+      }
+
+      void DescribeNegationTo(::std::ostream* os) const override {
+        *os << "value ";
+        result_matcher_.DescribeNegationTo(os);
+      }
+
+      bool MatchAndExplain(const Fut& fut,
+                           testing::MatchResultListener* listener) const override {
+        if (!fut.Wait(wait_seconds_)) {
+          *listener << "which didn't finish within " << wait_seconds_ << " seconds";
+          return false;
+        }
+
+        const Result<ValueType>& maybe_value = fut.result();
+        testing::StringMatchResultListener value_listener;
+        return result_matcher_.MatchAndExplain(maybe_value, &value_listener);
+      }
+
+      const testing::Matcher<Result<ValueType>> result_matcher_;
+      const double wait_seconds_;
+    };
+
+    return testing::Matcher<Fut>(new Impl(result_matcher_, wait_seconds_));
+  }
+
+ private:
+  const ResultMatcher result_matcher_;
+  const double wait_seconds_;
+};
 
 template <typename ValueMatcher>
 class ResultMatcher {
@@ -55,7 +106,7 @@ class ResultMatcher {
                     << " doesn't match";
           return false;
         }
-        const ValueType& value = GetValue(maybe_value);
+        const ValueType& value = maybe_value.ValueOrDie();
         testing::StringMatchResultListener value_listener;
         const bool match = value_matcher_.MatchAndExplain(value, &value_listener);
         *listener << "whose value " << testing::PrintToString(value)
@@ -71,23 +122,13 @@ class ResultMatcher {
   }
 
  private:
-  template <typename T>
-  static const T& GetValue(const Result<T>& maybe_value) {
-    return maybe_value.ValueOrDie();
-  }
-
-  template <typename T>
-  static const T& GetValue(const Future<T>& value_fut) {
-    return GetValue(value_fut.result());
-  }
-
   const ValueMatcher value_matcher_;
 };
 
-class StatusMatcher {
+class ErrorMatcher {
  public:
-  explicit StatusMatcher(StatusCode code,
-                         util::optional<testing::Matcher<std::string>> message_matcher)
+  explicit ErrorMatcher(StatusCode code,
+                        util::optional<testing::Matcher<std::string>> message_matcher)
       : code_(code), message_matcher_(std::move(message_matcher)) {}
 
   template <typename Res>
@@ -115,7 +156,7 @@ class StatusMatcher {
 
       bool MatchAndExplain(const Res& maybe_value,
                            testing::MatchResultListener* listener) const override {
-        const Status& status = GetStatus(maybe_value);
+        const Status& status = internal::GenericToStatus(maybe_value);
         testing::StringMatchResultListener value_listener;
 
         bool match = status.code() == code_;
@@ -138,40 +179,62 @@ class StatusMatcher {
   }
 
  private:
-  static const Status& GetStatus(const Status& status) { return status; }
-
-  template <typename T>
-  static const Status& GetStatus(const Result<T>& maybe_value) {
-    return maybe_value.status();
-  }
-
-  template <typename T>
-  static const Status& GetStatus(const Future<T>& value_fut) {
-    return value_fut.status();
-  }
-
   const StatusCode code_;
   const util::optional<testing::Matcher<std::string>> message_matcher_;
 };
 
-// Returns a matcher that matches the value of a successful Result<T> or Future<T>.
-// (Future<T> will be waited upon to acquire its result for matching.)
+class OkMatcher {
+ public:
+  template <typename Res>
+  operator testing::Matcher<Res>() const {  // NOLINT runtime/explicit
+    struct Impl : testing::MatcherInterface<const Res&> {
+      void DescribeTo(::std::ostream* os) const override { *os << "is ok"; }
+
+      void DescribeNegationTo(::std::ostream* os) const override { *os << "is not ok"; }
+
+      bool MatchAndExplain(const Res& maybe_value,
+                           testing::MatchResultListener* listener) const override {
+        const Status& status = internal::GenericToStatus(maybe_value);
+        testing::StringMatchResultListener value_listener;
+
+        const bool match = status.ok();
+        *listener << "whose value " << testing::PrintToString(status.ToString())
+                  << (match ? " matches" : " doesn't match");
+        testing::internal::PrintIfNotEmpty(value_listener.str(), listener->stream());
+        return match;
+      }
+    };
+
+    return testing::Matcher<Res>(new Impl());
+  }
+};
+
+// Returns a matcher that waits on a Future (by default for 16 seconds)
+// then applies a matcher to the result.
+template <typename ResultMatcher>
+FutureMatcher<ResultMatcher> Finishes(
+    const ResultMatcher& result_matcher,
+    double wait_seconds = kDefaultAssertFinishesWaitSeconds) {
+  return FutureMatcher<ResultMatcher>(result_matcher, wait_seconds);
+}
+
+// Returns a matcher that matches the value of a successful Result<T>.
 template <typename ValueMatcher>
 ResultMatcher<ValueMatcher> ResultWith(const ValueMatcher& value_matcher) {
   return ResultMatcher<ValueMatcher>(value_matcher);
 }
 
-// Returns a matcher that matches the StatusCode of a Status, Result<T>, or Future<T>.
-// (Future<T> will be waited upon to acquire its result for matching.)
-inline StatusMatcher Raises(StatusCode code) {
-  return StatusMatcher(code, util::nullopt);
-}
+// Returns a matcher that matches an ok Status or Result<T>.
+inline OkMatcher Ok() { return {}; }
 
-// Returns a matcher that matches the StatusCode and message of a Status, Result<T>, or
-// Future<T>. (Future<T> will be waited upon to acquire its result for matching.)
+// Returns a matcher that matches the StatusCode of a Status or Result<T>.
+// Do not use Raises(StatusCode::OK) to match a non error code.
+inline ErrorMatcher Raises(StatusCode code) { return ErrorMatcher(code, util::nullopt); }
+
+// Returns a matcher that matches the StatusCode and message of a Status or Result<T>.
 template <typename MessageMatcher>
-StatusMatcher Raises(StatusCode code, const MessageMatcher& message_matcher) {
-  return StatusMatcher(code, testing::MatcherCast<std::string>(message_matcher));
+ErrorMatcher Raises(StatusCode code, const MessageMatcher& message_matcher) {
+  return ErrorMatcher(code, testing::MatcherCast<std::string>(message_matcher));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -775,7 +775,7 @@ class PushGenerator {
   /// Producer API for PushGenerator
   class Producer {
    public:
-    explicit Producer(const std::shared_ptr<State> state) : weak_state_(state) {}
+    explicit Producer(const std::shared_ptr<State>& state) : weak_state_(state) {}
 
     /// \brief Push a value on the queue
     ///

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -272,6 +272,8 @@ class ConcreteFutureImpl : public FutureImpl {
         return true;
       case ShouldSchedule::IfUnfinished:
         return !in_add_callback;
+      case ShouldSchedule::IfDifferentExecutor:
+        return !callback_record.options.executor->OwnsThisThread();
       default:
         DCHECK(false) << "Unrecognized ShouldSchedule option";
         return false;
@@ -309,7 +311,7 @@ class ConcreteFutureImpl : public FutureImpl {
     }
     cv_.notify_all();
 
-    // run callbacks, lock not needed since the future is finsihed by this
+    // run callbacks, lock not needed since the future is finished by this
     // point so nothing else can modify the callbacks list and it is safe
     // to iterate.
     //

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -66,10 +66,10 @@ using first_arg_is_status =
     std::is_same<typename std::decay<internal::call_traits::argument_type<0, Fn>>::type,
                  Status>;
 
-template <typename Fn>
-struct has_no_args {
-  static constexpr bool value = internal::call_traits::argument_count<Fn>::value == 0;
-};
+template <typename Fn, typename Then, typename Else>
+using if_has_no_args =
+    typename std::conditional<internal::call_traits::argument_count<Fn>::value == 0, Then,
+                              Else>::type;
 
 /// Creates a callback that can be added to a future to mark a `dest` future finished
 template <typename Source, typename Dest, bool SourceEmpty = Source::is_empty,
@@ -169,6 +169,19 @@ struct ContinueFuture {
     MarkNextFinished<ContinueResult, NextFuture> callback{std::move(next)};
     signal_to_complete_next.AddCallback(std::move(callback));
   }
+
+  /// Helpers to conditionally ignore arguments to ContinueFunc
+  template <typename ContinueFunc, typename NextFuture, typename... Args>
+  void IgnoringArgsIf(std::true_type, NextFuture&& next, ContinueFunc&& f,
+                      Args&&...) const {
+    operator()(std::forward<NextFuture>(next), std::forward<ContinueFunc>(f));
+  }
+  template <typename ContinueFunc, typename NextFuture, typename... Args>
+  void IgnoringArgsIf(std::false_type, NextFuture&& next, ContinueFunc&& f,
+                      Args&&... a) const {
+    operator()(std::forward<NextFuture>(next), std::forward<ContinueFunc>(f),
+               std::forward<Args>(a)...);
+  }
 };
 
 /// Helper struct which tells us what kind of Future gets returned from `Then` based on
@@ -213,7 +226,10 @@ enum class ShouldSchedule {
   /// callback is added
   IfUnfinished = 1,
   /// Always schedule the callback as a new task
-  Always = 2
+  Always = 2,
+  /// Schedule a new task only if it would run on an executor other than
+  /// the specified executor.
+  IfDifferentExecutor = 3,
 };
 
 /// \brief Options that control how a continuation is run
@@ -222,9 +238,9 @@ struct CallbackOptions {
   ShouldSchedule should_schedule = ShouldSchedule::Never;
   /// If the callback is scheduled then this is the executor it should be scheduled
   /// on.  If this is NULL then should_schedule must be Never
-  internal::Executor* executor = NULL;
+  internal::Executor* executor = NULLPTR;
 
-  static CallbackOptions Defaults() { return CallbackOptions(); }
+  static CallbackOptions Defaults() { return {}; }
 };
 
 // Untyped private implementation
@@ -343,7 +359,7 @@ class ARROW_EXPORT FutureWaiter {
 /// to complete, or wait on multiple Futures at once (using WaitForAll,
 /// WaitForAny or AsCompletedIterator).
 template <typename T>
-class Future {
+class ARROW_MUST_USE_TYPE Future {
  public:
   using ValueType = T;
   using SyncType = typename detail::SyncType<T>::type;
@@ -464,6 +480,28 @@ class Future {
     return MakeFinished(E::ToResult(std::move(s)));
   }
 
+  template <typename OnComplete, bool = detail::first_arg_is_status<OnComplete>::value>
+  struct MaybeStatusyOnComplete;
+
+  template <typename OnComplete>
+  struct MaybeStatusyOnComplete<OnComplete, false> {
+    void operator()(const FutureImpl& impl) && {
+      std::move(on_complete)(*impl.CastResult<ValueType>());
+    }
+    OnComplete on_complete;
+  };
+
+  template <typename OnComplete>
+  struct MaybeStatusyOnComplete<OnComplete, true> {
+    static_assert(std::is_same<internal::Empty, ValueType>::value,
+                  "Callbacks for Future<> should accept Status and not Result");
+
+    void operator()(const FutureImpl& impl) && {
+      std::move(on_complete)(impl.CastResult<ValueType>()->status());
+    }
+    OnComplete on_complete;
+  };
+
   /// \brief Consumer API: Register a callback to run when this future completes
   ///
   /// The callback should receive the result of the future (const Result<T>&)
@@ -486,35 +524,12 @@ class Future {
   /// In this example `fut` falls out of scope but is not destroyed because it holds a
   /// cyclic reference to itself through the callback.
   template <typename OnComplete>
-  typename std::enable_if<!detail::first_arg_is_status<OnComplete>::value>::type
-  AddCallback(OnComplete on_complete,
-              CallbackOptions opts = CallbackOptions::Defaults()) const {
+  void AddCallback(OnComplete on_complete,
+                   CallbackOptions opts = CallbackOptions::Defaults()) const {
     // We know impl_ will not be dangling when invoking callbacks because at least one
     // thread will be waiting for MarkFinished to return. Thus it's safe to keep a
     // weak reference to impl_ here
-    struct Callback {
-      void operator()(const FutureImpl& impl) && {
-        std::move(on_complete)(*impl.CastResult<ValueType>());
-      }
-      OnComplete on_complete;
-    };
-    impl_->AddCallback(Callback{std::move(on_complete)}, opts);
-  }
-
-  /// Overload for callbacks accepting a Status
-  template <typename OnComplete>
-  typename std::enable_if<detail::first_arg_is_status<OnComplete>::value>::type
-  AddCallback(OnComplete on_complete,
-              CallbackOptions opts = CallbackOptions::Defaults()) const {
-    static_assert(std::is_same<internal::Empty, ValueType>::value,
-                  "Callbacks for Future<> should accept Status and not Result");
-    struct Callback {
-      void operator()(const FutureImpl& impl) && {
-        std::move(on_complete)(impl.CastResult<ValueType>()->status());
-      }
-      OnComplete on_complete;
-    };
-    impl_->AddCallback(Callback{std::move(on_complete)}, opts);
+    impl_->AddCallback(MaybeStatusyOnComplete<OnComplete>{std::move(on_complete)}, opts);
   }
 
   /// \brief Overload of AddCallback that will return false instead of running
@@ -531,36 +546,63 @@ class Future {
   /// Returns true if a callback was actually added and false if the callback failed
   /// to add because the future was marked complete.
   template <typename CallbackFactory,
-            typename OnComplete = detail::result_of_t<CallbackFactory()>>
-  typename std::enable_if<!detail::first_arg_is_status<OnComplete>::value, bool>::type
-  TryAddCallback(const CallbackFactory& callback_factory,
-                 CallbackOptions opts = CallbackOptions::Defaults()) const {
-    struct Callback {
-      void operator()(const FutureImpl& impl) && {
-        std::move(on_complete)(*static_cast<Result<ValueType>*>(impl.result_.get()));
-      }
-      OnComplete on_complete;
-    };
+            typename OnComplete = detail::result_of_t<CallbackFactory()>,
+            typename Callback = MaybeStatusyOnComplete<OnComplete>>
+  bool TryAddCallback(const CallbackFactory& callback_factory,
+                      CallbackOptions opts = CallbackOptions::Defaults()) const {
     return impl_->TryAddCallback(
         [&callback_factory]() { return Callback{callback_factory()}; }, opts);
   }
 
-  template <typename CallbackFactory,
-            typename OnComplete = detail::result_of_t<CallbackFactory()>>
-  typename std::enable_if<detail::first_arg_is_status<OnComplete>::value, bool>::type
-  TryAddCallback(const CallbackFactory& callback_factory,
-                 CallbackOptions opts = CallbackOptions::Defaults()) const {
-    struct Callback {
-      void operator()(const FutureImpl& impl) && {
-        std::move(on_complete)(
-            static_cast<Result<ValueType>*>(impl.result_.get())->status());
-      }
-      OnComplete on_complete;
-    };
+  template <typename OnSuccess, typename OnFailure>
+  struct ThenCallback {
+    static constexpr bool has_no_args =
+        internal::call_traits::argument_count<OnSuccess>::value == 0;
 
-    return impl_->TryAddCallback(
-        [&callback_factory]() { return Callback{callback_factory()}; }, opts);
-  }
+    using ContinuedFuture = detail::ContinueFuture::ForSignature<
+        detail::if_has_no_args<OnSuccess, OnSuccess && (), OnSuccess && (const T&)>>;
+
+    static_assert(
+        std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
+                     ContinuedFuture>::value,
+        "OnSuccess and OnFailure must continue with the same future type");
+
+    struct OnSuccessDummy {
+      void operator()(const T&);
+    };
+    using OnSuccessArg = typename std::decay<internal::call_traits::argument_type<
+        0, detail::if_has_no_args<OnSuccess, OnSuccessDummy, OnSuccess>>>::type;
+
+    static_assert(
+        !std::is_same<OnSuccessArg, typename EnsureResult<OnSuccessArg>::type>::value,
+        "OnSuccess' argument should not be a Result");
+
+    void operator()(const Result<T>& result) && {
+      detail::ContinueFuture continue_future;
+      if (ARROW_PREDICT_TRUE(result.ok())) {
+        // move on_failure to a(n immediately destroyed) temporary to free its resources
+        ARROW_UNUSED(OnFailure(std::move(on_failure)));
+        continue_future.IgnoringArgsIf(
+            detail::if_has_no_args<OnSuccess, std::true_type, std::false_type>{},
+            std::move(next), std::move(on_success), result.ValueOrDie());
+      } else {
+        ARROW_UNUSED(OnSuccess(std::move(on_success)));
+        continue_future(std::move(next), std::move(on_failure), result.status());
+      }
+    }
+
+    OnSuccess on_success;
+    OnFailure on_failure;
+    ContinuedFuture next;
+  };
+
+  template <typename OnSuccess>
+  struct PassthruFailure {
+    using ContinuedFuture = detail::ContinueFuture::ForSignature<
+        detail::if_has_no_args<OnSuccess, OnSuccess && (), OnSuccess && (const T&)>>;
+
+    Result<typename ContinuedFuture::ValueType> operator()(const Status& s) { return s; }
+  };
 
   /// \brief Consumer API: Register a continuation to run when this future completes
   ///
@@ -573,6 +615,7 @@ class Future {
   /// - OnSuccess, called with the result (const ValueType&) on successul completion.
   ///              for an empty future this will be called with nothing ()
   /// - OnFailure, called with the error (const Status&) on failed completion.
+  ///              This callback is optional and defaults to a passthru of any errors.
   ///
   /// Then() returns a Future whose ValueType is derived from the return type of the
   /// callbacks. If a callback returns:
@@ -595,112 +638,16 @@ class Future {
   /// and the returned future may already be marked complete.
   ///
   /// See AddCallback for general considerations when writing callbacks.
-  template <typename OnSuccess, typename OnFailure,
-            typename ContinuedFuture =
-                detail::ContinueFuture::ForSignature<OnSuccess && (const T&)>>
-  ContinuedFuture Then(
-      OnSuccess on_success, OnFailure on_failure,
-      typename std::enable_if<!detail::has_no_args<OnSuccess>::value>::type* =
-          NULLPTR) const {
-    static_assert(
-        std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
-                     ContinuedFuture>::value,
-        "OnSuccess and OnFailure must continue with the same future type");
-    using OnSuccessArg =
-        typename std::decay<internal::call_traits::argument_type<0, OnSuccess>>::type;
-    static_assert(
-        !std::is_same<OnSuccessArg, typename EnsureResult<OnSuccessArg>::type>::value,
-        "OnSuccess' argument should not be a Result");
-
+  template <typename OnSuccess, typename OnFailure = PassthruFailure<OnSuccess>,
+            typename Callback = ThenCallback<OnSuccess, OnFailure>,
+            typename ContinuedFuture = typename Callback::ContinuedFuture>
+  ContinuedFuture Then(OnSuccess on_success, OnFailure on_failure = {},
+                       CallbackOptions options = CallbackOptions::Defaults()) const {
     auto next = ContinuedFuture::Make();
-
-    struct Callback {
-      void operator()(const Result<T>& result) && {
-        detail::ContinueFuture continue_future;
-        if (ARROW_PREDICT_TRUE(result.ok())) {
-          // move on_failure to a(n immediately destroyed) temporary to free its resources
-          ARROW_UNUSED(OnFailure(std::move(on_failure)));
-          continue_future(std::move(next), std::move(on_success), result.ValueOrDie());
-        } else {
-          ARROW_UNUSED(OnSuccess(std::move(on_success)));
-          continue_future(std::move(next), std::move(on_failure), result.status());
-        }
-      }
-
-      OnSuccess on_success;
-      OnFailure on_failure;
-      ContinuedFuture next;
-    };
-
     AddCallback(Callback{std::forward<OnSuccess>(on_success),
-                         std::forward<OnFailure>(on_failure), next});
-
+                         std::forward<OnFailure>(on_failure), next},
+                options);
     return next;
-  }
-
-  /// \brief Overload for callbacks which ignore the value
-  template <
-      typename OnSuccess, typename OnFailure,
-      typename ContinuedFuture = detail::ContinueFuture::ForSignature<OnSuccess && ()>>
-  ContinuedFuture Then(
-      OnSuccess on_success, OnFailure on_failure,
-      typename std::enable_if<detail::has_no_args<OnSuccess>::value>::type* =
-          NULLPTR) const {
-    static_assert(
-        std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
-                     ContinuedFuture>::value,
-        "OnSuccess and OnFailure must continue with the same future type");
-
-    auto next = ContinuedFuture::Make();
-
-    struct Callback {
-      void operator()(const Result<T>& result) && {
-        detail::ContinueFuture continue_future;
-        if (ARROW_PREDICT_TRUE(result.ok())) {
-          // move on_failure to a(n immediately destroyed) temporary to free its resources
-          ARROW_UNUSED(OnFailure(std::move(on_failure)));
-          continue_future(std::move(next), std::move(on_success));
-        } else {
-          ARROW_UNUSED(OnSuccess(std::move(on_success)));
-          continue_future(std::move(next), std::move(on_failure), result.status());
-        }
-      }
-
-      OnSuccess on_success;
-      OnFailure on_failure;
-      ContinuedFuture next;
-    };
-
-    AddCallback(Callback{std::forward<OnSuccess>(on_success),
-                         std::forward<OnFailure>(on_failure), next});
-
-    return next;
-  }
-
-  /// \brief Overload without OnFailure. Failures will be passed through unchanged.
-  template <typename OnSuccess,
-            typename ContinuedFuture =
-                detail::ContinueFuture::ForSignature<OnSuccess && (const T&)>,
-            typename E = ValueType>
-  typename std::enable_if<!detail::has_no_args<OnSuccess>::value, ContinuedFuture>::type
-  Then(OnSuccess&& on_success) const {
-    return Then(std::forward<OnSuccess>(on_success), [](const Status& s) {
-      return Result<typename ContinuedFuture::ValueType>(s);
-    });
-  }
-
-  /// \brief Statusy overload without OnFailure
-  template <
-      typename OnSuccess,
-      typename ContinuedFuture = detail::ContinueFuture::ForSignature<OnSuccess && ()>,
-      typename E = ValueType>
-  typename std::enable_if<detail::has_no_args<OnSuccess>::value, ContinuedFuture>::type
-  Then(OnSuccess&& on_success) const {
-    static_assert(std::is_same<internal::Empty, ValueType>::value,
-                  "Then callback OnSuccess must receive const T&");
-    return Then(std::forward<OnSuccess>(on_success), [](const Status& s) {
-      return Result<typename ContinuedFuture::ValueType>(s);
-    });
   }
 
   /// \brief Implicit constructor to create a finished future from a value

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -1761,25 +1761,26 @@ TEST(FnOnceTest, MoveOnlyDataType) {
 
 TEST(FutureTest, MatcherExamples) {
   EXPECT_THAT(Future<int>::MakeFinished(Status::Invalid("arbitrary error")),
-              Raises(StatusCode::Invalid));
+              Finishes(Raises(StatusCode::Invalid)));
 
   EXPECT_THAT(Future<int>::MakeFinished(Status::Invalid("arbitrary error")),
-              Raises(StatusCode::Invalid, testing::HasSubstr("arbitrary")));
+              Finishes(Raises(StatusCode::Invalid, testing::HasSubstr("arbitrary"))));
 
   // message doesn't match, so no match
-  EXPECT_THAT(
-      Future<int>::MakeFinished(Status::Invalid("arbitrary error")),
-      testing::Not(Raises(StatusCode::Invalid, testing::HasSubstr("reasonable"))));
+  EXPECT_THAT(Future<int>::MakeFinished(Status::Invalid("arbitrary error")),
+              Finishes(testing::Not(
+                  Raises(StatusCode::Invalid, testing::HasSubstr("reasonable")))));
 
   // different error code, so no match
   EXPECT_THAT(Future<int>::MakeFinished(Status::TypeError("arbitrary error")),
-              testing::Not(Raises(StatusCode::Invalid)));
+              Finishes(testing::Not(Raises(StatusCode::Invalid))));
 
   // not an error, so no match
-  EXPECT_THAT(Future<int>::MakeFinished(333), testing::Not(Raises(StatusCode::Invalid)));
+  EXPECT_THAT(Future<int>::MakeFinished(333),
+              Finishes(testing::Not(Raises(StatusCode::Invalid))));
 
   EXPECT_THAT(Future<std::string>::MakeFinished("hello world"),
-              ResultWith(testing::HasSubstr("hello")));
+              Finishes(ResultWith(testing::HasSubstr("hello"))));
 
   // Matcher waits on Futures
   auto string_fut = Future<std::string>::Make();
@@ -1787,15 +1788,15 @@ TEST(FutureTest, MatcherExamples) {
     SleepABit();
     string_fut.MarkFinished("hello world");
   });
-  EXPECT_THAT(string_fut, ResultWith(testing::HasSubstr("hello")));
+  EXPECT_THAT(string_fut, Finishes(ResultWith(testing::HasSubstr("hello"))));
   finisher.join();
 
   EXPECT_THAT(Future<std::string>::MakeFinished(Status::Invalid("XXX")),
-              testing::Not(ResultWith(testing::HasSubstr("hello"))));
+              Finishes(testing::Not(ResultWith(testing::HasSubstr("hello")))));
 
   // holds a value, but that value doesn't match the given pattern
   EXPECT_THAT(Future<std::string>::MakeFinished("foo bar"),
-              testing::Not(ResultWith(testing::HasSubstr("hello"))));
+              Finishes(testing::Not(ResultWith(testing::HasSubstr("hello")))));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -82,16 +82,30 @@ class ARROW_EXPORT Executor {
 
   // Spawn a fire-and-forget task.
   template <typename Function>
-  Status Spawn(Function&& func, StopToken stop_token = StopToken::Unstoppable()) {
+  Status Spawn(Function&& func) {
+    return SpawnReal(TaskHints{}, std::forward<Function>(func), StopToken::Unstoppable(),
+                     StopCallback{});
+  }
+  template <typename Function>
+  Status Spawn(Function&& func, StopToken stop_token) {
     return SpawnReal(TaskHints{}, std::forward<Function>(func), std::move(stop_token),
                      StopCallback{});
   }
-
   template <typename Function>
-  Status Spawn(TaskHints hints, Function&& func,
-               StopToken stop_token = StopToken::Unstoppable()) {
+  Status Spawn(TaskHints hints, Function&& func) {
+    return SpawnReal(hints, std::forward<Function>(func), StopToken::Unstoppable(),
+                     StopCallback{});
+  }
+  template <typename Function>
+  Status Spawn(TaskHints hints, Function&& func, StopToken stop_token) {
     return SpawnReal(hints, std::forward<Function>(func), std::move(stop_token),
                      StopCallback{});
+  }
+  template <typename Function>
+  Status Spawn(TaskHints hints, Function&& func, StopToken stop_token,
+               StopCallback stop_callback) {
+    return SpawnReal(hints, std::forward<Function>(func), std::move(stop_token),
+                     std::move(stop_callback));
   }
 
   // Transfers a future to this executor.  Any continuations added to the
@@ -237,7 +251,7 @@ class ARROW_EXPORT SerialExecutor : public Executor {
   template <typename T = ::arrow::internal::Empty>
   using TopLevelTask = internal::FnOnce<Future<T>(Executor*)>;
 
-  ~SerialExecutor();
+  ~SerialExecutor() override;
 
   int GetCapacity() override { return 1; };
   Status SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken,

--- a/dev/archery/archery/lang/cpp.py
+++ b/dev/archery/archery/lang/cpp.py
@@ -42,7 +42,7 @@ class CppConfiguration:
                  cc=None, cxx=None, cxx_flags=None,
                  build_type=None, warn_level=None,
                  cpp_package_prefix=None, install_prefix=None, use_conda=None,
-                 build_static=False, build_shared=True,
+                 build_static=False, build_shared=True, build_unity=True,
                  # tests & examples
                  with_tests=None, with_benchmarks=None, with_examples=None,
                  with_integration=None,
@@ -76,6 +76,7 @@ class CppConfiguration:
         self._use_conda = use_conda
         self.build_static = build_static
         self.build_shared = build_shared
+        self.build_unity = build_unity
 
         self.with_tests = with_tests
         self.with_benchmarks = with_benchmarks
@@ -176,7 +177,6 @@ class CppConfiguration:
 
         yield ("CMAKE_EXPORT_COMPILE_COMMANDS", truthifier(True))
         yield ("CMAKE_BUILD_TYPE", self.build_type)
-        yield ("CMAKE_UNITY_BUILD", True)
 
         if not self.with_lint_only:
             yield ("BUILD_WARNING_LEVEL",
@@ -195,6 +195,7 @@ class CppConfiguration:
 
         yield ("ARROW_BUILD_STATIC", truthifier(self.build_static))
         yield ("ARROW_BUILD_SHARED", truthifier(self.build_shared))
+        yield ("CMAKE_UNITY_BUILD", truthifier(self.build_unity))
 
         # Tests and benchmarks
         yield ("ARROW_BUILD_TESTS", truthifier(self.with_tests))


### PR DESCRIPTION
Replaces the body of AsyncScanner::ScanBatchesAsync with usage of an ExecPlan