### PR TITLE
ARROW-13306: [Java][JDBC] use ResultSetMetaData.getColumnLabel instead of ResultSetMetaData.getColumnName

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -139,7 +139,7 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
   private void load(VectorSchemaRoot root) throws SQLException {
 
     for (int i = 1; i <= consumers.length; i++) {
-      consumers[i - 1].resetValueVector(root.getVector(rsmd.getColumnName(i)));
+      consumers[i - 1].resetValueVector(root.getVector(rsmd.getColumnLabel(i)));
     }
 
     consumeData(root);

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -115,7 +115,7 @@ public class JdbcToArrowUtils {
    * <ul>
    *  <li>{@link Constants#SQL_CATALOG_NAME_KEY} representing {@link ResultSetMetaData#getCatalogName(int)}</li>
    *  <li>{@link Constants#SQL_TABLE_NAME_KEY} representing {@link ResultSetMetaData#getTableName(int)}</li>
-   *  <li>{@link Constants#SQL_COLUMN_NAME_KEY} representing {@link ResultSetMetaData#getColumnName(int)}</li>
+   *  <li>{@link Constants#SQL_COLUMN_NAME_KEY} representing {@link ResultSetMetaData#getColumnLabel(int)}</li>
    *  <li>{@link Constants#SQL_TYPE_KEY} representing {@link ResultSetMetaData#getColumnTypeName(int)}</li>
    * </ul>
    * </p>
@@ -139,7 +139,7 @@ public class JdbcToArrowUtils {
     List<Field> fields = new ArrayList<>();
     int columnCount = rsmd.getColumnCount();
     for (int i = 1; i <= columnCount; i++) {
-      final String columnName = rsmd.getColumnName(i);
+      final String columnName = rsmd.getColumnLabel(i);
 
       final Map<String, String> metadata;
       if (config.shouldIncludeMetadata()) {
@@ -196,7 +196,7 @@ public class JdbcToArrowUtils {
 
     JdbcFieldInfo fieldInfo = config.getArraySubTypeByColumnIndex(arrayColumn);
     if (fieldInfo == null) {
-      fieldInfo = config.getArraySubTypeByColumnName(rsmd.getColumnName(arrayColumn));
+      fieldInfo = config.getArraySubTypeByColumnName(rsmd.getColumnLabel(arrayColumn));
     }
     return fieldInfo;
   }
@@ -246,7 +246,7 @@ public class JdbcToArrowUtils {
 
     JdbcConsumer[] consumers = new JdbcConsumer[columnCount];
     for (int i = 1; i <= columnCount; i++) {
-      FieldVector vector = root.getVector(rsmd.getColumnName(i));
+      FieldVector vector = root.getVector(rsmd.getColumnLabel(i));
       consumers[i - 1] = getConsumer(vector.getField().getType(), i, isColumnNullable(rs, i), vector, config);
     }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -263,7 +263,7 @@ public class JdbcToArrowTestHelper {
 
       assertEquals(rsmd.getCatalogName(i), metadata.get(Constants.SQL_CATALOG_NAME_KEY));
       assertEquals(rsmd.getTableName(i), metadata.get(Constants.SQL_TABLE_NAME_KEY));
-      assertEquals(rsmd.getColumnName(i), metadata.get(Constants.SQL_COLUMN_NAME_KEY));
+      assertEquals(rsmd.getColumnLabel(i), metadata.get(Constants.SQL_COLUMN_NAME_KEY));
       assertEquals(rsmd.getColumnTypeName(i), metadata.get(Constants.SQL_TYPE_KEY));
     }
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adapter.jdbc.h2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.apache.arrow.adapter.jdbc.JdbcToArrow;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JdbcAliasToArrowTest {
+  private Connection conn = null;
+
+  private static final String CREATE_STATEMENT =
+      "CREATE TABLE example_table (id INTEGER);";
+  private static final String INSERT_STATEMENT =
+      "INSERT INTO example_table (id) VALUES (?);";
+  private static final String QUERY = "SELECT id as a, id as b FROM example_table;";
+  private static final String DROP_STATEMENT = "DROP TABLE example_table;";
+  private static final String ORIGINAL_COLUMN_NAME = "ID";
+  private static final String COLUMN_A = "A";
+  private static final String COLUMN_B = "B";
+
+  @Before
+  public void setUp() throws Exception {
+    String url = "jdbc:h2:mem:JdbcAliasToArrowTest";
+    String driver = "org.h2.Driver";
+    Class.forName(driver);
+    conn = DriverManager.getConnection(url);
+    try (Statement stmt = conn.createStatement()) {
+      stmt.executeUpdate(CREATE_STATEMENT);
+    }
+  }
+
+  /**
+   * Test h2 database query with alias for column name and column label.
+   * To vetify reading field alias from an H2 database works as expected.
+   * If this test fails, something is either wrong with the setup,
+   * or the H2 SQL behavior changed.
+   */
+  @Test
+  public void testReadH2Alias() throws Exception {
+    // insert rows
+    int rowCount = 4;
+    insertRows(rowCount);
+
+    try (ResultSet resultSet = conn.createStatement().executeQuery(QUERY)) {
+      ResultSetMetaData rsmd = resultSet.getMetaData();
+      assertEquals(2, rsmd.getColumnCount());
+
+      // check column name and column label
+      assertEquals(ORIGINAL_COLUMN_NAME, rsmd.getColumnName(1));
+      assertEquals(COLUMN_A, rsmd.getColumnLabel(1));
+      assertEquals(ORIGINAL_COLUMN_NAME, rsmd.getColumnName(2));
+      assertEquals(COLUMN_B, rsmd.getColumnLabel(2));
+
+      int rowNum = 0;
+
+      while (resultSet.next()) {
+        assertEquals(rowNum, resultSet.getInt(COLUMN_A));
+        assertEquals(rowNum, resultSet.getInt(COLUMN_B));
+        ++rowNum;
+      }
+
+      assertEquals(rowCount, rowNum);
+    }
+  }
+
+  /**
+   * Test jdbc query results with alias to arrow works expected.
+   * Arrow result schema name should be field alias name.
+   */
+  @Test
+  public void testJdbcAliasToArrow() throws Exception {
+    int rowCount = 4;
+    insertRows(rowCount);
+
+    try (ResultSet resultSet = conn.createStatement().executeQuery(QUERY)) {
+      final VectorSchemaRoot vector =
+          JdbcToArrow.sqlToArrow(resultSet, new RootAllocator(Integer.MAX_VALUE));
+
+      assertEquals(rowCount, vector.getRowCount());
+      Schema vectorSchema = vector.getSchema();
+      List<Field> vectorFields = vectorSchema.getFields();
+      assertEquals(vectorFields.get(0).getName(), COLUMN_A);
+      assertEquals(vectorFields.get(1).getName(), COLUMN_B);
+    }
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      stmt.executeUpdate(DROP_STATEMENT);
+    } finally {
+      if (conn != null) {
+        conn.close();
+        conn = null;
+      }
+    }
+  }
+
+  private void insertRows(int numRows) throws SQLException {
+    // Insert [numRows] Rows
+    try (PreparedStatement stmt = conn.prepareStatement(INSERT_STATEMENT)) {
+      for (int i = 0; i < numRows; ++i) {
+        stmt.setInt(1, i);
+        stmt.executeUpdate();
+      }
+    }
+  }
+}

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -487,7 +487,7 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
         @Override
         public String getColumnLabel(int column) throws SQLException {
-          return null;
+          return getColumnName(column);
         }
 
         @Override


### PR DESCRIPTION
quick fixed using `getColumnLabel` instead of `getColumnName`