### PR TITLE
ARROW-13441: [C++][CSV] Skip empty batches in column decoder

### DIFF
--- a/cpp/src/arrow/csv/column_decoder.cc
+++ b/cpp/src/arrow/csv/column_decoder.cc
@@ -198,6 +198,13 @@ Result<std::shared_ptr<Array>> InferringColumnDecoder::RunInference(
 
 Future<std::shared_ptr<Array>> InferringColumnDecoder::Decode(
     const std::shared_ptr<BlockParser>& parser) {
+  // Empty arrays before the first inference run must be discarded since the type of the
+  // array will be NA and not match arrays decoded later
+  if (parser->num_rows() == 0) {
+    return Future<std::shared_ptr<Array>>::MakeFinished(
+        MakeArrayOfNull(converter_->type(), 0));
+  }
+
   bool already_taken = first_inferrer_.fetch_or(1);
   // First block: run inference
   if (!already_taken) {

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -383,14 +383,11 @@ TEST(StreamingReaderTests, SkipMultipleEmptyBlocksAtStart) {
   ASSERT_EQ(1, batch->num_rows());
   ASSERT_EQ(96, streaming_reader->bytes_read());
 
-  auto schema = streaming_reader->schema();
-  ASSERT_EQ(3, schema->num_fields());
-  ASSERT_EQ("aaa", schema->field(0)->name());
-  ASSERT_EQ(Type::INT64, schema->field(0)->type()->id());
-  ASSERT_EQ("bbb", schema->field(1)->name());
-  ASSERT_EQ(Type::INT64, schema->field(1)->type()->id());
-  ASSERT_EQ("ccc", schema->field(2)->name());
-  ASSERT_EQ(Type::INT64, schema->field(2)->type()->id());
+  auto expected_schema =
+      schema({field("aaa", int64()), field("bbb", int64()), field("ccc", int64())});
+  AssertSchemaEqual(expected_schema, streaming_reader->schema());
+  auto expected_batch = RecordBatchFromJSON(expected_schema, "[[233,343,536]]");
+  ASSERT_TRUE(expected_batch->Equals(*batch));
 
   ASSERT_OK(streaming_reader->ReadNext(&batch));
   ASSERT_EQ(nullptr, batch.get());

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -278,7 +278,7 @@ TEST(StreamingReaderTests, NestedParallelism) {
   TestNestedParallelism(thread_pool, table_factory);
 }
 
-TEST(StreamingReaderTest, BytesRead) {
+TEST(StreamingReaderTests, BytesRead) {
   ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
   auto table_buffer =
       std::make_shared<Buffer>("a,b,c\n123,456,789\n101,112,131\n415,161,718\n");
@@ -356,6 +356,44 @@ TEST(StreamingReaderTest, BytesRead) {
     ASSERT_OK(streaming_reader->ReadNext(&batch));
     ASSERT_EQ(batch.get(), nullptr);
   }
+}
+
+TEST(StreamingReaderTests, SkipMultipleEmptyBlocksAtStart) {
+  ASSERT_OK_AND_ASSIGN(auto thread_pool, internal::ThreadPool::Make(1));
+  auto table_buffer = std::make_shared<Buffer>(
+      "aaa,bbb,ccc\n123,456,789\n101,112,131\n415,161,718\n192,021,222\n324,252,627\n"
+      "282,930,313\n233,343,536\n");
+
+  auto input = std::make_shared<io::BufferReader>(table_buffer);
+
+  auto read_options = ReadOptions::Defaults();
+  read_options.block_size = 34;
+  read_options.skip_rows_after_names = 6;
+
+  ASSERT_OK_AND_ASSIGN(
+      auto streaming_reader,
+      StreamingReader::Make(io::default_io_context(), input, read_options,
+                            ParseOptions::Defaults(), ConvertOptions::Defaults()));
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_EQ(12, streaming_reader->bytes_read());
+
+  // The first batch should have the one and only row in it
+  ASSERT_OK(streaming_reader->ReadNext(&batch));
+  ASSERT_NE(nullptr, batch.get());
+  ASSERT_EQ(1, batch->num_rows());
+  ASSERT_EQ(96, streaming_reader->bytes_read());
+
+  auto schema = streaming_reader->schema();
+  ASSERT_EQ(3, schema->num_fields());
+  ASSERT_EQ("aaa", schema->field(0)->name());
+  ASSERT_EQ(Type::INT64, schema->field(0)->type()->id());
+  ASSERT_EQ("bbb", schema->field(1)->name());
+  ASSERT_EQ(Type::INT64, schema->field(1)->type()->id());
+  ASSERT_EQ("ccc", schema->field(2)->name());
+  ASSERT_EQ(Type::INT64, schema->field(2)->type()->id());
+
+  ASSERT_OK(streaming_reader->ReadNext(&batch));
+  ASSERT_EQ(nullptr, batch.get());
 }
 
 TEST(CountRowsAsync, Basics) {

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -324,13 +324,8 @@ def test_write_options():
 class BaseTestCSV:
     """Common tests which are shared by streaming and non streaming readers"""
 
-    def base_row_number_offset_in_errors(self, use_threads, read_bytes,
-                                         num_blocks=3):
-        """
-        num_blocks is a temporary work around because streaming reader does
-        not get schema from first non empty block
-        """
-
+    @staticmethod
+    def base_row_number_offset_in_errors(use_threads, read_bytes):
         # Row numbers are only correctly counted in serial reads
         def format_msg(msg_format, row, *args):
             if use_threads:
@@ -342,7 +337,7 @@ class BaseTestCSV:
         csv, _ = make_random_csv(4, 100, write_names=True)
 
         read_options = ReadOptions()
-        read_options.block_size = len(csv) / num_blocks
+        read_options.block_size = len(csv) / 3
         convert_options = ConvertOptions()
         convert_options.column_types = {"a": pa.int32()}
 
@@ -1618,8 +1613,7 @@ class TestStreamingCSVRead(BaseTestCSV):
         def read_bytes(b, **kwargs):
             return self.open_bytes(b, use_threads, **kwargs).read_all()
 
-        self.base_row_number_offset_in_errors(use_threads, read_bytes,
-                                              num_blocks=1)
+        self.base_row_number_offset_in_errors(use_threads, read_bytes)
 
 
 class BaseTestCompressedCSVRead:

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -332,11 +332,13 @@ class BaseTestCSV(abc.ABC):
         :param kwargs: arguments passed on to open the csv file
         :return: b parsed as a single RecordBatch
         """
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def use_threads(self):
-        """Return true if this test is multi-threaded"""
+        """Whether this test is multi-threaded"""
+        raise NotImplementedError
 
     @staticmethod
     def check_names(table, names):
@@ -608,6 +610,7 @@ class BaseCSVTableRead(BaseTestCSV):
         validate_full Whether or not to fully validate the resulting table
         kwargs Keyword arguments to be forwarded to pyarrow's read_csv
         """
+        assert isinstance(self.use_threads, bool)  # sanity check
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = self.use_threads
         table = read_csv(csv, *args, **kwargs)
@@ -1355,11 +1358,13 @@ class BaseCSVTableRead(BaseTestCSV):
 
 
 class TestSerialCSVTableRead(BaseCSVTableRead):
+    @property
     def use_threads(self):
         return False
 
 
 class TestThreadedCSVTableRead(BaseCSVTableRead):
+    @property
     def use_threads(self):
         return True
 
@@ -1687,11 +1692,13 @@ class BaseStreamingCSVRead(BaseTestCSV):
 
 
 class TestSerialStreamingCSVRead(BaseStreamingCSVRead, unittest.TestCase):
+    @property
     def use_threads(self):
         return False
 
 
 class TestThreadedStreamingCSVRead(BaseStreamingCSVRead, unittest.TestCase):
+    @property
     def use_threads(self):
         return True
 


### PR DESCRIPTION
When the infering column decoder encounters an empty batch just return an empty array immediatly and do not consider the batch as the first batch.