### PR TITLE
ARROW-13500 [C++] Fix using '-Wno-unknown-warning-option' with GCC

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -343,9 +343,6 @@ if(MSVC)
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /wd4065")
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  # Avoid error when an unknown warning flag is passed
-  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
-
   if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "7.0" OR CMAKE_CXX_COMPILER_VERSION
                                                        VERSION_GREATER "7.0")
     # Without this, gcc >= 7 warns related to changes in C++17


### PR DESCRIPTION
The `-Wno-unknown-warning-option` is implemented in Clang but not GCC.

Alternatively I could change this to pass `-Wno-unknown-warning` which seems to have similar behavior according to https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html