### PR TITLE
ARROW-13574: [C++] Add 'count all' option to count kernels

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -100,9 +100,9 @@ garrow_scalar_aggregate_options_new(void);
 
 /**
  * GArrowCountMode:
- * @GARROW_COUNT_MODE_NON_NULL:
+ * @GARROW_COUNT_MODE_ONLY_VALID:
  *   Only non-null values will be counted.
- * @GARROW_COUNT_MODE_NULLS:
+ * @GARROW_COUNT_MODE_ONLY_NULL:
  *   Only null values will be counted.
  * @GARROW_COUNT_MODE_ALL:
  *   All will be counted.
@@ -110,8 +110,8 @@ garrow_scalar_aggregate_options_new(void);
  * They correspond to the values of `arrow::compute::CountOptions::CountMode`.
  */
 typedef enum {
-  GARROW_COUNT_MODE_NON_NULL,
-  GARROW_COUNT_MODE_NULLS,
+  GARROW_COUNT_MODE_ONLY_VALID,
+  GARROW_COUNT_MODE_ONLY_NULL,
   GARROW_COUNT_MODE_ALL,
 } GArrowCountMode;
 

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -98,6 +98,38 @@ GARROW_AVAILABLE_IN_5_0
 GArrowScalarAggregateOptions *
 garrow_scalar_aggregate_options_new(void);
 
+/**
+ * GArrowCountMode:
+ * @GARROW_COUNT_MODE_NON_NULL:
+ *   Only non-null values will be counted.
+ * @GARROW_COUNT_MODE_NULLS:
+ *   Only null values will be counted.
+ * @GARROW_COUNT_MODE_ALL:
+ *   All will be counted.
+ *
+ * They correspond to the values of `arrow::compute::CountOptions::CountMode`.
+ */
+typedef enum {
+  GARROW_COUNT_MODE_NON_NULL,
+  GARROW_COUNT_MODE_NULLS,
+  GARROW_COUNT_MODE_ALL,
+} GArrowCountMode;
+
+#define GARROW_TYPE_COUNT_OPTIONS (garrow_count_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowCountOptions,
+                         garrow_count_options,
+                         GARROW,
+                         COUNT_OPTIONS,
+                         GObject)
+struct _GArrowCountOptionsClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_6_0
+GArrowCountOptions *
+garrow_count_options_new(void);
+
 
 /**
  * GArrowFilterNullSelectionBehavior:
@@ -242,7 +274,7 @@ GArrowDictionaryArray *garrow_array_dictionary_encode(GArrowArray *array,
                                                       GError **error);
 GARROW_AVAILABLE_IN_0_13
 gint64 garrow_array_count(GArrowArray *array,
-                          GArrowScalarAggregateOptions *options,
+                          GArrowCountOptions *options,
                           GError **error);
 GARROW_AVAILABLE_IN_0_13
 GArrowStructArray *garrow_array_count_values(GArrowArray *array,

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -53,6 +53,9 @@ arrow::compute::ScalarAggregateOptions *
 garrow_scalar_aggregate_options_get_raw(
   GArrowScalarAggregateOptions *scalar_aggregate_options);
 
+arrow::compute::CountOptions *
+garrow_count_options_get_raw(GArrowCountOptions *count_options);
+
 arrow::compute::FilterOptions *
 garrow_filter_options_get_raw(GArrowFilterOptions *filter_options);
 

--- a/c_glib/test/test-count.rb
+++ b/c_glib/test/test-count.rb
@@ -19,15 +19,25 @@ class TestCount < Test::Unit::TestCase
   include Helper::Buildable
   include Helper::Omittable
 
-  sub_test_case("skip_nulls") do
+  sub_test_case("mode") do
     def test_default
       assert_equal(2, build_int32_array([1, nil, 3]).count)
+
+      options = Arrow::CountOptions.new
+      options.mode = Arrow::CountMode::NON_NULL
+      assert_equal(2, build_int32_array([1, nil, 3]).count(options))
     end
 
-    def test_false
-      options = Arrow::ScalarAggregateOptions.new
-      options.skip_nulls = false
+    def test_nulls
+      options = Arrow::CountOptions.new
+      options.mode = Arrow::CountMode::NULLS
       assert_equal(1, build_int32_array([1, nil, 3]).count(options))
+    end
+
+    def test_all
+      options = Arrow::CountOptions.new
+      options.mode = Arrow::CountMode::ALL
+      assert_equal(3, build_int32_array([1, nil, 3]).count(options))
     end
   end
 end

--- a/c_glib/test/test-count.rb
+++ b/c_glib/test/test-count.rb
@@ -24,13 +24,13 @@ class TestCount < Test::Unit::TestCase
       assert_equal(2, build_int32_array([1, nil, 3]).count)
 
       options = Arrow::CountOptions.new
-      options.mode = Arrow::CountMode::NON_NULL
+      options.mode = Arrow::CountMode::ONLY_VALID
       assert_equal(2, build_int32_array([1, nil, 3]).count(options))
     end
 
     def test_nulls
       options = Arrow::CountOptions.new
-      options.mode = Arrow::CountMode::NULLS
+      options.mode = Arrow::CountMode::ONLY_NULL
       assert_equal(1, build_int32_array([1, nil, 3]).count(options))
     end
 

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -29,14 +29,14 @@ namespace arrow {
 namespace internal {
 template <>
 struct EnumTraits<compute::CountOptions::CountMode>
-    : BasicEnumTraits<compute::CountOptions::CountMode, compute::CountOptions::NON_NULL,
-                      compute::CountOptions::NULLS, compute::CountOptions::ALL> {
+    : BasicEnumTraits<compute::CountOptions::CountMode, compute::CountOptions::ONLY_VALID,
+                      compute::CountOptions::ONLY_NULL, compute::CountOptions::ALL> {
   static std::string name() { return "CountOptions::CountMode"; }
   static std::string value_name(compute::CountOptions::CountMode value) {
     switch (value) {
-      case compute::CountOptions::NON_NULL:
+      case compute::CountOptions::ONLY_VALID:
         return "NON_NULL";
-      case compute::CountOptions::NULLS:
+      case compute::CountOptions::ONLY_NULL:
         return "NULLS";
       case compute::CountOptions::ALL:
         return "ALL";

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -53,6 +53,26 @@ class ARROW_EXPORT ScalarAggregateOptions : public FunctionOptions {
   uint32_t min_count;
 };
 
+/// \brief Control count aggregate kernel behavior.
+///
+/// By default, only non-null values are counted.
+class ARROW_EXPORT CountOptions : public FunctionOptions {
+ public:
+  enum CountMode {
+    /// Count only non-null values.
+    NON_NULL = 0,
+    /// Count only null values.
+    NULLS,
+    /// Count both non-null and null values.
+    ALL,
+  };
+  explicit CountOptions(CountMode mode = CountMode::NON_NULL);
+  constexpr static char const kTypeName[] = "CountOptions";
+  static CountOptions Defaults() { return CountOptions{}; }
+
+  CountMode mode;
+};
+
 /// \brief Control Mode kernel behavior
 ///
 /// Returns top-n common values and counts.
@@ -139,9 +159,9 @@ class ARROW_EXPORT IndexOptions : public FunctionOptions {
 
 /// @}
 
-/// \brief Count non-null (or null) values in an array.
+/// \brief Count values in an array.
 ///
-/// \param[in] options counting options, see ScalarAggregateOptions for more information
+/// \param[in] options counting options, see CountOptions for more information
 /// \param[in] datum to count
 /// \param[in] ctx the function execution context, optional
 /// \return out resulting datum
@@ -149,10 +169,9 @@ class ARROW_EXPORT IndexOptions : public FunctionOptions {
 /// \since 1.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> Count(
-    const Datum& datum,
-    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
-    ExecContext* ctx = NULLPTR);
+Result<Datum> Count(const Datum& datum,
+                    const CountOptions& options = CountOptions::Defaults(),
+                    ExecContext* ctx = NULLPTR);
 
 /// \brief Compute the mean of a numeric array.
 ///

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -60,13 +60,13 @@ class ARROW_EXPORT CountOptions : public FunctionOptions {
  public:
   enum CountMode {
     /// Count only non-null values.
-    NON_NULL = 0,
+    ONLY_VALID = 0,
     /// Count only null values.
-    NULLS,
+    ONLY_NULL,
     /// Count both non-null and null values.
     ALL,
   };
-  explicit CountOptions(CountMode mode = CountMode::NON_NULL);
+  explicit CountOptions(CountMode mode = CountMode::ONLY_VALID);
   constexpr static char const kTypeName[] = "CountOptions";
   static CountOptions Defaults() { return CountOptions{}; }
 

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -40,6 +40,8 @@ TEST(FunctionOptions, Equality) {
   std::vector<std::shared_ptr<FunctionOptions>> options;
   options.emplace_back(new ScalarAggregateOptions());
   options.emplace_back(new ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/1));
+  options.emplace_back(new CountOptions());
+  options.emplace_back(new CountOptions(CountOptions::ALL));
   options.emplace_back(new ModeOptions());
   options.emplace_back(new ModeOptions(/*n=*/2));
   options.emplace_back(new VarianceOptions());

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -57,7 +57,7 @@ namespace aggregate {
 // Count implementation
 
 struct CountImpl : public ScalarAggregator {
-  explicit CountImpl(ScalarAggregateOptions options) : options(std::move(options)) {}
+  explicit CountImpl(CountOptions options) : options(std::move(options)) {}
 
   Status Consume(KernelContext*, const ExecBatch& batch) override {
     if (batch[0].is_array()) {
@@ -82,15 +82,23 @@ struct CountImpl : public ScalarAggregator {
 
   Status Finalize(KernelContext* ctx, Datum* out) override {
     const auto& state = checked_cast<const CountImpl&>(*ctx->state());
-    if (state.options.skip_nulls) {
-      *out = Datum(state.non_nulls);
-    } else {
-      *out = Datum(state.nulls);
+    switch (state.options.mode) {
+      case CountOptions::NON_NULL:
+        *out = Datum(state.non_nulls);
+        break;
+      case CountOptions::NULLS:
+        *out = Datum(state.nulls);
+        break;
+      case CountOptions::ALL:
+        *out = Datum(state.non_nulls + state.nulls);
+        break;
+      default:
+        DCHECK(false) << "unreachable";
     }
     return Status::OK();
   }
 
-  ScalarAggregateOptions options;
+  CountOptions options;
   int64_t non_nulls = 0;
   int64_t nulls = 0;
 };
@@ -98,7 +106,7 @@ struct CountImpl : public ScalarAggregator {
 Result<std::unique_ptr<KernelState>> CountInit(KernelContext*,
                                                const KernelInitArgs& args) {
   return ::arrow::internal::make_unique<CountImpl>(
-      static_cast<const ScalarAggregateOptions&>(*args.options));
+      static_cast<const CountOptions&>(*args.options));
 }
 
 // ----------------------------------------------------------------------
@@ -562,7 +570,7 @@ const FunctionDoc count_doc{"Count the number of null / non-null values",
                             ("By default, only non-null values are counted.\n"
                              "This can be changed through ScalarAggregateOptions."),
                             {"array"},
-                            "ScalarAggregateOptions"};
+                            "CountOptions"};
 
 const FunctionDoc sum_doc{
     "Compute the sum of a numeric array",
@@ -623,17 +631,15 @@ const FunctionDoc index_doc{"Find the index of the first occurrence of a given v
 
 void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   static auto default_scalar_aggregate_options = ScalarAggregateOptions::Defaults();
+  static auto default_count_options = CountOptions::Defaults();
 
   auto func = std::make_shared<ScalarAggregateFunction>(
-      "count", Arity::Unary(), &count_doc, &default_scalar_aggregate_options);
+      "count", Arity::Unary(), &count_doc, &default_count_options);
 
-  // Takes any array input, outputs int64 scalar
-  InputType any_array(ValueDescr::ARRAY);
-  AddAggKernel(KernelSignature::Make({any_array}, ValueDescr::Scalar(int64())),
+  // Takes any input, outputs int64 scalar
+  InputType any_input;
+  AddAggKernel(KernelSignature::Make({any_input}, ValueDescr::Scalar(int64())),
                aggregate::CountInit, func.get());
-  AddAggKernel(
-      KernelSignature::Make({InputType(ValueDescr::SCALAR)}, ValueDescr::Scalar(int64())),
-      aggregate::CountInit, func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   func = std::make_shared<ScalarAggregateFunction>("sum", Arity::Unary(), &sum_doc,

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -578,7 +578,7 @@ static CountPair NaiveCount(const Array& array) {
 
 void ValidateCount(const Array& input, CountPair expected) {
   CountOptions non_null;
-  CountOptions nulls(CountOptions::NULLS);
+  CountOptions nulls(CountOptions::ONLY_NULL);
   CountOptions all(CountOptions::ALL);
 
   ASSERT_OK_AND_ASSIGN(Datum result, Count(input, non_null));
@@ -612,10 +612,10 @@ TYPED_TEST(TestCountKernel, SimpleCount) {
 
   auto ty = TypeTraits<TypeParam>::type_singleton();
   EXPECT_THAT(Count(MakeNullScalar(ty)), ResultWith(Datum(int64_t(0))));
-  EXPECT_THAT(Count(MakeNullScalar(ty), CountOptions(CountOptions::NULLS)),
+  EXPECT_THAT(Count(MakeNullScalar(ty), CountOptions(CountOptions::ONLY_NULL)),
               ResultWith(Datum(int64_t(1))));
   EXPECT_THAT(Count(*MakeScalar(ty, 1)), ResultWith(Datum(int64_t(1))));
-  EXPECT_THAT(Count(*MakeScalar(ty, 1), CountOptions(CountOptions::NULLS)),
+  EXPECT_THAT(Count(*MakeScalar(ty, 1), CountOptions(CountOptions::ONLY_NULL)),
               ResultWith(Datum(int64_t(0))));
 
   CountOptions all(CountOptions::ALL);

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -861,7 +861,7 @@ struct GroupedCountImpl : public GroupedAggregator {
 
     auto g_begin = batch[1].array()->GetValues<uint32_t>(1);
     switch (options_.mode) {
-      case CountOptions::NON_NULL: {
+      case CountOptions::ONLY_VALID: {
         arrow::internal::VisitSetBitRunsVoid(input->buffers[0], input->offset,
                                              input->length,
                                              [&](int64_t offset, int64_t length) {
@@ -872,7 +872,7 @@ struct GroupedCountImpl : public GroupedAggregator {
                                              });
         break;
       }
-      case CountOptions::NULLS: {
+      case CountOptions::ONLY_NULL: {
         if (input->MayHaveNulls()) {
           auto end = input->offset + input->length;
           for (int64_t i = input->offset; i < end; ++i, ++g_begin) {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -1078,7 +1078,7 @@ TEST(GroupBy, CountAndSum) {
   ])");
 
   CountOptions count_options;
-  CountOptions count_nulls(CountOptions::NULLS);
+  CountOptions count_nulls(CountOptions::ONLY_NULL);
   CountOptions count_all(CountOptions::ALL);
   ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
   ASSERT_OK_AND_ASSIGN(
@@ -1256,8 +1256,8 @@ TEST(GroupBy, ConcreteCaseWithValidateGroupBy) {
   ])");
 
   ScalarAggregateOptions keepna{false, 1};
-  CountOptions nulls(CountOptions::NULLS);
-  CountOptions non_null(CountOptions::NON_NULL);
+  CountOptions nulls(CountOptions::ONLY_NULL);
+  CountOptions non_null(CountOptions::ONLY_VALID);
 
   using internal::Aggregate;
   for (auto agg : {
@@ -1282,7 +1282,7 @@ TEST(GroupBy, CountNull) {
     [3.0, "gama"]
   ])");
 
-  CountOptions keepna{CountOptions::NULLS}, skipna{CountOptions::NON_NULL};
+  CountOptions keepna{CountOptions::ONLY_NULL}, skipna{CountOptions::ONLY_VALID};
 
   using internal::Aggregate;
   for (auto agg : {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -1077,13 +1077,17 @@ TEST(GroupBy, CountAndSum) {
     [null,  3]
   ])");
 
-  ScalarAggregateOptions count_options;
+  CountOptions count_options;
+  CountOptions count_nulls(CountOptions::NULLS);
+  CountOptions count_all(CountOptions::ALL);
   ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
   ASSERT_OK_AND_ASSIGN(
       Datum aggregated_and_grouped,
       internal::GroupBy(
           {
               // NB: passing an argument twice or also using it as a key is legal
+              batch->GetColumnByName("argument"),
+              batch->GetColumnByName("argument"),
               batch->GetColumnByName("argument"),
               batch->GetColumnByName("argument"),
               batch->GetColumnByName("argument"),
@@ -1094,6 +1098,8 @@ TEST(GroupBy, CountAndSum) {
           },
           {
               {"hash_count", &count_options},
+              {"hash_count", &count_nulls},
+              {"hash_count", &count_all},
               {"hash_sum", nullptr},
               {"hash_sum", &min_count},
               {"hash_sum", nullptr},
@@ -1102,6 +1108,8 @@ TEST(GroupBy, CountAndSum) {
   AssertDatumsEqual(
       ArrayFromJSON(struct_({
                         field("hash_count", int64()),
+                        field("hash_count", int64()),
+                        field("hash_count", int64()),
                         // NB: summing a float32 array results in float64 sums
                         field("hash_sum", float64()),
                         field("hash_sum", float64()),
@@ -1109,10 +1117,10 @@ TEST(GroupBy, CountAndSum) {
                         field("key_0", int64()),
                     }),
                     R"([
-    [2, 4.25,   null,   3,    1],
-    [3, -0.125, -0.125, 6,    2],
-    [0, null,   null,   6,    3],
-    [2, 4.75,   null,   null, null]
+    [2, 1, 3, 4.25,   null,   3,    1],
+    [3, 0, 3, -0.125, -0.125, 6,    2],
+    [0, 2, 2, null,   null,   6,    3],
+    [2, 0, 2, 4.75,   null,   null, null]
   ])"),
       aggregated_and_grouped,
       /*verbose=*/true);
@@ -1248,13 +1256,14 @@ TEST(GroupBy, ConcreteCaseWithValidateGroupBy) {
   ])");
 
   ScalarAggregateOptions keepna{false, 1};
-  ScalarAggregateOptions skipna{true, 1};
+  CountOptions nulls(CountOptions::NULLS);
+  CountOptions non_null(CountOptions::NON_NULL);
 
   using internal::Aggregate;
   for (auto agg : {
            Aggregate{"hash_sum", nullptr},
-           Aggregate{"hash_count", &skipna},
-           Aggregate{"hash_count", &keepna},
+           Aggregate{"hash_count", &non_null},
+           Aggregate{"hash_count", &nulls},
            Aggregate{"hash_min_max", nullptr},
            Aggregate{"hash_min_max", &keepna},
        }) {
@@ -1273,7 +1282,7 @@ TEST(GroupBy, CountNull) {
     [3.0, "gama"]
   ])");
 
-  ScalarAggregateOptions keepna{false}, skipna{true};
+  CountOptions keepna{CountOptions::NULLS}, skipna{CountOptions::NON_NULL};
 
   using internal::Aggregate;
   for (auto agg : {
@@ -1323,7 +1332,6 @@ TEST(GroupBy, WithChunkedArray) {
                          {"argument": 0.75,  "key": null},
                          {"argument": null,  "key": 3}
                         ])"});
-  ScalarAggregateOptions count_options;
   ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
                        internal::GroupBy(
                            {
@@ -1335,7 +1343,7 @@ TEST(GroupBy, WithChunkedArray) {
                                table->GetColumnByName("key"),
                            },
                            {
-                               {"hash_count", &count_options},
+                               {"hash_count", nullptr},
                                {"hash_sum", nullptr},
                                {"hash_min_max", nullptr},
                            }));

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -190,23 +190,23 @@ Aggregations
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | any           | Unary | Boolean     | Scalar Boolean | :struct:`ScalarAggregateOptions` | \(1)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| count         | Unary | Any         | Scalar Int64   | :struct:`ScalarAggregateOptions` |       |
+| count         | Unary | Any         | Scalar Int64   | :struct:`CountOptions`           | \(2)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | index         | Unary | Any         | Scalar Int64   | :struct:`IndexOptions`           |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | mean          | Unary | Numeric     | Scalar Float64 | :struct:`ScalarAggregateOptions` |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| min_max       | Unary | Numeric     | Scalar Struct  | :struct:`ScalarAggregateOptions` | \(2)  |
+| min_max       | Unary | Numeric     | Scalar Struct  | :struct:`ScalarAggregateOptions` | \(3)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| mode          | Unary | Numeric     | Struct         | :struct:`ModeOptions`            | \(3)  |
+| mode          | Unary | Numeric     | Struct         | :struct:`ModeOptions`            | \(4)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| product       | Unary | Numeric     | Scalar Numeric | :struct:`ScalarAggregateOptions` | \(4)  |
+| product       | Unary | Numeric     | Scalar Numeric | :struct:`ScalarAggregateOptions` | \(5)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| quantile      | Unary | Numeric     | Scalar Numeric | :struct:`QuantileOptions`        | \(5)  |
+| quantile      | Unary | Numeric     | Scalar Numeric | :struct:`QuantileOptions`        | \(6)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | stddev        | Unary | Numeric     | Scalar Float64 | :struct:`VarianceOptions`        |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
-| sum           | Unary | Numeric     | Scalar Numeric | :struct:`ScalarAggregateOptions` | \(4)  |
+| sum           | Unary | Numeric     | Scalar Numeric | :struct:`ScalarAggregateOptions` | \(5)  |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
 | tdigest       | Unary | Numeric     | Scalar Float64 | :struct:`TDigestOptions`         |       |
 +---------------+-------+-------------+----------------+----------------------------------+-------+
@@ -218,18 +218,21 @@ Notes:
 * \(1) If null values are taken into account by setting ScalarAggregateOptions
   parameter skip_nulls = false then `Kleene logic`_ logic is applied.
 
-* \(2) Output is a ``{"min": input type, "max": input type}`` Struct.
+* \(2) CountMode controls whether only non-null values are counted (the
+  default), only null values are counted, or all values are counted.
 
-* \(3) Output is an array of ``{"mode": input type, "count": Int64}`` Struct.
+* \(3) Output is a ``{"min": input type, "max": input type}`` Struct.
+
+* \(4) Output is an array of ``{"mode": input type, "count": Int64}`` Struct.
   It contains the *N* most common elements in the input, in descending
   order, where *N* is given in :member:`ModeOptions::n`.
   If two values have the same count, the smallest one comes first.
   Note that the output can have less than *N* elements if the input has
   less than *N* distinct values.
 
-* \(4) Output is Int64, UInt64 or Float64, depending on the input type.
+* \(5) Output is Int64, UInt64 or Float64, depending on the input type.
 
-* \(5) Output is Float64 or input type, depending on QuantileOptions.
+* \(6) Output is Float64 or input type, depending on QuantileOptions.
 
 Element-wise ("scalar") functions
 ---------------------------------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -887,6 +887,23 @@ class ScalarAggregateOptions(_ScalarAggregateOptions):
         self._set_options(skip_nulls, min_count)
 
 
+cdef class _CountOptions(FunctionOptions):
+    def _set_options(self, mode):
+        if mode == 'non_null':
+            self.wrapped.reset(new CCountOptions(CCountMode_NON_NULL))
+        elif mode == 'nulls':
+            self.wrapped.reset(new CCountOptions(CCountMode_NULLS))
+        elif mode == 'all':
+            self.wrapped.reset(new CCountOptions(CCountMode_ALL))
+        else:
+            raise ValueError(f'"{mode}" is not a valid mode')
+
+
+class CountOptions(_CountOptions):
+    def __init__(self, mode='non_null'):
+        self._set_options(mode)
+
+
 cdef class _IndexOptions(FunctionOptions):
     def _set_options(self, Scalar scalar):
         self.wrapped.reset(new CIndexOptions(pyarrow_unwrap_scalar(scalar)))

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -889,10 +889,10 @@ class ScalarAggregateOptions(_ScalarAggregateOptions):
 
 cdef class _CountOptions(FunctionOptions):
     def _set_options(self, mode):
-        if mode == 'non_null':
-            self.wrapped.reset(new CCountOptions(CCountMode_NON_NULL))
-        elif mode == 'nulls':
-            self.wrapped.reset(new CCountOptions(CCountMode_NULLS))
+        if mode == 'only_valid':
+            self.wrapped.reset(new CCountOptions(CCountMode_ONLY_VALID))
+        elif mode == 'only_null':
+            self.wrapped.reset(new CCountOptions(CCountMode_ONLY_NULL))
         elif mode == 'all':
             self.wrapped.reset(new CCountOptions(CCountMode_ALL))
         else:
@@ -900,7 +900,7 @@ cdef class _CountOptions(FunctionOptions):
 
 
 class CountOptions(_CountOptions):
-    def __init__(self, mode='non_null'):
+    def __init__(self, mode='only_valid'):
         self._set_options(mode)
 
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -31,6 +31,7 @@ from pyarrow._compute import (  # noqa
     # Option classes
     ArraySortOptions,
     CastOptions,
+    CountOptions,
     DictionaryEncodeOptions,
     ElementWiseAggregateOptions,
     ExtractRegexOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1959,6 +1959,16 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         c_bool skip_nulls
         uint32_t min_count
 
+    enum CCountMode "arrow::compute::CountOptions::CountMode":
+        CCountMode_NON_NULL "arrow::compute::CountOptions::NON_NULL"
+        CCountMode_NULLS "arrow::compute::CountOptions::NULLS"
+        CCountMode_ALL "arrow::compute::CountOptions::ALL"
+
+    cdef cppclass CCountOptions \
+            "arrow::compute::CountOptions"(CFunctionOptions):
+        CCountOptions(CCountMode mode)
+        CCountMode mode
+
     cdef cppclass CModeOptions \
             "arrow::compute::ModeOptions"(CFunctionOptions):
         CModeOptions(int64_t n)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1960,8 +1960,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         uint32_t min_count
 
     enum CCountMode "arrow::compute::CountOptions::CountMode":
-        CCountMode_NON_NULL "arrow::compute::CountOptions::NON_NULL"
-        CCountMode_NULLS "arrow::compute::CountOptions::NULLS"
+        CCountMode_ONLY_VALID "arrow::compute::CountOptions::ONLY_VALID"
+        CCountMode_ONLY_NULL "arrow::compute::CountOptions::ONLY_NULL"
         CCountMode_ALL "arrow::compute::CountOptions::ALL"
 
     cdef cppclass CCountOptions \

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1439,11 +1439,9 @@ def test_extract_datetime_components():
 def test_count():
     arr = pa.array([1, 2, 3, None, None])
     assert pc.count(arr).as_py() == 3
-    assert pc.count(arr, skip_nulls=True).as_py() == 3
-    assert pc.count(arr, skip_nulls=False).as_py() == 2
-
-    with pytest.raises(TypeError, match="an integer is required"):
-        pc.count(arr, min_count='zzz')
+    assert pc.count(arr, mode='non_null').as_py() == 3
+    assert pc.count(arr, mode='nulls').as_py() == 2
+    assert pc.count(arr, mode='all').as_py() == 5
 
 
 def test_index():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1439,8 +1439,8 @@ def test_extract_datetime_components():
 def test_count():
     arr = pa.array([1, 2, 3, None, None])
     assert pc.count(arr).as_py() == 3
-    assert pc.count(arr, mode='non_null').as_py() == 3
-    assert pc.count(arr, mode='nulls').as_py() == 2
+    assert pc.count(arr, mode='only_valid').as_py() == 3
+    assert pc.count(arr, mode='only_null').as_py() == 2
     assert pc.count(arr, mode='all').as_py() == 5
 
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -172,11 +172,19 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
   }
 
   if (func_name == "min_max" || func_name == "sum" || func_name == "mean" ||
-      func_name == "count" || func_name == "any" || func_name == "all") {
+      func_name == "any" || func_name == "all") {
     using Options = arrow::compute::ScalarAggregateOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
     out->min_count = cpp11::as_cpp<int>(options["na.min_count"]);
     out->skip_nulls = cpp11::as_cpp<bool>(options["na.rm"]);
+    return out;
+  }
+
+  if (func_name == "count") {
+    using Options = arrow::compute::CountOptions;
+    auto out = std::make_shared<Options>(Options::Defaults());
+    out->mode =
+        cpp11::as_cpp<bool>(options["na.rm"]) ? Options::NON_NULL : Options::NULLS;
     return out;
   }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     using Options = arrow::compute::CountOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
     out->mode =
-        cpp11::as_cpp<bool>(options["na.rm"]) ? Options::NON_NULL : Options::NULLS;
+        cpp11::as_cpp<bool>(options["na.rm"]) ? Options::ONLY_VALID : Options::ONLY_NULL;
     return out;
   }
 


### PR DESCRIPTION
Pandas calls this 'size'. I opted not to extend ScalarAggregateOptions as the option wouldn't apply to any other kernel.