### PR TITLE
ARROW-13440: [C++] UBSAN error "applying non-zero offset to null pointer"

### DIFF
--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -196,6 +196,7 @@ class BaseSetBitRunReader {
   /// \param[in] start_offset bit offset into the source data
   /// \param[in] length number of bits to copy
   ARROW_NOINLINE
+  ARROW_DISABLE_UBSAN("pointer-overflow")
   BaseSetBitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
       : bitmap_(bitmap),
         length_(length),

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -196,13 +196,15 @@ class BaseSetBitRunReader {
   /// \param[in] start_offset bit offset into the source data
   /// \param[in] length number of bits to copy
   ARROW_NOINLINE
-  ARROW_DISABLE_UBSAN("pointer-overflow")
   BaseSetBitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
       : bitmap_(bitmap),
         length_(length),
         remaining_(length_),
         current_word_(0),
         current_num_bits_(0) {
+    if (bitmap_ == NULLPTR) {
+      return;
+    }
     if (Reverse) {
       bitmap_ += (start_offset + length) / 8;
       const int8_t end_bit_offset = static_cast<int8_t>((start_offset + length) % 8);

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -75,6 +75,7 @@ class BitmapReader {
 
 class BitmapUInt64Reader {
  public:
+  ARROW_DISABLE_UBSAN("pointer-overflow")
   BitmapUInt64Reader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
       : bitmap_(bitmap + start_offset / 8),
         num_carry_bits_(8 - start_offset % 8),

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -75,9 +75,8 @@ class BitmapReader {
 
 class BitmapUInt64Reader {
  public:
-  ARROW_DISABLE_UBSAN("pointer-overflow")
   BitmapUInt64Reader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
-      : bitmap_(bitmap + start_offset / 8),
+      : bitmap_((bitmap == NULLPTR) ? bitmap : bitmap + start_offset / 8),
         num_carry_bits_(8 - start_offset % 8),
         length_(length),
         remaining_length_(length_) {


### PR DESCRIPTION
~~I'm not sure disabling the warning is the way to go.  However, it appears we are explicitly testing this scenario so I'm not sure if that means we think it is a valid scenario or if the test was just to double check we don't break things in the event of an error.~~

The tests in question are `TestSetBitRunReader, Empty` and `TestBitmapUInt64Reader, Empty`.  In both cases a bitmap reader is explicitly created with a nullptr and various offsets.  ~~Ideally we could apply the suppression at the test method level but I couldn't figure out a way to make the suppression work on a parent method.~~

Rather than suppress the exceptions it was easy enough to change the types to just no do the arithmetic if the pointer was null.
