### PR TITLE
ARROW-13733 [Java]: Allow JDBC adapters to reuse vector schema roots

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -88,7 +88,12 @@ public final class JdbcToArrowConfig {
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.
    */
   JdbcToArrowConfig(BufferAllocator allocator, Calendar calendar) {
-    this(allocator, calendar, false, false, null, null, DEFAULT_TARGET_BATCH_SIZE, null);
+    this(allocator, calendar,
+        /* include metadata */ false,
+        /* reuse vector schema root */ false,
+        /* array sub-types by column index */ null,
+        /* array sub-types by column name */ null,
+        DEFAULT_TARGET_BATCH_SIZE, null);
   }
 
   /**

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -58,6 +58,7 @@ public final class JdbcToArrowConfig {
   private final Calendar calendar;
   private final BufferAllocator allocator;
   private final boolean includeMetadata;
+  private final boolean reuseVectorSchemaRoot;
   private final Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex;
   private final Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
 
@@ -87,7 +88,7 @@ public final class JdbcToArrowConfig {
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.
    */
   JdbcToArrowConfig(BufferAllocator allocator, Calendar calendar) {
-    this(allocator, calendar, false, null, null, DEFAULT_TARGET_BATCH_SIZE, null);
+    this(allocator, calendar, false, false, null, null, DEFAULT_TARGET_BATCH_SIZE, null);
   }
 
   /**
@@ -98,6 +99,7 @@ public final class JdbcToArrowConfig {
    * @param allocator       The memory allocator to construct the Arrow vectors with.
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.
    * @param includeMetadata Whether to include JDBC field metadata in the Arrow Schema Field metadata.
+   * @param reuseVectorSchemaRoot Whether to reuse the vector schema root for each data load.
    * @param arraySubTypesByColumnIndex The type of the JDBC array at the column index (1-based).
    * @param arraySubTypesByColumnName  The type of the JDBC array at the column name.
    * @param jdbcToArrowTypeConverter The function that maps JDBC field type information to arrow type. If set to null,
@@ -134,6 +136,7 @@ public final class JdbcToArrowConfig {
       BufferAllocator allocator,
       Calendar calendar,
       boolean includeMetadata,
+      boolean reuseVectorSchemaRoot,
       Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex,
       Map<String, JdbcFieldInfo> arraySubTypesByColumnName,
       int targetBatchSize,
@@ -142,6 +145,7 @@ public final class JdbcToArrowConfig {
     this.allocator = allocator;
     this.calendar = calendar;
     this.includeMetadata = includeMetadata;
+    this.reuseVectorSchemaRoot = reuseVectorSchemaRoot;
     this.arraySubTypesByColumnIndex = arraySubTypesByColumnIndex;
     this.arraySubTypesByColumnName = arraySubTypesByColumnName;
     this.targetBatchSize = targetBatchSize;
@@ -241,6 +245,13 @@ public final class JdbcToArrowConfig {
    */
   public int getTargetBatchSize() {
     return targetBatchSize;
+  }
+
+  /**
+   * Get whether it is allowed to reuse the vector schema root.
+   */
+  public boolean isReuseVectorSchemaRoot() {
+    return reuseVectorSchemaRoot;
   }
 
   /**

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -34,6 +34,7 @@ public class JdbcToArrowConfigBuilder {
   private Calendar calendar;
   private BufferAllocator allocator;
   private boolean includeMetadata;
+  private boolean reuseVectorSchemaRoot;
   private Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex;
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
 
@@ -49,6 +50,7 @@ public class JdbcToArrowConfigBuilder {
     this.allocator = null;
     this.calendar = null;
     this.includeMetadata = false;
+    this.reuseVectorSchemaRoot = false;
     this.arraySubTypesByColumnIndex = null;
     this.arraySubTypesByColumnName = null;
   }
@@ -76,6 +78,7 @@ public class JdbcToArrowConfigBuilder {
     this.allocator = allocator;
     this.calendar = calendar;
     this.includeMetadata = false;
+    this.reuseVectorSchemaRoot = false;
     this.targetBatchSize = DEFAULT_TARGET_BATCH_SIZE;
   }
 
@@ -172,6 +175,11 @@ public class JdbcToArrowConfigBuilder {
     return this;
   }
 
+  public JdbcToArrowConfigBuilder setReuseVectorSchemaRoot(boolean reuseVectorSchemaRoot) {
+    this.reuseVectorSchemaRoot = reuseVectorSchemaRoot;
+    return this;
+  }
+
   /**
    * This builds the {@link JdbcToArrowConfig} from the provided
    * {@link BufferAllocator} and {@link Calendar}.
@@ -184,6 +192,7 @@ public class JdbcToArrowConfigBuilder {
         allocator,
         calendar,
         includeMetadata,
+        reuseVectorSchemaRoot,
         arraySubTypesByColumnIndex,
         arraySubTypesByColumnName,
         targetBatchSize,

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -57,6 +57,7 @@ public abstract class AbstractJdbcToArrowTest {
 
   protected Connection conn = null;
   protected Table table;
+  protected boolean reuseVectorSchemaRoot;
 
   /**
    * This method creates Table object after reading YAML file.

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -116,13 +116,15 @@ public class JdbcToArrowConfigTest {
     config = new JdbcToArrowConfigBuilder(allocator, calendar, true).build();
     assertTrue(config.shouldIncludeMetadata());
 
-    config = new JdbcToArrowConfig(allocator, calendar, true, null,
+    config = new JdbcToArrowConfig(allocator, calendar, true, true, null,
         null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertTrue(config.shouldIncludeMetadata());
+    assertTrue(config.isReuseVectorSchemaRoot());
 
-    config = new JdbcToArrowConfig(allocator, calendar, false, null,
+    config = new JdbcToArrowConfig(allocator, calendar, false, false, null,
         null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertFalse(config.shouldIncludeMetadata());
+    assertFalse(config.isReuseVectorSchemaRoot());
   }
 
   @Test

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -116,13 +116,13 @@ public class JdbcToArrowConfigTest {
     config = new JdbcToArrowConfigBuilder(allocator, calendar, true).build();
     assertTrue(config.shouldIncludeMetadata());
 
-    config = new JdbcToArrowConfig(allocator, calendar, true, true, null,
-        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
+    config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ true,
+        /* reuse vector schema root */ true, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertTrue(config.shouldIncludeMetadata());
     assertTrue(config.isReuseVectorSchemaRoot());
 
-    config = new JdbcToArrowConfig(allocator, calendar, false, false, null,
-        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
+    config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ false,
+        /* reuse vector schema root */ false, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertFalse(config.shouldIncludeMetadata());
     assertFalse(config.isReuseVectorSchemaRoot());
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -235,7 +235,8 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
     int x = 0;
     final int targetRows = 600000;
     ResultSet rs = new FakeResultSet(targetRows);
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(allocator, JdbcToArrowUtils.getUtcCalendar(), false)
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(
+        allocator, JdbcToArrowUtils.getUtcCalendar(), /* include metadata */ false)
         .setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
 
     try (ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config)) {

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -67,6 +67,8 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
@@ -97,7 +99,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  * JUnit Test Class which contains methods to test JDBC to Arrow data conversion functionality with various data types
@@ -112,9 +113,11 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    * Constructor which populates the table object for each test iteration.
    *
    * @param table Table object
+   * @param reuseVectorSchemaRoot A flag indicating if we should reuse vector schema roots.
    */
-  public JdbcToArrowTest(Table table) {
+  public JdbcToArrowTest(Table table, boolean reuseVectorSchemaRoot) {
     this.table = table;
+    this.reuseVectorSchemaRoot = reuseVectorSchemaRoot;
   }
 
   /**
@@ -125,9 +128,10 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  @Parameters
+  @Parameterized.Parameters(name = "table = {0}, reuse batch = {1}")
   public static Collection<Object[]> getTestData() throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.asList(prepareTestData(testFiles, JdbcToArrowTest.class));
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowTest.class)).flatMap(row ->
+      Stream.of(new Object[] {row[0], true}, new Object[] {row[0], false})).collect(Collectors.toList());
   }
 
   /**
@@ -156,7 +160,8 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
   @Test
   public void testJdbcSchemaMetadata() throws SQLException {
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true).build();
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
+        .setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);
@@ -230,11 +235,16 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
     int x = 0;
     final int targetRows = 600000;
     ResultSet rs = new FakeResultSet(targetRows);
-    try (ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, allocator)) {
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(allocator, JdbcToArrowUtils.getUtcCalendar(), false)
+        .setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
+
+    try (ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config)) {
       while (iter.hasNext()) {
         VectorSchemaRoot root = iter.next();
         x += root.getRowCount();
-        root.close();
+        if (!reuseVectorSchemaRoot) {
+          root.close();
+        }
       }
     } finally {
       allocator.close();
@@ -618,7 +628,7 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
     @Override
     public boolean isAfterLast() throws SQLException {
-      return false;
+      return numRows < 0;
     }
 
     @Override

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -77,9 +77,10 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
    * Constructor which populates the table object for each test iteration.
    *
    * @param table Table object
+   * @param reuseVectorSchemaRoot A flag indicating if we should reuse vector schema roots.
    */
-  public JdbcToArrowVectorIteratorTest(Table table) {
-    super(table);
+  public JdbcToArrowVectorIteratorTest(Table table, boolean reuseVectorSchemaRoot) {
+    super(table, reuseVectorSchemaRoot);
   }
 
   @Test
@@ -113,7 +114,7 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
     // first experiment, with calendar and time zone.
     JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()).setTargetBatchSize(3).build();
+        Calendar.getInstance()).setTargetBatchSize(3).setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
     assertNotNull(config.getCalendar());
 
     try (ArrowVectorIterator iterator =
@@ -127,7 +128,7 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
     // second experiment, without calendar and time zone.
     config = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-        null).setTargetBatchSize(3).build();
+        null).setTargetBatchSize(3).setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
     assertNull(config.getCalendar());
 
     try (ArrowVectorIterator iterator =
@@ -164,6 +165,7 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     while (iterator.hasNext()) {
       VectorSchemaRoot root = iterator.next();
       roots.add(root);
+
       JdbcToArrowTestHelper.assertFieldMetadataIsEmpty(root);
 
       bigIntVectors.add((BigIntVector) root.getVector(BIGINT));
@@ -397,7 +399,8 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
   @Test
   public void testJdbcToArrowCustomTypeConversion() throws SQLException, IOException {
     JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE);
+        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE)
+        .setReuseVectorSchemaRoot(reuseVectorSchemaRoot);
 
     // first experiment, using default type converter
     JdbcToArrowConfig config = builder.build();


### PR DESCRIPTION
According to the current design of the JDBC adapter, it is not possible to reuse the vector schema roots. That is, a new vector schema root is created and released for each batch.

This can cause performance problems, because in many scenarios, the client code only reads data in vector schema root. So the vector schema roots can be reused in the following cycle: populate data -> client use data -> populate data -> ...

The current design has another problem. For most times, it has two alternating vector schema roots in memory, causing a large waste of memory, especially for large batches.

We solve both problems by providing a flag in the config, which allows the user to reuse the vector shema roots.