### PR TITLE
MINOR: [C++] Avoid C++11 narrowing error in Clang on MinGW32

### DIFF
--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -322,7 +322,8 @@ Status SparseCOOTensorToNdarray(const std::shared_ptr<SparseCOOTensor>& sparse_t
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base,
+      result_data.ref()));
 
   // Wrap indices
   PyObject* result_coords;
@@ -362,7 +363,8 @@ Status SparseCSXMatrixToNdarray(const std::shared_ptr<SparseTensor>& sparse_tens
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base,
+      result_data.ref()));
 
   *out_data = result_data.detach();
   *out_indptr = result_indptr.detach();
@@ -391,7 +393,8 @@ Status SparseCSFTensorToNdarray(const std::shared_ptr<SparseCSFTensor>& sparse_t
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base,
+      result_data.ref()));
 
   // Wrap indices
   int ndim = static_cast<int>(sparse_index.indices().size());

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -322,7 +322,7 @@ Status SparseCOOTensorToNdarray(const std::shared_ptr<SparseCOOTensor>& sparse_t
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
 
   // Wrap indices
   PyObject* result_coords;
@@ -362,7 +362,7 @@ Status SparseCSXMatrixToNdarray(const std::shared_ptr<SparseTensor>& sparse_tens
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
 
   *out_data = result_data.detach();
   *out_indptr = result_indptr.detach();
@@ -391,7 +391,7 @@ Status SparseCSFTensorToNdarray(const std::shared_ptr<SparseCSFTensor>& sparse_t
   // Wrap tensor data
   OwnedRef result_data;
   RETURN_NOT_OK(SparseTensorDataToNdarray(
-      *sparse_tensor, {sparse_tensor->non_zero_length(), 1}, base, result_data.ref()));
+      *sparse_tensor, {static_cast<npy_intp>(sparse_tensor->non_zero_length()), 1}, base, result_data.ref()));
 
   // Wrap indices
   int ndim = static_cast<int>(sparse_index.indices().size());


### PR DESCRIPTION
add static_cast to initializer list to avoid C++11 narrowing error in Clang targeting i686-w64-windows-gnu (AKA MinGW32).

error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]