### PR TITLE
[RFC] Alternative IR approach

### DIFF
--- a/format/IRFunction.fbs
+++ b/format/IRFunction.fbs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+include "Schema.fbs";
+
+namespace org.apache.arrow.ir.flatbuf;
+
+// A unique identifier for a particular function definition. 
+table FunctionId {
+  // the function description identifier.
+  id: uint32;
+  
+  // The origin of the function definition. Should be mapped to a domain such as "org.apache.arrow"
+  // The github definition paths for definitions are defined in 
+  // github.com/apache/arrow/format/functions.txt. Org 0 == Apache Arrow canonical definitions.
+  // Organizations < 1B are canonical organizations. For private functions, use
+  // Org id > 1B
+  org: uint32;
+}
+
+// List of function signatures available.
+message FunctionSignature {
+    function_id: FunctionId;
+    name: string;
+    argument: [Argument];
+    output: OutputDerivation;
+}
+
+union OutputDerivation {DirectOutputType, ComplexOutputType}
+
+// A well defined completely known type.
+table DirectOutputType {
+  type: Type;
+}
+
+table ComplexOutputBehavior {
+  // TODO. Complex output behaviors. For example Decimal math type derivation.
+}
+
+union Argument {WildcardArgument, DirectArgument}
+
+
+// Argument that supports [minimum_count..maximum_count] arguments of this type. A WildCardArgument must always be declared last.
+table WildcardArgument {
+  minimum_count: uint32;
+  maximum_count: uint32;
+  type: DirectArgument;
+}
+
+table DirectArgument {
+  // An Arrow datatype. Note that this type can incompletely formed to match a subset of types. 
+  // This is the one place a type can be incompletely formed. For example, List<nothing> 
+  // can be declared to match any list type, Decimal(na,na) can be used to match any decimal value, etc.
+  types: [Type];
+}
+
+

--- a/format/IRFunction.fbs
+++ b/format/IRFunction.fbs
@@ -32,19 +32,11 @@ table FunctionId {
   org: uint32;
 }
 
-// List of function signatures available.
-message FunctionSignature {
-    function_id: FunctionId;
-    name: string;
-    argument: [Argument];
-    output: OutputDerivation;
-}
-
-union OutputDerivation {DirectOutputType, ComplexOutputType}
+union OutputDerivation {DirectOutputType, ComplexOutputBehavior}
 
 // A well defined completely known type.
 table DirectOutputType {
-  type: Type;
+  type: org.apache.arrow.flatbuf.Type;
 }
 
 table ComplexOutputBehavior {
@@ -52,7 +44,6 @@ table ComplexOutputBehavior {
 }
 
 union Argument {WildcardArgument, DirectArgument}
-
 
 // Argument that supports [minimum_count..maximum_count] arguments of this type. A WildCardArgument must always be declared last.
 table WildcardArgument {
@@ -65,7 +56,13 @@ table DirectArgument {
   // An Arrow datatype. Note that this type can incompletely formed to match a subset of types. 
   // This is the one place a type can be incompletely formed. For example, List<nothing> 
   // can be declared to match any list type, Decimal(na,na) can be used to match any decimal value, etc.
-  types: [Type];
+  types: [org.apache.arrow.flatbuf.Type];
 }
 
-
+// List of function signatures available.
+table FunctionSignature {
+    function_id: FunctionId;
+    name: string;
+    argument: [Argument];
+    output: OutputDerivation;
+}

--- a/format/IRLiteral.fbs
+++ b/format/IRLiteral.fbs
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace org.apache.arrow.ir.flatbuf;
+
+import "Schema.fbs";
+import "IRFunctionExpression.fbs";
+
+table ArrayLiteral {
+  values: [RexLiteral];
+}
+
+table StructLiteral {
+  values: [KeyValue];
+}
+
+table KeyValue {
+  key: string;
+  value: RexLiteral;
+}
+
+table MapLiteral {
+  values: [KeyValue]; 
+}
+
+table I8Literal {
+  value: int8;
+}
+
+table I16Literal {
+  value: int16;
+}
+
+table I32Literal {
+  value: int32;
+}
+
+table I64Literal {
+  value: int64;
+}
+
+table U8Literal {
+  value: int8;
+}
+
+table U8Literal {
+  value: uint8;
+}
+
+table U16Literal {
+  value: uint16;
+}
+
+table U32Literal {
+  value: uint32;
+}
+
+table U64Literal {
+  value: uint64;
+}
+
+table HalfFloatLiteral {
+  value: uint16;
+}
+
+table FloatLiteral {
+  value: float32;
+}
+
+table DoubleLiteral {
+  value: float64;
+}
+
+table DecimalLiteral {
+  value: [uint8]; // 128 bit value.
+  scale: uint8;
+  precision: uint8;
+}
+
+table BooleanLiteral {
+  value: bool;
+}
+
+table DateLiteral {
+  // milliseconds since epoch
+  value: int64;
+}
+
+table TimeLiteral {
+  // nanosecond time value.
+  value: int64; 
+}
+
+table Timestamp {
+  //microsecond timestamp.
+  value: int64;
+  
+  // timezone value, same definition as used in Schema.fbs.
+  timezone: string;
+}
+
+table BinaryLiteral {
+  value: [byte];
+}
+
+table StringLiteral {
+  value: string;
+}
+
+// no union literal is defined as only one branch of a union can be resolved.
+// no literals for large string/binary types as flatbuffer is limited to 2gb.
+
+union RexLiteral {
+  BooleanLiteral, 
+  I8Literal, I16Literal, I32Literal, I64Literal, 
+  U8Literal, U16Literal, U32Literal, U64Literal,
+  DateLiteral, TimeLiteral, TimestampLiteral,
+  DecimalLiteral,
+  HalfFloatLiteral, FloatLiteral, DoubleLiteral, 
+  ArrayLiteral, StructLiteral, MapLiteral, 
+  StringLiteral, BinaryLiteral}
+
+root_type RexLiteral;

--- a/format/IRLiteral.fbs
+++ b/format/IRLiteral.fbs
@@ -15,10 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
+include "Schema.fbs";
+
 namespace org.apache.arrow.ir.flatbuf;
 
-import "Schema.fbs";
-import "IRFunctionExpression.fbs";
+// no union literal is defined as only one branch of a union can be resolved.
+// no literals for large string/binary types as flatbuffer is limited to 2gb.
+
+union RexLiteral {
+  BooleanLiteral,
+  I8Literal, I16Literal, I32Literal, I64Literal,
+  U8Literal, U16Literal, U32Literal, U64Literal,
+  DateLiteral, TimeLiteral, TimestampLiteral,
+  DecimalLiteral,
+  HalfFloatLiteral, FloatLiteral, DoubleLiteral,
+  ArrayLiteral, StructLiteral, MapLiteral,
+  StringLiteral, BinaryLiteral
+  }
 
 table ArrayLiteral {
   values: [RexLiteral];
@@ -55,10 +68,6 @@ table I64Literal {
 
 table U8Literal {
   value: int8;
-}
-
-table U8Literal {
-  value: uint8;
 }
 
 table U16Literal {
@@ -105,7 +114,7 @@ table TimeLiteral {
   value: int64; 
 }
 
-table Timestamp {
+table TimestampLiteral {
   //microsecond timestamp.
   value: int64;
   
@@ -121,17 +130,4 @@ table StringLiteral {
   value: string;
 }
 
-// no union literal is defined as only one branch of a union can be resolved.
-// no literals for large string/binary types as flatbuffer is limited to 2gb.
 
-union RexLiteral {
-  BooleanLiteral, 
-  I8Literal, I16Literal, I32Literal, I64Literal, 
-  U8Literal, U16Literal, U32Literal, U64Literal,
-  DateLiteral, TimeLiteral, TimestampLiteral,
-  DecimalLiteral,
-  HalfFloatLiteral, FloatLiteral, DoubleLiteral, 
-  ArrayLiteral, StructLiteral, MapLiteral, 
-  StringLiteral, BinaryLiteral}
-
-root_type RexLiteral;

--- a/format/IRRelational.fbs
+++ b/format/IRRelational.fbs
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace org.apache.arrow.ir.flatbuf;
+
+import "Schema.fbs";
+import "IRRowExpression.fbs";
+
+table EmitRemap {
+  output_mapping: [uint32];
+}
+
+table EmitDirect {}
+
+union Emit {Remap, Direct}
+
+table RelCommon {
+  // describes the emitting rules of the operation.
+  emit: Emit;
+  hints: Hints;
+  constraint: RuntimeConstraint;
+}
+
+table Hints {
+  
+  // one or more hints about operations. Can potentially inform 
+  // operations but should not logically change result.
+  hints: [HintKeyValue];
+  
+    // optional information about expected output of relational operation.
+  stats: Stats;
+}
+
+table RuntimeConstraint {
+  // TODO: nodes, cpu threads/%, memory, iops, etc.
+}
+
+table HintKeyValue {
+  key: string;
+  value: [uint8];
+}
+
+table Stats {
+  row_count: double;
+  record_size: double;
+}
+
+
+// Operation that redistributes data based on some type of expression
+// the direct emit mapping is equal to the incoming mapping.
+table RedistributeRel {
+  common: RelCommon;
+  redistribution: RedistributionMethod;
+}
+
+// A redistribution method that creates separate streams of data based on an expression.
+table ExpressionRedistribution {
+  // the number of buckets generated
+  bucket_count: int32;
+  
+  // an expression that returns a bucket based on a record.
+  expression: Rex;
+}
+
+// A redistribution method that maintains a set of ordered streams.
+table ExpressionRedistribution {
+  // the number of buckets generated
+  bucket_count: int32;
+  
+  // an expression that returns a stream position based on a record.
+  distribution_expression: Rex;
+  
+  //
+  sort_fields: [uint32];
+}
+
+// A redistribution algorithm that is best redistribution of data. Similar to round-robin 
+// but does not guarantee exact distribution. For example, a batch-by-batch round-robin 
+// redistribution would be sufficient even though some targets may receive more information 
+// than others.
+table EvenRedistribution {
+}
+
+union RedistributionMethod {ExpressionRedistribution, EvenRedistribution}
+
+table Grouping {
+  field: [Rex]
+}
+
+// An operation that collects values in one or more groupings.
+// Direct order is: 
+//   grouping_ordinal (if more than one), 
+//   grouping fields (using first appearance in grouping lists),
+//   measures (in order of declaration). 
+table AggRel {
+  common: RelCommon;
+  input: Rel;
+  groupings: [Grouping];
+  measures: [Rex];
+}
+
+
+enum CorrelateType {
+  // Output left and right for each match.
+  REGULAR = 1, 
+  
+  // Output LEFT for each record that matches at least one record from RIGHT.
+  SEMI = 2, 
+  
+  // Output LEFT for each record that matches zero records from RIGHT.
+  ANTI = 3
+}
+
+// An operation that behaves similar to a nested loop join based on a set of comparison columns. Output is based on the type of the left input.
+// Output schema is: REGULAR returns both sets of records. SEMI and ANTI only return records from left table.
+table CorrelateRel {
+  common: RelCommon;
+  type: CorrelateType;
+  left: Rel;
+  right: Rel;
+  // the expression that correlates the left and right inputs. Should only be used in cases that cannot be expressed using JoinRel.
+  expression: Rex; 
+}
+
+enum JoinType {
+  INNER, LEFT, RIGHT, OUTER
+}
+
+table JoinRel {
+  common: RelCommon;
+  join_type: JoinType;
+  left: Rel;
+  right: Rel;
+  
+  // field references are referred to left-first. So if left has three fields 
+  // and Right has two: 0..2 => left, 3..4 => right
+  condition: Rex;
+}
+
+enum SetOpType: byte {
+  // remove all matching inputs 1..N from input 0.
+  MINUS,
+  
+  // include data from all inputs.
+  UNION_ALL, 
+
+  // Return all records that exist in either set, eliminating duplicates.
+  UNION_DISTINCT,
+  
+  // Include data that exists in all inputs
+  INTERSECTION
+}
+
+// generic set operations
+// fields are ordered based the same as the input data.
+// output type maps to the fields of initial input.
+// all inputs must have matching schema types.    
+table SetRel {
+  inputs: [Rel];
+  set_op_type: SetOpType;
+}
+
+table SortRel {
+  common: RelCommon;
+  input: Rel;
+  sort: [SortField];
+}
+
+table ProjectRel {
+  common: RelCommon;
+  input: Rel;
+  exprs: [Rex];
+}
+
+table FetchRel {
+  common: RelCommon;
+  input: Rel;
+  start: int64;
+  end: int64;
+}
+
+table FilterRel {
+  common: RelCommon;
+  input: Rel;
+  condition: Rex;
+}
+
+table ReadRel {
+  common: RelCommon;
+  config: [byte];
+}
+
+table LiteralRel {
+  common: RelCommon;
+  values: [StructLiteral];
+}
+
+table WriteRel {
+  common: RelCommon;
+  schema: 
+  input: Rel;
+  config: [byte];
+}
+
+// TODO, Collect, Uncollect, Match, RepeatUnion.
+union Rel {AggRel, SortRel, FetchRel, ProjectRel, FilterRel, WriteRel, ReadRel, JoinRel, RedistributeRel}
+
+root_type Rel;
+

--- a/format/IRRelational.fbs
+++ b/format/IRRelational.fbs
@@ -15,10 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+include "Schema.fbs";
+include "IRLiteral.fbs";
+include "IRFunction.fbs";
+include "IRRowExpression.fbs";
+
 namespace org.apache.arrow.ir.flatbuf;
 
-import "Schema.fbs";
-import "IRRowExpression.fbs";
+// TODO, Collect, Uncollect, Match, RepeatUnion.
+union Rel {AggRel, SortRel, FetchRel, ProjectRel, FilterRel, WriteRel, ReadRel, JoinRel, RedistributeRel}
 
 table EmitRemap {
   output_mapping: [uint32];
@@ -26,7 +31,7 @@ table EmitRemap {
 
 table EmitDirect {}
 
-union Emit {Remap, Direct}
+union Emit {EmitDirect, EmitRemap}
 
 table RelCommon {
   // describes the emitting rules of the operation.
@@ -60,12 +65,7 @@ table Stats {
 }
 
 
-// Operation that redistributes data based on some type of expression
-// the direct emit mapping is equal to the incoming mapping.
-table RedistributeRel {
-  common: RelCommon;
-  redistribution: RedistributionMethod;
-}
+
 
 // A redistribution method that creates separate streams of data based on an expression.
 table ExpressionRedistribution {
@@ -77,7 +77,7 @@ table ExpressionRedistribution {
 }
 
 // A redistribution method that maintains a set of ordered streams.
-table ExpressionRedistribution {
+table OrderedRedistribution {
   // the number of buckets generated
   bucket_count: int32;
   
@@ -95,10 +95,17 @@ table ExpressionRedistribution {
 table EvenRedistribution {
 }
 
-union RedistributionMethod {ExpressionRedistribution, EvenRedistribution}
+union RedistributionMethod {ExpressionRedistribution, EvenRedistribution, OrderedRedistribution}
+
+// Operation that redistributes data based on some type of expression
+// the direct emit mapping is equal to the incoming mapping.
+table RedistributeRel {
+  common: RelCommon;
+  redistribution: RedistributionMethod;
+}
 
 table Grouping {
-  field: [Rex]
+  field: [Rex];
 }
 
 // An operation that collects values in one or more groupings.
@@ -114,15 +121,15 @@ table AggRel {
 }
 
 
-enum CorrelateType {
+enum CorrelateType: byte {
   // Output left and right for each match.
-  REGULAR = 1, 
+  REGULAR,
   
   // Output LEFT for each record that matches at least one record from RIGHT.
-  SEMI = 2, 
+  SEMI,
   
   // Output LEFT for each record that matches zero records from RIGHT.
-  ANTI = 3
+  ANTI
 }
 
 // An operation that behaves similar to a nested loop join based on a set of comparison columns. Output is based on the type of the left input.
@@ -136,7 +143,7 @@ table CorrelateRel {
   expression: Rex; 
 }
 
-enum JoinType {
+enum JoinType: byte {
   INNER, LEFT, RIGHT, OUTER
 }
 
@@ -211,13 +218,7 @@ table LiteralRel {
 
 table WriteRel {
   common: RelCommon;
-  schema: 
+  schema: org.apache.arrow.flatbuf.Struct_;
   input: Rel;
   config: [byte];
 }
-
-// TODO, Collect, Uncollect, Match, RepeatUnion.
-union Rel {AggRel, SortRel, FetchRel, ProjectRel, FilterRel, WriteRel, ReadRel, JoinRel, RedistributeRel}
-
-root_type Rel;
-

--- a/format/IRRowExpression.fbs
+++ b/format/IRRowExpression.fbs
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+namespace org.apache.arrow.ir.flatbuf;
+
+import "Schema.fbs";
+import "IRLiteral.fbs";
+import "IRFunctionExpression.fbs";
+
+table RexFunction {
+    id: FunctionId;
+    arguments: [Rex];
+}
+
+// a reference inside a simple or complex structure
+union RexDereferenceElement {RexStructField, RexName, RexArrayItem, RexArraySlice}
+
+table RexMapKey {
+  // describes a map key to retrieve
+  name: string;
+}
+
+table RexStructField {
+  // ordinal position of field in struct in schema
+    ordinal: int32;
+}
+
+table RexArrayPosition {
+  // starting from 1 position of value in array (per sql standard)
+  position: int32;
+}
+
+table RexArrayItem {
+  // returns a single value of the array's inner type.
+  // 0-index position of value in array
+  // Note: we use 0-index here despite sql standard 1-index due to this being an 
+  // lower level construct.
+  // if negative, is offset from end instead of beginning.
+  position: int64;
+}
+
+table RexArraySlice {
+  // returns an array
+  start_inclusive: int64;
+  end_exclusive: int64;
+}
+
+table RexDereference {
+    positions: [RexDereferenceElement];
+}
+
+table BoundPreceding {
+  offset: int64;
+}
+
+table BoundFollowing {
+  offset: int64;
+}
+
+table CurrentRow {}
+
+
+union Bound {BoundPreceding, BoundFollowing, CurrentRow
+
+
+enum SortType: byte {
+  UNKNOWN = 0,
+  ASC_NULLS_FIRST = 1,
+  ASC_NULLS_LAST = 2,
+  DESC_NULLS_FIRST = 3,
+  DESC_NULLS_LAST = 4,
+  // same values are collected together but their ordering is not guaranteed.
+  CLUSTERED = 5
+}
+    
+table SortField {
+    expr: Rex;
+    type: SortType;
+    // TODO: collation
+}
+
+table RexWindowFunction {
+    partitions: [Rex];
+    sorts: [SortField];
+    upper_bound: Bound;
+    lower_bound: Bound;
+}
+
+// TODO: evaluate the inclusion of conditions as first class entities.
+// TODO: evaluate the inclusion of boolean operations as first class entities.
+union Rex {RexLiteral, RexDereference, RexFunction, RexWindowFunction}
+
+root_type Rex;

--- a/format/IRRowExpression.fbs
+++ b/format/IRRowExpression.fbs
@@ -15,11 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+include "Schema.fbs";
+include "IRLiteral.fbs";
+include "IRFunction.fbs";
+
 namespace org.apache.arrow.ir.flatbuf;
 
-import "Schema.fbs";
-import "IRLiteral.fbs";
-import "IRFunctionExpression.fbs";
+// TODO: evaluate the inclusion of conditions as first class entities.
+// TODO: evaluate the inclusion of boolean operations as first class entities.
+union Rex {RexDereference, RexFunction, RexWindowFunction /**, RexLiteral **/}
 
 table RexFunction {
     id: FunctionId;
@@ -27,7 +31,7 @@ table RexFunction {
 }
 
 // a reference inside a simple or complex structure
-union RexDereferenceElement {RexStructField, RexName, RexArrayItem, RexArraySlice}
+union RexDereferenceElement {RexStructField, RexMapKey, RexArrayItem, RexArraySlice}
 
 table RexMapKey {
   // describes a map key to retrieve
@@ -74,7 +78,7 @@ table BoundFollowing {
 table CurrentRow {}
 
 
-union Bound {BoundPreceding, BoundFollowing, CurrentRow
+union Bound {BoundPreceding, BoundFollowing, CurrentRow}
 
 
 enum SortType: byte {
@@ -99,9 +103,3 @@ table RexWindowFunction {
     upper_bound: Bound;
     lower_bound: Bound;
 }
-
-// TODO: evaluate the inclusion of conditions as first class entities.
-// TODO: evaluate the inclusion of boolean operations as first class entities.
-union Rex {RexLiteral, RexDereference, RexFunction, RexWindowFunction}
-
-root_type Rex;


### PR DESCRIPTION
An alternative serialized representation that I created a few months ago for a project I was working on, converted from Protobuf to Flatbuf for discussion here.

Relate to #10856 and #10934.

Key points of focus: 
- All field references are ordinals. Column names are not part of any of the core processing (beyond mapping from schema at input and output). This is really a concern of the presentation tool, not the execution/analysis layer. In Calcite, for example, the validator returns the field names of the actual return expression. The internal field names are meaningless (and actually cause user confusion).
- Leans heavily on concepts that Calcite has presented
- Projection is only used for calculation, not for column addition/removal. For the latter, each relational operation expresses whether it has a direct emit or a remapped emit.
- My thinking is this should support both logical and physical plans.
- The idea with function signatures is that public ones are organizationally namespaced and managed via a formal asset that the Arrow project contains. People can also make their own with a subsection of the namespace.
- As opposed to other representations, focus more on row-wise literals as 99% this representation will be easier to work with (e.g. a < 5).

