### PR TITLE
ARROW-12701: [Website][Release] Include Rust contributors, committers, and commits in release notes

### DIFF
--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -155,7 +155,7 @@ This is a major release covering more than ${rough_n_development_months} months 
 
 ## Contributors
 
-This release includes ${n_commits} commits from ${n_contributors} distinct contributors.
+This release includes ${n_commits} commits from ${n_contributors} distinct contributors in ${#directories[@]} Arrow repositories.
 
 \`\`\`console
 ANNOUNCE

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -23,6 +23,7 @@ set -u
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARROW_DIR="${SOURCE_DIR}/../.."
 ARROW_SITE_DIR="${ARROW_DIR}/../arrow-site"
+ARROW_RS_DIR="${ARROW_DIR}/../arrow-rs"
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <previous-version> <version>"

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -61,16 +61,19 @@ git_range=apache-arrow-${previous_version}..${git_tag}
 directories=("${ARROW_DIR}" "${ARROW_RS_DIR}")
 git_ranges=(apache-arrow-${previous_version}..${git_tag} ${previous_version}..${version})
 
+
+format_results='
+      {person="";
+      for (x=2; x<=NF; x++) {person=person " " $x}; 
+      counts[person]+=$1 } END {for (person in counts) print counts[person], person}' 
+
 committers=$(
   for (( i=0; i<${#directories[@]}; i++ ));
   do
     cd ${directories[$i]}
     git shortlog -csn ${git_ranges[$i]}
   done | 
-  awk '{
-    name_email="";
-    for (i=2; i<=NF; i++) { name_email=name_email " " $i}; 
-    count_by_user[name_email]+=$1} END {for (name_email in count_by_user) print count_by_user[name_email], name_email}' |
+  awk "$format_results" |
   sort -rn 
 )
 
@@ -80,10 +83,7 @@ contributors=$(
     cd ${directories[$i]}
     git shortlog -sn ${git_ranges[$i]}
   done | 
-  awk '{
-    name_email="";
-    for (i=2; i<=NF; i++) { name_email=name_email " " $i}; 
-    count_by_user[name_email]+=$1} END {for (name_email in count_by_user) print count_by_user[name_email], name_email}' |
+  awk "$format_results" |
   sort -rn 
 )
 

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -57,6 +57,7 @@ rough_n_development_months=$((
 git_tag=apache-arrow-${version}
 git_range=apache-arrow-${previous_version}..${git_tag}
 
+# DataFusion directory and git ranges should be added here once git tagging convention confimed with DF team
 directories=("${ARROW_DIR}" "${ARROW_RS_DIR}")
 git_ranges=(apache-arrow-${previous_version}..${git_tag} ${previous_version}..${version})
 

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -180,6 +180,9 @@ cat <<ANNOUNCE >> "${announce_file}"
 
 ## Changelog
 
+The following changelog is for the `apache/arrow` repository. For the Rust
+implementation of Apache Arrow, see the [`apache/arrow-rs` changelog][7].
+
 ANNOUNCE
 
 archery release changelog generate ${version} | \
@@ -192,6 +195,7 @@ cat <<ANNOUNCE >> "${announce_file}"
 [4]: https://apache.jfrog.io/artifactory/arrow/python/${version}/
 [5]: https://apache.jfrog.io/artifactory/arrow/ubuntu/
 [6]: https://github.com/apache/arrow/releases/tag/apache-arrow-${version}
+[7]: https://github.com/apache/arrow-rs/blob/${version}/CHANGELOG.md
 ANNOUNCE
 git add "${announce_file}"
 

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -24,6 +24,7 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARROW_DIR="${SOURCE_DIR}/../.."
 ARROW_SITE_DIR="${ARROW_DIR}/../arrow-site"
 ARROW_RS_DIR="${ARROW_DIR}/../arrow-rs"
+ARROW_DF_DIR="${ARROW_DIR}/../arrow-datafusion"
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <previous-version> <version>"

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -24,7 +24,8 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARROW_DIR="${SOURCE_DIR}/../.."
 ARROW_SITE_DIR="${ARROW_DIR}/../arrow-site"
 ARROW_RS_DIR="${ARROW_DIR}/../arrow-rs"
-ARROW_DF_DIR="${ARROW_DIR}/../arrow-datafusion"
+# TODO: add this back in when we have datafusion releases included
+#ARROW_DF_DIR="${ARROW_DIR}/../arrow-datafusion"
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <previous-version> <version>"

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -57,7 +57,17 @@ rough_n_development_months=$((
 git_tag=apache-arrow-${version}
 git_range=apache-arrow-${previous_version}..${git_tag}
 
-# DataFusion directory and git ranges should be added here once git tagging convention confimed with DF team
+# Previously this code counted commits, committers, and contributors only to the
+# apache/arrow repository. After the Rust implementation of Arrow was moved to
+# the separate apache/arrow-rs repository, this code was modified to also count
+# commits, committers, and contributors to that repository.
+#
+# TODO: Add DataFusion directory and git ranges here once git tagging convention
+# for apache/arrow-datafusion repo is confirmed with DF team
+#
+# TODO: Consider counting other apache/arrow-* repos here if tagging conventions
+# permit (arrow-cookbook, arrow-site)
+
 directories=("${ARROW_DIR}" "${ARROW_RS_DIR}")
 git_ranges=(apache-arrow-${previous_version}..${git_tag} ${previous_version}..${version})
 

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -187,7 +187,7 @@ ANNOUNCE
 archery release changelog generate ${version} | \
   sed -e 's/^#/##/g' >> "${announce_file}"
 
-cat <<'ANNOUNCE' >> "${announce_file}"
+cat <<ANNOUNCE >> "${announce_file}"
 [1]: https://www.apache.org/dyn/closer.lua/arrow/arrow-${version}/
 [2]: https://apache.jfrog.io/artifactory/arrow/centos/
 [3]: https://apache.jfrog.io/artifactory/arrow/debian/

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -71,7 +71,6 @@ git_range=apache-arrow-${previous_version}..${git_tag}
 directories=("${ARROW_DIR}" "${ARROW_RS_DIR}")
 git_ranges=(apache-arrow-${previous_version}..${git_tag} ${previous_version}..${version})
 
-
 format_results='
       {person="";
       for (x=2; x<=NF; x++) {person=person " " $x}; 
@@ -97,9 +96,17 @@ contributors=$(
   sort -rn 
 )
 
-n_commits=$(git log --pretty=oneline ${git_range} | wc -l)
-n_contributors=$(${contributors} | wc -l)
+n_commits=0
+for (( i=0; i<${#directories[@]}; i++ ));
+do
+  cd ${directories[$i]}
+  commits_here=$(git log --pretty=oneline ${git_ranges[$i]} | wc -l)
+  n_commits=$((n_commits+commits_here))
+done
 
+n_contributors=$(echo "$contributors" | wc -l)
+
+pushd "${ARROW_DIR}"
 git_tag_hash=$(git log -n 1 --pretty=%H ${git_tag})
 
 popd

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -74,17 +74,17 @@ git_ranges=(apache-arrow-${previous_version}..${git_tag} ${previous_version}..${
 
 format_results='
       {person="";
-      for (x=2; x<=NF; x++) {person=person " " $x}; 
-      counts[person]+=$1 } END {for (person in counts) print counts[person], person}' 
+      for (x=2; x<=NF; x++) {person=person " " $x};
+      counts[person]+=$1 } END {for (person in counts) print counts[person], person}'
 
 committers=$(
   for (( i=0; i<${#directories[@]}; i++ ));
   do
     cd ${directories[$i]}
     git shortlog -csn ${git_ranges[$i]}
-  done | 
+  done |
   awk "$format_results" |
-  sort -rn 
+  sort -rn
 )
 
 contributors=$(
@@ -92,9 +92,9 @@ contributors=$(
   do
     cd ${directories[$i]}
     git shortlog -sn ${git_ranges[$i]}
-  done | 
+  done |
   awk "$format_results" |
-  sort -rn 
+  sort -rn
 )
 
 n_commits=0
@@ -105,11 +105,10 @@ do
   n_commits=$((n_commits+commits_here))
 done
 
-n_contributors=$(echo "$contributors" | wc -l)
+n_contributors=$(echo "$contributors" | awk 'END{print NR}')
 
 pushd "${ARROW_DIR}"
 git_tag_hash=$(git log -n 1 --pretty=%H ${git_tag})
-
 popd
 
 pushd "${ARROW_SITE_DIR}"
@@ -163,20 +162,20 @@ ANNOUNCE
 
 echo "${contributors}" >> "${announce_file}"
 
-cat <<ANNOUNCE >> "${announce_file}"
-\`\`\`
+cat <<'ANNOUNCE' >> "${announce_file}"
+```
 
 ## Patch Committers
 
 The following Apache committers merged contributed patches to Arrow repositories.
 
-\`\`\`console
+```console
 ANNOUNCE
 
 echo "${committers}" >> "${announce_file}"
 
-cat <<ANNOUNCE >> "${announce_file}"
-\`\`\`
+cat <<'ANNOUNCE' >> "${announce_file}"
+```
 
 ## Changelog
 
@@ -188,7 +187,7 @@ ANNOUNCE
 archery release changelog generate ${version} | \
   sed -e 's/^#/##/g' >> "${announce_file}"
 
-cat <<ANNOUNCE >> "${announce_file}"
+cat <<'ANNOUNCE' >> "${announce_file}"
 [1]: https://www.apache.org/dyn/closer.lua/arrow/arrow-${version}/
 [2]: https://apache.jfrog.io/artifactory/arrow/centos/
 [3]: https://apache.jfrog.io/artifactory/arrow/debian/

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -160,7 +160,7 @@ cat <<ANNOUNCE >> "${announce_file}"
 
 ## Patch Committers
 
-The following Apache committers merged contributed patches to the repository.
+The following Apache committers merged contributed patches to Arrow repositories.
 
 \`\`\`console
 ANNOUNCE


### PR DESCRIPTION
Note: this PR does not include DataFusion commits because it is not yet clear what release schedule and tagging conventions will be used for the DataFusion repo.