### PR TITLE
ARROW-13489: [R] Bump CI jobs after 5.0.0

### DIFF
--- a/dev/tasks/r/github.linux.version.compatibility.yml
+++ b/dev/tasks/r/github.linux.version.compatibility.yml
@@ -77,6 +77,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
+        - { old_arrow_version: '5.0.0', r: '4.1' }
         - { old_arrow_version: '4.0.0', r: '4.0' }
         - { old_arrow_version: '3.0.0', r: '4.0' }
         - { old_arrow_version: '2.0.0', r: '4.0' }


### PR DESCRIPTION
We will need to wait for 5.0.0 to hit the public RStudio Package Manager to merge this.