### PR TITLE
ARROW-13243: [R] altrep function call in R 3.5

### DIFF
--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -23,7 +23,27 @@
 
 #if defined(HAS_ALTREP)
 
+#if R_VERSION < R_Version(3, 6, 0)
+
+// workaround because R's <R_ext/Altrep.h> not so conveniently uses `class`
+// as a variable name, and C++ is not happy about that
+//
+// SEXP R_new_altrep(R_altrep_class_t class, SEXP data1, SEXP data2);
+//
+#define class klass
+
+// Because functions declared in <R_ext/Altrep.h> have C linkage
+extern "C" {
 #include <R_ext/Altrep.h>
+}
+
+// undo the workaround
+#undef class
+
+#else
+#include <R_ext/Altrep.h>
+#endif
+
 #include <arrow/array.h>
 
 namespace arrow {


### PR DESCRIPTION
This uses the workaround that @romainfrancois blogged about (https://purrple.cat/blog/2018/10/14/altrep-and-cpp/) on versions less than 3.6.0.