### PR TITLE
ARROW-13273: [C++] Don't use .pc only in CMake paths for Requires.private

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -239,7 +239,11 @@ macro(resolve_dependency DEPENDENCY_NAME)
     list(APPEND ARROW_SYSTEM_DEPENDENCIES ${PACKAGE_NAME})
     find_package(PkgConfig QUIET)
     foreach(ARG_PC_PACKAGE_NAME ${ARG_PC_PACKAGE_NAMES})
-      pkg_check_modules(${ARG_PC_PACKAGE_NAME}_PC ${ARG_PC_PACKAGE_NAME} QUIET)
+      pkg_check_modules(${ARG_PC_PACKAGE_NAME}_PC
+                        ${ARG_PC_PACKAGE_NAME}
+                        NO_CMAKE_PATH
+                        NO_CMAKE_EINVIRONMENT_PATH
+                        QUIET)
       if(${${ARG_PC_PACKAGE_NAME}_PC_FOUND})
         string(APPEND ARROW_PC_REQUIRES_PRIVATE " ${ARG_PC_PACKAGE_NAME}")
       endif()


### PR DESCRIPTION
Because they can't be found by raw pkg-config usage.