### PR TITLE
ARROW-13604 [Java]: Remove deprecation annotations for APIs representing unsupported operations

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -207,6 +207,13 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
     offsetBuffer.writerIndex((long) valueCount * OFFSET_WIDTH);
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
   @Override
   @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -189,6 +189,14 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
     typeBuffer.writerIndex(valueCount * TYPE_WIDTH);
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
      throw new UnsupportedOperationException("There are no inner vectors. Use geFieldBuffers");

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -190,7 +190,6 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
      throw new UnsupportedOperationException("There are no inner vectors. Use geFieldBuffers");
   }

--- a/java/vector/src/main/codegen/templates/ValueHolders.java
+++ b/java/vector/src/main/codegen/templates/ValueHolders.java
@@ -54,11 +54,15 @@ public final class ${className} implements ValueHolder{
     public ${field.type} ${field.name};
     </#list>
 
+    /**
+     * Reason for not supporting the operation is that ValueHolders are potential scalar
+     * replacements and hence we don't want any methods to be invoked on them.
+     */
     public int hashCode(){
       throw new UnsupportedOperationException();
     }
 
-    /*
+    /**
      * Reason for not supporting the operation is that ValueHolders are potential scalar
      * replacements and hence we don't want any methods to be invoked on them.
      */

--- a/java/vector/src/main/codegen/templates/ValueHolders.java
+++ b/java/vector/src/main/codegen/templates/ValueHolders.java
@@ -53,17 +53,15 @@ public final class ${className} implements ValueHolder{
     <#list fields as field>
     public ${field.type} ${field.name};
     </#list>
-    
-    @Deprecated
+
     public int hashCode(){
       throw new UnsupportedOperationException();
     }
 
     /*
-     * Reason for deprecation is that ValueHolders are potential scalar replacements
-     * and hence we don't want any methods to be invoked on them.
+     * Reason for not supporting the operation is that ValueHolders are potential scalar
+     * replacements and hence we don't want any methods to be invoked on them.
      */
-    @Deprecated
     public String toString(){
       throw new UnsupportedOperationException();
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -457,6 +457,14 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     lastValueCapacity = getValueCapacity();
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -458,7 +458,6 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -254,6 +254,13 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
     valueCount = 0;
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
   @Override
   @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -272,6 +272,14 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     valueCount = 0;
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -273,7 +273,6 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -214,6 +214,14 @@ public abstract class ExtensionTypeVector<T extends ValueVector & FieldVector> e
     return underlyingVector.getFieldBuffers();
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     return underlyingVector.getFieldInnerVectors();

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -63,8 +63,11 @@ public interface FieldVector extends ValueVector {
   /**
    * Get the inner vectors.
    *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
    * @return the inner vectors for this field as defined by the TypeLayout
    */
+  @Deprecated
   List<BufferBacked> getFieldInnerVectors();
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -166,6 +166,14 @@ public class NullVector implements FieldVector {
     return Collections.emptyList();
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     return Collections.emptyList();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -139,7 +139,6 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   @Override
-  @Deprecated
   public UInt4Vector getOffsetVector() {
     throw new UnsupportedOperationException("There is no inner offset vector");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -138,7 +138,14 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     offsetAllocationSizeInBytes = newAllocationSize;
   }
 
+  /**
+   * Get the offset vector.
+   * @deprecated This API will be removed, as the current implementations no longer hold inner offset vectors.
+   *
+   * @return the underlying offset vector or null if none exists.
+   */
   @Override
+  @Deprecated
   public UInt4Vector getOffsetVector() {
     throw new UnsupportedOperationException("There is no inner offset vector");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -183,6 +183,14 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -184,7 +184,6 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -274,7 +274,6 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -273,6 +273,14 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
     }
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
@@ -441,7 +449,14 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
     ComplexCopier.copy(in, out);
   }
 
+  /**
+   * Get the offset vector.
+   * @deprecated This API will be removed, as the current implementations no longer hold inner offset vectors.
+   *
+   * @return the underlying offset vector or null if none exists.
+   */
   @Override
+  @Deprecated
   public UInt4Vector getOffsetVector() {
     throw new UnsupportedOperationException("There is no inner offset vector");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -247,7 +247,6 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -246,6 +246,14 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     }
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
@@ -34,8 +34,11 @@ public interface RepeatedValueVector extends ValueVector, DensityAwareVector {
 
   /**
    * Get the offset vector.
+   * @deprecated This API will be removed, as the current implementations no longer hold inner offset vectors.
+   *
    * @return the underlying offset vector or null if none exists.
    */
+  @Deprecated
   UInt4Vector getOffsetVector();
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -141,6 +141,14 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     validityBuffer.writerIndex(BitVectorHelper.getValidityBufferSize(valueCount));
   }
 
+  /**
+   * Get the inner vectors.
+   *
+   * @deprecated This API will be removed as the current implementations no longer support inner vectors.
+   *
+   * @return the inner vectors for this field as defined by the TypeLayout
+   */
+  @Deprecated
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -142,7 +142,6 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   }
 
   @Override
-  @Deprecated
   public List<BufferBacked> getFieldInnerVectors() {
     throw new UnsupportedOperationException("There are no inner vectors. Use getFieldBuffers");
   }


### PR DESCRIPTION
Some APIs representing unsupported operations should not be annotated deprecated, unless the overriden APIs are deprecated in the super classes/interfaces.

According to the discussion in https://github.com/apache/arrow/pull/10864#issuecomment-895707729, we open a separate issue for this.