### PR TITLE
ARROW-1568: [C++] Implement Drop Null  Kernel for Arrays 

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -234,6 +234,20 @@ Result<std::shared_ptr<Array>> Take(const Array& values, const Array& indices,
 }
 
 // ----------------------------------------------------------------------
+// Dropnull functions
+
+Result<Datum> DropNull(const Datum& values, ExecContext* ctx) {
+  // Invoke metafunction which deals with Datum kinds other than just Array,
+  // ChunkedArray.
+  return CallFunction("dropnull", {values}, ctx);
+}
+
+Result<std::shared_ptr<Array>> DropNull(const Array& values, ExecContext* ctx) {
+  ARROW_ASSIGN_OR_RAISE(Datum out, DropNull(Datum(values), ctx));
+  return out.make_array();
+}
+
+// ----------------------------------------------------------------------
 // Deprecated functions
 
 Result<std::shared_ptr<Array>> SortToIndices(const Array& values, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -239,7 +239,7 @@ Result<std::shared_ptr<Array>> Take(const Array& values, const Array& indices,
 Result<Datum> DropNull(const Datum& values, ExecContext* ctx) {
   // Invoke metafunction which deals with Datum kinds other than just Array,
   // ChunkedArray.
-  return CallFunction("dropnull", {values}, ctx);
+  return CallFunction("drop_null", {values}, ctx);
 }
 
 Result<std::shared_ptr<Array>> DropNull(const Array& values, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -230,7 +230,6 @@ Result<std::shared_ptr<Array>> Take(const Array& values, const Array& indices,
 ARROW_EXPORT
 Result<Datum> DropNull(const Datum& values, ExecContext* ctx = NULLPTR);
 
-
 /// \brief DropNull with Array inputs and output
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> DropNull(const Array& values, ExecContext* ctx = NULLPTR);

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -216,7 +216,7 @@ Result<std::shared_ptr<Array>> Take(const Array& values, const Array& indices,
                                     const TakeOptions& options = TakeOptions::Defaults(),
                                     ExecContext* ctx = NULLPTR);
 
-/// \brief DropNull from an array of values
+/// \brief Drop Null from an array of values
 ///
 /// The output array will be of the same type as the input values
 /// array, with elements taken from the values array without nulls.

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -216,6 +216,25 @@ Result<std::shared_ptr<Array>> Take(const Array& values, const Array& indices,
                                     const TakeOptions& options = TakeOptions::Defaults(),
                                     ExecContext* ctx = NULLPTR);
 
+/// \brief DropNull from an array of values
+///
+/// The output array will be of the same type as the input values
+/// array, with elements taken from the values array without nulls.
+///
+/// For example given values = ["a", "b", "c", null, "e", "f"],
+/// the output will be = ["a", "b", "c", "e", "f"]
+///
+/// \param[in] values datum from which to take
+/// \param[in] ctx the function execution context, optional
+/// \return the resulting datum
+ARROW_EXPORT
+Result<Datum> DropNull(const Datum& values, ExecContext* ctx = NULLPTR);
+
+
+/// \brief DropNull with Array inputs and output
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> DropNull(const Array& values, ExecContext* ctx = NULLPTR);
+
 /// \brief Returns indices that partition an array around n-th
 /// sorted element.
 ///

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2172,6 +2172,9 @@ Result<std::shared_ptr<Array>> DropNullArray(const std::shared_ptr<Array>& value
   if (values->null_count() == 0) {
     return values;
   }
+  if (values->type()->Equals(arrow::null())) {
+    return std::make_shared<NullArray>(0);
+  }
   std::shared_ptr<BooleanArray> dropnull_filter;
   RETURN_NOT_OK(GetDropNullFilter(*values, ctx->memory_pool(), &dropnull_filter));
 

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2167,6 +2167,14 @@ Status CreateEmptyArray(std::shared_ptr<DataType> type, MemoryPool* memory_pool,
   return Status::OK();
 }
 
+Status CreateEmptyChunkedArray(std::shared_ptr<DataType> type, MemoryPool* memory_pool,
+                               std::shared_ptr<ChunkedArray>* output_array) {
+  std::vector<std::shared_ptr<Array>> new_chunks(1);  // Hard-coded 1 for now
+  ARROW_RETURN_NOT_OK(CreateEmptyArray(type, memory_pool, &new_chunks[0]));
+  *output_array = std::make_shared<ChunkedArray>(std::move(new_chunks));
+  return Status::OK();
+}
+
 Result<std::shared_ptr<Array>> DropNullArray(const std::shared_ptr<Array>& values,
                                              ExecContext* ctx) {
   if (values->null_count() == 0) {
@@ -2193,10 +2201,18 @@ Result<std::shared_ptr<Array>> DropNullArray(const std::shared_ptr<Array>& value
 
 Result<std::shared_ptr<ChunkedArray>> DropNullChunkedArray(const ChunkedArray& values,
                                                            ExecContext* ctx) {
-  auto num_chunks = values.num_chunks();
-  std::vector<std::shared_ptr<Array>> new_chunks(num_chunks);
-  for (int i = 0; i < num_chunks; i++) {
-    ARROW_ASSIGN_OR_RAISE(new_chunks[i], DropNullArray(values.chunk(i), ctx));
+  if (values.null_count() == values.length()) {
+    std::shared_ptr<ChunkedArray> empty_array;
+    RETURN_NOT_OK(
+        CreateEmptyChunkedArray(values.type(), ctx->memory_pool(), &empty_array));
+    return empty_array;
+  }
+  std::vector<std::shared_ptr<Array>> new_chunks;
+  for (const auto& chunk : values.chunks()) {
+    ARROW_ASSIGN_OR_RAISE(auto new_chunk, DropNullArray(chunk, ctx));
+    if (new_chunk->length() > 0) {
+      new_chunks.push_back(new_chunk);
+    }
   }
   return std::make_shared<ChunkedArray>(std::move(new_chunks));
 }
@@ -2204,28 +2220,17 @@ Result<std::shared_ptr<ChunkedArray>> DropNullChunkedArray(const ChunkedArray& v
 Result<std::shared_ptr<RecordBatch>> DropNullRecordBatch(const RecordBatch& batch,
                                                          ExecContext* ctx) {
   int64_t null_count = 0;
-  for (int col_index = 0; col_index < batch.num_columns(); ++col_index) {
-    const auto& column = batch.column(col_index);
+  for (const auto& column : batch.columns()) {
     null_count += column->null_count();
   }
   if (null_count == 0) {
     return RecordBatch::Make(batch.schema(), batch.num_rows(), batch.columns());
   }
-  if (null_count / batch.num_columns() == batch.num_rows()) {
-    std::vector<std::shared_ptr<Array>> empty_batch(batch.num_columns());
-    for (int i = 0; i < batch.num_columns(); i++) {
-      RETURN_NOT_OK(
-          CreateEmptyArray(batch.column(i)->type(), ctx->memory_pool(), &empty_batch[i]));
-    }
-    return RecordBatch::Make(batch.schema(), 0, empty_batch);
-  }
-
   ARROW_ASSIGN_OR_RAISE(auto dst,
                         AllocateEmptyBitmap(batch.num_rows(), ctx->memory_pool()));
   BitUtil::SetBitsTo(dst->mutable_data(), 0, batch.num_rows(), true);
 
-  for (int col_index = 0; col_index < batch.num_columns(); ++col_index) {
-    const auto& column = batch.column(col_index);
+  for (const auto& column : batch.columns()) {
     if (column->null_bitmap_data()) {
       ::arrow::internal::BitmapAnd(column->null_bitmap_data(), column->offset(),
                                    dst->data(), 0, column->length(), 0,
@@ -2234,30 +2239,62 @@ Result<std::shared_ptr<RecordBatch>> DropNullRecordBatch(const RecordBatch& batc
   }
   auto drop_null_filter =
       std::make_shared<BooleanArray>(batch.num_rows(), dst, nullptr, 0, 0);
+  if (drop_null_filter->null_count() == batch.num_rows()) {
+    std::vector<std::shared_ptr<Array>> empty_batch(batch.num_columns());
+    for (int i = 0; i < batch.num_columns(); i++) {
+      RETURN_NOT_OK(
+          CreateEmptyArray(batch.column(i)->type(), ctx->memory_pool(), &empty_batch[i]));
+    }
+    return RecordBatch::Make(batch.schema(), 0, empty_batch);
+  }
   ARROW_ASSIGN_OR_RAISE(Datum result, Filter(Datum(batch), Datum(drop_null_filter),
                                              FilterOptions::Defaults(), ctx));
   return result.record_batch();
 }
 
-using ::arrow::internal::Bitmap;
-
 Result<std::shared_ptr<Table>> DropNullTable(const Table& table, ExecContext* ctx) {
   if (table.num_rows() == 0) {
     return Table::Make(table.schema(), table.columns(), 0);
   }
-  const int num_columns = table.num_columns();
   int64_t null_count = 0;
-  for (int col_index = 0; col_index < num_columns; ++col_index) {
-    const ArrayVector& chunks = table.column(col_index)->chunks();
-    for (size_t chunk_index = 0; chunk_index < chunks.size(); ++chunk_index) {
-      const auto& column_chunk = chunks[chunk_index];
+  for (const auto& col : table.columns()) {
+    for (const auto& column_chunk : col->chunks()) {
       null_count += column_chunk->null_count();
     }
   }
   if (null_count == 0) {
     return Table::Make(table.schema(), table.columns(), table.num_rows());
   }
-  if (null_count / table.num_columns() == table.num_rows()) {
+  ARROW_ASSIGN_OR_RAISE(auto dst,
+                        AllocateEmptyBitmap(table.num_rows(), ctx->memory_pool()));
+  BitUtil::SetBitsTo(dst->mutable_data(), 0, table.num_rows(), true);
+
+  for (const auto& col : table.columns()) {
+    std::vector<::arrow::internal::Bitmap> bitmaps;
+    std::transform(col->chunks().begin(), col->chunks().end(),
+                   std::back_inserter(bitmaps), [](const std::shared_ptr<Array>& array) {
+                     return ::arrow::internal::Bitmap(array->null_bitmap_data(),
+                                                      array->offset(), array->length());
+                   });
+    int64_t global_offset = 0;
+    ARROW_ASSIGN_OR_RAISE(auto concatenated_bitmap,
+                          AllocateEmptyBitmap(table.num_rows(), ctx->memory_pool()));
+    BitUtil::SetBitsTo(concatenated_bitmap->mutable_data(), 0, table.num_rows(), true);
+    for (auto bitmap : bitmaps) {
+      if (bitmap.buffer()->data()) {
+        ::arrow::internal::CopyBitmap(bitmap.buffer()->data(), bitmap.offset(),
+                                      bitmap.length(),
+                                      concatenated_bitmap->mutable_data(), global_offset);
+      }
+      global_offset += bitmap.length();
+    }
+    ::arrow::internal::BitmapAnd(concatenated_bitmap->data(), 0, dst->data(), 0,
+                                 table.num_rows(), 0, dst->mutable_data());
+  }
+  auto drop_null_filter =
+      std::make_shared<BooleanArray>(table.num_rows(), dst, nullptr, 0, 0);
+
+  if (drop_null_filter->null_count() == table.num_rows()) {
     std::vector<std::shared_ptr<ChunkedArray>> empty_table(table.num_columns());
     for (int i = 0; i < table.num_columns(); i++) {
       std::shared_ptr<Array> empty_array;
@@ -2267,37 +2304,6 @@ Result<std::shared_ptr<Table>> DropNullTable(const Table& table, ExecContext* ct
     }
     return Table::Make(table.schema(), empty_table, 0);
   }
-
-  ARROW_ASSIGN_OR_RAISE(auto dst,
-                        AllocateEmptyBitmap(table.num_rows(), ctx->memory_pool()));
-  BitUtil::SetBitsTo(dst->mutable_data(), 0, table.num_rows(), true);
-
-  for (int col_index = 0; col_index < num_columns; ++col_index) {
-    const ArrayVector& chunks = table.column(col_index)->chunks();
-    std::vector<Bitmap> bitmaps(chunks.size());
-    for (size_t chunk_index = 0; chunk_index < chunks.size(); ++chunk_index) {
-      const auto& column_chunk = chunks[chunk_index];
-      bitmaps[chunk_index] = Bitmap(column_chunk->null_bitmap_data(),
-                                    column_chunk->offset(), column_chunk->length());
-    }
-    int64_t bitmap_offset = 0;
-    ARROW_ASSIGN_OR_RAISE(auto concatenated_bitmap,
-                          AllocateEmptyBitmap(table.num_rows(), ctx->memory_pool()));
-    BitUtil::SetBitsTo(concatenated_bitmap->mutable_data(), 0, table.num_rows(), true);
-
-    for (auto bitmap : bitmaps) {
-      if (bitmap.buffer()->data()) {
-        ::arrow::internal::CopyBitmap(bitmap.buffer()->data(), bitmap.offset(),
-                                      bitmap.length(),
-                                      concatenated_bitmap->mutable_data(), bitmap_offset);
-      }
-      bitmap_offset += bitmap.length();
-    }
-    ::arrow::internal::BitmapAnd(concatenated_bitmap->data(), 0, dst->data(), 0,
-                                 table.num_rows(), 0, dst->mutable_data());
-  }
-  auto drop_null_filter =
-      std::make_shared<BooleanArray>(table.num_rows(), dst, nullptr, 0, 0);
   ARROW_ASSIGN_OR_RAISE(Datum result, Filter(Datum(table), Datum(drop_null_filter),
                                              FilterOptions::Defaults(), ctx));
   return result.table();

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2226,18 +2226,14 @@ Result<std::shared_ptr<RecordBatch>> DropNullRecordBatch(const RecordBatch& batc
   if (null_count == 0) {
     return RecordBatch::Make(batch.schema(), batch.num_rows(), batch.columns());
   }
-  if (null_count == batch.num_rows() * batch.num_columns()) {
-    std::vector<std::shared_ptr<Array>> empty_batch(batch.num_columns());
-    for (int i = 0; i < batch.num_columns(); i++) {
-      RETURN_NOT_OK(
-          CreateEmptyArray(batch.column(i)->type(), ctx->memory_pool(), &empty_batch[i]));
-    }
-    return RecordBatch::Make(batch.schema(), 0, empty_batch);
-  }
   ARROW_ASSIGN_OR_RAISE(auto dst,
                         AllocateEmptyBitmap(batch.num_rows(), ctx->memory_pool()));
   BitUtil::SetBitsTo(dst->mutable_data(), 0, batch.num_rows(), true);
   for (const auto& column : batch.columns()) {
+    if (column->type()->Equals(arrow::null())) {
+      BitUtil::SetBitsTo(dst->mutable_data(), 0, batch.num_rows(), false);
+      break;
+    }
     if (column->null_bitmap_data()) {
       ::arrow::internal::BitmapAnd(column->null_bitmap_data(), column->offset(),
                                    dst->data(), 0, column->length(), 0,
@@ -2246,6 +2242,14 @@ Result<std::shared_ptr<RecordBatch>> DropNullRecordBatch(const RecordBatch& batc
   }
   auto drop_null_filter =
       std::make_shared<BooleanArray>(batch.num_rows(), dst, nullptr, 0, 0);
+  if (drop_null_filter->null_count() == batch.num_rows()) {
+    std::vector<std::shared_ptr<Array>> empty_batch(batch.num_columns());
+    for (int i = 0; i < batch.num_columns(); i++) {
+      RETURN_NOT_OK(
+          CreateEmptyArray(batch.column(i)->type(), ctx->memory_pool(), &empty_batch[i]));
+    }
+    return RecordBatch::Make(batch.schema(), 0, empty_batch);
+  }
   ARROW_ASSIGN_OR_RAISE(Datum result, Filter(Datum(batch), Datum(drop_null_filter),
                                              FilterOptions::Defaults(), ctx));
   return result.record_batch();
@@ -2264,22 +2268,16 @@ Result<std::shared_ptr<Table>> DropNullTable(const Table& table, ExecContext* ct
   if (null_count == 0) {
     return Table::Make(table.schema(), table.columns(), table.num_rows());
   }
-  if (null_count == table.num_rows() * table.num_columns()) {
-    std::vector<std::shared_ptr<ChunkedArray>> empty_table(table.num_columns());
-    for (int i = 0; i < table.num_columns(); i++) {
-      std::shared_ptr<Array> empty_array;
-      RETURN_NOT_OK(
-          CreateEmptyArray(table.column(i)->type(), ctx->memory_pool(), &empty_array));
-      empty_table[i] = std::make_shared<ChunkedArray>(ArrayVector{empty_array});
-    }
-    return Table::Make(table.schema(), empty_table, 0);
-  }
 
   ARROW_ASSIGN_OR_RAISE(auto dst,
                         AllocateEmptyBitmap(table.num_rows(), ctx->memory_pool()));
   BitUtil::SetBitsTo(dst->mutable_data(), 0, table.num_rows(), true);
 
   for (const auto& col : table.columns()) {
+    if (col->type()->Equals(arrow::null())) {
+      BitUtil::SetBitsTo(dst->mutable_data(), 0, table.num_rows(), false);
+      break;
+    }
     std::vector<::arrow::internal::Bitmap> bitmaps;
     std::transform(col->chunks().begin(), col->chunks().end(),
                    std::back_inserter(bitmaps), [](const std::shared_ptr<Array>& array) {
@@ -2303,6 +2301,16 @@ Result<std::shared_ptr<Table>> DropNullTable(const Table& table, ExecContext* ct
   }
   auto drop_null_filter =
       std::make_shared<BooleanArray>(table.num_rows(), dst, nullptr, 0, 0);
+  if (drop_null_filter->null_count() == table.num_rows()) {
+    std::vector<std::shared_ptr<ChunkedArray>> empty_table(table.num_columns());
+    for (int i = 0; i < table.num_columns(); i++) {
+      std::shared_ptr<Array> empty_array;
+      RETURN_NOT_OK(
+          CreateEmptyArray(table.column(i)->type(), ctx->memory_pool(), &empty_array));
+      empty_table[i] = std::make_shared<ChunkedArray>(ArrayVector{empty_array});
+    }
+    return Table::Make(table.schema(), empty_table, 0);
+  }
   ARROW_ASSIGN_OR_RAISE(Datum result, Filter(Datum(table), Datum(drop_null_filter),
                                              FilterOptions::Defaults(), ctx));
   return result.table();

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2317,9 +2317,12 @@ Result<std::shared_ptr<Table>> DropNullTable(const Table& table, ExecContext* ct
 }
 
 const FunctionDoc drop_null_doc(
-    "Drop Null kernel",
+    "Drop nulls from the input",
     ("The output is populated with values from the input (Array, ChunkedArray, "
-     "RecordBatch, or Table) without the null values"),
+     "RecordBatch, or Table) without the null values."
+     "Note that for the RecordBatch/Table cases, `drop_null` drops the full row if there "
+     "is any null"
+     "null."),
     {"input"});
 
 class DropNullMetaFunction : public MetaFunction {

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2321,8 +2321,7 @@ const FunctionDoc drop_null_doc(
     ("The output is populated with values from the input (Array, ChunkedArray, "
      "RecordBatch, or Table) without the null values."
      "Note that for the RecordBatch/Table cases, `drop_null` drops the full row if there "
-     "is any null"
-     "null."),
+     "is any null."),
     {"input"});
 
 class DropNullMetaFunction : public MetaFunction {
@@ -2336,7 +2335,8 @@ class DropNullMetaFunction : public MetaFunction {
       case Datum::ARRAY: {
         auto input_array = args[0].make_array();
         return DropNullArray(input_array, ctx);
-      } break;
+      }  // namespace
+      break;
       case Datum::CHUNKED_ARRAY: {
         return DropNullChunkedArray(*args[0].chunked_array(), ctx);
       } break;
@@ -2352,13 +2352,13 @@ class DropNullMetaFunction : public MetaFunction {
       } break;
       default:
         break;
-    }
+    }  // namespace internal
     return Status::NotImplemented(
         "Unsupported types for drop_null operation: "
         "values=",
         args[0].ToString());
-  }
-};
+  }  // namespace compute
+};   // namespace arrow
 
 // ----------------------------------------------------------------------
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2099,7 +2099,7 @@ TEST_F(TestDropNullKernelWithChunkedArray, DropNullChunkedArray) {
 
 TEST_F(TestDropNullKernelWithChunkedArray, DropNullChunkedArrayWithSlices) {
   // With Null Arrays
-  this->CheckDropNullWithSlices([this](int64_t size, double null_probability,
+  this->CheckDropNullWithSlices([this](int32_t size, double null_probability,
                                        std::shared_ptr<ChunkedArray>* out_chunked_array,
                                        std::shared_ptr<Array>* out_concatenated_array) {
     auto array = std::make_shared<NullArray>(size);
@@ -2111,7 +2111,7 @@ TEST_F(TestDropNullKernelWithChunkedArray, DropNullChunkedArrayWithSlices) {
                          Concatenate((*out_chunked_array)->chunks()));
   });
   // Without Null Arrays
-  this->CheckDropNullWithSlices([this](int64_t size, double null_probability,
+  this->CheckDropNullWithSlices([this](int32_t size, double null_probability,
                                        std::shared_ptr<ChunkedArray>* out_chunked_array,
                                        std::shared_ptr<Array>* out_concatenated_array) {
     auto array = this->rng_.ArrayOf(int16(), size, null_probability);
@@ -2211,13 +2211,13 @@ TEST_F(TestDropNullKernelWithTable, DropNullTable) {
     ])"};
     std::shared_ptr<Table> actual;
     ASSERT_OK(this->DoDropNull(schm, table_json, &actual));
-    ASSERT_TRUE(actual->num_rows() == 0);
+    ASSERT_EQ(actual->num_rows(), 0);
   }
 }
 
 TEST_F(TestDropNullKernelWithTable, DropNullTableWithWithSlices) {
   // With Null Arrays
-  this->CheckDropNullWithSlices([this](int64_t size, double null_probability,
+  this->CheckDropNullWithSlices([this](int32_t size, double null_probability,
                                        std::shared_ptr<Table>* out_table_w_slices,
                                        std::shared_ptr<Table>* out_table_wo_slices) {
     std::vector<std::shared_ptr<Field>> fields = {field("a", int32()),
@@ -2249,7 +2249,7 @@ TEST_F(TestDropNullKernelWithTable, DropNullTableWithWithSlices) {
   });
 
   // Without Null Arrays
-  this->CheckDropNullWithSlices([this](int64_t size, double null_probability,
+  this->CheckDropNullWithSlices([this](int32_t size, double null_probability,
                                        std::shared_ptr<Table>* out_table_w_slices,
                                        std::shared_ptr<Table>* out_table_wo_slices) {
     std::vector<std::shared_ptr<Field>> fields = {field("a", int32()),

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -56,6 +56,7 @@ TEST(GetTakeIndices, Basics) {
   };
 
   // Drop null cases
+  // TODO: aocsa
   CheckCase("[]", "[]", FilterOptions::DROP);
   CheckCase("[null]", "[]", FilterOptions::DROP);
   CheckCase("[null, false, true, true, false, true]", "[2, 3, 5]", FilterOptions::DROP);

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1785,6 +1785,8 @@ TEST_F(TestDropNullKernel, DropNull) {
 TEST_F(TestDropNullKernel, DropNullBoolean) {
   CheckDropNull(boolean(), "[true, false, true]", "[true, false, true]");
   CheckDropNull(boolean(), "[null, false, true]", "[false, true]");
+  CheckDropNull(boolean(), "[]", "[]");
+  CheckDropNull(boolean(), "[null, null]", "[]");
 
   TestNoValidityBitmapButUnknownNullCount(boolean(), "[true, false, true]");
 }

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -112,14 +112,20 @@ const std::shared_ptr<Schema>& Datum::schema() const {
 }
 
 int64_t Datum::length() const {
-  if (this->kind() == Datum::ARRAY) {
-    return util::get<std::shared_ptr<ArrayData>>(this->value)->length;
-  } else if (this->kind() == Datum::CHUNKED_ARRAY) {
-    return util::get<std::shared_ptr<ChunkedArray>>(this->value)->length();
-  } else if (this->kind() == Datum::SCALAR) {
-    return 1;
+  switch (this->kind()) {
+    case Datum::ARRAY:
+      return util::get<std::shared_ptr<ArrayData>>(this->value)->length;
+    case Datum::CHUNKED_ARRAY:
+      return util::get<std::shared_ptr<ChunkedArray>>(this->value)->length();
+    case Datum::RECORD_BATCH:
+      return util::get<std::shared_ptr<RecordBatch>>(this->value)->num_rows();
+    case Datum::TABLE:
+      return util::get<std::shared_ptr<Table>>(this->value)->num_rows();
+    case Datum::SCALAR:
+      return 1;
+    default:
+      return kUnknownLength;
   }
-  return kUnknownLength;
 }
 
 int64_t Datum::null_count() const {

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1164,23 +1164,30 @@ Associative transforms
 Selections
 ~~~~~~~~~~
 
-These functions select a subset of the first input defined by the second input.
+These functions select and return a subset of their input.
 
 +---------------+--------+--------------+--------------+--------------+-------------------------+-----------+
 | Function name | Arity  | Input type 1 | Input type 2 | Output type  | Options class           | Notes     |
 +===============+========+==============+==============+==============+=========================+===========+
-| filter        | Binary | Any          | Boolean      | Input type 1 | :struct:`FilterOptions` | \(1) \(2) |
+| drop_null     | Unary  | Any          | -            | Input type 1 |                         | \(1) \(2) |
 +---------------+--------+--------------+--------------+--------------+-------------------------+-----------+
-| take          | Binary | Any          | Integer      | Input type 1 | :struct:`TakeOptions`   | \(1) \(3) |
+| filter        | Binary | Any          | Boolean      | Input type 1 | :struct:`FilterOptions` | \(1) \(3) |
++---------------+--------+--------------+--------------+--------------+-------------------------+-----------+
+| take          | Binary | Any          | Integer      | Input type 1 | :struct:`TakeOptions`   | \(1) \(4) |
 +---------------+--------+--------------+--------------+--------------+-------------------------+-----------+
 
-* \(1) Unions are unsupported.
+* \(1) Sparse unions are unsupported.
 
-* \(2) Each element in input 1 is appended to the output iff the corresponding
-  element in input 2 is true.
+* \(2) Each element in the input is appended to the output iff it is non-null.
+  If the input is a record batch or table, any null value in a column drops
+  the entire row.
 
-* \(3) For each element *i* in input 2, the *i*'th element in input 1 is
-  appended to the output.
+* \(3) Each element in input 1 (the values) is appended to the output iff
+  the corresponding element in input 2 (the filter) is true.  How
+  nulls in the filter are handled can be configured using FilterOptions.
+
+* \(4) For each element *i* in input 2 (the indices), the *i*'th element
+  in input 1 (the values) is appended to the output.
 
 Sorts and partitions
 ~~~~~~~~~~~~~~~~~~~~

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1117,11 +1117,11 @@ cdef class Array(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
-    def dropnull(self):
+    def drop_null(self):
         """
         Remove missing values from an array.
         """
-        return _pc().dropnull(self)
+        return _pc().drop_null(self)
 
     def filter(self, Array mask, null_selection_behavior='drop'):
         """

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1117,6 +1117,12 @@ cdef class Array(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
+    def dropnull(self):
+        """
+        Remove missing values from an array.
+        """
+        return _pc().dropnull(self)
+
     def filter(self, Array mask, null_selection_behavior='drop'):
         """
         Select values from an array. See pyarrow.compute.filter for full usage.

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -591,6 +591,38 @@ def take(data, indices, *, boundscheck=True, memory_pool=None):
     return call_function('take', [data, indices], options, memory_pool)
 
 
+def dropnull(data, *, memory_pool=None):
+    """
+    Remove missing values (or records) from array- or table-like.
+
+    The result will be of the same type(s) as the input, with elements taken
+    from the input array (or record batch / table fields) without the nulls.
+
+    Parameters
+    ----------
+    data : Array, ChunkedArray, RecordBatch, or Table
+
+    Returns
+    -------
+    result : depends on inputs
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> arr = pa.array(["a", "b", "c", None, "e", "f"])
+    >>> arr.dropnull()
+    <pyarrow.lib.StringArray object at 0x7ffa4fc7d368>
+    [
+      "a",
+      "b",
+      "c",
+      "e",
+      "f"
+    ]
+    """
+    return call_function('dropnull', [data], memory_pool)
+
+
 def fill_null(values, fill_value):
     """
     Replace each null element in values with fill_value. The fill_value must be

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -591,7 +591,7 @@ def take(data, indices, *, boundscheck=True, memory_pool=None):
     return call_function('take', [data, indices], options, memory_pool)
 
 
-def dropnull(data, *, memory_pool=None):
+def drop_null(data, *, memory_pool=None):
     """
     Remove missing values (or records) from array- or table-like.
 
@@ -610,7 +610,7 @@ def dropnull(data, *, memory_pool=None):
     --------
     >>> import pyarrow as pa
     >>> arr = pa.array(["a", "b", "c", None, "e", "f"])
-    >>> arr.dropnull()
+    >>> arr.drop_null()
     <pyarrow.lib.StringArray object at 0x7ffa4fc7d368>
     [
       "a",
@@ -620,7 +620,7 @@ def dropnull(data, *, memory_pool=None):
       "f"
     ]
     """
-    return call_function('dropnull', [data], memory_pool)
+    return call_function('drop_null', [data], memory_pool)
 
 
 def fill_null(values, fill_value):

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -591,38 +591,6 @@ def take(data, indices, *, boundscheck=True, memory_pool=None):
     return call_function('take', [data, indices], options, memory_pool)
 
 
-def drop_null(data, memory_pool=None):
-    """
-    Remove missing values (or records) from array- or table-like.
-
-    The result will be of the same type(s) as the input, with elements taken
-    from the input array (or record batch / table fields) without the nulls.
-
-    Parameters
-    ----------
-    data : Array, ChunkedArray, RecordBatch, or Table
-
-    Returns
-    -------
-    result : depends on inputs
-
-    Examples
-    --------
-    >>> import pyarrow as pa
-    >>> arr = pa.array(["a", "b", "c", None, "e", "f"])
-    >>> arr.drop_null()
-    <pyarrow.lib.StringArray object at 0x7ffa4fc7d368>
-    [
-      "a",
-      "b",
-      "c",
-      "e",
-      "f"
-    ]
-    """
-    return call_function('drop_null', [data], memory_pool)
-
-
 def fill_null(values, fill_value):
     """
     Replace each null element in values with fill_value. The fill_value must be

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -591,7 +591,7 @@ def take(data, indices, *, boundscheck=True, memory_pool=None):
     return call_function('take', [data, indices], options, memory_pool)
 
 
-def drop_null(data, *, memory_pool=None):
+def drop_null(data, memory_pool=None):
     """
     Remove missing values (or records) from array- or table-like.
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -958,14 +958,14 @@ cdef class RecordBatch(_PandasConvertible):
 
     def take(self, object indices):
         """
-        Select records from an RecordBatch. See pyarrow.compute.take for full
+        Select records from a RecordBatch. See pyarrow.compute.take for full
         usage.
         """
         return _pc().take(self, indices)
 
     def drop_null(self):
         """
-        Remove missing values from an RecordBatch.
+        Remove missing values from a RecordBatch.
         See pyarrow.compute.drop_null for full usage.
         """
         return _pc().drop_null(self)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -399,7 +399,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
     def dropnull(self):
         """
-        Remove missing values from a chunked array. 
+        Remove missing values from a chunked array.
         See pyarrow.compute.dropnull for full usage.
         """
         return _pc().dropnull(self)
@@ -965,7 +965,7 @@ cdef class RecordBatch(_PandasConvertible):
 
     def dropnull(self):
         """
-        Remove missing values from an RecordBatch. 
+        Remove missing values from an RecordBatch.
         See pyarrow.compute.dropnull for full usage.
         """
         return _pc().dropnull(self)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -400,7 +400,7 @@ cdef class ChunkedArray(_PandasConvertible):
     def drop_null(self):
         """
         Remove missing values from a chunked array.
-        See pyarrow.compute.drop_null for full usage.
+        See pyarrow.compute.drop_null for full description.
         """
         return _pc().drop_null(self)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -397,6 +397,13 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
+    def dropnull(self):
+        """
+        Remove missing values from a chunked array. See pyarrow.compute.dropnull for full
+        usage.
+        """
+        return _pc().dropnull(self)
+
     def unify_dictionaries(self, MemoryPool memory_pool=None):
         """
         Unify dictionaries across all chunks.
@@ -956,6 +963,13 @@ cdef class RecordBatch(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
+    def dropnull(self):
+        """
+        Remove missing values from an RecordBatch. See pyarrow.compute.dropnull for full
+        usage.
+        """
+        return _pc().dropnull(self)
+
     def to_pydict(self):
         """
         Convert the RecordBatch to a dict or OrderedDict.
@@ -1318,10 +1332,17 @@ cdef class Table(_PandasConvertible):
 
     def take(self, object indices):
         """
-        Select records from an Table. See :func:`pyarrow.compute.take` for full
+        Select records from a Table. See :func:`pyarrow.compute.take` for full
         usage.
         """
         return _pc().take(self, indices)
+
+    def dropnull(self):
+        """
+        Remove missing values from a Table. See :func:`pyarrow.compute.dropnull` for full
+        usage.
+        """
+        return _pc().dropnull(self)
 
     def select(self, object columns):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -399,8 +399,8 @@ cdef class ChunkedArray(_PandasConvertible):
 
     def dropnull(self):
         """
-        Remove missing values from a chunked array. See pyarrow.compute.dropnull for full
-        usage.
+        Remove missing values from a chunked array. 
+        See pyarrow.compute.dropnull for full usage.
         """
         return _pc().dropnull(self)
 
@@ -965,8 +965,8 @@ cdef class RecordBatch(_PandasConvertible):
 
     def dropnull(self):
         """
-        Remove missing values from an RecordBatch. See pyarrow.compute.dropnull for full
-        usage.
+        Remove missing values from an RecordBatch. 
+        See pyarrow.compute.dropnull for full usage.
         """
         return _pc().dropnull(self)
 
@@ -1339,8 +1339,8 @@ cdef class Table(_PandasConvertible):
 
     def dropnull(self):
         """
-        Remove missing values from a Table. See :func:`pyarrow.compute.dropnull` for full
-        usage.
+        Remove missing values from a Table.
+        See :func:`pyarrow.compute.dropnull` for full usage.
         """
         return _pc().dropnull(self)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -397,12 +397,12 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
-    def dropnull(self):
+    def drop_null(self):
         """
         Remove missing values from a chunked array.
-        See pyarrow.compute.dropnull for full usage.
+        See pyarrow.compute.drop_null for full usage.
         """
-        return _pc().dropnull(self)
+        return _pc().drop_null(self)
 
     def unify_dictionaries(self, MemoryPool memory_pool=None):
         """
@@ -963,12 +963,12 @@ cdef class RecordBatch(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
-    def dropnull(self):
+    def drop_null(self):
         """
         Remove missing values from an RecordBatch.
-        See pyarrow.compute.dropnull for full usage.
+        See pyarrow.compute.drop_null for full usage.
         """
-        return _pc().dropnull(self)
+        return _pc().drop_null(self)
 
     def to_pydict(self):
         """
@@ -1337,12 +1337,12 @@ cdef class Table(_PandasConvertible):
         """
         return _pc().take(self, indices)
 
-    def dropnull(self):
+    def drop_null(self):
         """
         Remove missing values from a Table.
-        See :func:`pyarrow.compute.dropnull` for full usage.
+        See :func:`pyarrow.compute.drop_null` for full usage.
         """
-        return _pc().dropnull(self)
+        return _pc().drop_null(self)
 
     def select(self, object columns):
         """

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -994,15 +994,36 @@ def test_dropnull_chunked_array():
 def test_dropnull_record_batch():
     batch = pa.record_batch(
         [pa.array(["a", None, "c", "d", None])], names=["a'"])
-
     result = batch.dropnull()
     expected = pa.record_batch([pa.array(["a", "c", "d"])], names=["a'"])
+    assert result.equals(expected)
+
+    batch = pa.record_batch(
+        [pa.array(["a", None, "c", "d", None]),
+         pa.array([None, None, "c", None, "e"])], names=["a'", "b'"])
+
+    result = batch.dropnull()
+    expected = pa.record_batch(
+        [pa.array(["c"]), pa.array(["c"])], names=["a'", "b'"])
+    print(result["a'"])
+    print(expected["a'"])
     assert result.equals(expected)
 
 
 def test_dropnull_table():
     table = pa.table([pa.array(["a", None, "c", "d", None])], names=["a"])
     expected = pa.table([pa.array(["a", "c", "d"])], names=["a"])
+    result = table.dropnull()
+    assert result.equals(expected)
+
+    table = pa.table([pa.chunked_array([["a", None], ["c", "d", None]]),
+                      pa.chunked_array([["a", None], [None, "d", None]]),
+                      pa.chunked_array([["a"], ["b"], [None], ["d", None]])],
+                     names=["a", "b", "c"])
+    expected = pa.table([pa.array(["a", "d"]),
+                         pa.array(["a", "d"]),
+                         pa.array(["a", "d"])],
+                        names=["a", "b", "c"])
     result = table.dropnull()
     assert result.equals(expected)
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -975,26 +975,26 @@ def test_take_null_type():
 
 
 @pytest.mark.parametrize(('ty', 'values'), all_array_types)
-def test_dropnull(ty, values):
+def test_drop_null(ty, values):
     arr = pa.array(values, type=ty)
-    result = arr.dropnull()
+    result = arr.drop_null()
     result.validate()
     indices = [i for i in range(len(arr)) if arr[i].is_valid]
     expected = arr.take(pa.array(indices))
     assert result.equals(expected)
 
 
-def test_dropnull_chunked_array():
+def test_drop_null_chunked_array():
     arr = pa.chunked_array([["a", None], ["c", "d", None]])
     expected_drop = pa.chunked_array([["a"], ["c", "d"]])
-    result = arr.dropnull()
+    result = arr.drop_null()
     assert result.equals(expected_drop)
 
 
-def test_dropnull_record_batch():
+def test_drop_null_record_batch():
     batch = pa.record_batch(
         [pa.array(["a", None, "c", "d", None])], names=["a'"])
-    result = batch.dropnull()
+    result = batch.drop_null()
     expected = pa.record_batch([pa.array(["a", "c", "d"])], names=["a'"])
     assert result.equals(expected)
 
@@ -1002,7 +1002,7 @@ def test_dropnull_record_batch():
         [pa.array(["a", None, "c", "d", None]),
          pa.array([None, None, "c", None, "e"])], names=["a'", "b'"])
 
-    result = batch.dropnull()
+    result = batch.drop_null()
     expected = pa.record_batch(
         [pa.array(["c"]), pa.array(["c"])], names=["a'", "b'"])
     print(result["a'"])
@@ -1010,10 +1010,10 @@ def test_dropnull_record_batch():
     assert result.equals(expected)
 
 
-def test_dropnull_table():
+def test_drop_null_table():
     table = pa.table([pa.array(["a", None, "c", "d", None])], names=["a"])
     expected = pa.table([pa.array(["a", "c", "d"])], names=["a"])
-    result = table.dropnull()
+    result = table.drop_null()
     assert result.equals(expected)
 
     table = pa.table([pa.chunked_array([["a", None], ["c", "d", None]]),
@@ -1024,20 +1024,20 @@ def test_dropnull_table():
                          pa.array(["a", "d"]),
                          pa.array(["a", "d"])],
                         names=["a", "b", "c"])
-    result = table.dropnull()
+    result = table.drop_null()
     assert result.equals(expected)
 
 
-def test_dropnull_null_type():
+def test_drop_null_null_type():
     arr = pa.array([None] * 10)
     chunked_arr = pa.chunked_array([[None] * 5] * 2)
     batch = pa.record_batch([arr], names=['a'])
     table = pa.table({'a': arr})
 
-    assert len(arr.dropnull()) == 0
-    assert len(chunked_arr.dropnull()) == 0
-    assert len(batch.dropnull().column(0)) == 0
-    assert len(table.dropnull().column(0)) == 0
+    assert len(arr.drop_null()) == 0
+    assert len(chunked_arr.drop_null()) == 0
+    assert len(batch.drop_null().column(0)) == 0
+    assert len(table.drop_null().column(0)) == 0
 
 
 @pytest.mark.parametrize(('ty', 'values'), all_array_types)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -985,8 +985,9 @@ def test_drop_null(ty, values):
 
 
 def test_drop_null_chunked_array():
-    arr = pa.chunked_array([["a", None], ["c", "d", None]])
-    expected_drop = pa.chunked_array([["a"], ["c", "d"]])
+    arr = pa.chunked_array([["a", None], ["c", "d", None], [None], []])
+    expected_drop = pa.chunked_array([["a"], ["c", "d"], [], []])
+
     result = arr.drop_null()
     assert result.equals(expected_drop)
 
@@ -1005,8 +1006,6 @@ def test_drop_null_record_batch():
     result = batch.drop_null()
     expected = pa.record_batch(
         [pa.array(["c"]), pa.array(["c"])], names=["a'", "b'"])
-    print(result["a'"])
-    print(expected["a'"])
     assert result.equals(expected)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -978,7 +978,7 @@ def test_take_null_type():
 def test_drop_null(ty, values):
     arr = pa.array(values, type=ty)
     result = arr.drop_null()
-    result.validate()
+    result.validate(full=True)
     indices = [i for i in range(len(arr)) if arr[i].is_valid]
     expected = arr.take(pa.array(indices))
     assert result.equals(expected)
@@ -1027,12 +1027,12 @@ def test_drop_null_table():
     assert result.equals(expected)
 
     table = pa.table([pa.chunked_array([["a", "b"], ["c", "d", "e"]]),
-                      pa.chunked_array([["a"], ["b"], [None], ["d", None]]),
-                      pa.chunked_array([["a", None], ["c", "d", None]])],
+                      pa.chunked_array([["A"], ["B"], [None], ["D", None]]),
+                      pa.chunked_array([["a`", None], ["c`", "d`", None]])],
                      names=["a", "b", "c"])
     expected = pa.table([pa.array(["a", "d"]),
-                         pa.array(["a", "d"]),
-                         pa.array(["a", "d"])],
+                         pa.array(["A", "D"]),
+                         pa.array(["a`", "d`"])],
                         names=["a", "b", "c"])
     result = table.drop_null()
     assert result.equals(expected)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1027,6 +1027,17 @@ def test_drop_null_table():
     result = table.drop_null()
     assert result.equals(expected)
 
+    table = pa.table([pa.chunked_array([["a", "b"], ["c", "d", "e"]]),
+                      pa.chunked_array([["a"], ["b"], [None], ["d", None]]),
+                      pa.chunked_array([["a", None], ["c", "d", None]])],
+                     names=["a", "b", "c"])
+    expected = pa.table([pa.array(["a", "d"]),
+                         pa.array(["a", "d"]),
+                         pa.array(["a", "d"])],
+                        names=["a", "b", "c"])
+    result = table.drop_null()
+    assert result.equals(expected)
+
 
 def test_drop_null_null_type():
     arr = pa.array([None] * 10)


### PR DESCRIPTION
Implement "drop null" kernels that return array without nulls

Note: This can be implemented as a arrow::compute::VectorFunction because the size of the array is changed, so this function is not valid in a SQL-like context

 