### PR TITLE
ARROW-12673: [C++] Add callback to handle incorrect column counts

### DIFF
--- a/cpp/src/arrow/csv/invalid_row.h
+++ b/cpp/src/arrow/csv/invalid_row.h
@@ -30,7 +30,10 @@ struct InvalidRow {
   int32_t expected_columns;
   /// \brief Actual number of columns found in the row
   int32_t actual_columns;
-  /// \brief The row number if known or -1
+  /// \brief The physical row number if known or -1
+  ///
+  /// This number is one-based and also accounts for non-data rows (such as
+  /// CSV header rows).
   int64_t number;
   /// \brief View of the entire row. Memory will be freed after callback returns
   const util::string_view text;

--- a/cpp/src/arrow/csv/invalid_row.h
+++ b/cpp/src/arrow/csv/invalid_row.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <functional>
+
+#include "arrow/util/string_view.h"
+
+namespace arrow {
+namespace csv {
+
+/// \brief Description of an invalid row
+struct InvalidRow {
+  /// \brief Number of columns expected in the row
+  int32_t expected_columns;
+  /// \brief Actual number of columns found in the row
+  int32_t actual_columns;
+  /// \brief The row number if known or -1
+  int64_t number;
+  /// \brief View of the entire row. Memory will be freed after callback returns
+  const util::string_view text;
+};
+
+/// \brief Result returned by an InvalidRowHandler
+enum class InvalidRowResult {
+  // Generate an error describing this row
+  Error,
+  // Skip over this row
+  Skip
+};
+
+/// \brief callback for handling a row with an invalid number of columns while parsing
+/// \return result indicating if an error should be returned from the parser or the row is
+/// skipped
+using InvalidRowHandler = std::function<InvalidRowResult(const InvalidRow&)>;
+
+}  // namespace csv
+}  // namespace arrow

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -18,11 +18,13 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "arrow/csv/invalid_row.h"
 #include "arrow/csv/type_fwd.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
@@ -58,6 +60,8 @@ struct ARROW_EXPORT ParseOptions {
   /// Whether empty lines are ignored.  If false, an empty line represents
   /// a single empty value (assuming a one-column CSV file).
   bool ignore_empty_lines = true;
+  /// A handler function for rows which do not have the correct number of columns
+  InvalidRowHandler invalid_row_handler;
 
   /// Create parsing options with default values
   static ParseOptions Defaults();

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -215,15 +215,7 @@ class BlockParserImpl {
       if (options_.invalid_row_handler(row) == InvalidRowResult::Skip) {
         values_writer->RollbackLine();
         parsed_writer->RollbackLine();
-        auto last_skip = batch_.skipped_rows_.rbegin();
-        if (last_skip == batch_.skipped_rows_.rend() ||
-            last_skip->second + 1 != batch_row) {
-          batch_.skipped_rows_.emplace_back(batch_row, batch_row);
-        } else {
-          last_skip->second = batch_row;
-        }
-
-        ++batch_.num_skipped_rows_;
+        batch_.skipped_rows_.push_back(batch_row);
         *out_data = data;
         return Status::OK();
       }

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -40,19 +40,19 @@ Status ParseError(Args&&... args) {
   return Status::Invalid("CSV parse error: ", std::forward<Args>(args)...);
 }
 
-Status MismatchingColumns(int32_t expected, int32_t actual, int64_t row_num,
-                          util::string_view row) {
+Status MismatchingColumns(const InvalidRow& row) {
   std::string ellipse;
-  if (row.length() > 100) {
-    row = row.substr(0, 96);
+  auto row_string = row.text;
+  if (row_string.length() > 100) {
+    row_string = row_string.substr(0, 96);
     ellipse = " ...";
   }
-  if (row_num < 0) {
-    return ParseError("Expected ", expected, " columns, got ", actual, ": ", row,
-                      ellipse);
+  if (row.number < 0) {
+    return ParseError("Expected ", row.expected_columns, " columns, got ",
+                      row.actual_columns, ": ", row_string, ellipse);
   }
-  return ParseError("Row #", row_num, ": Expected ", expected, " columns, got ", actual,
-                    ": ", row, ellipse);
+  return ParseError("Row #", row.number, ": Expected ", row.expected_columns,
+                    " columns, got ", row.actual_columns, ": ", row_string, ellipse);
 }
 
 inline bool IsControlChar(uint8_t c) { return c < ' '; }
@@ -194,6 +194,44 @@ class BlockParserImpl {
 
   int64_t first_row_num() const { return first_row_; }
 
+  template <typename ValueDescWriter, typename DataWriter>
+  Status HandleInvalidRow(ValueDescWriter* values_writer, DataWriter* parsed_writer,
+                          const char* start, const char* data, int32_t num_cols,
+                          const char** out_data) {
+    // Find the end of the line without newline or carriage return
+    auto end = data;
+    if (*(end - 1) == '\n') {
+      --end;
+    }
+    if (*(end - 1) == '\r') {
+      --end;
+    }
+    int32_t batch_row = batch_.num_rows_ + batch_.num_skipped_rows();
+    InvalidRow row{batch_.num_cols_, num_cols,
+                   first_row_ < 0 ? -1 : first_row_ + batch_row,
+                   util::string_view(start, end - start)};
+
+    if (options_.invalid_row_handler) {
+      if (options_.invalid_row_handler(row) == InvalidRowResult::Skip) {
+        values_writer->RollbackLine();
+        parsed_writer->RollbackLine();
+        auto last_skip = batch_.skipped_rows_.rbegin();
+        if (last_skip == batch_.skipped_rows_.rend() ||
+            last_skip->second + 1 != batch_row) {
+          batch_.skipped_rows_.emplace_back(batch_row, batch_row);
+        } else {
+          last_skip->second = batch_row;
+        }
+
+        ++batch_.num_skipped_rows_;
+        *out_data = data;
+        return Status::OK();
+      }
+    }
+
+    return MismatchingColumns(row);
+  }
+
   template <typename SpecializedOptions, typename ValueDescWriter, typename DataWriter>
   Status ParseLine(ValueDescWriter* values_writer, DataWriter* parsed_writer,
                    const char* data, const char* data_end, bool is_final,
@@ -316,17 +354,8 @@ class BlockParserImpl {
       if (batch_.num_cols_ == -1) {
         batch_.num_cols_ = num_cols;
       } else {
-        // Find the end of the line without newline or carriage return
-        auto end = data;
-        if (*(end - 1) == '\n') {
-          --end;
-        }
-        if (*(end - 1) == '\r') {
-          --end;
-        }
-        return MismatchingColumns(batch_.num_cols_, num_cols,
-                                  first_row_ < 0 ? -1 : first_row_ + batch_.num_rows_,
-                                  util::string_view(start, end - start));
+        return HandleInvalidRow(values_writer, parsed_writer, start, data, num_cols,
+                                out_data);
       }
     }
     ++batch_.num_rows_;

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -56,13 +57,13 @@ class ARROW_EXPORT DataBatch {
  public:
   explicit DataBatch(int32_t num_cols) : num_cols_(num_cols) {}
 
-  /// \brief Return the number of parsed rows
+  /// \brief Return the number of parsed rows (not skipped)
   int32_t num_rows() const { return num_rows_; }
   /// \brief Return the number of parsed columns
   int32_t num_cols() const { return num_cols_; }
   /// \brief Return the total size in bytes of parsed data
   uint32_t num_bytes() const { return parsed_size_; }
-  /// \brief Return the total number of rows skipped
+  /// \brief Return the number of skipped rows
   int32_t num_skipped_rows() const { return static_cast<int32_t>(skipped_rows_.size()); }
 
   template <typename Visitor>
@@ -81,7 +82,7 @@ class ARROW_EXPORT DataBatch {
         auto quoted = values[pos + 1].quoted;
         Status status = visit(parsed_ + start, stop - start, quoted);
         if (ARROW_PREDICT_FALSE(!status.ok())) {
-          return DecorateWithRowNumber(status, first_row, batch_row);
+          return DecorateWithRowNumber(std::move(status), first_row, batch_row);
         }
       }
     }
@@ -107,20 +108,22 @@ class ARROW_EXPORT DataBatch {
   }
 
  protected:
-  Status DecorateWithRowNumber(Status& status, int64_t first_row,
+  Status DecorateWithRowNumber(Status&& status, int64_t first_row,
                                int32_t batch_row) const {
     if (first_row >= 0) {
-      for (auto iter = skipped_rows_.begin();
-           iter != skipped_rows_.end() && batch_row >= *iter; ++iter) {
-        ++batch_row;
-      }
-      status = status.WithMessage("Row #", batch_row + first_row, ": ", status.message());
+      // `skipped_rows_` is in ascending order by construction, so use bisection
+      // to find out how many rows were skipped before `batch_row`.
+      const auto skips_before =
+          std::upper_bound(skipped_rows_.begin(), skipped_rows_.end(), batch_row) -
+          skipped_rows_.begin();
+      status = status.WithMessage("Row #", batch_row + skips_before + first_row, ": ",
+                                  status.message());
     }
     // Use return_if so that when extra context is enabled it will be added
-    ARROW_RETURN_IF_(true, status, ARROW_STRINGIFY(status));
+    ARROW_RETURN_IF_(true, std::move(status), ARROW_STRINGIFY(status));
   }
 
-  // The number of rows in this batch
+  // The number of rows in this batch (not including any skipped ones)
   int32_t num_rows_ = 0;
   // The number of columns
   int32_t num_cols_ = 0;
@@ -129,9 +132,11 @@ class ARROW_EXPORT DataBatch {
   // It may help with null parsing...
   std::vector<std::shared_ptr<Buffer>> values_buffers_;
   std::shared_ptr<Buffer> parsed_buffer_;
-  std::vector<int32_t> skipped_rows_;
   const uint8_t* parsed_ = NULLPTR;
   int32_t parsed_size_ = 0;
+
+  // Record the current num_rows_ each time a row is skipped
+  std::vector<int32_t> skipped_rows_;
 
   friend class ::arrow::csv::BlockParserImpl;
 };
@@ -188,8 +193,15 @@ class ARROW_EXPORT BlockParser {
   int32_t num_cols() const { return parsed_batch().num_cols(); }
   /// \brief Return the total size in bytes of parsed data
   uint32_t num_bytes() const { return parsed_batch().num_bytes(); }
+
+  /// \brief Return the total number of rows including rows which were skipped
+  int32_t total_num_rows() const {
+    return parsed_batch().num_rows() + parsed_batch().num_skipped_rows();
+  }
+
   /// \brief Return the row number of the first row in the block or -1 if unsupported
   int64_t first_row_num() const;
+
   /// \brief Visit parsed values in a column
   ///
   /// The signature of the visitor is
@@ -198,11 +210,6 @@ class ARROW_EXPORT BlockParser {
   Status VisitColumn(int32_t col_index, Visitor&& visit) const {
     return parsed_batch().VisitColumn(col_index, first_row_num(),
                                       std::forward<Visitor>(visit));
-  }
-
-  /// \brief Return the total number of rows including rows which were skipped
-  int32_t total_num_rows() const {
-    return parsed_batch().num_rows() + parsed_batch().num_skipped_rows();
   }
 
   template <typename Visitor>

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -63,9 +63,7 @@ class ARROW_EXPORT DataBatch {
   /// \brief Return the total size in bytes of parsed data
   uint32_t num_bytes() const { return parsed_size_; }
   /// \brief Return the total number of rows skipped
-  int32_t num_skipped_rows() const {
-    return num_skipped_rows_;
-  }
+  int32_t num_skipped_rows() const { return static_cast<int32_t>(skipped_rows_.size()); }
 
   template <typename Visitor>
   Status VisitColumn(int32_t col_index, int64_t first_row, Visitor&& visit) const {
@@ -113,8 +111,8 @@ class ARROW_EXPORT DataBatch {
                                int32_t batch_row) const {
     if (first_row >= 0) {
       for (auto iter = skipped_rows_.begin();
-           iter != skipped_rows_.end() && batch_row >= iter->first; ++iter) {
-        batch_row += iter->second - iter->first + 1;
+           iter != skipped_rows_.end() && batch_row >= *iter; ++iter) {
+        ++batch_row;
       }
       status = status.WithMessage("Row #", batch_row + first_row, ": ", status.message());
     }
@@ -131,8 +129,7 @@ class ARROW_EXPORT DataBatch {
   // It may help with null parsing...
   std::vector<std::shared_ptr<Buffer>> values_buffers_;
   std::shared_ptr<Buffer> parsed_buffer_;
-  std::vector<std::pair<int32_t, int32_t>> skipped_rows_;
-  int32_t num_skipped_rows_ = 0;
+  std::vector<int32_t> skipped_rows_;
   const uint8_t* parsed_ = NULLPTR;
   int32_t parsed_size_ = 0;
 

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -426,7 +426,7 @@ class BlockParsingOperator {
       RETURN_NOT_OK(parser->Parse(views, &parsed_size));
     }
     if (count_rows_) {
-      num_rows_seen_ += parser->num_rows();
+      num_rows_seen_ += parser->total_num_rows();
     }
     RETURN_NOT_OK(block.consume_bytes(parsed_size));
     return ParsedBlock{std::move(parser), block.block_index,
@@ -737,7 +737,7 @@ class ReaderMixin {
       RETURN_NOT_OK(parser->Parse(views, &parsed_size));
     }
     if (count_rows_) {
-      num_rows_seen_ += parser->num_rows();
+      num_rows_seen_ += parser->total_num_rows();
     }
     return ParseResult{std::move(parser), static_cast<int64_t>(parsed_size)};
   }
@@ -1218,8 +1218,9 @@ class CSVRowCounter : public ReaderMixin,
           self->Parse(maybe_block.partial, maybe_block.completion, maybe_block.buffer,
                       maybe_block.block_index, maybe_block.is_final));
       RETURN_NOT_OK(maybe_block.consume_bytes(parser.parsed_bytes));
-      self->row_count_ += parser.parser->num_rows();
-      return parser.parser->num_rows();
+      int32_t total_row_count = parser.parser->total_num_rows();
+      self->row_count_ += total_row_count;
+      return total_row_count;
     };
     auto count_gen = MakeMappedGenerator(block_generator_, std::move(count_cb));
     return DiscardAllFromAsyncGenerator(count_gen).Then(

--- a/cpp/src/arrow/csv/test_common.cc
+++ b/cpp/src/arrow/csv/test_common.cc
@@ -17,8 +17,6 @@
 
 #include "arrow/csv/test_common.h"
 
-#include <cmath>
-
 #include "arrow/testing/gtest_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/csv/test_common.cc
+++ b/cpp/src/arrow/csv/test_common.cc
@@ -16,6 +16,9 @@
 // under the License.
 
 #include "arrow/csv/test_common.h"
+
+#include <cmath>
+
 #include "arrow/testing/gtest_util.h"
 
 namespace arrow {
@@ -98,15 +101,16 @@ static void WriteInvalidRow(std::ostream& writer, size_t row_index) {
 }
 }  // namespace
 
-Result<std::shared_ptr<Buffer>> MakeSampleCsvBuffer(size_t num_rows, bool valid) {
+Result<std::shared_ptr<Buffer>> MakeSampleCsvBuffer(
+    size_t num_rows, std::function<bool(size_t)> is_valid) {
   std::stringstream writer;
 
   WriteHeader(writer);
   for (size_t i = 0; i < num_rows; ++i) {
-    if (i == num_rows / 2 && !valid) {
-      WriteInvalidRow(writer, i);
-    } else {
+    if (!is_valid || is_valid(i)) {
       WriteRow(writer, i);
+    } else {
+      WriteInvalidRow(writer, i);
     }
   }
 

--- a/cpp/src/arrow/csv/test_common.h
+++ b/cpp/src/arrow/csv/test_common.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -47,7 +48,8 @@ ARROW_TESTING_EXPORT
 void MakeColumnParser(std::vector<std::string> items, std::shared_ptr<BlockParser>* out);
 
 ARROW_TESTING_EXPORT
-Result<std::shared_ptr<Buffer>> MakeSampleCsvBuffer(size_t num_rows, bool valid = true);
+Result<std::shared_ptr<Buffer>> MakeSampleCsvBuffer(
+    size_t num_rows, std::function<bool(size_t row_num)> is_valid = {});
 
 }  // namespace csv
 }  // namespace arrow


### PR DESCRIPTION
Add a new callback handler to the csv parser which is invoked when the column count in a row does not match the expected. The callback can return an enum which indicates if the row should result in an error result or it should be skipped.

Replaces https://github.com/apache/arrow/pull/10202