### PR TITLE
ARROW-13567: [C++] ConvertOptions::Defaults leaves `timestamp_parsers` uninitialized

### DIFF
--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -43,6 +43,7 @@ ConvertOptions ConvertOptions::Defaults() {
                          "NULL", "NaN",  "n/a",      "nan",     "null"};
   options.true_values = {"1", "True", "TRUE", "true"};
   options.false_values = {"0", "False", "FALSE", "false"};
+  options.timestamp_parsers = {};
   return options;
 }
 


### PR DESCRIPTION
Initialize `timestamp_parsers` to an empty list in the `ConvertOptions::Defaults` method