### PR TITLE
ARROW-13509: [C++] Take kernel with empty inputs

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2035,7 +2035,7 @@ Result<std::shared_ptr<ChunkedArray>> TakeCC(const ChunkedArray& values,
     ARROW_ASSIGN_OR_RAISE(new_chunks[i],
                           Concatenate(current_chunk->chunks(), ctx->memory_pool()));
   }
-  return std::make_shared<ChunkedArray>(std::move(new_chunks));
+  return std::make_shared<ChunkedArray>(std::move(new_chunks), values.type());
 }
 
 Result<std::shared_ptr<ChunkedArray>> TakeAC(const Array& values,

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2048,7 +2048,7 @@ Result<std::shared_ptr<ChunkedArray>> TakeAC(const Array& values,
     // Take with that indices chunk
     ARROW_ASSIGN_OR_RAISE(new_chunks[i], TakeAA(values, *indices.chunk(i), options, ctx));
   }
-  return std::make_shared<ChunkedArray>(std::move(new_chunks));
+  return std::make_shared<ChunkedArray>(std::move(new_chunks), values.type());
 }
 
 Result<std::shared_ptr<RecordBatch>> TakeRA(const RecordBatch& batch,

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -996,14 +996,20 @@ TEST_F(TestTakeKernel, InvalidIndexType) {
                                          "[0.0, 1.0, 0.1]", &arr));
 }
 
-TEST_F(TestTakeKernel, TakeEmptyIndices) {
-  Datum out;
-  auto dat = Datum(std::make_shared<ChunkedArray>(ArrayFromJSON(int8(), "[]")));
-  auto idx = Datum(std::make_shared<ChunkedArray>(ArrayVector(), int32()));
-  auto ret = Take(dat, idx).Value(&out);
-  ASSERT_OK(ret);
+TEST_F(TestTakeKernel, TakeCCEmptyIndices) {
+  Datum dat = ChunkedArrayFromJSON(int8(), {"[]"});
+  Datum idx = ChunkedArrayFromJSON(int32(), {});
+  ASSERT_OK_AND_ASSIGN(auto out, Take(dat, idx));
   ValidateOutput(out);
-  AssertDatumsEqual(dat, out, true);
+  AssertDatumsEqual(ChunkedArrayFromJSON(int8(), {"[]"}), out, true);
+}
+
+TEST_F(TestTakeKernel, TakeACEmptyIndices) {
+  Datum dat = ArrayFromJSON(int8(), {"[]"});
+  Datum idx = ChunkedArrayFromJSON(int32(), {});
+  ASSERT_OK_AND_ASSIGN(auto out, Take(dat, idx));
+  ValidateOutput(out);
+  AssertDatumsEqual(ChunkedArrayFromJSON(int8(), {"[]"}), out, true);
 }
 
 TEST_F(TestTakeKernel, DefaultOptions) {

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -996,6 +996,16 @@ TEST_F(TestTakeKernel, InvalidIndexType) {
                                          "[0.0, 1.0, 0.1]", &arr));
 }
 
+TEST_F(TestTakeKernel, TakeEmptyIndices) {
+  Datum out;
+  auto dat = Datum(std::make_shared<ChunkedArray>(ArrayFromJSON(int8(), "[]")));
+  auto idx = Datum(std::make_shared<ChunkedArray>(ArrayVector(), int32()));
+  auto ret = Take(dat, idx).Value(&out);
+  ASSERT_OK(ret);
+  ValidateOutput(out);
+  AssertDatumsEqual(dat, out, true);
+}
+
 TEST_F(TestTakeKernel, DefaultOptions) {
   auto indices = ArrayFromJSON(int8(), "[null, 2, 0, 3]");
   auto values = ArrayFromJSON(int8(), "[7, 8, 9, null]");


### PR DESCRIPTION
This PR makes the Take kernel pass the type from the input arrays when constructing the chunked array.
https://issues.apache.org/jira/browse/ARROW-13509