### PR TITLE
ARROW-13291: [GLib][CI] Require gobject-introspection 3.4.5 or later

### DIFF
--- a/c_glib/Gemfile
+++ b/c_glib/Gemfile
@@ -20,4 +20,4 @@
 source "https://rubygems.org/"
 
 gem "test-unit"
-gem "gobject-introspection"
+gem "gobject-introspection", ">= 3.4.5"

--- a/c_glib/test/flight/test-client.rb
+++ b/c_glib/test/flight/test-client.rb
@@ -16,10 +16,13 @@
 # under the License.
 
 class TestFlightClient < Test::Unit::TestCase
+  include Helper::Omittable
+
   def setup
     @server = nil
     omit("Arrow Flight is required") unless defined?(ArrowFlight)
     omit("Unstable on Windows") if Gem.win_platform?
+    require_gi_bindings(3, 4, 5)
     @server = Helper::FlightServer.new
     host = "127.0.0.1"
     location = ArrowFlight::Location.new("grpc://#{host}:0")


### PR DESCRIPTION
It's needed for Flight tests.