### PR TITLE
ARROW-4700: [C++] Added support for decimal128 and decimal256 json converted

### DIFF
--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -22,11 +22,13 @@
 
 #include "arrow/array.h"
 #include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_decimal.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/array/builder_time.h"
 #include "arrow/json/parser.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/value_parsing.h"
@@ -147,6 +149,41 @@ class NumericConverter : public PrimitiveConverter {
   const T& numeric_type_;
 };
 
+template <typename T>
+class DecimalConverter : public PrimitiveConverter {
+ public:
+  using value_type = typename TypeTraits<T>::BuilderType::ValueType;
+
+  DecimalConverter(MemoryPool* pool, const std::shared_ptr<DataType>& type)
+      : PrimitiveConverter(pool, type) {}
+
+  Status Convert(const std::shared_ptr<Array>& in, std::shared_ptr<Array>* out) override {
+    if (in->type_id() == Type::NA) {
+      return MakeArrayOfNull(out_type_, in->length(), pool_).Value(out);
+    }
+    const auto& dict_array = GetDictionaryArray(in);
+
+    using Builder = typename TypeTraits<T>::BuilderType;
+    Builder builder(out_type_, pool_);
+    RETURN_NOT_OK(builder.Resize(dict_array.indices()->length()));
+
+    auto visit_valid = [&](string_view repr) {
+      ARROW_ASSIGN_OR_RAISE(value_type value,
+                            TypeTraits<T>::BuilderType::ValueType::FromString(repr));
+      builder.UnsafeAppend(value);
+      return Status::OK();
+    };
+
+    auto visit_null = [&]() {
+      builder.UnsafeAppendNull();
+      return Status::OK();
+    };
+
+    RETURN_NOT_OK(VisitDictionaryEntries(dict_array, visit_valid, visit_null));
+    return builder.Finish(out);
+  }
+};
+
 template <typename DateTimeType>
 class DateTimeConverter : public PrimitiveConverter {
  public:
@@ -250,6 +287,8 @@ Status MakeConverter(const std::shared_ptr<DataType>& out_type, MemoryPool* pool
     CONVERTER_CASE(Type::STRING, BinaryConverter<StringType>);
     CONVERTER_CASE(Type::LARGE_BINARY, BinaryConverter<LargeBinaryType>);
     CONVERTER_CASE(Type::LARGE_STRING, BinaryConverter<LargeStringType>);
+    CONVERTER_CASE(Type::DECIMAL128, DecimalConverter<Decimal128Type>);
+    CONVERTER_CASE(Type::DECIMAL256, DecimalConverter<Decimal256Type>);
     default:
       return Status::NotImplemented("JSON conversion to ", *out_type,
                                     " is not supported");

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -167,14 +167,14 @@ class DecimalConverter : public PrimitiveConverter {
     Builder builder(out_type_, pool_);
     RETURN_NOT_OK(builder.Resize(dict_array.indices()->length()));
 
-    auto visit_valid = [&](string_view repr) {
+    auto visit_valid = [&builder](string_view repr) {
       ARROW_ASSIGN_OR_RAISE(value_type value,
                             TypeTraits<T>::BuilderType::ValueType::FromString(repr));
       builder.UnsafeAppend(value);
       return Status::OK();
     };
 
-    auto visit_null = [&]() {
+    auto visit_null = [&builder]() {
       builder.UnsafeAppendNull();
       return Status::OK();
     };

--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -17,9 +17,9 @@
 
 #include "arrow/json/converter.h"
 
-#include <string>
-
 #include <gtest/gtest.h>
+
+#include <string>
 
 #include "arrow/json/options.h"
 #include "arrow/json/test_common.h"
@@ -94,6 +94,28 @@ TEST(ConverterTest, LargeString) {
 TEST(ConverterTest, Timestamp) {
   std::string src = R"([null, "1970-01-01", "2018-11-13 17:11:10"])";
   AssertConvert(timestamp(TimeUnit::SECOND), src, src);
+}
+
+TEST(ConverterTest, Decimal128) {
+  std::string src = R"([
+          "02.0000000000",
+          "30.0000000000",
+          "22.0000000000",
+        "-121.0000000000",
+        null])";
+
+  AssertConvert(decimal128(38, 10), src, src);
+}
+
+TEST(ConverterTest, Decimal256) {
+  std::string src = R"([
+          "02.0000000000",
+          "30.0000000000",
+          "22.0000000000",
+        "-121.0000000000",
+        null])";
+
+  AssertConvert(decimal256(38, 10), src, src);
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -27,95 +27,187 @@
 namespace arrow {
 namespace json {
 
-using util::string_view;
-
-void AssertConvert(const std::shared_ptr<DataType>& expected_type,
-                   const std::string& expected_json,
-                   const std::string& unconverted_json) {
-  // make an unconverted array
-  auto scalar_values = ArrayFromJSON(utf8(), unconverted_json);
-  Int32Builder indices_builder;
-  ASSERT_OK(indices_builder.Resize(scalar_values->length()));
-  for (int i = 0; i < scalar_values->length(); ++i) {
-    if (scalar_values->IsNull(i)) {
-      indices_builder.UnsafeAppendNull();
-    } else {
-      indices_builder.UnsafeAppend(i);
-    }
-  }
-  std::shared_ptr<Array> indices, unconverted, converted;
-  ASSERT_OK(indices_builder.Finish(&indices));
-
-  auto unconverted_type = dictionary(int32(), scalar_values->type());
-  unconverted =
-      std::make_shared<DictionaryArray>(unconverted_type, indices, scalar_values);
-
+Result<std::shared_ptr<Array>> Convert(std::shared_ptr<DataType> type,
+                                       std::shared_ptr<Array> unconverted) {
+  std::shared_ptr<Array> converted;
   // convert the array
   std::shared_ptr<Converter> converter;
-  ASSERT_OK(MakeConverter(expected_type, default_memory_pool(), &converter));
-  ASSERT_OK(converter->Convert(unconverted, &converted));
-  ASSERT_OK(converted->ValidateFull());
-
-  // assert equality
-  auto expected = ArrayFromJSON(expected_type, expected_json);
-  AssertArraysEqual(*expected, *converted);
+  RETURN_NOT_OK(MakeConverter(type, default_memory_pool(), &converter));
+  RETURN_NOT_OK(converter->Convert(unconverted, &converted));
+  RETURN_NOT_OK(converted->ValidateFull());
+  return converted;
 }
 
 // bool, null are trivial pass throughs
 
 TEST(ConverterTest, Integers) {
-  for (auto expected_type : {uint8(), uint16(), uint32(), uint64()}) {
-    AssertConvert(expected_type, "[0, null, 1, 32, 45, 12, 64, 124]",
-                  R"(["0", null, "1", "32", "45", "12", "64", "124"])");
+  for (auto int_type : {int8(), int16(), int32(), int64()}) {
+    ParseOptions options;
+    options.explicit_schema = schema({field("", int_type)});
+
+    std::string json_source = R"(
+    {"" : -0}
+    {"" : null}
+    {"" : -1}
+    {"" : 32}
+    {"" : -45}
+    {"" : 12}
+    {"" : -64}
+    {"" : 124}
+  )";
+
+    std::shared_ptr<StructArray> parse_array;
+    ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+    // call to convert
+    ASSERT_OK_AND_ASSIGN(auto converted,
+                         Convert(int_type, parse_array->GetFieldByName("")));
+
+    // assert equality
+    auto expected = ArrayFromJSON(int_type, R"([
+          -0, null, -1, 32, -45, 12, -64, 124])");
+
+    AssertArraysEqual(*expected, *converted);
   }
-  for (auto expected_type : {int8(), int16(), int32(), int64()}) {
-    AssertConvert(expected_type, "[0, null, -1, 32, -45, 12, -64, 124]",
-                  R"(["-0", null, "-1", "32", "-45", "12", "-64", "124"])");
+}
+
+TEST(ConverterTest, UnsignedIntegers) {
+  for (auto uint_type : {uint8(), uint16(), uint32(), uint64()}) {
+    ParseOptions options;
+    options.explicit_schema = schema({field("", uint_type)});
+
+    std::string json_source = R"(
+    {"" : 0}
+    {"" : null}
+    {"" : 1}
+    {"" : 32}
+    {"" : 45}
+    {"" : 12}
+    {"" : 64}
+    {"" : 124}
+  )";
+
+    std::shared_ptr<StructArray> parse_array;
+    ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+    // call to convert
+    ASSERT_OK_AND_ASSIGN(auto converted,
+                         Convert(uint_type, parse_array->GetFieldByName("")));
+
+    // assert equality
+    auto expected = ArrayFromJSON(uint_type, R"([
+          0, null, 1, 32, 45, 12, 64, 124])");
+
+    AssertArraysEqual(*expected, *converted);
   }
 }
 
 TEST(ConverterTest, Floats) {
-  for (auto expected_type : {float32(), float64()}) {
-    AssertConvert(expected_type, "[0, -0.0, null, 32.0, 1e5]",
-                  R"(["0", "-0.0", null, "32.0", "1e5"])");
+  for (auto float_type : {float32(), float64()}) {
+    ParseOptions options;
+    options.explicit_schema = schema({field("", float_type)});
+
+    std::string json_source = R"(
+    {"" : 0}
+    {"" : -0.0}
+    {"" : null}
+    {"" : 32.0}
+    {"" : 1e5}
+  )";
+
+    std::shared_ptr<StructArray> parse_array;
+    ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+    // call to convert
+    ASSERT_OK_AND_ASSIGN(auto converted,
+                         Convert(float_type, parse_array->GetFieldByName("")));
+
+    // assert equality
+    auto expected = ArrayFromJSON(float_type, R"([
+          0, -0.0, null, 32.0, 1e5])");
+
+    AssertArraysEqual(*expected, *converted);
   }
 }
 
-TEST(ConverterTest, String) {
-  std::string src = R"(["a", "b c", null, "d e f", "g"])";
-  AssertConvert(utf8(), src, src);
-}
+TEST(ConverterTest, StringAndLargeString) {
+  for (auto string_type : {utf8(), large_utf8()}) {
+    ParseOptions options;
+    options.explicit_schema = schema({field("", string_type)});
 
-TEST(ConverterTest, LargeString) {
-  std::string src = R"(["a", "b c", null, "d e f", "g"])";
-  AssertConvert(large_utf8(), src, src);
+    std::string json_source = R"(
+    {"" : "a"}
+    {"" : "b c"}
+    {"" : null}
+    {"" : "d e f"}
+    {"" : "g"}
+  )";
+
+    std::shared_ptr<StructArray> parse_array;
+    ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+    // call to convert
+    ASSERT_OK_AND_ASSIGN(auto converted,
+                         Convert(string_type, parse_array->GetFieldByName("")));
+
+    // assert equality
+    auto expected = ArrayFromJSON(string_type, R"([
+          "a", "b c", null, "d e f", "g"])");
+
+    AssertArraysEqual(*expected, *converted);
+  }
 }
 
 TEST(ConverterTest, Timestamp) {
-  std::string src = R"([null, "1970-01-01", "2018-11-13 17:11:10"])";
-  AssertConvert(timestamp(TimeUnit::SECOND), src, src);
+  auto timestamp_type = timestamp(TimeUnit::SECOND);
+
+  ParseOptions options;
+  options.explicit_schema = schema({field("", timestamp_type)});
+
+  std::string json_source = R"(
+    {"" : null}
+    {"" : "1970-01-01"}
+    {"" : "2018-11-13 17:11:10"}
+  )";
+
+  std::shared_ptr<StructArray> parse_array;
+  ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+  // call to convert
+  ASSERT_OK_AND_ASSIGN(auto converted,
+                       Convert(timestamp_type, parse_array->GetFieldByName("")));
+
+  // assert equality
+  auto expected = ArrayFromJSON(timestamp_type, R"([
+          null, "1970-01-01", "2018-11-13 17:11:10"])");
+
+  AssertArraysEqual(*expected, *converted);
 }
 
-TEST(ConverterTest, Decimal128) {
-  std::string src = R"([
+TEST(ConverterTest, Decimal128And256) {
+  for (auto decimal_type : {decimal128(38, 10), decimal256(38, 10)}) {
+    ParseOptions options;
+    options.explicit_schema = schema({field("", decimal_type)});
+
+    std::string json_source = R"(
+    {"" : "02.0000000000"}
+    {"" : "30.0000000000"}
+  )";
+
+    std::shared_ptr<StructArray> parse_array;
+    ASSERT_OK(ParseFromString(options, json_source, &parse_array));
+
+    // call to convert
+    ASSERT_OK_AND_ASSIGN(auto converted,
+                         Convert(decimal_type, parse_array->GetFieldByName("")));
+
+    // assert equality
+    auto expected = ArrayFromJSON(decimal_type, R"([
           "02.0000000000",
-          "30.0000000000",
-          "22.0000000000",
-        "-121.0000000000",
-        null])";
+          "30.0000000000"])");
 
-  AssertConvert(decimal128(38, 10), src, src);
-}
-
-TEST(ConverterTest, Decimal256) {
-  std::string src = R"([
-          "02.0000000000",
-          "30.0000000000",
-          "22.0000000000",
-        "-121.0000000000",
-        null])";
-
-  AssertConvert(decimal256(38, 10), src, src);
+    AssertArraysEqual(*expected, *converted);
+  }
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -102,6 +102,8 @@ Status Kind::ForType(const DataType& type, Kind::type* kind) {
     Status Visit(const TimeType&) { return SetKind(Kind::kNumber); }
     Status Visit(const DateType&) { return SetKind(Kind::kNumber); }
     Status Visit(const BinaryType&) { return SetKind(Kind::kString); }
+    Status Visit(const LargeBinaryType&) { return SetKind(Kind::kString); }
+    Status Visit(const TimestampType&) { return SetKind(Kind::kString); }
     Status Visit(const FixedSizeBinaryType&) { return SetKind(Kind::kString); }
     Status Visit(const DictionaryType& dict_type) {
       return Kind::ForType(*dict_type.value_type(), kind_);

--- a/cpp/src/arrow/json/test_common.h
+++ b/cpp/src/arrow/json/test_common.h
@@ -24,21 +24,20 @@
 #include <utility>
 #include <vector>
 
-#include "arrow/json/rapidjson_defs.h"
-#include "rapidjson/document.h"
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/reader.h"
-#include "rapidjson/writer.h"
-
 #include "arrow/io/memory.h"
 #include "arrow/json/converter.h"
 #include "arrow/json/options.h"
 #include "arrow/json/parser.h"
+#include "arrow/json/rapidjson_defs.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/string_view.h"
 #include "arrow/visitor_inline.h"
+#include "rapidjson/document.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/reader.h"
+#include "rapidjson/writer.h"
 
 namespace arrow {
 
@@ -190,6 +189,14 @@ inline static Status ParseFromString(ParseOptions options, string_view src_str,
   RETURN_NOT_OK(BlockParser::Make(options, &parser));
   RETURN_NOT_OK(parser->Parse(src));
   return parser->Finish(parsed);
+}
+
+inline static Status ParseFromString(ParseOptions options, string_view src_str,
+                                     std::shared_ptr<StructArray>* parsed) {
+  std::shared_ptr<Array> parsed_non_struct;
+  RETURN_NOT_OK(ParseFromString(options, src_str, &parsed_non_struct));
+  *parsed = internal::checked_pointer_cast<StructArray>(parsed_non_struct);
+  return Status::OK();
 }
 
 static inline std::string PrettyPrint(string_view one_line) {


### PR DESCRIPTION
Changes:
- Added support for decimal128 and decimal256 json converted.
- Added unit tests for converting decimal128 and decimal256. (Note: This is not providing inferring support)