### PR TITLE
ARROW-9948: [C++] Fix scale handling in Decimal{128, 256}::FromString

### DIFF
--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -177,7 +177,7 @@ garrow_decimal_to_bytes(typename DecimalConverter<Decimal>::GArrowType *decimal)
 {
   DecimalConverter<Decimal> converter;
   const auto arrow_decimal = converter.get_raw(decimal);
-  uint8_t data[DecimalConverter<Decimal>::ArrowType::bit_width / 8];
+  uint8_t data[DecimalConverter<Decimal>::ArrowType::kBitWidth / 8];
   arrow_decimal->ToBytes(data);
   return g_bytes_new(data, sizeof(data));
 }

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -830,7 +830,7 @@ static inline DecimalStatus SingleDivide(const uint32_t* dividend,
                                          bool divisor_was_negative,
                                          DecimalClass* result) {
   uint64_t r = 0;
-  constexpr int64_t kDecimalArrayLength = DecimalClass::bit_width / sizeof(uint32_t) + 1;
+  constexpr int64_t kDecimalArrayLength = DecimalClass::kBitWidth / sizeof(uint32_t) + 1;
   uint32_t result_array[kDecimalArrayLength];
   for (int64_t j = 0; j < dividend_length; j++) {
     r <<= 32;
@@ -853,7 +853,7 @@ template <class DecimalClass>
 static inline DecimalStatus DecimalDivide(const DecimalClass& dividend,
                                           const DecimalClass& divisor,
                                           DecimalClass* result, DecimalClass* remainder) {
-  constexpr int64_t kDecimalArrayLength = DecimalClass::bit_width / sizeof(uint32_t);
+  constexpr int64_t kDecimalArrayLength = DecimalClass::kBitWidth / sizeof(uint32_t);
   // Split the dividend and divisor into integer pieces so that we can
   // work on them.
   uint32_t dividend_array[kDecimalArrayLength + 1];

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -62,6 +62,7 @@ class ARROW_EXPORT BasicDecimal128 {
 #endif
 
   /// \brief Create a BasicDecimal256 from the two's complement representation.
+  ///
   /// Input array is assumed to be in native endianness.
 #if ARROW_LITTLE_ENDIAN
   constexpr BasicDecimal128(const std::array<uint64_t, 2>& array) noexcept
@@ -71,7 +72,9 @@ class ARROW_EXPORT BasicDecimal128 {
       : high_bits_(static_cast<int64_t>(array[0])), low_bits_(array[1]) {}
 #endif
 
-  // XXX
+  /// \brief Create a BasicDecimal256 from the two's complement representation.
+  ///
+  /// Input array is assumed to be in little endianness, with native endian elements.
   BasicDecimal128(LittleEndianArrayTag, const std::array<uint64_t, 2>& array) noexcept
       : BasicDecimal128(BitUtil::LittleEndianArray::ToNative(array)) {}
 
@@ -142,6 +145,30 @@ class ARROW_EXPORT BasicDecimal128 {
 
   /// \brief Get the low bits of the two's complement representation of the number.
   inline constexpr uint64_t low_bits() const { return low_bits_; }
+
+  /// \brief Get the bits of the two's complement representation of the number.
+  ///
+  /// The 2 elements are in native endian order. The bits within each uint64_t element
+  /// are in native endian order. For example, on a little endian machine,
+  /// BasicDecimal128(123).native_endian_array() = {123, 0};
+  /// but on a big endian machine,
+  /// BasicDecimal128(123).native_endian_array() = {0, 123};
+  inline std::array<uint64_t, 2> native_endian_array() const {
+#if ARROW_LITTLE_ENDIAN
+    return {low_bits_, static_cast<uint64_t>(high_bits_)};
+#else
+    return {static_cast<uint64_t>(high_bits_), low_bits_};
+#endif
+  }
+
+  /// \brief Get the bits of the two's complement representation of the number.
+  ///
+  /// The 2 elements are in little endian order. However, the bits within each
+  /// uint64_t element are in native endian order.
+  /// For example, BasicDecimal128(123).little_endian_array() = {123, 0};
+  inline std::array<uint64_t, 2> little_endian_array() const {
+    return {low_bits_, static_cast<uint64_t>(high_bits_)};
+  }
 
   /// \brief Return the raw bytes of the value in native-endian byte order.
   std::array<uint8_t, 16> ToBytes() const;
@@ -232,11 +259,14 @@ class ARROW_EXPORT BasicDecimal256 {
   static constexpr LittleEndianArrayTag LittleEndianArray{};
 
   /// \brief Create a BasicDecimal256 from the two's complement representation.
+  ///
   /// Input array is assumed to be in native endianness.
   constexpr BasicDecimal256(const std::array<uint64_t, 4>& array) noexcept
       : array_(array) {}
 
-  // XXX
+  /// \brief Create a BasicDecimal256 from the two's complement representation.
+  ///
+  /// Input array is assumed to be in little endianness, with native endian elements.
   BasicDecimal256(LittleEndianArrayTag, const std::array<uint64_t, 4>& array) noexcept
       : BasicDecimal256(BitUtil::LittleEndianArray::ToNative(array)) {}
 
@@ -276,13 +306,27 @@ class ARROW_EXPORT BasicDecimal256 {
   /// \brief Subtract a number from this one. The result is truncated to 256 bits.
   BasicDecimal256& operator-=(const BasicDecimal256& right);
 
-  /// \brief Get the bits of the two's complement representation of the number. The 4
-  /// elements are in native endian order. The bits within each uint64_t element are in
-  /// native endian order. For example, on a little endian machine,
-  /// BasicDecimal256(123).native_endian_array() = {123, 0, 0, 0};
-  /// BasicDecimal256(-2).native_endian_array() = {0xFF...FE, 0xFF...FF, 0xFF...FF,
+  /// \brief Get the bits of the two's complement representation of the number.
+  ///
+  /// The 4 elements are in native endian order. The bits within each uint64_t element
+  /// are in native endian order. For example, on a little endian machine,
+  ///   BasicDecimal256(123).native_endian_array() = {123, 0, 0, 0};
+  ///   BasicDecimal256(-2).native_endian_array() = {0xFF...FE, 0xFF...FF, 0xFF...FF,
   /// 0xFF...FF}.
+  /// while on a big endian machine,
+  ///   BasicDecimal256(123).native_endian_array() = {0, 0, 0, 123};
+  ///   BasicDecimal256(-2).native_endian_array() = {0xFF...FF, 0xFF...FF, 0xFF...FF,
+  /// 0xFF...FE}.
   inline const std::array<uint64_t, 4>& native_endian_array() const { return array_; }
+
+  /// \brief Get the bits of the two's complement representation of the number.
+  ///
+  /// The 4 elements are in little endian order. However, the bits within each
+  /// uint64_t element are in native endian order.
+  /// For example, BasicDecimal256(123).little_endian_array() = {123, 0};
+  inline const std::array<uint64_t, 4> little_endian_array() const {
+    return BitUtil::LittleEndianArray::FromNative(array_);
+  }
 
   /// \brief Get the lowest bits of the two's complement representation of the number.
   inline uint64_t low_bits() const { return BitUtil::LittleEndianArray::Make(array_)[0]; }

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -504,17 +504,16 @@ inline Status ToArrowStatus(DecimalStatus dstatus, int num_bits) {
   return Status::OK();
 }
 
-}  // namespace
-
-Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
-                              int32_t* precision, int32_t* scale) {
+template <typename Decimal>
+Status DecimalFromString(const char* type_name, const util::string_view& s, Decimal* out,
+                         int32_t* precision, int32_t* scale) {
   if (s.empty()) {
-    return Status::Invalid("Empty string cannot be converted to decimal");
+    return Status::Invalid("Empty string cannot be converted to ", type_name);
   }
 
   DecimalComponents dec;
   if (!ParseDecimalComponents(s.data(), s.size(), &dec)) {
-    return Status::Invalid("The string '", s, "' is not a valid decimal number");
+    return Status::Invalid("The string '", s, "' is not a valid ", type_name, " number");
   }
 
   // Count number of significant digits (without leading zeros)
@@ -528,29 +527,33 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {
     auto adjusted_exponent = dec.exponent;
-    auto len = static_cast<int32_t>(significant_digits);
-    parsed_scale = -adjusted_exponent + len - 1;
+    parsed_scale =
+        -adjusted_exponent + static_cast<int32_t>(dec.fractional_digits.size());
   } else {
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
   }
 
   if (out != nullptr) {
-    std::array<uint64_t, 2> little_endian_array = {0, 0};
+    static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
+    std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array = {0, 0};
     ShiftAndAdd(dec.whole_digits, little_endian_array.data(), little_endian_array.size());
     ShiftAndAdd(dec.fractional_digits, little_endian_array.data(),
                 little_endian_array.size());
-    *out =
-        Decimal128(static_cast<int64_t>(little_endian_array[1]), little_endian_array[0]);
-    if (parsed_scale < 0) {
-      *out *= GetScaleMultiplier(-parsed_scale);
-    }
-
+    *out = Decimal(BitUtil::LittleEndianArray::ToNative(little_endian_array));
     if (dec.sign == '-') {
       out->Negate();
     }
   }
 
   if (parsed_scale < 0) {
+    // Force the scale to zero, to avoid negative scales (due to compatibility issues
+    // with external systems such as databases)
+    if (-parsed_scale > Decimal::kMaxScale) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
+    }
+    if (out != nullptr) {
+      *out *= Decimal::GetScaleMultiplier(-parsed_scale);
+    }
     parsed_precision -= parsed_scale;
     parsed_scale = 0;
   }
@@ -563,6 +566,13 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
   }
 
   return Status::OK();
+}
+
+}  // namespace
+
+Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
+                              int32_t* precision, int32_t* scale) {
+  return DecimalFromString("decimal128", s, out, precision, scale);
 }
 
 Status Decimal128::FromString(const std::string& s, Decimal128* out, int32_t* precision,
@@ -692,49 +702,7 @@ std::string Decimal256::ToString(int32_t scale) const {
 
 Status Decimal256::FromString(const util::string_view& s, Decimal256* out,
                               int32_t* precision, int32_t* scale) {
-  if (s.empty()) {
-    return Status::Invalid("Empty string cannot be converted to decimal");
-  }
-
-  DecimalComponents dec;
-  if (!ParseDecimalComponents(s.data(), s.size(), &dec)) {
-    return Status::Invalid("The string '", s, "' is not a valid decimal number");
-  }
-
-  // Count number of significant digits (without leading zeros)
-  size_t first_non_zero = dec.whole_digits.find_first_not_of('0');
-  size_t significant_digits = dec.fractional_digits.size();
-  if (first_non_zero != std::string::npos) {
-    significant_digits += dec.whole_digits.size() - first_non_zero;
-  }
-
-  if (precision != nullptr) {
-    *precision = static_cast<int32_t>(significant_digits);
-  }
-
-  if (scale != nullptr) {
-    if (dec.has_exponent) {
-      auto adjusted_exponent = dec.exponent;
-      auto len = static_cast<int32_t>(significant_digits);
-      *scale = -adjusted_exponent + len - 1;
-    } else {
-      *scale = static_cast<int32_t>(dec.fractional_digits.size());
-    }
-  }
-
-  if (out != nullptr) {
-    std::array<uint64_t, 4> little_endian_array = {0, 0, 0, 0};
-    ShiftAndAdd(dec.whole_digits, little_endian_array.data(), little_endian_array.size());
-    ShiftAndAdd(dec.fractional_digits, little_endian_array.data(),
-                little_endian_array.size());
-    *out = Decimal256(BitUtil::LittleEndianArray::ToNative(little_endian_array));
-
-    if (dec.sign == '-') {
-      out->Negate();
-    }
-  }
-
-  return Status::OK();
+  return DecimalFromString("decimal256", s, out, precision, scale);
 }
 
 Status Decimal256::FromString(const std::string& s, Decimal256* out, int32_t* precision,

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -535,7 +535,7 @@ Status DecimalFromString(const char* type_name, const util::string_view& s, Deci
 
   if (out != nullptr) {
     static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
-    std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array = {0, 0};
+    std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array{};
     ShiftAndAdd(dec.whole_digits, little_endian_array.data(), little_endian_array.size());
     ShiftAndAdd(dec.fractional_digits, little_endian_array.data(),
                 little_endian_array.size());

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -146,20 +146,20 @@ class DecimalFromStringTest : public ::testing::Test {
       int32_t expected_precision;
       int32_t expected_scale;
     };
-    for (const TestValue tv : std::vector<TestValue>{{"12.3", 123LL, 3, 1},
-                                                     {"0.00123", 123LL, 5, 5},
-                                                     {"1.23E-8", 123LL, 3, 10},
-                                                     {"-1.23E-8", -123LL, 3, 10},
-                                                     {"1.23E+3", 1230LL, 4, 0},
-                                                     {"-1.23E+3", -1230LL, 4, 0},
-                                                     {"1.23E+5", 123000LL, 6, 0},
-                                                     {"1.2345E+7", 12345000LL, 8, 0},
-                                                     {"1.23e-8", 123LL, 3, 10},
-                                                     {"-1.23e-8", -123LL, 3, 10},
-                                                     {"1.23e+3", 1230LL, 4, 0},
-                                                     {"-1.23e+3", -1230LL, 4, 0},
-                                                     {"1.23e+5", 123000LL, 6, 0},
-                                                     {"1.2345e+7", 12345000LL, 8, 0}}) {
+    for (const auto& tv : std::vector<TestValue>{{"12.3", 123LL, 3, 1},
+                                                 {"0.00123", 123LL, 5, 5},
+                                                 {"1.23E-8", 123LL, 3, 10},
+                                                 {"-1.23E-8", -123LL, 3, 10},
+                                                 {"1.23E+3", 1230LL, 4, 0},
+                                                 {"-1.23E+3", -1230LL, 4, 0},
+                                                 {"1.23E+5", 123000LL, 6, 0},
+                                                 {"1.2345E+7", 12345000LL, 8, 0},
+                                                 {"1.23e-8", 123LL, 3, 10},
+                                                 {"-1.23e-8", -123LL, 3, 10},
+                                                 {"1.23e+3", 1230LL, 4, 0},
+                                                 {"-1.23e+3", -1230LL, 4, 0},
+                                                 {"1.23e+5", 123000LL, 6, 0},
+                                                 {"1.2345e+7", 12345000LL, 8, 0}}) {
       ARROW_SCOPED_TRACE("s = '", tv.s, "'");
       AssertDecimalFromString(tv.s, DecimalType(tv.expected), tv.expected_precision,
                               tv.expected_scale);
@@ -571,17 +571,17 @@ class DecimalFromIntegerTest : public ::testing::Test {
   }
 
   void TestConstructibleFromAnyIntegerType() {
-    CheckConstructFrom<char>();
-    CheckConstructFrom<signed char>();
-    CheckConstructFrom<unsigned char>();
-    CheckConstructFrom<short>();
-    CheckConstructFrom<unsigned short>();
-    CheckConstructFrom<int>();
-    CheckConstructFrom<unsigned int>();
-    CheckConstructFrom<long>();
-    CheckConstructFrom<unsigned long>();
-    CheckConstructFrom<long long>();
-    CheckConstructFrom<unsigned long long>();
+    CheckConstructFrom<char>();                // NOLINT
+    CheckConstructFrom<signed char>();         // NOLINT
+    CheckConstructFrom<unsigned char>();       // NOLINT
+    CheckConstructFrom<short>();               // NOLINT
+    CheckConstructFrom<unsigned short>();      // NOLINT
+    CheckConstructFrom<int>();                 // NOLINT
+    CheckConstructFrom<unsigned int>();        // NOLINT
+    CheckConstructFrom<long>();                // NOLINT
+    CheckConstructFrom<unsigned long>();       // NOLINT
+    CheckConstructFrom<long long>();           // NOLINT
+    CheckConstructFrom<unsigned long long>();  // NOLINT
   }
 
   void TestConstructibleFromBool() {

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -28,9 +28,13 @@
 #include <gtest/gtest.h>
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "arrow/array.h"
+#include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/int128_internal.h"
@@ -38,8 +42,11 @@
 
 namespace arrow {
 
+using internal::checked_cast;
 using internal::int128_t;
 using internal::uint128_t;
+
+using DecimalTypes = ::testing::Types<Decimal128, Decimal256>;
 
 static const int128_t kInt128Max =
     (static_cast<int128_t>(INT64_MAX) << 64) + static_cast<int128_t>(UINT64_MAX);
@@ -56,6 +63,16 @@ void AssertDecimalFromString(const std::string& s, const DecimalType& expected,
   EXPECT_EQ(expected_scale, scale);
 }
 
+// Assert that the low bits of an array of integers are equal to `expected_low`,
+// and that all other bits are equal to `expected_high`.
+template <typename T, size_t N, typename U, typename V>
+void AssertArrayBits(const std::array<T, N>& a, U expected_low, V expected_high) {
+  EXPECT_EQ(a[0], expected_low);
+  for (size_t i = 1; i < N; ++i) {
+    EXPECT_EQ(a[i], expected_high);
+  }
+}
+
 Decimal128 Decimal128FromLE(const std::array<uint64_t, 2>& a) {
   return Decimal128(Decimal128::LittleEndianArray, a);
 }
@@ -64,44 +81,158 @@ Decimal256 Decimal256FromLE(const std::array<uint64_t, 4>& a) {
   return Decimal256(Decimal256::LittleEndianArray, a);
 }
 
-class Decimal128TestFixture : public ::testing::Test {
- public:
-  Decimal128TestFixture() : integer_value_(23423445), string_value_("234.23445") {}
-  Decimal128 integer_value_;
-  std::string string_value_;
+template <typename DecimalType>
+struct DecimalTraits {};
+
+template <>
+struct DecimalTraits<Decimal128> {
+  using ArrowType = Decimal128Type;
 };
 
-TEST_F(Decimal128TestFixture, TestFromString) {
-  Decimal128 expected(this->integer_value_);
-  Decimal128 result;
-  int32_t precision, scale;
-  ASSERT_OK(Decimal128::FromString(this->string_value_, &result, &precision, &scale));
-  ASSERT_EQ(result, expected);
-  ASSERT_EQ(precision, 8);
-  ASSERT_EQ(scale, 5);
+template <>
+struct DecimalTraits<Decimal256> {
+  using ArrowType = Decimal256Type;
+};
+
+template <typename DecimalType>
+class DecimalFromStringTest : public ::testing::Test {
+ public:
+  using ArrowType = typename DecimalTraits<DecimalType>::ArrowType;
+  using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
+
+  void TestBasics() { AssertDecimalFromString("234.23445", DecimalType(23423445), 8, 5); }
+
+  void TestStringStartingWithPlus() {
+    AssertDecimalFromString("+234.567", DecimalType(234567), 6, 3);
+    AssertDecimalFromString("+2342394230592.232349023094",
+                            DecimalType("2342394230592232349023094"), 25, 12);
+  }
+
+  void TestInvalidInput() {
+    for (const std::string invalid_value :
+         {"-", "0.0.0", "0-13-32", "a", "-23092.235-", "-+23092.235", "+-23092.235",
+          "00a", "1e1a", "0.00123D/3", "1.23eA8", "1.23E+3A", "-1.23E--5",
+          "1.2345E+++07"}) {
+      ARROW_SCOPED_TRACE("invalid_value = '", invalid_value, "'");
+      ASSERT_RAISES(Invalid, Decimal128::FromString(invalid_value));
+    }
+  }
+
+  void TestLeadingZerosNoDecimalPoint() {
+    AssertDecimalFromString("0000000", DecimalType(0), 0, 0);
+  }
+
+  void TestLeadingZerosDecimalPoint() {
+    AssertDecimalFromString("000.0000", DecimalType(0), 4, 4);
+  }
+
+  void TestNoLeadingZerosDecimalPoint() {
+    AssertDecimalFromString(".00000", DecimalType(0), 5, 5);
+  }
+
+  void TestNoDecimalPointExponent() {
+    AssertDecimalFromString("1E1", DecimalType(10), 2, 0);
+  }
+
+  void TestWithExponentAndNullptrScale() {
+    const DecimalType expected_value(123);
+    ASSERT_OK_AND_EQ(expected_value, DecimalType::FromString("1.23E-8"));
+  }
+
+  void TestSmallValues() {
+    struct TestValue {
+      std::string s;
+      int64_t expected;
+      int32_t expected_precision;
+      int32_t expected_scale;
+    };
+    for (const TestValue tv : std::vector<TestValue>{{"12.3", 123LL, 3, 1},
+                                                     {"0.00123", 123LL, 5, 5},
+                                                     {"1.23E-8", 123LL, 3, 10},
+                                                     {"-1.23E-8", -123LL, 3, 10},
+                                                     {"1.23E+3", 1230LL, 4, 0},
+                                                     {"-1.23E+3", -1230LL, 4, 0},
+                                                     {"1.23E+5", 123000LL, 6, 0},
+                                                     {"1.2345E+7", 12345000LL, 8, 0},
+                                                     {"1.23e-8", 123LL, 3, 10},
+                                                     {"-1.23e-8", -123LL, 3, 10},
+                                                     {"1.23e+3", 1230LL, 4, 0},
+                                                     {"-1.23e+3", -1230LL, 4, 0},
+                                                     {"1.23e+5", 123000LL, 6, 0},
+                                                     {"1.2345e+7", 12345000LL, 8, 0}}) {
+      ARROW_SCOPED_TRACE("s = '", tv.s, "'");
+      AssertDecimalFromString(tv.s, DecimalType(tv.expected), tv.expected_precision,
+                              tv.expected_scale);
+    }
+  }
+
+  void CheckRandomValuesRoundTrip(int32_t precision, int32_t scale) {
+    auto rnd = random::RandomArrayGenerator(42);
+    const auto ty = std::make_shared<ArrowType>(precision, scale);
+    const auto array = rnd.ArrayOf(ty, 100, /*null_probability=*/0.0);
+    for (int64_t i = 0; i < array->length(); ++i) {
+      ASSERT_OK_AND_ASSIGN(auto scalar, array->GetScalar(i));
+      const DecimalType& dec_value = checked_cast<const ScalarType&>(*scalar).value;
+      const auto s = dec_value.ToString(scale);
+      ASSERT_OK_AND_ASSIGN(auto round_tripped, DecimalType::FromString(s));
+      ASSERT_EQ(dec_value, round_tripped);
+    }
+  }
+
+  void TestRandomSmallValuesRoundTrip() {
+    for (int32_t scale : {0, 2, 9}) {
+      ARROW_SCOPED_TRACE("scale = ", scale);
+      CheckRandomValuesRoundTrip(9, scale);
+    }
+  }
+
+  void TestRandomValuesRoundTrip() {
+    const auto max_scale = DecimalType::kMaxScale;
+    for (int32_t scale : {0, 3, max_scale / 2, max_scale}) {
+      ARROW_SCOPED_TRACE("scale = ", scale);
+      CheckRandomValuesRoundTrip(DecimalType::kMaxPrecision, scale);
+    }
+  }
+};
+
+TYPED_TEST_SUITE(DecimalFromStringTest, DecimalTypes);
+
+TYPED_TEST(DecimalFromStringTest, Basics) { this->TestBasics(); }
+
+TYPED_TEST(DecimalFromStringTest, StringStartingWithPlus) {
+  this->TestStringStartingWithPlus();
 }
 
-TEST_F(Decimal128TestFixture, TestStringStartingWithPlus) {
-  std::string plus_value("+234.234");
-  Decimal128 out;
-  int32_t scale;
-  int32_t precision;
-  ASSERT_OK(Decimal128::FromString(plus_value, &out, &precision, &scale));
-  ASSERT_EQ(234234, out);
-  ASSERT_EQ(6, precision);
-  ASSERT_EQ(3, scale);
+TYPED_TEST(DecimalFromStringTest, InvalidInput) { this->TestInvalidInput(); }
+
+TYPED_TEST(DecimalFromStringTest, LeadingZerosDecimalPoint) {
+  this->TestLeadingZerosDecimalPoint();
 }
 
-TEST_F(Decimal128TestFixture, TestStringStartingWithPlus128) {
-  std::string plus_value("+2342394230592.232349023094");
-  Decimal128 expected_value("2342394230592232349023094");
-  Decimal128 out;
-  int32_t scale;
-  int32_t precision;
-  ASSERT_OK(Decimal128::FromString(plus_value, &out, &precision, &scale));
-  ASSERT_EQ(expected_value, out);
-  ASSERT_EQ(25, precision);
-  ASSERT_EQ(12, scale);
+TYPED_TEST(DecimalFromStringTest, LeadingZerosNoDecimalPoint) {
+  this->TestLeadingZerosNoDecimalPoint();
+}
+
+TYPED_TEST(DecimalFromStringTest, NoLeadingZerosDecimalPoint) {
+  this->TestNoLeadingZerosDecimalPoint();
+}
+
+TYPED_TEST(DecimalFromStringTest, NoDecimalPointExponent) {
+  this->TestNoDecimalPointExponent();
+}
+
+TYPED_TEST(DecimalFromStringTest, WithExponentAndNullptrScale) {
+  this->TestWithExponentAndNullptrScale();
+}
+
+TYPED_TEST(DecimalFromStringTest, SmallValues) { this->TestSmallValues(); }
+
+TYPED_TEST(DecimalFromStringTest, RandomSmallValuesRoundTrip) {
+  this->TestRandomSmallValuesRoundTrip();
+}
+
+TYPED_TEST(DecimalFromStringTest, RandomValuesRoundTrip) {
+  this->TestRandomValuesRoundTrip();
 }
 
 TEST(Decimal128Test, TestFromStringDecimal128) {
@@ -188,34 +319,6 @@ TEST(Decimal128Test, TestDecimalStringAndBytesRoundTrip) {
   Decimal128 result(bytes.data());
 
   ASSERT_EQ(expected, result);
-}
-
-TEST(Decimal128Test, FromStringInvalidInput) {
-  for (const std::string invalid_value : {"-", "0.0.0", "0-13-32", "a", "-23092.235-",
-                                          "-+23092.235", "+-23092.235", "00a", "1e1a"}) {
-    ARROW_SCOPED_TRACE("invalid_value = '", invalid_value, "'");
-    ASSERT_RAISES(Invalid, Decimal128::FromString(invalid_value));
-  }
-}
-
-TEST(Decimal128Test, LeadingZerosNoDecimalPoint) {
-  AssertDecimalFromString("0000000", Decimal128(0), 0, 0);
-}
-
-TEST(Decimal128Test, LeadingZerosDecimalPoint) {
-  AssertDecimalFromString("000.0000", Decimal128(0), 4, 4);
-  std::string string_value("000.0000");
-  Decimal128 d;
-  int32_t precision;
-  int32_t scale;
-  ASSERT_OK(Decimal128::FromString(string_value, &d, &precision, &scale));
-  ASSERT_EQ(4, precision);
-  ASSERT_EQ(4, scale);
-  ASSERT_EQ(0, d);
-}
-
-TEST(Decimal128Test, NoLeadingZerosDecimalPoint) {
-  AssertDecimalFromString(".00000", Decimal128(0), 5, 5);
 }
 
 /*
@@ -449,44 +552,58 @@ TEST(Decimal256Test, FromStringLimits) {
       dec76times9neg, 76, 76);
 }
 
-template <typename T>
-class Decimal128Test : public ::testing::Test {
+template <typename DecimalType>
+class DecimalFromIntegerTest : public ::testing::Test {
  public:
-  Decimal128Test() {}
+  template <typename IntegerType>
+  void CheckConstructFrom() {
+    DecimalType value(IntegerType{42});
+    AssertArrayBits(value.little_endian_array(), 42, 0);
+
+    DecimalType max_value(std::numeric_limits<IntegerType>::max());
+    AssertArrayBits(max_value.little_endian_array(),
+                    std::numeric_limits<IntegerType>::max(), 0);
+
+    DecimalType min_value(std::numeric_limits<IntegerType>::min());
+    AssertArrayBits(min_value.little_endian_array(),
+                    std::numeric_limits<IntegerType>::min(),
+                    (std::is_signed<IntegerType>::value ? -1 : 0));
+  }
+
+  void TestConstructibleFromAnyIntegerType() {
+    CheckConstructFrom<char>();
+    CheckConstructFrom<signed char>();
+    CheckConstructFrom<unsigned char>();
+    CheckConstructFrom<short>();
+    CheckConstructFrom<unsigned short>();
+    CheckConstructFrom<int>();
+    CheckConstructFrom<unsigned int>();
+    CheckConstructFrom<long>();
+    CheckConstructFrom<unsigned long>();
+    CheckConstructFrom<long long>();
+    CheckConstructFrom<unsigned long long>();
+  }
+
+  void TestConstructibleFromBool() {
+    {
+      DecimalType value(true);
+      AssertArrayBits(value.little_endian_array(), 1, 0);
+    }
+    {
+      DecimalType value(false);
+      AssertArrayBits(value.little_endian_array(), 0, 0);
+    }
+  }
 };
 
-using Decimal128Types =
-    ::testing::Types<char, unsigned char, short, unsigned short,  // NOLINT
-                     int, unsigned int, long, unsigned long,      // NOLINT
-                     long long, unsigned long long                // NOLINT
-                     >;
+TYPED_TEST_SUITE(DecimalFromIntegerTest, DecimalTypes);
 
-TYPED_TEST_SUITE(Decimal128Test, Decimal128Types);
-
-TYPED_TEST(Decimal128Test, ConstructibleFromAnyIntegerType) {
-  Decimal128 value(TypeParam{42});
-  EXPECT_EQ(42, value.low_bits());
-  EXPECT_EQ(0, value.high_bits());
-
-  Decimal128 max_value(std::numeric_limits<TypeParam>::max());
-  EXPECT_EQ(std::numeric_limits<TypeParam>::max(), max_value.low_bits());
-  EXPECT_EQ(0, max_value.high_bits());
-
-  Decimal128 min_value(std::numeric_limits<TypeParam>::min());
-  EXPECT_EQ(std::numeric_limits<TypeParam>::min(), min_value.low_bits());
-  EXPECT_EQ((std::is_signed<TypeParam>::value ? -1 : 0), min_value.high_bits());
+TYPED_TEST(DecimalFromIntegerTest, ConstructibleFromAnyIntegerType) {
+  this->TestConstructibleFromAnyIntegerType();
 }
 
-TEST(Decimal128TestTrue, ConstructibleFromBool) {
-  Decimal128 value(true);
-  EXPECT_EQ(1, value.low_bits());
-  EXPECT_EQ(0, value.high_bits());
-}
-
-TEST(Decimal128TestFalse, ConstructibleFromBool) {
-  Decimal128 value(false);
-  EXPECT_EQ(0, value.low_bits());
-  EXPECT_EQ(0, value.high_bits());
+TYPED_TEST(DecimalFromIntegerTest, ConstructibleFromBool) {
+  this->TestConstructibleFromBool();
 }
 
 TEST(Decimal128Test, Division) {
@@ -613,53 +730,6 @@ TEST_P(Decimal128ToStringTest, ToString) {
 INSTANTIATE_TEST_SUITE_P(Decimal128ToStringTest, Decimal128ToStringTest,
                          ::testing::ValuesIn(kToStringTestData));
 
-class Decimal128ParsingTest
-    : public ::testing::TestWithParam<std::tuple<std::string, uint64_t, int32_t>> {};
-
-TEST_P(Decimal128ParsingTest, Parse) {
-  std::string test_string;
-  uint64_t expected_low_bits;
-  int32_t expected_scale;
-  std::tie(test_string, expected_low_bits, expected_scale) = GetParam();
-  Decimal128 value;
-  int32_t scale;
-  ASSERT_OK(Decimal128::FromString(test_string, &value, nullptr, &scale));
-  ASSERT_EQ(value.low_bits(), expected_low_bits);
-  ASSERT_EQ(expected_scale, scale);
-}
-
-INSTANTIATE_TEST_SUITE_P(Decimal128ParsingTest, Decimal128ParsingTest,
-                         ::testing::Values(std::make_tuple("12.3", 123ULL, 1),
-                                           std::make_tuple("0.00123", 123ULL, 5),
-                                           std::make_tuple("1.23E-8", 123ULL, 10),
-                                           std::make_tuple("-1.23E-8", -123LL, 10),
-                                           std::make_tuple("1.23E+3", 1230ULL, 0),
-                                           std::make_tuple("-1.23E+3", -1230LL, 0),
-                                           std::make_tuple("1.23E+5", 123000ULL, 0),
-                                           std::make_tuple("1.2345E+7", 12345000ULL, 0),
-                                           std::make_tuple("1.23e-8", 123ULL, 10),
-                                           std::make_tuple("-1.23e-8", -123LL, 10),
-                                           std::make_tuple("1.23e+3", 1230ULL, 0),
-                                           std::make_tuple("-1.23e+3", -1230LL, 0),
-                                           std::make_tuple("1.23e+5", 123000ULL, 0),
-                                           std::make_tuple("1.2345e+7", 12345000ULL, 0)));
-
-class Decimal128ParsingTestInvalid : public ::testing::TestWithParam<std::string> {};
-
-TEST_P(Decimal128ParsingTestInvalid, Parse) {
-  std::string test_string = GetParam();
-  ASSERT_RAISES(Invalid, Decimal128::FromString(test_string));
-}
-
-INSTANTIATE_TEST_SUITE_P(Decimal128ParsingTestInvalid, Decimal128ParsingTestInvalid,
-                         ::testing::Values("0.00123D/3", "1.23eA8", "1.23E+3A",
-                                           "-1.23E--5", "1.2345E+++07"));
-
-TEST(Decimal128ParseTest, WithExponentAndNullptrScale) {
-  const Decimal128 expected_value(123);
-  ASSERT_OK_AND_EQ(expected_value, Decimal128::FromString("1.23E-8"));
-}
-
 template <typename Decimal, typename Real>
 void CheckDecimalFromReal(Real real, int32_t precision, int32_t scale,
                           const std::string& expected) {
@@ -763,8 +833,6 @@ TYPED_TEST_SUITE(TestDecimalFromReal, RealTypes);
 TYPED_TEST(TestDecimalFromReal, TestSuccess) { this->TestSuccess(); }
 
 TYPED_TEST(TestDecimalFromReal, TestErrors) { this->TestErrors(); }
-
-using DecimalTypes = ::testing::Types<Decimal128, Decimal256>;
 
 // Tests for Decimal128::FromReal(float, ...) and Decimal256::FromReal(float, ...)
 template <typename T>
@@ -1066,16 +1134,6 @@ TYPED_TEST(TestDecimalToRealDouble, Precision) {
 }
 
 #endif  // __MINGW32__
-
-TEST(Decimal128Test, TestNoDecimalPointExponential) {
-  Decimal128 value;
-  int32_t precision;
-  int32_t scale;
-  ASSERT_OK(Decimal128::FromString("1E1", &value, &precision, &scale));
-  ASSERT_EQ(10, value.low_bits());
-  ASSERT_EQ(2, precision);
-  ASSERT_EQ(0, scale);
-}
 
 TEST(Decimal128Test, TestFromBigEndian) {
   // We test out a variety of scenarios:

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -1012,7 +1012,7 @@ TEST_F(TestDecimal, TestCastDecimalVarCharInvalidInput) {
   arrow::ArrayVector outputs_1;
   status = projector->Evaluate(*in_batch_1, pool_, &outputs_1);
   EXPECT_FALSE(status.ok()) << status.message();
-  EXPECT_TRUE(status.message().find("not a valid decimal number") != std::string::npos);
+  EXPECT_NE(status.message().find("not a valid decimal128 number"), std::string::npos);
 }
 
 TEST_F(TestDecimal, TestVarCharDecimalNestedCast) {


### PR DESCRIPTION
* The wrong scale could be inferred if the input both had fractional digits and an exponent
* An out-of-bounds access could be provoked when correcting an excessive negative scale (for example "1e39")
* Make testing more generic and more thorough