### PR TITLE
ARROW-13286: [CI] Require docker-compose 1.27.0 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ before_install:
 
 install:
   - sudo -H pip3 install --upgrade pip
-  - sudo -H pip3 install docker-compose
+  - sudo -H pip3 install 'docker-compose>=1.27.0'
   - sudo -H pip3 install -e dev/archery[docker]
 
 script:


### PR DESCRIPTION
We need it for "extends".

See also:

  * https://issues.apache.org/jira/browse/ARROW-13199
  * https://github.com/apache/arrow/pull/10611
  * https://github.com/docker/compose/pull/7588