### PR TITLE
ARROW-13638: [C++] Hold owned copy of function options in GroupByNode

### DIFF
--- a/cpp/examples/arrow/compute_register_example.cc
+++ b/cpp/examples/arrow/compute_register_example.cc
@@ -48,6 +48,7 @@ class ExampleFunctionOptionsType : public cp::FunctionOptionsType {
   bool Compare(const cp::FunctionOptions&, const cp::FunctionOptions&) const override {
     return true;
   }
+  std::unique_ptr<cp::FunctionOptions> Copy(const cp::FunctionOptions&) const override;
   // optional: support for serialization
   // Result<std::shared_ptr<Buffer>> Serialize(const FunctionOptions&) const override;
   // Result<std::unique_ptr<FunctionOptions>> Deserialize(const Buffer&) const override;
@@ -62,6 +63,11 @@ class ExampleFunctionOptions : public cp::FunctionOptions {
  public:
   ExampleFunctionOptions() : cp::FunctionOptions(GetExampleFunctionOptionsType()) {}
 };
+
+std::unique_ptr<cp::FunctionOptions> ExampleFunctionOptionsType::Copy(
+    const cp::FunctionOptions&) const {
+  return std::unique_ptr<cp::FunctionOptions>(new ExampleFunctionOptions());
+}
 
 arrow::Status ExampleFunctionImpl(cp::KernelContext* ctx, const cp::ExecBatch& batch,
                                   arrow::Datum* out) {

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -256,14 +256,16 @@ struct GroupByNode : ExecNode {
               const std::vector<int>&& key_field_ids,
               const std::vector<int>&& agg_src_field_ids,
               const std::vector<internal::Aggregate>&& aggs,
-              const std::vector<const HashAggregateKernel*>&& agg_kernels)
+              const std::vector<const HashAggregateKernel*>&& agg_kernels,
+              std::vector<std::unique_ptr<FunctionOptions>> owned_options)
       : ExecNode(input->plan(), {input}, {"groupby"}, std::move(output_schema),
                  /*num_outputs=*/1),
         ctx_(ctx),
         key_field_ids_(std::move(key_field_ids)),
         agg_src_field_ids_(std::move(agg_src_field_ids)),
         aggs_(std::move(aggs)),
-        agg_kernels_(std::move(agg_kernels)) {}
+        agg_kernels_(std::move(agg_kernels)),
+        owned_options_(std::move(owned_options)) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -272,7 +274,8 @@ struct GroupByNode : ExecNode {
     auto input = inputs[0];
     const auto& aggregate_options = checked_cast<const AggregateNodeOptions&>(options);
     const auto& keys = aggregate_options.keys;
-    const auto& aggs = aggregate_options.aggregates;
+    // Copy (need to modify options pointer below)
+    auto aggs = aggregate_options.aggregates;
     const auto& field_names = aggregate_options.names;
 
     // Get input schema
@@ -328,11 +331,17 @@ struct GroupByNode : ExecNode {
       output_fields[base + i] = input_schema->field(key_field_id);
     }
 
-    auto aggs_copy = aggs;
+    std::vector<std::unique_ptr<FunctionOptions>> owned_options;
+    owned_options.reserve(aggs.size());
+    for (auto& agg : aggs) {
+      owned_options.push_back(agg.options ? agg.options->Copy() : nullptr);
+      agg.options = owned_options.back().get();
+    }
 
     return input->plan()->EmplaceNode<GroupByNode>(
         input, schema(std::move(output_fields)), ctx, std::move(key_field_ids),
-        std::move(agg_src_field_ids), std::move(aggs), std::move(agg_kernels));
+        std::move(agg_src_field_ids), std::move(aggs), std::move(agg_kernels),
+        std::move(owned_options));
   }
 
   const char* kind_name() override { return "GroupByNode"; }
@@ -574,6 +583,8 @@ struct GroupByNode : ExecNode {
   const std::vector<int> agg_src_field_ids_;
   const std::vector<internal::Aggregate> aggs_;
   const std::vector<const HashAggregateKernel*> agg_kernels_;
+  // ARROW-13638: must hold owned copy of function options
+  const std::vector<std::unique_ptr<FunctionOptions>> owned_options_;
 
   ThreadIndexer get_thread_index_;
   AtomicCounter input_counter_, output_counter_;

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -87,7 +87,8 @@ class ThreadIndexer {
   std::unordered_map<std::thread::id, size_t> id_to_index_;
 };
 
-struct ScalarAggregateNode : ExecNode {
+class ScalarAggregateNode : public ExecNode {
+ public:
   ScalarAggregateNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
                       std::shared_ptr<Schema> output_schema,
                       std::vector<int> target_field_ids,
@@ -251,12 +252,12 @@ struct ScalarAggregateNode : ExecNode {
   AtomicCounter input_counter_;
 };
 
-struct GroupByNode : ExecNode {
+class GroupByNode : public ExecNode {
+ public:
   GroupByNode(ExecNode* input, std::shared_ptr<Schema> output_schema, ExecContext* ctx,
-              const std::vector<int>&& key_field_ids,
-              const std::vector<int>&& agg_src_field_ids,
-              const std::vector<internal::Aggregate>&& aggs,
-              const std::vector<const HashAggregateKernel*>&& agg_kernels,
+              std::vector<int> key_field_ids, std::vector<int> agg_src_field_ids,
+              std::vector<internal::Aggregate> aggs,
+              std::vector<const HashAggregateKernel*> agg_kernels,
               std::vector<std::unique_ptr<FunctionOptions>> owned_options)
       : ExecNode(input->plan(), {input}, {"groupby"}, std::move(output_schema),
                  /*num_outputs=*/1),

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -55,6 +55,10 @@ bool FunctionOptions::Equals(const FunctionOptions& other) const {
   return options_type()->Compare(*this, other);
 }
 
+std::unique_ptr<FunctionOptions> FunctionOptions::Copy() const {
+  return options_type()->Copy(*this);
+}
+
 Result<std::shared_ptr<Buffer>> FunctionOptions::Serialize() const {
   return options_type()->Serialize(*this);
 }

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -52,6 +52,7 @@ class ARROW_EXPORT FunctionOptionsType {
   virtual Result<std::shared_ptr<Buffer>> Serialize(const FunctionOptions&) const;
   virtual Result<std::unique_ptr<FunctionOptions>> Deserialize(
       const Buffer& buffer) const;
+  virtual std::unique_ptr<FunctionOptions> Copy(const FunctionOptions&) const = 0;
 };
 
 /// \brief Base class for specifying options configuring a function's behavior,
@@ -68,6 +69,7 @@ class ARROW_EXPORT FunctionOptions : public util::EqualityComparable<FunctionOpt
   using util::EqualityComparable<FunctionOptions>::operator==;
   using util::EqualityComparable<FunctionOptions>::operator!=;
   std::string ToString() const;
+  std::unique_ptr<FunctionOptions> Copy() const;
   /// \brief Serialize an options struct to a buffer.
   Result<std::shared_ptr<Buffer>> Serialize() const;
   /// \brief Deserialize an options struct from a buffer.

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -89,7 +89,7 @@ struct TDigestImpl : public ScalarAggregator {
     return Status::OK();
   }
 
-  const std::vector<double>& q;
+  const std::vector<double> q;
   TDigest tdigest;
 };
 


### PR DESCRIPTION
GroupByNode lazily initializes per-thread kernel state, so it needs an owned copy of function options to do so.