### PR TITLE
ARROW-13680: [C++] Create an asynchronous nursery to simplify capture logic

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -190,6 +190,7 @@ set(ARROW_SRCS
     io/slow.cc
     io/stdio.cc
     io/transform.cc
+    util/async_nursery.cc
     util/basic_decimal.cc
     util/bit_block_counter.cc
     util/bit_run_reader.cc

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -26,56 +26,57 @@ arrow_install_all_headers("arrow/util")
 # arrow_test_main
 #
 
-if(WIN32)
-  # This manifest enables long file paths on Windows 10+
-  # See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
-  if(MSVC)
-    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
-  else()
-    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.rc)
-  endif()
-else()
-  set(IO_UTIL_TEST_SOURCES io_util_test.cc)
-endif()
+if (WIN32)
+    # This manifest enables long file paths on Windows 10+
+    # See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
+    if (MSVC)
+        set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
+    else ()
+        set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.rc)
+    endif ()
+else ()
+    set(IO_UTIL_TEST_SOURCES io_util_test.cc)
+endif ()
 
 add_arrow_test(utility-test
-               SOURCES
-               align_util_test.cc
-               async_generator_test.cc
-               bit_block_counter_test.cc
-               bit_util_test.cc
-               cache_test.cc
-               checked_cast_test.cc
-               compression_test.cc
-               decimal_test.cc
-               formatting_util_test.cc
-               key_value_metadata_test.cc
-               hashing_test.cc
-               int_util_test.cc
-               ${IO_UTIL_TEST_SOURCES}
-               iterator_test.cc
-               logging_test.cc
-               queue_test.cc
-               range_test.cc
-               reflection_test.cc
-               rle_encoding_test.cc
-               stl_util_test.cc
-               string_test.cc
-               tdigest_test.cc
-               test_common.cc
-               time_test.cc
-               trie_test.cc
-               uri_test.cc
-               utf8_util_test.cc
-               value_parsing_test.cc
-               variant_test.cc)
+        SOURCES
+        align_util_test.cc
+        async_generator_test.cc
+        async_nursery_test.cc
+        bit_block_counter_test.cc
+        bit_util_test.cc
+        cache_test.cc
+        checked_cast_test.cc
+        compression_test.cc
+        decimal_test.cc
+        formatting_util_test.cc
+        key_value_metadata_test.cc
+        hashing_test.cc
+        int_util_test.cc
+        ${IO_UTIL_TEST_SOURCES}
+        iterator_test.cc
+        logging_test.cc
+        queue_test.cc
+        range_test.cc
+        reflection_test.cc
+        rle_encoding_test.cc
+        stl_util_test.cc
+        string_test.cc
+        tdigest_test.cc
+        test_common.cc
+        time_test.cc
+        trie_test.cc
+        uri_test.cc
+        utf8_util_test.cc
+        value_parsing_test.cc
+        variant_test.cc)
 
 add_arrow_test(threading-utility-test
-               SOURCES
-               cancel_test.cc
-               future_test.cc
-               task_group_test.cc
-               thread_pool_test.cc)
+        SOURCES
+        cancel_test.cc
+        future_test.cc
+        task_group_test.cc
+        thread_pool_test.cc)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
 add_arrow_benchmark(bit_util_benchmark)

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -26,57 +26,57 @@ arrow_install_all_headers("arrow/util")
 # arrow_test_main
 #
 
-if (WIN32)
-    # This manifest enables long file paths on Windows 10+
-    # See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
-    if (MSVC)
-        set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
-    else ()
-        set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.rc)
-    endif ()
-else ()
-    set(IO_UTIL_TEST_SOURCES io_util_test.cc)
-endif ()
+if(WIN32)
+  # This manifest enables long file paths on Windows 10+
+  # See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
+  if(MSVC)
+    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
+  else()
+    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.rc)
+  endif()
+else()
+  set(IO_UTIL_TEST_SOURCES io_util_test.cc)
+endif()
 
 add_arrow_test(utility-test
-        SOURCES
-        align_util_test.cc
-        async_generator_test.cc
-        async_nursery_test.cc
-        bit_block_counter_test.cc
-        bit_util_test.cc
-        cache_test.cc
-        checked_cast_test.cc
-        compression_test.cc
-        decimal_test.cc
-        formatting_util_test.cc
-        key_value_metadata_test.cc
-        hashing_test.cc
-        int_util_test.cc
-        ${IO_UTIL_TEST_SOURCES}
-        iterator_test.cc
-        logging_test.cc
-        queue_test.cc
-        range_test.cc
-        reflection_test.cc
-        rle_encoding_test.cc
-        stl_util_test.cc
-        string_test.cc
-        tdigest_test.cc
-        test_common.cc
-        time_test.cc
-        trie_test.cc
-        uri_test.cc
-        utf8_util_test.cc
-        value_parsing_test.cc
-        variant_test.cc)
+               SOURCES
+               align_util_test.cc
+               async_generator_test.cc
+               async_nursery_test.cc
+               bit_block_counter_test.cc
+               bit_util_test.cc
+               cache_test.cc
+               checked_cast_test.cc
+               compression_test.cc
+               decimal_test.cc
+               formatting_util_test.cc
+               key_value_metadata_test.cc
+               hashing_test.cc
+               int_util_test.cc
+               ${IO_UTIL_TEST_SOURCES}
+               iterator_test.cc
+               logging_test.cc
+               queue_test.cc
+               range_test.cc
+               reflection_test.cc
+               rle_encoding_test.cc
+               stl_util_test.cc
+               string_test.cc
+               tdigest_test.cc
+               test_common.cc
+               time_test.cc
+               trie_test.cc
+               uri_test.cc
+               utf8_util_test.cc
+               value_parsing_test.cc
+               variant_test.cc)
 
 add_arrow_test(threading-utility-test
-        SOURCES
-        cancel_test.cc
-        future_test.cc
-        task_group_test.cc
-        thread_pool_test.cc)
+               SOURCES
+               cancel_test.cc
+               future_test.cc
+               task_group_test.cc
+               thread_pool_test.cc)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
 add_arrow_benchmark(bit_util_benchmark)

--- a/cpp/src/arrow/util/async_nursery.cc
+++ b/cpp/src/arrow/util/async_nursery.cc
@@ -45,7 +45,7 @@ void AsyncCloseable::AddDependentTask(const Future<>& task) {
   DCHECK(!closed_);
   if (num_tasks_outstanding_.fetch_add(1) == 1) {
     tasks_finished_ = Future<>::Make();
-  };
+  }
   task.AddCallback([this](const Status& st) {
     if (num_tasks_outstanding_.fetch_sub(1) == 1 && closed_.load()) {
       tasks_finished_.MarkFinished(st);
@@ -91,7 +91,7 @@ void AsyncCloseablePimpl::Init(AsyncCloseable* impl) { impl_ = impl; }
 void AsyncCloseablePimpl::Destroy() { impl_->Destroy(); }
 void AsyncCloseablePimpl::SetNursery(Nursery* nursery) { impl_->SetNursery(nursery); }
 
-Nursery::Nursery() : finished_(Future<>::Make()){};
+Nursery::Nursery() : finished_(Future<>::Make()) {}
 
 Status Nursery::WaitForFinish() {
   if (num_closeables_destroyed_.load() != num_closeables_created_.load()) {

--- a/cpp/src/arrow/util/async_nursery.cc
+++ b/cpp/src/arrow/util/async_nursery.cc
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/async_nursery.h"
+
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace util {
+
+AsyncCloseable::AsyncCloseable(AsyncCloseable* parent) : on_closed_(Future<>::Make()) {
+  if (parent) {
+    Mutex::Guard guard = mutex_.Lock();
+    parent->children_.push_back(this);
+    self_itr_ = --parent->children_.end();
+  }
+}
+
+AsyncCloseable::~AsyncCloseable() { DCHECK(close_complete_.load()); }
+
+Future<> AsyncCloseable::OnClosed() { return on_closed_; }
+
+Future<> AsyncCloseable::Close() {
+  {
+    Mutex::Guard guard = mutex_.Lock();
+    if (closed_.load()) {
+      return Future<>::MakeFinished();
+    }
+    closed_.store(true);
+  }
+  return DoClose()
+      .Then([this] {
+        close_complete_.store(true);
+        on_closed_.MarkFinished();
+        return CloseChildren();
+      })
+      .Then([] {},
+            [this](const Status& err) {
+              close_complete_.store(true);
+              on_closed_.MarkFinished(err);
+              return err;
+            });
+}
+
+Future<> AsyncCloseable::CloseChildren() {
+  for (auto& child : children_) {
+    tasks_.push_back(child->Close());
+  }
+  return AllComplete(tasks_);
+}
+
+Status AsyncCloseable::CheckClosed() const {
+  if (closed_.load()) {
+    return Status::Invalid("Invalid operation after Close");
+  }
+  return Status::OK();
+}
+
+void AsyncCloseable::AssertNotCloseComplete() const { DCHECK(!close_complete_); }
+
+void AsyncCloseable::AddDependentTask(Future<> task) {
+  tasks_.push_back(std::move(task));
+}
+
+OwnedAsyncCloseable::OwnedAsyncCloseable(AsyncCloseable* parent)
+    : AsyncCloseable(parent) {
+  parent_ = parent;
+}
+
+void OwnedAsyncCloseable::Init() {
+  Mutex::Guard lock = parent_->mutex_.Lock();
+  parent_->owned_children_.push_back(shared_from_this());
+  owned_self_itr_ = --parent_->owned_children_.end();
+}
+
+void OwnedAsyncCloseable::Evict() {
+  {
+    Mutex::Guard lock = parent_->mutex_.Lock();
+    if (parent_->closed_) {
+      // Parent is already closing, no need to do anything, the parent will call close on
+      // this instance eventually
+      return;
+    }
+    parent_->children_.erase(self_itr_);
+  }
+  // We need to add a dependent task to make sure our parent does not close itself
+  // while we are shutting down.
+  parent_->AddDependentTask(Close().Then([this] {
+    Mutex::Guard lock = parent_->mutex_.Lock();
+    parent_->owned_children_.erase(owned_self_itr_);
+  }));
+}
+
+NurseryPimpl::~NurseryPimpl() = default;
+
+Nursery::Nursery() : AsyncCloseable(nullptr) {}
+Future<> Nursery::DoClose() { return Future<>::MakeFinished(); }
+
+Status Nursery::RunInNursery(std::function<void(Nursery*)> task) {
+  Nursery nursery;
+  task(&nursery);
+  return nursery.Close().status();
+}
+
+Status Nursery::RunInNurserySt(std::function<Status(Nursery*)> task) {
+  Nursery nursery;
+  Status task_st = task(&nursery);
+  Status close_st = nursery.Close().status();
+  return task_st & close_st;
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/async_nursery.cc
+++ b/cpp/src/arrow/util/async_nursery.cc
@@ -24,7 +24,7 @@ namespace util {
 
 AsyncCloseable::AsyncCloseable() = default;
 AsyncCloseable::AsyncCloseable(AsyncCloseable* parent) {
-  AddDependentTask(parent->OnClosed());
+  parent->AddDependentTask(OnClosed());
 }
 
 AsyncCloseable::~AsyncCloseable() {

--- a/cpp/src/arrow/util/async_nursery.cc
+++ b/cpp/src/arrow/util/async_nursery.cc
@@ -87,6 +87,10 @@ Status AsyncCloseable::CheckClosed() const {
   return Status::OK();
 }
 
+void AsyncCloseablePimpl::Init(AsyncCloseable* impl) { impl_ = impl; }
+void AsyncCloseablePimpl::Destroy() { impl_->Destroy(); }
+void AsyncCloseablePimpl::SetNursery(Nursery* nursery) { impl_->SetNursery(nursery); }
+
 Nursery::Nursery() : finished_(Future<>::Make()){};
 
 Status Nursery::WaitForFinish() {

--- a/cpp/src/arrow/util/async_nursery.h
+++ b/cpp/src/arrow/util/async_nursery.h
@@ -32,7 +32,7 @@ class Nursery;
 class AsyncCloseablePimpl;
 
 template <typename T>
-struct DestroyingDeleter {
+struct ARROW_EXPORT DestroyingDeleter {
   void operator()(T* p) { p->Destroy(); }
 };
 
@@ -41,7 +41,7 @@ struct DestroyingDeleter {
 /// Any AsyncCloseable must be kept alive until its parent is destroyed (this is a given
 /// if the parent is a nursery).  For shorter lived tasks/objects consider
 /// OwnedAsyncCloseable adding a dependent task.
-class AsyncCloseable : public std::enable_shared_from_this<AsyncCloseable> {
+class ARROW_EXPORT AsyncCloseable : public std::enable_shared_from_this<AsyncCloseable> {
  public:
   AsyncCloseable();
   explicit AsyncCloseable(AsyncCloseable* parent);
@@ -80,7 +80,7 @@ class AsyncCloseable : public std::enable_shared_from_this<AsyncCloseable> {
   friend AsyncCloseablePimpl;
 };
 
-class AsyncCloseablePimpl {
+class ARROW_EXPORT AsyncCloseablePimpl {
  protected:
   void Init(AsyncCloseable* impl);
 
@@ -95,7 +95,7 @@ class AsyncCloseablePimpl {
   friend struct DestroyingDeleter;
 };
 
-class Nursery {
+class ARROW_EXPORT Nursery {
  public:
   // FIXME: Add static_assert that T extends AsyncCloseable for friendlier error message
   template <typename T, typename... Args>

--- a/cpp/src/arrow/util/async_nursery.h
+++ b/cpp/src/arrow/util/async_nursery.h
@@ -32,7 +32,7 @@ class Nursery;
 class AsyncCloseablePimpl;
 
 template <typename T>
-struct ARROW_EXPORT DestroyingDeleter {
+struct DestroyingDeleter {
   void operator()(T* p) { p->Destroy(); }
 };
 

--- a/cpp/src/arrow/util/async_nursery.h
+++ b/cpp/src/arrow/util/async_nursery.h
@@ -28,114 +28,109 @@
 namespace arrow {
 namespace util {
 
-class OwnedAsyncCloseable;
+class Nursery;
+
+template <typename T>
+struct DestroyingDeleter {
+  void operator()(T* p) { p->Destroy(); }
+};
 
 /// An object which should be asynchronously closed before it is destroyed
 ///
 /// Any AsyncCloseable must be kept alive until its parent is destroyed (this is a given
 /// if the parent is a nursery).  For shorter lived tasks/objects consider
 /// OwnedAsyncCloseable adding a dependent task.
-class AsyncCloseable {
+class AsyncCloseable : public std::enable_shared_from_this<AsyncCloseable> {
  public:
-  /// \brief Construct an AsyncCloseable as a child of `parent`
+  AsyncCloseable();
   explicit AsyncCloseable(AsyncCloseable* parent);
   virtual ~AsyncCloseable();
 
   /// Returns a future that is completed when this object is finished closing
-  Future<> OnClosed();
+  const Future<>& OnClosed();
 
  protected:
-  /// Closes the AsyncCloseable
-  /// This will first call DoClose and then simultaneously close all children and
-  /// tasks_
-  virtual Future<> Close();
-  /// Subclasses should override this and perform any cleanup that is not captured by
-  /// tasks_.  Once the future returned by this method finishes then this object is
-  /// eligible for destruction and any reference to `this` may be invalid
+  /// Subclasses should override this and perform any cleanup.  Once the future returned
+  /// by this method finishes then this object is eligible for destruction and any
+  /// reference to `this` will be invalid
   virtual Future<> DoClose() = 0;
 
   /// This method is called by subclasses to add tasks which must complete before the
   /// object can be safely deleted
-  void AddDependentTask(Future<> task);
+  void AddDependentTask(const Future<>& task);
   /// This method can be called by subclasses for error checking purposes.  It will
   /// return an invalid status if this object has started closing
   Status CheckClosed() const;
-  /// This can be used for sanity checking that a callback is not run after close has
-  /// been finished.  It will assert if the object has been fully closed (and `this`
-  /// references are unsafe)
-  void AssertNotCloseComplete() const;
 
  private:
-  Future<> CloseChildren();
+  void SetNursery(Nursery* nursery);
+  void Destroy();
 
-  std::list<AsyncCloseable*> children_;
-  std::list<AsyncCloseable*>::iterator self_itr_;
-  std::list<std::shared_ptr<AsyncCloseable>> owned_children_;
-  std::vector<Future<>> tasks_;
   Future<> on_closed_;
+  Future<> tasks_finished_;
   std::atomic<bool> closed_{false};
-  std::atomic<bool> close_complete_{false};
-  util::Mutex mutex_;
+  std::atomic<uint32_t> num_tasks_outstanding_{1};
+  Nursery* nursery_;
 
-  friend OwnedAsyncCloseable;
-};
-
-/// An override of AsyncCloseable which is eligible for eviction.  Instances must be
-/// created as shared pointers as this utilizes enable_shared_from_this.
-class OwnedAsyncCloseable : public AsyncCloseable,
-                            public std::enable_shared_from_this<OwnedAsyncCloseable> {
- public:
-  explicit OwnedAsyncCloseable(AsyncCloseable* parent);
-
-  void Init();
-  /// \brief Marks this instance as eligible for removal.  This will start the close
-  /// process and, when it is finished, the instance will be deleted.
-  void Evict();
-
- protected:
-  AsyncCloseable* parent_;
-  std::list<std::shared_ptr<AsyncCloseable>>::iterator owned_self_itr_;
-};
-
-/// Helper base class which allows classes that implement the pimpl pattern to
-/// participate in a nursery.  This is only needed if the type is going to be
-/// used as a nursery root.
-class NurseryPimpl {
- public:
-  virtual ~NurseryPimpl();
-  /// Transfers ownership of the impl to the nursery
-  virtual std::shared_ptr<AsyncCloseable> TransferOwnership() = 0;
-};
-
-class Nursery : private AsyncCloseable {
- public:
+  friend Nursery;
   template <typename T>
-  std::shared_ptr<T> AddRoot(std::function<std::shared_ptr<T>(AsyncCloseable*)> factory) {
-    std::shared_ptr<T> root = factory(this);
-    roots_.push_back(std::static_pointer_cast<AsyncCloseable>(root));
-    return root;
+  friend struct DestroyingDeleter;
+};
+
+class Nursery {
+ public:
+  // FIXME: Add static_assert that T extends AsyncCloseable for friendlier error message
+  template <typename T, typename... Args>
+  typename std::enable_if<!std::is_array<T>::value, std::shared_ptr<T>>::type
+  MakeSharedCloseable(Args&&... args) {
+    num_closeables_created_.fetch_add(1);
+    num_tasks_outstanding_.fetch_add(1);
+    std::shared_ptr<T> shared_closeable(new T(std::forward<Args&&>(args)...),
+                                        DestroyingDeleter<T>());
+    shared_closeable->SetNursery(this);
+    return shared_closeable;
+  }
+
+  template <typename T, typename... Args>
+  typename std::enable_if<!std::is_array<T>::value,
+                          std::unique_ptr<T, DestroyingDeleter<T>>>::type
+  MakeUniqueCloseable(Args&&... args) {
+    num_closeables_created_.fetch_add(1);
+    num_tasks_outstanding_.fetch_add(1);
+    auto unique_closeable = std::unique_ptr<T, DestroyingDeleter<T>>(
+        new T(std::forward<Args>(args)...), DestroyingDeleter<T>());
+    unique_closeable->SetNursery(this);
+    return unique_closeable;
   }
 
   template <typename T>
-  std::shared_ptr<T> AddPimplRoot(
-      std::function<std::shared_ptr<T>(AsyncCloseable*)> factory) {
-    std::shared_ptr<T> pimpl = factory(this);
-    roots_.push_back(pimpl->TransferOwnership());
-    return pimpl;
+  void AddDependentTask(const Future<T>& task) {
+    num_tasks_outstanding_.fetch_add(1);
+    task.AddCallback([this](const Result<T>& res) { OnTaskFinished(res.status()); });
   }
 
   /// Runs `task` within a nursery.  This method will not return until
   /// all roots added by the task have been closed and destroyed.
   static Status RunInNursery(std::function<void(Nursery*)> task);
   // FIXME template hackery to callable that can return void/Status/Result
+  // to work correctly with PIMPL objects this may just mean making sure the
+  // Destroy method works.  Or maybe we want a marker class for PIMPL?
   static Status RunInNurserySt(std::function<Status(Nursery*)> task);
 
  protected:
-  Future<> DoClose() override;
+  Status WaitForFinish();
+  void OnTaskFinished(Status st);
 
   Nursery();
 
-  std::vector<std::shared_ptr<AsyncCloseable>> roots_;
+  // Rather than keep a separate closing flag (and requiring mutex) we treat
+  // "closing" as a default task
+  std::atomic<uint32_t> num_tasks_outstanding_{1};
+  std::atomic<uint32_t> num_closeables_created_{0};
+  std::atomic<uint32_t> num_closeables_destroyed_{0};
+  Future<> finished_;
+
+  friend AsyncCloseable;
 };
 
 }  // namespace util

--- a/cpp/src/arrow/util/async_nursery.h
+++ b/cpp/src/arrow/util/async_nursery.h
@@ -96,7 +96,6 @@ class ARROW_EXPORT AsyncCloseablePimpl {
 
 class ARROW_EXPORT Nursery {
  public:
-  // FIXME: Add static_assert that T extends AsyncCloseable for friendlier error message
   template <typename T, typename... Args>
   typename std::enable_if<!std::is_array<T>::value, std::shared_ptr<T>>::type
   MakeSharedCloseable(Args&&... args) {

--- a/cpp/src/arrow/util/async_nursery.h
+++ b/cpp/src/arrow/util/async_nursery.h
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_ASYNC_NURSERY_H
+#define ARROW_ASYNC_NURSERY_H
+
+#include <list>
+
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/util/future.h"
+#include "arrow/util/mutex.h"
+
+namespace arrow {
+namespace util {
+
+class OwnedAsyncCloseable;
+
+/// An object which should be asynchronously closed before it is destroyed
+///
+/// Any AsyncCloseable must be kept alive until its parent is destroyed (this is a given
+/// if the parent is a nursery).  For shorter lived tasks/objects consider
+/// OwnedAsyncCloseable adding a dependent task.
+class AsyncCloseable {
+ public:
+  /// \brief Construct an AsyncCloseable as a child of `parent`
+  explicit AsyncCloseable(AsyncCloseable* parent);
+  virtual ~AsyncCloseable();
+
+  /// Returns a future that is completed when this object is finished closing
+  Future<> OnClosed();
+
+ protected:
+  /// Closes the AsyncCloseable
+  /// This will first call DoClose and then simultaneously close all children and
+  /// tasks_
+  virtual Future<> Close();
+  /// Subclasses should override this and perform any cleanup that is not captured by
+  /// tasks_.  Once the future returned by this method finishes then this object is
+  /// eligible for destruction and any reference to `this` may be invalid
+  virtual Future<> DoClose() = 0;
+
+  /// This method is called by subclasses to add tasks which must complete before the
+  /// object can be safely deleted
+  void AddDependentTask(Future<> task);
+  /// This method can be called by subclasses for error checking purposes.  It will
+  /// return an invalid status if this object has started closing
+  Status CheckClosed() const;
+  /// This can be used for sanity checking that a callback is not run after close has
+  /// been finished.  It will assert if the object has been fully closed (and `this`
+  /// references are unsafe)
+  void AssertNotCloseComplete() const;
+
+ private:
+  Future<> CloseChildren();
+
+  std::list<AsyncCloseable*> children_;
+  std::list<AsyncCloseable*>::iterator self_itr_;
+  std::list<std::shared_ptr<AsyncCloseable>> owned_children_;
+  std::vector<Future<>> tasks_;
+  Future<> on_closed_;
+  std::atomic<bool> closed_{false};
+  std::atomic<bool> close_complete_{false};
+  util::Mutex mutex_;
+
+  friend OwnedAsyncCloseable;
+};
+
+/// An override of AsyncCloseable which is eligible for eviction.  Instances must be
+/// created as shared pointers as this utilizes enable_shared_from_this.
+class OwnedAsyncCloseable : public AsyncCloseable,
+                            public std::enable_shared_from_this<OwnedAsyncCloseable> {
+ public:
+  explicit OwnedAsyncCloseable(AsyncCloseable* parent);
+
+  void Init();
+  /// \brief Marks this instance as eligible for removal.  This will start the close
+  /// process and, when it is finished, the instance will be deleted.
+  void Evict();
+
+ protected:
+  AsyncCloseable* parent_;
+  std::list<std::shared_ptr<AsyncCloseable>>::iterator owned_self_itr_;
+};
+
+/// Helper base class which allows classes that implement the pimpl pattern to
+/// participate in a nursery.  This is only needed if the type is going to be
+/// used as a nursery root.
+class NurseryPimpl {
+ public:
+  virtual ~NurseryPimpl();
+  /// Transfers ownership of the impl to the nursery
+  virtual std::shared_ptr<AsyncCloseable> TransferOwnership() = 0;
+};
+
+class Nursery : private AsyncCloseable {
+ public:
+  template <typename T>
+  std::shared_ptr<T> AddRoot(std::function<std::shared_ptr<T>(AsyncCloseable*)> factory) {
+    std::shared_ptr<T> root = factory(this);
+    roots_.push_back(std::static_pointer_cast<AsyncCloseable>(root));
+    return root;
+  }
+
+  template <typename T>
+  std::shared_ptr<T> AddPimplRoot(
+      std::function<std::shared_ptr<T>(AsyncCloseable*)> factory) {
+    std::shared_ptr<T> pimpl = factory(this);
+    roots_.push_back(pimpl->TransferOwnership());
+    return pimpl;
+  }
+
+  /// Runs `task` within a nursery.  This method will not return until
+  /// all roots added by the task have been closed and destroyed.
+  static Status RunInNursery(std::function<void(Nursery*)> task);
+  // FIXME template hackery to callable that can return void/Status/Result
+  static Status RunInNurserySt(std::function<Status(Nursery*)> task);
+
+ protected:
+  Future<> DoClose() override;
+
+  Nursery();
+
+  std::vector<std::shared_ptr<AsyncCloseable>> roots_;
+};
+
+}  // namespace util
+}  // namespace arrow
+
+#endif  // ARROW_ASYNC_NURSERY_H

--- a/cpp/src/arrow/util/async_nursery_test.cc
+++ b/cpp/src/arrow/util/async_nursery_test.cc
@@ -32,7 +32,8 @@ class GatingDoClose : public AsyncCloseable {
  public:
   GatingDoClose(AsyncCloseable* parent, Future<> close_future)
       : AsyncCloseable(parent), close_future_(std::move(close_future)) {}
-  GatingDoClose(Future<> close_future) : close_future_(std::move(close_future)) {}
+  explicit GatingDoClose(Future<> close_future)
+      : close_future_(std::move(close_future)) {}
 
   Future<> DoClose() override { return close_future_; }
 
@@ -69,7 +70,7 @@ class GatingDoCloseWithSharedChild : public AsyncCloseable {
 
 class GatingDoCloseAsDependentTask : public AsyncCloseable {
  public:
-  GatingDoCloseAsDependentTask(Future<> close_future) {
+  explicit GatingDoCloseAsDependentTask(Future<> close_future) {
     AddDependentTask(std::move(close_future));
   }
 
@@ -119,7 +120,7 @@ void AssertDoesNotCloseEarly() {
   gate.MarkFinished();
   BusyWait(10, [&] { return finished.load(); });
   thread.join();
-};
+}
 
 template <typename T>
 void AssertDoesNotCloseEarlyWithChild() {
@@ -136,7 +137,7 @@ void AssertDoesNotCloseEarlyWithChild() {
   gate.MarkFinished();
   BusyWait(10, [&] { return finished.load(); });
   thread.join();
-};
+}
 
 TEST(AsyncNursery, DoClose) { AssertDoesNotCloseEarly<GatingDoClose>(); }
 

--- a/cpp/src/arrow/util/async_nursery_test.cc
+++ b/cpp/src/arrow/util/async_nursery_test.cc
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/async_nursery.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "arrow/result.h"
+#include "arrow/testing/gtest_common.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow {
+namespace util {
+
+class GatingDoClose : public AsyncCloseable {
+ public:
+  GatingDoClose(AsyncCloseable* parent, Future<> close_future)
+      : AsyncCloseable(parent), close_future_(std::move(close_future)) {}
+
+  Future<> DoClose() override { return close_future_; }
+
+  Future<> close_future_;
+};
+
+class GatingDoCloseWithChild : public AsyncCloseable {
+ public:
+  GatingDoCloseWithChild(AsyncCloseable* parent, Future<> close_future)
+      : AsyncCloseable(parent), child_(this, std::move(close_future)) {}
+
+  Future<> DoClose() override { return Future<>::MakeFinished(); }
+
+  GatingDoClose child_;
+};
+
+class GatingDoCloseAsDependentTask : public AsyncCloseable {
+ public:
+  GatingDoCloseAsDependentTask(AsyncCloseable* parent, Future<> close_future)
+      : AsyncCloseable(parent) {
+    AddDependentTask(std::move(close_future));
+  }
+
+  Future<> DoClose() override { return Future<>::MakeFinished(); }
+};
+
+class EvictableChild : public OwnedAsyncCloseable {
+ public:
+  EvictableChild(AsyncCloseable* parent, Future<> close_future)
+      : OwnedAsyncCloseable(parent), close_future_(std::move(close_future)) {}
+
+  Future<> DoClose() override { return close_future_; }
+
+ private:
+  Future<> close_future_;
+};
+
+class EvictsChild : public AsyncCloseable {
+ public:
+  EvictsChild(AsyncCloseable* parent, Future<> child_future, Future<> final_future)
+      : AsyncCloseable(parent), final_close_future_(std::move(final_future)) {
+    owned_child_ = std::make_shared<EvictableChild>(this, std::move(child_future));
+    owned_child_->Init();
+    child_ = owned_child_;
+  }
+
+  void EvictChild() {
+    owned_child_->Evict();
+    owned_child_.reset();
+  }
+
+  bool ChildIsExpired() { return child_.expired(); }
+
+  Future<> DoClose() override { return final_close_future_; }
+
+ private:
+  Future<> final_close_future_;
+  std::shared_ptr<EvictableChild> owned_child_;
+  std::weak_ptr<EvictableChild> child_;
+};
+
+template <typename T>
+void AssertDoesNotCloseEarly() {
+  Future<> gate = Future<>::Make();
+  std::atomic<bool> finished{false};
+  std::thread thread([&] {
+    ASSERT_OK(Nursery::RunInNursery([&](Nursery* nursery) {
+      nursery->AddRoot<T>(
+          [&](AsyncCloseable* parent) { return std::make_shared<T>(parent, gate); });
+    }));
+    finished.store(true);
+  });
+
+  SleepABit();
+  ASSERT_FALSE(finished.load());
+  gate.MarkFinished();
+  BusyWait(10, [&] { return finished.load(); });
+  thread.join();
+};
+
+TEST(AsyncNursery, DoClose) { AssertDoesNotCloseEarly<GatingDoClose>(); }
+
+TEST(AsyncNursery, ChildDoClose) { AssertDoesNotCloseEarly<GatingDoCloseWithChild>(); }
+
+TEST(AsyncNursery, DependentTask) {
+  AssertDoesNotCloseEarly<GatingDoCloseAsDependentTask>();
+}
+
+TEST(AsyncNursery, EvictedChild) {
+  Future<> child_future = Future<>::Make();
+  Future<> final_future = Future<>::Make();
+  std::atomic<bool> finished{false};
+  std::thread thread([&] {
+    ASSERT_OK(Nursery::RunInNursery([&](Nursery* nursery) {
+      std::shared_ptr<EvictsChild> evicts_child =
+          nursery->AddRoot<EvictsChild>([&](AsyncCloseable* parent) {
+            return std::make_shared<EvictsChild>(parent, child_future, final_future);
+          });
+      evicts_child->EvictChild();
+      // Owner no longer has reference to child here but it's kept alive by nursery
+      // because it isn't done
+      ASSERT_FALSE(evicts_child->ChildIsExpired());
+      child_future.MarkFinished();
+      ASSERT_TRUE(evicts_child->ChildIsExpired());
+    }));
+    finished.store(true);
+  });
+
+  SleepABit();
+  ASSERT_FALSE(finished.load());
+  final_future.MarkFinished();
+  BusyWait(10, [&] { return finished.load(); });
+  thread.join();
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/async_nursery_test.cc
+++ b/cpp/src/arrow/util/async_nursery_test.cc
@@ -45,7 +45,10 @@ class GatingDoCloseWithUniqueChild : public AsyncCloseable {
       : child_(
             nursery->MakeUniqueCloseable<GatingDoClose>(this, std::move(close_future))) {}
 
-  Future<> DoClose() override { return Future<>::MakeFinished(); }
+  Future<> DoClose() override {
+    child_.reset();
+    return Future<>::MakeFinished();
+  }
 
   std::unique_ptr<GatingDoClose, DestroyingDeleter<GatingDoClose>> child_;
 };
@@ -56,7 +59,10 @@ class GatingDoCloseWithSharedChild : public AsyncCloseable {
       : child_(
             nursery->MakeSharedCloseable<GatingDoClose>(this, std::move(close_future))) {}
 
-  Future<> DoClose() override { return Future<>::MakeFinished(); }
+  Future<> DoClose() override {
+    child_.reset();
+    return Future<>::MakeFinished();
+  }
 
   std::shared_ptr<GatingDoClose> child_;
 };

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -312,10 +312,12 @@ class ConcreteFutureImpl : public FutureImpl {
         waiter_->MarkFutureFinishedUnlocked(waiter_arg_, state);
       }
     }
-    cv_.notify_all();
-
     auto callbacks = std::move(callbacks_);
     auto self = shared_from_this();
+
+    // Don't notify until we've saved off all state.  After notifying it is common for
+    // this to be deleted and we shouldn't access any local state.
+    cv_.notify_all();
 
     // run callbacks, lock not needed since the future is finished by this
     // point so nothing else can modify the callbacks list and it is safe


### PR DESCRIPTION
This PR aims to introduce some [structured concurrency](https://en.wikipedia.org/wiki/Structured_concurrency) utilities for working with futures.  The async nursery contains a few utilities for managing the lifetimes of objects to avoid constantly worrying about capturing shared_ptr's to maintain lifetimes.

A nursery is created with a lambda and everything that runs in that lambda runs "in the nursery".  Any object (that has a reference to the nursery) can add a future to the nursery as a dependent task.  The nursery will not finish until all of those futures are finished.  This means that any objects created outside the nursery (e.g. typically things like options objects, request objects, etc.) will remain valid and can be captured by reference.

Objects that spawn callbacks which need references to `this` can extend `AsyncCloseable` and override `DoClose` (which returns a `Future`).  These objects will not be deleted until the future returned by `DoClose` has been completed.  In addition, objects extending `AsyncCloseable` can add futures as dependent tasks and the object will be kept alive until those futures complete.  In order for this to work these objects must be created by the nursery using `MakeSharedCloseable` or `MakeUniqueCloseable`.  Any object created in this way will keep the nursery alive until the object's `DoClose` and any of the object's dependent tasks have finished.

Objects that extend `AsyncCloseable` have a `OnClosed` future which will only be completed when the object is destroyed.  This facilitates parent/child relationships.  If a parent needs to stay alive until a child has completed all of its work (often because the child has callbacks referencing parent state or the parent needs to perform some final cleanup) then the parent can add the child's `OnClosed` future as a dependent task.

Cons:

 * It's a bit tricky to get it working with the pimpl pattern but `NurseryPimpl` helps here
 * There are a lot of "nursery-like" objects starting to pop up (IOContext, ExecContext, cancellation tokens, ...) and we may want to consolidate at some point

ToDo:

 * Fix up some of the APIs with some template hackery (e.g. merging `RunInNursery` and `RunInNurserySt`)