### PR TITLE
ARROW-13764: [C++] Support CountOptions in grouped count distinct

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -2062,11 +2062,11 @@ struct GroupedDistinctImpl : public GroupedCountDistinctImpl {
     } else if (options_.mode == CountOptions::ONLY_VALID) {
       int32_t prev_offset = offsets[0];
       for (int64_t i = 0; i < list->length(); i++) {
-        const int64_t slot_length = offsets[i + 1] - prev_offset;
+        const int32_t slot_length = offsets[i + 1] - prev_offset;
         const int64_t null_count =
             slot_length - arrow::internal::CountSetBits(values->null_bitmap()->data(),
                                                         prev_offset, slot_length);
-        const int64_t offset = null_count > 0 ? slot_length - 1 : slot_length;
+        const int32_t offset = null_count > 0 ? slot_length - 1 : slot_length;
         prev_offset = offsets[i + 1];
         offsets[i + 1] = offsets[i] + offset;
       }
@@ -2081,11 +2081,11 @@ struct GroupedDistinctImpl : public GroupedCountDistinctImpl {
     // ONLY_NULL
     int32_t prev_offset = offsets[0];
     for (int64_t i = 0; i < list->length(); i++) {
-      const int64_t slot_length = offsets[i + 1] - prev_offset;
+      const int32_t slot_length = offsets[i + 1] - prev_offset;
       const int64_t null_count =
           slot_length - arrow::internal::CountSetBits(values->null_bitmap()->data(),
                                                       prev_offset, slot_length);
-      const int64_t offset = null_count > 0 ? 1 : 0;
+      const int32_t offset = null_count > 0 ? 1 : 0;
       prev_offset = offsets[i + 1];
       offsets[i + 1] = offsets[i] + offset;
     }

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -1240,6 +1240,9 @@ TEST(GroupBy, AnyAndAll) {
 }
 
 TEST(GroupBy, CountDistinct) {
+  CountOptions all(CountOptions::ALL);
+  CountOptions only_valid(CountOptions::ONLY_VALID);
+  CountOptions only_null(CountOptions::ONLY_NULL);
   for (bool use_threads : {true, false}) {
     SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
 
@@ -1250,6 +1253,7 @@ TEST(GroupBy, CountDistinct) {
 ])",
                                                                                       R"([
     [0,    2],
+    [null, 3],
     [null, 3]
 ])",
                                                                                       R"([
@@ -1273,12 +1277,16 @@ TEST(GroupBy, CountDistinct) {
                          internal::GroupBy(
                              {
                                  table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
                              },
                              {
                                  table->GetColumnByName("key"),
                              },
                              {
-                                 {"hash_count_distinct", nullptr},
+                                 {"hash_count_distinct", &all},
+                                 {"hash_count_distinct", &only_valid},
+                                 {"hash_count_distinct", &only_null},
                              },
                              use_threads));
     SortBy({"key_0"}, &aggregated_and_grouped);
@@ -1286,13 +1294,15 @@ TEST(GroupBy, CountDistinct) {
 
     AssertDatumsEqual(ArrayFromJSON(struct_({
                                         field("hash_count_distinct", int64()),
+                                        field("hash_count_distinct", int64()),
+                                        field("hash_count_distinct", int64()),
                                         field("key_0", int64()),
                                     }),
                                     R"([
-    [1, 1],
-    [2, 2],
-    [3, 3],
-    [4, null]
+    [1, 1, 0, 1],
+    [2, 2, 0, 2],
+    [3, 2, 1, 3],
+    [4, 4, 0, null]
   ])"),
                       aggregated_and_grouped,
                       /*verbose=*/true);
@@ -1304,6 +1314,7 @@ TEST(GroupBy, CountDistinct) {
 ])",
                                                                                    R"([
     ["bar",  2],
+    [null,   3],
     [null,   3]
 ])",
                                                                                    R"([
@@ -1327,12 +1338,16 @@ TEST(GroupBy, CountDistinct) {
                          internal::GroupBy(
                              {
                                  table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
+                                 table->GetColumnByName("argument"),
                              },
                              {
                                  table->GetColumnByName("key"),
                              },
                              {
-                                 {"hash_count_distinct", nullptr},
+                                 {"hash_count_distinct", &all},
+                                 {"hash_count_distinct", &only_valid},
+                                 {"hash_count_distinct", &only_null},
                              },
                              use_threads));
     ValidateOutput(aggregated_and_grouped);
@@ -1340,13 +1355,15 @@ TEST(GroupBy, CountDistinct) {
 
     AssertDatumsEqual(ArrayFromJSON(struct_({
                                         field("hash_count_distinct", int64()),
+                                        field("hash_count_distinct", int64()),
+                                        field("hash_count_distinct", int64()),
                                         field("key_0", int64()),
                                     }),
                                     R"([
-    [1, 1],
-    [2, 2],
-    [3, 3],
-    [4, null]
+    [1, 1, 0, 1],
+    [2, 2, 0, 2],
+    [3, 2, 1, 3],
+    [4, 4, 0, null]
   ])"),
                       aggregated_and_grouped,
                       /*verbose=*/true);

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -288,36 +288,42 @@ The supported aggregation functions are as follows. All function names are
 prefixed with ``hash_``, which differentiates them from their scalar
 equivalents above and reflects how they are implemented internally.
 
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| Function name | Arity | Input types | Output type     | Options class                    | Notes |
-+===============+=======+=============+=================+==================================+=======+
-| hash_all      | Unary | Boolean     | Boolean         | :struct:`ScalarAggregateOptions` | \(1)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_any      | Unary | Boolean     | Boolean         | :struct:`ScalarAggregateOptions` | \(1)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_count    | Unary | Any         | Int64           | :struct:`CountOptions`           | \(2)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_mean     | Unary | Numeric     | Decimal/Float64 | :struct:`ScalarAggregateOptions` |       |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_min_max  | Unary | Numeric     | Struct          | :struct:`ScalarAggregateOptions` | \(3)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_product  | Unary | Numeric     | Numeric         | :struct:`ScalarAggregateOptions` | \(4)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_stddev   | Unary | Numeric     | Float64         | :struct:`VarianceOptions`        |       |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_sum      | Unary | Numeric     | Numeric         | :struct:`ScalarAggregateOptions` | \(4)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_tdigest  | Unary | Numeric     | Float64         | :struct:`TDigestOptions`         | \(5)  |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
-| hash_variance | Unary | Numeric     | Float64         | :struct:`VarianceOptions`        |       |
-+---------------+-------+-------------+-----------------+----------------------------------+-------+
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| Function name       | Arity | Input types | Output type     | Options class                    | Notes |
++=====================+=======+=============+=================+==================================+=======+
+| hash_all            | Unary | Boolean     | Boolean         | :struct:`ScalarAggregateOptions` | \(1)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_any            | Unary | Boolean     | Boolean         | :struct:`ScalarAggregateOptions` | \(1)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_count          | Unary | Any         | Int64           | :struct:`CountOptions`           | \(2)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_count_distinct | Unary | Any         | Int64           | :struct:`CountOptions`           | \(2)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_distinct       | Unary | Any         | Input type      | :struct:`CountOptions`           | \(2)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_mean           | Unary | Numeric     | Decimal/Float64 | :struct:`ScalarAggregateOptions` |       |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_min_max        | Unary | Numeric     | Struct          | :struct:`ScalarAggregateOptions` | \(3)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_product        | Unary | Numeric     | Numeric         | :struct:`ScalarAggregateOptions` | \(4)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_stddev         | Unary | Numeric     | Float64         | :struct:`VarianceOptions`        |       |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_sum            | Unary | Numeric     | Numeric         | :struct:`ScalarAggregateOptions` | \(4)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_tdigest        | Unary | Numeric     | Float64         | :struct:`TDigestOptions`         | \(5)  |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
+| hash_variance       | Unary | Numeric     | Float64         | :struct:`VarianceOptions`        |       |
++---------------------+-------+-------------+-----------------+----------------------------------+-------+
 
 * \(1) If null values are taken into account, by setting the
   :member:`ScalarAggregateOptions::skip_nulls` to false, then `Kleene logic`_
   logic is applied. The min_count option is not respected.
 
-* \(2) CountMode controls whether only non-null values are counted (the
-  default), only null values are counted, or all values are counted.
+* \(2) CountMode controls whether only non-null values are counted
+  (the default), only null values are counted, or all values are
+  counted. For hash_distinct, it instead controls whether null values
+  are emitted.
 
 * \(3) Output is a ``{"min": input type, "max": input type}`` Struct scalar.
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -323,7 +323,8 @@ equivalents above and reflects how they are implemented internally.
 * \(2) CountMode controls whether only non-null values are counted
   (the default), only null values are counted, or all values are
   counted. For hash_distinct, it instead controls whether null values
-  are emitted.
+  are emitted. This never affects the grouping keys, only group values
+  (i.e. you may get a group where the key is null).
 
 * \(3) Output is a ``{"min": input type, "max": input type}`` Struct scalar.
 


### PR DESCRIPTION
This works by filtering the values (trading off time for memory usage).