### PR TITLE
ARROW-13428: [C++][Flight] Add missing -lssl with bundled gRPC and system shared OpenSSL

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2543,6 +2543,9 @@ macro(build_grpc)
       c-ares::cares
       ZLIB::ZLIB
       Threads::Threads)
+  if(ARROW_OPENSSL_USE_SHARED)
+    list(APPEND GRPC_LINK_LIBRARIES OpenSSL::SSL)
+  endif()
   set_target_properties(gRPC::grpc
                         PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GRPC}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}"

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2542,10 +2542,8 @@ macro(build_grpc)
       re2::re2
       c-ares::cares
       ZLIB::ZLIB
+      OpenSSL::SSL
       Threads::Threads)
-  if(ARROW_OPENSSL_USE_SHARED)
-    list(APPEND GRPC_LINK_LIBRARIES OpenSSL::SSL)
-  endif()
   set_target_properties(gRPC::grpc
                         PROPERTIES IMPORTED_LOCATION "${GRPC_STATIC_LIBRARY_GRPC}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}"


### PR DESCRIPTION
If bundled gRPC uses system shared OpenSSL, libarrow_flight.so should
link system shared OpenSSL.

See also: https://github.com/apache/arrow/pull/10768#issuecomment-884726000