### PR TITLE
ARROW-12540: [C++] Implementing casting support from date32/date64 to uft8/large_utf8

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -197,7 +197,8 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI)});
   ExpectCanCast(large_utf8(), {timestamp(TimeUnit::NANO)});
-  ExpectCannotCast(timestamp(TimeUnit::MICRO), {binary(), large_binary()});  // no formatting supported
+  ExpectCannotCast(timestamp(TimeUnit::MICRO),
+                   {binary(), large_binary()});  // no formatting supported
 
   ExpectCannotCast(fixed_size_binary(3),
                    {fixed_size_binary(3)});  // FIXME missing identity cast
@@ -1227,15 +1228,17 @@ TEST(Cast, TimeToString) {
   for (auto string_type : {utf8(), large_utf8()}) {
     CheckCast(ArrayFromJSON(time32(TimeUnit::SECOND), "[1, 62]"),
               ArrayFromJSON(string_type, R"(["00:00:01", "00:01:02"])"));
-    CheckCast(ArrayFromJSON(time64(TimeUnit::NANO), "[0, 1]"),
-              ArrayFromJSON(string_type, R"(["00:00:00.000000000", "00:00:00.000000001"])"));
+    CheckCast(
+        ArrayFromJSON(time64(TimeUnit::NANO), "[0, 1]"),
+        ArrayFromJSON(string_type, R"(["00:00:00.000000000", "00:00:00.000000001"])"));
   }
 }
 
 TEST(Cast, TimestampToString) {
   for (auto string_type : {utf8(), large_utf8()}) {
-    CheckCast(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[-30610224000, -5364662400]"),
-              ArrayFromJSON(string_type, R"(["1000-01-01 00:00:00", "1800-01-01 00:00:00"])"));
+    CheckCast(
+        ArrayFromJSON(timestamp(TimeUnit::SECOND), "[-30610224000, -5364662400]"),
+        ArrayFromJSON(string_type, R"(["1000-01-01 00:00:00", "1800-01-01 00:00:00"])"));
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -214,7 +214,6 @@ TEST(Cast, CanCast) {
   ExpectCanCast(timestamp(TimeUnit::MICRO), {utf8(), large_utf8()});
   ExpectCanCast(time32(TimeUnit::MILLI), {utf8(), large_utf8()});
   ExpectCanCast(time64(TimeUnit::NANO), {utf8(), large_utf8()});
-  //ExpectCanCast(duration(TimeUnit::SECOND), {utf8(), large_utf8()}); //FIXME
 }
 
 TEST(Cast, SameTypeZeroCopy) {
@@ -1221,6 +1220,22 @@ TEST(Cast, DateToString) {
               ArrayFromJSON(string_type, R"(["1970-01-01", null])"));
     CheckCast(ArrayFromJSON(date64(), "[86400000, null]"),
               ArrayFromJSON(string_type, R"(["1970-01-02", null])"));
+  }
+}
+
+TEST(Cast, TimeToString) {
+  for (auto string_type : {utf8(), large_utf8()}) {
+    CheckCast(ArrayFromJSON(time32(TimeUnit::SECOND), "[1, 62]"),
+              ArrayFromJSON(string_type, R"(["00:00:01", "00:01:02"])"));
+    CheckCast(ArrayFromJSON(time64(TimeUnit::NANO), "[0, 1]"),
+              ArrayFromJSON(string_type, R"(["00:00:00.000000000", "00:00:00.000000001"])"));
+  }
+}
+
+TEST(Cast, TimestampToString) {
+  for (auto string_type : {utf8(), large_utf8()}) {
+    CheckCast(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[-30610224000, -5364662400]"),
+              ArrayFromJSON(string_type, R"(["1000-01-01 00:00:00", "1800-01-01 00:00:00"])"));
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -197,8 +197,8 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI)});
   ExpectCanCast(large_utf8(), {timestamp(TimeUnit::NANO)});
-  ExpectCannotCast(timestamp(TimeUnit::MICRO),
-                   kBaseBinaryTypes);  // no formatting supported
+  // ExpectCannotCast(timestamp(TimeUnit::MICRO),
+  //                 kBaseBinaryTypes);  // no formatting supported
 
   ExpectCannotCast(fixed_size_binary(3),
                    {fixed_size_binary(3)});  // FIXME missing identity cast
@@ -208,6 +208,9 @@ TEST(Cast, CanCast) {
   ExpectCanCast(smallint(),
                 kNumericTypes);  // any cast which is valid for storage is supported
   ExpectCannotCast(null(), {smallint()});  // FIXME missing common cast from null
+
+  ExpectCanCast(date32(), {utf8(), large_utf8()});
+  ExpectCanCast(date64(), {utf8(), large_utf8()});
 }
 
 TEST(Cast, SameTypeZeroCopy) {
@@ -1206,6 +1209,15 @@ TEST(Cast, TimeZeroCopy) {
   }
   CheckCastZeroCopy(ArrayFromJSON(int64(), "[0, null, 2000, 1000, 0]"),
                     time64(TimeUnit::MICRO));
+}
+
+TEST(Cast, DateToString) {
+  for (auto string_type : {utf8(), large_utf8()}) {
+    CheckCast(ArrayFromJSON(date32(), "[0, null]"),
+              ArrayFromJSON(string_type, R"(["1970-01-01", null])"));
+    CheckCast(ArrayFromJSON(date64(), "[86400000, null]"),
+              ArrayFromJSON(string_type, R"(["1970-01-02", null])"));
+  }
 }
 
 TEST(Cast, DateToDate) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -197,8 +197,7 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI)});
   ExpectCanCast(large_utf8(), {timestamp(TimeUnit::NANO)});
-  // ExpectCannotCast(timestamp(TimeUnit::MICRO),
-  //                 kBaseBinaryTypes);  // no formatting supported
+  ExpectCannotCast(timestamp(TimeUnit::MICRO), {binary(), large_binary()});  // no formatting supported
 
   ExpectCannotCast(fixed_size_binary(3),
                    {fixed_size_binary(3)});  // FIXME missing identity cast
@@ -211,6 +210,11 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(date32(), {utf8(), large_utf8()});
   ExpectCanCast(date64(), {utf8(), large_utf8()});
+  ExpectCanCast(timestamp(TimeUnit::NANO), {utf8(), large_utf8()});
+  ExpectCanCast(timestamp(TimeUnit::MICRO), {utf8(), large_utf8()});
+  ExpectCanCast(time32(TimeUnit::MILLI), {utf8(), large_utf8()});
+  ExpectCanCast(time64(TimeUnit::NANO), {utf8(), large_utf8()});
+  //ExpectCanCast(duration(TimeUnit::SECOND), {utf8(), large_utf8()}); //FIXME
 }
 
 TEST(Cast, SameTypeZeroCopy) {

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -57,20 +57,26 @@ std::vector<WriterTestParams> GenerateTestCases() {
       {field("a", uint64())},
       {field("b\"", utf8())},
       {field("c ", int32())},
+      {field("d", date32())},
+      {field("e", date64())},
   });
   auto populated_batch = R"([{"a": 1, "c ": -1},
                              { "a": 1, "b\"": "abc\"efg", "c ": 2324},
                              { "b\"": "abcd", "c ": 5467},
                              { },
                              { "a": 546, "b\"": "", "c ": 517 },
-                             { "a": 124, "b\"": "a\"\"b\"" }])";
-  std::string expected_without_header = std::string("1,,-1") + "\n" +     // line 1
-                                        +R"(1,"abc""efg",2324)" + "\n" +  // line 2
-                                        R"(,"abcd",5467)" + "\n" +        // line 3
-                                        R"(,,)" + "\n" +                  // line 4
-                                        R"(546,"",517)" + "\n" +          // line 5
-                                        R"(124,"a""""b""",)" + "\n";      // line 6
-  std::string expected_header = std::string(R"("a","b""","c ")") + "\n";
+                             { "a": 124, "b\"": "a\"\"b\"" },
+                             { "d": 0 },
+                             { "e": 86400000 }])";
+  std::string expected_without_header = std::string("1,,-1,,") + "\n" +    // line 1
+                                        R"(1,"abc""efg",2324,,)" + "\n" +  // line 2
+                                        R"(,"abcd",5467,,)" + "\n" +       // line 3
+                                        R"(,,,,)" + "\n" +                 // line 4
+                                        R"(546,"",517,,)" + "\n" +         // line 5
+                                        R"(124,"a""""b""",,,)" + "\n" +    // line 6
+                                        R"(,,,1970-01-01,)" + "\n" +       // line 7
+                                        R"(,,,,1970-01-02)" + "\n";        // line 8
+  std::string expected_header = std::string(R"("a","b""","c ","d","e")") + "\n";
 
   return std::vector<WriterTestParams>{
       {abc_schema, "[]", DefaultTestOptions(/*header=*/false), ""},


### PR DESCRIPTION
Changes:
- Implemented casting support from date32/date64 to uft8/large_utf8
- Added unit tests for converting from date32/date64 to uft8/large_utf8.
