### PR TITLE
ARROW-12745: [C++][Compute] Add floor, ceiling, and truncate kernels

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -358,6 +358,9 @@ SCALAR_ARITHMETIC_BINARY(Power, "power", "power_checked")
 SCALAR_ARITHMETIC_BINARY(ShiftLeft, "shift_left", "shift_left_checked")
 SCALAR_ARITHMETIC_BINARY(ShiftRight, "shift_right", "shift_right_checked")
 SCALAR_EAGER_BINARY(Atan2, "atan2")
+SCALAR_EAGER_UNARY(Floor, "floor")
+SCALAR_EAGER_UNARY(Ceiling, "ceiling")
+SCALAR_EAGER_UNARY(Truncate, "truncate")
 
 Result<Datum> MaxElementWise(const std::vector<Datum>& args,
                              ElementWiseAggregateOptions options, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -359,8 +359,8 @@ SCALAR_ARITHMETIC_BINARY(ShiftLeft, "shift_left", "shift_left_checked")
 SCALAR_ARITHMETIC_BINARY(ShiftRight, "shift_right", "shift_right_checked")
 SCALAR_EAGER_BINARY(Atan2, "atan2")
 SCALAR_EAGER_UNARY(Floor, "floor")
-SCALAR_EAGER_UNARY(Ceiling, "ceiling")
-SCALAR_EAGER_UNARY(Truncate, "truncate")
+SCALAR_EAGER_UNARY(Ceil, "ceil")
+SCALAR_EAGER_UNARY(Trunc, "trunc")
 
 Result<Datum> MaxElementWise(const std::vector<Datum>& args,
                              ElementWiseAggregateOptions options, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -487,32 +487,34 @@ ARROW_EXPORT
 Result<Datum> Log1p(const Datum& arg, ArithmeticOptions options = ArithmeticOptions(),
                     ExecContext* ctx = NULLPTR);
 
-/// \brief Round down to the nearest integer. Array values can be of arbitrary
-/// length. If argument is null the result will be null.
+/// \brief Round to the nearest integer less than or equal in magnitude to the
+/// argument. Array values can be of arbitrary length. If argument is null the
+/// result will be null.
 ///
-/// \param[in] arg the value round
+/// \param[in] arg the value to round
 /// \param[in] ctx the function execution context, optional
 /// \return the rounded value
 ARROW_EXPORT
 Result<Datum> Floor(const Datum& arg, ExecContext* ctx = NULLPTR);
 
-/// \brief Round up to the nearest integer. Array values can be of arbitrary
-/// length. If argument is null the result will be null.
+/// \brief Round to the nearest integer greater than or equal in magnitude to the
+/// argument. Array values can be of arbitrary length. If argument is null the
+/// result will be null.
 ///
-/// \param[in] arg the value round
+/// \param[in] arg the value to round
 /// \param[in] ctx the function execution context, optional
 /// \return the rounded value
 ARROW_EXPORT
-Result<Datum> Ceiling(const Datum& arg, ExecContext* ctx = NULLPTR);
+Result<Datum> Ceil(const Datum& arg, ExecContext* ctx = NULLPTR);
 
-/// \brief Get the integral part of a value. Array values can be of arbitrary
-/// length. If argument is null the result will be null.
+/// \brief Get the integral part without fractional digits. Array values can be
+/// of arbitrary length. If argument is null the result will be null.
 ///
 /// \param[in] arg the value to truncate
 /// \param[in] ctx the function execution context, optional
 /// \return the truncated value
 ARROW_EXPORT
-Result<Datum> Truncate(const Datum& arg, ExecContext* ctx = NULLPTR);
+Result<Datum> Trunc(const Datum& arg, ExecContext* ctx = NULLPTR);
 
 /// \brief Find the element-wise maximum of any number of arrays or scalars.
 /// Array values must be the same length.

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -487,6 +487,33 @@ ARROW_EXPORT
 Result<Datum> Log1p(const Datum& arg, ArithmeticOptions options = ArithmeticOptions(),
                     ExecContext* ctx = NULLPTR);
 
+/// \brief Round down to the nearest integer. Array values can be of arbitrary
+/// length. If argument is null the result will be null.
+///
+/// \param[in] arg the value round
+/// \param[in] ctx the function execution context, optional
+/// \return the rounded value
+ARROW_EXPORT
+Result<Datum> Floor(const Datum& arg, ExecContext* ctx = NULLPTR);
+
+/// \brief Round up to the nearest integer. Array values can be of arbitrary
+/// length. If argument is null the result will be null.
+///
+/// \param[in] arg the value round
+/// \param[in] ctx the function execution context, optional
+/// \return the rounded value
+ARROW_EXPORT
+Result<Datum> Ceiling(const Datum& arg, ExecContext* ctx = NULLPTR);
+
+/// \brief Get the integral part of a value. Array values can be of arbitrary
+/// length. If argument is null the result will be null.
+///
+/// \param[in] arg the value to truncate
+/// \param[in] ctx the function execution context, optional
+/// \return the truncated value
+ARROW_EXPORT
+Result<Datum> Truncate(const Datum& arg, ExecContext* ctx = NULLPTR);
+
 /// \brief Find the element-wise maximum of any number of arrays or scalars.
 /// Array values must be the same length.
 ///

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1808,10 +1808,12 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   auto floor = MakeUnaryArithmeticFunctionFloatingPoint<Floor>("floor", &floor_doc);
   DCHECK_OK(registry->AddFunction(std::move(floor)));
 
-  auto ceiling = MakeUnaryArithmeticFunctionFloatingPoint<Ceiling>("ceiling", &ceiling_doc);
+  auto ceiling =
+      MakeUnaryArithmeticFunctionFloatingPoint<Ceiling>("ceiling", &ceiling_doc);
   DCHECK_OK(registry->AddFunction(std::move(ceiling)));
 
-  auto truncate = MakeUnaryArithmeticFunctionFloatingPoint<Truncate>("truncate", &truncate_doc);
+  auto truncate =
+      MakeUnaryArithmeticFunctionFloatingPoint<Truncate>("truncate", &truncate_doc);
   DCHECK_OK(registry->AddFunction(std::move(truncate)));
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -817,6 +817,27 @@ struct Log1pChecked {
   }
 };
 
+struct Floor {
+  template <typename T, typename Arg>
+  static constexpr enable_if_floating_point<T> Call(KernelContext*, Arg arg, Status*) {
+    return std::floor(arg);
+  }
+};
+
+struct Ceiling {
+  template <typename T, typename Arg>
+  static constexpr enable_if_floating_point<T> Call(KernelContext*, Arg arg, Status*) {
+    return std::ceil(arg);
+  }
+};
+
+struct Truncate {
+  template <typename T, typename Arg>
+  static constexpr enable_if_floating_point<T> Call(KernelContext*, Arg arg, Status*) {
+    return std::trunc(arg);
+  }
+};
+
 // Generate a kernel given an arithmetic functor
 template <template <typename... Args> class KernelGenerator, typename Op>
 ArrayKernelExec ArithmeticExecFromOp(detail::GetTypeId get_id) {
@@ -1391,16 +1412,16 @@ const FunctionDoc sign_doc{
     {"x"}};
 
 const FunctionDoc bit_wise_not_doc{
-    "Bit-wise negate the arguments element-wise", ("Null values return null."), {"x"}};
+    "Bit-wise negate the arguments element-wise", "Null values return null.", {"x"}};
 
 const FunctionDoc bit_wise_and_doc{
-    "Bit-wise AND the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise AND the arguments element-wise", "Null values return null.", {"x", "y"}};
 
 const FunctionDoc bit_wise_or_doc{
-    "Bit-wise OR the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise OR the arguments element-wise", "Null values return null.", {"x", "y"}};
 
 const FunctionDoc bit_wise_xor_doc{
-    "Bit-wise XOR the arguments element-wise", ("Null values return null."), {"x", "y"}};
+    "Bit-wise XOR the arguments element-wise", "Null values return null.", {"x", "y"}};
 
 const FunctionDoc shift_left_doc{
     "Left shift `x` by `y`",
@@ -1506,12 +1527,12 @@ const FunctionDoc acos_checked_doc{
     {"x"}};
 
 const FunctionDoc atan_doc{"Compute the principal value of the inverse tangent",
-                           ("Integer arguments return double values."),
+                           "Integer arguments return double values.",
                            {"x"}};
 
 const FunctionDoc atan2_doc{
     "Compute the inverse tangent using argument signs to determine the quadrant",
-    ("Integer arguments return double values."),
+    "Integer arguments return double values.",
     {"y", "x"}};
 
 const FunctionDoc ln_doc{
@@ -1567,6 +1588,21 @@ const FunctionDoc log1p_checked_doc{
      "Use function \"log1p\" if you want non-positive values to return "
      "-inf or NaN."),
     {"x"}};
+
+const FunctionDoc floor_doc{
+    "Calculate the greatest integer less than or equal to the argument element-wise",
+    "",
+    {"x"}};
+
+const FunctionDoc ceiling_doc{
+    "Calculate the least integer greater than or equal to the argument element-wise",
+    "",
+    {"x"}};
+
+const FunctionDoc truncate_doc{
+    "Calculate the nearest integer not greater than to the argument element-wise",
+    "",
+    {"x"}};
 }  // namespace
 
 void RegisterScalarArithmetic(FunctionRegistry* registry) {
@@ -1592,7 +1628,6 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(add_checked)));
 
   // ----------------------------------------------------------------------
-  // subtract
   auto subtract = MakeArithmeticFunction<Subtract>("subtract", &sub_doc);
   AddDecimalBinaryKernels<Subtract>("subtract", &subtract);
 
@@ -1767,6 +1802,17 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   auto log1p_checked = MakeUnaryArithmeticFunctionFloatingPointNotNull<Log1pChecked>(
       "log1p_checked", &log1p_checked_doc);
   DCHECK_OK(registry->AddFunction(std::move(log1p_checked)));
+
+  // ----------------------------------------------------------------------
+  // Rounding functions
+  auto floor = MakeUnaryArithmeticFunctionFloatingPoint<Floor>("floor", &floor_doc);
+  DCHECK_OK(registry->AddFunction(std::move(floor)));
+
+  auto ceiling = MakeUnaryArithmeticFunctionFloatingPoint<Ceiling>("ceiling", &ceiling_doc);
+  DCHECK_OK(registry->AddFunction(std::move(ceiling)));
+
+  auto truncate = MakeUnaryArithmeticFunctionFloatingPoint<Truncate>("truncate", &truncate_doc);
+  DCHECK_OK(registry->AddFunction(std::move(truncate)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1590,17 +1590,20 @@ const FunctionDoc log1p_checked_doc{
     {"x"}};
 
 const FunctionDoc floor_doc{
-    "Calculate the greatest integer less than or equal to the argument element-wise",
+    "Calculate the greatest integer in magnitude less than or equal to the "
+    "argument element-wise",
     "",
     {"x"}};
 
 const FunctionDoc ceiling_doc{
-    "Calculate the least integer greater than or equal to the argument element-wise",
+    "Calculate the least integer in magnitude greater than or equal to the "
+    "argument element-wise",
     "",
     {"x"}};
 
 const FunctionDoc truncate_doc{
-    "Calculate the nearest integer not greater than to the argument element-wise",
+    "Calculate the nearest integer not greater in magnitude than to the "
+    "argument element-wise",
     "",
     {"x"}};
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -824,14 +824,14 @@ struct Floor {
   }
 };
 
-struct Ceiling {
+struct Ceil {
   template <typename T, typename Arg>
   static constexpr enable_if_floating_point<T> Call(KernelContext*, Arg arg, Status*) {
     return std::ceil(arg);
   }
 };
 
-struct Truncate {
+struct Trunc {
   template <typename T, typename Arg>
   static constexpr enable_if_floating_point<T> Call(KernelContext*, Arg arg, Status*) {
     return std::trunc(arg);
@@ -1590,21 +1590,21 @@ const FunctionDoc log1p_checked_doc{
     {"x"}};
 
 const FunctionDoc floor_doc{
-    "Calculate the greatest integer in magnitude less than or equal to the "
-    "argument element-wise",
-    "",
+    "Round down to the nearest integer",
+    ("Calculate the nearest integer less than or equal in magnitude to the "
+     "argument element-wise"),
     {"x"}};
 
-const FunctionDoc ceiling_doc{
-    "Calculate the least integer in magnitude greater than or equal to the "
-    "argument element-wise",
-    "",
+const FunctionDoc ceil_doc{
+    "Round up to the nearest integer",
+    ("Calculate the nearest integer greater than or equal in magnitude to the "
+     "argument element-wise"),
     {"x"}};
 
-const FunctionDoc truncate_doc{
-    "Calculate the nearest integer not greater in magnitude than to the "
-    "argument element-wise",
-    "",
+const FunctionDoc trunc_doc{
+    "Get the integral part without fractional digits",
+    ("Calculate the nearest integer not greater in magnitude than to the "
+     "argument element-wise."),
     {"x"}};
 }  // namespace
 
@@ -1811,13 +1811,11 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   auto floor = MakeUnaryArithmeticFunctionFloatingPoint<Floor>("floor", &floor_doc);
   DCHECK_OK(registry->AddFunction(std::move(floor)));
 
-  auto ceiling =
-      MakeUnaryArithmeticFunctionFloatingPoint<Ceiling>("ceiling", &ceiling_doc);
-  DCHECK_OK(registry->AddFunction(std::move(ceiling)));
+  auto ceil = MakeUnaryArithmeticFunctionFloatingPoint<Ceil>("ceil", &ceil_doc);
+  DCHECK_OK(registry->AddFunction(std::move(ceil)));
 
-  auto truncate =
-      MakeUnaryArithmeticFunctionFloatingPoint<Truncate>("truncate", &truncate_doc);
-  DCHECK_OK(registry->AddFunction(std::move(truncate)));
+  auto trunc = MakeUnaryArithmeticFunctionFloatingPoint<Trunc>("trunc", &trunc_doc);
+  DCHECK_OK(registry->AddFunction(std::move(trunc)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -66,7 +66,7 @@ class TestUnaryArithmetic : public TestBase {
     return *arrow::MakeScalar(type_singleton(), value);
   }
 
-  // (Scalar, Scalar)
+  // (CScalar, CScalar)
   void AssertUnaryOp(UnaryFunction func, CType argument, CType expected) {
     auto arg = MakeScalar(argument);
     auto exp = MakeScalar(expected);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1067,7 +1067,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
     CheckDispatchFails(name, {null()});
   }
 
-  // Signed-only types
+  // Signed types
   for (std::string name : {"negate_checked"}) {
     for (const auto& ty : {int8(), int16(), int32(), int64(), float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});
@@ -1075,7 +1075,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
     }
   }
 
-  // Float-only types (with _checked variant)
+  // Float types (with _checked variant)
   for (std::string name :
        {"ln", "log2", "log10", "log1p", "sin", "cos", "tan", "asin", "acos"}) {
     for (std::string suffix : {"", "_checked"}) {
@@ -1087,7 +1087,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
     }
   }
 
-  // Float-only types
+  // Float types
   for (std::string name : {"atan", "sign", "floor", "ceiling", "truncate"}) {
     for (const auto& ty : {float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -991,6 +991,13 @@ TEST(TestBinaryArithmetic, DispatchBest) {
                         {float64(), float64()});
     }
   }
+
+  CheckDispatchBest("atan2", {int32(), float64()}, {float64(), float64()});
+  CheckDispatchBest("atan2", {int32(), uint8()}, {float64(), float64()});
+  CheckDispatchBest("atan2", {int32(), null()}, {float64(), float64()});
+  CheckDispatchBest("atan2", {float32(), float64()}, {float64(), float64()});
+  // Integer always promotes to double
+  CheckDispatchBest("atan2", {float32(), int8()}, {float64(), float64()});
 }
 
 TEST(TestBinaryArithmetic, AddWithImplicitCasts) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1063,7 +1063,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Fail on null type
-  for (std::string name : {"atan", "sign", "floor", "ceiling", "truncate"}) {
+  for (std::string name : {"atan", "sign", "floor", "ceil", "trunc"}) {
     CheckDispatchFails(name, {null()});
   }
 
@@ -1088,7 +1088,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Float types
-  for (std::string name : {"atan", "sign", "floor", "ceiling", "truncate"}) {
+  for (std::string name : {"atan", "floor", "ceil", "trunc"}) {
     for (const auto& ty : {float32(), float64()}) {
       CheckDispatchBest(name, {ty}, {ty});
       CheckDispatchBest(name, {dictionary(int8(), ty)}, {ty});
@@ -1109,7 +1109,7 @@ TEST(TestUnaryArithmetic, DispatchBest) {
   }
 
   // Integer -> Float64
-  for (std::string name : {"atan", "floor", "ceiling", "truncate"}) {
+  for (std::string name : {"atan", "floor", "ceil", "trunc"}) {
     for (const auto& ty :
          {int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(), uint64()}) {
       CheckDispatchBest(name, {ty}, {float64()});
@@ -2123,106 +2123,103 @@ TYPED_TEST(TestUnaryArithmeticFloating, Floor) {
   this->AssertUnaryOp(floor, this->MakeScalar(max), this->MakeScalar(max));
 }
 
-TYPED_TEST(TestUnaryArithmeticSigned, Ceiling) {
-  auto ceiling = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Ceiling(arg, ctx);
+TYPED_TEST(TestUnaryArithmeticSigned, Ceil) {
+  auto ceil = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Ceil(arg, ctx);
   };
 
-  this->AssertUnaryOp(ceiling, "[]", ArrayFromJSON(float64(), "[]"));
-  this->AssertUnaryOp(ceiling, "[null]", ArrayFromJSON(float64(), "[null]"));
-  this->AssertUnaryOp(ceiling, "[1, null, -10]",
-                      ArrayFromJSON(float64(), "[1, null, -10]"));
-  this->AssertUnaryOp(ceiling, "[0]", ArrayFromJSON(float64(), "[0]"));
-  this->AssertUnaryOp(ceiling, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
-  this->AssertUnaryOp(ceiling, "[-1, -10, -127]",
+  this->AssertUnaryOp(ceil, "[]", ArrayFromJSON(float64(), "[]"));
+  this->AssertUnaryOp(ceil, "[null]", ArrayFromJSON(float64(), "[null]"));
+  this->AssertUnaryOp(ceil, "[1, null, -10]", ArrayFromJSON(float64(), "[1, null, -10]"));
+  this->AssertUnaryOp(ceil, "[0]", ArrayFromJSON(float64(), "[0]"));
+  this->AssertUnaryOp(ceil, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
+  this->AssertUnaryOp(ceil, "[-1, -10, -127]",
                       ArrayFromJSON(float64(), "[-1, -10, -127]"));
 }
 
-TYPED_TEST(TestUnaryArithmeticUnsigned, Ceiling) {
-  auto ceiling = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Ceiling(arg, ctx);
+TYPED_TEST(TestUnaryArithmeticUnsigned, Ceil) {
+  auto ceil = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Ceil(arg, ctx);
   };
 
-  this->AssertUnaryOp(ceiling, "[]", ArrayFromJSON(float64(), "[]"));
-  this->AssertUnaryOp(ceiling, "[null]", ArrayFromJSON(float64(), "[null]"));
-  this->AssertUnaryOp(ceiling, "[1, null, 10]",
-                      ArrayFromJSON(float64(), "[1, null, 10]"));
-  this->AssertUnaryOp(ceiling, "[0]", ArrayFromJSON(float64(), "[0]"));
-  this->AssertUnaryOp(ceiling, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
+  this->AssertUnaryOp(ceil, "[]", ArrayFromJSON(float64(), "[]"));
+  this->AssertUnaryOp(ceil, "[null]", ArrayFromJSON(float64(), "[null]"));
+  this->AssertUnaryOp(ceil, "[1, null, 10]", ArrayFromJSON(float64(), "[1, null, 10]"));
+  this->AssertUnaryOp(ceil, "[0]", ArrayFromJSON(float64(), "[0]"));
+  this->AssertUnaryOp(ceil, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
 }
 
-TYPED_TEST(TestUnaryArithmeticFloating, Ceiling) {
+TYPED_TEST(TestUnaryArithmeticFloating, Ceil) {
   using CType = typename TestFixture::CType;
   auto min = std::numeric_limits<CType>::lowest();
   auto max = std::numeric_limits<CType>::max();
 
   this->SetNansEqual(true);
 
-  auto ceiling = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Ceiling(arg, ctx);
+  auto ceil = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Ceil(arg, ctx);
   };
 
-  this->AssertUnaryOp(ceiling, "[]", "[]");
-  this->AssertUnaryOp(ceiling, "[null]", "[null]");
-  this->AssertUnaryOp(ceiling, "[1.3, null, -10.80]", "[2, null, -10]");
-  this->AssertUnaryOp(ceiling, "[0.0, -0.0]", "[0, 0]");
-  this->AssertUnaryOp(ceiling, "[1.3, 10.80, 12748.001]", "[2, 11, 12749]");
-  this->AssertUnaryOp(ceiling, "[-1.3, -10.80, -12748.001]", "[-1, -10, -12748]");
-  this->AssertUnaryOp(ceiling, "[Inf, -Inf]", "[Inf, -Inf]");
-  this->AssertUnaryOp(ceiling, "[NaN]", "[NaN]");
-  this->AssertUnaryOp(ceiling, this->MakeScalar(min), this->MakeScalar(min));
-  this->AssertUnaryOp(ceiling, this->MakeScalar(max), this->MakeScalar(max));
+  this->AssertUnaryOp(ceil, "[]", "[]");
+  this->AssertUnaryOp(ceil, "[null]", "[null]");
+  this->AssertUnaryOp(ceil, "[1.3, null, -10.80]", "[2, null, -10]");
+  this->AssertUnaryOp(ceil, "[0.0, -0.0]", "[0, 0]");
+  this->AssertUnaryOp(ceil, "[1.3, 10.80, 12748.001]", "[2, 11, 12749]");
+  this->AssertUnaryOp(ceil, "[-1.3, -10.80, -12748.001]", "[-1, -10, -12748]");
+  this->AssertUnaryOp(ceil, "[Inf, -Inf]", "[Inf, -Inf]");
+  this->AssertUnaryOp(ceil, "[NaN]", "[NaN]");
+  this->AssertUnaryOp(ceil, this->MakeScalar(min), this->MakeScalar(min));
+  this->AssertUnaryOp(ceil, this->MakeScalar(max), this->MakeScalar(max));
 }
 
-TYPED_TEST(TestUnaryArithmeticSigned, Truncate) {
-  auto truncate = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Truncate(arg, ctx);
+TYPED_TEST(TestUnaryArithmeticSigned, Trunc) {
+  auto trunc = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Trunc(arg, ctx);
   };
 
-  this->AssertUnaryOp(truncate, "[]", ArrayFromJSON(float64(), "[]"));
-  this->AssertUnaryOp(truncate, "[null]", ArrayFromJSON(float64(), "[null]"));
-  this->AssertUnaryOp(truncate, "[1, null, -10]",
+  this->AssertUnaryOp(trunc, "[]", ArrayFromJSON(float64(), "[]"));
+  this->AssertUnaryOp(trunc, "[null]", ArrayFromJSON(float64(), "[null]"));
+  this->AssertUnaryOp(trunc, "[1, null, -10]",
                       ArrayFromJSON(float64(), "[1, null, -10]"));
-  this->AssertUnaryOp(truncate, "[0]", ArrayFromJSON(float64(), "[0]"));
-  this->AssertUnaryOp(truncate, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
-  this->AssertUnaryOp(truncate, "[-1, -10, -127]",
+  this->AssertUnaryOp(trunc, "[0]", ArrayFromJSON(float64(), "[0]"));
+  this->AssertUnaryOp(trunc, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
+  this->AssertUnaryOp(trunc, "[-1, -10, -127]",
                       ArrayFromJSON(float64(), "[-1, -10, -127]"));
 }
 
-TYPED_TEST(TestUnaryArithmeticUnsigned, Truncate) {
-  auto truncate = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Truncate(arg, ctx);
+TYPED_TEST(TestUnaryArithmeticUnsigned, Trunc) {
+  auto trunc = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Trunc(arg, ctx);
   };
 
-  this->AssertUnaryOp(truncate, "[]", ArrayFromJSON(float64(), "[]"));
-  this->AssertUnaryOp(truncate, "[null]", ArrayFromJSON(float64(), "[null]"));
-  this->AssertUnaryOp(truncate, "[1, null, 10]",
-                      ArrayFromJSON(float64(), "[1, null, 10]"));
-  this->AssertUnaryOp(truncate, "[0]", ArrayFromJSON(float64(), "[0]"));
-  this->AssertUnaryOp(truncate, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
+  this->AssertUnaryOp(trunc, "[]", ArrayFromJSON(float64(), "[]"));
+  this->AssertUnaryOp(trunc, "[null]", ArrayFromJSON(float64(), "[null]"));
+  this->AssertUnaryOp(trunc, "[1, null, 10]", ArrayFromJSON(float64(), "[1, null, 10]"));
+  this->AssertUnaryOp(trunc, "[0]", ArrayFromJSON(float64(), "[0]"));
+  this->AssertUnaryOp(trunc, "[1, 10, 127]", ArrayFromJSON(float64(), "[1, 10, 127]"));
 }
 
-TYPED_TEST(TestUnaryArithmeticFloating, Truncate) {
+TYPED_TEST(TestUnaryArithmeticFloating, Trunc) {
   using CType = typename TestFixture::CType;
   auto min = std::numeric_limits<CType>::lowest();
   auto max = std::numeric_limits<CType>::max();
 
   this->SetNansEqual(true);
 
-  auto truncate = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
-    return Truncate(arg, ctx);
+  auto trunc = [](const Datum& arg, ArithmeticOptions, ExecContext* ctx) {
+    return Trunc(arg, ctx);
   };
 
-  this->AssertUnaryOp(truncate, "[]", "[]");
-  this->AssertUnaryOp(truncate, "[null]", "[null]");
-  this->AssertUnaryOp(truncate, "[1.3, null, -10.80]", "[1, null, -10]");
-  this->AssertUnaryOp(truncate, "[0.0, -0.0]", "[0, 0]");
-  this->AssertUnaryOp(truncate, "[1.3, 10.80, 12748.001]", "[1, 10, 12748]");
-  this->AssertUnaryOp(truncate, "[-1.3, -10.80, -12748.001]", "[-1, -10, -12748]");
-  this->AssertUnaryOp(truncate, "[Inf, -Inf]", "[Inf, -Inf]");
-  this->AssertUnaryOp(truncate, "[NaN]", "[NaN]");
-  this->AssertUnaryOp(truncate, this->MakeScalar(min), this->MakeScalar(min));
-  this->AssertUnaryOp(truncate, this->MakeScalar(max), this->MakeScalar(max));
+  this->AssertUnaryOp(trunc, "[]", "[]");
+  this->AssertUnaryOp(trunc, "[null]", "[null]");
+  this->AssertUnaryOp(trunc, "[1.3, null, -10.80]", "[1, null, -10]");
+  this->AssertUnaryOp(trunc, "[0.0, -0.0]", "[0, 0]");
+  this->AssertUnaryOp(trunc, "[1.3, 10.80, 12748.001]", "[1, 10, 12748]");
+  this->AssertUnaryOp(trunc, "[-1.3, -10.80, -12748.001]", "[-1, -10, -12748]");
+  this->AssertUnaryOp(trunc, "[Inf, -Inf]", "[Inf, -Inf]");
+  this->AssertUnaryOp(trunc, "[NaN]", "[NaN]");
+  this->AssertUnaryOp(trunc, this->MakeScalar(min), this->MakeScalar(min));
+  this->AssertUnaryOp(trunc, this->MakeScalar(max), this->MakeScalar(max));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -348,6 +348,22 @@ Bit-wise functions
   out of bounds for the data type.  However, an overflow when shifting the
   first input is not error (truncated bits are silently discarded).
 
+Rounding functions
+~~~~~~~~~~~~~~~~~~
+
+Rounding functions convert a numeric input into an approximate value with a
+simpler representation based on the rounding strategy.
+
++------------------+--------+----------------+-----------------+-------+
+| Function name    | Arity  | Input types    | Output type     | Notes |
++==================+========+================+=================+=======+
+| floor            | Unary  | Numeric        | Float32/Float64 |       |
++------------------+--------+----------------+-----------------+-------+
+| ceiling          | Unary  | Numeric        | Float32/Float64 |       |
++------------------+--------+----------------+-----------------+-------+
+| truncate         | Unary  | Numeric        | Float32/Float64 |       |
++------------------+--------+----------------+-----------------+-------+
+
 Logarithmic functions
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -359,9 +359,9 @@ simpler representation based on the rounding strategy.
 +==================+========+================+=================+=======+
 | floor            | Unary  | Numeric        | Float32/Float64 |       |
 +------------------+--------+----------------+-----------------+-------+
-| ceiling          | Unary  | Numeric        | Float32/Float64 |       |
+| ceil             | Unary  | Numeric        | Float32/Float64 |       |
 +------------------+--------+----------------+-----------------+-------+
-| truncate         | Unary  | Numeric        | Float32/Float64 |       |
+| trunc            | Unary  | Numeric        | Float32/Float64 |       |
 +------------------+--------+----------------+-----------------+-------+
 
 Logarithmic functions

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -83,9 +83,9 @@ simpler representation based on the rounding strategy.
 .. autosummary::
    :toctree: ../generated/
 
-   ceiling
+   ceil
    floor
-   truncate
+   trunc
 
 Logarithmic Functions
 ---------------------

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -74,6 +74,19 @@ Bit-wise operations do not offer (or need) a checked variant.
    bit_wise_or
    bit_wise_xor
 
+Rounding Functions
+------------------
+
+Rounding functions convert a numeric input into an approximate value with a
+simpler representation based on the rounding strategy.
+
+.. autosummary::
+   :toctree: ../generated/
+
+   ceiling
+   floor
+   truncate
+
 Logarithmic Functions
 ---------------------
 


### PR DESCRIPTION
This PR adds floor, ceiling, and truncate scalar kernels. For all integral inputs, output is a 64-bit floating-point value.