### PR TITLE
ARROW-13275 [JS]: Fix perf tests

### DIFF
--- a/js/perf/config.ts
+++ b/js/perf/config.ts
@@ -57,7 +57,7 @@ const batches = Array.from({length: NUM_BATCHES}).map(() => {
     });
 });
 
-const tracks = new Arrow.Table(batches[0].schema, batches);
+const tracks = new Arrow.DataFrame(batches[0].schema, batches);
 
 console.timeEnd('Prepare Data');
 


### PR DESCRIPTION
We recently split `DataFrame`s from `Table`s so we should run tests on the former. 