### PR TITLE
ARROW-13510: [CI][R][C++] Add -Wall to fedora-clang-devel as-cran checks

### DIFF
--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -25,7 +25,7 @@ source_dir=${1}/r
 pushd ${source_dir}
 
 # Install R package dependencies
-${R_BIN} -e "install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys'))"
-${R_BIN} -e "remotes::install_deps(dependencies = TRUE)"
+${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys'))"
+${R_BIN} -e "options(warn=2); remotes::install_deps(dependencies = TRUE)"
 
 popd

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -25,7 +25,7 @@ source_dir=${1}/r
 pushd ${source_dir}
 
 # Install R package dependencies
-${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys'))"
-${R_BIN} -e "options(warn=2); remotes::install_deps(dependencies = TRUE)"
+${R_BIN} -e "install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys'))"
+${R_BIN} -e "remotes::install_deps(dependencies = TRUE)"
 
 popd

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -37,7 +37,8 @@ if [ "$RHUB_PLATFORM" = "linux-x86_64-fedora-clang" ]; then
   dnf install -y libcxx-devel
   sed -i.bak -E -e 's/(CXX1?1? =.*)/\1 -stdlib=libc++/g' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
-  echo 'CXXFLAGS="-g -O3 -Wall -pedantic -frtti"' >> $(${R_BIN} RHOME)/etc/Makeconf
+  sed -i.bak -E -e 's/(CXXFLAGS = )(.*)/\1 -g -O3 -Wall -pedantic -frtti/' $(${R_BIN} RHOME)/etc/Makeconf
+  rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
 fi
 
 # Special hacking to try to reproduce quirks on centos using non-default build

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -37,6 +37,7 @@ if [ "$RHUB_PLATFORM" = "linux-x86_64-fedora-clang" ]; then
   dnf install -y libcxx-devel
   sed -i.bak -E -e 's/(CXX1?1? =.*)/\1 -stdlib=libc++/g' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
+  echo 'CXXFLAGS="-g -O3 -Wall -pedantic -frtti"' >> $(${R_BIN} RHOME)/etc/Makeconf
 fi
 
 # Special hacking to try to reproduce quirks on centos using non-default build

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -37,7 +37,7 @@ if [ "$RHUB_PLATFORM" = "linux-x86_64-fedora-clang" ]; then
   dnf install -y libcxx-devel
   sed -i.bak -E -e 's/(CXX1?1? =.*)/\1 -stdlib=libc++/g' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
-  sed -i.bak -E -e 's/(CXXFLAGS = )(.*)/\1 -g -O3 -Wall -pedantic -frtti/' $(${R_BIN} RHOME)/etc/Makeconf
+  sed -i.bak -E -e 's/(CXXFLAGS = )(.*)/\1 -g -O3 -Wall -pedantic -frtti -fPIC/' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
 fi
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -37,6 +37,7 @@ if [ "$RHUB_PLATFORM" = "linux-x86_64-fedora-clang" ]; then
   dnf install -y libcxx-devel
   sed -i.bak -E -e 's/(CXX1?1? =.*)/\1 -stdlib=libc++/g' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
+  
   sed -i.bak -E -e 's/(CXXFLAGS = )(.*)/\1 -g -O3 -Wall -pedantic -frtti -fPIC/' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
 fi


### PR DESCRIPTION
This also includes a change that should cause builds to fail if R package dependencies don't install successfully. (They generally do fail already, just during the test run and not during the dependency installation step, so it's harder to diagnose.)