### PR TITLE
ARROW-13425: [Archery] Avoid importing PyArrow indirectly

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -28,6 +28,7 @@ import sys
 from .benchmark.codec import JsonEncoder
 from .benchmark.compare import RunnerComparator, DEFAULT_THRESHOLD
 from .benchmark.runner import CppBenchmarkRunner, JavaBenchmarkRunner
+from .compat import _import_pandas
 from .lang.cpp import CppCMakeDefinition, CppConfiguration
 from .utils.cli import ArrowBool, validate_arrow_sources, add_optional_command
 from .utils.lint import linter, python_numpydoc, LintValidationException
@@ -647,7 +648,7 @@ def _get_comparisons_as_json(comparisons):
 
 def _format_comparisons_with_pandas(comparisons_json, no_counters,
                                     ren_counters):
-    import pandas as pd
+    pd = _import_pandas()
     df = pd.read_json(StringIO(comparisons_json), lines=True)
     # parse change % so we can sort by it
     df['change %'] = df.pop('change').str[:-1].map(float)

--- a/dev/archery/archery/compat.py
+++ b/dev/archery/archery/compat.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import pathlib
+import sys
 
 
 def _is_path_like(path):
@@ -49,3 +50,10 @@ def _stringify_path(path):
             return str(path)
 
     raise TypeError("not a path-like object")
+
+
+def _import_pandas():
+    # ARROW-13425: avoid importing PyArrow from Pandas
+    sys.modules['pyarrow'] = None
+    import pandas as pd
+    return pd


### PR DESCRIPTION
Pandas will try to import PyArrow if seemingly available.
However, the currently installed PyArrow may not be compatible with the last compiled Arrow C++
(e.g. when using `archery benchmark diff ...`).