### PR TITLE
MINOR: [R] Bump 5.0.0 version in r/NEWS.md

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,7 +19,7 @@
 
 # arrow 5.0.0.9000
 
-# arrow 4.0.1.9000
+# arrow 5.0.0
 
 ## More dplyr
 


### PR DESCRIPTION
FYI @kszucs, this was missed in #10821. There's slightly different version bumping logic when going from snapshot to release than when going from release to snapshot: https://github.com/apache/arrow/blob/master/dev/release/utils-prepare.sh#L124-L136

So now that we don't rebase master on the release, when bumping the snapshot version on master after the release, it would be good to run `update_versions` twice, first to the release version, then to the new snapshot version. Or else first cherry-pick the version bump commit from the release branch.