### PR TITLE
ARROW-13485: [Release] Replace ${PREVIOUS_RELEASE}.9000 in r/NEWS.md by post-12-bump-versions.sh

### DIFF
--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -341,201 +341,198 @@ class PrepareTest < Test::Unit::TestCase
   end
 
   def test_version_post_tag
-    if on_release_branch?
-      bump_versions("VERSION_POST_TAG")
-    else
-      prepare("VERSION_PRE_TAG")
-      bump_versions("VERSION_POST_TAG")
-    end
+    omit_on_release_branch
+    bump_versions("VERSION_POST_TAG")
     assert_equal([
                    {
                      path: "c_glib/meson.build",
                      hunks: [
-                       ["-version = '#{@release_version}'",
+                       ["-version = '#{@snapshot_version}'",
                         "+version = '#{@next_snapshot_version}'"],
                      ],
                    },
                    {
                      path: "ci/scripts/PKGBUILD",
                      hunks: [
-                       ["-pkgver=#{@release_version}",
+                       ["-pkgver=#{@previous_version}.9000",
                         "+pkgver=#{@release_version}.9000"],
                      ],
                    },
                    {
                      path: "cpp/CMakeLists.txt",
                      hunks: [
-                       ["-set(ARROW_VERSION \"#{@release_version}\")",
+                       ["-set(ARROW_VERSION \"#{@snapshot_version}\")",
                         "+set(ARROW_VERSION \"#{@next_snapshot_version}\")"],
                      ],
                    },
                    {
                      path: "cpp/vcpkg.json",
                      hunks: [
-                       ["-  \"version-string\": \"#{@release_version}\",",
+                       ["-  \"version-string\": \"#{@snapshot_version}\",",
                         "+  \"version-string\": \"#{@next_snapshot_version}\","],
                      ],
                    },
                    {
                      path: "csharp/Directory.Build.props",
                      hunks: [
-                       ["-    <Version>#{@release_version}</Version>",
+                       ["-    <Version>#{@snapshot_version}</Version>",
                         "+    <Version>#{@next_snapshot_version}</Version>"],
                      ],
                    },
                    {
                      path: "dev/tasks/homebrew-formulae/apache-arrow.rb",
                      hunks: [
-                       ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@release_version}/apache-arrow-#{@release_version}.tar.gz\"",
+                       ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@snapshot_version}/apache-arrow-#{@snapshot_version}.tar.gz\"",
                         "+  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@next_snapshot_version}/apache-arrow-#{@next_snapshot_version}.tar.gz\""],
                      ],
                    },
                    {
                      path: "dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb",
                      hunks: [
-                       ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@release_version}/apache-arrow-#{@release_version}.tar.gz\"",
+                       ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@previous_version}.9000/apache-arrow-#{@previous_version}.9000.tar.gz\"",
                         "+  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@release_version}.9000/apache-arrow-#{@release_version}.9000.tar.gz\""],
                      ],
                    },
                    { path: "java/adapter/avro/pom.xml",
-                     hunks: [["-    <version>#{@release_version}</version>",
+                     hunks: [["-    <version>#{@snapshot_version}</version>",
                              "+    <version>#{@next_snapshot_version}</version>"]] },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"]],
                      path: "java/adapter/jdbc/pom.xml" },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"]],
                      path: "java/adapter/orc/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/algorithm/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/compression/pom.xml" },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"]],
                      path: "java/dataset/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/flight/flight-core/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/flight/flight-grpc/pom.xml" },
-                   { hunks: [["-  <version>#{@release_version}</version>", "+  <version>#{@next_snapshot_version}</version>"]],
+                   { hunks: [["-  <version>#{@snapshot_version}</version>", "+  <version>#{@next_snapshot_version}</version>"]],
                      path: "java/format/pom.xml" },
-                   { hunks: [["-      <version>#{@release_version}</version>",
+                   { hunks: [["-      <version>#{@snapshot_version}</version>",
                               "+      <version>#{@next_snapshot_version}</version>"]],
                      path: "java/gandiva/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/memory/memory-core/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/memory/memory-netty/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/memory/memory-unsafe/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/memory/pom.xml" },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"],
-                             ["-            <version>#{@release_version}</version>",
+                             ["-            <version>#{@snapshot_version}</version>",
                               "+            <version>#{@next_snapshot_version}</version>"]],
                      path: "java/performance/pom.xml" },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"]],
                      path: "java/plasma/pom.xml" },
-                   { hunks: [["-  <version>#{@release_version}</version>", "+  <version>#{@next_snapshot_version}</version>"]],
+                   { hunks: [["-  <version>#{@snapshot_version}</version>", "+  <version>#{@next_snapshot_version}</version>"]],
                      path: "java/pom.xml" },
-                   { hunks: [["-        <version>#{@release_version}</version>",
+                   { hunks: [["-        <version>#{@snapshot_version}</version>",
                               "+        <version>#{@next_snapshot_version}</version>"]],
                      path: "java/tools/pom.xml" },
-                   { hunks: [["-    <version>#{@release_version}</version>",
+                   { hunks: [["-    <version>#{@snapshot_version}</version>",
                               "+    <version>#{@next_snapshot_version}</version>"]],
                      path: "java/vector/pom.xml" },
                    {
                      path: "js/package.json",
                      hunks: [
-                       ["-  \"version\": \"#{@release_version}\"",
+                       ["-  \"version\": \"#{@snapshot_version}\"",
                         "+  \"version\": \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "matlab/CMakeLists.txt",
                      hunks: [
-                       ["-set(MLARROW_VERSION \"#{@release_version}\")",
+                       ["-set(MLARROW_VERSION \"#{@snapshot_version}\")",
                         "+set(MLARROW_VERSION \"#{@next_snapshot_version}\")"],
                      ],
                    },
                    {
                      path: "python/setup.py",
                      hunks: [
-                       ["-default_version = '#{@release_version}'",
+                       ["-default_version = '#{@snapshot_version}'",
                         "+default_version = '#{@next_snapshot_version}'"],
                      ],
                    },
                    {
                      path: "r/DESCRIPTION",
                      hunks: [
-                       ["-Version: #{@release_version}",
+                       ["-Version: #{@previous_version}.9000",
                         "+Version: #{@release_version}.9000"],
                      ],
                    },
                    {
                      path: "r/NEWS.md",
-                     # Note that these are additions only, no replacement
                      hunks: [
-                       ["+# arrow #{@release_version}.9000",
-                        "+"],
+                       ["-# arrow #{@previous_version}.9000",
+                        "+# arrow #{@release_version}.9000",
+                        "+",
+                        "+# arrow #{@release_version}",],
                      ],
                    },
                    {
                      path: "ruby/red-arrow-cuda/lib/arrow-cuda/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-arrow-dataset/lib/arrow-dataset/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-arrow-flight/lib/arrow-flight/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-arrow/lib/arrow/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-gandiva/lib/gandiva/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-parquet/lib/parquet/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-plasma/lib/plasma/version.rb",
                      hunks: [
-                       ["-  VERSION = \"#{@release_version}\"",
+                       ["-  VERSION = \"#{@snapshot_version}\"",
                         "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -121,17 +121,14 @@ update_versions() {
     DESCRIPTION
   rm -f DESCRIPTION.bak
   git add DESCRIPTION
+  # Replace dev version with release version
+  sed -i.bak -E -e \
+    "0,/^# arrow /s/^# arrow .+/# arrow ${base_version}/" \
+    NEWS.md
   if [ ${type} = "snapshot" ]; then
     # Add a news entry for the new dev version
-    echo "dev"
     sed -i.bak -E -e \
       "0,/^# arrow /s/^(# arrow .+)/# arrow ${r_version}\n\n\1/" \
-      NEWS.md
-  else
-    # Replace dev version with release version
-    echo "release"
-    sed -i.bak -E -e \
-      "0,/^# arrow /s/^# arrow .+/# arrow ${r_version}/" \
       NEWS.md
   fi
   rm -f NEWS.md.bak


### PR DESCRIPTION
We need this because we changed to use release branch style.