### PR TITLE
ARROW-13580: [C++] quoted_strings_can_be_null only applied to string columns

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -122,7 +122,7 @@ struct ValueDecoder {
   }
 
   bool IsNull(const uint8_t* data, uint32_t size, bool quoted) {
-    if (quoted) {
+    if (quoted && !options_.quoted_strings_can_be_null) {
       return false;
     }
     return null_trie_.Find(

--- a/cpp/src/arrow/csv/converter_test.cc
+++ b/cpp/src/arrow/csv/converter_test.cc
@@ -299,6 +299,7 @@ TEST(FixedSizeBinaryConversion, CustomNulls) {
   AssertConversion<FixedSizeBinaryType, std::string>(fixed_size_binary(2),
                                                      {"\"ab\",\"xxx\"\n"}, {{"ab"}, {""}},
                                                      {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(fixed_size_binary(2), {"\"ab\",\"xxx\"\n"}, {1}, options);
 
@@ -359,6 +360,7 @@ TEST(IntegerConversion, CustomNulls) {
 
   AssertConversion<Int8Type, int8_t>(int8(), {"\"12\",\"xxx\"\n"}, {{12}, {0}},
                                      {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(int8(), {"\"12\",\"xxx\"\n"}, {1}, options);
 
@@ -401,6 +403,7 @@ TEST(FloatingPointConversion, CustomNulls) {
 
   AssertConversion<FloatType, float>(float32(), {"\"1.5\",\"xxx\"\n"}, {{1.5}, {0}},
                                      {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(float32(), {"\"1.5\",\"xxx\"\n"}, {1}, options);
 
@@ -444,6 +447,7 @@ TEST(BooleanConversion, CustomNulls) {
 
   AssertConversion<BooleanType, bool>(boolean(), {"\"true\",\"xxx\"\n"}, {{1}, {0}},
                                       {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(boolean(), {"\"true\",\"xxx\"\n"}, {1}, options);
 
@@ -564,6 +568,7 @@ TEST(TimestampConversion, CustomNulls) {
 
   AssertConversion<TimestampType, int64_t>(type, {"\"1970-01-01 00:01:00\",\"xxx\"\n"},
                                            {{60000}, {0}}, {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(type, {"\"1970-01-01 00:01:00\",\"xxx\"\n"}, {1}, options);
 
@@ -617,6 +622,7 @@ TEST(DecimalConversion, CustomNulls) {
   AssertConversion<Decimal128Type, Decimal128>(decimal(14, 3), {"\"1.5\",\"xxx\"\n"},
                                                {{Dec128("1.500")}, {0}},
                                                {{true}, {false}}, options);
+
   options.quoted_strings_can_be_null = false;
   AssertConversionError(decimal(14, 3), {"\"1.5\",\"xxx\"\n"}, {1}, options);
 
@@ -685,6 +691,7 @@ TYPED_TEST(TestNumericDictConverter, Errors) {
   ASSERT_RAISES(Invalid, DictConversion(value_type, "xxx\n"));
 
   ConvertOptions options = ConvertOptions::Defaults();
+
   options.quoted_strings_can_be_null = false;
   ASSERT_RAISES(Invalid, DictConversion(value_type, "\"N/A\"\n", -1, options));
 

--- a/cpp/src/arrow/csv/converter_test.cc
+++ b/cpp/src/arrow/csv/converter_test.cc
@@ -296,6 +296,12 @@ TEST(FixedSizeBinaryConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
 
+  AssertConversion<FixedSizeBinaryType, std::string>(fixed_size_binary(2),
+                                                     {"\"ab\",\"xxx\"\n"}, {{"ab"}, {""}},
+                                                     {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(fixed_size_binary(2), {"\"ab\",\"xxx\"\n"}, {1}, options);
+
   AssertConversion<FixedSizeBinaryType, std::string>(
       fixed_size_binary(2), {"ab,xxx\n", "zzz,ij\n"}, {{"ab", "\0\0"}, {"\0\0", "ij"}},
       {{true, false}, {false, true}}, options);
@@ -351,6 +357,11 @@ TEST(IntegerConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
 
+  AssertConversion<Int8Type, int8_t>(int8(), {"\"12\",\"xxx\"\n"}, {{12}, {0}},
+                                     {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(int8(), {"\"12\",\"xxx\"\n"}, {1}, options);
+
   AssertConversion<Int8Type, int8_t>(int8(), {"12,xxx\n", "zzz,-128\n"},
                                      {{12, 0}, {0, -128}}, {{true, false}, {false, true}},
                                      options);
@@ -387,6 +398,11 @@ TEST(FloatingPointConversion, Nulls) {
 TEST(FloatingPointConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
+
+  AssertConversion<FloatType, float>(float32(), {"\"1.5\",\"xxx\"\n"}, {{1.5}, {0}},
+                                     {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(float32(), {"\"1.5\",\"xxx\"\n"}, {1}, options);
 
   AssertConversion<FloatType, float>(float32(), {"1.5,xxx\n", "zzz,-1e10\n"},
                                      {{1.5, 0.}, {0., -1e10f}},
@@ -425,6 +441,11 @@ TEST(BooleanConversion, Nulls) {
 TEST(BooleanConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
+
+  AssertConversion<BooleanType, bool>(boolean(), {"\"true\",\"xxx\"\n"}, {{1}, {0}},
+                                      {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(boolean(), {"\"true\",\"xxx\"\n"}, {1}, options);
 
   AssertConversion<BooleanType, bool>(boolean(), {"true,xxx\n", "zzz,0\n"},
                                       {{true, false}, {false, false}},
@@ -539,8 +560,13 @@ TEST(TimestampConversion, Nulls) {
 TEST(TimestampConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
-
   auto type = timestamp(TimeUnit::MILLI);
+
+  AssertConversion<TimestampType, int64_t>(type, {"\"1970-01-01 00:01:00\",\"xxx\"\n"},
+                                           {{60000}, {0}}, {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(type, {"\"1970-01-01 00:01:00\",\"xxx\"\n"}, {1}, options);
+
   AssertConversion<TimestampType, int64_t>(type, {"1970-01-01 00:01:00,xxx,zzz\n"},
                                            {{60000}, {0}, {0}},
                                            {{true}, {false}, {false}}, options);
@@ -587,6 +613,12 @@ TEST(DecimalConversion, Nulls) {
 TEST(DecimalConversion, CustomNulls) {
   auto options = ConvertOptions::Defaults();
   options.null_values = {"xxx", "zzz"};
+
+  AssertConversion<Decimal128Type, Decimal128>(decimal(14, 3), {"\"1.5\",\"xxx\"\n"},
+                                               {{Dec128("1.500")}, {0}},
+                                               {{true}, {false}}, options);
+  options.quoted_strings_can_be_null = false;
+  AssertConversionError(decimal(14, 3), {"\"1.5\",\"xxx\"\n"}, {1}, options);
 
   AssertConversion<Decimal128Type, Decimal128>(
       decimal(14, 3), {"1.5,xxx\n", "zzz,-1e3\n"},
@@ -645,11 +677,16 @@ TYPED_TEST(TestNumericDictConverter, Nulls) {
   auto expected_indices = ArrayFromJSON(int32(), "[0, 1, null, 0]");
 
   AssertDictConversion("4\n5\nN/A\n4\n", expected_indices, expected_dict);
+  AssertDictConversion("\"4\"\n\"5\"\n\"N/A\"\n\"4\"\n", expected_indices, expected_dict);
 }
 
 TYPED_TEST(TestNumericDictConverter, Errors) {
   auto value_type = this->type();
   ASSERT_RAISES(Invalid, DictConversion(value_type, "xxx\n"));
+
+  ConvertOptions options = ConvertOptions::Defaults();
+  options.quoted_strings_can_be_null = false;
+  ASSERT_RAISES(Invalid, DictConversion(value_type, "\"N/A\"\n", -1, options));
 
   // Overflow
   if (is_integer(value_type->id())) {

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -85,11 +85,11 @@ struct ARROW_EXPORT ConvertOptions {
   /// If true, then strings in "null_values" are considered null for string columns.
   /// If false, then all strings are valid string values.
   bool strings_can_be_null = false;
-  /// Whether string / binary columns can have quoted null values.
+
+  /// Whether quoted values can be null.
   ///
-  /// If true *and* `strings_can_be_null` is true, then quoted strings in
-  /// "null_values" are also considered null for string columns.  Otherwise,
-  /// quoted strings are never considered null.
+  /// If true, then strings in "null_values" are also considered null when they
+  /// appear quoted in the CSV file. Otherwise, quoted values are never considered null.
   bool quoted_strings_can_be_null = true;
 
   /// Whether to try to automatically dict-encode string / binary data.

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -451,11 +451,10 @@ cdef class ConvertOptions(_Weakrefable):
         string columns.
         If false, then all strings are valid string values.
     quoted_strings_can_be_null: bool, optional (default True)
-        Whether string / binary columns can have quoted null values.
-        If true *and* strings_can_be_null is true, then strings in
-        null_values are considered null for string columns, even when
-        quoted.
-        Otherwise, then all quoted strings are valid string values.
+        Whether quoted values can be null.
+        If true, then strings in "null_values" are also considered null
+        when they appear quoted in the CSV file. Otherwise, quoted values
+        are never considered null.
     auto_dict_encode: bool, optional (default False)
         Whether to try to automatically dict-encode string / binary data.
         If true, then when type inference detects a string or binary column,
@@ -543,7 +542,7 @@ cdef class ConvertOptions(_Weakrefable):
     @property
     def quoted_strings_can_be_null(self):
         """
-        Whether string / binary columns can have quoted null values.
+        Whether quoted values can be null.
         """
         return deref(self.options).quoted_strings_can_be_null
 


### PR DESCRIPTION
Allow quoted nulls if quoted_strings_can_be_null is true