### PR TITLE
ARROW-13627: [C++] Fully support ScalarAggregateOptions in (hash) any/all/sum/product/mean

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -42,14 +42,17 @@ class ExecContext;
 
 /// \brief Control general scalar aggregate kernel behavior
 ///
-/// By default, null values are ignored
+/// By default, null values are ignored (skip_nulls = true).
 class ARROW_EXPORT ScalarAggregateOptions : public FunctionOptions {
  public:
   explicit ScalarAggregateOptions(bool skip_nulls = true, uint32_t min_count = 1);
   constexpr static char const kTypeName[] = "ScalarAggregateOptions";
   static ScalarAggregateOptions Defaults() { return ScalarAggregateOptions{}; }
 
+  /// If true (the default), null values are ignored. Otherwise, if any value is null,
+  /// emit null.
   bool skip_nulls;
+  /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -176,6 +176,10 @@ TEST(TestBooleanAggregation, Sum) {
                           ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0));
   ValidateBooleanAgg<Sum>(json, std::make_shared<UInt64Scalar>(),
                           ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0));
+  ValidateBooleanAgg<Sum>("[]", std::make_shared<UInt64Scalar>(),
+                          ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
+  ValidateBooleanAgg<Sum>(json, std::make_shared<UInt64Scalar>(),
+                          ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
 
   EXPECT_THAT(Sum(MakeScalar(true)),
               ResultWith(Datum(std::make_shared<UInt64Scalar>(1))));
@@ -226,6 +230,12 @@ TEST(TestBooleanAggregation, Product) {
   ValidateBooleanAgg<Product>(
       json, std::make_shared<UInt64Scalar>(),
       ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0));
+  ValidateBooleanAgg<Product>(
+      "[]", std::make_shared<UInt64Scalar>(),
+      ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
+  ValidateBooleanAgg<Product>(
+      json, std::make_shared<UInt64Scalar>(),
+      ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
 
   EXPECT_THAT(Product(MakeScalar(true)),
               ResultWith(Datum(std::make_shared<UInt64Scalar>(1))));
@@ -273,6 +283,10 @@ TEST(TestBooleanAggregation, Mean) {
                            ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0));
   ValidateBooleanAgg<Mean>(json, std::make_shared<DoubleScalar>(),
                            ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0));
+  ValidateBooleanAgg<Mean>("[]", std::make_shared<DoubleScalar>(),
+                           ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
+  ValidateBooleanAgg<Mean>(json, std::make_shared<DoubleScalar>(),
+                           ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/3));
 
   EXPECT_THAT(Mean(MakeScalar(true)), ResultWith(ScalarFromJSON(float64(), "1.0")));
   EXPECT_THAT(Mean(MakeScalar(false)), ResultWith(ScalarFromJSON(float64(), "0.0")));

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1820,8 +1820,9 @@ struct GroupedAnyImpl : public GroupedAggregator {
           input.buffers[0], input.offset, input.length,
           [&](int64_t position) {
             counts[*g]++;
-            BitUtil::SetBitTo(
-                seen, *g, BitUtil::GetBit(seen, *g) || BitUtil::GetBit(bitmap, position));
+            if (!BitUtil::GetBit(seen, *g) && BitUtil::GetBit(bitmap, position)) {
+              BitUtil::SetBit(seen, *g);
+            }
             g++;
           },
           [&] { BitUtil::SetBitTo(no_nulls, *g++, false); });

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -916,8 +916,9 @@ struct GroupedSumImpl : public GroupedAggregator {
   Status Init(ExecContext* ctx, const FunctionOptions* options) override {
     pool_ = ctx->memory_pool();
     options_ = checked_cast<const ScalarAggregateOptions&>(*options);
-    sums_ = BufferBuilder(pool_);
-    counts_ = BufferBuilder(pool_);
+    sums_ = TypedBufferBuilder<SumType>(pool_);
+    counts_ = TypedBufferBuilder<int64_t>(pool_);
+    no_nulls_ = TypedBufferBuilder<bool>(pool_);
     out_type_ = TypeTraits<AccType>::type_singleton();
     return Status::OK();
   }
@@ -925,14 +926,16 @@ struct GroupedSumImpl : public GroupedAggregator {
   Status Resize(int64_t new_num_groups) override {
     auto added_groups = new_num_groups - num_groups_;
     num_groups_ = new_num_groups;
-    RETURN_NOT_OK(sums_.Append(added_groups * sizeof(AccType), 0));
-    RETURN_NOT_OK(counts_.Append(added_groups * sizeof(int64_t), 0));
+    RETURN_NOT_OK(sums_.Append(added_groups, SumType()));
+    RETURN_NOT_OK(counts_.Append(added_groups, 0));
+    RETURN_NOT_OK(no_nulls_.Append(added_groups, true));
     return Status::OK();
   }
 
   Status Consume(const ExecBatch& batch) override {
-    auto sums = reinterpret_cast<SumType*>(sums_.mutable_data());
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
+    SumType* sums = sums_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
 
     // XXX this uses naive summation; we should switch to pairwise summation as was
     // done for the scalar aggregate kernel in ARROW-11758
@@ -944,7 +947,7 @@ struct GroupedSumImpl : public GroupedAggregator {
           counts[*g] += 1;
           ++g;
         },
-        [&] { ++g; });
+        [&] { BitUtil::SetBitTo(no_nulls, *g++, false); });
     return Status::OK();
   }
 
@@ -952,23 +955,28 @@ struct GroupedSumImpl : public GroupedAggregator {
                const ArrayData& group_id_mapping) override {
     auto other = checked_cast<GroupedSumImpl*>(&raw_other);
 
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
-    auto sums = reinterpret_cast<SumType*>(sums_.mutable_data());
+    SumType* sums = sums_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
 
-    auto other_counts = reinterpret_cast<const int64_t*>(other->counts_.mutable_data());
-    auto other_sums = reinterpret_cast<const SumType*>(other->sums_.mutable_data());
+    const SumType* other_sums = other->sums_.data();
+    const int64_t* other_counts = other->counts_.data();
+    const uint8_t* other_no_nulls = no_nulls_.mutable_data();
 
     auto g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       counts[*g] += other_counts[other_g];
       sums[*g] += other_sums[other_g];
+      BitUtil::SetBitTo(
+          no_nulls, *g,
+          BitUtil::GetBit(no_nulls, *g) && BitUtil::GetBit(other_no_nulls, other_g));
     }
     return Status::OK();
   }
 
   Result<Datum> Finalize() override {
     std::shared_ptr<Buffer> null_bitmap;
-    const int64_t* counts = reinterpret_cast<const int64_t*>(counts_.data());
+    const int64_t* counts = counts_.data();
     int64_t null_count = 0;
 
     for (int64_t i = 0; i < num_groups_; ++i) {
@@ -983,19 +991,30 @@ struct GroupedSumImpl : public GroupedAggregator {
       BitUtil::SetBitTo(null_bitmap->mutable_data(), i, false);
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto sums, sums_.Finish());
+    if (!options_.skip_nulls) {
+      null_count = kUnknownNullCount;
+      if (null_bitmap) {
+        arrow::internal::BitmapAnd(null_bitmap->data(), /*left_offset=*/0,
+                                   no_nulls_.data(), /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, null_bitmap->mutable_data());
+      } else {
+        ARROW_ASSIGN_OR_RAISE(null_bitmap, no_nulls_.Finish());
+      }
+    }
 
+    ARROW_ASSIGN_OR_RAISE(auto sums, sums_.Finish());
     return ArrayData::Make(std::move(out_type_), num_groups_,
                            {std::move(null_bitmap), std::move(sums)}, null_count);
   }
 
   std::shared_ptr<DataType> out_type() const override { return out_type_; }
 
-  // NB: counts are used here instead of a simple "has_values_" bitmap since
-  // we expect to reuse this kernel to handle Mean
+  // NB: counts are used here to support Mean below
   int64_t num_groups_ = 0;
   ScalarAggregateOptions options_;
-  BufferBuilder sums_, counts_;
+  TypedBufferBuilder<SumType> sums_;
+  TypedBufferBuilder<int64_t> counts_;
+  TypedBufferBuilder<bool> no_nulls_;
   std::shared_ptr<DataType> out_type_;
   MemoryPool* pool_;
 };
@@ -1048,12 +1067,14 @@ struct GroupedProductImpl final : public GroupedAggregator {
     num_groups_ = new_num_groups;
     RETURN_NOT_OK(products_.Append(added_groups * sizeof(AccType), 1));
     RETURN_NOT_OK(counts_.Append(added_groups, 0));
+    RETURN_NOT_OK(no_nulls_.Append(added_groups, true));
     return Status::OK();
   }
 
   Status Consume(const ExecBatch& batch) override {
     ProductType* products = products_.mutable_data();
     int64_t* counts = counts_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
     auto g = batch[1].array()->GetValues<uint32_t>(1);
     VisitArrayDataInline<Type>(
         *batch[0].array(),
@@ -1062,7 +1083,7 @@ struct GroupedProductImpl final : public GroupedAggregator {
               to_unsigned(products[*g]) * to_unsigned(static_cast<ProductType>(value)));
           counts[*g++] += 1;
         },
-        [&] { ++g; });
+        [&] { BitUtil::SetBitTo(no_nulls, *g++, false); });
     return Status::OK();
   }
 
@@ -1072,15 +1093,20 @@ struct GroupedProductImpl final : public GroupedAggregator {
 
     int64_t* counts = counts_.mutable_data();
     ProductType* products = products_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
 
-    const int64_t* other_counts = other->counts_.mutable_data();
-    const ProductType* other_products = other->products_.mutable_data();
+    const int64_t* other_counts = other->counts_.data();
+    const ProductType* other_products = other->products_.data();
+    const uint8_t* other_no_nulls = other->no_nulls_.data();
     const uint32_t* g = group_id_mapping.GetValues<uint32_t>(1);
 
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       products[*g] = static_cast<ProductType>(to_unsigned(products[*g]) *
                                               to_unsigned(other_products[other_g]));
       counts[*g] += other_counts[other_g];
+      BitUtil::SetBitTo(
+          no_nulls, *g,
+          BitUtil::GetBit(no_nulls, *g) && BitUtil::GetBit(other_no_nulls, other_g));
     }
     return Status::OK();
   }
@@ -1104,6 +1130,17 @@ struct GroupedProductImpl final : public GroupedAggregator {
       BitUtil::SetBitTo(null_bitmap->mutable_data(), i, false);
     }
 
+    if (!options_.skip_nulls) {
+      null_count = kUnknownNullCount;
+      if (null_bitmap) {
+        arrow::internal::BitmapAnd(null_bitmap->data(), /*left_offset=*/0,
+                                   no_nulls_.data(), /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, null_bitmap->mutable_data());
+      } else {
+        ARROW_ASSIGN_OR_RAISE(null_bitmap, no_nulls_.Finish());
+      }
+    }
+
     return ArrayData::Make(std::move(out_type_), num_groups_,
                            {std::move(null_bitmap), std::move(products)}, null_count);
   }
@@ -1114,6 +1151,7 @@ struct GroupedProductImpl final : public GroupedAggregator {
   ScalarAggregateOptions options_;
   TypedBufferBuilder<ProductType> products_;
   TypedBufferBuilder<int64_t> counts_;
+  TypedBufferBuilder<bool> no_nulls_;
   std::shared_ptr<DataType> out_type_;
   MemoryPool* pool_;
 };
@@ -1157,8 +1195,8 @@ struct GroupedMeanImpl : public GroupedSumImpl<Type> {
                           AllocateBuffer(num_groups_ * sizeof(double), pool_));
     int64_t null_count = 0;
 
-    const int64_t* counts = reinterpret_cast<const int64_t*>(counts_.data());
-    const auto* sums = reinterpret_cast<const SumType*>(sums_.data());
+    const int64_t* counts = counts_.data();
+    const SumType* sums = sums_.data();
     double* means = reinterpret_cast<double*>(values->mutable_data());
     for (int64_t i = 0; i < num_groups_; ++i) {
       if (counts[i] >= options_.min_count) {
@@ -1176,6 +1214,17 @@ struct GroupedMeanImpl : public GroupedSumImpl<Type> {
       BitUtil::SetBitTo(null_bitmap->mutable_data(), i, false);
     }
 
+    if (!options_.skip_nulls) {
+      null_count = kUnknownNullCount;
+      if (null_bitmap) {
+        arrow::internal::BitmapAnd(null_bitmap->data(), /*left_offset=*/0,
+                                   no_nulls_.data(), /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, null_bitmap->mutable_data());
+      } else {
+        ARROW_ASSIGN_OR_RAISE(null_bitmap, no_nulls_.Finish());
+      }
+    }
+
     return ArrayData::Make(float64(), num_groups_,
                            {std::move(null_bitmap), std::move(values)}, null_count);
   }
@@ -1187,6 +1236,7 @@ struct GroupedMeanImpl : public GroupedSumImpl<Type> {
   using GroupedSumImpl<Type>::pool_;
   using GroupedSumImpl<Type>::counts_;
   using GroupedSumImpl<Type>::sums_;
+  using GroupedSumImpl<Type>::no_nulls_;
 };
 
 struct GroupedMeanFactory {
@@ -1741,9 +1791,11 @@ struct GroupedMinMaxFactory {
 
 struct GroupedAnyImpl : public GroupedAggregator {
   Status Init(ExecContext* ctx, const FunctionOptions* options) override {
-    options_ = *checked_cast<const ScalarAggregateOptions*>(options);
-    seen_ = TypedBufferBuilder<bool>(ctx->memory_pool());
-    has_nulls_ = TypedBufferBuilder<bool>(ctx->memory_pool());
+    options_ = checked_cast<const ScalarAggregateOptions&>(*options);
+    pool_ = ctx->memory_pool();
+    seen_ = TypedBufferBuilder<bool>(pool_);
+    no_nulls_ = TypedBufferBuilder<bool>(pool_);
+    counts_ = TypedBufferBuilder<int64_t>(pool_);
     return Status::OK();
   }
 
@@ -1751,75 +1803,117 @@ struct GroupedAnyImpl : public GroupedAggregator {
     auto added_groups = new_num_groups - num_groups_;
     num_groups_ = new_num_groups;
     RETURN_NOT_OK(seen_.Append(added_groups, false));
-    return has_nulls_.Append(added_groups, false);
+    RETURN_NOT_OK(no_nulls_.Append(added_groups, true));
+    return counts_.Append(added_groups, 0);
+  }
+
+  Status Consume(const ExecBatch& batch) override {
+    uint8_t* seen = seen_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+    const auto& input = *batch[0].array();
+    auto g = batch[1].array()->GetValues<uint32_t>(1);
+
+    if (input.MayHaveNulls()) {
+      const uint8_t* bitmap = input.buffers[1]->data();
+      arrow::internal::VisitBitBlocksVoid(
+          input.buffers[0], input.offset, input.length,
+          [&](int64_t position) {
+            counts[*g]++;
+            BitUtil::SetBitTo(
+                seen, *g, BitUtil::GetBit(seen, *g) || BitUtil::GetBit(bitmap, position));
+            g++;
+          },
+          [&] { BitUtil::SetBitTo(no_nulls, *g++, false); });
+    } else {
+      arrow::internal::VisitBitBlocksVoid(
+          input.buffers[1], input.offset, input.length,
+          [&](int64_t) {
+            counts[*g++]++;
+            BitUtil::SetBitTo(seen, *g++, true);
+          },
+          [&]() { counts[*g]++; });
+    }
+    return Status::OK();
   }
 
   Status Merge(GroupedAggregator&& raw_other,
                const ArrayData& group_id_mapping) override {
     auto other = checked_cast<GroupedAnyImpl*>(&raw_other);
 
-    auto seen = seen_.mutable_data();
-    auto other_seen = other->seen_.data();
-    auto has_nulls = has_nulls_.mutable_data();
-    auto other_has_nulls = other->has_nulls_.data();
+    uint8_t* seen = seen_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+
+    const uint8_t* other_seen = other->seen_.mutable_data();
+    const uint8_t* other_no_nulls = other->no_nulls_.mutable_data();
+    const int64_t* other_counts = other->counts_.mutable_data();
 
     auto g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
-      if (BitUtil::GetBit(other_seen, other_g)) BitUtil::SetBitTo(seen, *g, true);
-      if (BitUtil::GetBit(other_has_nulls, other_g)) {
-        BitUtil::SetBitTo(has_nulls, *g, true);
-      }
+      counts[*g] += other_counts[other_g];
+      BitUtil::SetBitTo(
+          seen, *g, BitUtil::GetBit(seen, *g) || BitUtil::GetBit(other_seen, other_g));
+      BitUtil::SetBitTo(
+          no_nulls, *g,
+          BitUtil::GetBit(no_nulls, *g) && BitUtil::GetBit(other_no_nulls, other_g));
     }
-    return Status::OK();
-  }
-
-  Status Consume(const ExecBatch& batch) override {
-    auto seen = seen_.mutable_data();
-    auto has_nulls = has_nulls_.mutable_data();
-
-    const auto& input = *batch[0].array();
-
-    auto g = batch[1].array()->GetValues<uint32_t>(1);
-    auto values = input.buffers[1]->data();
-    arrow::internal::VisitBitBlocksVoid(
-        input.buffers[0], input.offset, input.length,
-        [&](int64_t offset) {
-          BitUtil::SetBitTo(seen, *g,
-                            BitUtil::GetBit(seen, *g) ||
-                                BitUtil::GetBit(values, input.offset + offset));
-          g++;
-        },
-        [&]() { BitUtil::SetBitTo(has_nulls, *g++, true); });
     return Status::OK();
   }
 
   Result<Datum> Finalize() override {
-    ARROW_ASSIGN_OR_RAISE(auto seen, seen_.Finish());
-    if (options_.skip_nulls) {
-      return std::make_shared<BooleanArray>(num_groups_, std::move(seen));
+    std::shared_ptr<Buffer> null_bitmap;
+    const int64_t* counts = counts_.data();
+    int64_t null_count = 0;
+
+    for (int64_t i = 0; i < num_groups_; ++i) {
+      if (counts[i] >= options_.min_count) continue;
+
+      if (null_bitmap == nullptr) {
+        ARROW_ASSIGN_OR_RAISE(null_bitmap, AllocateBitmap(num_groups_, pool_));
+        BitUtil::SetBitsTo(null_bitmap->mutable_data(), 0, num_groups_, true);
+      }
+
+      null_count += 1;
+      BitUtil::SetBitTo(null_bitmap->mutable_data(), i, false);
     }
-    ARROW_ASSIGN_OR_RAISE(auto bitmap, has_nulls_.Finish());
-    // null if (~seen & has_nulls) -> not null if (seen | ~has_nulls)
-    ::arrow::internal::BitmapOrNot(seen->data(), /*left_offset=*/0, bitmap->data(),
-                                   /*right_offset=*/0, num_groups_, /*out_offset=*/0,
-                                   bitmap->mutable_data());
-    return std::make_shared<BooleanArray>(num_groups_, std::move(seen),
-                                          std::move(bitmap));
+
+    ARROW_ASSIGN_OR_RAISE(auto seen, seen_.Finish());
+    if (!options_.skip_nulls) {
+      null_count = kUnknownNullCount;
+      ARROW_ASSIGN_OR_RAISE(auto no_nulls, no_nulls_.Finish());
+      arrow::internal::BitmapOr(no_nulls->data(), /*left_offset=*/0, seen->data(),
+                                /*right_offset=*/0, num_groups_,
+                                /*out_offset=*/0, no_nulls->mutable_data());
+      if (null_bitmap) {
+        arrow::internal::BitmapAnd(null_bitmap->data(), /*left_offset=*/0,
+                                   no_nulls->data(), /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, null_bitmap->mutable_data());
+      } else {
+        null_bitmap = std::move(no_nulls);
+      }
+    }
+
+    return ArrayData::Make(out_type(), num_groups_,
+                           {std::move(null_bitmap), std::move(seen)}, null_count);
   }
 
   std::shared_ptr<DataType> out_type() const override { return boolean(); }
 
   int64_t num_groups_ = 0;
   ScalarAggregateOptions options_;
-  TypedBufferBuilder<bool> seen_;
-  TypedBufferBuilder<bool> has_nulls_;
+  TypedBufferBuilder<bool> seen_, no_nulls_;
+  TypedBufferBuilder<int64_t> counts_;
+  MemoryPool* pool_;
 };
 
 struct GroupedAllImpl : public GroupedAggregator {
   Status Init(ExecContext* ctx, const FunctionOptions* options) override {
-    options_ = *checked_cast<const ScalarAggregateOptions*>(options);
-    seen_ = TypedBufferBuilder<bool>(ctx->memory_pool());
-    has_nulls_ = TypedBufferBuilder<bool>(ctx->memory_pool());
+    options_ = checked_cast<const ScalarAggregateOptions&>(*options);
+    pool_ = ctx->memory_pool();
+    seen_ = TypedBufferBuilder<bool>(pool_);
+    no_nulls_ = TypedBufferBuilder<bool>(pool_);
+    counts_ = TypedBufferBuilder<int64_t>(pool_);
     return Status::OK();
   }
 
@@ -1827,77 +1921,108 @@ struct GroupedAllImpl : public GroupedAggregator {
     auto added_groups = new_num_groups - num_groups_;
     num_groups_ = new_num_groups;
     RETURN_NOT_OK(seen_.Append(added_groups, true));
-    return has_nulls_.Append(added_groups, false);
+    RETURN_NOT_OK(no_nulls_.Append(added_groups, true));
+    return counts_.Append(added_groups, 0);
+  }
+
+  Status Consume(const ExecBatch& batch) override {
+    uint8_t* seen = seen_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+    const auto& input = *batch[0].array();
+    auto g = batch[1].array()->GetValues<uint32_t>(1);
+
+    if (input.MayHaveNulls()) {
+      const uint8_t* bitmap = input.buffers[1]->data();
+      arrow::internal::VisitBitBlocksVoid(
+          input.buffers[0], input.offset, input.length,
+          [&](int64_t position) {
+            counts[*g]++;
+            BitUtil::SetBitTo(seen, *g,
+                              BitUtil::GetBit(seen, *g) &&
+                                  BitUtil::GetBit(bitmap, input.offset + position));
+            g++;
+          },
+          [&]() { BitUtil::SetBitTo(no_nulls, *g++, false); });
+    } else {
+      arrow::internal::VisitBitBlocksVoid(
+          input.buffers[1], input.offset, input.length, [&](int64_t) { counts[*g++]++; },
+          [&]() {
+            counts[*g]++;
+            BitUtil::SetBitTo(seen, *g++, false);
+          });
+    }
+    return Status::OK();
   }
 
   Status Merge(GroupedAggregator&& raw_other,
                const ArrayData& group_id_mapping) override {
     auto other = checked_cast<GroupedAllImpl*>(&raw_other);
 
-    auto seen = seen_.mutable_data();
-    auto other_seen = other->seen_.data();
-    auto has_nulls = has_nulls_.mutable_data();
-    auto other_has_nulls = other->has_nulls_.data();
+    uint8_t* seen = seen_.mutable_data();
+    uint8_t* no_nulls = no_nulls_.mutable_data();
+    int64_t* counts = counts_.mutable_data();
+
+    const uint8_t* other_seen = other->seen_.mutable_data();
+    const uint8_t* other_no_nulls = other->no_nulls_.mutable_data();
+    const int64_t* other_counts = other->counts_.mutable_data();
 
     auto g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
+      counts[*g] += other_counts[other_g];
       BitUtil::SetBitTo(
           seen, *g, BitUtil::GetBit(seen, *g) && BitUtil::GetBit(other_seen, other_g));
-      if (BitUtil::GetBit(other_has_nulls, other_g)) {
-        BitUtil::SetBitTo(has_nulls, *g, true);
-      }
-    }
-    return Status::OK();
-  }
-
-  Status Consume(const ExecBatch& batch) override {
-    auto seen = seen_.mutable_data();
-    auto has_nulls = has_nulls_.mutable_data();
-
-    const auto& input = *batch[0].array();
-
-    auto g = batch[1].array()->GetValues<uint32_t>(1);
-    if (input.MayHaveNulls()) {
-      const uint8_t* bitmap = input.buffers[1]->data();
-      arrow::internal::VisitBitBlocksVoid(
-          input.buffers[0], input.offset, input.length,
-          [&](int64_t position) {
-            BitUtil::SetBitTo(seen, *g,
-                              BitUtil::GetBit(seen, *g) &&
-                                  BitUtil::GetBit(bitmap, input.offset + position));
-            g++;
-          },
-          [&]() { BitUtil::SetBitTo(has_nulls, *g++, true); });
-    } else {
-      arrow::internal::VisitBitBlocksVoid(
-          input.buffers[1], input.offset, input.length, [&](int64_t) { g++; },
-          [&]() { BitUtil::SetBitTo(seen, *g++, false); });
+      BitUtil::SetBitTo(
+          no_nulls, *g,
+          BitUtil::GetBit(no_nulls, *g) && BitUtil::GetBit(other_no_nulls, other_g));
     }
     return Status::OK();
   }
 
   Result<Datum> Finalize() override {
-    ARROW_ASSIGN_OR_RAISE(auto seen, seen_.Finish());
-    if (options_.skip_nulls) {
-      return std::make_shared<BooleanArray>(num_groups_, std::move(seen));
+    std::shared_ptr<Buffer> null_bitmap;
+    const int64_t* counts = counts_.data();
+    int64_t null_count = 0;
+
+    for (int64_t i = 0; i < num_groups_; ++i) {
+      if (counts[i] >= options_.min_count) continue;
+
+      if (null_bitmap == nullptr) {
+        ARROW_ASSIGN_OR_RAISE(null_bitmap, AllocateBitmap(num_groups_, pool_));
+        BitUtil::SetBitsTo(null_bitmap->mutable_data(), 0, num_groups_, true);
+      }
+
+      null_count += 1;
+      BitUtil::SetBitTo(null_bitmap->mutable_data(), i, false);
     }
-    ARROW_ASSIGN_OR_RAISE(auto bitmap, has_nulls_.Finish());
-    // null if (seen & has_nulls)
-    ::arrow::internal::BitmapAnd(seen->data(), /*left_offset=*/0, bitmap->data(),
-                                 /*right_offset=*/0, num_groups_, /*out_offset=*/0,
-                                 bitmap->mutable_data());
-    ::arrow::internal::InvertBitmap(bitmap->data(), /*offset=*/0, num_groups_,
-                                    bitmap->mutable_data(), /*dest_offset=*/0);
-    return std::make_shared<BooleanArray>(num_groups_, std::move(seen),
-                                          std::move(bitmap));
+
+    ARROW_ASSIGN_OR_RAISE(auto seen, seen_.Finish());
+    if (!options_.skip_nulls) {
+      null_count = kUnknownNullCount;
+      ARROW_ASSIGN_OR_RAISE(auto no_nulls, no_nulls_.Finish());
+      arrow::internal::BitmapOrNot(no_nulls->data(), /*left_offset=*/0, seen->data(),
+                                   /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, no_nulls->mutable_data());
+      if (null_bitmap) {
+        arrow::internal::BitmapAnd(null_bitmap->data(), /*left_offset=*/0,
+                                   no_nulls->data(), /*right_offset=*/0, num_groups_,
+                                   /*out_offset=*/0, null_bitmap->mutable_data());
+      } else {
+        null_bitmap = std::move(no_nulls);
+      }
+    }
+
+    return ArrayData::Make(out_type(), num_groups_,
+                           {std::move(null_bitmap), std::move(seen)}, null_count);
   }
 
   std::shared_ptr<DataType> out_type() const override { return boolean(); }
 
   int64_t num_groups_ = 0;
   ScalarAggregateOptions options_;
-  TypedBufferBuilder<bool> seen_;
-  TypedBufferBuilder<bool> has_nulls_;
+  TypedBufferBuilder<bool> seen_, no_nulls_;
+  TypedBufferBuilder<int64_t> counts_;
+  MemoryPool* pool_;
 };
 
 }  // namespace
@@ -2176,7 +2301,8 @@ const FunctionDoc hash_product_doc{
     "Compute product of values of a numeric array",
     ("Null values are ignored.\n"
      "Overflow will wrap around as if the calculation was done with unsigned integers."),
-    {"array", "group_id_array"}};
+    {"array", "group_id_array"},
+    "ScalarAggregateOptions"};
 
 const FunctionDoc hash_mean_doc{"Average values of a numeric array",
                                 ("Null values are ignored."),
@@ -2216,11 +2342,13 @@ const FunctionDoc hash_min_max_doc{
 
 const FunctionDoc hash_any_doc{"Test whether any element evaluates to true",
                                ("Null values are ignored."),
-                               {"array", "group_id_array"}};
+                               {"array", "group_id_array"},
+                               "ScalarAggregateOptions"};
 
 const FunctionDoc hash_all_doc{"Test whether all elements evaluate to true",
                                ("Null values are ignored."),
-                               {"array", "group_id_array"}};
+                               {"array", "group_id_array"},
+                               "ScalarAggregateOptions"};
 }  // namespace
 
 void RegisterHashAggregateBasic(FunctionRegistry* registry) {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -1108,6 +1108,10 @@ TEST(GroupBy, AnyAndAll) {
     [null,  3]
                         ])"});
 
+    ScalarAggregateOptions no_min(/*skip_nulls=*/true, /*min_count=*/0);
+    ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
+    ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false, /*min_count=*/0);
+    ScalarAggregateOptions keep_nulls_min_count(/*skip_nulls=*/false, /*min_count=*/3);
     ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
                          internal::GroupBy(
                              {
@@ -1115,13 +1119,21 @@ TEST(GroupBy, AnyAndAll) {
                                  table->GetColumnByName("argument"),
                                  table->GetColumnByName("argument"),
                                  table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
                              },
                              {table->GetColumnByName("key")},
                              {
-                                 {"hash_any", nullptr},
-                                 {"hash_all", nullptr},
-                                 {"hash_any", &options},
-                                 {"hash_all", &options},
+                                 {"hash_any", &no_min},
+                                 {"hash_any", &min_count},
+                                 {"hash_any", &keep_nulls},
+                                 {"hash_any", &keep_nulls_min_count},
+                                 {"hash_all", &no_min},
+                                 {"hash_all", &min_count},
+                                 {"hash_all", &keep_nulls},
+                                 {"hash_all", &keep_nulls_min_count},
                              },
                              use_threads));
     SortBy({"key_0"}, &aggregated_and_grouped);
@@ -1134,18 +1146,22 @@ TEST(GroupBy, AnyAndAll) {
     // Group null: falses
     AssertDatumsEqual(ArrayFromJSON(struct_({
                                         field("hash_any", boolean()),
-                                        field("hash_all", boolean()),
                                         field("hash_any", boolean()),
+                                        field("hash_any", boolean()),
+                                        field("hash_any", boolean()),
+                                        field("hash_all", boolean()),
+                                        field("hash_all", boolean()),
+                                        field("hash_all", boolean()),
                                         field("hash_all", boolean()),
                                         field("key_0", int64()),
                                     }),
                                     R"([
-    [true,  true,  true,  null,  1],
-    [true,  false, true,  false, 2],
-    [false, true,  null,  null,  3],
-    [false, false, null,  false, 4],
-    [true,  true,  true,  true,  5],
-    [false, false, false, false, null]
+    [true,  null, true,  null, true,  null,  null,  null,  1],
+    [true,  true, true,  true, false, false, false, false, 2],
+    [false, null, null,  null, true,  null,  null,  null,  3],
+    [false, null, null,  null, false, null,  false, null,  4],
+    [true,  null, true,  null, true,  null,  true,  null,  5],
+    [false, null, false, null, false, null,  false, null,  null]
   ])"),
                       aggregated_and_grouped,
                       /*verbose=*/true);
@@ -1286,6 +1302,64 @@ TEST(GroupBy, Product) {
                                             field("key_0", int64()),
                                         }),
                                         R"([[8589934592, 1]])"),
+                          aggregated_and_grouped,
+                          /*verbose=*/true);
+}
+
+TEST(GroupBy, SumMeanProductKeepNulls) {
+  auto batch = RecordBatchFromJSON(
+      schema({field("argument", float64()), field("key", int64())}), R"([
+    [-1.0,  1],
+    [null,  1],
+    [0.0,   2],
+    [null,  3],
+    [4.0,   null],
+    [3.25,  1],
+    [0.125, 2],
+    [-0.25, 2],
+    [0.75,  null],
+    [null,  3]
+  ])");
+
+  ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false);
+  ScalarAggregateOptions min_count(/*skip_nulls=*/false, /*min_count=*/3);
+  ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                       internal::GroupBy(
+                           {
+                               batch->GetColumnByName("argument"),
+                               batch->GetColumnByName("argument"),
+                               batch->GetColumnByName("argument"),
+                               batch->GetColumnByName("argument"),
+                               batch->GetColumnByName("argument"),
+                               batch->GetColumnByName("argument"),
+                           },
+                           {
+                               batch->GetColumnByName("key"),
+                           },
+                           {
+                               {"hash_sum", &keep_nulls},
+                               {"hash_sum", &min_count},
+                               {"hash_mean", &keep_nulls},
+                               {"hash_mean", &min_count},
+                               {"hash_product", &keep_nulls},
+                               {"hash_product", &min_count},
+                           }));
+
+  AssertDatumsApproxEqual(ArrayFromJSON(struct_({
+                                            field("hash_sum", float64()),
+                                            field("hash_sum", float64()),
+                                            field("hash_mean", float64()),
+                                            field("hash_mean", float64()),
+                                            field("hash_product", float64()),
+                                            field("hash_product", float64()),
+                                            field("key_0", int64()),
+                                        }),
+                                        R"([
+    [null,   null,   null,       null,       null, null, 1],
+    [-0.125, -0.125, -0.0416667, -0.0416667, 0.0,  0.0,  2],
+    [null,   null,   null,       null,       null, null, 3],
+    [4.75,   null,   2.375,      null,       3.0,  null, null]
+  ])"),
                           aggregated_and_grouped,
                           /*verbose=*/true);
 }

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -551,7 +551,13 @@ def test_min_max():
 def test_any():
     # ARROW-1846
 
-    options = pc.ScalarAggregateOptions(skip_nulls=False)
+    options = pc.ScalarAggregateOptions(skip_nulls=False, min_count=0)
+
+    a = pa.array([], type='bool')
+    assert pc.any(a).as_py() is None
+    assert pc.any(a, min_count=0).as_py() is False
+    assert pc.any(a, options=options).as_py() is False
+
     a = pa.array([False, None, True])
     assert pc.any(a).as_py() is True
     assert pc.any(a, options=options).as_py() is True
@@ -564,9 +570,11 @@ def test_any():
 def test_all():
     # ARROW-10301
 
-    options = pc.ScalarAggregateOptions(skip_nulls=False)
+    options = pc.ScalarAggregateOptions(skip_nulls=False, min_count=0)
+
     a = pa.array([], type='bool')
-    assert pc.all(a).as_py() is True
+    assert pc.all(a).as_py() is None
+    assert pc.all(a, min_count=0).as_py() is True
     assert pc.all(a, options=options).as_py() is True
 
     a = pa.array([False, True])

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -300,8 +300,8 @@ ExecNode_Project <- function(input, exprs, names) {
   .Call(`_arrow_ExecNode_Project`, input, exprs, names)
 }
 
-ExecNode_Aggregate <- function(input, options, target_names, out_field_names, key_names){
-    .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
+ExecNode_Aggregate <- function(input, options, target_names, out_field_names, key_names) {
+  .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
 }
 
 RecordBatch__cast <- function(batch, schema, options) {
@@ -314,10 +314,6 @@ Table__cast <- function(table, schema, options) {
 
 compute__CallFunction <- function(func_name, args, options) {
   .Call(`_arrow_compute__CallFunction`, func_name, args, options)
-}
-
-compute__GroupBy <- function(arguments, keys, options) {
-  .Call(`_arrow_compute__GroupBy`, arguments, keys, options)
 }
 
 compute__GetFunctionNames <- function() {

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -122,12 +122,6 @@ max.ArrowDatum <- function(..., na.rm = FALSE) {
 
 scalar_aggregate <- function(FUN, ..., na.rm = FALSE, na.min_count = 0) {
   a <- collect_arrays_from_dots(list(...))
-  if (!na.rm) {
-    # When not removing null values, we require all values to be not null and
-    # return null otherwise. We do that by setting minimum count of non-null
-    # option values to the full array length.
-    na.min_count <- length(a)
-  }
   if (FUN == "min_max" && na.rm && a$null_count == length(a)) {
     Array$create(data.frame(min = Inf, max = -Inf))
     # If na.rm == TRUE and all values in array are NA, R returns

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -791,28 +791,20 @@ agg_funcs$sum <- function(x, na.rm = FALSE) {
   list(
     fun = "sum",
     data = x,
-    options = arrow_na_rm(na.rm = na.rm)
+    options = list(na.rm = na.rm, na.min_count = 0L)
   )
 }
 agg_funcs$any <- function(x, na.rm = FALSE) {
   list(
     fun = "any",
     data = x,
-    options = arrow_na_rm(na.rm)
+    options = list(na.rm = na.rm, na.min_count = 0L)
   )
 }
 agg_funcs$all <- function(x, na.rm = FALSE) {
   list(
     fun = "all",
     data = x,
-    options = arrow_na_rm(na.rm)
+    options = list(na.rm = na.rm, na.min_count = 0L)
   )
-}
-
-arrow_na_rm <- function(na.rm) {
-  if (!isTRUE(na.rm)) {
-    # TODO: ARROW-13497
-    arrow_not_supported(paste("na.rm =", na.rm))
-  }
-  list(na.rm = na.rm, na.min_count = 0L)
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1246,23 +1246,6 @@ extern "C" SEXP _arrow_compute__CallFunction(SEXP func_name_sexp, SEXP args_sexp
 
 // compute.cpp
 #if defined(ARROW_R_WITH_ARROW)
-SEXP compute__GroupBy(cpp11::list arguments, cpp11::list keys, cpp11::list options);
-extern "C" SEXP _arrow_compute__GroupBy(SEXP arguments_sexp, SEXP keys_sexp, SEXP options_sexp){
-BEGIN_CPP11
-	arrow::r::Input<cpp11::list>::type arguments(arguments_sexp);
-	arrow::r::Input<cpp11::list>::type keys(keys_sexp);
-	arrow::r::Input<cpp11::list>::type options(options_sexp);
-	return cpp11::as_sexp(compute__GroupBy(arguments, keys, options));
-END_CPP11
-}
-#else
-extern "C" SEXP _arrow_compute__GroupBy(SEXP arguments_sexp, SEXP keys_sexp, SEXP options_sexp){
-	Rf_error("Cannot call compute__GroupBy(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
-// compute.cpp
-#if defined(ARROW_R_WITH_ARROW)
 std::vector<std::string> compute__GetFunctionNames();
 extern "C" SEXP _arrow_compute__GetFunctionNames(){
 BEGIN_CPP11
@@ -7136,7 +7119,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_RecordBatch__cast", (DL_FUNC) &_arrow_RecordBatch__cast, 3}, 
 		{ "_arrow_Table__cast", (DL_FUNC) &_arrow_Table__cast, 3}, 
 		{ "_arrow_compute__CallFunction", (DL_FUNC) &_arrow_compute__CallFunction, 3}, 
-		{ "_arrow_compute__GroupBy", (DL_FUNC) &_arrow_compute__GroupBy, 3}, 
 		{ "_arrow_compute__GetFunctionNames", (DL_FUNC) &_arrow_compute__GetFunctionNames, 0}, 
 		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0}, 
 		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0}, 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -172,7 +172,9 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
   }
 
   if (func_name == "min_max" || func_name == "sum" || func_name == "mean" ||
-      func_name == "any" || func_name == "all") {
+      func_name == "any" || func_name == "all" || func_name == "hash_min_max" ||
+      func_name == "hash_sum" || func_name == "hash_mean" || func_name == "hash_any" ||
+      func_name == "hash_all") {
     using Options = arrow::compute::ScalarAggregateOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
     out->min_count = cpp11::as_cpp<int>(options["na.min_count"]);
@@ -387,29 +389,6 @@ SEXP compute__CallFunction(std::string func_name, cpp11::list args, cpp11::list 
   auto datum_args = arrow::r::from_r_list<arrow::Datum>(args);
   auto out = ValueOrStop(
       arrow::compute::CallFunction(func_name, datum_args, opts.get(), gc_context()));
-  return from_datum(std::move(out));
-}
-
-// [[arrow::export]]
-SEXP compute__GroupBy(cpp11::list arguments, cpp11::list keys, cpp11::list options) {
-  // options is a list of pairs: string function name, list of options
-
-  std::vector<std::shared_ptr<arrow::compute::FunctionOptions>> keep_alives;
-  std::vector<arrow::compute::internal::Aggregate> aggregates;
-
-  for (cpp11::list name_opts : options) {
-    auto name = cpp11::as_cpp<std::string>(name_opts[0]);
-    auto opts = make_compute_options(name, name_opts[1]);
-
-    aggregates.push_back(
-        arrow::compute::internal::Aggregate{std::move(name), opts.get()});
-    keep_alives.push_back(std::move(opts));
-  }
-
-  auto datum_arguments = arrow::r::from_r_list<arrow::Datum>(arguments);
-  auto datum_keys = arrow::r::from_r_list<arrow::Datum>(keys);
-  auto out = ValueOrStop(arrow::compute::internal::GroupBy(datum_arguments, datum_keys,
-                                                           aggregates, gc_context()));
   return from_datum(std::move(out));
 }
 

--- a/r/tests/testthat/test-dplyr-aggregate.R
+++ b/r/tests/testthat/test-dplyr-aggregate.R
@@ -59,9 +59,7 @@ test_that("Can aggregate in Arrow", {
     input %>%
       summarize(total = sum(int)) %>%
       collect(),
-    tbl,
-    # ARROW-13497: This is failing because the default is na.rm = FALSE
-    warning = TRUE
+    tbl
   )
 })
 
@@ -90,9 +88,7 @@ test_that("Group by sum on dataset", {
       summarize(total = sum(int)) %>%
       arrange(some_grouping) %>%
       collect(),
-    tbl,
-    # ARROW-13497: This is failing because the default is na.rm = FALSE
-    warning = TRUE
+    tbl
   )
 })
 
@@ -115,7 +111,22 @@ test_that("Group by any/all", {
       collect(),
     tbl
   )
-  # ARROW-13497: na.rm option also is not being passed/received to any/all
+  expect_dplyr_equal(
+    input %>%
+      group_by(some_grouping) %>%
+      summarize(any(lgl, na.rm = FALSE)) %>%
+      arrange(some_grouping) %>%
+      collect(),
+    tbl
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(some_grouping) %>%
+      summarize(all(lgl, na.rm = FALSE)) %>%
+      arrange(some_grouping) %>%
+      collect(),
+    tbl
+  )
 
   expect_dplyr_equal(
     input %>%


### PR DESCRIPTION
This should let R easily support na.RM = TRUE / FALSE by setting skip_nulls = false / true (respectively).