### PR TITLE
ARROW-13155: [C++] MapGenerator should optionally forward reentrant pressure

### DIFF
--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -1249,6 +1249,18 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
 
 Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
     io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    const ReadOptions& read_options, const ParseOptions& parse_options,
+    const ConvertOptions& convert_options) {
+  auto reader_fut =
+      MakeStreamingReader(io_context, std::move(input), internal::GetCpuThreadPool(),
+                          read_options, parse_options, convert_options);
+  auto reader_result = reader_fut.result();
+  ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
+  return reader;
+}
+
+Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
+    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
     internal::Executor* cpu_executor, const ReadOptions& read_options,
     const ParseOptions& parse_options, const ConvertOptions& convert_options) {
   auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -102,7 +102,8 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
 
   static Result<std::shared_ptr<StreamingReader>> Make(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,
-      const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+      internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&,
+      const ConvertOptions&);
 
   ARROW_DEPRECATED("Use IOContext-based overload")
   static Result<std::shared_ptr<StreamingReader>> Make(

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -102,6 +102,10 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
 
   static Result<std::shared_ptr<StreamingReader>> Make(
       io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+      const ReadOptions&, const ParseOptions&, const ConvertOptions&);
+
+  static Result<std::shared_ptr<StreamingReader>> Make(
+      io::IOContext io_context, std::shared_ptr<io::InputStream> input,
       internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&,
       const ConvertOptions&);
 

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -296,7 +296,7 @@ class MappingGenerator {
       Future<V> sink;
       bool end = !maybe_next.ok() || IsIterationEnd(*maybe_next);
       bool should_purge = false;
-      bool should_trigger;
+      bool should_trigger = false;
       {
         auto guard = state->mutex.Lock();
         bool already_finished = state->finished;
@@ -802,7 +802,11 @@ class ReadaheadGenerator {
       finished_fut = Future<>::Make();
     }
 
-    ~State() { finished_fut.Wait(); }
+    ~State() {
+      if (in_flight > 0) {
+        finished_fut.Wait();
+      }
+    }
 
     Future<T> AddMarkFinishedContinuation(Future<T> fut) {
       auto self = this->shared_from_this();

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -482,8 +482,8 @@ TEST_P(MapFixture, BasicMapFailStress) {
 }
 
 TEST_P(MapFixture, QueuingMapFailStress) {
-  constexpr int NTASKS = 100;
-  constexpr int NITEMS = 100;
+  constexpr int NTASKS = 10;
+  constexpr int NITEMS = 10;
   for (int i = 0; i < NTASKS; i++) {
     std::shared_ptr<std::atomic<bool>> done = std::make_shared<std::atomic<bool>>();
     auto gen = FailsAt(MakeJitteryIfSlowSource(RangeVector(NITEMS)), NITEMS / 2);
@@ -1103,6 +1103,14 @@ TEST(TestAsyncUtil, SerialReadaheadStressFailing) {
   }
 }
 
+TEST(TestAsyncUtil, ReadaheadEmpty) {
+  // The readahead generator waits for all in-flight tasks to finish when it
+  // terminates so this test just makes sure we don't hang waiting for nothing
+  // when nothing was started
+  auto source = AsyncVectorIt<TestInt>({});
+  auto readahead = MakeReadaheadGenerator(std::move(source), 8);
+}
+
 TEST(TestAsyncUtil, Readahead) {
   int num_delivered = 0;
   auto source = [&num_delivered]() {
@@ -1245,8 +1253,8 @@ TEST(TestAsyncUtil, ReadaheadFailed) {
 }
 
 TEST(TestAsyncUtil, ReadaheadFailedStress) {
-  constexpr int NTASKS = 100;
-  constexpr int NITEMS = 100;
+  constexpr int NTASKS = 10;
+  constexpr int NITEMS = 10;
   for (int i = 0; i < NTASKS; i++) {
     auto source = FailsAt(MakeJittery(AsyncVectorIt(RangeVector(NITEMS))), NITEMS / 2);
     auto readahead = MakeReadaheadGenerator(std::move(source), 8);


### PR DESCRIPTION
Added a basic mapping generator that does not queue incoming jobs.  This allows it to forward async-reentrant pressure to the source.  Fixed some issues in the CSV reader that were preventing it from running truly parallel.  Performance is now significantly better but still not quite the same as the threaded reader.  For the NY taxi dataset the streaming read time went from ~7 seconds to ~1.6 seconds.  However, the file reader is still at ~0.8 seconds.  I'll do more investigation later.

Leaving in draft as I want to extract a thread spawning generator I created into an independently tested thing.