### PR TITLE
ARROW-13495: [C++][Compute] Fixing unaligned memory access in GrouperFastImpl

### DIFF
--- a/cpp/src/arrow/compute/exec/util.h
+++ b/cpp/src/arrow/compute/exec/util.h
@@ -24,9 +24,9 @@
 #include "arrow/memory_pool.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/logging.h"
-#include "arrow/util/bit_util.h"
 
 #if defined(__clang__) || defined(__GNUC__)
 #define BYTESWAP(x) __builtin_bswap64(x)


### PR DESCRIPTION
Temp vectors used in grouper implementation were allocated using stack implementation.
The buffer addresses returned by the stack were not aligned to the size of requested vector element.
Changing this to have returned buffers aligned to 8 byte boundaries.