### PR TITLE
ARROW-13386: [R][C++] CSV streaming changes break Rtools 35 32-bit build

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -79,9 +79,9 @@ jobs:
             echo "CLANG_FORMAT_R=true" >> $GITHUB_ENV
           fi
       - name: Ensure clang-format has the appropriate versoin
-        if: env.CMAKE_FORMAT == 'true' || 
-          env.CLANG_FORMAT_CPP == 'true' || 
-          env.CLANG_FORMAT_R == 'true' || 
+        if: env.CMAKE_FORMAT == 'true' ||
+          env.CLANG_FORMAT_CPP == 'true' ||
+          env.CLANG_FORMAT_R == 'true' ||
           endsWith(github.event.comment.body, 'everything')
         run: |
           set -e
@@ -120,6 +120,8 @@ jobs:
         run: |
           source("ci/etc/rprofile")
           install.packages(c("remotes", "roxygen2"))
+          # We currently need dev roxygen2 (> 7.1.1) until they release
+          remotes::install_github("r-lib/roxygen2")
           remotes::install_deps("r")
           roxygen2::roxygenize("r")
       - name: Commit results

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -53,7 +53,7 @@
 #' It returns the appropriate subclass of `FileFormat` (e.g. `ParquetFileFormat`)
 #' @rdname FileFormat
 #' @name FileFormat
-#' @examplesIf arrow_with_dataset()
+#' @examplesIf arrow_with_dataset() && tolower(Sys.info()[["sysname"]]) == "windows"
 #' ## Semi-colon delimited files
 #' # Set up directory for examples
 #' tf <- tempfile()

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -53,7 +53,7 @@
 #' It returns the appropriate subclass of `FileFormat` (e.g. `ParquetFileFormat`)
 #' @rdname FileFormat
 #' @name FileFormat
-#' @examplesIf arrow_with_dataset() && tolower(Sys.info()[["sysname"]]) == "windows"
+#' @examplesIf arrow_with_dataset() && tolower(Sys.info()[["sysname"]]) != "windows"
 #' ## Semi-colon delimited files
 #' # Set up directory for examples
 #' tf <- tempfile()

--- a/r/man/ChunkedArray.Rd
+++ b/r/man/ChunkedArray.Rd
@@ -62,7 +62,7 @@ class_scores$num_chunks
 # When taking a Slice from a chunked_array, chunks are preserved
 class_scores$Slice(2, length = 5)
 
-# You can combine Take and SortIndices to return a ChunkedArray with 1 chunk 
+# You can combine Take and SortIndices to return a ChunkedArray with 1 chunk
 # containing all values, ordered.
 class_scores$Take(class_scores$SortIndices(descending = TRUE))
 

--- a/r/man/FileFormat.Rd
+++ b/r/man/FileFormat.Rd
@@ -52,7 +52,7 @@ It returns the appropriate subclass of \code{FileFormat} (e.g. \code{ParquetFile
 }
 
 \examples{
-\dontshow{if (arrow_with_dataset()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (arrow_with_dataset() && tolower(Sys.info()[["sysname"]]) != "windows") (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ## Semi-colon delimited files
 # Set up directory for examples
 tf <- tempfile()

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -27,6 +27,7 @@ Useful links:
 Authors:
 \itemize{
   \item Ian Cook \email{ianmcook@gmail.com}
+  \item Nic Crane \email{thisisnic@gmail.com}
   \item Jonathan Keane \email{jkeane@gmail.com}
   \item Romain François \email{romain@rstudio.com} (\href{https://orcid.org/0000-0002-2444-4226}{ORCID})
   \item Jeroen Ooms \email{jeroen@berkeley.edu}

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -30,8 +30,9 @@ tsv_dir <- make_temp_dir()
 skip_if_multithreading_disabled <- function() {
   is_32bit <- .Machine$sizeof.pointer < 8
   is_old_r <- getRversion() < "4.0.0"
-  if (is_32bit && is_old_r) {
-    skip_on_os("windows", message = "Multithreading does not work properly on this system")
+  is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
+  if (is_32bit && is_old_r && is_windows) {
+    skip("Multithreading does not work properly on this system")
   }
 }
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -27,6 +27,15 @@ ipc_dir <- make_temp_dir()
 csv_dir <- make_temp_dir()
 tsv_dir <- make_temp_dir()
 
+skip_if_multithreading_disabled <- function() {
+  is_32bit <- .Machine$sizeof.pointer < 8
+  is_old_r <- getRversion() < "4.0.0"
+  if (is_32bit && is_old_r) {
+    skip_on_os("windows", message = "Multithreading does not work properly on this system")
+  }
+}
+
+
 first_date <- lubridate::ymd_hms("2015-04-29 03:12:39")
 df1 <- tibble(
   int = 1:10,
@@ -342,6 +351,7 @@ test_that("IPC/Feather format data", {
 })
 
 test_that("CSV dataset", {
+  skip_if_multithreading_disabled()
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   expect_r6_class(ds$format, "CsvFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
@@ -369,6 +379,7 @@ test_that("CSV dataset", {
 })
 
 test_that("CSV scan options", {
+  skip_if_multithreading_disabled()
   options <- FragmentScanOptions$create("text")
   expect_equal(options$type, "csv")
   options <- FragmentScanOptions$create("csv",
@@ -408,6 +419,7 @@ test_that("CSV scan options", {
 })
 
 test_that("compressed CSV dataset", {
+  skip_if_multithreading_disabled()
   skip_if_not_available("gzip")
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv.gz")
@@ -431,6 +443,7 @@ test_that("compressed CSV dataset", {
 })
 
 test_that("CSV dataset options", {
+  skip_if_multithreading_disabled()
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv")
   df <- tibble(chr = letters[1:10])
@@ -458,6 +471,7 @@ test_that("CSV dataset options", {
 })
 
 test_that("Other text delimited dataset", {
+  skip_if_multithreading_disabled()
   ds1 <- open_dataset(tsv_dir, partitioning = "part", format = "tsv")
   expect_equivalent(
     ds1 %>%
@@ -486,6 +500,7 @@ test_that("Other text delimited dataset", {
 })
 
 test_that("readr parse options", {
+  skip_if_multithreading_disabled()
   arrow_opts <- names(formals(CsvParseOptions$create))
   readr_opts <- names(formals(readr_to_csv_parse_options))
 
@@ -1575,6 +1590,7 @@ test_that("Writing a dataset: Parquet format options", {
 })
 
 test_that("Writing a dataset: CSV format options", {
+  skip_if_multithreading_disabled()
   df <- tibble(
     int = 1:10,
     dbl = as.numeric(1:10),


### PR DESCRIPTION
The streaming CSV reader now creates more threads even when use_threads = false (it creates a CPU thread to do the worker tasks in an async way safe for nested parallelism).  This disturbs RTools 3.5 builds on Windows on 32 bit machines.  Per some discussion in Zulip I am disabling those tests as it is not clear the functionality is needed (i.e. it is not clear that there are many 32-bit consumers).