### PR TITLE
ARROW-13222: [C++] Improve type support for case_when

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -641,31 +641,31 @@ TEST_F(TestArray, TestAppendArraySlice) {
     std::unique_ptr<arrow::ArrayBuilder> builder;
     ASSERT_OK(MakeBuilder(pool_, scalar->type, &builder));
 
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 0, 4));
+    ASSERT_OK(builder->AppendArraySlice(*array->data(), 0, 4));
     ASSERT_EQ(4, builder->length());
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 0, 0));
+    ASSERT_OK(builder->AppendArraySlice(*array->data(), 0, 0));
     ASSERT_EQ(4, builder->length());
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 1, 0));
+    ASSERT_OK(builder->AppendArraySlice(*array->data(), 1, 0));
     ASSERT_EQ(4, builder->length());
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 1, 4));
+    ASSERT_OK(builder->AppendArraySlice(*array->data(), 1, 4));
     ASSERT_EQ(8, builder->length());
 
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 0, 4));
+    ASSERT_OK(builder->AppendArraySlice(*nulls->data(), 0, 4));
     ASSERT_EQ(12, builder->length());
     if (!is_union(scalar->type->id())) {
       ASSERT_EQ(4, builder->null_count());
     }
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 0, 0));
+    ASSERT_OK(builder->AppendArraySlice(*nulls->data(), 0, 0));
     ASSERT_EQ(12, builder->length());
     if (!is_union(scalar->type->id())) {
       ASSERT_EQ(4, builder->null_count());
     }
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 1, 0));
+    ASSERT_OK(builder->AppendArraySlice(*nulls->data(), 1, 0));
     ASSERT_EQ(12, builder->length());
     if (!is_union(scalar->type->id())) {
       ASSERT_EQ(4, builder->null_count());
     }
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 1, 4));
+    ASSERT_OK(builder->AppendArraySlice(*nulls->data(), 1, 4));
     ASSERT_EQ(16, builder->length());
     if (!is_union(scalar->type->id())) {
       ASSERT_EQ(8, builder->null_count());
@@ -683,13 +683,13 @@ TEST_F(TestArray, TestAppendArraySlice) {
   {
     ASSERT_OK_AND_ASSIGN(auto array, MakeArrayOfNull(null(), 16));
     NullBuilder builder(pool_);
-    ASSERT_OK(builder.AppendArraySliceUnchecked(*array->data(), 0, 4));
+    ASSERT_OK(builder.AppendArraySlice(*array->data(), 0, 4));
     ASSERT_EQ(4, builder.length());
-    ASSERT_OK(builder.AppendArraySliceUnchecked(*array->data(), 0, 0));
+    ASSERT_OK(builder.AppendArraySlice(*array->data(), 0, 0));
     ASSERT_EQ(4, builder.length());
-    ASSERT_OK(builder.AppendArraySliceUnchecked(*array->data(), 1, 0));
+    ASSERT_OK(builder.AppendArraySlice(*array->data(), 1, 0));
     ASSERT_EQ(4, builder.length());
-    ASSERT_OK(builder.AppendArraySliceUnchecked(*array->data(), 1, 4));
+    ASSERT_OK(builder.AppendArraySlice(*array->data(), 1, 4));
     ASSERT_EQ(8, builder.length());
     std::shared_ptr<Array> result;
     ASSERT_OK(builder.Finish(&result));

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -37,6 +37,7 @@
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_decimal.h"
 #include "arrow/array/builder_dict.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/array/data.h"
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
@@ -634,6 +635,8 @@ TEST_F(TestArray, TestAppendArraySlice) {
     // TODO(ARROW-13573): appending dictionary arrays not implemented
     if (is_dictionary(scalar->type->id())) continue;
 
+    auto is_union = arrow::is_union(scalar->type->id());
+
     ARROW_SCOPED_TRACE(*scalar->type);
     ASSERT_OK_AND_ASSIGN(auto array, MakeArrayFromScalar(*scalar, 16));
     ASSERT_OK_AND_ASSIGN(auto nulls, MakeArrayOfNull(scalar->type, 16));
@@ -641,7 +644,9 @@ TEST_F(TestArray, TestAppendArraySlice) {
     std::unique_ptr<arrow::ArrayBuilder> builder;
     ASSERT_OK(MakeBuilder(pool_, scalar->type, &builder));
 
-    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 0, 4));
+    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 0, 2));
+    ASSERT_EQ(2, builder->length());
+    ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 2, 2));
     ASSERT_EQ(4, builder->length());
     ASSERT_OK(builder->AppendArraySliceUnchecked(*array->data(), 0, 0));
     ASSERT_EQ(4, builder->length());
@@ -652,31 +657,39 @@ TEST_F(TestArray, TestAppendArraySlice) {
 
     ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 0, 4));
     ASSERT_EQ(12, builder->length());
-    if (!is_union(scalar->type->id())) {
-      ASSERT_EQ(4, builder->null_count());
-    }
+    ASSERT_EQ(is_union ? 0 : 4, builder->null_count());
     ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 0, 0));
     ASSERT_EQ(12, builder->length());
-    if (!is_union(scalar->type->id())) {
-      ASSERT_EQ(4, builder->null_count());
-    }
+    ASSERT_EQ(is_union ? 0 : 4, builder->null_count());
     ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 1, 0));
     ASSERT_EQ(12, builder->length());
-    if (!is_union(scalar->type->id())) {
-      ASSERT_EQ(4, builder->null_count());
-    }
+    ASSERT_EQ(is_union ? 0 : 4, builder->null_count());
     ASSERT_OK(builder->AppendArraySliceUnchecked(*nulls->data(), 1, 4));
     ASSERT_EQ(16, builder->length());
-    if (!is_union(scalar->type->id())) {
-      ASSERT_EQ(8, builder->null_count());
-    }
+    ASSERT_EQ(is_union ? 0 : 8, builder->null_count());
 
-    std::shared_ptr<Array> result;
-    ASSERT_OK(builder->Finish(&result));
-    ASSERT_OK(result->ValidateFull());
-    ASSERT_EQ(16, result->length());
-    if (!is_union(scalar->type->id())) {
-      ASSERT_EQ(8, result->null_count());
+    if (is_union) {
+      // Concatenate not supported by union
+      std::shared_ptr<Array> result;
+      ASSERT_OK(builder->Finish(&result));
+      ASSERT_OK(result->ValidateFull());
+      ASSERT_EQ(16, result->length());
+      ASSERT_EQ(0, result->null_count());
+    } else {
+      ASSERT_OK_AND_ASSIGN(auto both, Concatenate({array, nulls}));
+      ASSERT_OK(builder->AppendArraySliceUnchecked(*both->data(), 14, 4));
+      ASSERT_EQ(20, builder->length());
+      ASSERT_EQ(10, builder->null_count());
+      std::shared_ptr<Array> result;
+      ASSERT_OK(builder->Finish(&result));
+      ASSERT_OK(result->ValidateFull());
+      ASSERT_EQ(20, result->length());
+      ASSERT_EQ(10, result->null_count());
+
+      ASSERT_OK_AND_ASSIGN(auto expected,
+                           Concatenate({array->Slice(0, 4), array->Slice(1, 4),
+                                        nulls->Slice(0, 8), both->Slice(14, 4)}));
+      AssertArraysApproxEqual(*expected, *result, /*verbose=*/true);
     }
   }
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -189,6 +189,17 @@ class ARROW_EXPORT ArrayBuilder {
     null_count_ = null_bitmap_builder_.false_count();
   }
 
+  // Vector append. Copy from a given bitmap. If bitmap is null assume
+  // all of length bits are valid.
+  void UnsafeAppendToBitmap(const uint8_t* bitmap, int64_t offset, int64_t length) {
+    if (bitmap == NULLPTR) {
+      return UnsafeSetNotNull(length);
+    }
+    null_bitmap_builder_.UnsafeAppend(bitmap, offset, length);
+    length_ += length;
+    null_count_ = null_bitmap_builder_.false_count();
+  }
+
   // Append the same validity value a given number of times.
   void UnsafeAppendToBitmap(const int64_t num_bits, bool value) {
     if (value) {

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -123,22 +123,13 @@ class ARROW_EXPORT ArrayBuilder {
   Status AppendScalar(const Scalar& scalar, int64_t n_repeats);
   Status AppendScalars(const ScalarVector& scalars);
 
-  /// \brief Append a range of values from an array
-  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
-                          const int64_t length) {
-    if (!type()->Equals(*array.type)) {
-      // TODO: test this
-      return Status::TypeError("Expected array of type ", *type(),
-                               " but got array of type ", *array.type);
-    }
-    return AppendArraySliceUnchecked(array, offset, length);
-  }
-  /// \brief Append a range of values from an array without checking type compatibility
+  /// \brief Append a range of values from an array.
+  ///
+  /// The given array must be the same type as the builder.
   virtual Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
                                            const int64_t length) {
     return Status::NotImplemented("AppendArraySliceUnchecked for builder for ", *type());
   }
-  // TODO: overloads for arrays
 
   /// For cases where raw data was memcpy'd into the internal buffers, allows us
   /// to advance the length of the builder. It is your responsibility to use

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -126,8 +126,8 @@ class ARROW_EXPORT ArrayBuilder {
   /// \brief Append a range of values from an array.
   ///
   /// The given array must be the same type as the builder.
-  virtual Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
-                                           const int64_t length) {
+  virtual Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
+                                           int64_t length) {
     return Status::NotImplemented("AppendArraySliceUnchecked for builder for ", *type());
   }
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -123,6 +123,23 @@ class ARROW_EXPORT ArrayBuilder {
   Status AppendScalar(const Scalar& scalar, int64_t n_repeats);
   Status AppendScalars(const ScalarVector& scalars);
 
+  /// \brief Append a range of values from an array
+  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
+                          const int64_t length) {
+    if (!type()->Equals(*array.type)) {
+      // TODO: test this
+      return Status::TypeError("Expected array of type ", *type(),
+                               " but got array of type ", *array.type);
+    }
+    return AppendArraySliceUnchecked(array, offset, length);
+  }
+  /// \brief Append a range of values from an array without checking type compatibility
+  virtual Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
+                                           const int64_t length) {
+    return Status::NotImplemented("AppendArraySliceUnchecked for builder for ", *type());
+  }
+  // TODO: overloads for arrays
+
   /// For cases where raw data was memcpy'd into the internal buffers, allows us
   /// to advance the length of the builder. It is your responsibility to use
   /// this function responsibly.

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -126,9 +126,9 @@ class ARROW_EXPORT ArrayBuilder {
   /// \brief Append a range of values from an array.
   ///
   /// The given array must be the same type as the builder.
-  virtual Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                           int64_t length) {
-    return Status::NotImplemented("AppendArraySliceUnchecked for builder for ", *type());
+  virtual Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                                  int64_t length) {
+    return Status::NotImplemented("AppendArraySlice for builder for ", *type());
   }
 
   /// For cases where raw data was memcpy'd into the internal buffers, allows us

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -60,6 +60,14 @@ Status FixedSizeBinaryBuilder::AppendValues(const uint8_t* data, int64_t length,
   return byte_builder_.Append(data, length * byte_width_);
 }
 
+Status FixedSizeBinaryBuilder::AppendValues(const uint8_t* data, int64_t length,
+                                            const uint8_t* validity,
+                                            int64_t bitmap_offset) {
+  RETURN_NOT_OK(Reserve(length));
+  UnsafeAppendToBitmap(validity, bitmap_offset, length);
+  return byte_builder_.Append(data, length * byte_width_);
+}
+
 Status FixedSizeBinaryBuilder::AppendNull() {
   RETURN_NOT_OK(Reserve(1));
   UnsafeAppendNull();

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -283,9 +283,9 @@ class BaseBinaryBuilder : public ArrayBuilder {
       if (!bitmap || BitUtil::GetBit(bitmap, array.offset + offset + i)) {
         const offset_type start = offsets[offset + i];
         const offset_type end = offsets[offset + i + 1];
-        RETURN_NOT_OK(Append(data + start, end - start));
+        ARROW_RETURN_NOT_OK(Append(data + start, end - start));
       } else {
-        RETURN_NOT_OK(AppendNull());
+        ARROW_RETURN_NOT_OK(AppendNull());
       }
     }
     return Status::OK();

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -274,8 +274,8 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     auto bitmap = array.GetValues<uint8_t>(0, 0);
     auto offsets = array.GetValues<offset_type>(1);
     auto data = array.GetValues<uint8_t>(2, 0);
@@ -512,8 +512,8 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   Status AppendEmptyValue() final;
   Status AppendEmptyValues(int64_t length) final;
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     return AppendValues(
         array.GetValues<uint8_t>(1, 0) + ((array.offset + offset) * byte_width_), length,
         array.GetValues<uint8_t>(0, 0), array.offset + offset);

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -35,7 +35,6 @@
 #include "arrow/buffer_builder.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
-#include "arrow/util/bit_run_reader.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string_view.h"  // IWYU pragma: export
 #include "arrow/util/visibility.h"
@@ -277,44 +276,17 @@ class BaseBinaryBuilder : public ArrayBuilder {
 
   Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
                                    int64_t length) override {
-    if (length == 0) return Status::OK();
     auto bitmap = array.GetValues<uint8_t>(0, 0);
-    auto offsets = array.GetValues<offset_type>(1) + offset;
+    auto offsets = array.GetValues<offset_type>(1);
     auto data = array.GetValues<uint8_t>(2, 0);
-    ARROW_RETURN_NOT_OK(Reserve(length));
-
-    auto copy_values = [&](int64_t position, int64_t length) {
-      const offset_type first_offset = offsets[position];
-      const offset_type last_offset = offsets[position + length];
-      const offset_type data_length = last_offset - first_offset;
-      ARROW_RETURN_NOT_OK(ReserveData(data_length));
-      UnsafeAppendNextOffset();
-      const offset_type base_offset =
-          offsets_builder_.data()[offsets_builder_.length() - 1];
-      ARROW_RETURN_NOT_OK(value_data_builder_.Append(data + first_offset, data_length));
-      for (int64_t i = 1; i < length; i++) {
-        offsets_builder_.UnsafeAppend(base_offset +
-                                      (offsets[position + i] - first_offset));
-      }
-      UnsafeAppendToBitmap(length, true);
-      return Status::OK();
-    };
-
-    if (!bitmap) {
-      return copy_values(0, length);
-    }
-    internal::BitRunReader reader(bitmap, array.offset + offset, length);
-    int64_t position = 0;
-    while (true) {
-      internal::BitRun run = reader.NextRun();
-      if (run.length == 0) break;
-
-      if (run.set) {
-        ARROW_RETURN_NOT_OK(copy_values(position, run.length));
+    for (int64_t i = 0; i < length; i++) {
+      if (!bitmap || BitUtil::GetBit(bitmap, array.offset + offset + i)) {
+        const offset_type start = offsets[offset + i];
+        const offset_type end = offsets[offset + i + 1];
+        ARROW_RETURN_NOT_OK(Append(data + start, end - start));
       } else {
-        ARROW_RETURN_NOT_OK(AppendNulls(run.length));
+        ARROW_RETURN_NOT_OK(AppendNull());
       }
-      position += run.length;
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -486,6 +486,9 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   Status AppendValues(const uint8_t* data, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
 
+  Status AppendValues(const uint8_t* data, int64_t length, const uint8_t* validity,
+                      int64_t bitmap_offset);
+
   Status AppendNull() final;
   Status AppendNulls(int64_t length) final;
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -125,7 +125,7 @@ class BaseListBuilder : public ArrayBuilder {
   Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
                                    int64_t length) override {
     const offset_type* offsets = array.GetValues<offset_type>(1);
-    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : nullptr;
+    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
         ARROW_RETURN_NOT_OK(Append());
@@ -295,7 +295,7 @@ class ARROW_EXPORT MapBuilder : public ArrayBuilder {
   Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
                                    int64_t length) override {
     const int32_t* offsets = array.GetValues<int32_t>(1);
-    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : nullptr;
+    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
         ARROW_RETURN_NOT_OK(Append());
@@ -412,7 +412,7 @@ class ARROW_EXPORT FixedSizeListBuilder : public ArrayBuilder {
 
   Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
                                    int64_t length) final {
-    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : nullptr;
+    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
         ARROW_RETURN_NOT_OK(value_builder_->AppendArraySliceUnchecked(
@@ -524,7 +524,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
       ARROW_RETURN_NOT_OK(children_[i]->AppendArraySliceUnchecked(
           *array.child_data[i], array.offset + offset, length));
     }
-    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : nullptr;
+    const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       ARROW_RETURN_NOT_OK(
           Append(!validity || BitUtil::GetBit(validity, array.offset + row)));

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -122,16 +122,16 @@ class BaseListBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     const offset_type* offsets = array.GetValues<offset_type>(1);
     const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
         ARROW_RETURN_NOT_OK(Append());
         int64_t slot_length = offsets[row + 1] - offsets[row];
-        ARROW_RETURN_NOT_OK(value_builder_->AppendArraySliceUnchecked(
-            *array.child_data[0], offsets[row], slot_length));
+        ARROW_RETURN_NOT_OK(value_builder_->AppendArraySlice(*array.child_data[0],
+                                                             offsets[row], slot_length));
       } else {
         ARROW_RETURN_NOT_OK(AppendNull());
       }
@@ -292,17 +292,17 @@ class ARROW_EXPORT MapBuilder : public ArrayBuilder {
 
   Status AppendEmptyValues(int64_t length) final;
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     const int32_t* offsets = array.GetValues<int32_t>(1);
     const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
         ARROW_RETURN_NOT_OK(Append());
         const int64_t slot_length = offsets[row + 1] - offsets[row];
-        ARROW_RETURN_NOT_OK(key_builder_->AppendArraySliceUnchecked(
+        ARROW_RETURN_NOT_OK(key_builder_->AppendArraySlice(
             *array.child_data[0]->child_data[0], offsets[row], slot_length));
-        ARROW_RETURN_NOT_OK(item_builder_->AppendArraySliceUnchecked(
+        ARROW_RETURN_NOT_OK(item_builder_->AppendArraySlice(
             *array.child_data[0]->child_data[1], offsets[row], slot_length));
       } else {
         ARROW_RETURN_NOT_OK(AppendNull());
@@ -410,12 +410,11 @@ class ARROW_EXPORT FixedSizeListBuilder : public ArrayBuilder {
 
   Status AppendEmptyValues(int64_t length) final;
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) final {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset, int64_t length) final {
     const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     for (int64_t row = offset; row < offset + length; row++) {
       if (!validity || BitUtil::GetBit(validity, array.offset + row)) {
-        ARROW_RETURN_NOT_OK(value_builder_->AppendArraySliceUnchecked(
+        ARROW_RETURN_NOT_OK(value_builder_->AppendArraySlice(
             *array.child_data[0], list_size_ * (array.offset + row), list_size_));
         ARROW_RETURN_NOT_OK(Append());
       } else {
@@ -518,11 +517,11 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     for (int i = 0; static_cast<size_t>(i) < children_.size(); i++) {
-      ARROW_RETURN_NOT_OK(children_[i]->AppendArraySliceUnchecked(
-          *array.child_data[i], array.offset + offset, length));
+      ARROW_RETURN_NOT_OK(children_[i]->AppendArraySlice(*array.child_data[i],
+                                                         array.offset + offset, length));
     }
     const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
     ARROW_RETURN_NOT_OK(Reserve(length));

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -525,10 +525,8 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
           *array.child_data[i], array.offset + offset, length));
     }
     const uint8_t* validity = array.MayHaveNulls() ? array.buffers[0]->data() : NULLPTR;
-    for (int64_t row = offset; row < offset + length; row++) {
-      ARROW_RETURN_NOT_OK(
-          Append(!validity || BitUtil::GetBit(validity, array.offset + row)));
-    }
+    ARROW_RETURN_NOT_OK(Reserve(length));
+    UnsafeAppendToBitmap(validity, array.offset + offset, length);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -86,6 +86,14 @@ Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
 }
 
 Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
+                                    const uint8_t* validity, int64_t offset) {
+  RETURN_NOT_OK(Reserve(length));
+  data_builder_.UnsafeAppend(values, offset, length);
+  ArrayBuilder::UnsafeAppendToBitmap(validity, offset, length);
+  return Status::OK();
+}
+
+Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
                                     const std::vector<bool>& is_valid) {
   RETURN_NOT_OK(Reserve(length));
   DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -156,6 +156,21 @@ class NumericBuilder : public ArrayBuilder {
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values a contiguous C array of values
   /// \param[in] length the number of values to append
+  /// \param[in] bitmap a validity bitmap to copy (may be null)
+  /// \param[in] bitmap_offset an offset into the validity bitmap
+  /// \return Status
+  Status AppendValues(const value_type* values, int64_t length, const uint8_t* bitmap,
+                      int64_t bitmap_offset) {
+    ARROW_RETURN_NOT_OK(Reserve(length));
+    data_builder_.UnsafeAppend(values, length);
+    // length_ is update by these
+    ArrayBuilder::UnsafeAppendToBitmap(bitmap, bitmap_offset, length);
+    return Status::OK();
+  }
+
+  /// \brief Append a sequence of elements in one shot
+  /// \param[in] values a contiguous C array of values
+  /// \param[in] length the number of values to append
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -379,6 +379,15 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
                       const uint8_t* valid_bytes = NULLPTR);
 
   /// \brief Append a sequence of elements in one shot
+  /// \param[in] values a bitmap of values
+  /// \param[in] length the number of values to append
+  /// \param[in] validity a validity bitmap to copy (may be null)
+  /// \param[in] offset an offset into the values and validity bitmaps
+  /// \return Status
+  Status AppendValues(const uint8_t* values, int64_t length, const uint8_t* validity,
+                      int64_t offset);
+
+  /// \brief Append a sequence of elements in one shot
   /// \param[in] values a contiguous C array of values
   /// \param[in] length the number of values to append
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -53,6 +53,10 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   Status Append(std::nullptr_t) { return AppendNull(); }
 
+  Status AppendArraySliceUnchecked(const ArrayData&, int64_t, int64_t length) override {
+    return AppendNulls(length);
+  }
+
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
   /// \cond FALSE
@@ -271,6 +275,12 @@ class NumericBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
+  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
+                                   int64_t length) override {
+    return AppendValues(array.GetValues<value_type>(1) + offset, length,
+                        array.GetValues<uint8_t>(0, 0), array.offset + offset);
+  }
+
   /// Append a single scalar under the assumption that the underlying Buffer is
   /// large enough.
   ///
@@ -482,6 +492,12 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   }
 
   Status AppendValues(int64_t length, bool value);
+
+  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
+                                   int64_t length) override {
+    return AppendValues(array.GetValues<uint8_t>(1, 0), length,
+                        array.GetValues<uint8_t>(0, 0), array.offset + offset);
+  }
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -53,7 +53,7 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   Status Append(std::nullptr_t) { return AppendNull(); }
 
-  Status AppendArraySliceUnchecked(const ArrayData&, int64_t, int64_t length) override {
+  Status AppendArraySlice(const ArrayData&, int64_t, int64_t length) override {
     return AppendNulls(length);
   }
 
@@ -275,8 +275,8 @@ class NumericBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     return AppendValues(array.GetValues<value_type>(1) + offset, length,
                         array.GetValues<uint8_t>(0, 0), array.offset + offset);
   }
@@ -493,8 +493,8 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
 
   Status AppendValues(int64_t length, bool value);
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, int64_t offset,
-                                   int64_t length) override {
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override {
     return AppendValues(array.GetValues<uint8_t>(1, 0), length,
                         array.GetValues<uint8_t>(0, 0), array.offset + offset);
   }

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -45,6 +45,22 @@ Status BasicUnionBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
+Status DenseUnionBuilder::AppendArraySliceUnchecked(const ArrayData& array,
+                                                    const int64_t offset,
+                                                    const int64_t length) {
+  const int8_t* type_codes = array.GetValues<int8_t>(1);
+  const int32_t* offsets = array.GetValues<int32_t>(2);
+  for (int64_t row = offset; row < offset + length; row++) {
+    const int8_t type_code = type_codes[row];
+    const int child_id = type_id_to_child_id_[type_code];
+    const int32_t union_offset = offsets[row];
+    ARROW_RETURN_NOT_OK(Append(type_code));
+    ARROW_RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySliceUnchecked(
+        *array.child_data[child_id], union_offset, /*length=*/1));
+  }
+  return Status::OK();
+}
+
 Status DenseUnionBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   ARROW_RETURN_NOT_OK(BasicUnionBuilder::FinishInternal(out));
   (*out)->buffers.resize(3);
@@ -120,6 +136,18 @@ int8_t BasicUnionBuilder::NextTypeId() {
   type_id_to_child_id_.resize(type_id_to_child_id_.size() + 1);
   type_id_to_children_.resize(type_id_to_children_.size() + 1);
   return dense_type_id_++;
+}
+
+Status SparseUnionBuilder::AppendArraySliceUnchecked(const ArrayData& array,
+                                                     const int64_t offset,
+                                                     const int64_t length) {
+  for (size_t i = 0; i < type_codes_.size(); i++) {
+    type_id_to_children_[type_codes_[i]]->AppendArraySliceUnchecked(
+        *array.child_data[i], array.offset + offset, length);
+  }
+  const int8_t* type_codes = array.GetValues<int8_t>(1);
+  types_builder_.Append(type_codes + offset, length);
+  return Status::OK();
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -144,7 +144,7 @@ Status SparseUnionBuilder::AppendArraySlice(const ArrayData& array, const int64_
         *array.child_data[i], array.offset + offset, length));
   }
   const int8_t* type_codes = array.GetValues<int8_t>(1);
-  types_builder_.Append(type_codes + offset, length);
+  RETURN_NOT_OK(types_builder_.Append(type_codes + offset, length));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -64,6 +64,7 @@ BasicUnionBuilder::BasicUnionBuilder(
   type_codes_ = union_type.type_codes();
   children_ = children;
 
+  type_id_to_child_id_.resize(union_type.max_type_code() + 1, -1);
   type_id_to_children_.resize(union_type.max_type_code() + 1, nullptr);
   DCHECK_LE(
       type_id_to_children_.size() - 1,
@@ -73,6 +74,7 @@ BasicUnionBuilder::BasicUnionBuilder(
     child_fields_[i] = union_type.field(static_cast<int>(i));
 
     auto type_id = union_type.type_codes()[i];
+    type_id_to_child_id_[type_id] = i;
     type_id_to_children_[type_id] = children[i].get();
   }
 }
@@ -82,6 +84,7 @@ int8_t BasicUnionBuilder::AppendChild(const std::shared_ptr<ArrayBuilder>& new_c
   children_.push_back(new_child);
   auto new_type_id = NextTypeId();
 
+  type_id_to_child_id_[new_type_id] = static_cast<int>(children_.size() - 1);
   type_id_to_children_[new_type_id] = new_child.get();
   child_fields_.push_back(field(field_name, nullptr));
   type_codes_.push_back(static_cast<int8_t>(new_type_id));
@@ -114,6 +117,7 @@ int8_t BasicUnionBuilder::NextTypeId() {
       static_cast<decltype(type_id_to_children_)::size_type>(UnionType::kMaxTypeCode));
 
   // type_id_to_children_ is already densely packed, so just append the new child
+  type_id_to_child_id_.resize(type_id_to_child_id_.size() + 1);
   type_id_to_children_.resize(type_id_to_children_.size() + 1);
   return dense_type_id_++;
 }

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -89,7 +89,7 @@ BasicUnionBuilder::BasicUnionBuilder(
     child_fields_[i] = union_type.field(static_cast<int>(i));
 
     auto type_id = union_type.type_codes()[i];
-    type_id_to_child_id_[type_id] = i;
+    type_id_to_child_id_[type_id] = static_cast<int>(i);
     type_id_to_children_[type_id] = children[i].get();
   }
 }

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -53,8 +53,8 @@ Status DenseUnionBuilder::AppendArraySlice(const ArrayData& array, const int64_t
     const int8_t type_code = type_codes[row];
     const int child_id = type_id_to_child_id_[type_code];
     const int32_t union_offset = offsets[row];
-    ARROW_RETURN_NOT_OK(Append(type_code));
-    ARROW_RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySlice(
+    RETURN_NOT_OK(Append(type_code));
+    RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySlice(
         *array.child_data[child_id], union_offset, /*length=*/1));
   }
   return Status::OK();
@@ -140,8 +140,8 @@ int8_t BasicUnionBuilder::NextTypeId() {
 Status SparseUnionBuilder::AppendArraySlice(const ArrayData& array, const int64_t offset,
                                             const int64_t length) {
   for (size_t i = 0; i < type_codes_.size(); i++) {
-    type_id_to_children_[type_codes_[i]]->AppendArraySlice(*array.child_data[i],
-                                                           array.offset + offset, length);
+    RETURN_NOT_OK(type_id_to_children_[type_codes_[i]]->AppendArraySlice(
+        *array.child_data[i], array.offset + offset, length));
   }
   const int8_t* type_codes = array.GetValues<int8_t>(1);
   types_builder_.Append(type_codes + offset, length);

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -156,8 +156,8 @@ class ARROW_EXPORT DenseUnionBuilder : public BasicUnionBuilder {
     return offsets_builder_.Append(offset);
   }
 
-  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
-                          const int64_t length) override;
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override;
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
@@ -235,8 +235,8 @@ class ARROW_EXPORT SparseUnionBuilder : public BasicUnionBuilder {
   /// is called, and all other child builders must have null or empty value appended.
   Status Append(int8_t next_type) { return types_builder_.Append(next_type); }
 
-  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
-                          const int64_t length) override;
+  Status AppendArraySlice(const ArrayData& array, int64_t offset,
+                          int64_t length) override;
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -157,19 +157,7 @@ class ARROW_EXPORT DenseUnionBuilder : public BasicUnionBuilder {
   }
 
   Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
-                                   const int64_t length) override {
-    const int8_t* type_codes = array.GetValues<int8_t>(1);
-    const int32_t* offsets = array.GetValues<int32_t>(2);
-    for (int64_t row = offset; row < offset + length; row++) {
-      const int8_t type_code = type_codes[row];
-      const int child_id = type_id_to_child_id_[type_code];
-      const int32_t union_offset = offsets[row];
-      ARROW_RETURN_NOT_OK(Append(type_code));
-      ARROW_RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySliceUnchecked(
-          *array.child_data[child_id], union_offset, /*length=*/1));
-    }
-    return Status::OK();
-  }
+                                   const int64_t length) override;
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
@@ -248,15 +236,7 @@ class ARROW_EXPORT SparseUnionBuilder : public BasicUnionBuilder {
   Status Append(int8_t next_type) { return types_builder_.Append(next_type); }
 
   Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
-                                   const int64_t length) override {
-    for (size_t i = 0; i < type_codes_.size(); i++) {
-      type_id_to_children_[type_codes_[i]]->AppendArraySliceUnchecked(
-          *array.child_data[i], array.offset + offset, length);
-    }
-    const int8_t* type_codes = array.GetValues<int8_t>(1);
-    types_builder_.Append(type_codes + offset, length);
-    return Status::OK();
-  }
+                                   const int64_t length) override;
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -156,8 +156,8 @@ class ARROW_EXPORT DenseUnionBuilder : public BasicUnionBuilder {
     return offsets_builder_.Append(offset);
   }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
-                                   const int64_t length) override;
+  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
+                          const int64_t length) override;
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
@@ -235,8 +235,8 @@ class ARROW_EXPORT SparseUnionBuilder : public BasicUnionBuilder {
   /// is called, and all other child builders must have null or empty value appended.
   Status Append(int8_t next_type) { return types_builder_.Append(next_type); }
 
-  Status AppendArraySliceUnchecked(const ArrayData& array, const int64_t offset,
-                                   const int64_t length) override;
+  Status AppendArraySlice(const ArrayData& array, const int64_t offset,
+                          const int64_t length) override;
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -164,8 +164,8 @@ class ARROW_EXPORT DenseUnionBuilder : public BasicUnionBuilder {
       const int8_t type_code = type_codes[row];
       const int child_id = type_id_to_child_id_[type_code];
       const int32_t union_offset = offsets[row];
-      RETURN_NOT_OK(Append(type_code));
-      RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySliceUnchecked(
+      ARROW_RETURN_NOT_OK(Append(type_code));
+      ARROW_RETURN_NOT_OK(type_id_to_children_[type_code]->AppendArraySliceUnchecked(
           *array.child_data[child_id], union_offset, /*length=*/1));
     }
     return Status::OK();

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -445,9 +445,8 @@ class NullArrayFactory {
     out_->buffers[1] = buffer_;
     // buffer_ is zeroed, but 0 may not be a valid type code
     if (type.type_codes()[0] != 0) {
-      ARROW_ASSIGN_OR_RAISE(out_->buffers[1], AllocateBuffer(buffer_->size(), pool_));
-      std::memset(out_->buffers[1]->mutable_data(), type.type_codes()[0],
-                  buffer_->size());
+      ARROW_ASSIGN_OR_RAISE(out_->buffers[1], AllocateBuffer(length_, pool_));
+      std::memset(out_->buffers[1]->mutable_data(), type.type_codes()[0], length_);
     }
 
     // For sparse unions, we now create children with the same length as the

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -28,6 +28,7 @@
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_generate.h"
+#include "arrow/util/bitmap_ops.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/util/visibility.h"
@@ -339,6 +340,7 @@ class TypedBufferBuilder<bool> {
     ++bit_length_;
   }
 
+  /// \brief Append bits from an array of bytes (one value per byte)
   void UnsafeAppend(const uint8_t* bytes, int64_t num_elements) {
     if (num_elements == 0) return;
     int64_t i = 0;
@@ -350,14 +352,11 @@ class TypedBufferBuilder<bool> {
     bit_length_ += num_elements;
   }
 
+  /// \brief Append bits from a packed bitmap
   void UnsafeAppend(const uint8_t* bitmap, int64_t offset, int64_t num_elements) {
     if (num_elements == 0) return;
-    int64_t i = offset;
-    internal::GenerateBitsUnrolled(mutable_data(), bit_length_, num_elements, [&] {
-      bool value = BitUtil::GetBit(bitmap, i++);
-      false_count_ += !value;
-      return value;
-    });
+    internal::CopyBitmap(bitmap, offset, num_elements, mutable_data(), bit_length_);
+    false_count_ += num_elements - internal::CountSetBits(bitmap, offset, num_elements);
     bit_length_ += num_elements;
   }
 

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -350,6 +350,17 @@ class TypedBufferBuilder<bool> {
     bit_length_ += num_elements;
   }
 
+  void UnsafeAppend(const uint8_t* bitmap, int64_t offset, int64_t num_elements) {
+    if (num_elements == 0) return;
+    int64_t i = offset;
+    internal::GenerateBitsUnrolled(mutable_data(), bit_length_, num_elements, [&] {
+      bool value = BitUtil::GetBit(bitmap, i++);
+      false_count_ += !value;
+      return value;
+    });
+    bit_length_ += num_elements;
+  }
+
   void UnsafeAppend(const int64_t num_copies, bool value) {
     BitUtil::SetBitsTo(mutable_data(), bit_length_, num_copies, value);
     false_count_ += num_copies * !value;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1880,7 +1880,7 @@ struct CaseWhenFunctor<MapType> {
     return ExecVarWidthArrayCaseWhen(
         ctx, batch, out,
         // ReserveData
-        [](ArrayBuilder*) {},
+        [](ArrayBuilder*) { return Status::OK(); },
         // AppendScalar
         [](ArrayBuilder* raw_builder, const Scalar& scalar) {
           return raw_builder->AppendScalar(scalar);
@@ -1919,7 +1919,7 @@ struct CaseWhenFunctor<StructType> {
     return ExecVarWidthArrayCaseWhen(
         ctx, batch, out,
         // ReserveData
-        [](ArrayBuilder*) {},
+        [](ArrayBuilder*) { return Status::OK(); },
         // AppendScalar
         [](ArrayBuilder* raw_builder, const Scalar& scalar) {
           return raw_builder->AppendScalar(scalar);

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1610,6 +1610,9 @@ struct CaseWhenFunctor<Type, enable_if_var_size_list<Type>> {
   }
 };
 
+// No-op reserve function, pulled out to avoid apparent miscompilation on MinGW
+Status ReserveNoData(ArrayBuilder*) { return Status::OK(); }
+
 template <>
 struct CaseWhenFunctor<MapType> {
   static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
@@ -1623,9 +1626,7 @@ struct CaseWhenFunctor<MapType> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
-      return Status::OK();
-    };
+    std::function<Status(ArrayBuilder*)> reserve_data = ReserveNoData;
     return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };
@@ -1643,9 +1644,7 @@ struct CaseWhenFunctor<StructType> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
-      return Status::OK();
-    };
+    std::function<Status(ArrayBuilder*)> reserve_data = ReserveNoData;
     return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };
@@ -1690,9 +1689,7 @@ struct CaseWhenFunctor<Type, enable_if_union<Type>> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
-      return Status::OK();
-    };
+    std::function<Status(ArrayBuilder*)> reserve_data = ReserveNoData;
     return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1471,7 +1471,7 @@ static Status ExecVarWidthArrayCaseWhen(KernelContext* ctx, const ExecBatch& bat
   RETURN_NOT_OK(reserve_data(raw_builder.get()));
 
   for (int64_t row = 0; row < batch.length; row++) {
-    int64_t selected = have_else_arg ? batch.values.size() - 1 : -1;
+    int64_t selected = have_else_arg ? static_cast<int64_t>(batch.values.size() - 1) : -1;
     for (int64_t arg = 0; static_cast<size_t>(arg) < conds_array.child_data.size();
          arg++) {
       const ArrayData& cond_array = *conds_array.child_data[arg];

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1468,7 +1468,7 @@ static Status ExecVarWidthArrayCaseWhen(KernelContext* ctx, const ExecBatch& bat
   std::unique_ptr<ArrayBuilder> raw_builder;
   RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(), out->type(), &raw_builder));
   RETURN_NOT_OK(raw_builder->Reserve(batch.length));
-  reserve_data(raw_builder.get());
+  RETURN_NOT_OK(reserve_data(raw_builder.get()));
 
   for (int64_t row = 0; row < batch.length; row++) {
     int64_t selected = have_else_arg ? batch.values.size() - 1 : -1;
@@ -1653,8 +1653,8 @@ struct GetAppenders {
       auto data = array->GetValues<uint8_t>(2, 0);
       for (int64_t i = 0; i < length; i++) {
         if (!bitmap || BitUtil::GetBit(bitmap, offset + i)) {
-          const int32_t start = offsets[offset + i];
-          const int32_t end = offsets[offset + i + 1];
+          const offset_type start = offsets[offset + i];
+          const offset_type end = offsets[offset + i + 1];
           RETURN_NOT_OK(builder->Append(data + start, end - start));
         } else {
           RETURN_NOT_OK(builder->AppendNull());

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1623,9 +1623,10 @@ struct CaseWhenFunctor<MapType> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    return ExecVarWidthArrayCaseWhen(ctx, batch, out,
-                                     // ReserveData
-                                     [](ArrayBuilder*) { return Status::OK(); });
+    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
+      return Status::OK();
+    };
+    return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };
 
@@ -1642,9 +1643,10 @@ struct CaseWhenFunctor<StructType> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    return ExecVarWidthArrayCaseWhen(ctx, batch, out,
-                                     // ReserveData
-                                     [](ArrayBuilder*) { return Status::OK(); });
+    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
+      return Status::OK();
+    };
+    return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };
 
@@ -1688,10 +1690,10 @@ struct CaseWhenFunctor<Type, enable_if_union<Type>> {
   }
 
   static Status ExecArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    return ExecVarWidthArrayCaseWhen(
-        ctx, batch, out,
-        // ReserveData
-        [&](ArrayBuilder* raw_builder) { return Status::OK(); });
+    std::function<Status(ArrayBuilder*)> reserve_data = [](ArrayBuilder*) {
+      return Status::OK();
+    };
+    return ExecVarWidthArrayCaseWhen(ctx, batch, out, std::move(reserve_data));
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1580,7 +1580,8 @@ struct CaseWhenFunctor<Type, enable_if_base_binary<Type>> {
         [](ArrayBuilder* raw_builder, const Scalar& raw_scalar) {
           const auto& scalar = checked_cast<const BaseBinaryScalar&>(raw_scalar);
           return checked_cast<BuilderType*>(raw_builder)
-              ->Append(scalar.value->data(), scalar.value->size());
+              ->Append(scalar.value->data(),
+                       static_cast<offset_type>(scalar.value->size()));
         },
         // AppendArray
         [](ArrayBuilder* raw_builder, const std::shared_ptr<ArrayData>& array,

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1499,7 +1499,7 @@ static Status ExecVarWidthArrayCaseWhenImpl(
       const auto& array = source.array();
       if (!array->buffers[0] ||
           BitUtil::GetBit(array->buffers[0]->data(), array->offset + row)) {
-        RETURN_NOT_OK(raw_builder->AppendArraySliceUnchecked(*array, row, /*length=*/1));
+        RETURN_NOT_OK(raw_builder->AppendArraySlice(*array, row, /*length=*/1));
       } else {
         RETURN_NOT_OK(raw_builder->AppendNull());
       }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1417,8 +1417,8 @@ struct CaseWhenFunctor<NullType> {
   }
 };
 
-static Status ExecVarWidthScalarCaseWhen(KernelContext* ctx, const ExecBatch& batch,
-                                         Datum* out) {
+Status ExecVarWidthScalarCaseWhen(KernelContext* ctx, const ExecBatch& batch,
+                                  Datum* out) {
   const auto& conds = checked_cast<const StructScalar&>(*batch.values[0].scalar());
   Datum result;
   for (size_t i = 0; i < batch.values.size() - 1; i++) {
@@ -1435,6 +1435,7 @@ static Status ExecVarWidthScalarCaseWhen(KernelContext* ctx, const ExecBatch& ba
     }
   }
   if (out->is_scalar()) {
+    DCHECK(result.is_scalar() || result.kind() == Datum::NONE);
     *out = result.is_scalar() ? result.scalar() : MakeNullScalar(out->type());
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -159,12 +159,6 @@ static void CaseWhenBench(benchmark::State& state) {
 
   random::RandomArrayGenerator rand(/*seed=*/0);
 
-  auto cond1 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
-  auto cond2 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
-  auto cond3 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
   auto cond_field =
       field("cond", boolean(), key_value_metadata({{"null_probability", "0.01"}}));
   auto cond = rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),
@@ -198,12 +192,6 @@ static void CaseWhenBenchList(benchmark::State& state) {
 
   random::RandomArrayGenerator rand(/*seed=*/0);
 
-  auto cond1 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
-  auto cond2 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
-  auto cond3 = std::static_pointer_cast<BooleanArray>(
-      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
   auto cond_field =
       field("cond", boolean(), key_value_metadata({{"null_probability", "0.01"}}));
   auto cond = rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -27,32 +27,31 @@ namespace arrow {
 namespace compute {
 
 const int64_t kNumItems = 1024 * 1024;
+const int64_t kFewItems = 64 * 1024;
 
 template <typename Type, typename Enable = void>
-struct SetBytesProcessed {};
+struct GetBytesProcessed {};
+
+template <>
+struct GetBytesProcessed<BooleanType> {
+  static int64_t Get(const std::shared_ptr<Array>& arr) { return arr->length() / 8; }
+};
 
 template <typename Type>
-struct SetBytesProcessed<Type, enable_if_number<Type>> {
-  static void Set(const std::shared_ptr<Array>& cond, const std::shared_ptr<Array>& left,
-                  const std::shared_ptr<Array>& right, benchmark::State* state) {
+struct GetBytesProcessed<Type, enable_if_number<Type>> {
+  static int64_t Get(const std::shared_ptr<Array>& arr) {
     using CType = typename Type::c_type;
-    state->SetBytesProcessed(state->iterations() *
-                             (cond->length() / 8 + 2 * cond->length() * sizeof(CType)));
+    return arr->length() * sizeof(CType);
   }
 };
 
 template <typename Type>
-struct SetBytesProcessed<Type, enable_if_base_binary<Type>> {
-  static void Set(const std::shared_ptr<Array>& cond, const std::shared_ptr<Array>& left,
-                  const std::shared_ptr<Array>& right, benchmark::State* state) {
+struct GetBytesProcessed<Type, enable_if_base_binary<Type>> {
+  static int64_t Get(const std::shared_ptr<Array>& arr) {
     using ArrayType = typename TypeTraits<Type>::ArrayType;
     using OffsetType = typename TypeTraits<Type>::OffsetType::c_type;
-
-    state->SetBytesProcessed(
-        state->iterations() *
-        (cond->length() / 8 + 2 * cond->length() * sizeof(OffsetType) +
-         std::static_pointer_cast<ArrayType>(left)->total_values_length() +
-         std::static_pointer_cast<ArrayType>(right)->total_values_length()));
+    return arr->length() * sizeof(OffsetType) +
+           std::static_pointer_cast<ArrayType>(arr)->total_values_length();
   }
 };
 
@@ -80,7 +79,10 @@ static void IfElseBench(benchmark::State& state) {
     ABORT_NOT_OK(IfElse(cond, left, right));
   }
 
-  SetBytesProcessed<Type>::Set(cond, left, right, &state);
+  state.SetBytesProcessed(state.iterations() *
+                          (GetBytesProcessed<BooleanType>::Get(cond) +
+                           GetBytesProcessed<Type>::Get(left) +
+                           GetBytesProcessed<Type>::Get(right)));
 }
 
 template <typename Type>
@@ -109,7 +111,10 @@ static void IfElseBenchContiguous(benchmark::State& state) {
     ABORT_NOT_OK(IfElse(cond, left, right));
   }
 
-  SetBytesProcessed<Type>::Set(cond, left, right, &state);
+  state.SetBytesProcessed(state.iterations() *
+                          (GetBytesProcessed<BooleanType>::Get(cond) +
+                           GetBytesProcessed<Type>::Get(left) +
+                           GetBytesProcessed<Type>::Get(right)));
 }
 
 static void IfElseBench64(benchmark::State& state) {
@@ -146,7 +151,6 @@ static void IfElseBenchString32Contiguous(benchmark::State& state) {
 
 template <typename Type>
 static void CaseWhenBench(benchmark::State& state) {
-  using CType = typename Type::c_type;
   auto type = TypeTraits<Type>::type_singleton();
   using ArrayType = typename TypeTraits<Type>::ArrayType;
 
@@ -180,12 +184,50 @@ static void CaseWhenBench(benchmark::State& state) {
                                        val3->Slice(offset), val4->Slice(offset)}));
   }
 
-  state.SetBytesProcessed(state.iterations() * (len - offset) * sizeof(CType));
+  // Set bytes processed to ~length of output
+  state.SetBytesProcessed(state.iterations() * GetBytesProcessed<Type>::Get(val1));
+  state.SetItemsProcessed(state.iterations() * (len - offset));
+}
+
+static void CaseWhenBenchList(benchmark::State& state) {
+  auto type = list(int64());
+  auto fld = field("", type);
+
+  int64_t len = state.range(0);
+  int64_t offset = state.range(1);
+
+  random::RandomArrayGenerator rand(/*seed=*/0);
+
+  auto cond1 = std::static_pointer_cast<BooleanArray>(
+      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
+  auto cond2 = std::static_pointer_cast<BooleanArray>(
+      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
+  auto cond3 = std::static_pointer_cast<BooleanArray>(
+      rand.ArrayOf(boolean(), len, /*null_probability=*/0.01));
+  auto cond_field =
+      field("cond", boolean(), key_value_metadata({{"null_probability", "0.01"}}));
+  auto cond = rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),
+                                  key_value_metadata({{"null_probability", "0.0"}})),
+                           len);
+  auto val1 = rand.ArrayOf(*fld, len);
+  auto val2 = rand.ArrayOf(*fld, len);
+  auto val3 = rand.ArrayOf(*fld, len);
+  auto val4 = rand.ArrayOf(*fld, len);
+  for (auto _ : state) {
+    ABORT_NOT_OK(
+        CaseWhen(cond->Slice(offset), {val1->Slice(offset), val2->Slice(offset),
+                                       val3->Slice(offset), val4->Slice(offset)}));
+  }
+
+  // Set bytes processed to ~length of output
+  state.SetBytesProcessed(state.iterations() *
+                          GetBytesProcessed<Int64Type>::Get(
+                              std::static_pointer_cast<ListArray>(val1)->values()));
+  state.SetItemsProcessed(state.iterations() * (len - offset));
 }
 
 template <typename Type>
 static void CaseWhenBenchContiguous(benchmark::State& state) {
-  using CType = typename Type::c_type;
   auto type = TypeTraits<Type>::type_singleton();
   using ArrayType = typename TypeTraits<Type>::ArrayType;
 
@@ -216,7 +258,9 @@ static void CaseWhenBenchContiguous(benchmark::State& state) {
                                                 val3->Slice(offset)}));
   }
 
-  state.SetBytesProcessed(state.iterations() * (len - offset) * sizeof(CType));
+  // Set bytes processed to ~length of output
+  state.SetBytesProcessed(state.iterations() * GetBytesProcessed<Type>::Get(val1));
+  state.SetItemsProcessed(state.iterations() * (len - offset));
 }
 
 static void CaseWhenBench64(benchmark::State& state) {
@@ -225,6 +269,14 @@ static void CaseWhenBench64(benchmark::State& state) {
 
 static void CaseWhenBench64Contiguous(benchmark::State& state) {
   return CaseWhenBenchContiguous<UInt64Type>(state);
+}
+
+static void CaseWhenBenchString(benchmark::State& state) {
+  return CaseWhenBench<StringType>(state);
+}
+
+static void CaseWhenBenchStringContiguous(benchmark::State& state) {
+  return CaseWhenBenchContiguous<StringType>(state);
 }
 
 template <typename Type>
@@ -336,6 +388,15 @@ BENCHMARK(CaseWhenBench64)->Args({kNumItems, 99});
 
 BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 0});
 BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 99});
+
+BENCHMARK(CaseWhenBenchList)->Args({kFewItems, 0});
+BENCHMARK(CaseWhenBenchList)->Args({kFewItems, 99});
+
+BENCHMARK(CaseWhenBenchString)->Args({kFewItems, 0});
+BENCHMARK(CaseWhenBenchString)->Args({kFewItems, 99});
+
+BENCHMARK(CaseWhenBenchStringContiguous)->Args({kFewItems, 0});
+BENCHMARK(CaseWhenBenchStringContiguous)->Args({kFewItems, 99});
 
 BENCHMARK(CoalesceBench64)->Args({kNumItems, 0});
 BENCHMARK(CoalesceBench64)->Args({kNumItems, 99});

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -886,47 +886,48 @@ TYPED_TEST(TestCaseWhenBinary, Basics) {
   auto values1 = ArrayFromJSON(type, R"(["cDE", null, "degfhi", "efg"])");
   auto values2 = ArrayFromJSON(type, R"(["fghijk", "ghi", null, "hi"])");
 
-  CheckScalar("case_when", {MakeStruct({}), values1}, values1);
-  CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
+  // CheckScalar("case_when", {MakeStruct({}), values1}, values1);
+  // CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
 
-  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
-              *MakeArrayFromScalar(*scalar1, 4));
-  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+  // CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+  //             *MakeArrayFromScalar(*scalar1, 4));
+  // CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
 
-  CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
-  CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
-  CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
-  CheckScalar("case_when", {MakeStruct({cond_true}), values1, values2}, values1);
-  CheckScalar("case_when", {MakeStruct({cond_false}), values1, values2}, values2);
-  CheckScalar("case_when", {MakeStruct({cond_null}), values1, values2}, values2);
+  // CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
+  // CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
+  // CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
+  // CheckScalar("case_when", {MakeStruct({cond_true}), values1, values2}, values1);
+  // CheckScalar("case_when", {MakeStruct({cond_false}), values1, values2}, values2);
+  // CheckScalar("case_when", {MakeStruct({cond_null}), values1, values2}, values2);
 
-  CheckScalar("case_when", {MakeStruct({cond_true, cond_true}), values1, values2},
-              values1);
-  CheckScalar("case_when", {MakeStruct({cond_false, cond_false}), values1, values2},
-              values_null);
-  CheckScalar("case_when", {MakeStruct({cond_true, cond_false}), values1, values2},
-              values1);
-  CheckScalar("case_when", {MakeStruct({cond_false, cond_true}), values1, values2},
-              values2);
-  CheckScalar("case_when", {MakeStruct({cond_null, cond_true}), values1, values2},
-              values2);
-  CheckScalar("case_when",
-              {MakeStruct({cond_false, cond_false}), values1, values2, values2}, values2);
+  // CheckScalar("case_when", {MakeStruct({cond_true, cond_true}), values1, values2},
+  //             values1);
+  // CheckScalar("case_when", {MakeStruct({cond_false, cond_false}), values1, values2},
+  //             values_null);
+  // CheckScalar("case_when", {MakeStruct({cond_true, cond_false}), values1, values2},
+  //             values1);
+  // CheckScalar("case_when", {MakeStruct({cond_false, cond_true}), values1, values2},
+  //             values2);
+  // CheckScalar("case_when", {MakeStruct({cond_null, cond_true}), values1, values2},
+  //             values2);
+  // CheckScalar("case_when",
+  //             {MakeStruct({cond_false, cond_false}), values1, values2, values2},
+  //             values2);
 
-  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2},
-              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", null])"));
-  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null}, values_null);
-  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null, scalar1},
-              ArrayFromJSON(type, R"([null, null, "aBxYz", "aBxYz"])"));
-  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2, scalar1},
-              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", "aBxYz"])"));
+  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2},
+  //             ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", null])"));
+  // CheckScalar("case_when", {MakeStruct({cond1}), scalar_null}, values_null);
+  // CheckScalar("case_when", {MakeStruct({cond1}), scalar_null, scalar1},
+  //             ArrayFromJSON(type, R"([null, null, "aBxYz", "aBxYz"])"));
+  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2, scalar1},
+  //             ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", "aBxYz"])"));
 
-  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
-              ArrayFromJSON(type, R"(["cDE", null, null, null])"));
+  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
+  //             ArrayFromJSON(type, R"(["cDE", null, null, null])"));
   CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
               ArrayFromJSON(type, R"(["cDE", null, null, "efg"])"));
-  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
-              ArrayFromJSON(type, R"([null, null, null, "efg"])"));
+  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
+  //             ArrayFromJSON(type, R"([null, null, null, "efg"])"));
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -886,48 +886,47 @@ TYPED_TEST(TestCaseWhenBinary, Basics) {
   auto values1 = ArrayFromJSON(type, R"(["cDE", null, "degfhi", "efg"])");
   auto values2 = ArrayFromJSON(type, R"(["fghijk", "ghi", null, "hi"])");
 
-  // CheckScalar("case_when", {MakeStruct({}), values1}, values1);
-  // CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
+  CheckScalar("case_when", {MakeStruct({}), values1}, values1);
+  CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
 
-  // CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
-  //             *MakeArrayFromScalar(*scalar1, 4));
-  // CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
 
-  // CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
-  // CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
-  // CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
-  // CheckScalar("case_when", {MakeStruct({cond_true}), values1, values2}, values1);
-  // CheckScalar("case_when", {MakeStruct({cond_false}), values1, values2}, values2);
-  // CheckScalar("case_when", {MakeStruct({cond_null}), values1, values2}, values2);
+  CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
+  CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond_true}), values1, values2}, values1);
+  CheckScalar("case_when", {MakeStruct({cond_false}), values1, values2}, values2);
+  CheckScalar("case_when", {MakeStruct({cond_null}), values1, values2}, values2);
 
-  // CheckScalar("case_when", {MakeStruct({cond_true, cond_true}), values1, values2},
-  //             values1);
-  // CheckScalar("case_when", {MakeStruct({cond_false, cond_false}), values1, values2},
-  //             values_null);
-  // CheckScalar("case_when", {MakeStruct({cond_true, cond_false}), values1, values2},
-  //             values1);
-  // CheckScalar("case_when", {MakeStruct({cond_false, cond_true}), values1, values2},
-  //             values2);
-  // CheckScalar("case_when", {MakeStruct({cond_null, cond_true}), values1, values2},
-  //             values2);
-  // CheckScalar("case_when",
-  //             {MakeStruct({cond_false, cond_false}), values1, values2, values2},
-  //             values2);
+  CheckScalar("case_when", {MakeStruct({cond_true, cond_true}), values1, values2},
+              values1);
+  CheckScalar("case_when", {MakeStruct({cond_false, cond_false}), values1, values2},
+              values_null);
+  CheckScalar("case_when", {MakeStruct({cond_true, cond_false}), values1, values2},
+              values1);
+  CheckScalar("case_when", {MakeStruct({cond_false, cond_true}), values1, values2},
+              values2);
+  CheckScalar("case_when", {MakeStruct({cond_null, cond_true}), values1, values2},
+              values2);
+  CheckScalar("case_when",
+              {MakeStruct({cond_false, cond_false}), values1, values2, values2}, values2);
 
-  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2},
-  //             ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", null])"));
-  // CheckScalar("case_when", {MakeStruct({cond1}), scalar_null}, values_null);
-  // CheckScalar("case_when", {MakeStruct({cond1}), scalar_null, scalar1},
-  //             ArrayFromJSON(type, R"([null, null, "aBxYz", "aBxYz"])"));
-  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2, scalar1},
-  //             ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", "aBxYz"])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2},
+              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", null])"));
+  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null, scalar1},
+              ArrayFromJSON(type, R"([null, null, "aBxYz", "aBxYz"])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2, scalar1},
+              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", "aBxYz"])"));
 
-  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
-  //             ArrayFromJSON(type, R"(["cDE", null, null, null])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
+              ArrayFromJSON(type, R"(["cDE", null, null, null])"));
   CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
               ArrayFromJSON(type, R"(["cDE", null, null, "efg"])"));
-  // CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
-  //             ArrayFromJSON(type, R"([null, null, null, "efg"])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
+              ArrayFromJSON(type, R"([null, null, null, "efg"])"));
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -531,6 +531,10 @@ TYPED_TEST(TestCaseWhenNumeric, FixedSize) {
   CheckScalar("case_when", {MakeStruct({}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
 
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+
   CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
   CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
@@ -632,6 +636,10 @@ TEST(TestCaseWhen, Boolean) {
   CheckScalar("case_when", {MakeStruct({}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
 
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+
   CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
   CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
@@ -684,6 +692,10 @@ TEST(TestCaseWhen, DayTimeInterval) {
 
   CheckScalar("case_when", {MakeStruct({}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
+
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
 
   CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
@@ -738,6 +750,10 @@ TEST(TestCaseWhen, Decimal) {
 
     CheckScalar("case_when", {MakeStruct({}), values1}, values1);
     CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
+
+    CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+                *MakeArrayFromScalar(*scalar1, 4));
+    CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
 
     CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
     CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
@@ -794,6 +810,10 @@ TEST(TestCaseWhen, FixedSizeBinary) {
   CheckScalar("case_when", {MakeStruct({}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
 
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+
   CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
   CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
   CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
@@ -826,6 +846,68 @@ TEST(TestCaseWhen, FixedSizeBinary) {
               ArrayFromJSON(type, R"(["cde", null, null, null])"));
   CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
               ArrayFromJSON(type, R"(["cde", null, null, "efg"])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
+              ArrayFromJSON(type, R"([null, null, null, "efg"])"));
+}
+
+template <typename Type>
+class TestCaseWhenBinary : public ::testing::Test {};
+
+TYPED_TEST_SUITE(TestCaseWhenBinary, BinaryTypes);
+
+TYPED_TEST(TestCaseWhenBinary, Basics) {
+  auto type = default_type_instance<TypeParam>();
+  auto cond_true = ScalarFromJSON(boolean(), "true");
+  auto cond_false = ScalarFromJSON(boolean(), "false");
+  auto cond_null = ScalarFromJSON(boolean(), "null");
+  auto cond1 = ArrayFromJSON(boolean(), "[true, true, null, null]");
+  auto cond2 = ArrayFromJSON(boolean(), "[true, false, true, null]");
+  auto scalar_null = ScalarFromJSON(type, "null");
+  auto scalar1 = ScalarFromJSON(type, R"("aBxYz")");
+  auto scalar2 = ScalarFromJSON(type, R"("b")");
+  auto values_null = ArrayFromJSON(type, "[null, null, null, null]");
+  auto values1 = ArrayFromJSON(type, R"(["cDE", null, "degfhi", "efg"])");
+  auto values2 = ArrayFromJSON(type, R"(["fghijk", "ghi", null, "hi"])");
+
+  CheckScalar("case_when", {MakeStruct({}), values1}, values1);
+  CheckScalar("case_when", {MakeStruct({}), values_null}, values_null);
+
+  CheckScalar("case_when", {MakeStruct({cond_true}), scalar1, values1},
+              *MakeArrayFromScalar(*scalar1, 4));
+  CheckScalar("case_when", {MakeStruct({cond_false}), scalar1, values1}, values1);
+
+  CheckScalar("case_when", {MakeStruct({cond_true}), values1}, values1);
+  CheckScalar("case_when", {MakeStruct({cond_false}), values1}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond_null}), values1}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond_true}), values1, values2}, values1);
+  CheckScalar("case_when", {MakeStruct({cond_false}), values1, values2}, values2);
+  CheckScalar("case_when", {MakeStruct({cond_null}), values1, values2}, values2);
+
+  CheckScalar("case_when", {MakeStruct({cond_true, cond_true}), values1, values2},
+              values1);
+  CheckScalar("case_when", {MakeStruct({cond_false, cond_false}), values1, values2},
+              values_null);
+  CheckScalar("case_when", {MakeStruct({cond_true, cond_false}), values1, values2},
+              values1);
+  CheckScalar("case_when", {MakeStruct({cond_false, cond_true}), values1, values2},
+              values2);
+  CheckScalar("case_when", {MakeStruct({cond_null, cond_true}), values1, values2},
+              values2);
+  CheckScalar("case_when",
+              {MakeStruct({cond_false, cond_false}), values1, values2, values2}, values2);
+
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2},
+              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", null])"));
+  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null}, values_null);
+  CheckScalar("case_when", {MakeStruct({cond1}), scalar_null, scalar1},
+              ArrayFromJSON(type, R"([null, null, "aBxYz", "aBxYz"])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), scalar1, scalar2, scalar1},
+              ArrayFromJSON(type, R"(["aBxYz", "aBxYz", "b", "aBxYz"])"));
+
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
+              ArrayFromJSON(type, R"(["cDE", null, null, null])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
+              ArrayFromJSON(type, R"(["cDE", null, null, "efg"])"));
   CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
               ArrayFromJSON(type, R"([null, null, null, "efg"])"));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -977,6 +977,41 @@ TYPED_TEST(TestCaseWhenList, ListOfString) {
               ArrayFromJSON(type, R"([null, null, null, ["ef", "g"]])"));
 }
 
+TYPED_TEST(TestCaseWhenList, ListOfInt) {
+  // More minimal test to check type coverage
+  auto type = std::make_shared<TypeParam>(int64());
+  auto cond1 = ArrayFromJSON(boolean(), "[true, true, null, null]");
+  auto cond2 = ArrayFromJSON(boolean(), "[true, false, true, null]");
+  auto values_null = ArrayFromJSON(type, "[null, null, null, null]");
+  auto values1 = ArrayFromJSON(type, R"([[1, 2], null, [3, 4, 5], [6, null]])");
+  auto values2 = ArrayFromJSON(type, R"([[8, 9, 10], [11], null, [12]])");
+
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
+              ArrayFromJSON(type, R"([[1, 2], null, null, null])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
+              ArrayFromJSON(type, R"([[1, 2], null, null, [6, null]])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
+              ArrayFromJSON(type, R"([null, null, null, [6, null]])"));
+}
+
+TYPED_TEST(TestCaseWhenList, ListOfListOfInt) {
+  // More minimal test to check type coverage
+  auto type = std::make_shared<TypeParam>(list(int64()));
+  auto cond1 = ArrayFromJSON(boolean(), "[true, true, null, null]");
+  auto cond2 = ArrayFromJSON(boolean(), "[true, false, true, null]");
+  auto values_null = ArrayFromJSON(type, "[null, null, null, null]");
+  auto values1 =
+      ArrayFromJSON(type, R"([[[1, 2], []], null, [[3, 4, 5]], [[6, null], null]])");
+  auto values2 = ArrayFromJSON(type, R"([[[8, 9, 10]], [[11]], null, [[12]]])");
+
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2},
+              ArrayFromJSON(type, R"([[[1, 2], []], null, null, null])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values1, values2, values1},
+              ArrayFromJSON(type, R"([[[1, 2], []], null, null, [[6, null], null]])"));
+  CheckScalar("case_when", {MakeStruct({cond1, cond2}), values_null, values2, values1},
+              ArrayFromJSON(type, R"([null, null, null, [[6, null], null]])"));
+}
+
 TEST(TestCaseWhen, Map) {
   auto type = map(int64(), utf8());
   auto cond_true = ScalarFromJSON(boolean(), "true");

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -170,6 +170,8 @@ using BinaryArrowTypes =
 
 using StringArrowTypes = ::testing::Types<StringType, LargeStringType>;
 
+using ListArrowTypes = ::testing::Types<ListType, LargeListType>;
+
 using UnionArrowTypes = ::testing::Types<SparseUnionType, DenseUnionType>;
 
 class Array;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1005,6 +1005,17 @@ static inline bool is_nested(Type::type type_id) {
   return false;
 }
 
+static inline bool is_union(Type::type type_id) {
+  switch (type_id) {
+    case Type::SPARSE_UNION:
+    case Type::DENSE_UNION:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
 static inline int offset_bit_width(Type::type type_id) {
   switch (type_id) {
     case Type::STRING:

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -902,7 +902,7 @@ Structural transforms
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
 | Function name            | Arity      | Input types                                       | Output type         | Notes   |
 +==========================+============+===================================================+=====================+=========+
-| case_when                | Varargs    | Struct of Boolean (Arg 0), Any fixed-width (rest) | Input type          | \(1)    |
+| case_when                | Varargs    | Struct of Boolean (Arg 0), Any (rest)             | Input type          | \(1)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
 | choose                   | Varargs    | Integral (Arg 0); Fixed-width/Binary-like (rest)  | Input type          | \(2)    |
 +--------------------------+------------+---------------------------------------------------+---------------------+---------+
@@ -935,6 +935,9 @@ Structural transforms
   same type as the value inputs; each row will be the corresponding value from
   the first value datum for which the corresponding Boolean is true, or the
   corresponding value from the 'default' input, or null otherwise.
+
+  Note that currently, while all types are supported, dictionaries will be
+  unpacked.
 
 * \(2) The first input must be an integral type. The rest of the arguments can be
   any type, but must all be the same type or promotable to a common type. Each


### PR DESCRIPTION
This adds support for nearly everything except dictionaries and extension types. Binary types, maps, lists (fixed-size and variable), unions, and structs are supported. The benchmark is also extended to show that performance is not entirely terrible (the first attempt using purely AppendScalar ran at ~50MB/s, this runs at a couple GB/s similar to the other kernel cases). This does leverage AppendScalar for the scalar cases.

Dictionaries are still supported, but will be unpacked. For direct support there's work described in ARROW-13573, but I'd like to validate my approach here before making the changes necessary.
