### PR TITLE
ARROW-13506: [C++][Java] Upgrade ORC to 1.6.9

### DIFF
--- a/cpp/thirdparty/versions.txt
+++ b/cpp/thirdparty/versions.txt
@@ -43,7 +43,7 @@ ARROW_LZ4_BUILD_VERSION=v1.9.3
 # mimalloc 1.6.7 didn't build on Visual Studio 2015
 # https://github.com/microsoft/mimalloc/issues/353
 ARROW_MIMALLOC_BUILD_VERSION=v1.7.2
-ARROW_ORC_BUILD_VERSION=1.6.6
+ARROW_ORC_BUILD_VERSION=1.6.9
 ARROW_PROTOBUF_BUILD_VERSION=v3.14.0
 # Because of https://github.com/Tencent/rapidjson/pull/1323, we require
 # a pre-release version of RapidJSON to build with GCC 8 without

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -35,7 +35,7 @@
 	<dependency>
             <groupId>org.apache.orc</groupId>
             <artifactId>orc-core</artifactId>
-            <version>1.5.5</version>
+            <version>1.6.9</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-storage-api</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR aims to upgrade Apache ORC to 1.6.9 to bring the latest bug fixes and updates.

- 1.6.9: https://orc.apache.org/news/2021/07/02/ORC-1.6.9/

Currently, `C++` module is using Apache ORC 1.6.6 and `Java` module is using 1.5.5.
Apache ORC 1.5.5 is too old and we had better make it consistent at this time. 
Apache ORC community highly recommends 1.6.9.

From Apache ORC 1.6.0+, the followings are added.
- ORC-14 Add column encryption.
- ORC-189 Add timestamp with local timezone
- ORC-203 Trim minimum and maximum string values
- ORC-363 Add zstd support in Java
- ORC-397 Support selectively disabling dictionaries
- ORC-522 Add type annotations