### PR TITLE
ARROW-12513: [C++][Parquet] Parquet Writer always puts null_count=0 in Parquet statistics for dictionary-encoded array with nulls

### DIFF
--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -464,7 +464,6 @@ TEST(TestTupleVectorFromTable, ListType) {
   using tuple_type = std::tuple<std::vector<int64_t>>;
 
   compute::ExecContext ctx;
-  ctx.set_use_threads(false);
   compute::CastOptions cast_options;
   auto expected_schema =
       std::shared_ptr<Schema>(new Schema({field("column1", list(int64()), false)}));

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -464,6 +464,7 @@ TEST(TestTupleVectorFromTable, ListType) {
   using tuple_type = std::tuple<std::vector<int64_t>>;
 
   compute::ExecContext ctx;
+  ctx.set_use_threads(false);
   compute::CastOptions cast_options;
   auto expected_schema =
       std::shared_ptr<Schema>(new Schema({field("column1", list(int64()), false)}));

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3819,17 +3819,17 @@ class TestArrowWriteDictionary : public ::testing::Test {
     for (char val = start; val <= end; val++) {
       int32_t index = static_cast<int32_t>(val - start);
       if (val - start >= num_nulls) {
-        indices_builder.Append(index);
+        ASSERT_OK(indices_builder.Append(index));
       } else {
-        indices_builder.AppendNull();
+        ASSERT_OK(indices_builder.AppendNull());
       }
-      dictionary_builder.Append(&val, 1);
+      ASSERT_OK(dictionary_builder.Append(&val, 1));
     }
 
     std::shared_ptr<::arrow::Array> dictionary;
     std::shared_ptr<::arrow::Array> indices;
-    dictionary_builder.Finish(&dictionary);
-    indices_builder.Finish(&indices);
+    ASSERT_OK(dictionary_builder.Finish(&dictionary));
+    ASSERT_OK(indices_builder.Finish(&indices));
 
     ASSERT_OK_AND_ASSIGN(auto test_column,
                          ::arrow::DictionaryArray::FromArrays(indices, dictionary));

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3796,20 +3796,34 @@ TEST(TestArrowWriterAdHoc, SchemaMismatch) {
   ASSERT_RAISES(Invalid, writer->WriteTable(*tbl, 1));
 }
 
-TEST(TestArrowWriteDictionary, Statistics) {
+class TestArrowWriteDictionary : public ::testing::TestWithParam<ParquetDataPageVersion> {
+ public:
+  ParquetDataPageVersion ParquetDataPageVersion() { return GetParam(); }
+};
+
+TEST_P(TestArrowWriteDictionary, Statistics) {
   std::vector<std::shared_ptr<::arrow::Array>> test_dictionaries = {
+      ArrayFromJSON(::arrow::utf8(), R"(["b", "c", "d", "a", "b", "c", "d", "a"])"),
       ArrayFromJSON(::arrow::utf8(), R"(["b", "c", "d", "a", "b", "c", "d", "a"])"),
       ArrayFromJSON(::arrow::binary(), R"(["d", "c", "b", "a", "d", "c", "b", "a"])"),
       ArrayFromJSON(::arrow::large_utf8(), R"(["a", "b", "c", "a", "b", "c"])")};
   std::vector<std::shared_ptr<::arrow::Array>> test_indices = {
       ArrayFromJSON(::arrow::int32(), R"([0, null, 3, 0, null, 3])"),
+      ArrayFromJSON(::arrow::int32(), R"([0, 1, null, 0, 1, null])"),
       ArrayFromJSON(::arrow::int32(), R"([0, 1, 3, 0, 1, 3])"),
       ArrayFromJSON(::arrow::int32(), R"([null, null, null, null, null, null])")};
-  // Pairs of (valid, null) counters (per batch so half the total value)
-  std::vector<std::vector<int64_t>> expected_counts = {{2, 1}, {3, 0}, {0, 3}};
+  // Arrays will be written with 3 values per row group, 2 values per data page.  The
+  // row groups are identical for ease of testing.
+  std::vector<int32_t> expected_valid_counts = {2, 2, 3, 0};
+  std::vector<int32_t> expected_null_counts = {1, 1, 0, 3};
+  std::vector<int> expected_num_data_pages = {2, 2, 2, 1};
+  std::vector<std::vector<int32_t>> expected_valid_by_page = {
+      {1, 1}, {2, 0}, {2, 1}, {0}};
+  std::vector<std::vector<int64_t>> expected_null_by_page = {{1, 0}, {0, 1}, {0, 0}, {3}};
+  std::vector<int32_t> expected_dict_counts = {4, 4, 4, 3};
   // Pairs of (min, max)
   std::vector<std::vector<std::string>> expected_min_max_ = {
-      {"a", "b"}, {"a", "d"}, {"", ""}};
+      {"a", "b"}, {"b", "c"}, {"a", "d"}, {"", ""}};
 
   for (std::size_t case_index = 0; case_index < test_dictionaries.size(); case_index++) {
     SCOPED_TRACE(test_dictionaries[case_index]->type()->ToString());
@@ -3822,8 +3836,11 @@ TEST(TestArrowWriteDictionary, Statistics) {
 
     std::shared_ptr<::arrow::ResizableBuffer> serialized_data = AllocateBuffer();
     auto out_stream = std::make_shared<::arrow::io::BufferOutputStream>(serialized_data);
-    std::shared_ptr<WriterProperties> writer_properties =
-        WriterProperties::Builder().max_row_group_length(3)->build();
+    std::shared_ptr<WriterProperties> writer_properties = WriterProperties::Builder()
+                                                              .max_row_group_length(3)
+                                                              ->write_batch_size(2)
+                                                              ->data_pagesize(2)
+                                                              ->build();
     std::unique_ptr<FileWriter> writer;
     ASSERT_OK(FileWriter::Open(*schema, ::arrow::default_memory_pool(), out_stream,
                                writer_properties, default_arrow_writer_properties(),
@@ -3835,25 +3852,51 @@ TEST(TestArrowWriteDictionary, Statistics) {
     auto buffer_reader = std::make_shared<::arrow::io::BufferReader>(serialized_data);
     std::unique_ptr<ParquetFileReader> parquet_reader =
         ParquetFileReader::Open(std::move(buffer_reader));
+
+    // Check row group statistics
     std::shared_ptr<FileMetaData> metadata = parquet_reader->metadata();
-
     ASSERT_EQ(metadata->num_row_groups(), 2);
-
     for (int row_group_index = 0; row_group_index < 2; row_group_index++) {
       ASSERT_EQ(metadata->RowGroup(row_group_index)->num_columns(), 1);
       std::shared_ptr<Statistics> stats =
           metadata->RowGroup(row_group_index)->ColumnChunk(0)->statistics();
 
-      std::vector<int64_t> case_expected_counts = expected_counts[case_index];
-      EXPECT_EQ(stats->num_values(), case_expected_counts[0]);
-      EXPECT_EQ(stats->null_count(), case_expected_counts[1]);
+      EXPECT_EQ(stats->num_values(), expected_valid_counts[case_index]);
+      EXPECT_EQ(stats->null_count(), expected_null_counts[case_index]);
 
       std::vector<std::string> case_expected_min_max = expected_min_max_[case_index];
       EXPECT_EQ(stats->EncodeMin(), case_expected_min_max[0]);
       EXPECT_EQ(stats->EncodeMax(), case_expected_min_max[1]);
     }
+
+    for (int row_group_index = 0; row_group_index < 2; row_group_index++) {
+      std::unique_ptr<PageReader> page_reader =
+          parquet_reader->RowGroup(row_group_index)->GetColumnPageReader(0);
+      std::shared_ptr<Page> page = page_reader->NextPage();
+      ASSERT_NE(page, nullptr);
+      DictionaryPage* dict_page = (DictionaryPage*)page.get();
+      ASSERT_EQ(dict_page->num_values(), expected_dict_counts[case_index]);
+      for (int page_index = 0; page_index < expected_num_data_pages[case_index];
+           page_index++) {
+        page = page_reader->NextPage();
+        ASSERT_NE(page, nullptr);
+        DataPage* data_page = (DataPage*)page.get();
+        const EncodedStatistics& stats = data_page->statistics();
+        EXPECT_EQ(stats.null_count, expected_null_by_page[case_index][page_index]);
+        EXPECT_EQ(stats.has_min, false);
+        EXPECT_EQ(stats.has_max, false);
+        EXPECT_EQ(data_page->num_values(),
+                  expected_valid_by_page[case_index][page_index] +
+                      expected_null_by_page[case_index][page_index]);
+      }
+      ASSERT_EQ(page_reader->NextPage(), nullptr);
+    }
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(WriteDictionary, TestArrowWriteDictionary,
+                         ::testing::Values(ParquetDataPageVersion::V1,
+                                           ParquetDataPageVersion::V2));
 
 // ----------------------------------------------------------------------
 // Tests for directly reading DictionaryArray

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3798,7 +3798,7 @@ TEST(TestArrowWriterAdHoc, SchemaMismatch) {
 
 class TestArrowWriteDictionary : public ::testing::TestWithParam<ParquetDataPageVersion> {
  public:
-  ParquetDataPageVersion ParquetDataPageVersion() { return GetParam(); }
+  ParquetDataPageVersion GetParquetDataPageVersion() { return GetParam(); }
 };
 
 TEST_P(TestArrowWriteDictionary, Statistics) {
@@ -3836,11 +3836,13 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
 
     std::shared_ptr<::arrow::ResizableBuffer> serialized_data = AllocateBuffer();
     auto out_stream = std::make_shared<::arrow::io::BufferOutputStream>(serialized_data);
-    std::shared_ptr<WriterProperties> writer_properties = WriterProperties::Builder()
-                                                              .max_row_group_length(3)
-                                                              ->write_batch_size(2)
-                                                              ->data_pagesize(2)
-                                                              ->build();
+    std::shared_ptr<WriterProperties> writer_properties =
+        WriterProperties::Builder()
+            .max_row_group_length(3)
+            ->data_page_version(this->GetParquetDataPageVersion())
+            ->write_batch_size(2)
+            ->data_pagesize(2)
+            ->build();
     std::unique_ptr<FileWriter> writer;
     ASSERT_OK(FileWriter::Open(*schema, ::arrow::default_memory_pool(), out_stream,
                                writer_properties, default_arrow_writer_properties(),

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1490,7 +1490,8 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
     // TODO(wesm): If some dictionary values are unobserved, then the
     // statistics will be inaccurate. Do we care enough to fix it?
     if (page_statistics_ != nullptr) {
-      PARQUET_CATCH_NOT_OK(page_statistics_->Update(*dictionary));
+      PARQUET_CATCH_NOT_OK(
+          page_statistics_->UpdateArrowDictionary(*indices, *dictionary));
     }
     preserved_dictionary_ = dictionary;
   } else if (!dictionary->Equals(*preserved_dictionary_)) {

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1495,6 +1495,7 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
       // Once the MinMax kernel supports all data types we should use that kernel instead
       // as it does not make any copies.
       ::arrow::compute::ExecContext exec_ctx(ctx->memory_pool);
+      exec_ctx.set_use_threads(false);
       PARQUET_ASSIGN_OR_THROW(::arrow::Datum referenced_indices,
                               ::arrow::compute::Unique(*indices, &exec_ctx));
       PARQUET_ASSIGN_OR_THROW(

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -939,13 +939,13 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
                             combined->CopySlice(0, combined->size(), allocator_));
     std::unique_ptr<DataPage> page_ptr(new DataPageV2(
         combined, num_values, null_count, num_values, encoding_, def_levels_byte_length,
-        rep_levels_byte_length, uncompressed_size, pager_->has_compressor()));
+        rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats));
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
     data_pages_.push_back(std::move(page_ptr));
   } else {
     DataPageV2 page(combined, num_values, null_count, num_values, encoding_,
                     def_levels_byte_length, rep_levels_byte_length, uncompressed_size,
-                    pager_->has_compressor());
+                    pager_->has_compressor(), page_stats);
     WriteDataPage(page);
   }
 }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1488,9 +1488,9 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
     }
 
     if (page_statistics_ != nullptr) {
-      // TODO(PARQUET-2068) This approach makes two copies.  First, a copy of the indices
-      // array to a (hopefully smaller) referenced indices array.  Second, a copy of the
-      // values array to a (probably not smaller) referenced values array.
+      // TODO(PARQUET-2068) This approach may make two copies.  First, a copy of the
+      // indices array to a (hopefully smaller) referenced indices array.  Second, a copy
+      // of the values array to a (probably not smaller) referenced values array.
       //
       // Once the MinMax kernel supports all data types we should use that kernel instead
       // as it does not make any copies.

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -569,7 +569,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
 
   void UpdateArrowDictionary(const ::arrow::Array& indices,
-                             const ::arrow::Array& dictionary) {
+                             const ::arrow::Array& dictionary) override {
     IncrementNullCount(indices.null_count());
     IncrementNumValues(indices.length() - indices.null_count());
 

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -289,13 +289,25 @@ class TypedStatistics : public Statistics {
   /// conversion to a primitive Parquet C type. Only implemented for certain
   /// Parquet type / Arrow type combinations like BYTE_ARRAY /
   /// arrow::BinaryArray
-  virtual void Update(const ::arrow::Array& values) = 0;
-
-  virtual void UpdateArrowDictionary(const ::arrow::Array& indices,
-                                     const ::arrow::Array& dictionary) = 0;
+  ///
+  /// If update_counts is true then the null_count and num_values will be updated
+  /// based on the null_count of values.  Set to false if these are updated
+  /// elsewhere (e.g. when updating a dictionary where the counts are taken from
+  /// the indices and not the values)
+  virtual void Update(const ::arrow::Array& values, bool update_counts = true) = 0;
 
   /// \brief Set min and max values to particular values
   virtual void SetMinMax(const T& min, const T& max) = 0;
+
+  /// \brief Increments the null count directly
+  /// Use Update to extract the null count from data.  Use this if you determine
+  /// the null count through some other means (e.g. dictionary arrays where the
+  /// null count is determined from the indices)
+  virtual void IncrementNullCount(int64_t n) = 0;
+
+  /// \brief Increments the number ov values directly
+  /// The same note on IncrementNullCount applies here
+  virtual void IncrementNumValues(int64_t n) = 0;
 };
 
 using BoolStatistics = TypedStatistics<BooleanType>;

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -291,6 +291,9 @@ class TypedStatistics : public Statistics {
   /// arrow::BinaryArray
   virtual void Update(const ::arrow::Array& values) = 0;
 
+  virtual void UpdateArrowDictionary(const ::arrow::Array& indices,
+                                     const ::arrow::Array& dictionary) = 0;
+
   /// \brief Set min and max values to particular values
   virtual void SetMinMax(const T& min, const T& max) = 0;
 };


### PR DESCRIPTION
This fixes two issues.
* The null_count must be obtained from the indices array and not the values array
* The min/max should be based on referenced values and not all values in the values array

Note: This further adds a dependency from parquet onto arrow::compute (I use it both to compute the unique indices and to take the referenced values).  This dependency already existed (column_writer.cc relies on arrow::compute::Cast) so I'm pretty sure this isn't a problem.  Related: ARROW-8891