### PR TITLE
ARROW-13660: [C++] Remove seq_num from ExecNode::InputReceived

### DIFF
--- a/cpp/examples/arrow/compute_register_example.cc
+++ b/cpp/examples/arrow/compute_register_example.cc
@@ -100,7 +100,7 @@ class ExampleNode : public cp::ExecNode {
 
   void InputReceived(ExecNode* input, cp::ExecBatch batch) override {}
   void ErrorReceived(ExecNode* input, arrow::Status error) override {}
-  void InputFinished(ExecNode* input, int seq_stop) override {}
+  void InputFinished(ExecNode* input, int total_batches) override {}
 
   arrow::Future<> finished() override { return inputs_[0]->finished(); }
 };

--- a/cpp/examples/arrow/compute_register_example.cc
+++ b/cpp/examples/arrow/compute_register_example.cc
@@ -98,7 +98,7 @@ class ExampleNode : public cp::ExecNode {
   void StopProducing(ExecNode* output) override { inputs_[0]->StopProducing(this); }
   void StopProducing() override { inputs_[0]->StopProducing(); }
 
-  void InputReceived(ExecNode* input, int seq_num, cp::ExecBatch batch) override {}
+  void InputReceived(ExecNode* input, cp::ExecBatch batch) override {}
   void ErrorReceived(ExecNode* input, arrow::Status error) override {}
   void InputFinished(ExecNode* input, int seq_stop) override {}
 

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -192,10 +192,10 @@ class ScalarAggregateNode : public ExecNode {
     outputs_[0]->ErrorReceived(this, std::move(error));
   }
 
-  void InputFinished(ExecNode* input, int num_total) override {
+  void InputFinished(ExecNode* input, int total_batches) override {
     DCHECK_EQ(input, inputs_[0]);
 
-    if (input_counter_.SetTotal(num_total)) {
+    if (input_counter_.SetTotal(total_batches)) {
       ErrorIfNotOk(Finish());
     }
   }
@@ -490,13 +490,13 @@ class GroupByNode : public ExecNode {
     outputs_[0]->ErrorReceived(this, std::move(error));
   }
 
-  void InputFinished(ExecNode* input, int num_total) override {
+  void InputFinished(ExecNode* input, int total_batches) override {
     // bail if StopProducing was called
     if (finished_.is_finished()) return;
 
     DCHECK_EQ(input, inputs_[0]);
 
-    if (input_counter_.SetTotal(num_total)) {
+    if (input_counter_.SetTotal(total_batches)) {
       ErrorIfNotOk(OutputResult());
     }
   }

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -175,7 +175,7 @@ class ScalarAggregateNode : public ExecNode {
     return Status::OK();
   }
 
-  void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
+  void InputReceived(ExecNode* input, ExecBatch batch) override {
     DCHECK_EQ(input, inputs_[0]);
 
     auto thread_index = get_thread_index_();
@@ -237,7 +237,7 @@ class ScalarAggregateNode : public ExecNode {
       RETURN_NOT_OK(kernels_[i]->finalize(&ctx, &batch.values[i]));
     }
 
-    outputs_[0]->InputReceived(this, 0, std::move(batch));
+    outputs_[0]->InputReceived(this, std::move(batch));
     finished_.MarkFinished();
     return Status::OK();
   }
@@ -441,7 +441,7 @@ class GroupByNode : public ExecNode {
     if (finished_.is_finished()) return;
 
     int64_t batch_size = output_batch_size();
-    outputs_[0]->InputReceived(this, n, out_data_.Slice(batch_size * n, batch_size));
+    outputs_[0]->InputReceived(this, out_data_.Slice(batch_size * n, batch_size));
 
     if (output_counter_.Increment()) {
       finished_.MarkFinished();
@@ -471,7 +471,7 @@ class GroupByNode : public ExecNode {
     return Status::OK();
   }
 
-  void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
+  void InputReceived(ExecNode* input, ExecBatch batch) override {
     // bail if StopProducing was called
     if (finished_.is_finished()) return;
 

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -139,7 +139,7 @@ class ARROW_EXPORT ExecNode {
   /// This may be called before all inputs are received.  This simply fixes
   /// the total number of incoming batches for an input, so that the ExecNode
   /// knows when it has received all input, regardless of order.
-  virtual void InputFinished(ExecNode* input, int seq_stop) = 0;
+  virtual void InputFinished(ExecNode* input, int total_batches) = 0;
 
   /// Lifecycle API:
   /// - start / stop to initiate and terminate production

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -129,7 +129,7 @@ class ARROW_EXPORT ExecNode {
   ///   and StopProducing()
 
   /// Transfer input batch to ExecNode
-  virtual void InputReceived(ExecNode* input, int seq_num, ExecBatch batch) = 0;
+  virtual void InputReceived(ExecNode* input, ExecBatch batch) = 0;
 
   /// Signal error to ExecNode
   virtual void ErrorReceived(ExecNode* input, Status error) = 0;

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -96,14 +96,14 @@ class FilterNode : public ExecNode {
     return ExecBatch::Make(std::move(values));
   }
 
-  void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
+  void InputReceived(ExecNode* input, ExecBatch batch) override {
     DCHECK_EQ(input, inputs_[0]);
 
     auto maybe_filtered = DoFilter(std::move(batch));
     if (ErrorIfNotOk(maybe_filtered.status())) return;
 
     maybe_filtered->guarantee = batch.guarantee;
-    outputs_[0]->InputReceived(this, seq, maybe_filtered.MoveValueUnsafe());
+    outputs_[0]->InputReceived(this, maybe_filtered.MoveValueUnsafe());
   }
 
   void ErrorReceived(ExecNode* input, Status error) override {

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -111,9 +111,9 @@ class FilterNode : public ExecNode {
     outputs_[0]->ErrorReceived(this, std::move(error));
   }
 
-  void InputFinished(ExecNode* input, int seq) override {
+  void InputFinished(ExecNode* input, int total_batches) override {
     DCHECK_EQ(input, inputs_[0]);
-    outputs_[0]->InputFinished(this, seq);
+    outputs_[0]->InputFinished(this, total_batches);
   }
 
   Status StartProducing() override { return Status::OK(); }

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -87,14 +87,14 @@ class ProjectNode : public ExecNode {
     return ExecBatch{std::move(values), target.length};
   }
 
-  void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
+  void InputReceived(ExecNode* input, ExecBatch batch) override {
     DCHECK_EQ(input, inputs_[0]);
 
     auto maybe_projected = DoProject(std::move(batch));
     if (ErrorIfNotOk(maybe_projected.status())) return;
 
     maybe_projected->guarantee = batch.guarantee;
-    outputs_[0]->InputReceived(this, seq, maybe_projected.MoveValueUnsafe());
+    outputs_[0]->InputReceived(this, maybe_projected.MoveValueUnsafe());
   }
 
   void ErrorReceived(ExecNode* input, Status error) override {

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -102,9 +102,9 @@ class ProjectNode : public ExecNode {
     outputs_[0]->ErrorReceived(this, std::move(error));
   }
 
-  void InputFinished(ExecNode* input, int seq) override {
+  void InputFinished(ExecNode* input, int total_batches) override {
     DCHECK_EQ(input, inputs_[0]);
-    outputs_[0]->InputFinished(this, seq);
+    outputs_[0]->InputFinished(this, total_batches);
   }
 
   Status StartProducing() override { return Status::OK(); }

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -127,8 +127,8 @@ class SinkNode : public ExecNode {
     inputs_[0]->StopProducing(this);
   }
 
-  void InputFinished(ExecNode* input, int seq_stop) override {
-    if (input_counter_.SetTotal(seq_stop)) {
+  void InputFinished(ExecNode* input, int total_batches) override {
+    if (input_counter_.SetTotal(total_batches)) {
       Finish();
     }
   }

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -61,7 +61,7 @@ struct SourceNode : ExecNode {
   [[noreturn]] static void NoInputs() {
     Unreachable("no inputs; this should never be called");
   }
-  [[noreturn]] void InputReceived(ExecNode*, int, ExecBatch) override { NoInputs(); }
+  [[noreturn]] void InputReceived(ExecNode*, ExecBatch) override { NoInputs(); }
   [[noreturn]] void ErrorReceived(ExecNode*, Status) override { NoInputs(); }
   [[noreturn]] void InputFinished(ExecNode*, int) override { NoInputs(); }
 
@@ -95,7 +95,7 @@ struct SourceNode : ExecNode {
                         }
                         lock.unlock();
 
-                        outputs_[0]->InputReceived(this, seq, *batch);
+                        outputs_[0]->InputReceived(this, *batch);
                         return Continue();
                       },
                       [=](const Status& error) -> ControlFlow<int> {

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -80,9 +80,9 @@ struct SourceNode : ExecNode {
 
     finished_ = Loop([this, options] {
                   std::unique_lock<std::mutex> lock(mutex_);
-                  int seq = batch_count_++;
+                  int total_batches = batch_count_++;
                   if (stop_requested_) {
-                    return Future<ControlFlow<int>>::MakeFinished(Break(seq));
+                    return Future<ControlFlow<int>>::MakeFinished(Break(total_batches));
                   }
                   lock.unlock();
 
@@ -91,7 +91,7 @@ struct SourceNode : ExecNode {
                         std::unique_lock<std::mutex> lock(mutex_);
                         if (IsIterationEnd(batch) || stop_requested_) {
                           stop_requested_ = true;
-                          return Break(seq);
+                          return Break(total_batches);
                         }
                         lock.unlock();
 
@@ -108,10 +108,12 @@ struct SourceNode : ExecNode {
                         stop_requested_ = true;
                         lock.unlock();
                         outputs_[0]->ErrorReceived(this, error);
-                        return Break(seq);
+                        return Break(total_batches);
                       },
                       options);
-                }).Then([&](int seq) { outputs_[0]->InputFinished(this, seq); });
+                }).Then([&](int total_batches) {
+      outputs_[0]->InputFinished(this, total_batches);
+    });
 
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -64,7 +64,7 @@ struct DummyNode : ExecNode {
 
   const char* kind_name() override { return "Dummy"; }
 
-  void InputReceived(ExecNode* input, int seq_num, ExecBatch batch) override {}
+  void InputReceived(ExecNode* input, ExecBatch batch) override {}
 
   void ErrorReceived(ExecNode* input, Status error) override {}
 

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -68,7 +68,7 @@ struct DummyNode : ExecNode {
 
   void ErrorReceived(ExecNode* input, Status error) override {}
 
-  void InputFinished(ExecNode* input, int seq_stop) override {}
+  void InputFinished(ExecNode* input, int total_batches) override {}
 
   Status StartProducing() override {
     if (start_producing_) {

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -72,13 +72,13 @@ struct UnionNode : ExecNode {
     return plan->EmplaceNode<UnionNode>(plan, std::move(inputs));
   }
 
-  void InputReceived(ExecNode* input, int seq, ExecBatch batch) override {
+  void InputReceived(ExecNode* input, ExecBatch batch) override {
     ARROW_DCHECK(std::find(inputs_.begin(), inputs_.end(), input) != inputs_.end());
 
     if (finished_.is_finished()) {
       return;
     }
-    outputs_[0]->InputReceived(this, seq, std::move(batch));
+    outputs_[0]->InputReceived(this, std::move(batch));
     if (batch_count_.Increment()) {
       finished_.MarkFinished();
     }

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -91,10 +91,10 @@ struct UnionNode : ExecNode {
     StopProducing();
   }
 
-  void InputFinished(ExecNode* input, int num_total) override {
+  void InputFinished(ExecNode* input, int total_batches) override {
     ARROW_DCHECK(std::find(inputs_.begin(), inputs_.end(), input) != inputs_.end());
 
-    total_batches_.fetch_add(num_total);
+    total_batches_.fetch_add(total_batches);
 
     if (input_count_.Increment()) {
       outputs_[0]->InputFinished(this, total_batches_.load());


### PR DESCRIPTION
seq_num wasn't very useful especially as there weren't many guarantees around it, and it was tempting to misuse, so let's just remove it.