### PR TITLE
ARROW-13311: [C++][Documentation] Document hash aggregate kernels

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -2169,7 +2169,8 @@ const FunctionDoc hash_count_doc{"Count the number of null / non-null values",
 
 const FunctionDoc hash_sum_doc{"Sum values of a numeric array",
                                ("Null values are ignored."),
-                               {"array", "group_id_array"}};
+                               {"array", "group_id_array"},
+                               "ScalarAggregateOptions"};
 
 const FunctionDoc hash_product_doc{
     "Compute product of values of a numeric array",
@@ -2179,7 +2180,8 @@ const FunctionDoc hash_product_doc{
 
 const FunctionDoc hash_mean_doc{"Average values of a numeric array",
                                 ("Null values are ignored."),
-                                {"array", "group_id_array"}};
+                                {"array", "group_id_array"},
+                                "ScalarAggregateOptions"};
 
 const FunctionDoc hash_stddev_doc{
     "Calculate the standard deviation of a numeric array",

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1718,11 +1718,11 @@ struct GroupedMinMaxFactory {
   }
 
   Status Visit(const HalfFloatType& type) {
-    return Status::NotImplemented("Summing data of type ", type);
+    return Status::NotImplemented("Computing min/max of data of type ", type);
   }
 
   Status Visit(const DataType& type) {
-    return Status::NotImplemented("Summing data of type ", type);
+    return Status::NotImplemented("Computing min/max of data of type ", type);
   }
 
   static Result<HashAggregateKernel> Make(const std::shared_ptr<DataType>& type) {
@@ -2313,7 +2313,6 @@ void RegisterHashAggregateBasic(FunctionRegistry* registry) {
     auto func = std::make_shared<HashAggregateFunction>(
         "hash_min_max", Arity::Binary(), &hash_min_max_doc,
         &default_scalar_aggregate_options);
-    DCHECK_OK(AddHashAggKernels({boolean()}, GroupedSumFactory::Make, func.get()));
     DCHECK_OK(AddHashAggKernels(NumericTypes(), GroupedMinMaxFactory::Make, func.get()));
     // Type parameters are ignored
     DCHECK_OK(AddHashAggKernels({decimal128(1, 1), decimal256(1, 1)},

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1784,7 +1784,10 @@ struct GroupedAnyImpl : public GroupedAggregator {
     arrow::internal::VisitBitBlocksVoid(
         input.buffers[0], input.offset, input.length,
         [&](int64_t offset) {
-          BitUtil::SetBitTo(seen, *g++, BitUtil::GetBit(values, input.offset + offset));
+          BitUtil::SetBitTo(seen, *g,
+                            BitUtil::GetBit(seen, *g) ||
+                                BitUtil::GetBit(values, input.offset + offset));
+          g++;
         },
         [&]() { BitUtil::SetBitTo(has_nulls, *g++, true); });
     return Status::OK();

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -1103,7 +1103,7 @@ TEST(GroupBy, AnyAndAll) {
     [true,  2]
                         ])",
                                                                                       R"([
-    [true,  2],
+    [false, 2],
     [false, null],
     [null,  3]
                         ])"});

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -291,11 +291,11 @@ equivalents above and reflects how they are implemented internally.
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | Function name | Arity | Input types | Output type    | Options class                    | Notes |
 +===============+=======+=============+================+==================================+=======+
-| hash_all      | Unary | Boolean     | Int64          | :struct:`ScalarAggregateOptions` | \(1)  |
+| hash_all      | Unary | Boolean     | Boolean        | :struct:`ScalarAggregateOptions` | \(1)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_any      | Unary | Any         | Int64          | :struct:`ScalarAggregateOptions` | \(1)  |
+| hash_any      | Unary | Boolean     | Boolean        | :struct:`ScalarAggregateOptions` | \(1)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_count    | Unary | Boolean     | Int64          | :struct:`CountOptions`           | \(2)  |
+| hash_count    | Unary | Any         | Int64          | :struct:`CountOptions`           | \(2)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | hash_mean     | Unary | Numeric     | Float64        | :struct:`ScalarAggregateOptions` |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -285,7 +285,7 @@ treated as a distinct key value.
 +-----------------+-------------------+
 
 The supported aggregation functions are as follows. All function names are
-prefixed with "hash\_", which differentiates them from their scalar
+prefixed with ``hash\_``, which differentiates them from their scalar
 equivalents above and reflects how they are implemented internally.
 
 +---------------+-------+-------------+----------------+----------------------------------+-------+

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -255,34 +255,34 @@ emitting one output value per input group.
 As an example, for the following table:
 
 +-----------------+--------------+
-| Column "x"      | Column "key" |
+| Column ``key``  | Column ``x`` |
 +=================+==============+
-| 2               | "a"          |
+| "a"             | 2            |
 +-----------------+--------------+
-| 5               | "a"          |
+| "a"             | 5            |
 +-----------------+--------------+
-| null            | "b"          |
+| "b"             | null         |
 +-----------------+--------------+
-| null            | "b"          |
+| "b"             | null         |
 +-----------------+--------------+
 | null            | null         |
 +-----------------+--------------+
-| 9               | null         |
+| null            | 9            |
 +-----------------+--------------+
 
-we can compute a sum of the column "x", grouped on the column "key".
+we can compute a sum of the column ``x``, grouped on the column ``key``.
 This gives us three groups, with the following results. Note that null is
 treated as a distinct key value.
 
-+-----------------+--------------+
-| Column "sum(x)" | Column "key" |
-+=================+==============+
-| 7               | "a"          |
-+-----------------+--------------+
-| null            | "b"          |
-+-----------------+--------------+
-| 9               | null         |
-+-----------------+--------------+
++-----------------+-------------------+
+| Column ``key``  | Column ``sum(x)`` |
++=================+===================+
+| "a"             | 7                 |
++-----------------+-------------------+
+| "b"             | null              |
++-----------------+-------------------+
+| null            | 9                 |
++-----------------+-------------------+
 
 The supported aggregation functions are as follows. All function names are
 prefixed with "hash\_", which differentiates them from their scalar

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -248,9 +248,9 @@ Grouped Aggregations ("group by")
 Grouped aggregations are not directly invokable, but are used as part of a
 SQL-style "group by" operation. Like scalar aggregations, grouped aggregations
 reduce multiple input values to a single output value. Instead of aggregating
-all values of the input, however, grouped aggregations partition of the input
+all values of the input, however, grouped aggregations partition the input
 values on some set of "key" columns, then aggregate each group individually,
-emitting one output per input group.
+emitting one output value per input group.
 
 As an example, for the following table:
 
@@ -267,12 +267,12 @@ As an example, for the following table:
 +-----------------+--------------+
 | null            | null         |
 +-----------------+--------------+
-| 5               | null         |
+| 9               | null         |
 +-----------------+--------------+
 
-We compute a sum of column "x", grouped on the key column "key". This gives us
-three groups, with the following results. Note that null is treated as a
-distinct key.
+we can compute a sum of the column "x", grouped on the column "key".
+This gives us three groups, with the following results. Note that null is
+treated as a distinct key value.
 
 +-----------------+--------------+
 | Column "sum(x)" | Column "key" |
@@ -281,12 +281,12 @@ distinct key.
 +-----------------+--------------+
 | null            | "b"          |
 +-----------------+--------------+
-| 5               | null         |
+| 9               | null         |
 +-----------------+--------------+
 
-The supported aggregation functions are as follows. Note that currently, all
-function names are prefixed with "hash\_", which differentiates them from their
-scalar equivalents above and reflects how they are implemented internally.
+The supported aggregation functions are as follows. All function names are
+prefixed with "hash\_", which differentiates them from their scalar
+equivalents above and reflects how they are implemented internally.
 
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | Function name | Arity | Input types | Output type    | Options class                    | Notes |
@@ -311,7 +311,7 @@ scalar equivalents above and reflects how they are implemented internally.
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 
 * \(1) If null values are taken into account, by setting the
-  ScalarAggregateOptions parameter skip_nulls = false, then `Kleene logic`_
+  :member:`ScalarAggregateOptions::skip_nulls` to false, then `Kleene logic`_
   logic is applied. The min_count option is not respected.
 
 * \(2) CountMode controls whether only non-null values are counted (the
@@ -321,7 +321,7 @@ scalar equivalents above and reflects how they are implemented internally.
 
 * \(4) Output is Int64, UInt64 or Float64, depending on the input type.
 
-* \(5) tdigest/t-digest computes approximate quantiles, and so only needs a
+* \(5) T-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -246,11 +246,11 @@ Grouped Aggregations ("group by")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Grouped aggregations are not directly invokable, but are used as part of a
-group by operation. Like scalar aggregations, grouped aggregations reduce
-multiple input values to a single output value. Instead of aggregating all
-values of the input, however, grouped aggregations partition of the input
+SQL-style "group by" operation. Like scalar aggregations, grouped aggregations
+reduce multiple input values to a single output value. Instead of aggregating
+all values of the input, however, grouped aggregations partition of the input
 values on some set of "key" columns, then aggregate each group individually,
-and emit one output per input group.
+emitting one output per input group.
 
 As an example, for the following table:
 
@@ -271,7 +271,8 @@ As an example, for the following table:
 +-----------------+--------------+
 
 We compute a sum of column "x", grouped on the key column "key". This gives us
-three groups:
+three groups, with the following results. Note that null is treated as a
+distinct key.
 
 +-----------------+--------------+
 | Column "sum(x)" | Column "key" |
@@ -283,7 +284,9 @@ three groups:
 | 5               | null         |
 +-----------------+--------------+
 
-The supported aggregation functions are as follows.
+The supported aggregation functions are as follows. Note that currently, all
+function names are prefixed with "hash\_", which differentiates them from their
+scalar equivalents above and reflects how they are implemented internally.
 
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | Function name | Arity | Input types | Output type    | Options class                    | Notes |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -254,38 +254,38 @@ emitting one output value per input group.
 
 As an example, for the following table:
 
-+-----------------+--------------+
-| Column ``key``  | Column ``x`` |
-+=================+==============+
-| "a"             | 2            |
-+-----------------+--------------+
-| "a"             | 5            |
-+-----------------+--------------+
-| "b"             | null         |
-+-----------------+--------------+
-| "b"             | null         |
-+-----------------+--------------+
-| null            | null         |
-+-----------------+--------------+
-| null            | 9            |
-+-----------------+--------------+
++------------------+-----------------+
+| Column ``key``   | Column ``x``    |
++==================+=================+
+| "a"              | 2               |
++------------------+-----------------+
+| "a"              | 5               |
++------------------+-----------------+
+| "b"              | null            |
++------------------+-----------------+
+| "b"              | null            |
++------------------+-----------------+
+| null             | null            |
++------------------+-----------------+
+| null             | 9               |
++------------------+-----------------+
 
 we can compute a sum of the column ``x``, grouped on the column ``key``.
 This gives us three groups, with the following results. Note that null is
 treated as a distinct key value.
 
-+-----------------+-------------------+
-| Column ``key``  | Column ``sum(x)`` |
-+=================+===================+
-| "a"             | 7                 |
-+-----------------+-------------------+
-| "b"             | null              |
-+-----------------+-------------------+
-| null            | 9                 |
-+-----------------+-------------------+
++------------------+-------------------+
+| Column ``key``   | Column ``sum(x)`` |
++==================+===================+
+| "a"              | 7                 |
++------------------+-------------------+
+| "b"              | null              |
++------------------+-------------------+
+| null             | 9                 |
++------------------+-------------------+
 
 The supported aggregation functions are as follows. All function names are
-prefixed with ``hash\_``, which differentiates them from their scalar
+prefixed with ``hash_``, which differentiates them from their scalar
 equivalents above and reflects how they are implemented internally.
 
 +---------------+-------+-------------+----------------+----------------------------------+-------+

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -248,14 +248,48 @@ Notes:
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
 
-Hash Aggregations ("group by")
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Grouped Aggregations ("group by")
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Hash aggregations are not directly invokable, but are used as part of a group
-by operation. Like scalar aggregations, hash aggregations reduce their input
-to a single output value, but do so on subsets of the input, based on a
-partitioning of the input values on some set of "key" columns, and emit one
-output per input group.
+Grouped aggregations are not directly invokable, but are used as part of a
+group by operation. Like scalar aggregations, grouped aggregations reduce
+multiple input values to a single output value. Instead of aggregating all
+values of the input, however, grouped aggregations partition of the input
+values on some set of "key" columns, then aggregate each group individually,
+and emit one output per input group.
+
+As an example, for the following table:
+
++-----------------+--------------+
+| Column "x"      | Column "key" |
++=================+==============+
+| 2               | "a"          |
++-----------------+--------------+
+| 5               | "a"          |
++-----------------+--------------+
+| null            | "b"          |
++-----------------+--------------+
+| null            | "b"          |
++-----------------+--------------+
+| null            | null         |
++-----------------+--------------+
+| 5               | null         |
++-----------------+--------------+
+
+We compute a sum of column "x", grouped on the key column "key". This gives us
+three groups:
+
++-----------------+--------------+
+| Column "sum(x)" | Column "key" |
++=================+==============+
+| 7               | "a"          |
++-----------------+--------------+
+| null            | "b"          |
++-----------------+--------------+
+| 5               | null         |
++-----------------+--------------+
+
+The supported aggregation functions are as follows.
 
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | Function name | Arity | Input types | Output type    | Options class                    | Notes |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -288,23 +288,23 @@ The supported aggregation functions are as follows.
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | Function name | Arity | Input types | Output type    | Options class                    | Notes |
 +===============+=======+=============+================+==================================+=======+
-| hash_all      | Unary | Boolean     | Scalar Int64   | :struct:`ScalarAggregateOptions` | \(1)  |
+| hash_all      | Unary | Boolean     | Int64          | :struct:`ScalarAggregateOptions` | \(1)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_any      | Unary | Any         | Scalar Int64   | :struct:`ScalarAggregateOptions` | \(1)  |
+| hash_any      | Unary | Any         | Int64          | :struct:`ScalarAggregateOptions` | \(1)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_count    | Unary | Boolean     | Scalar Int64   | :struct:`CountOptions`           | \(2)  |
+| hash_count    | Unary | Boolean     | Int64          | :struct:`CountOptions`           | \(2)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_mean     | Unary | Numeric     | Scalar Float64 |                                  |       |
+| hash_mean     | Unary | Numeric     | Float64        | :struct:`ScalarAggregateOptions` |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_min_max  | Unary | Numeric     | Scalar Struct  | :struct:`ScalarAggregateOptions` | \(3)  |
+| hash_min_max  | Unary | Numeric     | Struct         | :struct:`ScalarAggregateOptions` | \(3)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_stddev   | Unary | Numeric     | Scalar Float64 | :struct:`VarianceOptions`        |       |
+| hash_stddev   | Unary | Numeric     | Float64        | :struct:`VarianceOptions`        |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_sum      | Unary | Numeric     | Scalar Numeric |                                  |       |
+| hash_sum      | Unary | Numeric     | Numeric        | :struct:`ScalarAggregateOptions` | \(4)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_tdigest  | Unary | Numeric     | Scalar Float64 | :struct:`TDigestOptions`         | \(4)  |
+| hash_tdigest  | Unary | Numeric     | Float64        | :struct:`TDigestOptions`         | \(5)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| hash_variance | Unary | Numeric     | Scalar Float64 | :struct:`VarianceOptions`        |       |
+| hash_variance | Unary | Numeric     | Float64        | :struct:`VarianceOptions`        |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 
 * \(1) If null values are taken into account, by setting the
@@ -316,7 +316,9 @@ The supported aggregation functions are as follows.
 
 * \(3) Output is a ``{"min": input type, "max": input type}`` Struct scalar.
 
-* \(4) tdigest/t-digest computes approximate quantiles, and so only needs a
+* \(4) Output is Int64, UInt64 or Float64, depending on the input type.
+
+* \(5) tdigest/t-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -274,15 +274,15 @@ we can compute a sum of the column ``x``, grouped on the column ``key``.
 This gives us three groups, with the following results. Note that null is
 treated as a distinct key value.
 
-+------------------+-------------------+
-| Column ``key``   | Column ``sum(x)`` |
-+==================+===================+
-| "a"              | 7                 |
-+------------------+-------------------+
-| "b"              | null              |
-+------------------+-------------------+
-| null             | 9                 |
-+------------------+-------------------+
++------------------+-----------------------+
+| Column ``key``   | Column ``sum(x)``     |
++==================+=======================+
+| "a"              | 7                     |
++------------------+-----------------------+
+| "b"              | null                  |
++------------------+-----------------------+
+| null             | 9                     |
++------------------+-----------------------+
 
 The supported aggregation functions are as follows. All function names are
 prefixed with ``hash_``, which differentiates them from their scalar

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -211,7 +211,7 @@ the input to a single output value.
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | sum           | Unary | Numeric     | Scalar Numeric | :struct:`ScalarAggregateOptions` | \(5)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| tdigest       | Unary | Numeric     | Scalar Float64 | :struct:`TDigestOptions`         | \(6)  |
+| tdigest       | Unary | Numeric     | Scalar Float64 | :struct:`TDigestOptions`         | \(7)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | variance      | Unary | Numeric     | Scalar Float64 | :struct:`VarianceOptions`        |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
@@ -234,17 +234,11 @@ Notes:
   Note that the output can have less than *N* elements if the input has
   less than *N* distinct values.
 
-  The mode kernel is not a proper aggregate (it is actually a vector
-  function, see below).
-
 * \(5) Output is Int64, UInt64 or Float64, depending on the input type.
 
 * \(6) Output is Float64 or input type, depending on QuantileOptions.
 
-  The quantile kernel is not a proper aggregate (it is actually a vector
-  function, see below).
-
-* \(6) tdigest/t-digest computes approximate quantiles, and so only needs a
+* \(7) tdigest/t-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
 


### PR DESCRIPTION
This adds a section about hash aggregates. Also, adds Kleene logic to the hash any/all kernels.