### PR TITLE
ARROW-13737: [C++] Support for grouped aggregation over scalar columns

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1939,6 +1939,10 @@ struct GroupedBooleanAggregator : public GroupedAggregator {
           Impl::UpdateGroupWith(seen, *g, value);
           counts[*g++]++;
         }
+      } else {
+        for (int64_t i = 0; i < batch.length; i++) {
+          BitUtil::SetBitTo(no_nulls, *g++, false);
+        }
       }
     }
     return Status::OK();


### PR DESCRIPTION
Also fixes a major bug in grouped var/std, where multiple batches fed to the same state instance would improperly update state.