### PR TITLE
ARROW-13475: [Release] Don't consider rust tarballs when cleaning up old releases

### DIFF
--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -52,7 +52,7 @@ svn add ${tmp_dir}/release/${release_version}
 echo "Keep only the three most recent versions"
 old_releases=$(
   svn ls ${tmp_dir}/release/ | \
-  grep '^arrow-' | \
+  grep -E '^arrow-[0-9\.]+' | \
   sort --version-sort --reverse | \
   tail -n +4
 )


### PR DESCRIPTION
After uploading the source release to apache svn I realized that all of the earlier arrow releases were removed. 
Since we ship rust tarballs separately the regex pattern filtered out all previous apache/arrow releases.

I had to revert the svn repository to the previous revision.