### PR TITLE
ARROW-13341: [C++][Compute] Fix race condition in ScalarAggregateNode

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -736,7 +736,7 @@ struct ScalarAggregateNode : ExecNode {
   Status MaybeFinish(std::unique_lock<std::mutex>* lock) {
     if (num_received_ != num_total_) return Status::OK();
 
-    if (finished_.is_finished()) return Status::OK();
+    if (states_.empty()) return Status::OK();
 
     ExecBatch batch{{}, 1};
     batch.values.resize(kernels_.size());
@@ -747,6 +747,7 @@ struct ScalarAggregateNode : ExecNode {
                                              kernels_[i], &ctx, std::move(states_[i])));
       RETURN_NOT_OK(kernels_[i]->finalize(&ctx, &batch.values[i]));
     }
+    states_.clear();
     lock->unlock();
 
     outputs_[0]->InputReceived(this, 0, batch);

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -760,7 +760,7 @@ struct ScalarAggregateNode : ExecNode {
   std::vector<std::vector<std::unique_ptr<KernelState>>> states_;
   std::unordered_map<std::thread::id, size_t> thread_indices_;
   std::mutex mutex_;
-  int num_received_ = 0, num_total_;
+  int num_received_ = 0, num_total_ = -1;
 };
 
 Result<ExecNode*> MakeScalarAggregateNode(ExecNode* input, std::string label,

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -675,7 +675,6 @@ struct ScalarAggregateNode : ExecNode {
     std::unique_lock<std::mutex> lock(mutex_);
     auto it =
         thread_indices_.emplace(std::this_thread::get_id(), thread_indices_.size()).first;
-    ++num_received_;
     auto thread_index = it->second;
 
     lock.unlock();
@@ -687,6 +686,7 @@ struct ScalarAggregateNode : ExecNode {
     }
 
     lock.lock();
+    ++num_received_;
     st = MaybeFinish(&lock);
     if (!st.ok()) {
       outputs_[0]->ErrorReceived(this, std::move(st));


### PR DESCRIPTION
Multiple threads starting DoConsume would already have incremented `num_received_`, so if one were delayed another might erroneously begin to merge/finalize (leaving invalidated states)