### PR TITLE
ARROW-13290: [C++] Add missing include

### DIFF
--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <queue>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
Noticed this issue compiling w/ clang-12 and gcc-11 on Arch linux (both using the PKGBUILD and building from source).