### PR TITLE
ARROW-9719: [Python] Improve HadoopFileSystem docstring

### DIFF
--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -37,6 +37,8 @@ cdef class HadoopFileSystem(FileSystem):
         HDFS host to connect to.
     port : int, default 8020
         HDFS port to connect to.
+    user : str, default None
+        Username when connecting to HDFS; None implies login user.
     replication : int, default 3
         Number of copies each block will have.
     buffer_size : int, default 0
@@ -47,6 +49,9 @@ cdef class HadoopFileSystem(FileSystem):
         128 MB.
     kerb_ticket : string or path, default None
         If not None, the path to the Kerberos ticket cache.
+    extra_conf : dict, default None
+        Extra key/value pairs for configuration; will override any
+        hdfs-site.xml properties.
     """
 
     cdef:


### PR DESCRIPTION
Document missing parameters.