### PR TITLE
ARROW-13645 [Java]: Allow NullVectors to have distinct field names

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -46,7 +46,40 @@ public class NullVector implements FieldVector {
 
   private int valueCount;
 
+  protected Field field;
+
+  /**
+   * Instantiate a NullVector.
+   *
+   * @param name name of the vector
+   */
+  public NullVector(String name) {
+    this(name, FieldType.nullable(Types.MinorType.NULL.getType()));
+  }
+
+  /**
+   * Instantiate a NullVector.
+   *
+   * @param name      name of the vector
+   * @param fieldType type of Field materialized by this vector.
+   */
+  public NullVector(String name, FieldType fieldType) {
+    this(new Field(name, fieldType, null));
+  }
+
+  /**
+   * Instantiate a NullVector.
+   *
+   * @param field field materialized by this vector.
+   */
+  public NullVector(Field field) {
+    this.valueCount = 0;
+    this.field = field;
+  }
+
+  @Deprecated
   public NullVector() {
+    this(new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
   }
 
   @Override
@@ -63,7 +96,7 @@ public class NullVector implements FieldVector {
 
   @Override
   public Field getField() {
-    return new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null);
+    return field;
   }
 
   @Override
@@ -259,6 +292,11 @@ public class NullVector implements FieldVector {
   private class TransferImpl implements TransferPair {
     NullVector to;
 
+    public TransferImpl(String ref) {
+      to = new NullVector(ref);
+    }
+
+    @Deprecated
     public TransferImpl() {
       to = new NullVector();
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -20,6 +20,8 @@ package org.apache.arrow.vector;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -29,6 +31,35 @@ import org.apache.arrow.vector.util.TransferPair;
 public final class ZeroVector extends NullVector {
   public static final ZeroVector INSTANCE = new ZeroVector();
 
+  /**
+   * Instantiate a ZeroVector.
+   *
+   * @param name name of the vector
+   */
+  public ZeroVector(String name) {
+    super(name);
+  }
+
+  /**
+   * Instantiate a ZeroVector.
+   *
+   * @param name      name of the vector
+   * @param fieldType type of Field materialized by this vector.
+   */
+  public ZeroVector(String name, FieldType fieldType) {
+    super(name, fieldType);
+  }
+
+  /**
+   * Instantiate a ZeroVector.
+   *
+   * @param field field materialized by this vector.
+   */
+  public ZeroVector(Field field) {
+    super(field);
+  }
+
+  @Deprecated
   public ZeroVector() {
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -150,7 +150,7 @@ public class Types {
           Field field,
           BufferAllocator allocator,
           CallBack schemaChangeCallback) {
-        return new NullVector();
+        return new NullVector(field.getName());
       }
 
       @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2371,8 +2371,8 @@ public class TestValueVector {
 
   @Test
   public void testZeroVectorEquals() {
-    try (final ZeroVector vector1 = new ZeroVector();
-        final ZeroVector vector2 = new ZeroVector()) {
+    try (final ZeroVector vector1 = new ZeroVector("vector");
+        final ZeroVector vector2 = new ZeroVector("vector")) {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor();
       assertTrue(visitor.vectorEquals(vector1, vector2));
@@ -2382,13 +2382,18 @@ public class TestValueVector {
   @Test
   public void testZeroVectorNotEquals() {
     try (final IntVector intVector = new IntVector("int", allocator);
-        final ZeroVector zeroVector = new ZeroVector()) {
+        final ZeroVector zeroVector = new ZeroVector("zero");
+        final ZeroVector zeroVector1 = new ZeroVector("zero1")) {
 
       VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor();
       assertFalse(zeroVisitor.vectorEquals(intVector, zeroVector));
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor();
       assertFalse(intVisitor.vectorEquals(zeroVector, intVector));
+
+      VectorEqualsVisitor twoZeroVisitor = new VectorEqualsVisitor();
+      // they are not equal because of distinct names
+      assertFalse(twoZeroVisitor.vectorEquals(zeroVector, zeroVector1));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -456,7 +456,7 @@ public class TestRangeEqualsVisitor {
   @Test
   public void testEqualsWithOutTypeCheck() {
     try (final IntVector intVector = new IntVector("int", allocator);
-         final ZeroVector zeroVector = new ZeroVector()) {
+         final ZeroVector zeroVector = new ZeroVector("zero")) {
 
       assertTrue(VectorEqualsVisitor.vectorEquals(intVector, zeroVector, null));
       assertTrue(VectorEqualsVisitor.vectorEquals(zeroVector, intVector, null));

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -533,8 +533,8 @@ public class BaseFileTest {
   }
 
   protected VectorSchemaRoot writeNullData(int valueCount) {
-    NullVector nullVector1 = new NullVector();
-    NullVector nullVector2 = new NullVector();
+    NullVector nullVector1 = new NullVector("vector1");
+    NullVector nullVector2 = new NullVector("vector2");
     nullVector1.setValueCount(valueCount);
     nullVector2.setValueCount(valueCount);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -241,7 +241,7 @@ public class TestArrowReaderWriter {
 
     int valueCount = 3;
 
-    NullVector nullVector = new NullVector();
+    NullVector nullVector = new NullVector("vector");
     nullVector.setValueCount(valueCount);
 
     Schema schema = new Schema(asList(nullVector.getField()));

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
@@ -296,6 +296,6 @@ public class TestValidateVectorTypeVisitor {
 
   @Test
   public void testNullVector() {
-    testPositiveCase(() -> new NullVector());
+    testPositiveCase(() -> new NullVector("null vec"));
   }
 }


### PR DESCRIPTION
As discussed in the ML (https://lists.apache.org/thread.html/r19aad8a34f63334d3fcd627106f69be13f689740b83930a4eecc17b3%40%3Cdev.arrow.apache.org%3E), the current implementation use hard-coded field names. This may cause some problems, for example, when reconstruct a usable schema from a list of FieldVectors.

So we resolve this problem by allowing NullVectors to have distinct field names.

This also makes the `NullVector` consistent with other types of vectors.