### PR TITLE
MINOR: [Python][Doc] Added sort example to docs

### DIFF
--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -49,6 +49,22 @@ Below are a few simple examples:
    >>> pc.multiply(x, y)
    <pyarrow.DoubleScalar: 72.54>
 
+These functions can do more than just element-by-element operations. 
+Here is an example of sorting a table:
+
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> t = pa.table({'x':[1,2,3],'y':[3,2,1]})
+    >>> i = pc.sort_indices(t, sort_keys=[('y', 'ascending')])
+    >>> i
+    <pyarrow.lib.UInt64Array object at 0x7fcee5df75e8>
+    [
+      2,
+      1,
+      0
+    ]
+
+
 
 .. seealso::
 


### PR DESCRIPTION
I added an example to the docs, but wasn't exactly clear where the doc string for sort_indices came from. That  doc string could use a description of how sort_keys are used and a reference to take()

Is compute.cpp the right place to make changes? If so, I am happy to update this pull request to add more info.