### PR TITLE
MINOR: Rename setup options chunk

### DIFF
--- a/r/vignettes/developing.Rmd
+++ b/r/vignettes/developing.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup options, include=FALSE}
+```{r setup-options, include=FALSE}
 knitr::opts_chunk$set(error = TRUE, eval = FALSE)
 
 # Get environment variables describing what to evaluate


### PR DESCRIPTION
There is a typo in the "Arrow R Developer Guide" where there is a space in the name of a code chunk instead of a hyphen.  I'm doing some automated analyses of the different code chunks and can't parse this one due to the typo.  This PR just adds a hyphen.