### PR TITLE
ARROW-13424: [C++] Remove needless workaround for conda and benchmark

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -17,7 +17,7 @@
 
 # workaround for https://issues.apache.org/jira/browse/ARROW-13134
 aws-sdk-cpp<1.9
-benchmark=1.5.2
+benchmark>=1.5.4
 boost-cpp>=1.68.0
 brotli
 bzip2

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1837,18 +1837,6 @@ endmacro()
 if(ARROW_BUILD_BENCHMARKS)
   # ArgsProduct() is available since 1.5.2
   set(BENCHMARK_REQUIRED_VERSION 1.5.2)
-  if("${ARROW_DEPENDENCY_SOURCE}" STREQUAL "CONDA" AND "${benchmark_SOURCE}" STREQUAL
-                                                       "SYSTEM")
-    # TODO: Remove this workaround once
-    # https://github.com/google/benchmark/issues/1046 is resolved.
-    #
-    # benchmark doesn't set suitable version when we use released
-    # archive. So the benchmark package on conda-forge isn't report
-    # the real version. We accept all the benchmark package with
-    # conda. Conda users should install benchmark 1.5.2 or later by
-    # ci/conda_env_cpp.txt.
-    set(BENCHMARK_REQUIRED_VERSION 0.0.0)
-  endif()
   resolve_dependency(benchmark
                      REQUIRED_VERSION
                      ${BENCHMARK_REQUIRED_VERSION}


### PR DESCRIPTION
https://github.com/google/benchmark/issues/1046 has been resolved.