### PR TITLE
ARROW-13324: [R] Typo in bindings for utf8_reverse and ascii_reverse

### DIFF
--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -31,7 +31,7 @@
   "str_to_lower" = "utf8_lower",
   "str_to_upper" = "utf8_upper",
   # str_pad is defined in dplyr-functions.R
-  "str_reverse" = "utf8_reverse",
+  "stri_reverse" = "utf8_reverse",
   # str_trim is defined in dplyr-functions.R
   "year" = "year",
   "isoyear" = "iso_year",

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -774,8 +774,7 @@ test_that("arrow_find_substring and arrow_find_substring_regex", {
 })
 
 test_that("stri_reverse and arrow_ascii_reverse functions", {
-  # TODO: these actually aren't implemented (ARROW-12869)
-  # Fix them, then remove the `warning = TRUE` arguments
+  
   df_ascii <- tibble(x = c("Foo\nand bar", "baz\tand qux and quux"))
 
   df_utf8 <- tibble(x = c("Foo\u00A0\u0061nd\u00A0bar", "\u0062az\u00A0and\u00A0qux\u3000and\u00A0quux"))
@@ -784,16 +783,14 @@ test_that("stri_reverse and arrow_ascii_reverse functions", {
     input %>%
       mutate(x = stri_reverse(x)) %>%
       collect(),
-    df_utf8,
-    warning = TRUE # Remove me
+    df_utf8
   )
 
   expect_dplyr_equal(
     input %>%
       mutate(x = stri_reverse(x)) %>%
       collect(),
-    df_ascii,
-    warning = TRUE # Remove me
+    df_ascii
   )
 
   expect_equivalent(


### PR DESCRIPTION
This PR fixes a typo in the binding for stri_reverse