### PR TITLE
ARROW-13747: [Python][CI] Requiring s3fs >= 2021.8

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -27,6 +27,6 @@ pytest
 pytest-faulthandler
 pytest-lazy-fixture
 pytz
-s3fs>=0.4
+s3fs>=2021.8.0
 setuptools
 setuptools_scm


### PR DESCRIPTION
aiobotocore recently released 1.4.0 which is incompatible with s3fs < 2021.8 (which was also just released).  Related: https://stackoverflow.com/questions/68864939/s3fs-suddenly-stopped-working-in-google-colab-with-error-attributeerror-module  

Some nightly builds are failing.  Even though conda-forge now has s3fs 2021.8 the builds are caching previous results.  This issue should just resolve itself eventually when the conda/docker caches clear.  However, if we want to force it working again this PR requires the newer version of s3fs.