### PR TITLE
ARROW-13469: [C++] Suppress -Wmissing-field-initializers in DayMilliseconds arrow/type.h

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1297,6 +1297,9 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
   struct DayMilliseconds {
     int32_t days = 0;
     int32_t milliseconds = 0;
+    DayMilliseconds() = default;
+    DayMilliseconds(int32_t days, int32_t milliseconds)
+        : days(days), milliseconds(milliseconds) {}
     bool operator==(DayMilliseconds other) const {
       return this->days == other.days && this->milliseconds == other.milliseconds;
     }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1295,8 +1295,8 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
 class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
  public:
   struct DayMilliseconds {
-    int32_t days;
-    int32_t milliseconds;
+    int32_t days = 0;
+    int32_t milliseconds = 0;
     bool operator==(DayMilliseconds other) const {
       return this->days == other.days && this->milliseconds == other.milliseconds;
     }


### PR DESCRIPTION
Set initial values to DayMilliseconds with 0