### PR TITLE
ARROW-13426: [C++][Gandiva] Use platform pointer sizes in code generation

### DIFF
--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <vector>
+
 #include "gandiva/llvm_includes.h"
 #include "gandiva/selection_vector.h"
 #include "gandiva/value_validity_pair.h"
@@ -25,7 +26,7 @@
 namespace gandiva {
 
 using EvalFunc = int (*)(uint8_t** buffers, int64_t* offsets, uint8_t** local_bitmaps,
-                         const uint8_t* selection_buffer, int64_t execution_ctx_ptr,
+                         const uint8_t* selection_buffer, void* execution_ctx_ptr,
                          int64_t record_count);
 
 /// \brief Tracks the compiled state for one expression.

--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -29,23 +29,23 @@ void ExportedContextFunctions::AddMappings(Engine* engine) const {
   auto types = engine->types();
 
   // gdv_fn_context_set_error_msg
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type()};   // char const* err_msg
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type()};     // char const* err_msg
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_set_error_msg", types->void_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_context_set_error_msg));
 
   // gdv_fn_context_arena_malloc
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i32_type()};      // int32_t size
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i32_type()};        // int32_t size
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_arena_malloc", types->i8_ptr_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_context_arena_malloc));
 
   // gdv_fn_context_arena_reset
-  args = {types->void_ptr_type()};  // void* context_ptr
+  args = {types->opaque_ptr_type()};  // void* context_ptr
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_arena_reset", types->void_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_context_arena_reset));

--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -18,10 +18,9 @@
 // This file is also used in the pre-compiled unit tests, which do include
 // llvm/engine/..
 #ifndef GANDIVA_UNIT_TEST
+#include "gandiva/engine.h"
 #include "gandiva/exported_funcs.h"
 #include "gandiva/gdv_function_stubs.h"
-
-#include "gandiva/engine.h"
 
 namespace gandiva {
 
@@ -30,23 +29,23 @@ void ExportedContextFunctions::AddMappings(Engine* engine) const {
   auto types = engine->types();
 
   // gdv_fn_context_set_error_msg
-  args = {types->i64_type(),      // int64_t context_ptr
-          types->i8_ptr_type()};  // char const* err_msg
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type()};   // char const* err_msg
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_set_error_msg", types->void_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_context_set_error_msg));
 
   // gdv_fn_context_arena_malloc
-  args = {types->i64_type(),   // int64_t context_ptr
-          types->i32_type()};  // int32_t size
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i32_type()};      // int32_t size
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_arena_malloc", types->i8_ptr_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_context_arena_malloc));
 
   // gdv_fn_context_arena_reset
-  args = {types->i64_type()};  // int64_t context_ptr
+  args = {types->void_ptr_type()};  // void* context_ptr
 
   engine->AddGlobalMappingForFunc("gdv_fn_context_arena_reset", types->void_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_context_arena_reset));
@@ -59,17 +58,17 @@ void ExportedContextFunctions::AddMappings(Engine* engine) const {
 
 extern "C" {
 
-void gdv_fn_context_set_error_msg(int64_t context_ptr, char const* err_msg) {
+void gdv_fn_context_set_error_msg(void* context_ptr, char const* err_msg) {
   auto context = reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
   context->set_error_msg(err_msg);
 }
 
-uint8_t* gdv_fn_context_arena_malloc(int64_t context_ptr, int32_t size) {
+uint8_t* gdv_fn_context_arena_malloc(void* context_ptr, int32_t size) {
   auto context = reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
   return context->arena()->Allocate(size);
 }
 
-void gdv_fn_context_arena_reset(int64_t context_ptr) {
+void gdv_fn_context_arena_reset(void* context_ptr) {
   auto context = reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
   return context->arena()->Reset();
 }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -42,29 +42,31 @@
 
 extern "C" {
 
-bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
-                           const char* pattern, int pattern_len) {
+bool gdv_fn_like_utf8_utf8(void* ptr, const char* data, int data_len, const char* pattern,
+                           int pattern_len) {
   gandiva::LikeHolder* holder = reinterpret_cast<gandiva::LikeHolder*>(ptr);
   return (*holder)(std::string(data, data_len));
 }
 
-bool gdv_fn_like_utf8_utf8_utf8(int64_t ptr, const char* data, int data_len,
+bool gdv_fn_like_utf8_utf8_utf8(void* ptr, const char* data, int data_len,
                                 const char* pattern, int pattern_len,
                                 const char* escape_char, int escape_char_len) {
   gandiva::LikeHolder* holder = reinterpret_cast<gandiva::LikeHolder*>(ptr);
   return (*holder)(std::string(data, data_len));
 }
 
-bool gdv_fn_ilike_utf8_utf8(int64_t ptr, const char* data, int data_len,
+bool gdv_fn_ilike_utf8_utf8(void* ptr, const char* data, int data_len,
                             const char* pattern, int pattern_len) {
   gandiva::LikeHolder* holder = reinterpret_cast<gandiva::LikeHolder*>(ptr);
   return (*holder)(std::string(data, data_len));
 }
 
-const char* gdv_fn_regexp_replace_utf8_utf8(
-    int64_t ptr, int64_t holder_ptr, const char* data, int32_t data_len,
-    const char* /*pattern*/, int32_t /*pattern_len*/, const char* replace_string,
-    int32_t replace_string_len, int32_t* out_length) {
+const char* gdv_fn_regexp_replace_utf8_utf8(void* ptr, void* holder_ptr, const char* data,
+                                            int32_t data_len, const char* /*pattern*/,
+                                            int32_t /*pattern_len*/,
+                                            const char* replace_string,
+                                            int32_t replace_string_len,
+                                            int32_t* out_length) {
   gandiva::ExecutionContext* context = reinterpret_cast<gandiva::ExecutionContext*>(ptr);
 
   gandiva::ReplaceHolder* holder = reinterpret_cast<gandiva::ReplaceHolder*>(holder_ptr);
@@ -73,29 +75,28 @@ const char* gdv_fn_regexp_replace_utf8_utf8(
                    out_length);
 }
 
-double gdv_fn_random(int64_t ptr) {
+double gdv_fn_random(void* ptr) {
   gandiva::RandomGeneratorHolder* holder =
       reinterpret_cast<gandiva::RandomGeneratorHolder*>(ptr);
   return (*holder)();
 }
 
-double gdv_fn_random_with_seed(int64_t ptr, int32_t seed, bool seed_validity) {
+double gdv_fn_random_with_seed(void* ptr, int32_t seed, bool seed_validity) {
   gandiva::RandomGeneratorHolder* holder =
       reinterpret_cast<gandiva::RandomGeneratorHolder*>(ptr);
   return (*holder)();
 }
 
-int64_t gdv_fn_to_date_utf8_utf8(int64_t context_ptr, int64_t holder_ptr,
-                                 const char* data, int data_len, bool in1_validity,
-                                 const char* pattern, int pattern_len, bool in2_validity,
-                                 bool* out_valid) {
+int64_t gdv_fn_to_date_utf8_utf8(void* context_ptr, void* holder_ptr, const char* data,
+                                 int data_len, bool in1_validity, const char* pattern,
+                                 int pattern_len, bool in2_validity, bool* out_valid) {
   gandiva::ExecutionContext* context =
       reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
   gandiva::ToDateHolder* holder = reinterpret_cast<gandiva::ToDateHolder*>(holder_ptr);
   return (*holder)(context, data, data_len, in1_validity, out_valid);
 }
 
-int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t context_ptr, int64_t holder_ptr,
+int64_t gdv_fn_to_date_utf8_utf8_int32(void* context_ptr, void* holder_ptr,
                                        const char* data, int data_len, bool in1_validity,
                                        const char* pattern, int pattern_len,
                                        bool in2_validity, int32_t suppress_errors,
@@ -106,7 +107,7 @@ int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t context_ptr, int64_t holder_ptr,
   return (*holder)(context, data, data_len, in1_validity, out_valid);
 }
 
-bool gdv_fn_in_expr_lookup_int32(int64_t ptr, int32_t value, bool in_validity) {
+bool gdv_fn_in_expr_lookup_int32(void* ptr, int32_t value, bool in_validity) {
   if (!in_validity) {
     return false;
   }
@@ -114,7 +115,7 @@ bool gdv_fn_in_expr_lookup_int32(int64_t ptr, int32_t value, bool in_validity) {
   return holder->HasValue(value);
 }
 
-bool gdv_fn_in_expr_lookup_int64(int64_t ptr, int64_t value, bool in_validity) {
+bool gdv_fn_in_expr_lookup_int64(void* ptr, int64_t value, bool in_validity) {
   if (!in_validity) {
     return false;
   }
@@ -122,7 +123,7 @@ bool gdv_fn_in_expr_lookup_int64(int64_t ptr, int64_t value, bool in_validity) {
   return holder->HasValue(value);
 }
 
-bool gdv_fn_in_expr_lookup_decimal(int64_t ptr, int64_t value_high, int64_t value_low,
+bool gdv_fn_in_expr_lookup_decimal(void* ptr, int64_t value_high, int64_t value_low,
                                    int32_t precision, int32_t scale, bool in_validity) {
   if (!in_validity) {
     return false;
@@ -133,7 +134,7 @@ bool gdv_fn_in_expr_lookup_decimal(int64_t ptr, int64_t value_high, int64_t valu
   return holder->HasValue(value);
 }
 
-bool gdv_fn_in_expr_lookup_float(int64_t ptr, float value, bool in_validity) {
+bool gdv_fn_in_expr_lookup_float(void* ptr, float value, bool in_validity) {
   if (!in_validity) {
     return false;
   }
@@ -141,7 +142,7 @@ bool gdv_fn_in_expr_lookup_float(int64_t ptr, float value, bool in_validity) {
   return holder->HasValue(value);
 }
 
-bool gdv_fn_in_expr_lookup_double(int64_t ptr, double value, bool in_validity) {
+bool gdv_fn_in_expr_lookup_double(void* ptr, double value, bool in_validity) {
   if (!in_validity) {
     return false;
   }
@@ -149,7 +150,7 @@ bool gdv_fn_in_expr_lookup_double(int64_t ptr, double value, bool in_validity) {
   return holder->HasValue(value);
 }
 
-bool gdv_fn_in_expr_lookup_utf8(int64_t ptr, const char* data, int data_len,
+bool gdv_fn_in_expr_lookup_utf8(void* ptr, const char* data, int data_len,
                                 bool in_validity) {
   if (!in_validity) {
     return false;
@@ -159,7 +160,7 @@ bool gdv_fn_in_expr_lookup_utf8(int64_t ptr, const char* data, int data_len,
   return holder->HasValue(arrow::util::string_view(data, data_len));
 }
 
-int32_t gdv_fn_populate_varlen_vector(int64_t context_ptr, int8_t* data_ptr,
+int32_t gdv_fn_populate_varlen_vector(void* context_ptr, int8_t* data_ptr,
                                       int32_t* offsets, int64_t slot,
                                       const char* entry_buf, int32_t entry_len) {
   auto buffer = reinterpret_cast<arrow::ResizableBuffer*>(data_ptr);
@@ -184,54 +185,54 @@ int32_t gdv_fn_populate_varlen_vector(int64_t context_ptr, int8_t* data_ptr,
   return 0;
 }
 
-#define SHA1_HASH_FUNCTION(TYPE)                                                   \
-  GANDIVA_EXPORT                                                                   \
-  const char* gdv_fn_sha1_##TYPE(int64_t context, gdv_##TYPE value, bool validity, \
-                                 int32_t* out_length) {                            \
-    if (!validity) {                                                               \
-      return gandiva::gdv_hash_using_sha1(context, NULLPTR, 0, out_length);        \
-    }                                                                              \
-    auto value_as_long = gandiva::gdv_double_to_long((double)value);               \
-    const char* result = gandiva::gdv_hash_using_sha1(                             \
-        context, &value_as_long, sizeof(value_as_long), out_length);               \
-                                                                                   \
-    return result;                                                                 \
-  }
-
-#define SHA1_HASH_FUNCTION_BUF(TYPE)                                               \
-  GANDIVA_EXPORT                                                                   \
-  const char* gdv_fn_sha1_##TYPE(int64_t context, gdv_##TYPE value,                \
-                                 int32_t value_length, bool value_validity,        \
-                                 int32_t* out_length) {                            \
-    if (!value_validity) {                                                         \
-      return gandiva::gdv_hash_using_sha1(context, NULLPTR, 0, out_length);        \
-    }                                                                              \
-    return gandiva::gdv_hash_using_sha1(context, value, value_length, out_length); \
-  }
-
-#define SHA256_HASH_FUNCTION(TYPE)                                                   \
+#define SHA1_HASH_FUNCTION(TYPE)                                                     \
   GANDIVA_EXPORT                                                                     \
-  const char* gdv_fn_sha256_##TYPE(int64_t context, gdv_##TYPE value, bool validity, \
-                                   int32_t* out_length) {                            \
+  const char* gdv_fn_sha1_##TYPE(void* context_ptr, gdv_##TYPE value, bool validity, \
+                                 int32_t* out_length) {                              \
     if (!validity) {                                                                 \
-      return gandiva::gdv_hash_using_sha256(context, NULLPTR, 0, out_length);        \
+      return gandiva::gdv_hash_using_sha1(context_ptr, NULLPTR, 0, out_length);      \
     }                                                                                \
     auto value_as_long = gandiva::gdv_double_to_long((double)value);                 \
-    const char* result = gandiva::gdv_hash_using_sha256(                             \
-        context, &value_as_long, sizeof(value_as_long), out_length);                 \
+    const char* result = gandiva::gdv_hash_using_sha1(                               \
+        context_ptr, &value_as_long, sizeof(value_as_long), out_length);             \
+                                                                                     \
     return result;                                                                   \
   }
 
-#define SHA256_HASH_FUNCTION_BUF(TYPE)                                               \
-  GANDIVA_EXPORT                                                                     \
-  const char* gdv_fn_sha256_##TYPE(int64_t context, gdv_##TYPE value,                \
-                                   int32_t value_length, bool value_validity,        \
-                                   int32_t* out_length) {                            \
-    if (!value_validity) {                                                           \
-      return gandiva::gdv_hash_using_sha256(context, NULLPTR, 0, out_length);        \
-    }                                                                                \
-                                                                                     \
-    return gandiva::gdv_hash_using_sha256(context, value, value_length, out_length); \
+#define SHA1_HASH_FUNCTION_BUF(TYPE)                                                   \
+  GANDIVA_EXPORT                                                                       \
+  const char* gdv_fn_sha1_##TYPE(void* context_ptr, gdv_##TYPE value,                  \
+                                 int32_t value_length, bool value_validity,            \
+                                 int32_t* out_length) {                                \
+    if (!value_validity) {                                                             \
+      return gandiva::gdv_hash_using_sha1(context_ptr, NULLPTR, 0, out_length);        \
+    }                                                                                  \
+    return gandiva::gdv_hash_using_sha1(context_ptr, value, value_length, out_length); \
+  }
+
+#define SHA256_HASH_FUNCTION(TYPE)                                                     \
+  GANDIVA_EXPORT                                                                       \
+  const char* gdv_fn_sha256_##TYPE(void* context_ptr, gdv_##TYPE value, bool validity, \
+                                   int32_t* out_length) {                              \
+    if (!validity) {                                                                   \
+      return gandiva::gdv_hash_using_sha256(context_ptr, NULLPTR, 0, out_length);      \
+    }                                                                                  \
+    auto value_as_long = gandiva::gdv_double_to_long((double)value);                   \
+    const char* result = gandiva::gdv_hash_using_sha256(                               \
+        context_ptr, &value_as_long, sizeof(value_as_long), out_length);               \
+    return result;                                                                     \
+  }
+
+#define SHA256_HASH_FUNCTION_BUF(TYPE)                                                   \
+  GANDIVA_EXPORT                                                                         \
+  const char* gdv_fn_sha256_##TYPE(void* context_ptr, gdv_##TYPE value,                  \
+                                   int32_t value_length, bool value_validity,            \
+                                   int32_t* out_length) {                                \
+    if (!value_validity) {                                                               \
+      return gandiva::gdv_hash_using_sha256(context_ptr, NULLPTR, 0, out_length);        \
+    }                                                                                    \
+                                                                                         \
+    return gandiva::gdv_hash_using_sha256(context_ptr, value, value_length, out_length); \
   }
 
 // Expand inner macro for all numeric types.
@@ -268,39 +269,39 @@ SHA_VAR_LEN_PARAMS(SHA1_HASH_FUNCTION_BUF)
 
 // Add functions for decimal128
 GANDIVA_EXPORT
-const char* gdv_fn_sha256_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+const char* gdv_fn_sha256_decimal128(void* context_ptr, int64_t x_high, uint64_t x_low,
                                      int32_t /*x_precision*/, int32_t /*x_scale*/,
                                      gdv_boolean x_isvalid, int32_t* out_length) {
   if (!x_isvalid) {
-    return gandiva::gdv_hash_using_sha256(context, NULLPTR, 0, out_length);
+    return gandiva::gdv_hash_using_sha256(context_ptr, NULLPTR, 0, out_length);
   }
 
   const gandiva::BasicDecimal128 decimal_128(x_high, x_low);
-  return gandiva::gdv_hash_using_sha256(context, decimal_128.ToBytes().data(), 16,
+  return gandiva::gdv_hash_using_sha256(context_ptr, decimal_128.ToBytes().data(), 16,
                                         out_length);
 }
 
 GANDIVA_EXPORT
-const char* gdv_fn_sha1_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+const char* gdv_fn_sha1_decimal128(void* context_ptr, int64_t x_high, uint64_t x_low,
                                    int32_t /*x_precision*/, int32_t /*x_scale*/,
                                    gdv_boolean x_isvalid, int32_t* out_length) {
   if (!x_isvalid) {
-    return gandiva::gdv_hash_using_sha1(context, NULLPTR, 0, out_length);
+    return gandiva::gdv_hash_using_sha1(context_ptr, NULLPTR, 0, out_length);
   }
 
   const gandiva::BasicDecimal128 decimal_128(x_high, x_low);
-  return gandiva::gdv_hash_using_sha1(context, decimal_128.ToBytes().data(), 16,
+  return gandiva::gdv_hash_using_sha1(context_ptr, decimal_128.ToBytes().data(), 16,
                                       out_length);
 }
 
-int32_t gdv_fn_dec_from_string(int64_t context, const char* in, int32_t in_length,
+int32_t gdv_fn_dec_from_string(void* context_ptr, const char* in, int32_t in_length,
                                int32_t* precision_from_str, int32_t* scale_from_str,
                                int64_t* dec_high_from_str, uint64_t* dec_low_from_str) {
   arrow::Decimal128 dec;
   auto status = arrow::Decimal128::FromString(std::string(in, in_length), &dec,
                                               precision_from_str, scale_from_str);
   if (!status.ok()) {
-    gdv_fn_context_set_error_msg(context, status.message().data());
+    gdv_fn_context_set_error_msg(context_ptr, status.message().data());
     return -1;
   }
   *dec_high_from_str = dec.high_bits();
@@ -308,15 +309,16 @@ int32_t gdv_fn_dec_from_string(int64_t context, const char* in, int32_t in_lengt
   return 0;
 }
 
-char* gdv_fn_dec_to_string(int64_t context, int64_t x_high, uint64_t x_low,
+char* gdv_fn_dec_to_string(void* context_ptr, int64_t x_high, uint64_t x_low,
                            int32_t x_scale, int32_t* dec_str_len) {
   arrow::Decimal128 dec(arrow::BasicDecimal128(x_high, x_low));
   std::string dec_str = dec.ToString(x_scale);
   *dec_str_len = static_cast<int32_t>(dec_str.length());
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *dec_str_len));
+  char* ret =
+      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *dec_str_len));
   if (ret == nullptr) {
     std::string err_msg = "Could not allocate memory for string: " + dec_str;
-    gdv_fn_context_set_error_msg(context, err_msg.data());
+    gdv_fn_context_set_error_msg(context_ptr, err_msg.data());
     return nullptr;
   }
   memcpy(ret, dec_str.data(), *dec_str_len);
@@ -324,10 +326,10 @@ char* gdv_fn_dec_to_string(int64_t context, int64_t x_high, uint64_t x_low,
 }
 
 GANDIVA_EXPORT
-const char* gdv_fn_base64_encode_binary(int64_t context, const char* in, int32_t in_len,
+const char* gdv_fn_base64_encode_binary(void* context_ptr, const char* in, int32_t in_len,
                                         int32_t* out_len) {
   if (in_len < 0) {
-    gdv_fn_context_set_error_msg(context, "Buffer length can not be negative");
+    gdv_fn_context_set_error_msg(context_ptr, "Buffer length can not be negative");
     *out_len = 0;
     return "";
   }
@@ -341,9 +343,9 @@ const char* gdv_fn_base64_encode_binary(int64_t context, const char* in, int32_t
   *out_len = static_cast<int32_t>(encoded_str.length());
   // allocate memory for response
   char* ret = reinterpret_cast<char*>(
-      gdv_fn_context_arena_malloc(context, static_cast<int32_t>(*out_len)));
+      gdv_fn_context_arena_malloc(context_ptr, static_cast<int32_t>(*out_len)));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory");
+    gdv_fn_context_set_error_msg(context_ptr, "Could not allocate memory");
     *out_len = 0;
     return "";
   }
@@ -352,10 +354,10 @@ const char* gdv_fn_base64_encode_binary(int64_t context, const char* in, int32_t
 }
 
 GANDIVA_EXPORT
-const char* gdv_fn_base64_decode_utf8(int64_t context, const char* in, int32_t in_len,
+const char* gdv_fn_base64_decode_utf8(void* context_ptr, const char* in, int32_t in_len,
                                       int32_t* out_len) {
   if (in_len < 0) {
-    gdv_fn_context_set_error_msg(context, "Buffer length can not be negative");
+    gdv_fn_context_set_error_msg(context_ptr, "Buffer length can not be negative");
     *out_len = 0;
     return "";
   }
@@ -368,9 +370,9 @@ const char* gdv_fn_base64_decode_utf8(int64_t context, const char* in, int32_t i
   *out_len = static_cast<int32_t>(decoded_str.length());
   // allocate memory for response
   char* ret = reinterpret_cast<char*>(
-      gdv_fn_context_arena_malloc(context, static_cast<int32_t>(*out_len)));
+      gdv_fn_context_arena_malloc(context_ptr, static_cast<int32_t>(*out_len)));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory");
+    gdv_fn_context_set_error_msg(context_ptr, "Could not allocate memory");
     *out_len = 0;
     return "";
   }
@@ -378,28 +380,28 @@ const char* gdv_fn_base64_decode_utf8(int64_t context, const char* in, int32_t i
   return ret;
 }
 
-#define CAST_NUMERIC_FROM_VARLEN_TYPES(OUT_TYPE, ARROW_TYPE, TYPE_NAME, INNER_TYPE)  \
-  GANDIVA_EXPORT                                                                     \
-  OUT_TYPE gdv_fn_cast##TYPE_NAME##_##INNER_TYPE(int64_t context, const char* data,  \
-                                                 int32_t len) {                      \
-    OUT_TYPE val = 0;                                                                \
-    /* trim leading and trailing spaces */                                           \
-    int32_t trimmed_len;                                                             \
-    int32_t start = 0, end = len - 1;                                                \
-    while (start <= end && data[start] == ' ') {                                     \
-      ++start;                                                                       \
-    }                                                                                \
-    while (end >= start && data[end] == ' ') {                                       \
-      --end;                                                                         \
-    }                                                                                \
-    trimmed_len = end - start + 1;                                                   \
-    const char* trimmed_data = data + start;                                         \
-    if (!arrow::internal::ParseValue<ARROW_TYPE>(trimmed_data, trimmed_len, &val)) { \
-      std::string err =                                                              \
-          "Failed to cast the string " + std::string(data, len) + " to " #OUT_TYPE;  \
-      gdv_fn_context_set_error_msg(context, err.c_str());                            \
-    }                                                                                \
-    return val;                                                                      \
+#define CAST_NUMERIC_FROM_VARLEN_TYPES(OUT_TYPE, ARROW_TYPE, TYPE_NAME, INNER_TYPE)   \
+  GANDIVA_EXPORT                                                                      \
+  OUT_TYPE gdv_fn_cast##TYPE_NAME##_##INNER_TYPE(void* context_ptr, const char* data, \
+                                                 int32_t len) {                       \
+    OUT_TYPE val = 0;                                                                 \
+    /* trim leading and trailing spaces */                                            \
+    int32_t trimmed_len;                                                              \
+    int32_t start = 0, end = len - 1;                                                 \
+    while (start <= end && data[start] == ' ') {                                      \
+      ++start;                                                                        \
+    }                                                                                 \
+    while (end >= start && data[end] == ' ') {                                        \
+      --end;                                                                          \
+    }                                                                                 \
+    trimmed_len = end - start + 1;                                                    \
+    const char* trimmed_data = data + start;                                          \
+    if (!arrow::internal::ParseValue<ARROW_TYPE>(trimmed_data, trimmed_len, &val)) {  \
+      std::string err =                                                               \
+          "Failed to cast the string " + std::string(data, len) + " to " #OUT_TYPE;   \
+      gdv_fn_context_set_error_msg(context_ptr, err.c_str());                         \
+    }                                                                                 \
+    return val;                                                                       \
   }
 
 #define CAST_NUMERIC_FROM_STRING(OUT_TYPE, ARROW_TYPE, TYPE_NAME) \
@@ -422,76 +424,76 @@ CAST_NUMERIC_FROM_VARBINARY(double, arrow::DoubleType, FLOAT8)
 
 #undef CAST_NUMERIC_STRING
 
-#define GDV_FN_CAST_VARLEN_TYPE_FROM_INTEGER(IN_TYPE, CAST_NAME, ARROW_TYPE)      \
-  GANDIVA_EXPORT                                                                  \
-  const char* gdv_fn_cast##CAST_NAME##_##IN_TYPE##_int64(                         \
-      int64_t context, gdv_##IN_TYPE value, int64_t len, int32_t * out_len) {     \
-    if (len < 0) {                                                                \
-      gdv_fn_context_set_error_msg(context, "Buffer length can not be negative"); \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    if (len == 0) {                                                               \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    arrow::internal::StringFormatter<arrow::ARROW_TYPE> formatter;                \
-    char* ret = reinterpret_cast<char*>(                                          \
-        gdv_fn_context_arena_malloc(context, static_cast<int32_t>(len)));         \
-    if (ret == nullptr) {                                                         \
-      gdv_fn_context_set_error_msg(context, "Could not allocate memory");         \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    arrow::Status status = formatter(value, [&](arrow::util::string_view v) {     \
-      int64_t size = static_cast<int64_t>(v.size());                              \
-      *out_len = static_cast<int32_t>(len < size ? len : size);                   \
-      memcpy(ret, v.data(), *out_len);                                            \
-      return arrow::Status::OK();                                                 \
-    });                                                                           \
-    if (!status.ok()) {                                                           \
-      std::string err = "Could not cast " + std::to_string(value) + " to string"; \
-      gdv_fn_context_set_error_msg(context, err.c_str());                         \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    return ret;                                                                   \
+#define GDV_FN_CAST_VARLEN_TYPE_FROM_INTEGER(IN_TYPE, CAST_NAME, ARROW_TYPE)          \
+  GANDIVA_EXPORT                                                                      \
+  const char* gdv_fn_cast##CAST_NAME##_##IN_TYPE##_int64(                             \
+      void* context_ptr, gdv_##IN_TYPE value, int64_t len, int32_t* out_len) {        \
+    if (len < 0) {                                                                    \
+      gdv_fn_context_set_error_msg(context_ptr, "Buffer length can not be negative"); \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    if (len == 0) {                                                                   \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    arrow::internal::StringFormatter<arrow::ARROW_TYPE> formatter;                    \
+    char* ret = reinterpret_cast<char*>(                                              \
+        gdv_fn_context_arena_malloc(context_ptr, static_cast<int32_t>(len)));         \
+    if (ret == nullptr) {                                                             \
+      gdv_fn_context_set_error_msg(context_ptr, "Could not allocate memory");         \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    arrow::Status status = formatter(value, [&](arrow::util::string_view v) {         \
+      int64_t size = static_cast<int64_t>(v.size());                                  \
+      *out_len = static_cast<int32_t>(len < size ? len : size);                       \
+      memcpy(ret, v.data(), *out_len);                                                \
+      return arrow::Status::OK();                                                     \
+    });                                                                               \
+    if (!status.ok()) {                                                               \
+      std::string err = "Could not cast " + std::to_string(value) + " to string";     \
+      gdv_fn_context_set_error_msg(context_ptr, err.c_str());                         \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    return ret;                                                                       \
   }
 
-#define GDV_FN_CAST_VARLEN_TYPE_FROM_REAL(IN_TYPE, CAST_NAME, ARROW_TYPE)         \
-  GANDIVA_EXPORT                                                                  \
-  const char* gdv_fn_cast##CAST_NAME##_##IN_TYPE##_int64(                         \
-      int64_t context, gdv_##IN_TYPE value, int64_t len, int32_t * out_len) {     \
-    if (len < 0) {                                                                \
-      gdv_fn_context_set_error_msg(context, "Buffer length can not be negative"); \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    if (len == 0) {                                                               \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    gandiva::GdvStringFormatter<arrow::ARROW_TYPE> formatter;                     \
-    char* ret = reinterpret_cast<char*>(                                          \
-        gdv_fn_context_arena_malloc(context, static_cast<int32_t>(len)));         \
-    if (ret == nullptr) {                                                         \
-      gdv_fn_context_set_error_msg(context, "Could not allocate memory");         \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    arrow::Status status = formatter(value, [&](arrow::util::string_view v) {     \
-      int64_t size = static_cast<int64_t>(v.size());                              \
-      *out_len = static_cast<int32_t>(len < size ? len : size);                   \
-      memcpy(ret, v.data(), *out_len);                                            \
-      return arrow::Status::OK();                                                 \
-    });                                                                           \
-    if (!status.ok()) {                                                           \
-      std::string err = "Could not cast " + std::to_string(value) + " to string"; \
-      gdv_fn_context_set_error_msg(context, err.c_str());                         \
-      *out_len = 0;                                                               \
-      return "";                                                                  \
-    }                                                                             \
-    return ret;                                                                   \
+#define GDV_FN_CAST_VARLEN_TYPE_FROM_REAL(IN_TYPE, CAST_NAME, ARROW_TYPE)             \
+  GANDIVA_EXPORT                                                                      \
+  const char* gdv_fn_cast##CAST_NAME##_##IN_TYPE##_int64(                             \
+      void* context_ptr, gdv_##IN_TYPE value, int64_t len, int32_t* out_len) {        \
+    if (len < 0) {                                                                    \
+      gdv_fn_context_set_error_msg(context_ptr, "Buffer length can not be negative"); \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    if (len == 0) {                                                                   \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    gandiva::GdvStringFormatter<arrow::ARROW_TYPE> formatter;                         \
+    char* ret = reinterpret_cast<char*>(                                              \
+        gdv_fn_context_arena_malloc(context_ptr, static_cast<int32_t>(len)));         \
+    if (ret == nullptr) {                                                             \
+      gdv_fn_context_set_error_msg(context_ptr, "Could not allocate memory");         \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    arrow::Status status = formatter(value, [&](arrow::util::string_view v) {         \
+      int64_t size = static_cast<int64_t>(v.size());                                  \
+      *out_len = static_cast<int32_t>(len < size ? len : size);                       \
+      memcpy(ret, v.data(), *out_len);                                                \
+      return arrow::Status::OK();                                                     \
+    });                                                                               \
+    if (!status.ok()) {                                                               \
+      std::string err = "Could not cast " + std::to_string(value) + " to string";     \
+      gdv_fn_context_set_error_msg(context_ptr, err.c_str());                         \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    return ret;                                                                       \
   }
 
 #define CAST_VARLEN_TYPE_FROM_NUMERIC(VARLEN_TYPE)                    \
@@ -525,18 +527,18 @@ int32_t gdv_fn_utf8_char_length(char c) {
 }
 
 GDV_FORCE_INLINE
-void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
+void gdv_fn_set_error_for_invalid_utf8(void* context_ptr, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, fmt, (unsigned char)val);
-  gdv_fn_context_set_error_msg(execution_context, error);
+  gdv_fn_context_set_error_msg(context_ptr, error);
   free(error);
 }
 
 // Convert an utf8 string to its corresponding uppercase string
 GANDIVA_EXPORT
-const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_upper_utf8(void* context_ptr, const char* data, int32_t data_len,
                               int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
@@ -546,9 +548,11 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
   // If it is a single-byte character (ASCII), corresponding uppercase is always 1-byte
   // long; if it is >= 2 bytes long, uppercase can be at most 4 bytes long, so length of
   // the output can be at most twice the length of the input
-  char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, 2 * data_len));
+  char* out =
+      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, 2 * data_len));
   if (out == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -582,7 +586,7 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
 
     // If it is an invalid utf8 character, UTF8Decode evaluates to false
     if (!is_valid_utf8_char) {
-      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      gdv_fn_set_error_for_invalid_utf8(context_ptr, data[i]);
       *out_len = 0;
       return "";
     }
@@ -608,7 +612,7 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
 
 // Convert an utf8 string to its corresponding lowercase string
 GANDIVA_EXPORT
-const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_lower_utf8(void* context_ptr, const char* data, int32_t data_len,
                               int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
@@ -618,9 +622,11 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
   // If it is a single-byte character (ASCII), corresponding lowercase is always 1-byte
   // long; if it is >= 2 bytes long, lowercase can be at most 4 bytes long, so length of
   // the output can be at most twice the length of the input
-  char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, 2 * data_len));
+  char* out =
+      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, 2 * data_len));
   if (out == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -654,7 +660,7 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
 
     // If it is an invalid utf8 character, UTF8Decode evaluates to false
     if (!is_valid_utf8_char) {
-      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      gdv_fn_set_error_for_invalid_utf8(context_ptr, data[i]);
       *out_len = 0;
       return "";
     }
@@ -700,7 +706,7 @@ bool gdv_fn_is_codepoint_for_space(uint32_t val) {
 // the others e.g:
 //     - "IT is a tEXt str" -> "It Is A Text Str"
 GANDIVA_EXPORT
-const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_initcap_utf8(void* context_ptr, const char* data, int32_t data_len,
                                 int32_t* out_len) {
   if (data_len == 0) {
     *out_len = data_len;
@@ -710,9 +716,11 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
   // If it is a single-byte character (ASCII), corresponding uppercase is always 1-byte
   // long; if it is >= 2 bytes long, uppercase can be at most 4 bytes long, so length of
   // the output can be at most twice the length of the input
-  char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, 2 * data_len));
+  char* out =
+      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, 2 * data_len));
   if (out == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -762,7 +770,7 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
 
     // If it is an invalid utf8 character, UTF8Decode evaluates to false
     if (!is_valid_utf8_char) {
-      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      gdv_fn_set_error_for_invalid_utf8(context_ptr, data[i]);
       *out_len = 0;
       return "";
     }
@@ -802,10 +810,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_int32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // int32_t value
-      types->i64_type(),     // int64_t out value length
-      types->i32_ptr_type()  // int32_t out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // int32_t value
+      types->i64_type(),       // int64_t out value length
+      types->i32_ptr_type()    // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -814,10 +822,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_int64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // int64_t value
-      types->i64_type(),     // int64_t out value length
-      types->i32_ptr_type()  // int32_t out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // int64_t value
+      types->i64_type(),       // int64_t out value length
+      types->i32_ptr_type()    // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -826,10 +834,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_float32
   args = {
-      types->i64_type(),     // context
-      types->float_type(),   // float value
-      types->i64_type(),     // int64_t out value length
-      types->i64_ptr_type()  // int32_t out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->float_type(),     // float value
+      types->i64_type(),       // int64_t out value length
+      types->i64_ptr_type()    // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -838,10 +846,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_float64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // double value
-      types->i64_type(),     // int64_t out value length
-      types->i32_ptr_type()  // int32_t out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // double value
+      types->i64_type(),       // int64_t out value length
+      types->i32_ptr_type()    // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -850,13 +858,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_dec_from_string
   args = {
-      types->i64_type(),      // context
-      types->i8_ptr_type(),   // const char* in
-      types->i32_type(),      // int32_t in_length
-      types->i32_ptr_type(),  // int32_t* precision_from_str
-      types->i32_ptr_type(),  // int32_t* scale_from_str
-      types->i64_ptr_type(),  // int64_t* dec_high_from_str
-      types->i64_ptr_type(),  // int64_t* dec_low_from_str
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char* in
+      types->i32_type(),       // int32_t in_length
+      types->i32_ptr_type(),   // int32_t* precision_from_str
+      types->i32_ptr_type(),   // int32_t* scale_from_str
+      types->i64_ptr_type(),   // int64_t* dec_high_from_str
+      types->i64_ptr_type(),   // int64_t* dec_low_from_str
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_dec_from_string",
@@ -865,11 +873,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_dec_to_string
   args = {
-      types->i64_type(),      // context
-      types->i64_type(),      // int64_t x_high
-      types->i64_type(),      // int64_t x_low
-      types->i32_type(),      // int32_t x_scale
-      types->i64_ptr_type(),  // int64_t* dec_str_len
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // int64_t x_high
+      types->i64_type(),       // int64_t x_low
+      types->i32_type(),       // int32_t x_scale
+      types->i64_ptr_type(),   // int64_t* dec_str_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_dec_to_string",
@@ -877,43 +885,43 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_dec_to_string));
 
   // gdv_fn_like_utf8_utf8
-  args = {types->i64_type(),     // int64_t ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type(),     // int data_len
-          types->i8_ptr_type(),  // const char* pattern
-          types->i32_type()};    // int pattern_len
+  args = {types->void_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type(),       // int data_len
+          types->i8_ptr_type(),    // const char* pattern
+          types->i32_type()};      // int pattern_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_like_utf8_utf8));
 
   // gdv_fn_like_utf8_utf8_utf8
-  args = {types->i64_type(),     // int64_t ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type(),     // int data_len
-          types->i8_ptr_type(),  // const char* pattern
-          types->i32_type(),     // int pattern_len
-          types->i8_ptr_type(),  // const char* escape_char
-          types->i32_type()};    // int escape_char_len
+  args = {types->void_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type(),       // int data_len
+          types->i8_ptr_type(),    // const char* pattern
+          types->i32_type(),       // int pattern_len
+          types->i8_ptr_type(),    // const char* escape_char
+          types->i32_type()};      // int escape_char_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_like_utf8_utf8_utf8));
 
   // gdv_fn_ilike_utf8_utf8
-  args = {types->i64_type(),     // int64_t ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type(),     // int data_len
-          types->i8_ptr_type(),  // const char* pattern
-          types->i32_type()};    // int pattern_len
+  args = {types->void_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type(),       // int data_len
+          types->i8_ptr_type(),    // const char* pattern
+          types->i32_type()};      // int pattern_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_ilike_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_ilike_utf8_utf8));
 
   // gdv_fn_regexp_replace_utf8_utf8
-  args = {types->i64_type(),       // int64_t ptr
-          types->i64_type(),       // int64_t holder_ptr
+  args = {types->void_ptr_type(),  // void* ptr
+          types->void_ptr_type(),  // void* holder_ptr
           types->i8_ptr_type(),    // const char* data
           types->i32_type(),       // int data_len
           types->i8_ptr_type(),    // const char* pattern
@@ -927,8 +935,8 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_regexp_replace_utf8_utf8));
 
   // gdv_fn_to_date_utf8_utf8
-  args = {types->i64_type(),                   // int64_t execution_context
-          types->i64_type(),                   // int64_t holder_ptr
+  args = {types->void_ptr_type(),              // void* context_ptr
+          types->void_ptr_type(),              // void* holder_ptr
           types->i8_ptr_type(),                // const char* data
           types->i32_type(),                   // int data_len
           types->i1_type(),                    // bool in1_validity
@@ -942,8 +950,8 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8));
 
   // gdv_fn_to_date_utf8_utf8_int32
-  args = {types->i64_type(),                   // int64_t execution_context
-          types->i64_type(),                   // int64_t holder_ptr
+  args = {types->void_ptr_type(),              // void* context_ptr
+          types->void_ptr_type(),              // void* holder_ptr
           types->i8_ptr_type(),                // const char* data
           types->i32_type(),                   // int data_len
           types->i1_type(),                    // bool in1_validity
@@ -959,67 +967,67 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8_int32));
 
   // gdv_fn_in_expr_lookup_int32
-  args = {types->i64_type(),  // int64_t in holder ptr
-          types->i32_type(),  // int32 value
-          types->i1_type()};  // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->i32_type(),       // int32 value
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_int32",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_int32));
 
   // gdv_fn_in_expr_lookup_int64
-  args = {types->i64_type(),  // int64_t in holder ptr
-          types->i64_type(),  // int64 value
-          types->i1_type()};  // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->i64_type(),       // int64 value
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_int64",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_int64));
 
   // gdv_fn_in_expr_lookup_decimal
-  args = {types->i64_type(),  // int64_t in holder ptr
-          types->i64_type(),  // high decimal value
-          types->i64_type(),  // low decimal value
-          types->i32_type(),  // decimal precision value
-          types->i32_type(),  // decimal scale value
-          types->i1_type()};  // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->i64_type(),       // high decimal value
+          types->i64_type(),       // low decimal value
+          types->i32_type(),       // decimal precision value
+          types->i32_type(),       // decimal scale value
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_decimal",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_decimal));
 
   // gdv_fn_in_expr_lookup_utf8
-  args = {types->i64_type(),     // int64_t in holder ptr
-          types->i8_ptr_type(),  // const char* value
-          types->i32_type(),     // int value_len
-          types->i1_type()};     // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->i8_ptr_type(),    // const char* value
+          types->i32_type(),       // int value_len
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_utf8));
   // gdv_fn_in_expr_lookup_float
-  args = {types->i64_type(),    // int64_t in holder ptr
-          types->float_type(),  // float value
-          types->i1_type()};    // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->float_type(),     // float value
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_float",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_float));
   // gdv_fn_in_expr_lookup_double
-  args = {types->i64_type(),     // int64_t in holder ptr
-          types->double_type(),  // double value
-          types->i1_type()};     // bool in_validity
+  args = {types->void_ptr_type(),  // void* holder_ptr
+          types->double_type(),    // double value
+          types->i1_type()};       // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_double",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_double));
   // gdv_fn_populate_varlen_vector
-  args = {types->i64_type(),      // int64_t execution_context
-          types->i8_ptr_type(),   // int8_t* data ptr
-          types->i32_ptr_type(),  // int32_t* offsets ptr
-          types->i64_type(),      // int64_t slot
-          types->i8_ptr_type(),   // const char* entry_buf
-          types->i32_type()};     // int32_t entry__len
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // int8_t* data ptr
+          types->i32_ptr_type(),   // int32_t* offsets ptr
+          types->i64_type(),       // int64_t slot
+          types->i8_ptr_type(),    // const char* entry_buf
+          types->i32_type()};      // int32_t entry__len
 
   engine->AddGlobalMappingForFunc("gdv_fn_populate_varlen_vector",
                                   types->i32_type() /*return_type*/, args,
@@ -1034,36 +1042,36 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
   engine->AddGlobalMappingForFunc("gdv_fn_random_with_seed", types->double_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_random_with_seed));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castINT_utf8", types->i32_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castINT_utf8));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castBIGINT_utf8", types->i64_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castBIGINT_utf8));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT4_utf8", types->float_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT4_utf8));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT8_utf8", types->double_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT8_utf8));
 
   // gdv_fn_castVARCHAR_int32_int64
-  args = {types->i64_type(),       // int64_t execution_context
+  args = {types->void_ptr_type(),  // void* context_ptr
           types->i32_type(),       // int32_t value
           types->i64_type(),       // int64_t len
           types->i32_ptr_type()};  // int32_t* out_len
@@ -1072,7 +1080,7 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_int32_int64));
 
   // gdv_fn_castVARCHAR_int64_int64
-  args = {types->i64_type(),       // int64_t execution_context
+  args = {types->void_ptr_type(),  // void* context_ptr
           types->i64_type(),       // int64_t value
           types->i64_type(),       // int64_t len
           types->i32_ptr_type()};  // int32_t* out_len
@@ -1081,7 +1089,7 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_int64_int64));
 
   // gdv_fn_castVARCHAR_float32_int64
-  args = {types->i64_type(),       // int64_t execution_context
+  args = {types->void_ptr_type(),  // void* context_ptr
           types->float_type(),     // float value
           types->i64_type(),       // int64_t len
           types->i32_ptr_type()};  // int32_t* out_len
@@ -1090,7 +1098,7 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_float32_int64));
 
   // gdv_fn_castVARCHAR_float64_int64
-  args = {types->i64_type(),       // int64_t execution_context
+  args = {types->void_ptr_type(),  // void* context_ptr
           types->double_type(),    // double value
           types->i64_type(),       // int64_t len
           types->i32_ptr_type()};  // int32_t* out_len
@@ -1098,31 +1106,31 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       "gdv_fn_castVARCHAR_float64_int64", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_float64_int64));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castINT_varbinary", types->i32_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castINT_varbinary));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castBIGINT_varbinary", types->i64_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castBIGINT_varbinary));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT4_varbinary", types->float_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT4_varbinary));
 
-  args = {types->i64_type(),     // int64_t context_ptr
-          types->i8_ptr_type(),  // const char* data
-          types->i32_type()};    // int32_t lenr
+  args = {types->void_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),    // const char* data
+          types->i32_type()};      // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT8_varbinary", types->double_type(),
                                   args,
@@ -1130,10 +1138,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int8
   args = {
-      types->i64_type(),     // context
-      types->i8_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1141,10 +1149,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int16
   args = {
-      types->i64_type(),     // context
-      types->i16_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i16_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1152,10 +1160,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1163,10 +1171,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int32
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1174,10 +1182,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint8
   args = {
-      types->i64_type(),     // context
-      types->i8_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1185,10 +1193,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint16
   args = {
-      types->i64_type(),     // context
-      types->i16_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i16_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1196,10 +1204,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1207,10 +1215,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1218,10 +1226,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_float32
   args = {
-      types->i64_type(),     // context
-      types->float_type(),   // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->float_type(),     // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_float32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1229,10 +1237,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_float64
   args = {
-      types->i64_type(),     // context
-      types->double_type(),  // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->double_type(),    // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_float64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1240,10 +1248,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_boolean
   args = {
-      types->i64_type(),     // context
-      types->i1_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i1_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_boolean",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1251,10 +1259,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_date64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_date64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1262,10 +1270,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_date32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_date32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1273,10 +1281,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_time32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_time32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1284,10 +1292,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_timestamp
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_timestamp",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1295,11 +1303,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_from_utf8
   args = {
-      types->i64_type(),     // context
-      types->i8_ptr_type(),  // const char*
-      types->i32_type(),     // value_length
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char*
+      types->i32_type(),       // value_length
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_utf8",
@@ -1308,11 +1316,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_from_binary
   args = {
-      types->i64_type(),     // context
-      types->i8_ptr_type(),  // const char*
-      types->i32_type(),     // value_length
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char*
+      types->i32_type(),       // value_length
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_binary",
@@ -1321,10 +1329,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int8
   args = {
-      types->i64_type(),     // context
-      types->i8_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1332,10 +1340,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int16
   args = {
-      types->i64_type(),     // context
-      types->i16_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i16_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1343,10 +1351,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1354,10 +1362,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int32
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1365,10 +1373,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint8
   args = {
-      types->i64_type(),     // context
-      types->i8_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1376,10 +1384,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint16
   args = {
-      types->i64_type(),     // context
-      types->i16_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i16_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1387,10 +1395,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1398,10 +1406,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1409,10 +1417,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_float32
   args = {
-      types->i64_type(),     // context
-      types->float_type(),   // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->float_type(),     // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_float32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1420,10 +1428,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_float64
   args = {
-      types->i64_type(),     // context
-      types->double_type(),  // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->double_type(),    // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_float64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1431,10 +1439,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_boolean
   args = {
-      types->i64_type(),     // context
-      types->i1_type(),      // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i1_type(),        // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_boolean",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1442,10 +1450,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_date64
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_date64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1453,10 +1461,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_date32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_date32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1464,10 +1472,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_time32
   args = {
-      types->i64_type(),     // context
-      types->i32_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i32_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_time32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1475,10 +1483,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_timestamp
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // value
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // value
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_timestamp",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1486,11 +1494,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_hash_sha256_from_utf8
   args = {
-      types->i64_type(),     // context
-      types->i8_ptr_type(),  // const char*
-      types->i32_type(),     // value_length
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char*
+      types->i32_type(),       // value_length
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_utf8",
@@ -1499,11 +1507,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_hash_sha256_from_binary
   args = {
-      types->i64_type(),     // context
-      types->i8_ptr_type(),  // const char*
-      types->i32_type(),     // value_length
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char*
+      types->i32_type(),       // value_length
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_binary",
@@ -1512,13 +1520,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_decimal128
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // high_bits
-      types->i64_type(),     // low_bits
-      types->i32_type(),     // precision
-      types->i32_type(),     // scale
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // high_bits
+      types->i64_type(),       // low_bits
+      types->i32_type(),       // precision
+      types->i32_type(),       // scale
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_decimal128",
@@ -1526,13 +1534,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_sha1_decimal128));
   // gdv_fn_sha256_decimal128
   args = {
-      types->i64_type(),     // context
-      types->i64_type(),     // high_bits
-      types->i64_type(),     // low_bits
-      types->i32_type(),     // precision
-      types->i32_type(),     // scale
-      types->i1_type(),      // validity
-      types->i32_ptr_type()  // out length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i64_type(),       // high_bits
+      types->i64_type(),       // low_bits
+      types->i32_type(),       // precision
+      types->i32_type(),       // scale
+      types->i1_type(),        // validity
+      types->i32_ptr_type()    // out length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_decimal128",
@@ -1541,10 +1549,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_base64_encode_utf8
   args = {
-      types->i64_type(),      // context
-      types->i8_ptr_type(),   // in
-      types->i32_type(),      // in_len
-      types->i32_ptr_type(),  // out_len
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // in
+      types->i32_type(),       // in_len
+      types->i32_ptr_type(),   // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_base64_encode_binary",
@@ -1553,10 +1561,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_base64_decode_utf8
   args = {
-      types->i64_type(),      // context
-      types->i8_ptr_type(),   // in
-      types->i32_type(),      // in_len
-      types->i32_ptr_type(),  // out_len
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // in
+      types->i32_type(),       // in_len
+      types->i32_ptr_type(),   // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_base64_decode_utf8",
@@ -1565,10 +1573,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_upper_utf8
   args = {
-      types->i64_type(),      // context
-      types->i8_ptr_type(),   // data
-      types->i32_type(),      // data_len
-      types->i32_ptr_type(),  // out_len
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // data
+      types->i32_type(),       // data_len
+      types->i32_ptr_type(),   // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_upper_utf8",
@@ -1576,10 +1584,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_upper_utf8));
   // gdv_fn_lower_utf8
   args = {
-      types->i64_type(),      // context
-      types->i8_ptr_type(),   // data
-      types->i32_type(),      // data_len
-      types->i32_ptr_type(),  // out_len
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // data
+      types->i32_type(),       // data_len
+      types->i32_ptr_type(),   // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_lower_utf8",
@@ -1588,10 +1596,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_initcap_utf8
   args = {
-      types->i64_type(),     // context
-      types->i8_ptr_type(),  // const char*
-      types->i32_type(),     // value_length
-      types->i32_ptr_type()  // out_length
+      types->void_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),    // const char*
+      types->i32_type(),       // value_length
+      types->i32_ptr_type()    // out_length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_initcap_utf8",

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -810,10 +810,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_int32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // int32_t value
-      types->i64_type(),       // int64_t out value length
-      types->i32_ptr_type()    // int32_t out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // int32_t value
+      types->i64_type(),         // int64_t out value length
+      types->i32_ptr_type()      // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -822,10 +822,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_int64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // int64_t value
-      types->i64_type(),       // int64_t out value length
-      types->i32_ptr_type()    // int32_t out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // int64_t value
+      types->i64_type(),         // int64_t out value length
+      types->i32_ptr_type()      // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -834,10 +834,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_float32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->float_type(),     // float value
-      types->i64_type(),       // int64_t out value length
-      types->i64_ptr_type()    // int32_t out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->float_type(),       // float value
+      types->i64_type(),         // int64_t out value length
+      types->i64_ptr_type()      // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -846,10 +846,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_castVARBINARY_float64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // double value
-      types->i64_type(),       // int64_t out value length
-      types->i32_ptr_type()    // int32_t out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // double value
+      types->i64_type(),         // int64_t out value length
+      types->i32_ptr_type()      // int32_t out_length
   };
 
   engine->AddGlobalMappingForFunc(
@@ -858,13 +858,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_dec_from_string
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char* in
-      types->i32_type(),       // int32_t in_length
-      types->i32_ptr_type(),   // int32_t* precision_from_str
-      types->i32_ptr_type(),   // int32_t* scale_from_str
-      types->i64_ptr_type(),   // int64_t* dec_high_from_str
-      types->i64_ptr_type(),   // int64_t* dec_low_from_str
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char* in
+      types->i32_type(),         // int32_t in_length
+      types->i32_ptr_type(),     // int32_t* precision_from_str
+      types->i32_ptr_type(),     // int32_t* scale_from_str
+      types->i64_ptr_type(),     // int64_t* dec_high_from_str
+      types->i64_ptr_type(),     // int64_t* dec_low_from_str
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_dec_from_string",
@@ -873,11 +873,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_dec_to_string
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // int64_t x_high
-      types->i64_type(),       // int64_t x_low
-      types->i32_type(),       // int32_t x_scale
-      types->i64_ptr_type(),   // int64_t* dec_str_len
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // int64_t x_high
+      types->i64_type(),         // int64_t x_low
+      types->i32_type(),         // int32_t x_scale
+      types->i64_ptr_type(),     // int64_t* dec_str_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_dec_to_string",
@@ -885,58 +885,58 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_dec_to_string));
 
   // gdv_fn_like_utf8_utf8
-  args = {types->void_ptr_type(),  // void* ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type(),       // int data_len
-          types->i8_ptr_type(),    // const char* pattern
-          types->i32_type()};      // int pattern_len
+  args = {types->opaque_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type(),         // int data_len
+          types->i8_ptr_type(),      // const char* pattern
+          types->i32_type()};        // int pattern_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_like_utf8_utf8));
 
   // gdv_fn_like_utf8_utf8_utf8
-  args = {types->void_ptr_type(),  // void* ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type(),       // int data_len
-          types->i8_ptr_type(),    // const char* pattern
-          types->i32_type(),       // int pattern_len
-          types->i8_ptr_type(),    // const char* escape_char
-          types->i32_type()};      // int escape_char_len
+  args = {types->opaque_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type(),         // int data_len
+          types->i8_ptr_type(),      // const char* pattern
+          types->i32_type(),         // int pattern_len
+          types->i8_ptr_type(),      // const char* escape_char
+          types->i32_type()};        // int escape_char_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_like_utf8_utf8_utf8));
 
   // gdv_fn_ilike_utf8_utf8
-  args = {types->void_ptr_type(),  // void* ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type(),       // int data_len
-          types->i8_ptr_type(),    // const char* pattern
-          types->i32_type()};      // int pattern_len
+  args = {types->opaque_ptr_type(),  // void* ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type(),         // int data_len
+          types->i8_ptr_type(),      // const char* pattern
+          types->i32_type()};        // int pattern_len
 
   engine->AddGlobalMappingForFunc("gdv_fn_ilike_utf8_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_ilike_utf8_utf8));
 
   // gdv_fn_regexp_replace_utf8_utf8
-  args = {types->void_ptr_type(),  // void* ptr
-          types->void_ptr_type(),  // void* holder_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type(),       // int data_len
-          types->i8_ptr_type(),    // const char* pattern
-          types->i32_type(),       // int pattern_len
-          types->i8_ptr_type(),    // const char* replace_string
-          types->i32_type(),       // int32_t replace_string_len
-          types->i32_ptr_type()};  // int32_t* out_length
+  args = {types->opaque_ptr_type(),  // void* ptr
+          types->opaque_ptr_type(),  // void* holder_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type(),         // int data_len
+          types->i8_ptr_type(),      // const char* pattern
+          types->i32_type(),         // int pattern_len
+          types->i8_ptr_type(),      // const char* replace_string
+          types->i32_type(),         // int32_t replace_string_len
+          types->i32_ptr_type()};    // int32_t* out_length
 
   engine->AddGlobalMappingForFunc(
       "gdv_fn_regexp_replace_utf8_utf8", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_regexp_replace_utf8_utf8));
 
   // gdv_fn_to_date_utf8_utf8
-  args = {types->void_ptr_type(),              // void* context_ptr
-          types->void_ptr_type(),              // void* holder_ptr
+  args = {types->opaque_ptr_type(),            // void* context_ptr
+          types->opaque_ptr_type(),            // void* holder_ptr
           types->i8_ptr_type(),                // const char* data
           types->i32_type(),                   // int data_len
           types->i1_type(),                    // bool in1_validity
@@ -950,8 +950,8 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8));
 
   // gdv_fn_to_date_utf8_utf8_int32
-  args = {types->void_ptr_type(),              // void* context_ptr
-          types->void_ptr_type(),              // void* holder_ptr
+  args = {types->opaque_ptr_type(),            // void* context_ptr
+          types->opaque_ptr_type(),            // void* holder_ptr
           types->i8_ptr_type(),                // const char* data
           types->i32_type(),                   // int data_len
           types->i1_type(),                    // bool in1_validity
@@ -967,67 +967,67 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
       reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8_int32));
 
   // gdv_fn_in_expr_lookup_int32
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->i32_type(),       // int32 value
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->i32_type(),         // int32 value
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_int32",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_int32));
 
   // gdv_fn_in_expr_lookup_int64
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->i64_type(),       // int64 value
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->i64_type(),         // int64 value
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_int64",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_int64));
 
   // gdv_fn_in_expr_lookup_decimal
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->i64_type(),       // high decimal value
-          types->i64_type(),       // low decimal value
-          types->i32_type(),       // decimal precision value
-          types->i32_type(),       // decimal scale value
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->i64_type(),         // high decimal value
+          types->i64_type(),         // low decimal value
+          types->i32_type(),         // decimal precision value
+          types->i32_type(),         // decimal scale value
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_decimal",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_decimal));
 
   // gdv_fn_in_expr_lookup_utf8
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->i8_ptr_type(),    // const char* value
-          types->i32_type(),       // int value_len
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->i8_ptr_type(),      // const char* value
+          types->i32_type(),         // int value_len
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_utf8",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_utf8));
   // gdv_fn_in_expr_lookup_float
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->float_type(),     // float value
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->float_type(),       // float value
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_float",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_float));
   // gdv_fn_in_expr_lookup_double
-  args = {types->void_ptr_type(),  // void* holder_ptr
-          types->double_type(),    // double value
-          types->i1_type()};       // bool in_validity
+  args = {types->opaque_ptr_type(),  // void* holder_ptr
+          types->double_type(),      // double value
+          types->i1_type()};         // bool in_validity
 
   engine->AddGlobalMappingForFunc("gdv_fn_in_expr_lookup_double",
                                   types->i1_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_in_expr_lookup_double));
   // gdv_fn_populate_varlen_vector
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // int8_t* data ptr
-          types->i32_ptr_type(),   // int32_t* offsets ptr
-          types->i64_type(),       // int64_t slot
-          types->i8_ptr_type(),    // const char* entry_buf
-          types->i32_type()};      // int32_t entry__len
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // int8_t* data ptr
+          types->i32_ptr_type(),     // int32_t* offsets ptr
+          types->i64_type(),         // int64_t slot
+          types->i8_ptr_type(),      // const char* entry_buf
+          types->i32_type()};        // int32_t entry__len
 
   engine->AddGlobalMappingForFunc("gdv_fn_populate_varlen_vector",
                                   types->i32_type() /*return_type*/, args,
@@ -1042,95 +1042,95 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
   engine->AddGlobalMappingForFunc("gdv_fn_random_with_seed", types->double_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_random_with_seed));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castINT_utf8", types->i32_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castINT_utf8));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castBIGINT_utf8", types->i64_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castBIGINT_utf8));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT4_utf8", types->float_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT4_utf8));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT8_utf8", types->double_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT8_utf8));
 
   // gdv_fn_castVARCHAR_int32_int64
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i32_type(),       // int32_t value
-          types->i64_type(),       // int64_t len
-          types->i32_ptr_type()};  // int32_t* out_len
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i32_type(),         // int32_t value
+          types->i64_type(),         // int64_t len
+          types->i32_ptr_type()};    // int32_t* out_len
   engine->AddGlobalMappingForFunc(
       "gdv_fn_castVARCHAR_int32_int64", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_int32_int64));
 
   // gdv_fn_castVARCHAR_int64_int64
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i64_type(),       // int64_t value
-          types->i64_type(),       // int64_t len
-          types->i32_ptr_type()};  // int32_t* out_len
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i64_type(),         // int64_t value
+          types->i64_type(),         // int64_t len
+          types->i32_ptr_type()};    // int32_t* out_len
   engine->AddGlobalMappingForFunc(
       "gdv_fn_castVARCHAR_int64_int64", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_int64_int64));
 
   // gdv_fn_castVARCHAR_float32_int64
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->float_type(),     // float value
-          types->i64_type(),       // int64_t len
-          types->i32_ptr_type()};  // int32_t* out_len
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->float_type(),       // float value
+          types->i64_type(),         // int64_t len
+          types->i32_ptr_type()};    // int32_t* out_len
   engine->AddGlobalMappingForFunc(
       "gdv_fn_castVARCHAR_float32_int64", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_float32_int64));
 
   // gdv_fn_castVARCHAR_float64_int64
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->double_type(),    // double value
-          types->i64_type(),       // int64_t len
-          types->i32_ptr_type()};  // int32_t* out_len
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->double_type(),      // double value
+          types->i64_type(),         // int64_t len
+          types->i32_ptr_type()};    // int32_t* out_len
   engine->AddGlobalMappingForFunc(
       "gdv_fn_castVARCHAR_float64_int64", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_castVARCHAR_float64_int64));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castINT_varbinary", types->i32_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castINT_varbinary));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castBIGINT_varbinary", types->i64_type(), args,
                                   reinterpret_cast<void*>(gdv_fn_castBIGINT_varbinary));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT4_varbinary", types->float_type(),
                                   args,
                                   reinterpret_cast<void*>(gdv_fn_castFLOAT4_varbinary));
 
-  args = {types->void_ptr_type(),  // void* context_ptr
-          types->i8_ptr_type(),    // const char* data
-          types->i32_type()};      // int32_t lenr
+  args = {types->opaque_ptr_type(),  // void* context_ptr
+          types->i8_ptr_type(),      // const char* data
+          types->i32_type()};        // int32_t lenr
 
   engine->AddGlobalMappingForFunc("gdv_fn_castFLOAT8_varbinary", types->double_type(),
                                   args,
@@ -1138,10 +1138,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1149,10 +1149,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int16
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i16_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i16_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1160,10 +1160,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1171,10 +1171,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_int32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_int64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1182,10 +1182,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1193,10 +1193,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint16
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i16_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i16_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1204,10 +1204,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1215,10 +1215,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_uint64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_uint64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1226,10 +1226,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_float32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->float_type(),     // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->float_type(),       // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_float32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1237,10 +1237,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_float64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->double_type(),    // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->double_type(),      // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_float64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1248,10 +1248,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_boolean
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i1_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i1_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_boolean",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1259,10 +1259,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_date64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_date64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1270,10 +1270,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_date32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_date32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1281,10 +1281,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_time32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_time32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1292,10 +1292,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_timestamp
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_timestamp",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1303,11 +1303,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_from_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char*
-      types->i32_type(),       // value_length
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char*
+      types->i32_type(),         // value_length
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_utf8",
@@ -1316,11 +1316,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_from_binary
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char*
-      types->i32_type(),       // value_length
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char*
+      types->i32_type(),         // value_length
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_binary",
@@ -1329,10 +1329,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1340,10 +1340,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int16
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i16_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i16_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1351,10 +1351,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1362,10 +1362,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_int32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_int64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1373,10 +1373,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint8",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1384,10 +1384,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint16
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i16_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i16_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint16",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1395,10 +1395,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1406,10 +1406,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_uint64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_uint64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1417,10 +1417,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_float32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->float_type(),     // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->float_type(),       // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_float32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1428,10 +1428,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_float64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->double_type(),    // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->double_type(),      // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_float64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1439,10 +1439,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_boolean
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i1_type(),        // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i1_type(),          // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_boolean",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1450,10 +1450,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_date64
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_date64",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1461,10 +1461,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_date32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_date32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1472,10 +1472,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_time32
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i32_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i32_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_time32",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1483,10 +1483,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha256_timestamp
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // value
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // value
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out_length
   };
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_timestamp",
                                   types->i8_ptr_type() /*return_type*/, args,
@@ -1494,11 +1494,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_hash_sha256_from_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char*
-      types->i32_type(),       // value_length
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char*
+      types->i32_type(),         // value_length
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_utf8",
@@ -1507,11 +1507,11 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_hash_sha256_from_binary
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char*
-      types->i32_type(),       // value_length
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char*
+      types->i32_type(),         // value_length
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_binary",
@@ -1520,13 +1520,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_sha1_decimal128
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // high_bits
-      types->i64_type(),       // low_bits
-      types->i32_type(),       // precision
-      types->i32_type(),       // scale
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // high_bits
+      types->i64_type(),         // low_bits
+      types->i32_type(),         // precision
+      types->i32_type(),         // scale
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha1_decimal128",
@@ -1534,13 +1534,13 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_sha1_decimal128));
   // gdv_fn_sha256_decimal128
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i64_type(),       // high_bits
-      types->i64_type(),       // low_bits
-      types->i32_type(),       // precision
-      types->i32_type(),       // scale
-      types->i1_type(),        // validity
-      types->i32_ptr_type()    // out length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i64_type(),         // high_bits
+      types->i64_type(),         // low_bits
+      types->i32_type(),         // precision
+      types->i32_type(),         // scale
+      types->i1_type(),          // validity
+      types->i32_ptr_type()      // out length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_sha256_decimal128",
@@ -1549,10 +1549,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_base64_encode_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // in
-      types->i32_type(),       // in_len
-      types->i32_ptr_type(),   // out_len
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // in
+      types->i32_type(),         // in_len
+      types->i32_ptr_type(),     // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_base64_encode_binary",
@@ -1561,10 +1561,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_base64_decode_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // in
-      types->i32_type(),       // in_len
-      types->i32_ptr_type(),   // out_len
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // in
+      types->i32_type(),         // in_len
+      types->i32_ptr_type(),     // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_base64_decode_utf8",
@@ -1573,10 +1573,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_upper_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // data
-      types->i32_type(),       // data_len
-      types->i32_ptr_type(),   // out_len
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // data
+      types->i32_type(),         // data_len
+      types->i32_ptr_type(),     // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_upper_utf8",
@@ -1584,10 +1584,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   reinterpret_cast<void*>(gdv_fn_upper_utf8));
   // gdv_fn_lower_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // data
-      types->i32_type(),       // data_len
-      types->i32_ptr_type(),   // out_len
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // data
+      types->i32_type(),         // data_len
+      types->i32_ptr_type(),     // out_len
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_lower_utf8",
@@ -1596,10 +1596,10 @@ void ExportedStubFunctions::AddMappings(Engine* engine) const {
 
   // gdv_fn_initcap_utf8
   args = {
-      types->void_ptr_type(),  // void* context_ptr
-      types->i8_ptr_type(),    // const char*
-      types->i32_type(),       // value_length
-      types->i32_ptr_type()    // out_length
+      types->opaque_ptr_type(),  // void* context_ptr
+      types->i8_ptr_type(),      // const char*
+      types->i32_type(),         // value_length
+      types->i32_ptr_type()      // out_length
   };
 
   engine->AddGlobalMappingForFunc("gdv_fn_initcap_utf8",

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -55,119 +55,119 @@ using gdv_month_interval = int32_t;
 #endif
 #endif
 
-bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
-                           const char* pattern, int pattern_len);
+bool gdv_fn_like_utf8_utf8(void* ptr, const char* data, int data_len, const char* pattern,
+                           int pattern_len);
 
-bool gdv_fn_like_utf8_utf8_utf8(int64_t ptr, const char* data, int data_len,
+bool gdv_fn_like_utf8_utf8_utf8(void* ptr, const char* data, int data_len,
                                 const char* pattern, int pattern_len,
                                 const char* escape_char, int escape_char_len);
 
-bool gdv_fn_ilike_utf8_utf8(int64_t ptr, const char* data, int data_len,
+bool gdv_fn_ilike_utf8_utf8(void* ptr, const char* data, int data_len,
                             const char* pattern, int pattern_len);
 
-int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t context, int64_t ptr, const char* data,
+int64_t gdv_fn_to_date_utf8_utf8_int32(void* context_ptr, void* ptr, const char* data,
                                        int data_len, bool in1_validity,
                                        const char* pattern, int pattern_len,
                                        bool in2_validity, int32_t suppress_errors,
                                        bool in3_validity, bool* out_valid);
 
-void gdv_fn_context_set_error_msg(int64_t context_ptr, const char* err_msg);
+void gdv_fn_context_set_error_msg(void* context_ptr, const char* err_msg);
 
-uint8_t* gdv_fn_context_arena_malloc(int64_t context_ptr, int32_t data_len);
+uint8_t* gdv_fn_context_arena_malloc(void* context_ptr, int32_t data_len);
 
-void gdv_fn_context_arena_reset(int64_t context_ptr);
+void gdv_fn_context_arena_reset(void* context_ptr);
 
-bool in_expr_lookup_int32(int64_t ptr, int32_t value, bool in_validity);
+bool in_expr_lookup_int32(void* ptr, int32_t value, bool in_validity);
 
-bool in_expr_lookup_int64(int64_t ptr, int64_t value, bool in_validity);
+bool in_expr_lookup_int64(void* ptr, int64_t value, bool in_validity);
 
-bool in_expr_lookup_utf8(int64_t ptr, const char* data, int data_len, bool in_validity);
+bool in_expr_lookup_utf8(void* ptr, const char* data, int data_len, bool in_validity);
 
 int gdv_fn_time_with_zone(int* time_fields, const char* zone, int zone_len,
                           int64_t* ret_time);
 
 GANDIVA_EXPORT
-const char* gdv_fn_base64_encode_binary(int64_t context, const char* in, int32_t in_len,
+const char* gdv_fn_base64_encode_binary(void* context_ptr, const char* in, int32_t in_len,
                                         int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_base64_decode_utf8(int64_t context, const char* in, int32_t in_len,
+const char* gdv_fn_base64_decode_utf8(void* context_ptr, const char* in, int32_t in_len,
                                       int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_castVARBINARY_int32_int64(int64_t context, gdv_int32 value,
+const char* gdv_fn_castVARBINARY_int32_int64(void* context_ptr, gdv_int32 value,
                                              int64_t out_len, int32_t* out_length);
 
 GANDIVA_EXPORT
-const char* gdv_fn_castVARBINARY_int64_int64(int64_t context, gdv_int64 value,
+const char* gdv_fn_castVARBINARY_int64_int64(void* context_ptr, gdv_int64 value,
                                              int64_t out_len, int32_t* out_length);
 
 GANDIVA_EXPORT
-const char* gdv_fn_sha256_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+const char* gdv_fn_sha256_decimal128(void* context_ptr, int64_t x_high, uint64_t x_low,
                                      int32_t x_precision, int32_t x_scale,
                                      gdv_boolean x_isvalid, int32_t* out_length);
 
 GANDIVA_EXPORT
-const char* gdv_fn_sha1_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+const char* gdv_fn_sha1_decimal128(void* context_ptr, int64_t x_high, uint64_t x_low,
                                    int32_t x_precision, int32_t x_scale,
                                    gdv_boolean x_isvalid, int32_t* out_length);
 
-int32_t gdv_fn_dec_from_string(int64_t context, const char* in, int32_t in_length,
+int32_t gdv_fn_dec_from_string(void* context_ptr, const char* in, int32_t in_length,
                                int32_t* precision_from_str, int32_t* scale_from_str,
                                int64_t* dec_high_from_str, uint64_t* dec_low_from_str);
 
-char* gdv_fn_dec_to_string(int64_t context, int64_t x_high, uint64_t x_low,
+char* gdv_fn_dec_to_string(void* context_ptr, int64_t x_high, uint64_t x_low,
                            int32_t x_scale, int32_t* dec_str_len);
 
 GANDIVA_EXPORT
-int32_t gdv_fn_castINT_utf8(int64_t context, const char* data, int32_t data_len);
+int32_t gdv_fn_castINT_utf8(void* context_ptr, const char* data, int32_t data_len);
 
 GANDIVA_EXPORT
-int64_t gdv_fn_castBIGINT_utf8(int64_t context, const char* data, int32_t data_len);
+int64_t gdv_fn_castBIGINT_utf8(void* context_ptr, const char* data, int32_t data_len);
 
 GANDIVA_EXPORT
-float gdv_fn_castFLOAT4_utf8(int64_t context, const char* data, int32_t data_len);
+float gdv_fn_castFLOAT4_utf8(void* context_ptr, const char* data, int32_t data_len);
 
 GANDIVA_EXPORT
-double gdv_fn_castFLOAT8_utf8(int64_t context, const char* data, int32_t data_len);
+double gdv_fn_castFLOAT8_utf8(void* context_ptr, const char* data, int32_t data_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_castVARCHAR_int32_int64(int64_t context, int32_t value, int64_t len,
+const char* gdv_fn_castVARCHAR_int32_int64(void* context_ptr, int32_t value, int64_t len,
                                            int32_t* out_len);
 GANDIVA_EXPORT
-const char* gdv_fn_castVARCHAR_int64_int64(int64_t context, int64_t value, int64_t len,
+const char* gdv_fn_castVARCHAR_int64_int64(void* context_ptr, int64_t value, int64_t len,
                                            int32_t* out_len);
 GANDIVA_EXPORT
-const char* gdv_fn_castVARCHAR_float32_int64(int64_t context, float value, int64_t len,
+const char* gdv_fn_castVARCHAR_float32_int64(void* context_ptr, float value, int64_t len,
                                              int32_t* out_len);
 GANDIVA_EXPORT
-const char* gdv_fn_castVARCHAR_float64_int64(int64_t context, double value, int64_t len,
+const char* gdv_fn_castVARCHAR_float64_int64(void* context_ptr, double value, int64_t len,
                                              int32_t* out_len);
 
 GANDIVA_EXPORT
 int32_t gdv_fn_utf8_char_length(char c);
 
 GANDIVA_EXPORT
-const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_upper_utf8(void* context_ptr, const char* data, int32_t data_len,
                               int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_lower_utf8(void* context_ptr, const char* data, int32_t data_len,
                               int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_len,
+const char* gdv_fn_initcap_utf8(void* context_ptr, const char* data, int32_t data_len,
                                 int32_t* out_len);
 
 GANDIVA_EXPORT
-int32_t gdv_fn_castINT_varbinary(gdv_int64 context, const char* in, int32_t in_len);
+int32_t gdv_fn_castINT_varbinary(void* context_ptr, const char* in, int32_t in_len);
 
 GANDIVA_EXPORT
-int64_t gdv_fn_castBIGINT_varbinary(gdv_int64 context, const char* in, int32_t in_len);
+int64_t gdv_fn_castBIGINT_varbinary(void* context_ptr, const char* in, int32_t in_len);
 
 GANDIVA_EXPORT
-float gdv_fn_castFLOAT4_varbinary(gdv_int64 context, const char* in, int32_t in_len);
+float gdv_fn_castFLOAT4_varbinary(void* context_ptr, const char* in, int32_t in_len);
 
 GANDIVA_EXPORT
-double gdv_fn_castFLOAT8_varbinary(gdv_int64 context, const char* in, int32_t in_len);
+double gdv_fn_castFLOAT8_varbinary(void* context_ptr, const char* in, int32_t in_len);
 }

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -25,745 +25,755 @@
 namespace gandiva {
 
 TEST(TestGdvFnStubs, TestCastVarbinaryNumeric) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
   // tests for integer values as input
-  const char* out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, -46, 100, &out_len);
+  const char* out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, -46, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-46");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, 2147483647, 100, &out_len);
+  out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, 2147483647, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "2147483647");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, -2147483647 - 1, 100, &out_len);
+  out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, -2147483647 - 1, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-2147483648");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, 0, 100, &out_len);
+  out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, 0, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, 34567, 3, &out_len);
+  out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, 34567, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "345");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int32_int64(ctx_ptr, 347, 0, &out_len);
+  out_str = gdv_fn_castVARBINARY_int32_int64(context_ptr, 347, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  gdv_fn_castVARBINARY_int32_int64(ctx_ptr, 347, -1, &out_len);
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer length can not be negative"));
-  ctx.Reset();
+  gdv_fn_castVARBINARY_int32_int64(context_ptr, 347, -1, &out_len);
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer length can not be negative"));
+  context.Reset();
 
   // tests for big integer values as input
   out_str =
-      gdv_fn_castVARBINARY_int64_int64(ctx_ptr, 9223372036854775807LL, 100, &out_len);
+      gdv_fn_castVARBINARY_int64_int64(context_ptr, 9223372036854775807LL, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "9223372036854775807");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int64_int64(ctx_ptr, -9223372036854775807LL - 1, 100,
+  out_str = gdv_fn_castVARBINARY_int64_int64(context_ptr, -9223372036854775807LL - 1, 100,
                                              &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-9223372036854775808");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARBINARY_int64_int64(ctx_ptr, 0, 100, &out_len);
+  out_str = gdv_fn_castVARBINARY_int64_int64(context_ptr, 0, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARBINARY_int64_int64(ctx_ptr, 12345, 3, &out_len);
+  out_str = gdv_fn_castVARBINARY_int64_int64(context_ptr, 12345, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestGdvFnStubs, TestBase64Encode) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  auto value = gdv_fn_base64_encode_binary(ctx_ptr, "hello", 5, &out_len);
+  auto value = gdv_fn_base64_encode_binary(context_ptr, "hello", 5, &out_len);
   std::string out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "aGVsbG8=");
 
-  value = gdv_fn_base64_encode_binary(ctx_ptr, "test", 4, &out_len);
+  value = gdv_fn_base64_encode_binary(context_ptr, "test", 4, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "dGVzdA==");
 
-  value = gdv_fn_base64_encode_binary(ctx_ptr, "hive", 4, &out_len);
+  value = gdv_fn_base64_encode_binary(context_ptr, "hive", 4, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "aGl2ZQ==");
 
-  value = gdv_fn_base64_encode_binary(ctx_ptr, "", 0, &out_len);
+  value = gdv_fn_base64_encode_binary(context_ptr, "", 0, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "");
 
-  value = gdv_fn_base64_encode_binary(ctx_ptr, "test", -5, &out_len);
+  value = gdv_fn_base64_encode_binary(context_ptr, "test", -5, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "");
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer length can not be negative"));
-  ctx.Reset();
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer length can not be negative"));
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestBase64Decode) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  auto value = gdv_fn_base64_decode_utf8(ctx_ptr, "aGVsbG8=", 8, &out_len);
+  auto value = gdv_fn_base64_decode_utf8(context_ptr, "aGVsbG8=", 8, &out_len);
   std::string out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "hello");
 
-  value = gdv_fn_base64_decode_utf8(ctx_ptr, "dGVzdA==", 8, &out_len);
+  value = gdv_fn_base64_decode_utf8(context_ptr, "dGVzdA==", 8, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "test");
 
-  value = gdv_fn_base64_decode_utf8(ctx_ptr, "aGl2ZQ==", 8, &out_len);
+  value = gdv_fn_base64_decode_utf8(context_ptr, "aGl2ZQ==", 8, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "hive");
 
-  value = gdv_fn_base64_decode_utf8(ctx_ptr, "", 0, &out_len);
+  value = gdv_fn_base64_decode_utf8(context_ptr, "", 0, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "");
 
-  value = gdv_fn_base64_decode_utf8(ctx_ptr, "test", -5, &out_len);
+  value = gdv_fn_base64_decode_utf8(context_ptr, "test", -5, &out_len);
   out_value = std::string(value, out_len);
   EXPECT_EQ(out_value, "");
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer length can not be negative"));
-  ctx.Reset();
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer length can not be negative"));
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastINT) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "-45", 3), -45);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "0", 1), 0);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "2147483647", 10), 2147483647);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "02147483647", 11), 2147483647);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "-2147483648", 11), -2147483648LL);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, "-02147483648", 12), -2147483648LL);
-  EXPECT_EQ(gdv_fn_castINT_utf8(ctx_ptr, " 12 ", 4), 12);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "-45", 3), -45);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "0", 1), 0);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "2147483647", 10), 2147483647);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "02147483647", 11), 2147483647);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "-2147483648", 11), -2147483648LL);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, "-02147483648", 12), -2147483648LL);
+  EXPECT_EQ(gdv_fn_castINT_utf8(context_ptr, " 12 ", 4), 12);
 
-  gdv_fn_castINT_utf8(ctx_ptr, "2147483648", 10);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "2147483648", 10);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 2147483648 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_utf8(ctx_ptr, "-2147483649", 11);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "-2147483649", 11);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string -2147483649 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_utf8(ctx_ptr, "12.34", 5);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "12.34", 5);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 12.34 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_utf8(ctx_ptr, "abc", 3);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "abc", 3);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string abc to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_utf8(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_utf8(ctx_ptr, "-", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_utf8(context_ptr, "-", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string - to int32"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastBIGINT) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "-45", 3), -45);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "0", 1), 0);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "9223372036854775807", 19),
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "-45", 3), -45);
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "0", 1), 0);
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "9223372036854775807", 19),
             9223372036854775807LL);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "09223372036854775807", 20),
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "09223372036854775807", 20),
             9223372036854775807LL);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "-9223372036854775808", 20),
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "-9223372036854775808", 20),
             -9223372036854775807LL - 1);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, "-009223372036854775808", 22),
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, "-009223372036854775808", 22),
             -9223372036854775807LL - 1);
-  EXPECT_EQ(gdv_fn_castBIGINT_utf8(ctx_ptr, " 12 ", 4), 12);
+  EXPECT_EQ(gdv_fn_castBIGINT_utf8(context_ptr, " 12 ", 4), 12);
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "9223372036854775808", 19);
+  gdv_fn_castBIGINT_utf8(context_ptr, "9223372036854775808", 19);
   EXPECT_THAT(
-      ctx.get_error(),
+      context.get_error(),
       ::testing::HasSubstr("Failed to cast the string 9223372036854775808 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "-9223372036854775809", 20);
+  gdv_fn_castBIGINT_utf8(context_ptr, "-9223372036854775809", 20);
   EXPECT_THAT(
-      ctx.get_error(),
+      context.get_error(),
       ::testing::HasSubstr("Failed to cast the string -9223372036854775809 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "12.34", 5);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_utf8(context_ptr, "12.34", 5);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 12.34 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "abc", 3);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_utf8(context_ptr, "abc", 3);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string abc to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_utf8(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_utf8(ctx_ptr, "-", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_utf8(context_ptr, "-", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string - to int64"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastFloat4) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(ctx_ptr, "-45.34", 6), -45.34f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(ctx_ptr, "0", 1), 0.0f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(ctx_ptr, "5", 1), 5.0f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(ctx_ptr, " 3.4 ", 5), 3.4f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(context_ptr, "-45.34", 6), -45.34f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(context_ptr, "0", 1), 0.0f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(context_ptr, "5", 1), 5.0f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_utf8(context_ptr, " 3.4 ", 5), 3.4f);
 
-  gdv_fn_castFLOAT4_utf8(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT4_utf8(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to float"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castFLOAT4_utf8(ctx_ptr, "e", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT4_utf8(context_ptr, "e", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string e to float"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastFloat8) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(ctx_ptr, "-45.34", 6), -45.34);
-  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(ctx_ptr, "0", 1), 0.0);
-  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(ctx_ptr, "5", 1), 5.0);
-  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(ctx_ptr, " 3.4 ", 5), 3.4);
+  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(context_ptr, "-45.34", 6), -45.34);
+  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(context_ptr, "0", 1), 0.0);
+  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(context_ptr, "5", 1), 5.0);
+  EXPECT_EQ(gdv_fn_castFLOAT8_utf8(context_ptr, " 3.4 ", 5), 3.4);
 
-  gdv_fn_castFLOAT8_utf8(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT8_utf8(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to double"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castFLOAT8_utf8(ctx_ptr, "e", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT8_utf8(context_ptr, "e", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string e to double"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVARCHARFromInt32) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  const char* out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, -46, 100, &out_len);
+  const char* out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, -46, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-46");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, 2147483647, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, 2147483647, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "2147483647");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, -2147483647 - 1, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, -2147483647 - 1, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-2147483648");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, 0, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, 0, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, 34567, 3, &out_len);
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, 34567, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "345");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, 347, 0, &out_len);
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, 347, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int32_int64(ctx_ptr, 347, -1, &out_len);
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer length can not be negative"));
-  ctx.Reset();
+  out_str = gdv_fn_castVARCHAR_int32_int64(context_ptr, 347, -1, &out_len);
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer length can not be negative"));
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVARCHARFromInt64) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
   const char* out_str =
-      gdv_fn_castVARCHAR_int64_int64(ctx_ptr, 9223372036854775807LL, 100, &out_len);
+      gdv_fn_castVARCHAR_int64_int64(context_ptr, 9223372036854775807LL, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "9223372036854775807");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str =
-      gdv_fn_castVARCHAR_int64_int64(ctx_ptr, -9223372036854775807LL - 1, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_int64_int64(context_ptr, -9223372036854775807LL - 1, 100,
+                                           &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-9223372036854775808");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_int64_int64(ctx_ptr, 0, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_int64_int64(context_ptr, 0, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARCHAR_int64_int64(ctx_ptr, 12345, 3, &out_len);
+  out_str = gdv_fn_castVARCHAR_int64_int64(context_ptr, 12345, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestGdvFnStubs, TestCastVARCHARFromFloat) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  const char* out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 4.567f, 100, &out_len);
+  const char* out_str =
+      gdv_fn_castVARCHAR_float32_int64(context_ptr, 4.567f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "4.567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, -3.4567f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, -3.4567f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-3.4567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 0.00001f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 0.00001f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1.0E-5");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 0.00099999f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 0.00099999f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "9.9999E-4");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 0.0f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 0.0f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0.0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 10.00000f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 10.00000f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "10.0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 1.2345f, 3, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 1.2345f, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1.2");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestGdvFnStubs, TestCastVARCHARFromDouble) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  const char* out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, 4.567, 100, &out_len);
+  const char* out_str =
+      gdv_fn_castVARCHAR_float64_int64(context_ptr, 4.567, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "4.567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, -3.4567, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float64_int64(context_ptr, -3.4567, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "-3.4567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, 0.00001, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float64_int64(context_ptr, 0.00001, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1.0E-5");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float32_int64(ctx_ptr, 0.00099999f, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float32_int64(context_ptr, 0.00099999f, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "9.9999E-4");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, 0.0, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float64_int64(context_ptr, 0.0, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0.0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, 10.0000000000, 100, &out_len);
+  out_str = gdv_fn_castVARCHAR_float64_int64(context_ptr, 10.0000000000, 100, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "10.0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // test with required length less than actual buffer length
-  out_str = gdv_fn_castVARCHAR_float64_int64(ctx_ptr, 1.2345, 3, &out_len);
+  out_str = gdv_fn_castVARCHAR_float64_int64(context_ptr, 1.2345, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1.2");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestGdvFnStubs, TestUpper) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = gdv_fn_upper_utf8(ctx_ptr, "AbcDEfGh", 8, &out_len);
+  const char* out_str = gdv_fn_upper_utf8(context_ptr, "AbcDEfGh", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ABCDEFGH");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "asdfj", 5, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "asdfj", 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ASDFJ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "s;dcGS,jO!l", 11, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "s;dcGS,jO!l", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "S;DCGS,JO!L");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "münchen", 8, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "münchen", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "MÜNCHEN");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "CITROËN", 8, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "CITROËN", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "CITROËN");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "âBćDëFGH", 11, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "âBćDëFGH", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ÂBĆDËFGH");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "øhpqRšvñ", 11, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "øhpqRšvñ", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ØHPQRŠVÑ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "Möbelträgerfüße", 19, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "Möbelträgerfüße", 19, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "MÖBELTRÄGERFÜẞE");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "{õhp,PQŚv}ń+", 15, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "{õhp,PQŚv}ń+", 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "{ÕHP,PQŚV}Ń+");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_upper_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = gdv_fn_upper_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d("AbOJjÜoß\xc3");
-  out_str = gdv_fn_upper_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), &out_len);
+  out_str =
+      gdv_fn_upper_utf8(context_ptr, d.data(), static_cast<int>(d.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 
   std::string e(
       "åbÑg\xe0\xa0"
       "åBUå");
-  out_str = gdv_fn_upper_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), &out_len);
+  out_str =
+      gdv_fn_upper_utf8(context_ptr, e.data(), static_cast<int>(e.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\e0 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestLower) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = gdv_fn_lower_utf8(ctx_ptr, "AbcDEfGh", 8, &out_len);
+  const char* out_str = gdv_fn_lower_utf8(context_ptr, "AbcDEfGh", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcdefgh");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "asdfj", 5, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "asdfj", 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdfj");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "S;DCgs,Jo!L", 11, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "S;DCgs,Jo!L", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "s;dcgs,jo!l");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "MÜNCHEN", 8, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "MÜNCHEN", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "münchen");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "citroën", 8, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "citroën", 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "citroën");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "ÂbĆDËFgh", 11, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "ÂbĆDËFgh", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "âbćdëfgh");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "ØHPQrŠvÑ", 11, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "ØHPQrŠvÑ", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "øhpqršvñ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "MÖBELTRÄGERFÜẞE", 20, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "MÖBELTRÄGERFÜẞE", 20, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "möbelträgerfüße");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "{ÕHP,pqśv}Ń+", 15, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "{ÕHP,pqśv}Ń+", 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "{õhp,pqśv}ń+");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_lower_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = gdv_fn_lower_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d("AbOJjÜoß\xc3");
-  out_str = gdv_fn_lower_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), &out_len);
+  out_str =
+      gdv_fn_lower_utf8(context_ptr, d.data(), static_cast<int>(d.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 
   std::string e(
       "åbÑg\xe0\xa0"
       "åBUå");
-  out_str = gdv_fn_lower_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), &out_len);
+  out_str =
+      gdv_fn_lower_utf8(context_ptr, e.data(), static_cast<int>(e.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\e0 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestInitCap) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = gdv_fn_initcap_utf8(ctx_ptr, "test string", 11, &out_len);
+  const char* out_str = gdv_fn_initcap_utf8(context_ptr, "test string", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test String");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "asdfj\nhlqf", 10, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "asdfj\nhlqf", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Asdfj\nHlqf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "s;DCgs,Jo!l", 11, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "s;DCgs,Jo!l", 11, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "S;Dcgs,Jo!L");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, " mÜNCHEN", 9, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, " mÜNCHEN", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), " München");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "citroën CaR", 12, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "citroën CaR", 12, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Citroën Car");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "ÂbĆDËFgh\néll", 16, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "ÂbĆDËFgh\néll", 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Âbćdëfgh\nÉll");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "  øhpqršvñ  \n\n", 17, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "  øhpqršvñ  \n\n", 17, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "  Øhpqršvñ  \n\n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str =
-      gdv_fn_initcap_utf8(ctx_ptr, "möbelträgerfüße   \nmöbelträgerfüße", 42, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "möbelträgerfüße   \nmöbelträgerfüße", 42,
+                                &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Möbelträgerfüße   \nMöbelträgerfüße");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "{ÕHP,pqśv}Ń+", 15, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "{ÕHP,pqśv}Ń+", 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "{Õhp,Pqśv}Ń+");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "sɦasasdsɦsd\"sdsdɦ", 19, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "sɦasasdsɦsd\"sdsdɦ", 19, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Sɦasasdsɦsd\"Sdsdɦ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "mysuperscipt@number²isfine", 27, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "mysuperscipt@number²isfine", 27, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Mysuperscipt@Number²Isfine");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "Ő<tŵas̓老ƕɱ¢vIYwށ", 25, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "Ő<tŵas̓老ƕɱ¢vIYwށ", 25, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Ő<Tŵas̓老Ƕɱ¢Viywށ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "ↆcheckↆnumberisspace", 24, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "ↆcheckↆnumberisspace", 24, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ↆcheckↆnumberisspace");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "testing ᾌTitleᾌcase", 23, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "testing ᾌTitleᾌcase", 23, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Testing ᾌtitleᾄcase");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "ʳTesting mʳodified", 20, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "ʳTesting mʳodified", 20, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ʳTesting MʳOdified");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = gdv_fn_initcap_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d("AbOJjÜoß\xc3");
   out_str =
-      gdv_fn_initcap_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), &out_len);
+      gdv_fn_initcap_utf8(context_ptr, d.data(), static_cast<int>(d.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 
   std::string e(
       "åbÑg\xe0\xa0"
       "åBUå");
   out_str =
-      gdv_fn_initcap_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), &out_len);
+      gdv_fn_initcap_utf8(context_ptr, e.data(), static_cast<int>(e.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\e0 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryINT) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "-45", 3), -45);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "0", 1), 0);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "2147483647", 10), 2147483647);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "\x32\x33", 2), 23);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "02147483647", 11), 2147483647);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "-2147483648", 11), -2147483648LL);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, "-02147483648", 12), -2147483648LL);
-  EXPECT_EQ(gdv_fn_castINT_varbinary(ctx_ptr, " 12 ", 4), 12);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "-45", 3), -45);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "0", 1), 0);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "2147483647", 10), 2147483647);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "\x32\x33", 2), 23);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "02147483647", 11), 2147483647);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "-2147483648", 11), -2147483648LL);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, "-02147483648", 12), -2147483648LL);
+  EXPECT_EQ(gdv_fn_castINT_varbinary(context_ptr, " 12 ", 4), 12);
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "2147483648", 10);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "2147483648", 10);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 2147483648 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "-2147483649", 11);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "-2147483649", 11);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string -2147483649 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "12.34", 5);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "12.34", 5);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 12.34 to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "abc", 3);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "abc", 3);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string abc to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to int32"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castINT_varbinary(ctx_ptr, "-", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castINT_varbinary(context_ptr, "-", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string - to int32"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryBIGINT) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "-45", 3), -45);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "0", 1), 0);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "9223372036854775807", 19),
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "-45", 3), -45);
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "0", 1), 0);
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "9223372036854775807", 19),
             9223372036854775807LL);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "09223372036854775807", 20),
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "09223372036854775807", 20),
             9223372036854775807LL);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "-9223372036854775808", 20),
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "-9223372036854775808", 20),
             -9223372036854775807LL - 1);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, "-009223372036854775808", 22),
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, "-009223372036854775808", 22),
             -9223372036854775807LL - 1);
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr, " 12 ", 4), 12);
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr, " 12 ", 4), 12);
 
-  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(ctx_ptr,
+  EXPECT_EQ(gdv_fn_castBIGINT_varbinary(context_ptr,
                                         "\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39", 10),
             9999999999LL);
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "9223372036854775808", 19);
+  gdv_fn_castBIGINT_varbinary(context_ptr, "9223372036854775808", 19);
   EXPECT_THAT(
-      ctx.get_error(),
+      context.get_error(),
       ::testing::HasSubstr("Failed to cast the string 9223372036854775808 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "-9223372036854775809", 20);
+  gdv_fn_castBIGINT_varbinary(context_ptr, "-9223372036854775809", 20);
   EXPECT_THAT(
-      ctx.get_error(),
+      context.get_error(),
       ::testing::HasSubstr("Failed to cast the string -9223372036854775809 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "12.34", 5);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_varbinary(context_ptr, "12.34", 5);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string 12.34 to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "abc", 3);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_varbinary(context_ptr, "abc", 3);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string abc to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_varbinary(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to int64"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castBIGINT_varbinary(ctx_ptr, "-", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castBIGINT_varbinary(context_ptr, "-", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string - to int64"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryFloat4) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(ctx_ptr, "-45.34", 6), -45.34f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(ctx_ptr, "0", 1), 0.0f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(ctx_ptr, "5", 1), 5.0f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(ctx_ptr, " 3.4 ", 5), 3.4f);
-  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(ctx_ptr, " \x33\x2E\x34 ", 5), 3.4f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(context_ptr, "-45.34", 6), -45.34f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(context_ptr, "0", 1), 0.0f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(context_ptr, "5", 1), 5.0f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(context_ptr, " 3.4 ", 5), 3.4f);
+  EXPECT_EQ(gdv_fn_castFLOAT4_varbinary(context_ptr, " \x33\x2E\x34 ", 5), 3.4f);
 
-  gdv_fn_castFLOAT4_varbinary(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT4_varbinary(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to float"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castFLOAT4_varbinary(ctx_ptr, "e", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT4_varbinary(context_ptr, "e", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string e to float"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryFloat8) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(ctx_ptr, "-45.34", 6), -45.34);
-  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(ctx_ptr, "0", 1), 0.0);
-  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(ctx_ptr, "5", 1), 5.0);
-  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(ctx_ptr, " \x33\x2E\x34 ", 5), 3.4);
+  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(context_ptr, "-45.34", 6), -45.34);
+  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(context_ptr, "0", 1), 0.0);
+  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(context_ptr, "5", 1), 5.0);
+  EXPECT_EQ(gdv_fn_castFLOAT8_varbinary(context_ptr, " \x33\x2E\x34 ", 5), 3.4);
 
-  gdv_fn_castFLOAT8_varbinary(ctx_ptr, "", 0);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT8_varbinary(context_ptr, "", 0);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string  to double"));
-  ctx.Reset();
+  context.Reset();
 
-  gdv_fn_castFLOAT8_varbinary(ctx_ptr, "e", 1);
-  EXPECT_THAT(ctx.get_error(),
+  gdv_fn_castFLOAT8_varbinary(context_ptr, "e", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Failed to cast the string e to double"));
-  ctx.Reset();
+  context.Reset();
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/hash_utils.cc
+++ b/cpp/src/gandiva/hash_utils.cc
@@ -16,7 +16,9 @@
 // under the License.
 
 #include "gandiva/hash_utils.h"
+
 #include <cstring>
+
 #include "arrow/util/logging.h"
 #include "gandiva/gdv_function_stubs.h"
 #include "openssl/evp.h"
@@ -24,7 +26,7 @@
 namespace gandiva {
 /// Hashes a generic message using the SHA256 algorithm
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha256(int64_t context, const void* message,
+const char* gdv_hash_using_sha256(void* context, const void* message,
                                   size_t message_length, int32_t* out_length) {
   constexpr int sha256_result_length = 64;
   return gdv_hash_using_sha(context, message, message_length, EVP_sha256(),
@@ -33,8 +35,8 @@ const char* gdv_hash_using_sha256(int64_t context, const void* message,
 
 /// Hashes a generic message using the SHA1 algorithm
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha1(int64_t context, const void* message,
-                                size_t message_length, int32_t* out_length) {
+const char* gdv_hash_using_sha1(void* context, const void* message, size_t message_length,
+                                int32_t* out_length) {
   constexpr int sha1_result_length = 40;
   return gdv_hash_using_sha(context, message, message_length, EVP_sha1(),
                             sha1_result_length, out_length);
@@ -46,9 +48,9 @@ const char* gdv_hash_using_sha1(int64_t context, const void* message,
 /// the hash. The type of the hash is defined by the
 /// \b hash_type \b parameter.
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha(int64_t context, const void* message,
-                               size_t message_length, const EVP_MD* hash_type,
-                               uint32_t result_buf_size, int32_t* out_length) {
+const char* gdv_hash_using_sha(void* context, const void* message, size_t message_length,
+                               const EVP_MD* hash_type, uint32_t result_buf_size,
+                               int32_t* out_length) {
   EVP_MD_CTX* md_ctx = EVP_MD_CTX_new();
 
   if (md_ctx == nullptr) {

--- a/cpp/src/gandiva/hash_utils.h
+++ b/cpp/src/gandiva/hash_utils.h
@@ -20,22 +20,23 @@
 
 #include <cstdint>
 #include <cstdlib>
+
 #include "gandiva/visibility.h"
 #include "openssl/evp.h"
 
 namespace gandiva {
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha256(int64_t context, const void* message,
+const char* gdv_hash_using_sha256(void* context, const void* message,
                                   size_t message_length, int32_t* out_length);
 
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha1(int64_t context, const void* message,
-                                size_t message_length, int32_t* out_length);
+const char* gdv_hash_using_sha1(void* context, const void* message, size_t message_length,
+                                int32_t* out_length);
 
 GANDIVA_EXPORT
-const char* gdv_hash_using_sha(int64_t context, const void* message,
-                               size_t message_length, const EVP_MD* hash_type,
-                               uint32_t result_buf_size, int32_t* out_length);
+const char* gdv_hash_using_sha(void* context, const void* message, size_t message_length,
+                               const EVP_MD* hash_type, uint32_t result_buf_size,
+                               int32_t* out_length);
 
 GANDIVA_EXPORT
 uint64_t gdv_double_to_long(double value);

--- a/cpp/src/gandiva/hash_utils_test.cc
+++ b/cpp/src/gandiva/hash_utils_test.cc
@@ -15,16 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "gandiva/hash_utils.h"
+
 #include <gtest/gtest.h>
+
 #include <unordered_set>
 
 #include "gandiva/execution_context.h"
-#include "gandiva/hash_utils.h"
 
 TEST(TestShaHashUtils, TestSha1Numeric) {
   gandiva::ExecutionContext ctx;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  auto ctx_ptr = reinterpret_cast<void*>(&ctx);
 
   std::vector<uint64_t> values_to_be_hashed;
 
@@ -59,7 +61,7 @@ TEST(TestShaHashUtils, TestSha1Numeric) {
 TEST(TestShaHashUtils, TestSha256Numeric) {
   gandiva::ExecutionContext ctx;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  auto ctx_ptr = reinterpret_cast<void*>(&ctx);
 
   std::vector<uint64_t> values_to_be_hashed;
 
@@ -94,7 +96,7 @@ TEST(TestShaHashUtils, TestSha256Numeric) {
 TEST(TestShaHashUtils, TestSha1Varlen) {
   gandiva::ExecutionContext ctx;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  auto ctx_ptr = reinterpret_cast<void*>(&ctx);
 
   std::string first_string =
       "ði ıntəˈnæʃənəl fəˈnɛtık əsoʊsiˈeıʃn\nY [ˈʏpsilɔn], "
@@ -129,7 +131,7 @@ TEST(TestShaHashUtils, TestSha1Varlen) {
 TEST(TestShaHashUtils, TestSha256Varlen) {
   gandiva::ExecutionContext ctx;
 
-  auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  auto ctx_ptr = reinterpret_cast<void*>(&ctx);
 
   std::string first_string =
       "ði ıntəˈnæʃənəl fəˈnɛtık əsoʊsiˈeıʃn\nY [ˈʏpsilɔn], "

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -264,8 +264,8 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, int buffer_count,
     case SelectionVector::MODE_UINT64:
       arguments.push_back(types()->i64_ptr_type());
   }
-  arguments.push_back(types()->void_ptr_type());  // ctx_ptr
-  arguments.push_back(types()->i64_type());       // nrec
+  arguments.push_back(types()->opaque_ptr_type());  // ctx_ptr
+  arguments.push_back(types()->i64_type());         // nrec
   llvm::FunctionType* prototype =
       llvm::FunctionType::get(types()->i32_type(), arguments, false /*isVarArg*/);
 
@@ -1002,7 +1002,7 @@ void LLVMGenerator::Visitor::VisitInExpression(const InExprDexBase<Type>& dex) {
 
   const InExprDex<Type>& dex_instance = dynamic_cast<const InExprDex<Type>&>(dex);
   /* add the holder at the beginning */
-  llvm::Constant* holder_ptr = types->void_ptr_constant(dex_instance.in_holder().get());
+  llvm::Constant* holder_ptr = types->opaque_ptr_constant(dex_instance.in_holder().get());
   params.push_back(holder_ptr);
 
   /* eval expr result */
@@ -1042,7 +1042,7 @@ void LLVMGenerator::Visitor::VisitInExpression<gandiva::DecimalScalar128>(
   const InExprDex<gandiva::DecimalScalar128>& dex_instance =
       dynamic_cast<const InExprDex<gandiva::DecimalScalar128>&>(dex);
   /* add the holder at the beginning */
-  llvm::Constant* holder_ptr = types->void_ptr_constant(dex_instance.in_holder().get());
+  llvm::Constant* holder_ptr = types->opaque_ptr_constant(dex_instance.in_holder().get());
   params.push_back(holder_ptr);
 
   /* eval expr result */
@@ -1234,7 +1234,7 @@ std::vector<llvm::Value*> LLVMGenerator::Visitor::BuildParams(
 
   // if the function has holder, add the holder pointer.
   if (holder != nullptr) {
-    auto ptr = types->void_ptr_constant(holder);
+    auto ptr = types->opaque_ptr_constant(holder);
     params.push_back(ptr);
   }
 

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -677,8 +677,7 @@ void LLVMGenerator::Visitor::Visit(const LiteralDex& dex) {
     case arrow::Type::BINARY: {
       const std::string& str = arrow::util::get<std::string>(dex.holder());
 
-      llvm::Constant* str_int_cast = types->i64_constant((int64_t)str.c_str());
-      value = llvm::ConstantExpr::getIntToPtr(str_int_cast, types->i8_ptr_type());
+      value = types->i8_ptr_constant((int8_t*)str.c_str());
       len = types->i32_constant(static_cast<int32_t>(str.length()));
       break;
     }
@@ -1383,12 +1382,10 @@ void LLVMGenerator::AddTrace(const std::string& msg, llvm::Value* value) {
 
   // cast this to an llvm pointer.
   const char* str = trace_strings_.back().c_str();
-  llvm::Constant* str_int_cast = types()->i64_constant((int64_t)str);
-  llvm::Constant* str_ptr_cast =
-      llvm::ConstantExpr::getIntToPtr(str_int_cast, types()->i8_ptr_type());
+  llvm::Constant* str_ptr = types()->i8_ptr_constant((int8_t*)str);
 
   std::vector<llvm::Value*> args;
-  args.push_back(str_ptr_cast);
+  args.push_back(str_ptr);
   if (value != nullptr) {
     args.push_back(value);
   }

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -62,11 +62,15 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }
 
+  llvm::PointerType* i16_ptr_type() { return ptr_type(i16_type()); }
+
   llvm::PointerType* i32_ptr_type() { return ptr_type(i32_type()); }
 
   llvm::PointerType* i64_ptr_type() { return ptr_type(i64_type()); }
 
   llvm::PointerType* i128_ptr_type() { return ptr_type(i128_type()); }
+
+  llvm::PointerType* i8_ptr_ptr_type() { return ptr_type(ptr_type(i8_type())); }
 
   template <typename ctype, size_t N = (sizeof(ctype) * CHAR_BIT)>
   llvm::Constant* int_constant(ctype val) {

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -99,6 +99,11 @@ class GANDIVA_EXPORT LLVMTypes {
     return llvm::ConstantExpr::getIntToPtr(ptr_int, void_ptr_type());
   }
 
+  llvm::Constant* i8_ptr_constant(int8_t* val) {
+    auto ptr_int = int_constant<uintptr_t>(reinterpret_cast<uintptr_t>(val));
+    return llvm::ConstantExpr::getIntToPtr(ptr_int, i8_ptr_type());
+  }
+
   llvm::Constant* NullConstant(llvm::Type* type) {
     if (type->isIntegerTy()) {
       return llvm::ConstantInt::get(type, 0);

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -57,6 +58,8 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::PointerType* ptr_type(llvm::Type* type) { return type->getPointerTo(); }
 
+  llvm::PointerType* void_ptr_type() { return ptr_type(void_type()); }
+
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }
 
   llvm::PointerType* i32_ptr_type() { return ptr_type(i32_type()); }
@@ -89,6 +92,11 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::Constant* double_constant(double val) {
     return llvm::ConstantFP::get(double_type(), val);
+  }
+
+  llvm::Constant* void_ptr_constant(void* val) {
+    auto ptr_int = int_constant<uintptr_t>(reinterpret_cast<uintptr_t>(val));
+    return llvm::ConstantExpr::getIntToPtr(ptr_int, void_ptr_type());
   }
 
   llvm::Constant* NullConstant(llvm::Type* type) {

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -58,7 +58,7 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::PointerType* ptr_type(llvm::Type* type) { return type->getPointerTo(); }
 
-  llvm::PointerType* void_ptr_type() { return ptr_type(void_type()); }
+  llvm::PointerType* opaque_ptr_type() { return ptr_type(i8_type()); }
 
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }
 
@@ -98,9 +98,9 @@ class GANDIVA_EXPORT LLVMTypes {
     return llvm::ConstantFP::get(double_type(), val);
   }
 
-  llvm::Constant* void_ptr_constant(void* val) {
+  llvm::Constant* opaque_ptr_constant(void* val) {
     auto ptr_int = int_constant<uintptr_t>(reinterpret_cast<uintptr_t>(val));
-    return llvm::ConstantExpr::getIntToPtr(ptr_int, void_ptr_type());
+    return llvm::ConstantExpr::getIntToPtr(ptr_int, opaque_ptr_type());
   }
 
   llvm::Constant* i8_ptr_constant(int8_t* val) {

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -18,6 +18,7 @@
 extern "C" {
 
 #include <math.h>
+
 #include "./types.h"
 
 // Expand inner macro for all numeric types.
@@ -81,7 +82,7 @@ MOD_OP(mod, int64, int64, int64)
 
 #undef MOD_OP
 
-gdv_float64 mod_float64_float64(int64_t context, gdv_float64 x, gdv_float64 y) {
+gdv_float64 mod_float64_float64(void* context, gdv_float64 x, gdv_float64 y) {
   if (y == 0.0) {
     char const* err_msg = "divide by zero error";
     gdv_fn_context_set_error_msg(context, err_msg);
@@ -208,30 +209,30 @@ NUMERIC_BOOL_DATE_FUNCTION(IS_NOT_DISTINCT_FROM)
 #undef IS_DISTINCT_FROM
 #undef IS_NOT_DISTINCT_FROM
 
-#define DIVIDE(TYPE)                                                                     \
-  FORCE_INLINE                                                                           \
-  gdv_##TYPE divide_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
-    if (in2 == 0) {                                                                      \
-      char const* err_msg = "divide by zero error";                                      \
-      gdv_fn_context_set_error_msg(context, err_msg);                                    \
-      return 0;                                                                          \
-    }                                                                                    \
-    return static_cast<gdv_##TYPE>(in1 / in2);                                           \
+#define DIVIDE(TYPE)                                                                 \
+  FORCE_INLINE                                                                       \
+  gdv_##TYPE divide_##TYPE##_##TYPE(void* context, gdv_##TYPE in1, gdv_##TYPE in2) { \
+    if (in2 == 0) {                                                                  \
+      char const* err_msg = "divide by zero error";                                  \
+      gdv_fn_context_set_error_msg(context, err_msg);                                \
+      return 0;                                                                      \
+    }                                                                                \
+    return static_cast<gdv_##TYPE>(in1 / in2);                                       \
   }
 
 NUMERIC_FUNCTION(DIVIDE)
 
 #undef DIVIDE
 
-#define DIV(TYPE)                                                                     \
-  FORCE_INLINE                                                                        \
-  gdv_##TYPE div_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
-    if (in2 == 0) {                                                                   \
-      char const* err_msg = "divide by zero error";                                   \
-      gdv_fn_context_set_error_msg(context, err_msg);                                 \
-      return 0;                                                                       \
-    }                                                                                 \
-    return static_cast<gdv_##TYPE>(in1 / in2);                                        \
+#define DIV(TYPE)                                                                 \
+  FORCE_INLINE                                                                    \
+  gdv_##TYPE div_##TYPE##_##TYPE(void* context, gdv_##TYPE in1, gdv_##TYPE in2) { \
+    if (in2 == 0) {                                                               \
+      char const* err_msg = "divide by zero error";                               \
+      gdv_fn_context_set_error_msg(context, err_msg);                             \
+      return 0;                                                                   \
+    }                                                                             \
+    return static_cast<gdv_##TYPE>(in1 / in2);                                    \
   }
 
 DIV(int32)
@@ -239,15 +240,15 @@ DIV(int64)
 
 #undef DIV
 
-#define DIV_FLOAT(TYPE)                                                               \
-  FORCE_INLINE                                                                        \
-  gdv_##TYPE div_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
-    if (in2 == 0) {                                                                   \
-      char const* err_msg = "divide by zero error";                                   \
-      gdv_fn_context_set_error_msg(context, err_msg);                                 \
-      return 0;                                                                       \
-    }                                                                                 \
-    return static_cast<gdv_##TYPE>(::trunc(in1 / in2));                               \
+#define DIV_FLOAT(TYPE)                                                           \
+  FORCE_INLINE                                                                    \
+  gdv_##TYPE div_##TYPE##_##TYPE(void* context, gdv_##TYPE in1, gdv_##TYPE in2) { \
+    if (in2 == 0) {                                                               \
+      char const* err_msg = "divide by zero error";                               \
+      gdv_fn_context_set_error_msg(context, err_msg);                             \
+      return 0;                                                                   \
+    }                                                                             \
+    return static_cast<gdv_##TYPE>(::trunc(in1 / in2));                           \
   }
 
 DIV_FLOAT(float32)

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -17,6 +17,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "../execution_context.h"
 #include "gandiva/precompiled/types.h"
 
@@ -40,62 +41,59 @@ TEST(TestArithmeticOps, TestMod) {
 
   const double acceptable_abs_error = 0.00000000001;  // 1e-10
 
-  EXPECT_DOUBLE_EQ(mod_float64_float64(reinterpret_cast<gdv_int64>(&context), 2.5, 0.0),
-                   0.0);
+  EXPECT_DOUBLE_EQ(mod_float64_float64(reinterpret_cast<void*>(&context), 2.5, 0.0), 0.0);
   EXPECT_TRUE(context.has_error());
   EXPECT_EQ(context.get_error(), "divide by zero error");
 
   context.Reset();
-  EXPECT_NEAR(mod_float64_float64(reinterpret_cast<gdv_int64>(&context), 2.5, 1.2), 0.1,
+  EXPECT_NEAR(mod_float64_float64(reinterpret_cast<void*>(&context), 2.5, 1.2), 0.1,
               acceptable_abs_error);
   EXPECT_FALSE(context.has_error());
 
   context.Reset();
-  EXPECT_DOUBLE_EQ(mod_float64_float64(reinterpret_cast<gdv_int64>(&context), 2.5, 2.5),
-                   0.0);
+  EXPECT_DOUBLE_EQ(mod_float64_float64(reinterpret_cast<void*>(&context), 2.5, 2.5), 0.0);
   EXPECT_FALSE(context.has_error());
 
   context.Reset();
-  EXPECT_NEAR(mod_float64_float64(reinterpret_cast<gdv_int64>(&context), 9.2, 3.7), 1.8,
+  EXPECT_NEAR(mod_float64_float64(reinterpret_cast<void*>(&context), 9.2, 3.7), 1.8,
               acceptable_abs_error);
   EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestArithmeticOps, TestDivide) {
   gandiva::ExecutionContext context;
-  EXPECT_EQ(divide_int64_int64(reinterpret_cast<gdv_int64>(&context), 10, 0), 0);
+  EXPECT_EQ(divide_int64_int64(reinterpret_cast<void*>(&context), 10, 0), 0);
   EXPECT_EQ(context.has_error(), true);
   EXPECT_EQ(context.get_error(), "divide by zero error");
 
   context.Reset();
-  EXPECT_EQ(divide_int64_int64(reinterpret_cast<gdv_int64>(&context), 10, 2), 5);
+  EXPECT_EQ(divide_int64_int64(reinterpret_cast<void*>(&context), 10, 2), 5);
   EXPECT_EQ(context.has_error(), false);
 }
 
 TEST(TestArithmeticOps, TestDiv) {
   gandiva::ExecutionContext context;
-  EXPECT_EQ(div_int64_int64(reinterpret_cast<gdv_int64>(&context), 101, 0), 0);
+  EXPECT_EQ(div_int64_int64(reinterpret_cast<void*>(&context), 101, 0), 0);
   EXPECT_EQ(context.has_error(), true);
   EXPECT_EQ(context.get_error(), "divide by zero error");
   context.Reset();
 
-  EXPECT_EQ(div_int64_int64(reinterpret_cast<gdv_int64>(&context), 101, 111), 0);
+  EXPECT_EQ(div_int64_int64(reinterpret_cast<void*>(&context), 101, 111), 0);
   EXPECT_EQ(context.has_error(), false);
   context.Reset();
 
-  EXPECT_EQ(div_float64_float64(reinterpret_cast<gdv_int64>(&context), 1010.1010, 2.1),
+  EXPECT_EQ(div_float64_float64(reinterpret_cast<void*>(&context), 1010.1010, 2.1),
             481.0);
   EXPECT_EQ(context.has_error(), false);
   context.Reset();
 
-  EXPECT_EQ(
-      div_float64_float64(reinterpret_cast<gdv_int64>(&context), 1010.1010, 0.00000),
-      0.0);
+  EXPECT_EQ(div_float64_float64(reinterpret_cast<void*>(&context), 1010.1010, 0.00000),
+            0.0);
   EXPECT_EQ(context.has_error(), true);
   EXPECT_EQ(context.get_error(), "divide by zero error");
   context.Reset();
 
-  EXPECT_EQ(div_float32_float32(reinterpret_cast<gdv_int64>(&context), 1010.1010f, 2.1f),
+  EXPECT_EQ(div_float32_float32(reinterpret_cast<void*>(&context), 1010.1010f, 2.1f),
             481.0f);
   EXPECT_EQ(context.has_error(), false);
   context.Reset();

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -347,7 +347,7 @@ BasicDecimal128 Multiply(const BasicDecimalScalar128& x, const BasicDecimalScala
   return result;
 }
 
-BasicDecimal128 Divide(int64_t context, const BasicDecimalScalar128& x,
+BasicDecimal128 Divide(void* context, const BasicDecimalScalar128& x,
                        const BasicDecimalScalar128& y, int32_t out_precision,
                        int32_t out_scale, bool* overflow) {
   if (y.value() == 0) {
@@ -392,7 +392,7 @@ BasicDecimal128 Divide(int64_t context, const BasicDecimalScalar128& x,
   return result;
 }
 
-BasicDecimal128 Mod(int64_t context, const BasicDecimalScalar128& x,
+BasicDecimal128 Mod(void* context, const BasicDecimalScalar128& x,
                     const BasicDecimalScalar128& y, int32_t out_precision,
                     int32_t out_scale, bool* overflow) {
   if (y.value() == 0) {

--- a/cpp/src/gandiva/precompiled/decimal_ops.h
+++ b/cpp/src/gandiva/precompiled/decimal_ops.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <string>
+
 #include "gandiva/basic_decimal_scalar.h"
 
 namespace gandiva {
@@ -41,12 +42,12 @@ arrow::BasicDecimal128 Multiply(const BasicDecimalScalar128& x,
                                 int32_t out_scale, bool* overflow);
 
 /// Divide 'x' by 'y', and return the result.
-arrow::BasicDecimal128 Divide(int64_t context, const BasicDecimalScalar128& x,
+arrow::BasicDecimal128 Divide(void* context, const BasicDecimalScalar128& x,
                               const BasicDecimalScalar128& y, int32_t out_precision,
                               int32_t out_scale, bool* overflow);
 
 /// Divide 'x' by 'y', and return the remainder.
-arrow::BasicDecimal128 Mod(int64_t context, const BasicDecimalScalar128& x,
+arrow::BasicDecimal128 Mod(void* context, const BasicDecimalScalar128& x,
                            const BasicDecimalScalar128& y, int32_t out_precision,
                            int32_t out_scale, bool* overflow);
 

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -52,7 +52,7 @@ void multiply_decimal128_decimal128(int64_t x_high, uint64_t x_low, int32_t x_pr
 }
 
 FORCE_INLINE
-void divide_decimal128_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+void divide_decimal128_decimal128(void* context, int64_t x_high, uint64_t x_low,
                                   int32_t x_precision, int32_t x_scale, int64_t y_high,
                                   uint64_t y_low, int32_t y_precision, int32_t y_scale,
                                   int32_t out_precision, int32_t out_scale,
@@ -69,7 +69,7 @@ void divide_decimal128_decimal128(int64_t context, int64_t x_high, uint64_t x_lo
 }
 
 FORCE_INLINE
-void mod_decimal128_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
+void mod_decimal128_decimal128(void* context, int64_t x_high, uint64_t x_low,
                                int32_t x_precision, int32_t x_scale, int64_t y_high,
                                uint64_t y_low, int32_t y_precision, int32_t y_scale,
                                int32_t out_precision, int32_t out_scale,
@@ -395,7 +395,7 @@ gdv_boolean is_distinct_from_decimal128_decimal128(int64_t x_high, uint64_t x_lo
 }
 
 FORCE_INLINE
-void castDECIMAL_utf8(int64_t context, const char* in, int32_t in_length,
+void castDECIMAL_utf8(void* context, const char* in, int32_t in_length,
                       int32_t out_precision, int32_t out_scale, int64_t* out_high,
                       uint64_t* out_low) {
   int64_t dec_high_from_str;
@@ -418,7 +418,7 @@ void castDECIMAL_utf8(int64_t context, const char* in, int32_t in_length,
 }
 
 FORCE_INLINE
-char* castVARCHAR_decimal128_int64(int64_t context, int64_t x_high, uint64_t x_low,
+char* castVARCHAR_decimal128_int64(void* context, int64_t x_high, uint64_t x_low,
                                    int32_t x_precision, int32_t x_scale,
                                    int64_t out_len_param, int32_t* out_length) {
   int32_t full_dec_str_len;

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -28,6 +28,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "./types.h"
 
 // Expand the inner fn for types that support extended math.
@@ -78,7 +79,7 @@ ENUMERIC_TYPES_UNARY(LOG, float64)
 ENUMERIC_TYPES_UNARY(LOG10, float64)
 
 FORCE_INLINE
-void set_error_for_logbase(int64_t execution_context, double base) {
+void set_error_for_logbase(void* execution_context, double base) {
   char const* prefix = "divide by zero error with log of base";
   int size = static_cast<int>(strlen(prefix)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
@@ -90,11 +91,11 @@ void set_error_for_logbase(int64_t execution_context, double base) {
 // log with base
 #define LOG_WITH_BASE(IN_TYPE1, IN_TYPE2, OUT_TYPE)                                  \
   FORCE_INLINE                                                                       \
-  gdv_##OUT_TYPE log_##IN_TYPE1##_##IN_TYPE2(gdv_int64 context, gdv_##IN_TYPE1 base, \
+  gdv_##OUT_TYPE log_##IN_TYPE1##_##IN_TYPE2(void* context_ptr, gdv_##IN_TYPE1 base, \
                                              gdv_##IN_TYPE2 value) {                 \
     gdv_##OUT_TYPE log_of_base = LOGL(base);                                         \
     if (log_of_base == 0) {                                                          \
-      set_error_for_logbase(context, static_cast<gdv_float64>(base));                \
+      set_error_for_logbase(context_ptr, static_cast<gdv_float64>(base));            \
       return 0;                                                                      \
     }                                                                                \
     return LOGL(value) / LOGL(base);                                                 \
@@ -368,38 +369,38 @@ gdv_float64 get_scale_multiplier(gdv_int32 scale) {
 }
 
 // returns the binary representation of a given integer (e.g. 928 -> 1110100000)
-#define BIN_INTEGER(IN_TYPE)                                                          \
-  FORCE_INLINE                                                                        \
-  const char* bin_##IN_TYPE(int64_t context, gdv_##IN_TYPE value, int32_t* out_len) { \
-    *out_len = 0;                                                                     \
-    int32_t len = 8 * sizeof(value);                                                  \
-    char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, len));   \
-    if (ret == nullptr) {                                                             \
-      gdv_fn_context_set_error_msg(context, "Could not allocate memory for output");  \
-      return "";                                                                      \
-    }                                                                                 \
-    /* handle case when value is zero */                                              \
-    if (value == 0) {                                                                 \
-      *out_len = 1;                                                                   \
-      ret[0] = '0';                                                                   \
-      return ret;                                                                     \
-    }                                                                                 \
-    /* generate binary representation iteratively */                                  \
-    gdv_u##IN_TYPE i;                                                                 \
-    int8_t count = 0;                                                                 \
-    bool first = false; /* flag for not printing left zeros in positive numbers */    \
-    for (i = static_cast<gdv_u##IN_TYPE>(1) << (len - 1); i > 0; i = i / 2) {         \
-      if ((value & i) != 0) {                                                         \
-        ret[count] = '1';                                                             \
-        if (!first) first = true;                                                     \
-      } else {                                                                        \
-        if (!first) continue;                                                         \
-        ret[count] = '0';                                                             \
-      }                                                                               \
-      count += 1;                                                                     \
-    }                                                                                 \
-    *out_len = count;                                                                 \
-    return ret;                                                                       \
+#define BIN_INTEGER(IN_TYPE)                                                             \
+  FORCE_INLINE                                                                           \
+  const char* bin_##IN_TYPE(void* context_ptr, gdv_##IN_TYPE value, int32_t* out_len) {  \
+    *out_len = 0;                                                                        \
+    int32_t len = 8 * sizeof(value);                                                     \
+    char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, len));  \
+    if (ret == nullptr) {                                                                \
+      gdv_fn_context_set_error_msg(context_ptr, "Could not allocate memory for output"); \
+      return "";                                                                         \
+    }                                                                                    \
+    /* handle case when value is zero */                                                 \
+    if (value == 0) {                                                                    \
+      *out_len = 1;                                                                      \
+      ret[0] = '0';                                                                      \
+      return ret;                                                                        \
+    }                                                                                    \
+    /* generate binary representation iteratively */                                     \
+    gdv_u##IN_TYPE i;                                                                    \
+    int8_t count = 0;                                                                    \
+    bool first = false; /* flag for not printing left zeros in positive numbers */       \
+    for (i = static_cast<gdv_u##IN_TYPE>(1) << (len - 1); i > 0; i = i / 2) {            \
+      if ((value & i) != 0) {                                                            \
+        ret[count] = '1';                                                                \
+        if (!first) first = true;                                                        \
+      } else {                                                                           \
+        if (!first) continue;                                                            \
+        ret[count] = '0';                                                                \
+      }                                                                                  \
+      count += 1;                                                                        \
+    }                                                                                    \
+    *out_len = count;                                                                    \
+    return ret;                                                                          \
   }
 
 BIN_INTEGER(int32)

--- a/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
@@ -20,7 +20,9 @@
 #endif
 
 #include <gtest/gtest.h>
+
 #include <cmath>
+
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/types.h"
 
@@ -78,14 +80,14 @@ TEST(TestExtendedMathOps, TestPower) {
 TEST(TestExtendedMathOps, TestLogWithBase) {
   gandiva::ExecutionContext context;
   gdv_float64 out =
-      log_int32_int32(reinterpret_cast<gdv_int64>(&context), 1 /*base*/, 10 /*value*/);
+      log_int32_int32(reinterpret_cast<void*>(&context), 1 /*base*/, 10 /*value*/);
   VerifyFuzzyEquals(out, 0);
   EXPECT_EQ(context.has_error(), true);
   EXPECT_TRUE(context.get_error().find("divide by zero error") != std::string::npos)
       << context.get_error();
 
   gandiva::ExecutionContext context1;
-  out = log_int32_int32(reinterpret_cast<gdv_int64>(&context), 2 /*base*/, 64 /*value*/);
+  out = log_int32_int32(reinterpret_cast<void*>(&context), 2 /*base*/, 64 /*value*/);
   VerifyFuzzyEquals(out, 6);
   EXPECT_EQ(context1.has_error(), false);
 }
@@ -274,76 +276,76 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
 }
 
 TEST(TestExtendedMathOps, TestBinRepresentation) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = bin_int32(ctx_ptr, 7, &out_len);
+  const char* out_str = bin_int32(context_ptr, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "111");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, 0, &out_len);
+  out_str = bin_int32(context_ptr, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, 28550, &out_len);
+  out_str = bin_int32(context_ptr, 28550, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "110111110000110");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, -28550, &out_len);
+  out_str = bin_int32(context_ptr, -28550, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "11111111111111111001000001111010");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, 58117, &out_len);
+  out_str = bin_int32(context_ptr, 58117, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1110001100000101");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, -58117, &out_len);
+  out_str = bin_int32(context_ptr, -58117, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "11111111111111110001110011111011");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, INT32_MAX, &out_len);
+  out_str = bin_int32(context_ptr, INT32_MAX, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1111111111111111111111111111111");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int32(ctx_ptr, INT32_MIN, &out_len);
+  out_str = bin_int32(context_ptr, INT32_MIN, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "10000000000000000000000000000000");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, 7, &out_len);
+  out_str = bin_int64(context_ptr, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "111");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, 0, &out_len);
+  out_str = bin_int64(context_ptr, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "0");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, 28550, &out_len);
+  out_str = bin_int64(context_ptr, 28550, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "110111110000110");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, -28550, &out_len);
+  out_str = bin_int64(context_ptr, -28550, &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "1111111111111111111111111111111111111111111111111001000001111010");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, 58117, &out_len);
+  out_str = bin_int64(context_ptr, 58117, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1110001100000101");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, -58117, &out_len);
+  out_str = bin_int64(context_ptr, -58117, &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "1111111111111111111111111111111111111111111111110001110011111011");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, INT64_MAX, &out_len);
+  out_str = bin_int64(context_ptr, INT64_MAX, &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "111111111111111111111111111111111111111111111111111111111111111");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = bin_int64(ctx_ptr, INT64_MIN, &out_len);
+  out_str = bin_int64(context_ptr, INT64_MIN, &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "1000000000000000000000000000000000000000000000000000000000000000");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -149,12 +149,12 @@ gdv_int32 utf8_char_length(char c) {
 }
 
 FORCE_INLINE
-void set_error_for_invalid_utf(int64_t execution_context, char val) {
+void set_error_for_invalid_utf(void* context_ptr, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, fmt, (unsigned char)val);
-  gdv_fn_context_set_error_msg(execution_context, error);
+  gdv_fn_context_set_error_msg(context_ptr, error);
   free(error);
 }
 
@@ -172,18 +172,18 @@ bool validate_utf8_following_bytes(const char* data, int32_t data_len,
 // Count the number of utf8 characters
 // return 0 for invalid/incomplete input byte sequences
 FORCE_INLINE
-gdv_int32 utf8_length(gdv_int64 context, const char* data, gdv_int32 data_len) {
+gdv_int32 utf8_length(void* context_ptr, const char* data, gdv_int32 data_len) {
   int char_len = 0;
   int count = 0;
   for (int i = 0; i < data_len; i += char_len) {
     char_len = utf8_char_length(data[i]);
     if (char_len == 0 || i + char_len > data_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, data[i]);
+      set_error_for_invalid_utf(context_ptr, data[i]);
       return 0;
     }
     for (int j = 1; j < char_len; ++j) {
       if ((data[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
-        set_error_for_invalid_utf(context, data[i + j]);
+        set_error_for_invalid_utf(context_ptr, data[i + j]);
         return 0;
       }
     }
@@ -216,7 +216,7 @@ gdv_int32 utf8_length_ignore_invalid(const char* data, gdv_int32 data_len) {
 // Get the byte position corresponding to a character position for a non-empty utf8
 // sequence
 FORCE_INLINE
-gdv_int32 utf8_byte_pos(gdv_int64 context, const char* str, gdv_int32 str_len,
+gdv_int32 utf8_byte_pos(void* context_ptr, const char* str, gdv_int32 str_len,
                         gdv_int32 char_pos) {
   int char_len = 0;
   int byte_index = 0;
@@ -225,7 +225,7 @@ gdv_int32 utf8_byte_pos(gdv_int64 context, const char* str, gdv_int32 str_len,
     char_len = utf8_char_length(str[byte_index]);
     if (char_len == 0 ||
         byte_index + char_len > str_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, str[byte_index]);
+      set_error_for_invalid_utf(context_ptr, str[byte_index]);
       return -1;
     }
     byte_index += char_len;
@@ -235,8 +235,8 @@ gdv_int32 utf8_byte_pos(gdv_int64 context, const char* str, gdv_int32 str_len,
 
 #define UTF8_LENGTH(NAME, TYPE)                                                 \
   FORCE_INLINE                                                                  \
-  gdv_int32 NAME##_##TYPE(gdv_int64 context, gdv_##TYPE in, gdv_int32 in_len) { \
-    return utf8_length(context, in, in_len);                                    \
+  gdv_int32 NAME##_##TYPE(void* context_ptr, gdv_##TYPE in, gdv_int32 in_len) { \
+    return utf8_length(context_ptr, in, in_len);                                \
   }
 
 UTF8_LENGTH(char_length, utf8)
@@ -244,25 +244,27 @@ UTF8_LENGTH(length, utf8)
 UTF8_LENGTH(lengthUtf8, binary)
 
 // Returns a string of 'n' spaces.
-#define SPACE_STR(IN_TYPE)                                                              \
-  GANDIVA_EXPORT                                                                        \
-  const char* space_##IN_TYPE(gdv_int64 ctx, gdv_##IN_TYPE n, int32_t* out_len) {       \
-    gdv_int32 n_times = static_cast<gdv_int32>(n);                                      \
-    if (n_times <= 0) {                                                                 \
-      *out_len = 0;                                                                     \
-      return "";                                                                        \
-    }                                                                                   \
-    char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(ctx, n_times));     \
-    if (ret == nullptr) {                                                               \
-      gdv_fn_context_set_error_msg(ctx, "Could not allocate memory for output string"); \
-      *out_len = 0;                                                                     \
-      return "";                                                                        \
-    }                                                                                   \
-    for (int i = 0; i < n_times; i++) {                                                 \
-      ret[i] = ' ';                                                                     \
-    }                                                                                   \
-    *out_len = n_times;                                                                 \
-    return ret;                                                                         \
+#define SPACE_STR(IN_TYPE)                                                            \
+  GANDIVA_EXPORT                                                                      \
+  const char* space_##IN_TYPE(void* context_ptr, gdv_##IN_TYPE n, int32_t* out_len) { \
+    gdv_int32 n_times = static_cast<gdv_int32>(n);                                    \
+    if (n_times <= 0) {                                                               \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    char* ret =                                                                       \
+        reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, n_times));   \
+    if (ret == nullptr) {                                                             \
+      gdv_fn_context_set_error_msg(context_ptr,                                       \
+                                   "Could not allocate memory for output string");    \
+      *out_len = 0;                                                                   \
+      return "";                                                                      \
+    }                                                                                 \
+    for (int i = 0; i < n_times; i++) {                                               \
+      ret[i] = ' ';                                                                   \
+    }                                                                                 \
+    *out_len = n_times;                                                               \
+    return ret;                                                                       \
   }
 
 SPACE_STR(int32)
@@ -270,16 +272,17 @@ SPACE_STR(int64)
 
 // Reverse a utf8 sequence
 FORCE_INLINE
-const char* reverse_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* reverse_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                          int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
     return "";
   }
 
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, data_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, data_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -289,14 +292,14 @@ const char* reverse_utf8(gdv_int64 context, const char* data, gdv_int32 data_len
     char_len = utf8_char_length(data[i]);
 
     if (char_len == 0 || i + char_len > data_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, data[i]);
+      set_error_for_invalid_utf(context_ptr, data[i]);
       *out_len = 0;
       return "";
     }
 
     for (gdv_int32 j = 0; j < char_len; ++j) {
       if (j > 0 && (data[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
-        set_error_for_invalid_utf(context, data[i + j]);
+        set_error_for_invalid_utf(context_ptr, data[i + j]);
         *out_len = 0;
         return "";
       }
@@ -309,7 +312,7 @@ const char* reverse_utf8(gdv_int64 context, const char* data, gdv_int32 data_len
 
 // Trims whitespaces from the left end of the input utf8 sequence
 FORCE_INLINE
-const char* ltrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* ltrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
@@ -328,7 +331,7 @@ const char* ltrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
 
 // Trims whitespaces from the right end of the input utf8 sequence
 FORCE_INLINE
-const char* rtrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* rtrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
@@ -347,7 +350,7 @@ const char* rtrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
 
 // Trims whitespaces from both the ends of the input utf8 sequence
 FORCE_INLINE
-const char* btrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* btrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len) {
   if (data_len == 0) {
     *out_len = 0;
@@ -371,7 +374,7 @@ const char* btrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
 
 // Trims characters present in the trim text from the left end of the base text
 FORCE_INLINE
-const char* ltrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* ltrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len) {
   if (basetext_len == 0) {
@@ -389,7 +392,7 @@ const char* ltrim_utf8_utf8(gdv_int64 context, const char* basetext,
     char_len = utf8_char_length(basetext[start_ptr]);
     if (char_len == 0 || start_ptr + char_len > basetext_len) {
       // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, basetext[start_ptr]);
+      set_error_for_invalid_utf(context_ptr, basetext[start_ptr]);
       *out_len = 0;
       return "";
     }
@@ -404,7 +407,7 @@ const char* ltrim_utf8_utf8(gdv_int64 context, const char* basetext,
 
 // Trims characters present in the trim text from the right end of the base text
 FORCE_INLINE
-const char* rtrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* rtrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len) {
   if (basetext_len == 0) {
@@ -426,7 +429,7 @@ const char* rtrim_utf8_utf8(gdv_int64 context, const char* basetext,
     }
     // this is the first byte of a character, hence check if char_len = char_cnt
     if (byte_cnt != char_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, basetext[end_ptr]);
+      set_error_for_invalid_utf(context_ptr, basetext[end_ptr]);
       *out_len = 0;
       return "";
     }
@@ -449,7 +452,7 @@ const char* rtrim_utf8_utf8(gdv_int64 context, const char* basetext,
 
 // Trims characters present in the trim text from both ends of the base text
 FORCE_INLINE
-const char* btrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* btrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len) {
   if (basetext_len == 0) {
@@ -467,7 +470,7 @@ const char* btrim_utf8_utf8(gdv_int64 context, const char* basetext,
     char_len = utf8_char_length(basetext[start_ptr]);
     if (char_len == 0 || start_ptr + char_len > basetext_len) {
       // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, basetext[start_ptr]);
+      set_error_for_invalid_utf(context_ptr, basetext[start_ptr]);
       *out_len = 0;
       return "";
     }
@@ -483,7 +486,7 @@ const char* btrim_utf8_utf8(gdv_int64 context, const char* basetext,
     }
     // this is the first byte of a character, hence check if char_len = char_cnt
     if (byte_cnt != char_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, basetext[end_ptr]);
+      set_error_for_invalid_utf(context_ptr, basetext[end_ptr]);
       *out_len = 0;
       return "";
     }
@@ -530,9 +533,9 @@ gdv_boolean compare_lower_strings(const char* base_str, gdv_int32 base_str_len,
 // Try to cast the received string ('0', '1', 'true', 'false'), ignoring leading
 // and trailing spaces, also ignoring lower and upper case.
 FORCE_INLINE
-gdv_boolean castBIT_utf8(gdv_int64 context, const char* data, gdv_int32 data_len) {
+gdv_boolean castBIT_utf8(void* context_ptr, const char* data, gdv_int32 data_len) {
   if (data_len <= 0) {
-    gdv_fn_context_set_error_msg(context, "Invalid value for boolean.");
+    gdv_fn_context_set_error_msg(context_ptr, "Invalid value for boolean.");
     return false;
   }
 
@@ -561,111 +564,112 @@ gdv_boolean castBIT_utf8(gdv_int64 context, const char* data, gdv_int32 data_len
     if (compare_lower_strings("false", 5, trimmed_data, trimmed_len)) return false;
   }
   // if no 'true', 'false', '0' or '1' value is found, set an error
-  gdv_fn_context_set_error_msg(context, "Invalid value for boolean.");
+  gdv_fn_context_set_error_msg(context_ptr, "Invalid value for boolean.");
   return false;
 }
 
 FORCE_INLINE
-const char* castVARCHAR_bool_int64(gdv_int64 context, gdv_boolean value,
+const char* castVARCHAR_bool_int64(void* context_ptr, gdv_boolean value,
                                    gdv_int64 out_len, gdv_int32* out_length) {
   gdv_int32 len = static_cast<gdv_int32>(out_len);
   if (len < 0) {
-    gdv_fn_context_set_error_msg(context, "Output buffer length can't be negative");
+    gdv_fn_context_set_error_msg(context_ptr, "Output buffer length can't be negative");
     *out_length = 0;
     return "";
   }
   const char* out =
-      reinterpret_cast<const char*>(gdv_fn_context_arena_malloc(context, 5));
+      reinterpret_cast<const char*>(gdv_fn_context_arena_malloc(context_ptr, 5));
   out = value ? "true" : "false";
   *out_length = value ? ((len > 4) ? 4 : len) : ((len > 5) ? 5 : len);
   return out;
 }
 
 // Truncates the string to given length
-#define CAST_VARCHAR_FROM_VARLEN_TYPE(TYPE)                                            \
-  FORCE_INLINE                                                                         \
-  const char* castVARCHAR_##TYPE##_int64(gdv_int64 context, const char* data,          \
-                                         gdv_int32 data_len, int64_t out_len,          \
-                                         int32_t* out_length) {                        \
-    int32_t len = static_cast<int32_t>(out_len);                                       \
-                                                                                       \
-    if (len < 0) {                                                                     \
-      gdv_fn_context_set_error_msg(context, "Output buffer length can't be negative"); \
-      *out_length = 0;                                                                 \
-      return "";                                                                       \
-    }                                                                                  \
-                                                                                       \
-    if (len >= data_len || len == 0) {                                                 \
-      *out_length = data_len;                                                          \
-      return data;                                                                     \
-    }                                                                                  \
-                                                                                       \
-    int32_t remaining = len;                                                           \
-    int32_t index = 0;                                                                 \
-    bool is_multibyte = false;                                                         \
-    do {                                                                               \
-      /* In utf8, MSB of a single byte unicode char is always 0,                       \
-       * whereas for a multibyte character the MSB of each byte is 1.                  \
-       * So for a single byte char, a bitwise-and with x80 (10000000) will be 0        \
-       * and it won't be 0 for bytes of a multibyte char.                              \
-       */                                                                              \
-      char* data_ptr = const_cast<char*>(data);                                        \
-                                                                                       \
-      /* advance byte by byte till the 8-byte boundary then advance 8 bytes */         \
-      auto num_bytes = reinterpret_cast<uintptr_t>(data_ptr) & 0x07;                   \
-      num_bytes = (8 - num_bytes) & 0x07;                                              \
-      while (num_bytes > 0) {                                                          \
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(data_ptr + index);                   \
-        if ((*ptr & 0x80) != 0) {                                                      \
-          is_multibyte = true;                                                         \
-          break;                                                                       \
-        }                                                                              \
-        index++;                                                                       \
-        remaining--;                                                                   \
-        num_bytes--;                                                                   \
-      }                                                                                \
-      if (is_multibyte) break;                                                         \
-      while (remaining >= 8) {                                                         \
-        uint64_t* ptr = reinterpret_cast<uint64_t*>(data_ptr + index);                 \
-        if ((*ptr & 0x8080808080808080) != 0) {                                        \
-          is_multibyte = true;                                                         \
-          break;                                                                       \
-        }                                                                              \
-        index += 8;                                                                    \
-        remaining -= 8;                                                                \
-      }                                                                                \
-      if (is_multibyte) break;                                                         \
-      if (remaining >= 4) {                                                            \
-        uint32_t* ptr = reinterpret_cast<uint32_t*>(data_ptr + index);                 \
-        if ((*ptr & 0x80808080) != 0) break;                                           \
-        index += 4;                                                                    \
-        remaining -= 4;                                                                \
-      }                                                                                \
-      while (remaining > 0) {                                                          \
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(data_ptr + index);                   \
-        if ((*ptr & 0x80) != 0) {                                                      \
-          is_multibyte = true;                                                         \
-          break;                                                                       \
-        }                                                                              \
-        index++;                                                                       \
-        remaining--;                                                                   \
-      }                                                                                \
-      if (is_multibyte) break;                                                         \
-      /* reached here; all are single byte characters */                               \
-      *out_length = len;                                                               \
-      return data;                                                                     \
-    } while (false);                                                                   \
-                                                                                       \
-    /* detected multibyte utf8 characters; slow path */                                \
-    int32_t byte_pos =                                                                 \
-        utf8_byte_pos(context, data + index, data_len - index, len - index);           \
-    if (byte_pos < 0) {                                                                \
-      *out_length = 0;                                                                 \
-      return "";                                                                       \
-    }                                                                                  \
-                                                                                       \
-    *out_length = index + byte_pos;                                                    \
-    return data;                                                                       \
+#define CAST_VARCHAR_FROM_VARLEN_TYPE(TYPE)                                      \
+  FORCE_INLINE                                                                   \
+  const char* castVARCHAR_##TYPE##_int64(void* context_ptr, const char* data,    \
+                                         gdv_int32 data_len, int64_t out_len,    \
+                                         int32_t* out_length) {                  \
+    int32_t len = static_cast<int32_t>(out_len);                                 \
+                                                                                 \
+    if (len < 0) {                                                               \
+      gdv_fn_context_set_error_msg(context_ptr,                                  \
+                                   "Output buffer length can't be negative");    \
+      *out_length = 0;                                                           \
+      return "";                                                                 \
+    }                                                                            \
+                                                                                 \
+    if (len >= data_len || len == 0) {                                           \
+      *out_length = data_len;                                                    \
+      return data;                                                               \
+    }                                                                            \
+                                                                                 \
+    int32_t remaining = len;                                                     \
+    int32_t index = 0;                                                           \
+    bool is_multibyte = false;                                                   \
+    do {                                                                         \
+      /* In utf8, MSB of a single byte unicode char is always 0,                 \
+       * whereas for a multibyte character the MSB of each byte is 1.            \
+       * So for a single byte char, a bitwise-and with x80 (10000000) will be 0  \
+       * and it won't be 0 for bytes of a multibyte char.                        \
+       */                                                                        \
+      char* data_ptr = const_cast<char*>(data);                                  \
+                                                                                 \
+      /* advance byte by byte till the 8-byte boundary then advance 8 bytes */   \
+      auto num_bytes = reinterpret_cast<uintptr_t>(data_ptr) & 0x07;             \
+      num_bytes = (8 - num_bytes) & 0x07;                                        \
+      while (num_bytes > 0) {                                                    \
+        uint8_t* ptr = reinterpret_cast<uint8_t*>(data_ptr + index);             \
+        if ((*ptr & 0x80) != 0) {                                                \
+          is_multibyte = true;                                                   \
+          break;                                                                 \
+        }                                                                        \
+        index++;                                                                 \
+        remaining--;                                                             \
+        num_bytes--;                                                             \
+      }                                                                          \
+      if (is_multibyte) break;                                                   \
+      while (remaining >= 8) {                                                   \
+        uint64_t* ptr = reinterpret_cast<uint64_t*>(data_ptr + index);           \
+        if ((*ptr & 0x8080808080808080) != 0) {                                  \
+          is_multibyte = true;                                                   \
+          break;                                                                 \
+        }                                                                        \
+        index += 8;                                                              \
+        remaining -= 8;                                                          \
+      }                                                                          \
+      if (is_multibyte) break;                                                   \
+      if (remaining >= 4) {                                                      \
+        uint32_t* ptr = reinterpret_cast<uint32_t*>(data_ptr + index);           \
+        if ((*ptr & 0x80808080) != 0) break;                                     \
+        index += 4;                                                              \
+        remaining -= 4;                                                          \
+      }                                                                          \
+      while (remaining > 0) {                                                    \
+        uint8_t* ptr = reinterpret_cast<uint8_t*>(data_ptr + index);             \
+        if ((*ptr & 0x80) != 0) {                                                \
+          is_multibyte = true;                                                   \
+          break;                                                                 \
+        }                                                                        \
+        index++;                                                                 \
+        remaining--;                                                             \
+      }                                                                          \
+      if (is_multibyte) break;                                                   \
+      /* reached here; all are single byte characters */                         \
+      *out_length = len;                                                         \
+      return data;                                                               \
+    } while (false);                                                             \
+                                                                                 \
+    /* detected multibyte utf8 characters; slow path */                          \
+    int32_t byte_pos =                                                           \
+        utf8_byte_pos(context_ptr, data + index, data_len - index, len - index); \
+    if (byte_pos < 0) {                                                          \
+      *out_length = 0;                                                           \
+      return "";                                                                 \
+    }                                                                            \
+                                                                                 \
+    *out_length = index + byte_pos;                                              \
+    return data;                                                                 \
   }
 
 CAST_VARCHAR_FROM_VARLEN_TYPE(utf8)
@@ -674,24 +678,25 @@ CAST_VARCHAR_FROM_VARLEN_TYPE(binary)
 #undef CAST_VARCHAR_FROM_VARLEN_TYPE
 
 // Add functions for castVARBINARY
-#define CAST_VARBINARY_FROM_STRING_AND_BINARY(TYPE)                                    \
-  GANDIVA_EXPORT                                                                       \
-  const char* castVARBINARY_##TYPE##_int64(gdv_int64 context, const char* data,        \
-                                           gdv_int32 data_len, int64_t out_len,        \
-                                           int32_t* out_length) {                      \
-    int32_t len = static_cast<int32_t>(out_len);                                       \
-    if (len < 0) {                                                                     \
-      gdv_fn_context_set_error_msg(context, "Output buffer length can't be negative"); \
-      *out_length = 0;                                                                 \
-      return "";                                                                       \
-    }                                                                                  \
-                                                                                       \
-    if (len >= data_len || len == 0) {                                                 \
-      *out_length = data_len;                                                          \
-    } else {                                                                           \
-      *out_length = len;                                                               \
-    }                                                                                  \
-    return data;                                                                       \
+#define CAST_VARBINARY_FROM_STRING_AND_BINARY(TYPE)                             \
+  GANDIVA_EXPORT                                                                \
+  const char* castVARBINARY_##TYPE##_int64(void* context_ptr, const char* data, \
+                                           gdv_int32 data_len, int64_t out_len, \
+                                           int32_t* out_length) {               \
+    int32_t len = static_cast<int32_t>(out_len);                                \
+    if (len < 0) {                                                              \
+      gdv_fn_context_set_error_msg(context_ptr,                                 \
+                                   "Output buffer length can't be negative");   \
+      *out_length = 0;                                                          \
+      return "";                                                                \
+    }                                                                           \
+                                                                                \
+    if (len >= data_len || len == 0) {                                          \
+      *out_length = data_len;                                                   \
+    } else {                                                                    \
+      *out_length = len;                                                        \
+    }                                                                           \
+    return data;                                                                \
   }
 
 CAST_VARBINARY_FROM_STRING_AND_BINARY(utf8)
@@ -733,7 +738,7 @@ VAR_LEN_TYPES(IS_NOT_NULL, isnotnull)
  - If position is 0 then it is treated as 1.
  */
 FORCE_INLINE
-const char* substr_utf8_int64_int64(gdv_int64 context, const char* input,
+const char* substr_utf8_int64_int64(void* context_ptr, const char* input,
                                     gdv_int32 in_data_len, gdv_int64 position,
                                     gdv_int64 substring_length, gdv_int32* out_data_len) {
   if (substring_length <= 0 || input == nullptr || in_data_len <= 0) {
@@ -742,7 +747,7 @@ const char* substr_utf8_int64_int64(gdv_int64 context, const char* input,
   }
 
   gdv_int64 in_glyphs_count =
-      static_cast<gdv_int64>(utf8_length(context, input, in_data_len));
+      static_cast<gdv_int64>(utf8_length(context_ptr, input, in_data_len));
 
   // in_glyphs_count is zero if input has invalid glyphs
   if (in_glyphs_count == 0) {
@@ -792,9 +797,10 @@ const char* substr_utf8_int64_int64(gdv_int64 context, const char* input,
 
   *out_data_len = static_cast<gdv_int32>(end_pos - start_pos);
   char* ret =
-      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_data_len));
+      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_data_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_data_len = 0;
     return "";
   }
@@ -803,13 +809,13 @@ const char* substr_utf8_int64_int64(gdv_int64 context, const char* input,
 }
 
 FORCE_INLINE
-const char* substr_utf8_int64(gdv_int64 context, const char* input, gdv_int32 in_len,
+const char* substr_utf8_int64(void* context_ptr, const char* input, gdv_int32 in_len,
                               gdv_int64 offset64, gdv_int32* out_len) {
-  return substr_utf8_int64_int64(context, input, in_len, offset64, in_len, out_len);
+  return substr_utf8_int64_int64(context_ptr, input, in_len, offset64, in_len, out_len);
 }
 
 FORCE_INLINE
-const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_len,
+const char* repeat_utf8_int32(void* context_ptr, const char* in, gdv_int32 in_len,
                               gdv_int32 repeat_number, gdv_int32* out_len) {
   // if the repeat number is zero, then return empty string
   if (repeat_number == 0 || in_len <= 0) {
@@ -818,14 +824,15 @@ const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_le
   }
   // if the repeat number is a negative number, an error is set on context
   if (repeat_number < 0) {
-    gdv_fn_context_set_error_msg(context, "Repeat number can't be negative");
+    gdv_fn_context_set_error_msg(context_ptr, "Repeat number can't be negative");
     *out_len = 0;
     return "";
   }
   *out_len = repeat_number * in_len;
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -836,7 +843,7 @@ const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_le
 }
 
 FORCE_INLINE
-const char* concat_utf8_utf8(gdv_int64 context, const char* left, gdv_int32 left_len,
+const char* concat_utf8_utf8(void* context_ptr, const char* left, gdv_int32 left_len,
                              bool left_validity, const char* right, gdv_int32 right_len,
                              bool right_validity, gdv_int32* out_len) {
   if (!left_validity) {
@@ -845,11 +852,11 @@ const char* concat_utf8_utf8(gdv_int64 context, const char* left, gdv_int32 left
   if (!right_validity) {
     right_len = 0;
   }
-  return concatOperator_utf8_utf8(context, left, left_len, right, right_len, out_len);
+  return concatOperator_utf8_utf8(context_ptr, left, left_len, right, right_len, out_len);
 }
 
 FORCE_INLINE
-const char* concatOperator_utf8_utf8(gdv_int64 context, const char* left,
+const char* concatOperator_utf8_utf8(void* context_ptr, const char* left,
                                      gdv_int32 left_len, const char* right,
                                      gdv_int32 right_len, gdv_int32* out_len) {
   *out_len = left_len + right_len;
@@ -857,9 +864,10 @@ const char* concatOperator_utf8_utf8(gdv_int64 context, const char* left,
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -869,7 +877,7 @@ const char* concatOperator_utf8_utf8(gdv_int64 context, const char* left,
 }
 
 FORCE_INLINE
-const char* concat_utf8_utf8_utf8(gdv_int64 context, const char* in1, gdv_int32 in1_len,
+const char* concat_utf8_utf8_utf8(void* context_ptr, const char* in1, gdv_int32 in1_len,
                                   bool in1_validity, const char* in2, gdv_int32 in2_len,
                                   bool in2_validity, const char* in3, gdv_int32 in3_len,
                                   bool in3_validity, gdv_int32* out_len) {
@@ -882,12 +890,12 @@ const char* concat_utf8_utf8_utf8(gdv_int64 context, const char* in1, gdv_int32 
   if (!in3_validity) {
     in3_len = 0;
   }
-  return concatOperator_utf8_utf8_utf8(context, in1, in1_len, in2, in2_len, in3, in3_len,
-                                       out_len);
+  return concatOperator_utf8_utf8_utf8(context_ptr, in1, in1_len, in2, in2_len, in3,
+                                       in3_len, out_len);
 }
 
 FORCE_INLINE
-const char* concatOperator_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concatOperator_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                           gdv_int32 in1_len, const char* in2,
                                           gdv_int32 in2_len, const char* in3,
                                           gdv_int32 in3_len, gdv_int32* out_len) {
@@ -896,9 +904,10 @@ const char* concatOperator_utf8_utf8_utf8(gdv_int64 context, const char* in1,
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -909,7 +918,7 @@ const char* concatOperator_utf8_utf8_utf8(gdv_int64 context, const char* in1,
 }
 
 FORCE_INLINE
-const char* concat_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concat_utf8_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                        gdv_int32 in1_len, bool in1_validity,
                                        const char* in2, gdv_int32 in2_len,
                                        bool in2_validity, const char* in3,
@@ -928,12 +937,12 @@ const char* concat_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in1,
   if (!in4_validity) {
     in4_len = 0;
   }
-  return concatOperator_utf8_utf8_utf8_utf8(context, in1, in1_len, in2, in2_len, in3,
+  return concatOperator_utf8_utf8_utf8_utf8(context_ptr, in1, in1_len, in2, in2_len, in3,
                                             in3_len, in4, in4_len, out_len);
 }
 
 FORCE_INLINE
-const char* concatOperator_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concatOperator_utf8_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                                gdv_int32 in1_len, const char* in2,
                                                gdv_int32 in2_len, const char* in3,
                                                gdv_int32 in3_len, const char* in4,
@@ -943,9 +952,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -958,7 +968,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -978,14 +988,14 @@ const char* concat_utf8_utf8_utf8_utf8_utf8(
   if (!in5_validity) {
     in5_len = 0;
   }
-  return concatOperator_utf8_utf8_utf8_utf8_utf8(context, in1, in1_len, in2, in2_len, in3,
-                                                 in3_len, in4, in4_len, in5, in5_len,
+  return concatOperator_utf8_utf8_utf8_utf8_utf8(context_ptr, in1, in1_len, in2, in2_len,
+                                                 in3, in3_len, in4, in4_len, in5, in5_len,
                                                  out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, gdv_int32* out_len) {
   *out_len = in1_len + in2_len + in3_len + in4_len + in5_len;
@@ -993,9 +1003,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1009,7 +1020,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8(
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -1032,14 +1043,14 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8(
   if (!in6_validity) {
     in6_len = 0;
   }
-  return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(context, in1, in1_len, in2, in2_len,
-                                                      in3, in3_len, in4, in4_len, in5,
-                                                      in5_len, in6, in6_len, out_len);
+  return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
+      context_ptr, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len,
+      in6, in6_len, out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, gdv_int32* out_len) {
@@ -1048,9 +1059,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1065,7 +1077,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -1093,13 +1105,13 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     in7_len = 0;
   }
   return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      context, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len, in6,
-      in6_len, in7, in7_len, out_len);
+      context_ptr, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len,
+      in6, in6_len, in7, in7_len, out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, gdv_int32* out_len) {
@@ -1108,9 +1120,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1126,7 +1139,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -1158,13 +1171,13 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     in8_len = 0;
   }
   return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      context, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len, in6,
-      in6_len, in7, in7_len, in8, in8_len, out_len);
+      context_ptr, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len,
+      in6, in6_len, in7, in7_len, in8, in8_len, out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
@@ -1175,9 +1188,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1195,7 +1209,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -1231,13 +1245,13 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     in9_len = 0;
   }
   return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      context, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len, in6,
-      in6_len, in7, in7_len, in8, in8_len, in9, in9_len, out_len);
+      context_ptr, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len,
+      in6, in6_len, in7, in7_len, in8, in8_len, in9, in9_len, out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
@@ -1248,9 +1262,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1271,7 +1286,7 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
 
 FORCE_INLINE
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -1310,13 +1325,13 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     in10_len = 0;
   }
   return concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      context, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len, in6,
-      in6_len, in7, in7_len, in8, in8_len, in9, in9_len, in10, in10_len, out_len);
+      context_ptr, in1, in1_len, in2, in2_len, in3, in3_len, in4, in4_len, in5, in5_len,
+      in6, in6_len, in7, in7_len, in8, in8_len, in9, in9_len, in10, in10_len, out_len);
 }
 
 FORCE_INLINE
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
@@ -1328,9 +1343,10 @@ const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     *out_len = 0;
     return "";
   }
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1362,12 +1378,13 @@ gdv_int32 ascii_utf8(const char* data, gdv_int32 data_len) {
 }
 
 FORCE_INLINE
-const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_int32 len,
+const char* convert_fromUTF8_binary(void* context_ptr, const char* bin_in, gdv_int32 len,
                                     gdv_int32* out_len) {
   *out_len = len;
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1376,22 +1393,24 @@ const char* convert_fromUTF8_binary(gdv_int64 context, const char* bin_in, gdv_i
 }
 
 FORCE_INLINE
-const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char* text_in,
-                                                    int32_t text_len,
+const char* convert_replace_invalid_fromUTF8_binary(void* context_ptr,
+                                                    const char* text_in, int32_t text_len,
                                                     const char* char_to_replace,
                                                     int32_t char_to_replace_len,
                                                     int32_t* out_len) {
   if (char_to_replace_len > 1) {
-    gdv_fn_context_set_error_msg(context, "Replacement of multiple bytes not supported");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Replacement of multiple bytes not supported");
     *out_len = 0;
     return "";
   }
   // actually the convert_replace function replaces invalid chars with an ASCII
   // character so the output length will be the same as the input length
   *out_len = text_len;
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -1448,12 +1467,12 @@ static inline void reverse_char_buf(char* buf, int32_t len) {
 
 // Converts a double variable to binary
 FORCE_INLINE
-const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len) {
+const char* convert_toDOUBLE(void* context_ptr, double value, int32_t* out_len) {
   *out_len = sizeof(value);
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context,
+    gdv_fn_context_set_error_msg(context_ptr,
                                  "Could not allocate memory for the output string");
 
     *out_len = 0;
@@ -1466,10 +1485,10 @@ const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len) {
 }
 
 FORCE_INLINE
-const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len) {
+const char* convert_toDOUBLE_be(void* context_ptr, double value, int32_t* out_len) {
   // The function behaves like convert_toDOUBLE, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toDOUBLE(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toDOUBLE(context_ptr, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   reverse_char_buf(ret, *out_len);
@@ -1480,12 +1499,12 @@ const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len)
 
 // Converts a float variable to binary
 FORCE_INLINE
-const char* convert_toFLOAT(int64_t context, float value, int32_t* out_len) {
+const char* convert_toFLOAT(void* context_ptr, float value, int32_t* out_len) {
   *out_len = sizeof(value);
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context,
+    gdv_fn_context_set_error_msg(context_ptr,
                                  "Could not allocate memory for the output string");
 
     *out_len = 0;
@@ -1498,10 +1517,10 @@ const char* convert_toFLOAT(int64_t context, float value, int32_t* out_len) {
 }
 
 FORCE_INLINE
-const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len) {
+const char* convert_toFLOAT_be(void* context_ptr, float value, int32_t* out_len) {
   // The function behaves like convert_toFLOAT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toFLOAT(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toFLOAT(context_ptr, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   reverse_char_buf(ret, *out_len);
@@ -1512,12 +1531,12 @@ const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len) {
 
 // Converts a bigint(int with 64 bits) variable to binary
 FORCE_INLINE
-const char* convert_toBIGINT(int64_t context, int64_t value, int32_t* out_len) {
+const char* convert_toBIGINT(void* context_ptr, int64_t value, int32_t* out_len) {
   *out_len = sizeof(value);
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context,
+    gdv_fn_context_set_error_msg(context_ptr,
                                  "Could not allocate memory for the output string");
 
     *out_len = 0;
@@ -1530,10 +1549,10 @@ const char* convert_toBIGINT(int64_t context, int64_t value, int32_t* out_len) {
 }
 
 FORCE_INLINE
-const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len) {
+const char* convert_toBIGINT_be(void* context_ptr, int64_t value, int32_t* out_len) {
   // The function behaves like convert_toBIGINT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toBIGINT(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toBIGINT(context_ptr, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   reverse_char_buf(ret, *out_len);
@@ -1544,12 +1563,12 @@ const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len
 
 // Converts an integer(with 32 bits) variable to binary
 FORCE_INLINE
-const char* convert_toINT(int64_t context, int32_t value, int32_t* out_len) {
+const char* convert_toINT(void* context_ptr, int32_t value, int32_t* out_len) {
   *out_len = sizeof(value);
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context,
+    gdv_fn_context_set_error_msg(context_ptr,
                                  "Could not allocate memory for the output string");
 
     *out_len = 0;
@@ -1562,10 +1581,10 @@ const char* convert_toINT(int64_t context, int32_t value, int32_t* out_len) {
 }
 
 FORCE_INLINE
-const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len) {
+const char* convert_toINT_be(void* context_ptr, int32_t value, int32_t* out_len) {
   // The function behaves like convert_toINT, but always return the result
   // in big endian format
-  char* ret = const_cast<char*>(convert_toINT(context, value, out_len));
+  char* ret = const_cast<char*>(convert_toINT(context_ptr, value, out_len));
 
 #if ARROW_LITTLE_ENDIAN
   reverse_char_buf(ret, *out_len);
@@ -1576,12 +1595,12 @@ const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len) {
 
 // Converts a boolean variable to binary
 FORCE_INLINE
-const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len) {
+const char* convert_toBOOLEAN(void* context_ptr, bool value, int32_t* out_len) {
   *out_len = sizeof(value);
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context,
+    gdv_fn_context_set_error_msg(context_ptr,
                                  "Could not allocate memory for the output string");
 
     *out_len = 0;
@@ -1595,48 +1614,48 @@ const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len) {
 
 // Converts a time variable to binary
 FORCE_INLINE
-const char* convert_toTIME_EPOCH(int64_t context, int32_t value, int32_t* out_len) {
-  return convert_toINT(context, value, out_len);
+const char* convert_toTIME_EPOCH(void* context_ptr, int32_t value, int32_t* out_len) {
+  return convert_toINT(context_ptr, value, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value, int32_t* out_len) {
+const char* convert_toTIME_EPOCH_be(void* context_ptr, int32_t value, int32_t* out_len) {
   // The function behaves as convert_toTIME_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toINT_be(context, value, out_len);
+  return convert_toINT_be(context_ptr, value, out_len);
 }
 
 // Converts a timestamp variable to binary
 FORCE_INLINE
-const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH(void* context_ptr, int64_t timestamp,
                                       int32_t* out_len) {
-  return convert_toBIGINT(context, timestamp, out_len);
+  return convert_toBIGINT(context_ptr, timestamp, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH_be(void* context_ptr, int64_t timestamp,
                                          int32_t* out_len) {
   // The function behaves as convert_toTIMESTAMP_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toBIGINT_be(context, timestamp, out_len);
+  return convert_toBIGINT_be(context_ptr, timestamp, out_len);
 }
 
 // Converts a date variable to binary
 FORCE_INLINE
-const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len) {
-  return convert_toBIGINT(context, date, out_len);
+const char* convert_toDATE_EPOCH(void* context_ptr, int64_t date, int32_t* out_len) {
+  return convert_toBIGINT(context_ptr, date, out_len);
 }
 
 FORCE_INLINE
-const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date, int32_t* out_len) {
+const char* convert_toDATE_EPOCH_be(void* context_ptr, int64_t date, int32_t* out_len) {
   // The function behaves as convert_toDATE_EPOCH, but
   // returns the bytes in big endian format
-  return convert_toBIGINT_be(context, date, out_len);
+  return convert_toBIGINT_be(context_ptr, date, out_len);
 }
 
 // Converts a string variable to binary
 FORCE_INLINE
-const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
+const char* convert_toUTF8(void* context_ptr, const char* value, int32_t value_len,
                            int32_t* out_len) {
   *out_len = value_len;
   return value;
@@ -1645,25 +1664,25 @@ const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len
 // Search for a string within another string
 // Same as "locate(substr, str)", except for the reverse order of the arguments.
 FORCE_INLINE
-gdv_int32 strpos_utf8_utf8(gdv_int64 context, const char* str, gdv_int32 str_len,
+gdv_int32 strpos_utf8_utf8(void* context_ptr, const char* str, gdv_int32 str_len,
                            const char* sub_str, gdv_int32 sub_str_len) {
-  return locate_utf8_utf8_int32(context, sub_str, sub_str_len, str, str_len, 1);
+  return locate_utf8_utf8_int32(context_ptr, sub_str, sub_str_len, str, str_len, 1);
 }
 
 // Search for a string within another string
 FORCE_INLINE
-gdv_int32 locate_utf8_utf8(gdv_int64 context, const char* sub_str, gdv_int32 sub_str_len,
+gdv_int32 locate_utf8_utf8(void* context_ptr, const char* sub_str, gdv_int32 sub_str_len,
                            const char* str, gdv_int32 str_len) {
-  return locate_utf8_utf8_int32(context, sub_str, sub_str_len, str, str_len, 1);
+  return locate_utf8_utf8_int32(context_ptr, sub_str, sub_str_len, str, str_len, 1);
 }
 
 // Search for a string within another string starting at position start-pos (1-indexed)
 FORCE_INLINE
-gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
+gdv_int32 locate_utf8_utf8_int32(void* context_ptr, const char* sub_str,
                                  gdv_int32 sub_str_len, const char* str,
                                  gdv_int32 str_len, gdv_int32 start_pos) {
   if (start_pos < 1) {
-    gdv_fn_context_set_error_msg(context, "Start position must be greater than 0");
+    gdv_fn_context_set_error_msg(context_ptr, "Start position must be greater than 0");
     return 0;
   }
 
@@ -1671,20 +1690,20 @@ gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
     return 0;
   }
 
-  gdv_int32 byte_pos = utf8_byte_pos(context, str, str_len, start_pos - 1);
+  gdv_int32 byte_pos = utf8_byte_pos(context_ptr, str, str_len, start_pos - 1);
   if (byte_pos < 0 || byte_pos >= str_len) {
     return 0;
   }
   for (gdv_int32 i = byte_pos; i <= str_len - sub_str_len; ++i) {
     if (memcmp(str + i, sub_str, sub_str_len) == 0) {
-      return utf8_length(context, str, i) + 1;
+      return utf8_length(context_ptr, str, i) + 1;
     }
   }
   return 0;
 }
 
 FORCE_INLINE
-const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,
+const char* replace_with_max_len_utf8_utf8_utf8(void* context_ptr, const char* text,
                                                 gdv_int32 text_len, const char* from_str,
                                                 gdv_int32 from_str_len,
                                                 const char* to_str, gdv_int32 to_str_len,
@@ -1707,15 +1726,16 @@ const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* t
   for (; text_index <= text_len - from_str_len;) {
     if (memcmp(text + text_index, from_str, from_str_len) == 0) {
       if (out_index + text_index - last_match_index + to_str_len > max_length) {
-        gdv_fn_context_set_error_msg(context, "Buffer overflow for output string");
+        gdv_fn_context_set_error_msg(context_ptr, "Buffer overflow for output string");
         *out_len = 0;
         return "";
       }
       if (!found) {
         // found match for first time
-        out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_length));
+        out =
+            reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, max_length));
         if (out == nullptr) {
-          gdv_fn_context_set_error_msg(context,
+          gdv_fn_context_set_error_msg(context_ptr,
                                        "Could not allocate memory for output string");
           *out_len = 0;
           return "";
@@ -1742,7 +1762,7 @@ const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* t
   }
 
   if (out_index + text_len - last_match_index > max_length) {
-    gdv_fn_context_set_error_msg(context, "Buffer overflow for output string");
+    gdv_fn_context_set_error_msg(context_ptr, "Buffer overflow for output string");
     *out_len = 0;
     return "";
   }
@@ -1753,17 +1773,17 @@ const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* t
 }
 
 FORCE_INLINE
-const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
+const char* replace_utf8_utf8_utf8(void* context_ptr, const char* text,
                                    gdv_int32 text_len, const char* from_str,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len) {
-  return replace_with_max_len_utf8_utf8_utf8(context, text, text_len, from_str,
+  return replace_with_max_len_utf8_utf8_utf8(context_ptr, text, text_len, from_str,
                                              from_str_len, to_str, to_str_len, 65535,
                                              out_len);
 }
 
 FORCE_INLINE
-const char* lpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* lpad_utf8_int32_utf8(void* context_ptr, const char* text, gdv_int32 text_len,
                                  gdv_int32 return_length, const char* fill_text,
                                  gdv_int32 fill_text_len, gdv_int32* out_len) {
   // if the text length or the defined return length (number of characters to return)
@@ -1784,16 +1804,16 @@ const char* lpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 
     return text;
   } else if (return_length < text_char_count) {
     // case where it truncates the result on return length.
-    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    *out_len = utf8_byte_pos(context_ptr, text, text_len, return_length);
     return text;
   } else {
     // case (return_length > text_char_count)
     // case where it needs to copy "fill_text" on the string left. The total number
     // of chars to copy is given by (return_length -  text_char_count)
-    char* ret =
-        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, return_length));
+    char* ret = reinterpret_cast<gdv_binary>(
+        gdv_fn_context_arena_malloc(context_ptr, return_length));
     if (ret == nullptr) {
-      gdv_fn_context_set_error_msg(context,
+      gdv_fn_context_set_error_msg(context_ptr,
                                    "Could not allocate memory for output string");
       *out_len = 0;
       return "";
@@ -1825,7 +1845,7 @@ const char* lpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 
 }
 
 FORCE_INLINE
-const char* rpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* rpad_utf8_int32_utf8(void* context_ptr, const char* text, gdv_int32 text_len,
                                  gdv_int32 return_length, const char* fill_text,
                                  gdv_int32 fill_text_len, gdv_int32* out_len) {
   // if the text length or the defined return length (number of characters to return)
@@ -1846,15 +1866,15 @@ const char* rpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 
     return text;
   } else if (return_length < text_char_count) {
     // case where it truncates the result on return length.
-    *out_len = utf8_byte_pos(context, text, text_len, return_length);
+    *out_len = utf8_byte_pos(context_ptr, text, text_len, return_length);
     return text;
   } else {
     // case (return_length > text_char_count)
     // case where it needs to copy "fill_text" on the string right
-    char* ret =
-        reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, return_length));
+    char* ret = reinterpret_cast<gdv_binary>(
+        gdv_fn_context_arena_malloc(context_ptr, return_length));
     if (ret == nullptr) {
-      gdv_fn_context_set_error_msg(context,
+      gdv_fn_context_set_error_msg(context_ptr,
                                    "Could not allocate memory for output string");
       *out_len = 0;
       return "";
@@ -1886,19 +1906,21 @@ const char* rpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 
 }
 
 FORCE_INLINE
-const char* lpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* lpad_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 return_length, gdv_int32* out_len) {
-  return lpad_utf8_int32_utf8(context, text, text_len, return_length, " ", 1, out_len);
+  return lpad_utf8_int32_utf8(context_ptr, text, text_len, return_length, " ", 1,
+                              out_len);
 }
 
 FORCE_INLINE
-const char* rpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* rpad_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 return_length, gdv_int32* out_len) {
-  return rpad_utf8_int32_utf8(context, text, text_len, return_length, " ", 1, out_len);
+  return rpad_utf8_int32_utf8(context_ptr, text, text_len, return_length, " ", 1,
+                              out_len);
 }
 
 FORCE_INLINE
-const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* split_part(void* context_ptr, const char* text, gdv_int32 text_len,
                        const char* delimiter, gdv_int32 delim_len, gdv_int32 index,
                        gdv_int32* out_len) {
   *out_len = 0;
@@ -1906,7 +1928,7 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
     char error_message[100];
     snprintf(error_message, sizeof(error_message),
              "Index in split_part must be positive, value provided was %d", index);
-    gdv_fn_context_set_error_msg(context, error_message);
+    gdv_fn_context_set_error_msg(context_ptr, error_message);
     return "";
   }
 
@@ -1937,9 +1959,9 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
 
         *out_len = end_pos - i;
         char* out_str =
-            reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
+            reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
         if (out_str == nullptr) {
-          gdv_fn_context_set_error_msg(context,
+          gdv_fn_context_set_error_msg(context_ptr,
                                        "Could not allocate memory for output string");
           *out_len = 0;
           return "";
@@ -1961,7 +1983,7 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
 //     LEFT("TestString", 3) => "Tes"
 //     LEFT("TestString", -3) => "TestStr"
 FORCE_INLINE
-const char* left_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* left_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 number, gdv_int32* out_len) {
   // returns the 'number' left most characters of a given text
   if (text_len == 0 || number == 0) {
@@ -1976,13 +1998,13 @@ const char* left_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_
   for (int i = 0; i < text_len; i += char_len) {
     char_len = utf8_char_length(text[i]);
     if (char_len == 0 || i + char_len > text_len) {  // invalid byte or incomplete glyph
-      set_error_for_invalid_utf(context, text[i]);
+      set_error_for_invalid_utf(context_ptr, text[i]);
       *out_len = 0;
       return "";
     }
     for (int j = 1; j < char_len; ++j) {
       if ((text[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
-        set_error_for_invalid_utf(context, text[i + j]);
+        set_error_for_invalid_utf(context_ptr, text[i + j]);
         *out_len = 0;
         return "";
       }
@@ -2005,7 +2027,7 @@ const char* left_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_
 //     RIGHT("TestString", 3) => "ing"
 //     RIGHT("TestString", -3) => "tString"
 FORCE_INLINE
-const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* right_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                              gdv_int32 number, gdv_int32* out_len) {
   // returns the 'number' left most characters of a given text
   if (text_len == 0 || number == 0) {
@@ -2014,7 +2036,7 @@ const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text
   }
 
   // initially counts the number of utf8 characters in the defined text
-  int32_t char_count = utf8_length(context, text, text_len);
+  int32_t char_count = utf8_length(context_ptr, text, text_len);
   // char_count is zero if input has invalid utf8 char
   if (char_count == 0) {
     *out_len = 0;
@@ -2033,14 +2055,15 @@ const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text
   }
 
   // calculate the start byte position and the output length
-  int32_t start_byte_pos = utf8_byte_pos(context, text, text_len, start_char_pos);
-  *out_len = utf8_byte_pos(context, text, text_len, end_char_len);
+  int32_t start_byte_pos = utf8_byte_pos(context_ptr, text, text_len, start_char_pos);
+  *out_len = utf8_byte_pos(context_ptr, text, text_len, end_char_len);
 
   // try to allocate memory for the response
   char* ret =
-      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, *out_len));
+      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context_ptr, *out_len));
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -2049,13 +2072,14 @@ const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text
 }
 
 FORCE_INLINE
-const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* binary_string(void* context_ptr, const char* text, gdv_int32 text_len,
                           gdv_int32* out_len) {
   gdv_binary ret =
-      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, text_len));
+      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context_ptr, text_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }
@@ -2090,9 +2114,9 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
 #define CAST_INT_BIGINT_VARBINARY(OUT_TYPE, TYPE_NAME)                                 \
   FORCE_INLINE                                                                         \
   OUT_TYPE                                                                             \
-  cast##TYPE_NAME##_varbinary(gdv_int64 context, const char* in, int32_t in_len) {     \
+  cast##TYPE_NAME##_varbinary(void* context_ptr, const char* in, int32_t in_len) {     \
     if (in_len == 0) {                                                                 \
-      gdv_fn_context_set_error_msg(context, "Can't cast an empty string.");            \
+      gdv_fn_context_set_error_msg(context_ptr, "Can't cast an empty string.");        \
       return -1;                                                                       \
     }                                                                                  \
     char sign = in[0];                                                                 \
@@ -2106,7 +2130,7 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
     }                                                                                  \
                                                                                        \
     if (negative && in_len == 0) {                                                     \
-      gdv_fn_context_set_error_msg(context,                                            \
+      gdv_fn_context_set_error_msg(context_ptr,                                        \
                                    "Can't cast hexadecimal with only a minus sign.");  \
       return -1;                                                                       \
     }                                                                                  \
@@ -2123,13 +2147,13 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
         OUT_TYPE next = result * 16 - digit;                                           \
                                                                                        \
         if (next > result) {                                                           \
-          gdv_fn_context_set_error_msg(context, "Integer overflow.");                  \
+          gdv_fn_context_set_error_msg(context_ptr, "Integer overflow.");              \
           return -1;                                                                   \
         }                                                                              \
         result = next;                                                                 \
         read_index++;                                                                  \
       } else {                                                                         \
-        gdv_fn_context_set_error_msg(context,                                          \
+        gdv_fn_context_set_error_msg(context_ptr,                                      \
                                      "The hexadecimal given has invalid characters."); \
         return -1;                                                                     \
       }                                                                                \
@@ -2138,7 +2162,7 @@ const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_le
       result *= -1;                                                                    \
                                                                                        \
       if (result < 0) {                                                                \
-        gdv_fn_context_set_error_msg(context, "Integer overflow.");                    \
+        gdv_fn_context_set_error_msg(context_ptr, "Integer overflow.");                \
         return -1;                                                                     \
       }                                                                                \
     }                                                                                  \
@@ -2159,7 +2183,7 @@ CAST_INT_BIGINT_VARBINARY(int64_t, BIGINT)
 //     BYTE_SUBSTR("TestString", -6, 10) => "String"
 //     BYTE_SUBSTR("TestString", -600, 10) => "TestString"
 FORCE_INLINE
-const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
+const char* byte_substr_binary_int32_int32(void* context_ptr, const char* text,
                                            gdv_int32 text_len, gdv_int32 offset,
                                            gdv_int32 length, gdv_int32* out_len) {
   // the first offset position for a string is 1, so not consider offset == 0
@@ -2170,10 +2194,11 @@ const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
   }
 
   char* ret =
-      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, text_len));
+      reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context_ptr, text_len));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context_ptr,
+                                 "Could not allocate memory for output string");
     *out_len = 0;
     return "";
   }

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -71,26 +71,26 @@ TEST(TestStringOps, TestBeginsEnds) {
 
 TEST(TestStringOps, TestSpace) {
   // Space - returns a string with 'n' spaces
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
 
-  auto out = space_int32(ctx_ptr, 1, &out_len);
+  auto out = space_int32(context_ptr, 1, &out_len);
   EXPECT_EQ(std::string(out, out_len), " ");
-  out = space_int32(ctx_ptr, 10, &out_len);
+  out = space_int32(context_ptr, 10, &out_len);
   EXPECT_EQ(std::string(out, out_len), "          ");
-  out = space_int32(ctx_ptr, 5, &out_len);
+  out = space_int32(context_ptr, 5, &out_len);
   EXPECT_EQ(std::string(out, out_len), "     ");
-  out = space_int32(ctx_ptr, -5, &out_len);
+  out = space_int32(context_ptr, -5, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
 
-  out = space_int64(ctx_ptr, 2, &out_len);
+  out = space_int64(context_ptr, 2, &out_len);
   EXPECT_EQ(std::string(out, out_len), "  ");
-  out = space_int64(ctx_ptr, 9, &out_len);
+  out = space_int64(context_ptr, 9, &out_len);
   EXPECT_EQ(std::string(out, out_len), "         ");
-  out = space_int64(ctx_ptr, 4, &out_len);
+  out = space_int64(context_ptr, 4, &out_len);
   EXPECT_EQ(std::string(out, out_len), "    ");
-  out = space_int64(ctx_ptr, -5, &out_len);
+  out = space_int64(context_ptr, -5, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
 }
 
@@ -104,58 +104,58 @@ TEST(TestStringOps, TestIsSubstr) {
 }
 
 TEST(TestStringOps, TestCharLength) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(utf8_length(ctx_ptr, "hello sir", 9), 9);
+  EXPECT_EQ(utf8_length(context_ptr, "hello sir", 9), 9);
 
   std::string a("âpple");
-  EXPECT_EQ(utf8_length(ctx_ptr, a.data(), static_cast<int>(a.length())), 5);
+  EXPECT_EQ(utf8_length(context_ptr, a.data(), static_cast<int>(a.length())), 5);
 
   std::string b("मदन");
-  EXPECT_EQ(utf8_length(ctx_ptr, b.data(), static_cast<int>(b.length())), 3);
+  EXPECT_EQ(utf8_length(context_ptr, b.data(), static_cast<int>(b.length())), 3);
 
   // invalid utf8
   std::string c("\xf8\x28");
-  EXPECT_EQ(utf8_length(ctx_ptr, c.data(), static_cast<int>(c.length())), 0);
-  EXPECT_TRUE(ctx.get_error().find(
+  EXPECT_EQ(utf8_length(context_ptr, c.data(), static_cast<int>(c.length())), 0);
+  EXPECT_TRUE(context.get_error().find(
                   "unexpected byte \\f8 encountered while decoding utf8 string") !=
               std::string::npos)
-      << ctx.get_error();
-  ctx.Reset();
+      << context.get_error();
+  context.Reset();
 
   std::string d("aa\xc3");
-  EXPECT_EQ(utf8_length(ctx_ptr, d.data(), static_cast<int>(d.length())), 0);
-  EXPECT_TRUE(ctx.get_error().find(
+  EXPECT_EQ(utf8_length(context_ptr, d.data(), static_cast<int>(d.length())), 0);
+  EXPECT_TRUE(context.get_error().find(
                   "unexpected byte \\c3 encountered while decoding utf8 string") !=
               std::string::npos)
-      << ctx.get_error();
-  ctx.Reset();
+      << context.get_error();
+  context.Reset();
 
   std::string e(
       "a\xc3"
       "a");
-  EXPECT_EQ(utf8_length(ctx_ptr, e.data(), static_cast<int>(e.length())), 0);
-  EXPECT_TRUE(ctx.get_error().find(
+  EXPECT_EQ(utf8_length(context_ptr, e.data(), static_cast<int>(e.length())), 0);
+  EXPECT_TRUE(context.get_error().find(
                   "unexpected byte \\61 encountered while decoding utf8 string") !=
               std::string::npos)
-      << ctx.get_error();
-  ctx.Reset();
+      << context.get_error();
+  context.Reset();
 
   std::string f(
       "a\xc3\xe3"
       "a");
-  EXPECT_EQ(utf8_length(ctx_ptr, f.data(), static_cast<int>(f.length())), 0);
-  EXPECT_TRUE(ctx.get_error().find(
+  EXPECT_EQ(utf8_length(context_ptr, f.data(), static_cast<int>(f.length())), 0);
+  EXPECT_TRUE(context.get_error().find(
                   "unexpected byte \\e3 encountered while decoding utf8 string") !=
               std::string::npos)
-      << ctx.get_error();
-  ctx.Reset();
+      << context.get_error();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   // invalid utf8 (xf8 is invalid but x28 is not - x28 = '(')
   std::string a(
@@ -163,1566 +163,1587 @@ TEST(TestStringOps, TestConvertReplaceInvalidUtf8Char) {
       "-a");
   auto a_in_out_len = static_cast<int>(a.length());
   const char* a_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, a.data(), a_in_out_len, "a", 1, &a_in_out_len);
+      context_ptr, a.data(), a_in_out_len, "a", 1, &a_in_out_len);
   EXPECT_EQ(std::string(a_str, a_in_out_len), "ok-a(-a");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // invalid utf8 (xa0 and xa1 are invalid)
   std::string b("ok-\xa0\xa1-valid");
   auto b_in_out_len = static_cast<int>(b.length());
   const char* b_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
+      context_ptr, b.data(), b_in_out_len, "b", 1, &b_in_out_len);
   EXPECT_EQ(std::string(b_str, b_in_out_len), "ok-bb-valid");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // full valid utf8
   std::string c("all-valid");
   auto c_in_out_len = static_cast<int>(c.length());
   const char* c_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
+      context_ptr, c.data(), c_in_out_len, "c", 1, &c_in_out_len);
   EXPECT_EQ(std::string(c_str, c_in_out_len), "all-valid");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // valid utf8 (महसुस is 4-char string, each char of which is likely a multibyte char)
   std::string d("ok-महसुस-valid-new");
   auto d_in_out_len = static_cast<int>(d.length());
   const char* d_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, d.data(), d_in_out_len, "d", 1, &d_in_out_len);
+      context_ptr, d.data(), d_in_out_len, "d", 1, &d_in_out_len);
   EXPECT_EQ(std::string(d_str, d_in_out_len), "ok-महसुस-valid-new");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // full valid utf8, but invalid replacement char length
   std::string e("all-valid");
   auto e_in_out_len = static_cast<int>(e.length());
   const char* e_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, e.data(), e_in_out_len, "ee", 2, &e_in_out_len);
+      context_ptr, e.data(), e_in_out_len, "ee", 2, &e_in_out_len);
   EXPECT_EQ(std::string(e_str, e_in_out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   // invalid utf8 (xa0 and xa1 are invalid) with empty replacement char length
   std::string f("ok-\xa0\xa1-valid");
   auto f_in_out_len = static_cast<int>(f.length());
   const char* f_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, f.data(), f_in_out_len, "", 0, &f_in_out_len);
+      context_ptr, f.data(), f_in_out_len, "", 0, &f_in_out_len);
   EXPECT_EQ(std::string(f_str, f_in_out_len), "ok--valid");
-  EXPECT_FALSE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_FALSE(context.has_error());
+  context.Reset();
 
   // invalid utf8 (xa0 and xa1 are invalid) with empty replacement char length
   std::string g("\xa0\xa1-ok-\xa0\xa1-valid-\xa0\xa1");
   auto g_in_out_len = static_cast<int>(g.length());
   const char* g_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, g.data(), g_in_out_len, "", 0, &g_in_out_len);
+      context_ptr, g.data(), g_in_out_len, "", 0, &g_in_out_len);
   EXPECT_EQ(std::string(g_str, g_in_out_len), "-ok--valid-");
-  EXPECT_FALSE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_FALSE(context.has_error());
+  context.Reset();
 
   std::string h("\xa0\xa1-valid");
   auto h_in_out_len = static_cast<int>(h.length());
   const char* h_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, h.data(), h_in_out_len, "", 0, &h_in_out_len);
+      context_ptr, h.data(), h_in_out_len, "", 0, &h_in_out_len);
   EXPECT_EQ(std::string(h_str, h_in_out_len), "-valid");
-  EXPECT_FALSE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_FALSE(context.has_error());
+  context.Reset();
 
   std::string i("\xa0\xa1-valid-\xa0\xa1-valid-\xa0\xa1");
   auto i_in_out_len = static_cast<int>(i.length());
   const char* i_str = convert_replace_invalid_fromUTF8_binary(
-      ctx_ptr, i.data(), i_in_out_len, "", 0, &i_in_out_len);
+      context_ptr, i.data(), i_in_out_len, "", 0, &i_in_out_len);
   EXPECT_EQ(std::string(i_str, i_in_out_len), "-valid--valid-");
-  EXPECT_FALSE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_FALSE(context.has_error());
+  context.Reset();
 }
 
 TEST(TestStringOps, TestRepeat) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = repeat_utf8_int32(ctx_ptr, "abc", 3, 2, &out_len);
+  const char* out_str = repeat_utf8_int32(context_ptr, "abc", 3, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcabc");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = repeat_utf8_int32(ctx_ptr, "a", 1, 5, &out_len);
+  out_str = repeat_utf8_int32(context_ptr, "a", 1, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "aaaaa");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = repeat_utf8_int32(ctx_ptr, "", 0, 10, &out_len);
+  out_str = repeat_utf8_int32(context_ptr, "", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = repeat_utf8_int32(ctx_ptr, "", -20, 10, &out_len);
+  out_str = repeat_utf8_int32(context_ptr, "", -20, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = repeat_utf8_int32(ctx_ptr, "a", 1, -10, &out_len);
+  out_str = repeat_utf8_int32(context_ptr, "a", 1, -10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Repeat number can't be negative"));
-  ctx.Reset();
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Repeat number can't be negative"));
+  context.Reset();
 }
 
 TEST(TestStringOps, TestCastBoolToVarchar) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = castVARCHAR_bool_int64(ctx_ptr, true, 2, &out_len);
+  const char* out_str = castVARCHAR_bool_int64(context_ptr, true, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "tr");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_bool_int64(ctx_ptr, true, 7, &out_len);
+  out_str = castVARCHAR_bool_int64(context_ptr, true, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "true");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_bool_int64(ctx_ptr, false, 4, &out_len);
+  out_str = castVARCHAR_bool_int64(context_ptr, false, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "fals");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_bool_int64(ctx_ptr, false, 5, &out_len);
+  out_str = castVARCHAR_bool_int64(context_ptr, false, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "false");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  castVARCHAR_bool_int64(ctx_ptr, true, -3, &out_len);
-  EXPECT_THAT(ctx.get_error(),
+  castVARCHAR_bool_int64(context_ptr, true, -3, &out_len);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Output buffer length can't be negative"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestCastVarcharToBool) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "true", 4), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "true", 4), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "     true     ", 14), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "     true     ", 14), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "true     ", 9), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "true     ", 9), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "     true", 9), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "     true", 9), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "TRUE", 4), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "TRUE", 4), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "TrUe", 4), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "TrUe", 4), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "1", 1), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "1", 1), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "  1", 3), true);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "  1", 3), true);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "false", 5), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "false", 5), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "false     ", 10), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "false     ", 10), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "     false", 10), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "     false", 10), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "0", 1), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "0", 1), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "0   ", 4), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "0   ", 4), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "FALSE", 5), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "FALSE", 5), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "FaLsE", 5), false);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_EQ(castBIT_utf8(context_ptr, "FaLsE", 5), false);
+  EXPECT_FALSE(context.has_error());
 
-  EXPECT_EQ(castBIT_utf8(ctx_ptr, "test", 4), false);
-  EXPECT_TRUE(ctx.has_error());
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Invalid value for boolean"));
-  ctx.Reset();
+  EXPECT_EQ(castBIT_utf8(context_ptr, "test", 4), false);
+  EXPECT_TRUE(context.has_error());
+  EXPECT_THAT(context.get_error(), ::testing::HasSubstr("Invalid value for boolean"));
+  context.Reset();
 }
 
 TEST(TestStringOps, TestCastVarchar) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   // BINARY TESTS
-  const char* out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 1, &out_len);
+  const char* out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "a");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 6, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 3, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 4, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 5, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // do not truncate if output length is 0
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "asdf", 4, 0, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "asdf", 4, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "", 0, 3, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "", 0, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†", 9, 3, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "çåå†", 9, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†", 9, 4, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "çåå†", 9, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†", 9, 5, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "çåå†", 9, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†", 9, 10, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "çåå†", 9, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†", 9, 6, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "çåå†", 9, 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "abc", 3, -1, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "abc", 3, -1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Output buffer length can't be negative"));
-  ctx.Reset();
+  context.Reset();
 
   std::string z("aa\xc3");
-  out_str = castVARCHAR_binary_int64(ctx_ptr, z.data(), static_cast<int>(z.length()), 2,
-                                     &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, z.data(), static_cast<int>(z.length()),
+                                     2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "aa");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 16, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567812341234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 15, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 12, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 12, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 8, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "12345678");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 7, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 4, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812341234", 16, 3, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "1234567812341234", 16, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "1234567812çåå†123456", 25, 16, &out_len);
+  out_str =
+      castVARCHAR_binary_int64(context_ptr, "1234567812çåå†123456", 25, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567812çåå†12");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "123456781234çåå†1234", 25, 15, &out_len);
+  out_str =
+      castVARCHAR_binary_int64(context_ptr, "123456781234çåå†1234", 25, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "12çåå†34567812123456", 25, 16, &out_len);
+  out_str =
+      castVARCHAR_binary_int64(context_ptr, "12çåå†34567812123456", 25, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "12çåå†3456781212");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†1234567812123456", 25, 4, &out_len);
+  out_str =
+      castVARCHAR_binary_int64(context_ptr, "çåå†1234567812123456", 25, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "çåå†1234567812123456", 25, 3, &out_len);
+  out_str =
+      castVARCHAR_binary_int64(context_ptr, "çåå†1234567812123456", 25, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_binary_int64(ctx_ptr, "123456781234çåå†", 21, 40, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, "123456781234çåå†", 21, 40, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string f("123456781234çåå\xc3");
-  out_str = castVARCHAR_binary_int64(ctx_ptr, f.data(), static_cast<int32_t>(f.length()),
-                                     16, &out_len);
+  out_str = castVARCHAR_binary_int64(context_ptr, f.data(),
+                                     static_cast<int32_t>(f.length()), 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 
   // UTF8 TESTS
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 1, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "a");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 6, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 3, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 4, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 5, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   // do not truncate if output length is 0
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "asdf", 4, 0, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "asdf", 4, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "", 0, 3, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "", 0, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†", 9, 3, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†", 9, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†", 9, 4, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†", 9, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†", 9, 5, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†", 9, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†", 9, 10, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†", 9, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†", 9, 6, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†", 9, 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "abc", 3, -1, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "abc", 3, -1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Output buffer length can't be negative"));
-  ctx.Reset();
+  context.Reset();
 
   std::string d("aa\xc3");
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, d.data(), static_cast<int>(d.length()), 2,
+  out_str = castVARCHAR_utf8_int64(context_ptr, d.data(), static_cast<int>(d.length()), 2,
                                    &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "aa");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 16, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567812341234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 15, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 12, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 12, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 8, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 8, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "12345678");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 7, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 4, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812341234", 16, 3, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812341234", 16, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "1234567812çåå†123456", 25, 16, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "1234567812çåå†123456", 25, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "1234567812çåå†12");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "123456781234çåå†1234", 25, 15, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "123456781234çåå†1234", 25, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "12çåå†34567812123456", 25, 16, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "12çåå†34567812123456", 25, 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "12çåå†3456781212");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†1234567812123456", 25, 4, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†1234567812123456", 25, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "çåå†1234567812123456", 25, 3, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "çåå†1234567812123456", 25, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çåå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, "123456781234çåå†", 21, 40, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, "123456781234çåå†", 21, 40, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123456781234çåå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string y("123456781234çåå\xc3");
-  out_str = castVARCHAR_utf8_int64(ctx_ptr, y.data(), static_cast<int32_t>(y.length()),
-                                   16, &out_len);
+  out_str = castVARCHAR_utf8_int64(context_ptr, y.data(),
+                                   static_cast<int32_t>(y.length()), 16, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestSubstring) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
-  const char* out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 1, 0, &out_len);
+  const char* out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, 1, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 1, 2, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, 1, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "as");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 1, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, 1, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 0, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, 0, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, -2, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, -2, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "df");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, -5, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "asdf", 4, -5, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "अपाचे एरो", 25, 1, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "अपाचे एरो", 25, 1, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "अपाचे");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "अपाचे एरो", 25, 7, 4, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "अपाचे एरो", 25, 7, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "एरो");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "çåå†", 9, 4, 4, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "çåå†", 9, 4, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "çåå†", 9, 2, 2, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "çåå†", 9, 2, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "åå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "çåå†", 9, 0, 2, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "çåå†", 9, 0, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "çå");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "afg", 4, 0, -5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "afg", 4, 0, -5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "", 0, 5, 5, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "", 0, 5, 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64(ctx_ptr, "abcd", 4, 2, &out_len);
+  out_str = substr_utf8_int64(context_ptr, "abcd", 4, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "bcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64(ctx_ptr, "abcd", 4, 0, &out_len);
+  out_str = substr_utf8_int64(context_ptr, "abcd", 4, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = substr_utf8_int64(ctx_ptr, "çåå†", 9, 2, &out_len);
+  out_str = substr_utf8_int64(context_ptr, "çåå†", 9, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "åå†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestSubstringInvalidInputs) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   char bytes[] = {'\xA7', 'a'};
-  const char* out_str = substr_utf8_int64_int64(ctx_ptr, bytes, 2, 1, 1, &out_len);
+  const char* out_str = substr_utf8_int64_int64(context_ptr, bytes, 2, 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   char midbytes[] = {'c', '\xA7', 'a'};
-  out_str = substr_utf8_int64_int64(ctx_ptr, midbytes, 3, 1, 1, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, midbytes, 3, 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   char midbytes2[] = {'\xC3', 'a', 'a'};
-  out_str = substr_utf8_int64_int64(ctx_ptr, midbytes2, 3, 1, 2, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, midbytes2, 3, 1, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   char endbytes[] = {'a', 'a', '\xA7'};
-  out_str = substr_utf8_int64_int64(ctx_ptr, endbytes, 3, 1, 1, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, endbytes, 3, 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   char endbytes2[] = {'a', 'a', '\xC3'};
-  out_str = substr_utf8_int64_int64(ctx_ptr, endbytes2, 3, 1, 3, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, endbytes2, 3, 1, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
-  out_str = substr_utf8_int64_int64(ctx_ptr, "çåå†", 9, 2147483656, 2, &out_len);
+  out_str = substr_utf8_int64_int64(context_ptr, "çåå†", 9, 2147483656, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryUtf8) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
   const char* input = "abc";
   const char* out;
 
-  out = castVARBINARY_utf8_int64(ctx_ptr, input, 3, 0, &out_len);
+  out = castVARBINARY_utf8_int64(context_ptr, input, 3, 0, &out_len);
   EXPECT_EQ(std::string(out, out_len), input);
 
-  out = castVARBINARY_utf8_int64(ctx_ptr, input, 3, 1, &out_len);
+  out = castVARBINARY_utf8_int64(context_ptr, input, 3, 1, &out_len);
   EXPECT_EQ(std::string(out, out_len), "a");
 
-  out = castVARBINARY_utf8_int64(ctx_ptr, input, 3, 500, &out_len);
+  out = castVARBINARY_utf8_int64(context_ptr, input, 3, 500, &out_len);
   EXPECT_EQ(std::string(out, out_len), input);
 
-  out = castVARBINARY_utf8_int64(ctx_ptr, input, 3, -10, &out_len);
+  out = castVARBINARY_utf8_int64(context_ptr, input, 3, -10, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Output buffer length can't be negative"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestGdvFnStubs, TestCastVarbinaryBinary) {
-  gandiva::ExecutionContext ctx;
+  gandiva::ExecutionContext context;
 
-  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   int32_t out_len = 0;
   const char* input = "\\x41\\x42\\x43";
   const char* out;
 
-  out = castVARBINARY_binary_int64(ctx_ptr, input, 12, 0, &out_len);
+  out = castVARBINARY_binary_int64(context_ptr, input, 12, 0, &out_len);
   EXPECT_EQ(std::string(out, out_len), input);
 
-  out = castVARBINARY_binary_int64(ctx_ptr, input, 8, 8, &out_len);
+  out = castVARBINARY_binary_int64(context_ptr, input, 8, 8, &out_len);
   EXPECT_EQ(std::string(out, out_len), "\\x41\\x42");
 
-  out = castVARBINARY_binary_int64(ctx_ptr, input, 12, 500, &out_len);
+  out = castVARBINARY_binary_int64(context_ptr, input, 12, 500, &out_len);
   EXPECT_EQ(std::string(out, out_len), input);
 
-  out = castVARBINARY_binary_int64(ctx_ptr, input, 12, -10, &out_len);
+  out = castVARBINARY_binary_int64(context_ptr, input, 12, -10, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Output buffer length can't be negative"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestConcat) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   const char* out_str =
-      concat_utf8_utf8(ctx_ptr, "abcd", 4, true, "\npq", 3, false, &out_len);
+      concat_utf8_utf8(context_ptr, "abcd", 4, true, "\npq", 3, false, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8(ctx_ptr, "asdf", 4, "jkl", 3, &out_len);
+  out_str = concatOperator_utf8_utf8(context_ptr, "asdf", 4, "jkl", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdfjkl");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8(ctx_ptr, "asdf", 4, "", 0, &out_len);
+  out_str = concatOperator_utf8_utf8(context_ptr, "asdf", 4, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdf");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8(ctx_ptr, "", 0, "jkl", 3, &out_len);
+  out_str = concatOperator_utf8_utf8(context_ptr, "", 0, "jkl", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "jkl");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8(ctx_ptr, "", 0, "", 0, &out_len);
+  out_str = concatOperator_utf8_utf8(context_ptr, "", 0, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8(ctx_ptr, "abcd\n", 5, "a", 1, &out_len);
+  out_str = concatOperator_utf8_utf8(context_ptr, "abcd\n", 5, "a", 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcd\na");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concat_utf8_utf8_utf8(ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3,
-                                  true, &out_len);
+  out_str = concat_utf8_utf8_utf8(context_ptr, "abcd", 4, false, "\npq", 3, true, "ard",
+                                  3, true, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqard");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str =
-      concatOperator_utf8_utf8_utf8(ctx_ptr, "abcd\n", 5, "a", 1, "bcd", 3, &out_len);
+      concatOperator_utf8_utf8_utf8(context_ptr, "abcd\n", 5, "a", 1, "bcd", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcd\nabcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8_utf8(ctx_ptr, "abcd", 4, "a", 1, "", 0, &out_len);
+  out_str =
+      concatOperator_utf8_utf8_utf8(context_ptr, "abcd", 4, "a", 1, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abcda");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8_utf8(ctx_ptr, "", 0, "a", 1, "pqrs", 4, &out_len);
+  out_str =
+      concatOperator_utf8_utf8_utf8(context_ptr, "", 0, "a", 1, "pqrs", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "apqrs");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concat_utf8_utf8_utf8_utf8(ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard",
-                                       3, true, "uvw", 3, false, &out_len);
+  out_str = concat_utf8_utf8_utf8_utf8(context_ptr, "abcd", 4, false, "\npq", 3, true,
+                                       "ard", 3, true, "uvw", 3, false, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqard");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8_utf8_utf8(ctx_ptr, "pqrs", 4, "", 0, "\nabc", 4, "y",
-                                               1, &out_len);
+  out_str = concatOperator_utf8_utf8_utf8_utf8(context_ptr, "pqrs", 4, "", 0, "\nabc", 4,
+                                               "y", 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrs\nabcy");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concat_utf8_utf8_utf8_utf8_utf8(ctx_ptr, "abcd", 4, false, "\npq", 3, true,
-                                            "ard", 3, true, "uvw", 3, false, "abc\n", 4,
-                                            true, &out_len);
+  out_str = concat_utf8_utf8_utf8_utf8_utf8(context_ptr, "abcd", 4, false, "\npq", 3,
+                                            true, "ard", 3, true, "uvw", 3, false,
+                                            "abc\n", 4, true, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = concatOperator_utf8_utf8_utf8_utf8_utf8(ctx_ptr, "pqrs", 4, "", 0, "\nabc", 4,
-                                                    "y", 1, "", 0, &out_len);
+  out_str = concatOperator_utf8_utf8_utf8_utf8_utf8(context_ptr, "pqrs", 4, "", 0,
+                                                    "\nabc", 4, "y", 1, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrs\nabcy");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concat_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
+      context_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
       "abc\n", 4, true, "sdfgs", 5, true, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\nsdfgs");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "pqrs", 4, "", 0, "\nabc", 4, "y", 1, "", 0, "\nbcd", 4, &out_len);
+      context_ptr, "pqrs", 4, "", 0, "\nabc", 4, "y", 1, "", 0, "\nbcd", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrs\nabcy\nbcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
+      context_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
       "abc\n", 4, true, "sdfgs", 5, true, "wfw", 3, false, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\nsdfgs");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3,
+      context_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3,
       &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrsabc\nyasdfjkl");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
+      context_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
       "abc\n", 4, true, "sdfgs", 5, true, "wfw", 3, false, "", 0, true, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\nsdfgs");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3, "", 0,
-      &out_len);
+      context_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3, "",
+      0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrsabc\nyasdfjkl");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
+      context_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
       "abc\n", 4, true, "sdfgs", 5, true, "wfw", 3, false, "", 0, true, "qwert|n", 7,
       true, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\nsdfgsqwert|n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3, "", 0,
-      "sfl\n", 4, &out_len);
+      context_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "jkl", 3, "",
+      0, "sfl\n", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrsabc\nyasdfjklsfl\n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
+      context_ptr, "abcd", 4, false, "\npq", 3, true, "ard", 3, true, "uvw", 3, false,
       "abc\n", 4, true, "sdfgs", 5, true, "wfw", 3, false, "", 0, true, "qwert|n", 7,
       true, "ewfwe", 5, false, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "\npqardabc\nsdfgsqwert|n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str = concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-      ctx_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "", 0, "jkl", 3,
-      "sfl\n", 4, "", 0, &out_len);
+      context_ptr, "", 0, "pqrs", 4, "abc\n", 4, "y", 1, "", 0, "asdf", 4, "", 0, "jkl",
+      3, "sfl\n", 4, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "pqrsabc\nyasdfjklsfl\n");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestReverse) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   const char* out_str;
-  out_str = reverse_utf8(ctx_ptr, "TestString", 10, &out_len);
+  out_str = reverse_utf8(context_ptr, "TestString", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "gnirtStseT");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = reverse_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = reverse_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = reverse_utf8(ctx_ptr, "çåå†", 9, &out_len);
+  out_str = reverse_utf8(context_ptr, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "†ååç");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d("aa\xc3");
-  out_str = reverse_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), &out_len);
+  out_str = reverse_utf8(context_ptr, d.data(), static_cast<int>(d.length()), &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestLtrim) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = ltrim_utf8(ctx_ptr, "TestString  ", 12, &out_len);
+  out_str = ltrim_utf8(context_ptr, "TestString  ", 12, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString  ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8(ctx_ptr, "      TestString  ", 18, &out_len);
+  out_str = ltrim_utf8(context_ptr, "      TestString  ", 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString  ");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8(ctx_ptr, " Test  çåå†bD", 18, &out_len);
+  out_str = ltrim_utf8(context_ptr, " Test  çåå†bD", 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test  çåå†bD");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = ltrim_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8(ctx_ptr, "      ", 6, &out_len);
+  out_str = ltrim_utf8(context_ptr, "      ", 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "", 0, "TestString", 10, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "", 0, "TestString", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "TestString", 10, "", 0, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "TestString", 10, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "abcbbaccabbcdef", 15, "abc", 3, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "abcbbaccabbcdef", 15, "abc", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "abcbbaccabbcdef", 15, "ababbac", 7, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "abcbbaccabbcdef", 15, "ababbac", 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "ååçåå†eç†Dd", 21, "çåå†", 9, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "ååçåå†eç†Dd", 21, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "eç†Dd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d(
       "aa\xc3"
       "bcd");
-  out_str =
-      ltrim_utf8_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), "a", 1, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, d.data(), static_cast<int>(d.length()), "a", 1,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "\xc3"
             "bcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string e(
       "åå\xe0\xa0"
       "bcd");
-  out_str =
-      ltrim_utf8_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), "å", 2, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, e.data(), static_cast<int>(e.length()), "å", 2,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "\xE0\xa0"
             "bcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "TestString", 10, "abcd", 4, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "TestString", 10, "abcd", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = ltrim_utf8_utf8(ctx_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
+  out_str = ltrim_utf8_utf8(context_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestLpadString) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
   // LPAD function tests - with defined fill pad text
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 4, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 0, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 0, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  out_str =
+      lpad_utf8_int32_utf8(context_ptr, "TestString", 10, -500, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 500, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFillTestString");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFTestString");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "FillFillFiTestString");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "абвгд", 10, 7, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ддабвгд");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
 
-  out_str = lpad_utf8_int32_utf8(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  out_str = lpad_utf8_int32_utf8(context_ptr, "hello", 5, 6, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "дhello");
 
   // LPAD function tests - with NO pad text
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 4, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 0, 10, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 0, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, -500, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 18, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "        TestString");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "TestString", 10, 15, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "TestString", 10, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "     TestString");
 
-  out_str = lpad_utf8_int32(ctx_ptr, "абвгд", 10, 7, &out_len);
+  out_str = lpad_utf8_int32(context_ptr, "абвгд", 10, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "  абвгд");
 }
 
 TEST(TestStringOps, TestRpadString) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
   // RPAD function tests - with defined fill pad text
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 4, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 4, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 10, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 0, 10, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 0, 10, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 0, "fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 0, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, -500, "fill", 4, &out_len);
+  out_str =
+      rpad_utf8_int32_utf8(context_ptr, "TestString", 10, -500, "fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 500, "", 0, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 500, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 18, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFill");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 15, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillF");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "TestString", 10, 20, "Fill", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestStringFillFillFi");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 7, "д", 2, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "абвгд", 10, 7, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгддд");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "абвгд", 10, 20, "абвгд", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгдабвгдабвгдабвгд");
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, "hello", 5, 6, "д", 2, &out_len);
+  out_str = rpad_utf8_int32_utf8(context_ptr, "hello", 5, 6, "д", 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "helloд");
 
   // RPAD function tests - with NO pad text
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 4, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 0, 10, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 0, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, -500, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 18, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString        ");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "TestString", 10, 15, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "TestString", 10, 15, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString     ");
 
-  out_str = rpad_utf8_int32(ctx_ptr, "абвгд", 10, 7, &out_len);
+  out_str = rpad_utf8_int32(context_ptr, "абвгд", 10, 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "абвгд  ");
 }
 
 TEST(TestStringOps, TestRtrim) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = rtrim_utf8(ctx_ptr, "  TestString", 12, &out_len);
+  out_str = rtrim_utf8(context_ptr, "  TestString", 12, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "  TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8(ctx_ptr, "  TestString      ", 18, &out_len);
+  out_str = rtrim_utf8(context_ptr, "  TestString      ", 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "  TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8(ctx_ptr, "Test  çåå†bD   ", 20, &out_len);
+  out_str = rtrim_utf8(context_ptr, "Test  çåå†bD   ", 20, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test  çåå†bD");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = rtrim_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8(ctx_ptr, "      ", 6, &out_len);
+  out_str = rtrim_utf8(context_ptr, "      ", 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "", 0, "TestString", 10, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "", 0, "TestString", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "TestString", 10, "", 0, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "TestString", 10, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "TestString", 10, "ring", 4, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "TestString", 10, "ring", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestSt");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "defabcbbaccabbc", 15, "abc", 3, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "defabcbbaccabbc", 15, "abc", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "defabcbbaccabbc", 15, "ababbac", 7, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "defabcbbaccabbc", 15, "ababbac", 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "eDdç†ååçåå†", 21, "çåå†", 9, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "eDdç†ååçåå†", 21, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "eDd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d(
       "\xc3"
       "aaa");
-  out_str =
-      rtrim_utf8_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), "a", 1, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, d.data(), static_cast<int>(d.length()), "a", 1,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   std::string e(
       "\xe0\xa0"
       "åå");
-  out_str =
-      rtrim_utf8_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), "å", 2, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, e.data(), static_cast<int>(e.length()), "å", 2,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "åeçå", 7, "çå", 4, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "åeçå", 7, "çå", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "åe");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "TestString", 10, "abcd", 4, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "TestString", 10, "abcd", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = rtrim_utf8_utf8(ctx_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
+  out_str = rtrim_utf8_utf8(context_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestBtrim) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = btrim_utf8(ctx_ptr, "TestString", 10, &out_len);
+  out_str = btrim_utf8(context_ptr, "TestString", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8(ctx_ptr, "      TestString  ", 18, &out_len);
+  out_str = btrim_utf8(context_ptr, "      TestString  ", 18, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8(ctx_ptr, " Test  çåå†bD   ", 21, &out_len);
+  out_str = btrim_utf8(context_ptr, " Test  çåå†bD   ", 21, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test  çåå†bD");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = btrim_utf8(context_ptr, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8(ctx_ptr, "      ", 6, &out_len);
+  out_str = btrim_utf8(context_ptr, "      ", 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "", 0, "TestString", 10, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "", 0, "TestString", 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "TestString", 10, "Test", 4, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "TestString", 10, "Test", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "TestString", 10, "String", 6, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "TestString", 10, "String", 6, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Tes");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "TestString", 10, "", 0, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "TestString", 10, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "abcbbadefccabbc", 15, "abc", 3, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "abcbbadefccabbc", 15, "abc", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "abcbbadefccabbc", 15, "ababbac", 7, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "abcbbadefccabbc", 15, "ababbac", 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "ååçåå†Ddeç†", 21, "çåå†", 9, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "ååçåå†Ddeç†", 21, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Dde");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "ç†ååçåå†", 18, "çåå†", 9, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_FALSE(context.has_error());
+  context.Reset();
 
   std::string d(
       "acd\xc3"
       "aaa");
-  out_str =
-      btrim_utf8_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), "a", 1, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, d.data(), static_cast<int>(d.length()), "a", 1,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   std::string e(
       "åbc\xe0\xa0"
       "åå");
-  out_str =
-      btrim_utf8_utf8(ctx_ptr, e.data(), static_cast<int>(e.length()), "å", 2, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, e.data(), static_cast<int>(e.length()), "å", 2,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_TRUE(ctx.has_error());
-  ctx.Reset();
+  EXPECT_TRUE(context.has_error());
+  context.Reset();
 
   std::string f(
       "aa\xc3"
       "bcd");
-  out_str =
-      btrim_utf8_utf8(ctx_ptr, f.data(), static_cast<int>(f.length()), "a", 1, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, f.data(), static_cast<int>(f.length()), "a", 1,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "\xc3"
             "bcd");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string g(
       "åå\xe0\xa0"
       "bcå");
-  out_str =
-      btrim_utf8_utf8(ctx_ptr, g.data(), static_cast<int>(g.length()), "å", 2, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, g.data(), static_cast<int>(g.length()), "å", 2,
+                            &out_len);
   EXPECT_EQ(std::string(out_str, out_len),
             "\xe0\xa0"
             "bc");
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "åe†çå", 10, "çå", 4, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "åe†çå", 10, "çå", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "e†");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "TestString", 10, "abcd", 4, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "TestString", 10, "abcd", 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = btrim_utf8_utf8(ctx_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
+  out_str = btrim_utf8_utf8(context_ptr, "acbabbcabb", 10, "abcbd", 5, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestLocate) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   int pos;
 
-  pos = locate_utf8_utf8(ctx_ptr, "String", 6, "TestString", 10);
+  pos = locate_utf8_utf8(context_ptr, "String", 6, "TestString", 10);
   EXPECT_EQ(pos, 5);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "String", 6, "TestString", 10, 1);
+  pos = locate_utf8_utf8_int32(context_ptr, "String", 6, "TestString", 10, 1);
   EXPECT_EQ(pos, 5);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "abc", 3, "abcabc", 6, 2);
+  pos = locate_utf8_utf8_int32(context_ptr, "abc", 3, "abcabc", 6, 2);
   EXPECT_EQ(pos, 4);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8(ctx_ptr, "çåå", 6, "s†å†emçåå†d", 21);
+  pos = locate_utf8_utf8(context_ptr, "çåå", 6, "s†å†emçåå†d", 21);
   EXPECT_EQ(pos, 7);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "bar", 3, "†barbar", 9, 3);
+  pos = locate_utf8_utf8_int32(context_ptr, "bar", 3, "†barbar", 9, 3);
   EXPECT_EQ(pos, 5);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "sub", 3, "", 0, 1);
+  pos = locate_utf8_utf8_int32(context_ptr, "sub", 3, "", 0, 1);
   EXPECT_EQ(pos, 0);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "", 0, "str", 3, 1);
+  pos = locate_utf8_utf8_int32(context_ptr, "", 0, "str", 3, 1);
   EXPECT_EQ(pos, 0);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "bar", 3, "barbar", 6, 0);
+  pos = locate_utf8_utf8_int32(context_ptr, "bar", 3, "barbar", 6, 0);
   EXPECT_EQ(pos, 0);
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr("Start position must be greater than 0"));
-  ctx.Reset();
+  context.Reset();
 
-  pos = locate_utf8_utf8_int32(ctx_ptr, "bar", 3, "barbar", 6, 7);
+  pos = locate_utf8_utf8_int32(context_ptr, "bar", 3, "barbar", 6, 7);
   EXPECT_EQ(pos, 0);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d(
       "a\xff"
       "c");
-  pos =
-      locate_utf8_utf8_int32(ctx_ptr, "c", 1, d.data(), static_cast<int>(d.length()), 3);
+  pos = locate_utf8_utf8_int32(context_ptr, "c", 1, d.data(),
+                               static_cast<int>(d.length()), 3);
   EXPECT_EQ(pos, 0);
-  EXPECT_THAT(ctx.get_error(),
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\ff encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestByteSubstr) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   const char* out_str;
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 5, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, -6, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, -6, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 0, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 0, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 0, -500, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 0, -500, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 1, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 4, &out_len);
+  out_str = byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 1, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 1, 1000, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 1, 1000, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 3, &out_len);
+  out_str = byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 5, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Str");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, 5, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, 5, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "String");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = byte_substr_binary_int32_int32(ctx_ptr, "TestString", 10, -100, 10, &out_len);
+  out_str =
+      byte_substr_binary_int32_int32(context_ptr, "TestString", 10, -100, 10, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 }
 
 TEST(TestStringOps, TestStrPos) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   int pos;
 
-  pos = strpos_utf8_utf8(ctx_ptr, "TestString", 10, "String", 6);
+  pos = strpos_utf8_utf8(context_ptr, "TestString", 10, "String", 6);
   EXPECT_EQ(pos, 5);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "TestString", 10, "String", 6);
+  pos = strpos_utf8_utf8(context_ptr, "TestString", 10, "String", 6);
   EXPECT_EQ(pos, 5);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "abcabc", 6, "abc", 3);
+  pos = strpos_utf8_utf8(context_ptr, "abcabc", 6, "abc", 3);
   EXPECT_EQ(pos, 1);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "s†å†emçåå†d", 21, "çåå", 6);
+  pos = strpos_utf8_utf8(context_ptr, "s†å†emçåå†d", 21, "çåå", 6);
   EXPECT_EQ(pos, 7);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "†barbar", 9, "bar", 3);
+  pos = strpos_utf8_utf8(context_ptr, "†barbar", 9, "bar", 3);
   EXPECT_EQ(pos, 2);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "", 0, "sub", 3);
+  pos = strpos_utf8_utf8(context_ptr, "", 0, "sub", 3);
   EXPECT_EQ(pos, 0);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  pos = strpos_utf8_utf8(ctx_ptr, "str", 3, "", 0);
+  pos = strpos_utf8_utf8(context_ptr, "str", 3, "", 0);
   EXPECT_EQ(pos, 0);
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   std::string d(
       "a\xff"
       "c");
-  pos = strpos_utf8_utf8(ctx_ptr, d.data(), static_cast<int>(d.length()), "c", 1);
-  EXPECT_THAT(ctx.get_error(),
+  pos = strpos_utf8_utf8(context_ptr, d.data(), static_cast<int>(d.length()), "c", 1);
+  EXPECT_THAT(context.get_error(),
               ::testing::HasSubstr(
                   "unexpected byte \\ff encountered while decoding utf8 string"));
-  ctx.Reset();
+  context.Reset();
 }
 
 TEST(TestStringOps, TestReplace) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
 
   const char* out_str;
-  out_str = replace_utf8_utf8_utf8(ctx_ptr, "TestString1String2", 18, "String", 6,
+  out_str = replace_utf8_utf8_utf8(context_ptr, "TestString1String2", 18, "String", 6,
                                    "Replace", 7, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestReplace1Replace2");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str =
-      replace_utf8_utf8_utf8(ctx_ptr, "TestString1", 11, "String", 6, "", 0, &out_len);
+  out_str = replace_utf8_utf8_utf8(context_ptr, "TestString1", 11, "String", 6, "", 0,
+                                   &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test1");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = replace_utf8_utf8_utf8(ctx_ptr, "", 0, "test", 4, "rep", 3, &out_len);
+  out_str = replace_utf8_utf8_utf8(context_ptr, "", 0, "test", 4, "rep", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = replace_utf8_utf8_utf8(ctx_ptr, "Ç††çåå†", 17, "†", 3, "t", 1, &out_len);
+  out_str = replace_utf8_utf8_utf8(context_ptr, "Ç††çåå†", 17, "†", 3, "t", 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Çttçååt");
-  EXPECT_FALSE(ctx.has_error());
-
-  out_str = replace_utf8_utf8_utf8(ctx_ptr, "TestString", 10, "", 0, "rep", 3, &out_len);
-  EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str =
-      replace_utf8_utf8_utf8(ctx_ptr, "Test", 4, "TestString", 10, "rep", 3, &out_len);
+      replace_utf8_utf8_utf8(context_ptr, "TestString", 10, "", 0, "rep", 3, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "TestString");
+  EXPECT_FALSE(context.has_error());
+
+  out_str = replace_utf8_utf8_utf8(context_ptr, "Test", 4, "TestString", 10, "rep", 3,
+                                   &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Test");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  out_str = replace_utf8_utf8_utf8(ctx_ptr, "Test", 4, "Test", 4, "", 0, &out_len);
+  out_str = replace_utf8_utf8_utf8(context_ptr, "Test", 4, "Test", 4, "", 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
   out_str =
-      replace_utf8_utf8_utf8(ctx_ptr, "TestString", 10, "abc", 3, "xyz", 3, &out_len);
+      replace_utf8_utf8_utf8(context_ptr, "TestString", 10, "abc", 3, "xyz", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "TestString");
-  EXPECT_FALSE(ctx.has_error());
+  EXPECT_FALSE(context.has_error());
 
-  replace_with_max_len_utf8_utf8_utf8(ctx_ptr, "Hell", 4, "ell", 3, "ollow", 5, 5,
+  replace_with_max_len_utf8_utf8_utf8(context_ptr, "Hell", 4, "ell", 3, "ollow", 5, 5,
                                       &out_len);
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer overflow for output string"));
-  ctx.Reset();
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer overflow for output string"));
+  context.Reset();
 
-  replace_with_max_len_utf8_utf8_utf8(ctx_ptr, "eeee", 4, "e", 1, "aaaa", 4, 14,
+  replace_with_max_len_utf8_utf8_utf8(context_ptr, "eeee", 4, "e", 1, "aaaa", 4, 14,
                                       &out_len);
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Buffer overflow for output string"));
-  ctx.Reset();
+  EXPECT_THAT(context.get_error(),
+              ::testing::HasSubstr("Buffer overflow for output string"));
+  context.Reset();
 }
 
 TEST(TestStringOps, TestLeftString) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = left_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = left_utf8_int32(context_ptr, "TestString", 10, 10, &out_len);
   std::string output = std::string(out_str, out_len);
   EXPECT_EQ(output, "TestString");
 
-  out_str = left_utf8_int32(ctx_ptr, "", 0, 0, &out_len);
+  out_str = left_utf8_int32(context_ptr, "", 0, 0, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
 
-  out_str = left_utf8_int32(ctx_ptr, "", 0, 500, &out_len);
+  out_str = left_utf8_int32(context_ptr, "", 0, 500, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
 
-  out_str = left_utf8_int32(ctx_ptr, "TestString", 10, 3, &out_len);
+  out_str = left_utf8_int32(context_ptr, "TestString", 10, 3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "Tes");
 
-  out_str = left_utf8_int32(ctx_ptr, "TestString", 10, -3, &out_len);
+  out_str = left_utf8_int32(context_ptr, "TestString", 10, -3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "TestStr");
 
   // the text length for this string is 10 (each utf8 char is represented by two bytes)
-  out_str = left_utf8_int32(ctx_ptr, "абвгд", 10, 3, &out_len);
+  out_str = left_utf8_int32(context_ptr, "абвгд", 10, 3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "абв");
 }
 
 TEST(TestStringOps, TestRightString) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = right_utf8_int32(ctx_ptr, "TestString", 10, 10, &out_len);
+  out_str = right_utf8_int32(context_ptr, "TestString", 10, 10, &out_len);
   std::string output = std::string(out_str, out_len);
   EXPECT_EQ(output, "TestString");
 
-  out_str = right_utf8_int32(ctx_ptr, "", 0, 0, &out_len);
+  out_str = right_utf8_int32(context_ptr, "", 0, 0, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
 
-  out_str = right_utf8_int32(ctx_ptr, "", 0, 500, &out_len);
+  out_str = right_utf8_int32(context_ptr, "", 0, 500, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
 
-  out_str = right_utf8_int32(ctx_ptr, "TestString", 10, 3, &out_len);
+  out_str = right_utf8_int32(context_ptr, "TestString", 10, 3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "ing");
 
-  out_str = right_utf8_int32(ctx_ptr, "TestString", 10, -3, &out_len);
+  out_str = right_utf8_int32(context_ptr, "TestString", 10, -3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "tString");
 
   // the text length for this string is 10 (each utf8 char is represented by two bytes)
-  out_str = right_utf8_int32(ctx_ptr, "абвгд", 10, 3, &out_len);
+  out_str = right_utf8_int32(context_ptr, "абвгд", 10, 3, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "вгд");
 }
 
 TEST(TestStringOps, TestBinaryString) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = binary_string(ctx_ptr, "TestString", 10, &out_len);
+  out_str = binary_string(context_ptr, "TestString", 10, &out_len);
   std::string output = std::string(out_str, out_len);
   EXPECT_EQ(output, "TestString");
 
-  out_str = binary_string(ctx_ptr, "", 0, &out_len);
+  out_str = binary_string(context_ptr, "", 0, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
 
-  out_str = binary_string(ctx_ptr, "T", 1, &out_len);
+  out_str = binary_string(context_ptr, "T", 1, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "T");
 
-  out_str = binary_string(ctx_ptr, "\\x41\\x42\\x43", 12, &out_len);
+  out_str = binary_string(context_ptr, "\\x41\\x42\\x43", 12, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "ABC");
 
-  out_str = binary_string(ctx_ptr, "\\x41", 4, &out_len);
+  out_str = binary_string(context_ptr, "\\x41", 4, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "A");
 
-  out_str = binary_string(ctx_ptr, "\\x6d\\x6D", 8, &out_len);
+  out_str = binary_string(context_ptr, "\\x6d\\x6D", 8, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "mm");
 
-  out_str = binary_string(ctx_ptr, "\\x6f\\x6d", 8, &out_len);
+  out_str = binary_string(context_ptr, "\\x6f\\x6d", 8, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "om");
 
-  out_str = binary_string(ctx_ptr, "\\x4f\\x4D", 8, &out_len);
+  out_str = binary_string(context_ptr, "\\x4f\\x4D", 8, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "OM");
 }
 
 TEST(TestStringOps, TestSplitPart) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
-  out_str = split_part(ctx_ptr, "A,B,C", 5, ",", 1, 0, &out_len);
+  out_str = split_part(context_ptr, "A,B,C", 5, ",", 1, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_THAT(
-      ctx.get_error(),
+      context.get_error(),
       ::testing::HasSubstr("Index in split_part must be positive, value provided was 0"));
 
-  out_str = split_part(ctx_ptr, "A,B,C", 5, ",", 1, 1, &out_len);
+  out_str = split_part(context_ptr, "A,B,C", 5, ",", 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "A");
 
-  out_str = split_part(ctx_ptr, "A,B,C", 5, ",", 1, 2, &out_len);
+  out_str = split_part(context_ptr, "A,B,C", 5, ",", 1, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "B");
 
-  out_str = split_part(ctx_ptr, "A,B,C", 5, ",", 1, 3, &out_len);
+  out_str = split_part(context_ptr, "A,B,C", 5, ",", 1, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "C");
 
-  out_str = split_part(ctx_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 1, &out_len);
+  out_str = split_part(context_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "abc");
 
-  out_str = split_part(ctx_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 2, &out_len);
+  out_str = split_part(context_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "def");
 
-  out_str = split_part(ctx_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 3, &out_len);
+  out_str = split_part(context_ptr, "abc~@~def~@~ghi", 15, "~@~", 3, 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ghi");
 
   // Result must be empty when the index is > no of elements
-  out_str = split_part(ctx_ptr, "123|456|789", 11, "|", 1, 4, &out_len);
+  out_str = split_part(context_ptr, "123|456|789", 11, "|", 1, 4, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = split_part(ctx_ptr, "123|", 4, "|", 1, 1, &out_len);
+  out_str = split_part(context_ptr, "123|", 4, "|", 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "123");
 
-  out_str = split_part(ctx_ptr, "|123", 4, "|", 1, 1, &out_len);
+  out_str = split_part(context_ptr, "|123", 4, "|", 1, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
 
-  out_str = split_part(ctx_ptr, "ç†ååçåå†", 18, "å", 2, 1, &out_len);
+  out_str = split_part(context_ptr, "ç†ååçåå†", 18, "å", 2, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ç†");
 
-  out_str = split_part(ctx_ptr, "ç†ååçåå†", 18, "†åå", 6, 1, &out_len);
+  out_str = split_part(context_ptr, "ç†ååçåå†", 18, "†åå", 6, 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ç");
 
-  out_str = split_part(ctx_ptr, "ç†ååçåå†", 18, "†", 3, 2, &out_len);
+  out_str = split_part(context_ptr, "ç†ååçåå†", 18, "†", 3, 2, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "ååçåå");
 }
 
 TEST(TestStringOps, TestConvertTo) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   const char* out_str;
 
   const int32_t ALL_BYTES_MATCH = 0;
 
   int32_t integer_value = std::numeric_limits<int32_t>::max();
-  out_str = convert_toINT(ctx_ptr, integer_value, &out_len);
+  out_str = convert_toINT(context_ptr, integer_value, &out_len);
   EXPECT_EQ(out_len, sizeof(integer_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &integer_value, out_len));
 
   int64_t big_integer_value = std::numeric_limits<int64_t>::max();
-  out_str = convert_toBIGINT(ctx_ptr, big_integer_value, &out_len);
+  out_str = convert_toBIGINT(context_ptr, big_integer_value, &out_len);
   EXPECT_EQ(out_len, sizeof(big_integer_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &big_integer_value, out_len));
 
   float float_value = std::numeric_limits<float>::max();
-  out_str = convert_toFLOAT(ctx_ptr, float_value, &out_len);
+  out_str = convert_toFLOAT(context_ptr, float_value, &out_len);
   EXPECT_EQ(out_len, sizeof(float_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &float_value, out_len));
 
   double double_value = std::numeric_limits<double>::max();
-  out_str = convert_toDOUBLE(ctx_ptr, double_value, &out_len);
+  out_str = convert_toDOUBLE(context_ptr, double_value, &out_len);
   EXPECT_EQ(out_len, sizeof(double_value));
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, &double_value, out_len));
 
   const char* test_string = "test string";
   int32_t str_len = 11;
-  out_str = convert_toUTF8(ctx_ptr, test_string, str_len, &out_len);
+  out_str = convert_toUTF8(context_ptr, test_string, str_len, &out_len);
   EXPECT_EQ(out_len, str_len);
   EXPECT_EQ(ALL_BYTES_MATCH, memcmp(out_str, test_string, out_len));
 }
 
 TEST(TestStringOps, TestConvertToBigEndian) {
-  gandiva::ExecutionContext ctx;
-  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gandiva::ExecutionContext context;
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len = 0;
   gdv_int32 out_len_big_endian = 0;
   const char* out_str;
   const char* out_str_big_endian;
 
   int64_t big_integer_value = std::numeric_limits<int64_t>::max();
-  out_str = convert_toBIGINT(ctx_ptr, big_integer_value, &out_len);
+  out_str = convert_toBIGINT(context_ptr, big_integer_value, &out_len);
   out_str_big_endian =
-      convert_toBIGINT_be(ctx_ptr, big_integer_value, &out_len_big_endian);
+      convert_toBIGINT_be(context_ptr, big_integer_value, &out_len_big_endian);
   EXPECT_EQ(out_len_big_endian, sizeof(big_integer_value));
   EXPECT_EQ(out_len_big_endian, out_len);
 
@@ -1738,8 +1759,9 @@ TEST(TestStringOps, TestConvertToBigEndian) {
 #endif
 
   double double_value = std::numeric_limits<double>::max();
-  out_str = convert_toDOUBLE(ctx_ptr, double_value, &out_len);
-  out_str_big_endian = convert_toDOUBLE_be(ctx_ptr, double_value, &out_len_big_endian);
+  out_str = convert_toDOUBLE(context_ptr, double_value, &out_len);
+  out_str_big_endian =
+      convert_toDOUBLE_be(context_ptr, double_value, &out_len_big_endian);
   EXPECT_EQ(out_len_big_endian, sizeof(double_value));
   EXPECT_EQ(out_len_big_endian, out_len);
 

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -26,7 +26,7 @@ namespace gandiva {
 
 TEST(TestTime, TestCastDate) {
   ExecutionContext context;
-  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   EXPECT_EQ(castDATE_utf8(context_ptr, "1967-12-1", 9), -65836800000);
   EXPECT_EQ(castDATE_utf8(context_ptr, "2067-12-1", 9), 3089923200000);
@@ -59,7 +59,7 @@ TEST(TestTime, TestCastDate) {
 
 TEST(TestTime, TestCastTimestamp) {
   ExecutionContext context;
-  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "1967-12-1", 9), -65836800000);
   EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2067-12-1", 9), 3089923200000);
@@ -138,7 +138,7 @@ TEST(TestTime, TestCastTimestamp) {
 
 TEST(TestTime, TestCastTimestampWithTZ) {
   ExecutionContext context;
-  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "2000-09-23 9:45:30.920 Canada/Pacific", 37),
             969727530920);
@@ -150,7 +150,7 @@ TEST(TestTime, TestCastTimestampWithTZ) {
 
 TEST(TestTime, TestCastTimestampErrors) {
   ExecutionContext context;
-  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+  void* context_ptr = reinterpret_cast<void*>(&context);
 
   // error cases
   EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, "20000923", 8), 0);
@@ -706,7 +706,7 @@ TEST(TestTime, TestMonthsBetween) {
 
 TEST(TestTime, castVarcharTimestamp) {
   ExecutionContext context;
-  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+  void* context_ptr = reinterpret_cast<void*>(&context);
   gdv_int32 out_len;
   gdv_timestamp ts = StringToTimestamp("2000-05-01 10:20:34");
   const char* out = castVARCHAR_timestamp_int64(context_ptr, ts, 30L, &out_len);
@@ -887,7 +887,7 @@ TEST(TestTime, TestCastIntYearInterval) {
 
 TEST(TestTime, TestCastNullableInterval) {
   ExecutionContext context;
-  auto context_ptr = reinterpret_cast<int64_t>(&context);
+  auto context_ptr = reinterpret_cast<void*>(&context);
   // Test castNULLABLEINTERVALDAY for int and bigint
   EXPECT_EQ(castNULLABLEINTERVALDAY_int32(1), 1);
   EXPECT_EQ(castNULLABLEINTERVALDAY_int32(12), 12);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -116,7 +116,7 @@ gdv_int64 date_sub_timestamp_int32(gdv_timestamp, gdv_int32);
 gdv_int64 subtract_timestamp_int32(gdv_timestamp, gdv_int32);
 gdv_int64 date_diff_timestamp_int64(gdv_timestamp, gdv_int64);
 
-gdv_boolean castBIT_utf8(gdv_int64 context, const char* data, gdv_int32 data_len);
+gdv_boolean castBIT_utf8(void* context_ptr, const char* data, gdv_int32 data_len);
 
 bool is_distinct_from_timestamp_timestamp(gdv_int64, bool, gdv_int64, bool);
 bool is_not_distinct_from_int32_int32(gdv_int32, bool, gdv_int32, bool);
@@ -139,13 +139,13 @@ gdv_int32 mem_compare(const char* left, gdv_int32 left_len, const char* right,
                       gdv_int32 right_len);
 
 gdv_int32 mod_int64_int32(gdv_int64 left, gdv_int32 right);
-gdv_float64 mod_float64_float64(gdv_int64 context, gdv_float64 left, gdv_float64 right);
+gdv_float64 mod_float64_float64(void* context_ptr, gdv_float64 left, gdv_float64 right);
 
-gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
+gdv_int64 divide_int64_int64(void* context_ptr, gdv_int64 in1, gdv_int64 in2);
 
-gdv_int64 div_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
-gdv_float32 div_float32_float32(gdv_int64 context, gdv_float32 in1, gdv_float32 in2);
-gdv_float64 div_float64_float64(gdv_int64 context, gdv_float64 in1, gdv_float64 in2);
+gdv_int64 div_int64_int64(void* context_ptr, gdv_int64 in1, gdv_int64 in2);
+gdv_float32 div_float32_float32(void* context_ptr, gdv_float32 in1, gdv_float32 in2);
+gdv_float64 div_float64_float64(void* context_ptr, gdv_float64 in1, gdv_float64 in2);
 
 gdv_float32 round_float32(gdv_float32);
 gdv_float64 round_float64(gdv_float64);
@@ -158,8 +158,8 @@ gdv_int32 round_int32(gdv_int32);
 gdv_int64 round_int64(gdv_int64);
 gdv_int64 get_power_of_10(gdv_int32);
 
-const char* bin_int32(int64_t context, gdv_int32 value, int32_t* out_len);
-const char* bin_int64(int64_t context, gdv_int64 value, int32_t* out_len);
+const char* bin_int32(void* context_ptr, gdv_int32 value, int32_t* out_len);
+const char* bin_int64(void* context_ptr, gdv_int64 value, int32_t* out_len);
 
 gdv_float64 cbrt_int32(gdv_int32);
 gdv_float64 cbrt_int64(gdv_int64);
@@ -243,7 +243,7 @@ gdv_int64 bitwise_not_int64(gdv_int64);
 
 gdv_float64 power_float64_float64(gdv_float64, gdv_float64);
 
-gdv_float64 log_int32_int32(gdv_int64 context, gdv_int32 base, gdv_int32 value);
+gdv_float64 log_int32_int32(void* context_ptr, gdv_int32 base, gdv_int32 value);
 
 bool starts_with_utf8_utf8(const char* data, gdv_int32 data_len, const char* prefix,
                            gdv_int32 prefix_len);
@@ -252,11 +252,11 @@ bool ends_with_utf8_utf8(const char* data, gdv_int32 data_len, const char* suffi
 bool is_substr_utf8_utf8(const char* data, gdv_int32 data_len, const char* substr,
                          gdv_int32 substr_len);
 
-gdv_int32 utf8_length(gdv_int64 context, const char* data, gdv_int32 data_len);
+gdv_int32 utf8_length(void* context_ptr, const char* data, gdv_int32 data_len);
 
-gdv_int32 utf8_last_char_pos(gdv_int64 context, const char* data, gdv_int32 data_len);
+gdv_int32 utf8_last_char_pos(void* context_ptr, const char* data, gdv_int32 data_len);
 
-gdv_date64 castDATE_utf8(int64_t execution_context, const char* input, gdv_int32 length);
+gdv_date64 castDATE_utf8(void* context_ptr, const char* input, gdv_int32 length);
 
 gdv_date64 castDATE_int64(gdv_int64 date);
 
@@ -264,63 +264,62 @@ gdv_date64 castDATE_date32(gdv_date32 date);
 
 gdv_date32 castDATE_int32(gdv_int32 date);
 
-gdv_timestamp castTIMESTAMP_utf8(int64_t execution_context, const char* input,
-                                 gdv_int32 length);
+gdv_timestamp castTIMESTAMP_utf8(void* context_ptr, const char* input, gdv_int32 length);
 gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);
 gdv_time32 castTIME_timestamp(gdv_timestamp timestamp_in_millis);
-const char* castVARCHAR_timestamp_int64(int64_t, gdv_timestamp, gdv_int64, gdv_int32*);
+const char* castVARCHAR_timestamp_int64(void*, gdv_timestamp, gdv_int64, gdv_int32*);
 gdv_date64 last_day_from_timestamp(gdv_date64 millis);
 
 gdv_int64 truncate_int64_int32(gdv_int64 in, gdv_int32 out_scale);
 
-const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_len,
+const char* repeat_utf8_int32(void* context_ptr, const char* in, gdv_int32 in_len,
                               gdv_int32 repeat_times, gdv_int32* out_len);
 
-const char* substr_utf8_int64_int64(gdv_int64 context, const char* input,
+const char* substr_utf8_int64_int64(void* context_ptr, const char* input,
                                     gdv_int32 in_len, gdv_int64 offset64,
                                     gdv_int64 length, gdv_int32* out_len);
-const char* substr_utf8_int64(gdv_int64 context, const char* input, gdv_int32 in_len,
+const char* substr_utf8_int64(void* context_ptr, const char* input, gdv_int32 in_len,
                               gdv_int64 offset64, gdv_int32* out_len);
 
-const char* concat_utf8_utf8(gdv_int64 context, const char* left, gdv_int32 left_len,
+const char* concat_utf8_utf8(void* context_ptr, const char* left, gdv_int32 left_len,
                              bool left_validity, const char* right, gdv_int32 right_len,
                              bool right_validity, gdv_int32* out_len);
-const char* concat_utf8_utf8_utf8(gdv_int64 context, const char* in1, gdv_int32 in1_len,
+const char* concat_utf8_utf8_utf8(void* context_ptr, const char* in1, gdv_int32 in1_len,
                                   bool in1_validity, const char* in2, gdv_int32 in2_len,
                                   bool in2_validity, const char* in3, gdv_int32 in3_len,
                                   bool in3_validity, gdv_int32* out_len);
-const char* concat_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concat_utf8_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                        gdv_int32 in1_len, bool in1_validity,
                                        const char* in2, gdv_int32 in2_len,
                                        bool in2_validity, const char* in3,
                                        gdv_int32 in3_len, bool in3_validity,
                                        const char* in4, gdv_int32 in4_len,
                                        bool in4_validity, gdv_int32* out_len);
-const char* space_int32(gdv_int64 ctx, gdv_int32 n, int32_t* out_len);
-const char* space_int64(gdv_int64 ctx, gdv_int64 n, int32_t* out_len);
+const char* space_int32(void* context_ptr, gdv_int32 n, int32_t* out_len);
+const char* space_int64(void* context_ptr, gdv_int64 n, int32_t* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
     gdv_int32* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
     const char* in6, gdv_int32 in6_len, bool in6_validity, gdv_int32* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
     const char* in6, gdv_int32 in6_len, bool in6_validity, const char* in7,
     gdv_int32 in7_len, bool in7_validity, gdv_int32* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -328,7 +327,7 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     gdv_int32 in7_len, bool in7_validity, const char* in8, gdv_int32 in8_len,
     bool in8_validity, gdv_int32* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -337,7 +336,7 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     bool in8_validity, const char* in9, gdv_int32 in9_len, bool in9_validity,
     gdv_int32* out_len);
 const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, bool in1_validity,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, bool in1_validity,
     const char* in2, gdv_int32 in2_len, bool in2_validity, const char* in3,
     gdv_int32 in3_len, bool in3_validity, const char* in4, gdv_int32 in4_len,
     bool in4_validity, const char* in5, gdv_int32 in5_len, bool in5_validity,
@@ -346,208 +345,208 @@ const char* concat_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
     bool in8_validity, const char* in9, gdv_int32 in9_len, bool in9_validity,
     const char* in10, gdv_int32 in10_len, bool in10_validity, gdv_int32* out_len);
 
-const char* concatOperator_utf8_utf8(gdv_int64 context, const char* left,
+const char* concatOperator_utf8_utf8(void* context_ptr, const char* left,
                                      gdv_int32 left_len, const char* right,
                                      gdv_int32 right_len, gdv_int32* out_len);
-const char* concatOperator_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concatOperator_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                           gdv_int32 in1_len, const char* in2,
                                           gdv_int32 in2_len, const char* in3,
                                           gdv_int32 in3_len, gdv_int32* out_len);
-const char* concatOperator_utf8_utf8_utf8_utf8(gdv_int64 context, const char* in1,
+const char* concatOperator_utf8_utf8_utf8_utf8(void* context_ptr, const char* in1,
                                                gdv_int32 in1_len, const char* in2,
                                                gdv_int32 in2_len, const char* in3,
                                                gdv_int32 in3_len, const char* in4,
                                                gdv_int32 in4_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
     gdv_int32 in8_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
     gdv_int32 in8_len, const char* in9, gdv_int32 in9_len, gdv_int32* out_len);
 const char* concatOperator_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8_utf8(
-    gdv_int64 context, const char* in1, gdv_int32 in1_len, const char* in2,
+    void* context_ptr, const char* in1, gdv_int32 in1_len, const char* in2,
     gdv_int32 in2_len, const char* in3, gdv_int32 in3_len, const char* in4,
     gdv_int32 in4_len, const char* in5, gdv_int32 in5_len, const char* in6,
     gdv_int32 in6_len, const char* in7, gdv_int32 in7_len, const char* in8,
     gdv_int32 in8_len, const char* in9, gdv_int32 in9_len, const char* in10,
     gdv_int32 in10_len, gdv_int32* out_len);
 
-const char* castVARCHAR_binary_int64(gdv_int64 context, const char* data,
+const char* castVARCHAR_binary_int64(void* context_ptr, const char* data,
                                      gdv_int32 data_len, int64_t out_len,
                                      int32_t* out_length);
 
-const char* castVARCHAR_utf8_int64(gdv_int64 context, const char* data,
+const char* castVARCHAR_utf8_int64(void* context_ptr, const char* data,
                                    gdv_int32 data_len, int64_t out_len,
                                    int32_t* out_length);
 
-const char* castVARBINARY_utf8_int64(gdv_int64 context, const char* data,
+const char* castVARBINARY_utf8_int64(void* context_ptr, const char* data,
                                      gdv_int32 data_len, int64_t out_len,
                                      int32_t* out_length);
 
-const char* castVARBINARY_binary_int64(gdv_int64 context, const char* data,
+const char* castVARBINARY_binary_int64(void* context_ptr, const char* data,
                                        gdv_int32 data_len, int64_t out_len,
                                        int32_t* out_length);
 
-const char* reverse_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* reverse_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                          int32_t* out_len);
 
-const char* ltrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* ltrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len);
 
-const char* rtrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* rtrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len);
 
-const char* btrim_utf8(gdv_int64 context, const char* data, gdv_int32 data_len,
+const char* btrim_utf8(void* context_ptr, const char* data, gdv_int32 data_len,
                        int32_t* out_len);
 
-const char* ltrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* ltrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len);
 
-const char* rtrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* rtrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len);
 
-const char* btrim_utf8_utf8(gdv_int64 context, const char* basetext,
+const char* btrim_utf8_utf8(void* context_ptr, const char* basetext,
                             gdv_int32 basetext_len, const char* trimtext,
                             gdv_int32 trimtext_len, int32_t* out_len);
 
 gdv_int32 ascii_utf8(const char* data, gdv_int32 data_len);
 
-gdv_int32 locate_utf8_utf8(gdv_int64 context, const char* sub_str, gdv_int32 sub_str_len,
+gdv_int32 locate_utf8_utf8(void* context_ptr, const char* sub_str, gdv_int32 sub_str_len,
                            const char* str, gdv_int32 str_len);
 
-gdv_int32 strpos_utf8_utf8(gdv_int64 context, const char* str, gdv_int32 str_len,
+gdv_int32 strpos_utf8_utf8(void* context_ptr, const char* str, gdv_int32 str_len,
                            const char* sub_str, gdv_int32 sub_str_len);
 
-gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
+gdv_int32 locate_utf8_utf8_int32(void* context_ptr, const char* sub_str,
                                  gdv_int32 sub_str_len, const char* str,
                                  gdv_int32 str_len, gdv_int32 start_pos);
 
-const char* lpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* lpad_utf8_int32_utf8(void* context_ptr, const char* text, gdv_int32 text_len,
                                  gdv_int32 return_length, const char* fill_text,
                                  gdv_int32 fill_text_len, gdv_int32* out_len);
 
-const char* rpad_utf8_int32_utf8(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* rpad_utf8_int32_utf8(void* context_ptr, const char* text, gdv_int32 text_len,
                                  gdv_int32 return_length, const char* fill_text,
                                  gdv_int32 fill_text_len, gdv_int32* out_len);
 
-const char* lpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* lpad_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 return_length, gdv_int32* out_len);
 
-const char* rpad_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* rpad_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 return_length, gdv_int32* out_len);
 
-const char* replace_with_max_len_utf8_utf8_utf8(gdv_int64 context, const char* text,
+const char* replace_with_max_len_utf8_utf8_utf8(void* context_ptr, const char* text,
                                                 gdv_int32 text_len, const char* from_str,
                                                 gdv_int32 from_str_len,
                                                 const char* to_str, gdv_int32 to_str_len,
                                                 gdv_int32 max_length, gdv_int32* out_len);
 
-const char* replace_utf8_utf8_utf8(gdv_int64 context, const char* text,
+const char* replace_utf8_utf8_utf8(void* context_ptr, const char* text,
                                    gdv_int32 text_len, const char* from_str,
                                    gdv_int32 from_str_len, const char* to_str,
                                    gdv_int32 to_str_len, gdv_int32* out_len);
 
-const char* convert_replace_invalid_fromUTF8_binary(int64_t context, const char* text_in,
-                                                    int32_t text_len,
+const char* convert_replace_invalid_fromUTF8_binary(void* context_ptr,
+                                                    const char* text_in, int32_t text_len,
                                                     const char* char_to_replace,
                                                     int32_t char_to_replace_len,
                                                     int32_t* out_len);
 
-const char* convert_toDOUBLE(int64_t context, double value, int32_t* out_len);
+const char* convert_toDOUBLE(void* context_ptr, double value, int32_t* out_len);
 
-const char* convert_toDOUBLE_be(int64_t context, double value, int32_t* out_len);
+const char* convert_toDOUBLE_be(void* context_ptr, double value, int32_t* out_len);
 
-const char* convert_toFLOAT(int64_t context, float value, int32_t* out_len);
+const char* convert_toFLOAT(void* context_ptr, float value, int32_t* out_len);
 
-const char* convert_toFLOAT_be(int64_t context, float value, int32_t* out_len);
+const char* convert_toFLOAT_be(void* context_ptr, float value, int32_t* out_len);
 
-const char* convert_toBIGINT(int64_t context, int64_t value, int32_t* out_len);
+const char* convert_toBIGINT(void* context_ptr, int64_t value, int32_t* out_len);
 
-const char* convert_toBIGINT_be(int64_t context, int64_t value, int32_t* out_len);
+const char* convert_toBIGINT_be(void* context_ptr, int64_t value, int32_t* out_len);
 
-const char* convert_toINT(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toINT(void* context_ptr, int32_t value, int32_t* out_len);
 
-const char* convert_toINT_be(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toINT_be(void* context_ptr, int32_t value, int32_t* out_len);
 
-const char* convert_toBOOLEAN(int64_t context, bool value, int32_t* out_len);
+const char* convert_toBOOLEAN(void* context_ptr, bool value, int32_t* out_len);
 
-const char* convert_toTIME_EPOCH(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toTIME_EPOCH(void* context_ptr, int32_t value, int32_t* out_len);
 
-const char* convert_toTIME_EPOCH_be(int64_t context, int32_t value, int32_t* out_len);
+const char* convert_toTIME_EPOCH_be(void* context_ptr, int32_t value, int32_t* out_len);
 
-const char* convert_toTIMESTAMP_EPOCH(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH(void* context_ptr, int64_t timestamp,
                                       int32_t* out_len);
-const char* convert_toTIMESTAMP_EPOCH_be(int64_t context, int64_t timestamp,
+const char* convert_toTIMESTAMP_EPOCH_be(void* context_ptr, int64_t timestamp,
                                          int32_t* out_len);
 
-const char* convert_toDATE_EPOCH(int64_t context, int64_t date, int32_t* out_len);
+const char* convert_toDATE_EPOCH(void* context_ptr, int64_t date, int32_t* out_len);
 
-const char* convert_toDATE_EPOCH_be(int64_t context, int64_t date, int32_t* out_len);
+const char* convert_toDATE_EPOCH_be(void* context_ptr, int64_t date, int32_t* out_len);
 
-const char* convert_toUTF8(int64_t context, const char* value, int32_t value_len,
+const char* convert_toUTF8(void* context_ptr, const char* value, int32_t value_len,
                            int32_t* out_len);
 
-const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* split_part(void* context_ptr, const char* text, gdv_int32 text_len,
                        const char* splitter, gdv_int32 split_len, gdv_int32 index,
                        gdv_int32* out_len);
 
-const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
+const char* byte_substr_binary_int32_int32(void* context_ptr, const char* text,
                                            gdv_int32 text_len, gdv_int32 offset,
                                            gdv_int32 length, gdv_int32* out_len);
 
-const char* castVARCHAR_bool_int64(gdv_int64 context, gdv_boolean value,
+const char* castVARCHAR_bool_int64(void* context_ptr, gdv_boolean value,
                                    gdv_int64 out_len, gdv_int32* out_length);
 
-const char* castVARCHAR_int32_int64(int64_t context, int32_t value, int64_t len,
+const char* castVARCHAR_int32_int64(void* context_ptr, int32_t value, int64_t len,
                                     int32_t* out_len);
 
-const char* castVARCHAR_int64_int64(int64_t context, int64_t value, int64_t len,
+const char* castVARCHAR_int64_int64(void* context_ptr, int64_t value, int64_t len,
                                     int32_t* out_len);
 
-const char* castVARCHAR_float32_int64(int64_t context, float value, int64_t len,
+const char* castVARCHAR_float32_int64(void* context_ptr, float value, int64_t len,
                                       int32_t* out_len);
 
-const char* castVARCHAR_float64_int64(int64_t context, double value, int64_t len,
+const char* castVARCHAR_float64_int64(void* context_ptr, double value, int64_t len,
                                       int32_t* out_len);
 
-const char* left_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* left_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                             gdv_int32 number, gdv_int32* out_len);
 
-const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* right_utf8_int32(void* context_ptr, const char* text, gdv_int32 text_len,
                              gdv_int32 number, gdv_int32* out_len);
 
-const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_len,
+const char* binary_string(void* context_ptr, const char* text, gdv_int32 text_len,
                           gdv_int32* out_len);
 
-int32_t castINT_utf8(int64_t context, const char* data, int32_t len);
+int32_t castINT_utf8(void* context_ptr, const char* data, int32_t len);
 
-int64_t castBIGINT_utf8(int64_t context, const char* data, int32_t len);
+int64_t castBIGINT_utf8(void* context_ptr, const char* data, int32_t len);
 
-float castFLOAT4_utf8(int64_t context, const char* data, int32_t len);
+float castFLOAT4_utf8(void* context_ptr, const char* data, int32_t len);
 
-double castFLOAT8_utf8(int64_t context, const char* data, int32_t len);
+double castFLOAT8_utf8(void* context_ptr, const char* data, int32_t len);
 
 int32_t castINT_float32(gdv_float32 value);
 
@@ -567,8 +566,8 @@ gdv_day_time_interval castNULLABLEINTERVALDAY_int32(gdv_int32 in);
 
 gdv_day_time_interval castNULLABLEINTERVALDAY_int64(gdv_int64 in);
 
-gdv_month_interval castNULLABLEINTERVALYEAR_int32(int64_t context, gdv_int32 in);
+gdv_month_interval castNULLABLEINTERVALYEAR_int32(void* context_ptr, gdv_int32 in);
 
-gdv_month_interval castNULLABLEINTERVALYEAR_int64(int64_t context, gdv_int64 in);
+gdv_month_interval castNULLABLEINTERVALYEAR_int64(void* context_ptr, gdv_int64 in);
 
 }  // extern "C"


### PR DESCRIPTION
Hey there!

This PR uses pointers in the JIT code generation / function invocation instead of the hard-coded `int64_t` type, which especially breaks when indexing into pointers to pointers on platforms where the pointer size is not 64 bit wide.