### PR TITLE
ARROW-9616: [C++][R] Remove templated base classes named `/.*ConcurrencyWrapper/`

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -227,6 +227,12 @@ jobs:
           rtools-version: 35
           r-version: "3.6"
           Ncpus: 2
+      - name: Turn on LTO for R
+        if: ${{ matrix.rtools != 35 }}
+        shell: Rscript {0}
+        run: |
+          dir.create("~/.R")
+          writeLines(c("CPPFLAGS=-flto", "AR=gcc-ar", "NM=gcc-nm", "RANLIB=gcc-ranlib"), "~/.R/Makevars")
       - name: Build Arrow C++
         shell: bash
         env:

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -444,9 +444,15 @@ Result<std::shared_ptr<BufferedInputStream>> BufferedInputStream::Create(
   return result;
 }
 
-Status BufferedInputStream::DoClose() { return impl_->Close(); }
+Status BufferedInputStream::Close() {
+  auto guard = lock_.CloseGuard();
+  return impl_->Close();
+}
 
-Status BufferedInputStream::DoAbort() { return impl_->Abort(); }
+Status BufferedInputStream::Abort() {
+  auto guard = lock_.AbortGuard();
+  return impl_->Abort();
+}
 
 bool BufferedInputStream::closed() const { return impl_->closed(); }
 
@@ -454,9 +460,13 @@ std::shared_ptr<InputStream> BufferedInputStream::Detach() { return impl_->Detac
 
 std::shared_ptr<InputStream> BufferedInputStream::raw() const { return impl_->raw(); }
 
-Result<int64_t> BufferedInputStream::DoTell() const { return impl_->Tell(); }
+Result<int64_t> BufferedInputStream::Tell() const {
+  auto guard = lock_.TellGuard();
+  return impl_->Tell();
+}
 
-Result<util::string_view> BufferedInputStream::DoPeek(int64_t nbytes) {
+Result<util::string_view> BufferedInputStream::Peek(int64_t nbytes) {
+  auto guard = lock_.PeekGuard();
   return impl_->Peek(nbytes);
 }
 
@@ -468,11 +478,13 @@ int64_t BufferedInputStream::bytes_buffered() const { return impl_->bytes_buffer
 
 int64_t BufferedInputStream::buffer_size() const { return impl_->buffer_size(); }
 
-Result<int64_t> BufferedInputStream::DoRead(int64_t nbytes, void* out) {
+Result<int64_t> BufferedInputStream::Read(int64_t nbytes, void* out) {
+  auto guard = lock_.ReadGuard();
   return impl_->Read(nbytes, out);
 }
 
-Result<std::shared_ptr<Buffer>> BufferedInputStream::DoRead(int64_t nbytes) {
+Result<std::shared_ptr<Buffer>> BufferedInputStream::Read(int64_t nbytes) {
+  auto guard = lock_.ReadGuard();
   return impl_->Read(nbytes);
 }
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -308,7 +308,7 @@ Result<std::shared_ptr<ReadableFile>> ReadableFile::Open(int fd, MemoryPool* poo
   return file;
 }
 
-Status ReadableFile::DoClose() { return impl_->Close(); }
+Status ReadableFile::Close() { return impl_->Close(); }
 
 bool ReadableFile::closed() const { return !impl_->is_open(); }
 
@@ -316,27 +316,40 @@ Status ReadableFile::WillNeed(const std::vector<ReadRange>& ranges) {
   return impl_->WillNeed(ranges);
 }
 
-Result<int64_t> ReadableFile::DoTell() const { return impl_->Tell(); }
+Result<int64_t> ReadableFile::Tell() const {
+  auto guard = lock_.TellGuard();
+  return impl_->Tell();
+}
 
-Result<int64_t> ReadableFile::DoRead(int64_t nbytes, void* out) {
+Result<int64_t> ReadableFile::Read(int64_t nbytes, void* out) {
+  auto guard = lock_.ReadGuard();
   return impl_->Read(nbytes, out);
 }
 
-Result<int64_t> ReadableFile::DoReadAt(int64_t position, int64_t nbytes, void* out) {
+Result<int64_t> ReadableFile::ReadAt(int64_t position, int64_t nbytes, void* out) {
+  auto guard = lock_.ReadAtGuard();
   return impl_->ReadAt(position, nbytes, out);
 }
 
-Result<std::shared_ptr<Buffer>> ReadableFile::DoReadAt(int64_t position, int64_t nbytes) {
+Result<std::shared_ptr<Buffer>> ReadableFile::ReadAt(int64_t position, int64_t nbytes) {
+  auto guard = lock_.ReadAtGuard();
   return impl_->ReadBufferAt(position, nbytes);
 }
 
-Result<std::shared_ptr<Buffer>> ReadableFile::DoRead(int64_t nbytes) {
+Result<std::shared_ptr<Buffer>> ReadableFile::Read(int64_t nbytes) {
+  auto guard = lock_.ReadGuard();
   return impl_->ReadBuffer(nbytes);
 }
 
-Result<int64_t> ReadableFile::DoGetSize() { return impl_->size(); }
+Result<int64_t> ReadableFile::GetSize() {
+  auto guard = lock_.GetSizeGuard();
+  return impl_->size();
+}
 
-Status ReadableFile::DoSeek(int64_t pos) { return impl_->Seek(pos); }
+Status ReadableFile::Seek(int64_t pos) {
+  auto guard = lock_.SeekGuard();
+  return impl_->Seek(pos);
+}
 
 int ReadableFile::file_descriptor() const { return impl_->fd(); }
 

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -300,8 +300,8 @@ ExecNode_Project <- function(input, exprs, names) {
   .Call(`_arrow_ExecNode_Project`, input, exprs, names)
 }
 
-ExecNode_Aggregate <- function(input, options, target_names, out_field_names, key_names){
-    .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
+ExecNode_Aggregate <- function(input, options, target_names, out_field_names, key_names) {
+  .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
 }
 
 RecordBatch__cast <- function(batch, schema, options) {

--- a/r/configure
+++ b/r/configure
@@ -251,7 +251,7 @@ if [ $? -eq 0 ] || [ "$UNAME" = "Darwin" ]; then
     fi
   fi
   # prepend PKG_DIRS and append BUNDLED_LIBS to PKG_LIBS
-  PKG_LIBS="$PKG_DIRS $PKG_LIBS $BUNDLED_LIBS -fno-lto"
+  PKG_LIBS="$PKG_DIRS $PKG_LIBS $BUNDLED_LIBS"
   echo "PKG_CFLAGS=$PKG_CFLAGS"
   echo "PKG_LIBS=$PKG_LIBS"
 else

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -290,23 +290,6 @@ R_CMD_config <- function(var) {
 }
 
 build_libarrow <- function(src_dir, dst_dir) {
-  if (grepl("-flto", R_CMD_config("LTO"))) {
-    # DESCRIPTION says UseLTO: false, but the user can override this with
-    # R CMD INSTALL --use-LTO
-    # In this case, we need to return a library with some features disabled.
-    # The full library builds and links successfully with LTO, but then there's
-    # a segfault on load. This is a temporary solution while we continue to
-    # debug and search for a proper resolution in the upstream C++ project.
-    #
-    # References:
-    # * https://github.com/apache/arrow/pull/10894
-    # * https://github.com/apache/arrow/pull/10889
-    # * https://issues.apache.org/jira/browse/ARROW-13507
-    # * https://issues.apache.org/jira/browse/ARROW-12853
-    # * https://issues.apache.org/jira/browse/ARROW-9616
-    stop("Full library features not supported with LTO", call. = FALSE)
-  }
-
   # We'll need to compile R bindings with these libs, so delete any .o files
   system("rm src/*.o", ignore.stdout = TRUE, ignore.stderr = TRUE)
   # Set up make for parallel building


### PR DESCRIPTION
This is a guess; Windows assumptions about linkage + templated base classes have been problematic in the past