### PR TITLE
MINOR: [C++][CI] Fix s3fs_test.cc compile error

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
 #include <exception>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
Fix this error:
```
C:\Miniconda37-x64\envs\arrow\Library\include\boost/process/detail/traits/wchar_t.hpp(150): error C2039: 'transform': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include\locale(20): note: see declaration of 'std'
C:\Miniconda37-x64\envs\arrow\Library\include\boost/process/detail/traits/wchar_t.hpp(150): error C3861: 'transform': identifier not found
```

.. seen on AppVeyor:
https://ci.appveyor.com/project/ApacheSoftwareFoundation/arrow/builds/40350532/job/xr1qhmak9jtdn7rl#L1217

The underlying problem may be a missing include in boost/process.