### PR TITLE
ARROW-3699: [C++] Dockerfile for testing 32-bit C++ build

### DIFF
--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -72,7 +72,13 @@ RUN apt-get update -y -q && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
+<<<<<<< HEAD
 RUN /arrow/ci/scripts/install_minio.sh latest /usr/local
+=======
+RUN if [ "${arch}" != "i386" ]; then \
+      /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local; \
+    fi
+>>>>>>> 35114b428 (debian i386)
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -72,13 +72,7 @@ RUN apt-get update -y -q && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
-<<<<<<< HEAD
 RUN /arrow/ci/scripts/install_minio.sh latest /usr/local
-=======
-RUN if [ "${arch}" != "i386" ]; then \
-      /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local; \
-    fi
->>>>>>> 35114b428 (debian i386)
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/ci/scripts/install_minio.sh
+++ b/ci/scripts/install_minio.sh
@@ -30,25 +30,25 @@ platforms=([Linux]=linux
 
 arch=$(uname -m)
 platform=$(uname)
+version=$1
+prefix=$2
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <prefix>"
   exit 1
-elif [[ -z ${archs[$arch]} ]]; then
+elif [ -z ${archs[$arch]} ]; then
   echo "Unsupported architecture: ${arch}"
   exit 0
-elif [[ -z ${archs[$platform]} ]]; then
-  echo "Unexpected platform: ${platform}"
+elif [ -z ${platforms[$platform]} ]; then
+  echo "Unsupported platform: ${platform}"
   exit 0
-elif [[ ${version} != "latest" ]]; then
+elif [ "${version}" != "latest" ]; then
   echo "Cannot fetch specific versions of minio, only latest is supported."
   exit 1
 fi
 
 arch=${archs[$arch]}
 platform=${platforms[$platform]}
-version=$1
-prefix=$2
 
 if [[ ! -x ${prefix}/bin/minio ]]; then
   url="https://dl.min.io/server/minio/release/${platform}-${arch}/minio"

--- a/ci/scripts/install_minio.sh
+++ b/ci/scripts/install_minio.sh
@@ -28,18 +28,27 @@ declare -A platforms
 platforms=([Linux]=linux
            [Darwin]=darwin)
 
-arch=${archs[$(uname -m)]}
-platform=${platforms[$(uname)]}
-version=$1
-prefix=$2
+arch=$(uname -m)
+platform=$(uname)
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <prefix>"
   exit 1
+elif [[ -z ${archs[$arch]} ]]; then
+  echo "Unsupported architecture: ${arch}"
+  exit 0
+elif [[ -z ${archs[$platform]} ]]; then
+  echo "Unexpected platform: ${platform}"
+  exit 0
 elif [[ ${version} != "latest" ]]; then
   echo "Cannot fetch specific versions of minio, only latest is supported."
   exit 1
 fi
+
+arch=${archs[$arch]}
+platform=${platforms[$platform]}
+version=$1
+prefix=$2
 
 if [[ ! -x ${prefix}/bin/minio ]]; then
   url="https://dl.min.io/server/minio/release/${platform}-${arch}/minio"

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3451,7 +3451,7 @@ TEST_F(TestInt64QuantileKernel, Int64) {
 #undef DOUBLE
 #undef O
 
-#if ARROW_BITNESS != 32
+#if !defined(__MINGW32__) && !defined(__i386__)
 template <typename ArrowType>
 class TestRandomQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {
   using CType = typename ArrowType::c_type;

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3451,7 +3451,7 @@ TEST_F(TestInt64QuantileKernel, Int64) {
 #undef DOUBLE
 #undef O
 
-#ifndef __MINGW32__
+#if ARROW_BITNESS != 32
 template <typename ArrowType>
 class TestRandomQuantileKernel : public TestPrimitiveQuantileKernel<ArrowType> {
   using CType = typename ArrowType::c_type;

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -981,7 +981,7 @@ tasks:
       image: ubuntu-cpp
 
 {% for arch, flags in [("amd64", ""), ("i386", "-e ARROW_S3=OFF -e ARROW_GANDIVA=OFF")] %}
-  {% for debian_version in [("10", "11"] %}
+  {% for debian_version in ["10", "11"] %}
   test-debian-{{ debian_version }}-cpp-{{ arch }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -980,18 +980,25 @@ tasks:
       flags: -e ARROW_SKYHOOK=ON
       image: ubuntu-cpp
 
-{% for arch, flags in [("amd64", ""), ("i386", "-e ARROW_S3=OFF -e ARROW_GANDIVA=OFF")] %}
-  {% for debian_version in ["10", "11"] %}
-  test-debian-{{ debian_version }}-cpp-{{ arch }}:
+{% for debian_version in ["10", "11"] %}
+  test-debian-{{ debian_version }}-cpp-amd64:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        ARCH: "{{ arch }}"
+        ARCH: "amd64"
         DEBIAN: "{{ debian_version }}"
-      flags: "{{ flags }}"
       image: debian-cpp
-  {% endfor %}
+
+  test-debian-{{ debian_version }}-cpp-i386:
+    ci: github
+    template: docker-tests/github.linux.yml
+    params:
+      env:
+        ARCH: "i386"
+        DEBIAN: "{{ debian_version }}"
+      flags: "-e ARROW_S3=OFF -e ARROW_GANDIVA=OFF"
+      image: debian-cpp
 {% endfor %}
 
   test-fedora-33-cpp:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -980,14 +980,18 @@ tasks:
       flags: -e ARROW_SKYHOOK=ON
       image: ubuntu-cpp
 
-{% for debian_version in ["10", "11"] %}
-  test-debian-{{ debian_version }}-cpp:
+{% for arch, flags in [("amd64", ""), ("i386", "-e ARROW_S3=OFF -e ARROW_GANDIVA=OFF")] %}
+  {% for debian_version in [("10", "11"] %}
+  test-debian-{{ debian_version }}-cpp-{{ arch }}:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
+        ARCH: "{{ arch }}"
         DEBIAN: "{{ debian_version }}"
+      flags: "{{ flags }}"
       image: debian-cpp
+  {% endfor %}
 {% endfor %}
 
   test-fedora-33-cpp:


### PR DESCRIPTION
I'm not sure whether this is going to work on a amd64 linux host, but it actually runs on docker for mac. 

@pitrou could you please try 

```
ARCH=i386 archery docker run -e ARROW_GANDIVA=OFF -e ARROW_S3=OFF debian-cpp
``` 

locally?