### PR TITLE
ARROW-13597: [C++][Compute] Remove AddOnLoad helper

### DIFF
--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -594,19 +594,26 @@ class GroupByNode : public ExecNode {
   ExecBatch out_data_;
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterAggregate(
-    "aggregate",
-    [](ExecPlan* plan, std::vector<ExecNode*> inputs,
-       const ExecNodeOptions& options) -> Result<ExecNode*> {
-      const auto& aggregate_options = checked_cast<const AggregateNodeOptions&>(options);
-
-      if (aggregate_options.keys.empty()) {
-        // construct scalar agg node
-        return ScalarAggregateNode::Make(plan, std::move(inputs), options);
-      }
-      return GroupByNode::Make(plan, std::move(inputs), options);
-    });
-
 }  // namespace
+
+namespace internal {
+
+void RegisterAggregateNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory(
+      "aggregate",
+      [](ExecPlan* plan, std::vector<ExecNode*> inputs,
+         const ExecNodeOptions& options) -> Result<ExecNode*> {
+        const auto& aggregate_options =
+            checked_cast<const AggregateNodeOptions&>(options);
+
+        if (aggregate_options.keys.empty()) {
+          // construct scalar agg node
+          return ScalarAggregateNode::Make(plan, std::move(inputs), options);
+        }
+        return GroupByNode::Make(plan, std::move(inputs), options);
+      }));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -311,6 +311,7 @@ namespace internal {
 void RegisterSourceNode(ExecFactoryRegistry*);
 void RegisterFilterNode(ExecFactoryRegistry*);
 void RegisterProjectNode(ExecFactoryRegistry*);
+void RegisterUnionNode(ExecFactoryRegistry*);
 void RegisterAggregateNode(ExecFactoryRegistry*);
 void RegisterSinkNode(ExecFactoryRegistry*);
 
@@ -323,6 +324,7 @@ ExecFactoryRegistry* default_exec_factory_registry() {
       internal::RegisterSourceNode(this);
       internal::RegisterFilterNode(this);
       internal::RegisterProjectNode(this);
+      internal::RegisterUnionNode(this);
       internal::RegisterAggregateNode(this);
       internal::RegisterSinkNode(this);
     }

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -253,13 +253,6 @@ class ARROW_EXPORT ExecFactoryRegistry {
   ///
   /// will raise if factory_name is already in the registry
   virtual Status AddFactory(std::string factory_name, Factory factory) = 0;
-
-  /// Helper for declaring on-load registration of ExecNode factories,
-  /// including built-in factories.
-  struct ARROW_EXPORT AddOnLoad {
-    AddOnLoad(std::string factory_name, Factory factory, ExecFactoryRegistry* registry);
-    AddOnLoad(std::string factory_name, Factory factory);
-  };
 };
 
 /// The default registry, which includes built-in factories.

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -135,8 +135,14 @@ class FilterNode : public ExecNode {
   Expression filter_;
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterFilter("filter", FilterNode::Make);
-
 }  // namespace
+
+namespace internal {
+
+void RegisterFilterNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("filter", FilterNode::Make));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -126,8 +126,14 @@ class ProjectNode : public ExecNode {
   std::vector<Expression> exprs_;
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterProject("project", ProjectNode::Make);
-
 }  // namespace
+
+namespace internal {
+
+void RegisterProjectNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("project", ProjectNode::Make));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -219,10 +219,15 @@ struct OrderBySinkNode final : public SinkNode {
   std::vector<std::shared_ptr<RecordBatch>> batches_;
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterSink("sink", SinkNode::Make);
-ExecFactoryRegistry::AddOnLoad kRegisterOrderBySink("order_by_sink",
-                                                    OrderBySinkNode::Make);
-
 }  // namespace
+
+namespace internal {
+
+void RegisterSinkNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("order_by_sink", OrderBySinkNode::Make));
+  DCHECK_OK(registry->AddFactory("sink", SinkNode::Make));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -142,8 +142,14 @@ struct SourceNode : ExecNode {
   AsyncGenerator<util::optional<ExecBatch>> generator_;
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterSource("source", SourceNode::Make);
-
 }  // namespace
+
+namespace internal {
+
+void RegisterSourceNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("source", SourceNode::Make));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -43,7 +43,9 @@ std::vector<std::string> GetInputLabels(const ExecNode::NodeVector& inputs) {
   return labels;
 }
 }  // namespace
-struct UnionNode : ExecNode {
+
+class UnionNode : public ExecNode {
+ public:
   UnionNode(ExecPlan* plan, std::vector<ExecNode*> inputs)
       : ExecNode(plan, inputs, GetInputLabels(inputs),
                  /*output_schema=*/inputs[0]->output_schema(),
@@ -141,7 +143,12 @@ struct UnionNode : ExecNode {
   Future<> finished_ = Future<>::MakeFinished();
 };
 
-ExecFactoryRegistry::AddOnLoad kRegisterUnion("union", UnionNode::Make);
+namespace internal {
 
+void RegisterUnionNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("union", UnionNode::Make));
+}
+
+}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -29,6 +29,9 @@
 #include "arrow/util/make_unique.h"
 
 namespace arrow {
+
+using internal::checked_pointer_cast;
+
 namespace dataset {
 
 Fragment::Fragment(compute::Expression partition_expression,
@@ -145,7 +148,7 @@ Result<RecordBatchGenerator> InMemoryFragment::ScanBatchesAsync(
 
     std::shared_ptr<State> state;
   };
-  return Generator(internal::checked_pointer_cast<InMemoryFragment>(shared_from_this()),
+  return Generator(checked_pointer_cast<InMemoryFragment>(shared_from_this()),
                    options->batch_size);
 }
 

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -28,6 +28,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/scalar.h"
 #include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/iterator.h"
 
 namespace arrow {
@@ -84,7 +85,7 @@ arrow::Result<std::shared_ptr<T>> GetFragmentScanOptions(
     return Status::Invalid("FragmentScanOptions of type ", source->type_name(),
                            " were provided for scanning a fragment of type ", type_name);
   }
-  return internal::checked_pointer_cast<T>(source);
+  return ::arrow::internal::checked_pointer_cast<T>(source);
 }
 
 class FragmentDataset : public Dataset {

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -46,6 +46,9 @@
 #include "arrow/util/variant.h"
 
 namespace arrow {
+
+using internal::checked_pointer_cast;
+
 namespace dataset {
 
 Result<std::shared_ptr<io::RandomAccessFile>> FileSource::Open() const {
@@ -184,7 +187,7 @@ Future<util::optional<int64_t>> FileFragment::CountRows(
   if (!predicate.IsSatisfiable()) {
     return Future<util::optional<int64_t>>::MakeFinished(0);
   }
-  auto self = internal::checked_pointer_cast<FileFragment>(shared_from_this());
+  auto self = checked_pointer_cast<FileFragment>(shared_from_this());
   return format()->CountRows(self, std::move(predicate), options);
 }
 
@@ -389,8 +392,8 @@ class WriteQueue {
     auto dir =
         fs::internal::EnsureTrailingSlash(write_options.base_dir) + partition_expression_;
 
-    auto basename = internal::Replace(write_options.basename_template, kIntegerToken,
-                                      std::to_string(index_));
+    auto basename = ::arrow::internal::Replace(write_options.basename_template,
+                                               kIntegerToken, std::to_string(index_));
     if (!basename) {
       return Status::Invalid("string interpolation of basename template failed");
     }
@@ -456,15 +459,15 @@ Status WriteNextBatch(WriteState* state, const std::shared_ptr<Fragment>& fragme
       // lookup the queue to which batch should be appended
       auto queues_lock = state->mutex.Lock();
 
-      queue = internal::GetOrInsertGenerated(
+      queue = ::arrow::internal::GetOrInsertGenerated(
                   &state->queues, std::move(part),
                   [&](const std::string& emplaced_part) {
                     // lookup in `queues` also failed,
                     // generate a new WriteQueue
                     size_t queue_index = state->queues.size() - 1;
 
-                    return internal::make_unique<WriteQueue>(emplaced_part, queue_index,
-                                                             batch->schema());
+                    return ::arrow::internal::make_unique<WriteQueue>(
+                        emplaced_part, queue_index, batch->schema());
                   })
                   ->second.get();
     }
@@ -494,10 +497,8 @@ Status WriteInternal(const ScanOptions& scan_options, WriteState* state,
           [&](std::shared_ptr<RecordBatch> batch) {
             return WriteNextBatch(state, scan_task->fragment(), std::move(batch));
           };
-      return internal::RunSynchronously<Future<>>(
-          [&](internal::Executor* executor) {
-            return scan_task->SafeVisit(executor, visitor);
-          },
+      return ::arrow::internal::RunSynchronously<Future<>>(
+          [&](Executor* executor) { return scan_task->SafeVisit(executor, visitor); },
           /*use_threads=*/false);
     });
   }

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -66,7 +66,8 @@ class TestCsvFileFormat : public FileFormatFixtureMixin<CsvFormatHelper>,
 
   std::unique_ptr<FileSource> GetFileSource(std::string csv) {
     if (GetCompression() == Compression::UNCOMPRESSED) {
-      return internal::make_unique<FileSource>(Buffer::FromString(std::move(csv)));
+      return ::arrow::internal::make_unique<FileSource>(
+          Buffer::FromString(std::move(csv)));
     }
     std::string path = "test.csv";
     switch (GetCompression()) {
@@ -94,7 +95,7 @@ class TestCsvFileFormat : public FileFormatFixtureMixin<CsvFormatHelper>,
     ARROW_EXPECT_OK(stream->Write(csv));
     ARROW_EXPECT_OK(stream->Close());
     EXPECT_OK_AND_ASSIGN(auto info, fs->GetFileInfo(path));
-    return internal::make_unique<FileSource>(info, fs, GetCompression());
+    return ::arrow::internal::make_unique<FileSource>(info, fs, GetCompression());
   }
 
   RecordBatchIterator Batches(ScanTaskIterator scan_task_it) {

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -139,8 +139,7 @@ class IpcScanTask : public ScanTask {
       int i_;
     };
 
-    return Impl::Make(source_,
-                      *internal::checked_pointer_cast<FileFragment>(fragment_)->format(),
+    return Impl::Make(source_, *checked_pointer_cast<FileFragment>(fragment_)->format(),
                       *options_);
   }
 
@@ -216,10 +215,10 @@ Result<RecordBatchGenerator> IpcFileFormat::ScanBatchesAsync(
     RecordBatchGenerator generator;
     if (ipc_scan_options->cache_options) {
       // Transferring helps performance when coalescing
-      ARROW_ASSIGN_OR_RAISE(
-          generator, reader->GetRecordBatchGenerator(
-                         /*coalesce=*/true, options->io_context,
-                         *ipc_scan_options->cache_options, internal::GetCpuThreadPool()));
+      ARROW_ASSIGN_OR_RAISE(generator, reader->GetRecordBatchGenerator(
+                                           /*coalesce=*/true, options->io_context,
+                                           *ipc_scan_options->cache_options,
+                                           ::arrow::internal::GetCpuThreadPool()));
     } else {
       ARROW_ASSIGN_OR_RAISE(generator, reader->GetRecordBatchGenerator(
                                            /*coalesce=*/false, options->io_context));
@@ -235,7 +234,7 @@ Future<util::optional<int64_t>> IpcFileFormat::CountRows(
   if (ExpressionHasFieldRefs(predicate)) {
     return Future<util::optional<int64_t>>::MakeFinished(util::nullopt);
   }
-  auto self = internal::checked_pointer_cast<IpcFileFormat>(shared_from_this());
+  auto self = checked_pointer_cast<IpcFileFormat>(shared_from_this());
   return DeferNotOk(options->io_context.executor()->Submit(
       [self, file]() -> Result<util::optional<int64_t>> {
         ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(file->source()));

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -37,9 +37,10 @@
 #include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
-namespace dataset {
 
 using internal::checked_pointer_cast;
+
+namespace dataset {
 
 class IpcFormatHelper {
  public:

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -34,10 +34,12 @@
 #include "arrow/util/io_util.h"
 
 namespace arrow {
+
+using internal::TemporaryDir;
+
 namespace dataset {
 
 using fs::internal::GetAbstractPathExtension;
-using internal::TemporaryDir;
 using testing::ContainerEq;
 
 TEST(FileSource, PathBased) {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -47,12 +47,14 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 using util::string_view;
 
+using internal::DictionaryMemoTable;
+
 namespace dataset {
 
 namespace {
 /// Apply UriUnescape, then ensure the results are valid UTF-8.
 Result<std::string> SafeUriUnescape(util::string_view encoded) {
-  auto decoded = internal::UriUnescape(encoded);
+  auto decoded = ::arrow::internal::UriUnescape(encoded);
   if (!util::ValidateUTF8(decoded)) {
     return Status::Invalid("Partition segment was not valid UTF-8 after URL decoding: ",
                            encoded);
@@ -481,15 +483,15 @@ class KeyValuePartitioningFactory : public PartitioningFactory {
     repr_memos_.clear();
   }
 
-  std::unique_ptr<internal::DictionaryMemoTable> MakeMemo() {
-    return internal::make_unique<internal::DictionaryMemoTable>(default_memory_pool(),
-                                                                utf8());
+  std::unique_ptr<DictionaryMemoTable> MakeMemo() {
+    return ::arrow::internal::make_unique<DictionaryMemoTable>(default_memory_pool(),
+                                                               utf8());
   }
 
   PartitioningFactoryOptions options_;
   ArrayVector dictionaries_;
   std::unordered_map<std::string, int> name_to_index_;
-  std::vector<std::unique_ptr<internal::DictionaryMemoTable>> repr_memos_;
+  std::vector<std::unique_ptr<DictionaryMemoTable>> repr_memos_;
 };
 
 class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -36,6 +36,7 @@
 #include "arrow/util/range.h"
 
 namespace arrow {
+
 using internal::checked_pointer_cast;
 
 namespace dataset {
@@ -319,8 +320,8 @@ TEST_F(TestPartitioning, DictionaryHasUniqueValues) {
   AssertInspect({"/a", "/b", "/a", "/b", "/c", "/a"}, {alpha});
   ASSERT_OK_AND_ASSIGN(auto partitioning, factory_->Finish(schema({alpha})));
 
-  auto expected_dictionary = internal::checked_pointer_cast<StringArray>(
-      ArrayFromJSON(utf8(), R"(["a", "b", "c"])"));
+  auto expected_dictionary =
+      checked_pointer_cast<StringArray>(ArrayFromJSON(utf8(), R"(["a", "b", "c"])"));
 
   for (int32_t i = 0; i < expected_dictionary->length(); ++i) {
     DictionaryScalar::ValueType index_and_dictionary{std::make_shared<Int32Scalar>(i),
@@ -481,8 +482,8 @@ TEST_F(TestPartitioning, HiveDictionaryHasUniqueValues) {
                 {alpha});
   ASSERT_OK_AND_ASSIGN(auto partitioning, factory_->Finish(schema({alpha})));
 
-  auto expected_dictionary = internal::checked_pointer_cast<StringArray>(
-      ArrayFromJSON(utf8(), R"(["a", "b", "c"])"));
+  auto expected_dictionary =
+      checked_pointer_cast<StringArray>(ArrayFromJSON(utf8(), R"(["a", "b", "c"])"));
 
   for (int32_t i = 0; i < expected_dictionary->length(); ++i) {
     DictionaryScalar::ValueType index_and_dictionary{std::make_shared<Int32Scalar>(i),

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -408,7 +408,9 @@ class ARROW_DS_EXPORT AsyncScanner : public Scanner,
  public:
   AsyncScanner(std::shared_ptr<Dataset> dataset,
                std::shared_ptr<ScanOptions> scan_options)
-      : Scanner(std::move(scan_options)), dataset_(std::move(dataset)) {}
+      : Scanner(std::move(scan_options)), dataset_(std::move(dataset)) {
+    internal::Initialize();
+  }
 
   Status Scan(std::function<Status(TaggedRecordBatch)> visitor) override;
   Result<TaggedRecordBatchIterator> ScanBatches() override;
@@ -571,7 +573,6 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   auto exec_context =
       std::make_shared<compute::ExecContext>(scan_options_->pool, cpu_executor);
 
-  internal::Initialize();
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context.get()));
   AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
 
@@ -742,7 +743,6 @@ Result<int64_t> AsyncScanner::CountRows() {
       scan_options_->use_threads ? ::arrow::internal::GetCpuThreadPool() : nullptr;
   compute::ExecContext exec_context(scan_options_->pool, cpu_executor);
 
-  internal::Initialize();
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
   // Drop projection since we only need to count rows
   const auto options = std::make_shared<ScanOptions>(*scan_options_);

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -40,6 +40,11 @@
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {
+
+using internal::Executor;
+using internal::SerialExecutor;
+using internal::TaskGroup;
+
 namespace dataset {
 
 using FragmentGenerator = std::function<Future<std::shared_ptr<Fragment>>()>;
@@ -57,10 +62,6 @@ std::vector<std::string> ScanOptions::MaterializedFields() const {
   return fields;
 }
 
-using arrow::internal::Executor;
-using arrow::internal::SerialExecutor;
-using arrow::internal::TaskGroup;
-
 std::shared_ptr<TaskGroup> ScanOptions::TaskGroup() const {
   if (use_threads) {
     auto* thread_pool = arrow::internal::GetCpuThreadPool();
@@ -73,15 +74,14 @@ Result<RecordBatchIterator> InMemoryScanTask::Execute() {
   return MakeVectorIterator(record_batches_);
 }
 
-Future<RecordBatchVector> ScanTask::SafeExecute(internal::Executor* executor) {
+Future<RecordBatchVector> ScanTask::SafeExecute(Executor* executor) {
   // If the ScanTask can't possibly be async then just execute it
   ARROW_ASSIGN_OR_RAISE(auto rb_it, Execute());
   return Future<RecordBatchVector>::MakeFinished(rb_it.ToVector());
 }
 
 Future<> ScanTask::SafeVisit(
-    internal::Executor* executor,
-    std::function<Status(std::shared_ptr<RecordBatch>)> visitor) {
+    Executor* executor, std::function<Status(std::shared_ptr<RecordBatch>)> visitor) {
   // If the ScanTask can't possibly be async then just execute it
   ARROW_ASSIGN_OR_RAISE(auto rb_it, Execute());
   return Future<>::MakeFinished(rb_it.Visit(visitor));
@@ -331,7 +331,7 @@ class ARROW_DS_EXPORT SyncScanner : public Scanner {
   /// \brief GetFragments returns an iterator over all Fragments in this scan.
   Result<FragmentIterator> GetFragments();
   Result<TaggedRecordBatchIterator> ScanBatches(ScanTaskIterator scan_task_it);
-  Future<std::shared_ptr<Table>> ToTableInternal(internal::Executor* cpu_executor);
+  Future<std::shared_ptr<Table>> ToTableInternal(Executor* cpu_executor);
   Result<ScanTaskIterator> ScanInternal();
 
   std::shared_ptr<Dataset> dataset_;
@@ -419,12 +419,11 @@ class ARROW_DS_EXPORT AsyncScanner : public Scanner,
   Result<int64_t> CountRows() override;
 
  private:
-  Result<TaggedRecordBatchGenerator> ScanBatchesAsync(internal::Executor* executor);
+  Result<TaggedRecordBatchGenerator> ScanBatchesAsync(Executor* executor);
   Future<> VisitBatchesAsync(std::function<Status(TaggedRecordBatch)> visitor,
-                             internal::Executor* executor);
-  Result<EnumeratedRecordBatchGenerator> ScanBatchesUnorderedAsync(
-      internal::Executor* executor);
-  Future<std::shared_ptr<Table>> ToTableAsync(internal::Executor* executor);
+                             Executor* executor);
+  Result<EnumeratedRecordBatchGenerator> ScanBatchesUnorderedAsync(Executor* executor);
+  Future<std::shared_ptr<Table>> ToTableAsync(Executor* executor);
 
   Result<FragmentGenerator> GetFragments() const;
 
@@ -501,7 +500,7 @@ class OneShotFragment : public Fragment {
         auto background_gen,
         MakeBackgroundGenerator(std::move(batch_it_), options->io_context.executor()));
     return MakeTransferredGenerator(std::move(background_gen),
-                                    internal::GetCpuThreadPool());
+                                    ::arrow::internal::GetCpuThreadPool());
   }
   std::string type_name() const override { return "one-shot"; }
 
@@ -524,23 +523,24 @@ Result<FragmentGenerator> AsyncScanner::GetFragments() const {
 }
 
 Result<TaggedRecordBatchIterator> AsyncScanner::ScanBatches() {
-  ARROW_ASSIGN_OR_RAISE(auto batches_gen, ScanBatchesAsync(internal::GetCpuThreadPool()));
+  ARROW_ASSIGN_OR_RAISE(auto batches_gen,
+                        ScanBatchesAsync(::arrow::internal::GetCpuThreadPool()));
   return MakeGeneratorIterator(std::move(batches_gen));
 }
 
 Result<EnumeratedRecordBatchIterator> AsyncScanner::ScanBatchesUnordered() {
   ARROW_ASSIGN_OR_RAISE(auto batches_gen,
-                        ScanBatchesUnorderedAsync(internal::GetCpuThreadPool()));
+                        ScanBatchesUnorderedAsync(::arrow::internal::GetCpuThreadPool()));
   return MakeGeneratorIterator(std::move(batches_gen));
 }
 
 Result<std::shared_ptr<Table>> AsyncScanner::ToTable() {
-  auto table_fut = ToTableAsync(internal::GetCpuThreadPool());
+  auto table_fut = ToTableAsync(::arrow::internal::GetCpuThreadPool());
   return table_fut.result();
 }
 
 Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync() {
-  return ScanBatchesUnorderedAsync(internal::GetCpuThreadPool());
+  return ScanBatchesUnorderedAsync(::arrow::internal::GetCpuThreadPool());
 }
 
 namespace {
@@ -563,7 +563,7 @@ Result<EnumeratedRecordBatch> ToEnumeratedRecordBatch(
 }  // namespace
 
 Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
-    internal::Executor* cpu_executor) {
+    Executor* cpu_executor) {
   if (!scan_options_->use_threads) {
     cpu_executor = nullptr;
   }
@@ -571,6 +571,7 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   auto exec_context =
       std::make_shared<compute::ExecContext>(scan_options_->pool, cpu_executor);
 
+  internal::Initialize();
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context.get()));
   AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
 
@@ -617,11 +618,11 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
 }
 
 Result<TaggedRecordBatchGenerator> AsyncScanner::ScanBatchesAsync() {
-  return ScanBatchesAsync(internal::GetCpuThreadPool());
+  return ScanBatchesAsync(::arrow::internal::GetCpuThreadPool());
 }
 
 Result<TaggedRecordBatchGenerator> AsyncScanner::ScanBatchesAsync(
-    internal::Executor* cpu_executor) {
+    Executor* cpu_executor) {
   ARROW_ASSIGN_OR_RAISE(auto unordered, ScanBatchesUnorderedAsync(cpu_executor));
   // We need an initial value sentinel, so we use one with fragment.index < 0
   auto is_before_any = [](const EnumeratedRecordBatch& batch) {
@@ -702,17 +703,17 @@ Status AsyncScanner::Scan(std::function<Status(TaggedRecordBatch)> visitor) {
   auto top_level_task = [this, &visitor](Executor* executor) {
     return VisitBatchesAsync(visitor, executor);
   };
-  return internal::RunSynchronously<Future<>>(top_level_task, scan_options_->use_threads);
+  return ::arrow::internal::RunSynchronously<Future<>>(top_level_task,
+                                                       scan_options_->use_threads);
 }
 
 Future<> AsyncScanner::VisitBatchesAsync(std::function<Status(TaggedRecordBatch)> visitor,
-                                         internal::Executor* executor) {
+                                         Executor* executor) {
   ARROW_ASSIGN_OR_RAISE(auto batches_gen, ScanBatchesAsync(executor));
   return VisitAsyncGenerator(std::move(batches_gen), visitor);
 }
 
-Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(
-    internal::Executor* cpu_executor) {
+Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(Executor* cpu_executor) {
   auto scan_options = scan_options_;
   ARROW_ASSIGN_OR_RAISE(auto positioned_batch_gen,
                         ScanBatchesUnorderedAsync(cpu_executor));
@@ -737,9 +738,11 @@ Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(
 Result<int64_t> AsyncScanner::CountRows() {
   ARROW_ASSIGN_OR_RAISE(auto fragment_gen, GetFragments());
 
-  auto cpu_executor = scan_options_->use_threads ? internal::GetCpuThreadPool() : nullptr;
+  auto cpu_executor =
+      scan_options_->use_threads ? ::arrow::internal::GetCpuThreadPool() : nullptr;
   compute::ExecContext exec_context(scan_options_->pool, cpu_executor);
 
+  internal::Initialize();
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
   // Drop projection since we only need to count rows
   const auto options = std::make_shared<ScanOptions>(*scan_options_);
@@ -934,10 +937,9 @@ Result<std::shared_ptr<Table>> SyncScanner::ToTable() {
     auto id = scan_task_id++;
     task_group->Append([state, id, scan_task] {
       ARROW_ASSIGN_OR_RAISE(
-          auto local, internal::SerialExecutor::RunInSerialExecutor<RecordBatchVector>(
-                          [&](internal::Executor* executor) {
-                            return scan_task->SafeExecute(executor);
-                          }));
+          auto local,
+          ::arrow::internal::SerialExecutor::RunInSerialExecutor<RecordBatchVector>(
+              [&](Executor* executor) { return scan_task->SafeExecute(executor); }));
       state->Emplace(std::move(local), id);
       return Status::OK();
     });
@@ -1179,7 +1181,6 @@ Result<compute::ExecNode*> MakeScanNode(compute::ExecPlan* plan,
       "source", plan, {},
       compute::SourceNodeOptions{schema(std::move(fields)), std::move(gen)});
 }
-compute::ExecFactoryRegistry::AddOnLoad kRegisterScan("scan", MakeScanNode);
 
 Result<compute::ExecNode*> MakeAugmentedProjectNode(
     compute::ExecPlan* plan, std::vector<compute::ExecNode*> inputs,
@@ -1203,8 +1204,6 @@ Result<compute::ExecNode*> MakeAugmentedProjectNode(
       "project", plan, std::move(inputs),
       compute::ProjectNodeOptions{std::move(exprs), std::move(names)});
 }
-compute::ExecFactoryRegistry::AddOnLoad kRegisterProject("augmented_project",
-                                                         MakeAugmentedProjectNode);
 
 Result<compute::ExecNode*> MakeOrderedSinkNode(compute::ExecPlan* plan,
                                                std::vector<compute::ExecNode*> inputs,
@@ -1285,9 +1284,21 @@ Result<compute::ExecNode*> MakeOrderedSinkNode(compute::ExecPlan* plan,
 
   return node;
 }
-compute::ExecFactoryRegistry::AddOnLoad kRegisterSink("ordered_sink",
-                                                      MakeOrderedSinkNode);
 
 }  // namespace
+
+namespace internal {
+
+void Initialize() {
+  static auto registry = compute::default_exec_factory_registry();
+  if (registry) {
+    DCHECK_OK(registry->AddFactory("scan", MakeScanNode));
+    DCHECK_OK(registry->AddFactory("ordered_sink", MakeOrderedSinkNode));
+    DCHECK_OK(registry->AddFactory("augmented_project", MakeAugmentedProjectNode));
+    registry = nullptr;
+  }
+}
+
+}  // namespace internal
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -440,5 +440,11 @@ class ARROW_DS_EXPORT InMemoryScanTask : public ScanTask {
   std::vector<std::shared_ptr<RecordBatch>> record_batches_;
 };
 
+namespace internal {
+
+/// This function must be called before using dataset ExecNode factories
+ARROW_DS_EXPORT void Initialize();
+
+}  // namespace internal
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner_internal.h
+++ b/cpp/src/arrow/dataset/scanner_internal.h
@@ -151,7 +151,7 @@ class FilterAndProjectScanTask : public ScanTask {
     return ProjectSingleBatch(filtered, simplified_projection, options_);
   }
 
-  inline Future<RecordBatchVector> SafeExecute(internal::Executor* executor) override {
+  inline Future<RecordBatchVector> SafeExecute(Executor* executor) override {
     return task_->SafeExecute(executor).Then(
         // This should only be run via SerialExecutor so it should be safe to capture
         // `this`
@@ -162,7 +162,7 @@ class FilterAndProjectScanTask : public ScanTask {
   }
 
   inline Future<> SafeVisit(
-      internal::Executor* executor,
+      Executor* executor,
       std::function<Status(std::shared_ptr<RecordBatch>)> visitor) override {
     auto filter_and_project_visitor =
         [this, visitor](const std::shared_ptr<RecordBatch>& batch) {

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -54,6 +54,11 @@
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
+using internal::TemporaryDir;
+
 namespace dataset {
 
 using compute::call;
@@ -74,14 +79,11 @@ using compute::or_;
 using compute::project;
 
 using fs::internal::GetAbstractPathExtension;
-using internal::checked_cast;
-using internal::checked_pointer_cast;
-using internal::TemporaryDir;
 
 class FileSourceFixtureMixin : public ::testing::Test {
  public:
   std::unique_ptr<FileSource> GetSource(std::shared_ptr<Buffer> buffer) {
-    return internal::make_unique<FileSource>(std::move(buffer));
+    return ::arrow::internal::make_unique<FileSource>(std::move(buffer));
   }
 };
 
@@ -103,7 +105,8 @@ class GeneratedRecordBatch : public RecordBatchReader {
 template <typename Gen>
 std::unique_ptr<GeneratedRecordBatch<Gen>> MakeGeneratedRecordBatch(
     std::shared_ptr<Schema> schema, Gen&& gen) {
-  return internal::make_unique<GeneratedRecordBatch<Gen>>(schema, std::forward<Gen>(gen));
+  return ::arrow::internal::make_unique<GeneratedRecordBatch<Gen>>(
+      schema, std::forward<Gen>(gen));
 }
 
 std::unique_ptr<RecordBatchReader> MakeGeneratedRecordBatch(
@@ -840,7 +843,7 @@ struct MakeFileSystemDatasetMixin {
 static const std::string& PathOf(const std::shared_ptr<Fragment>& fragment) {
   EXPECT_NE(fragment, nullptr);
   EXPECT_THAT(fragment->type_name(), "dummy");
-  return internal::checked_cast<const FileFragment&>(*fragment).source().path();
+  return checked_cast<const FileFragment&>(*fragment).source().path();
 }
 
 class TestFileSystemDataset : public ::testing::Test,
@@ -854,7 +857,7 @@ static std::vector<std::string> PathsOf(const FragmentVector& fragments) {
 
 void AssertFilesAre(const std::shared_ptr<Dataset>& dataset,
                     std::vector<std::string> expected) {
-  auto fs_dataset = internal::checked_cast<FileSystemDataset*>(dataset.get());
+  auto fs_dataset = checked_cast<FileSystemDataset*>(dataset.get());
   EXPECT_THAT(fs_dataset->files(), testing::UnorderedElementsAreArray(expected));
 }
 

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -105,7 +105,7 @@ struct BitBlockCount {
 class ARROW_EXPORT BitBlockCounter {
  public:
   BitBlockCounter(const uint8_t* bitmap, int64_t start_offset, int64_t length)
-      : bitmap_(bitmap + start_offset / 8),
+      : bitmap_(util::MakeNonNull(bitmap) + start_offset / 8),
         bits_remaining_(length),
         offset_(start_offset % 8) {}
 
@@ -263,9 +263,9 @@ class ARROW_EXPORT BinaryBitBlockCounter {
  public:
   BinaryBitBlockCounter(const uint8_t* left_bitmap, int64_t left_offset,
                         const uint8_t* right_bitmap, int64_t right_offset, int64_t length)
-      : left_bitmap_(left_bitmap + left_offset / 8),
+      : left_bitmap_(util::MakeNonNull(left_bitmap) + left_offset / 8),
         left_offset_(left_offset % 8),
-        right_bitmap_(right_bitmap + right_offset / 8),
+        right_bitmap_(util::MakeNonNull(right_bitmap) + right_offset / 8),
         right_offset_(right_offset % 8),
         bits_remaining_(length) {}
 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -84,6 +84,8 @@ std::shared_ptr<compute::ExecNode> ExecNode_Scan(
     const std::shared_ptr<arrow::dataset::Dataset>& dataset,
     const std::shared_ptr<compute::Expression>& filter,
     std::vector<std::string> materialized_field_names) {
+  arrow::dataset::internal::Initialize();
+
   // TODO: pass in FragmentScanOptions
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
 


### PR DESCRIPTION
These AddOnLoad's constructors can be removed by LTO (which means the factories don't make it to the registry), so make registration more rugged