### PR TITLE
ARROW-13432: [Release] Fix ssh connection to the binary uploader container

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -129,6 +129,7 @@ docker_run \
   rake \
     "${rake_tasks[@]}" \
     APT_TARGETS=$(IFS=,; echo "${apt_targets[*]}") \
+    ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \
     VERSION=${version} \

--- a/dev/release/utils-binary.sh
+++ b/dev/release/utils-binary.sh
@@ -70,7 +70,7 @@ fi
 /usr/sbin/sshd -D
 "
   local container_id=$(cat ${container_id_file})
-  local ssh_port=$(docker port ${container_id} | grep -E -o '[0-9]+$')
+  local ssh_port=$(docker port ${container_id} | grep -E -o '[0-9]+$' | head -n 1)
   # Wait for sshd available
   while ! docker_gpg_ssh ${ssh_port} : > /dev/null 2>&1; do
     sleep 0.1


### PR DESCRIPTION
Out of the sudden the binary upload script has stopped working for me, it was just hanging infinitely.
After a lot of digging found that the `ssh_port` variable contained two identical ports, thus the port number [was passed to the ssh command as an additional argument](https://github.com/apache/arrow/blob/master/dev/release/utils-binary.sh#L45).

