### PR TITLE
ARROW-13773: [C++] Cross platform initializer blocks

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -321,7 +321,6 @@ ExecFactoryRegistry* default_exec_factory_registry() {
   class DefaultRegistry : public ExecFactoryRegistry {
    public:
     DefaultRegistry() {
-      internal::RegisterSourceNode(this);
       internal::RegisterFilterNode(this);
       internal::RegisterProjectNode(this);
       internal::RegisterUnionNode(this);

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -29,6 +29,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
+#include "arrow/util/init.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/optional.h"
 #include "arrow/util/thread_pool.h"
@@ -142,14 +143,10 @@ struct SourceNode : ExecNode {
   AsyncGenerator<util::optional<ExecBatch>> generator_;
 };
 
+ARROW_INITIALIZER({
+  DCHECK_OK(default_exec_factory_registry()->AddFactory("source", SourceNode::Make));
+});
+
 }  // namespace
-
-namespace internal {
-
-void RegisterSourceNode(ExecFactoryRegistry* registry) {
-  DCHECK_OK(registry->AddFactory("source", SourceNode::Make));
-}
-
-}  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/util/init.h
+++ b/cpp/src/arrow/util/init.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/util/macros.h"
+
+namespace arrow {
+namespace internal {
+
+#define ARROW_INITIALIZER_NAME(counter) ARROW_CONCAT(arrow_initializer_, counter)
+
+/// Declares a block of code to be executed on load of the library.
+/// The init block can only fail by aborting, so use this with caution.
+///
+///     ARROW_INITIALIZER({
+///       DCHECK_OK(registry->Add(Thing::Make()));
+///     });
+#define ARROW_INITIALIZER(...) \
+  ARROW_INITIALIZER_IMPL(ARROW_INITIALIZER_NAME(__COUNTER__), __VA_ARGS__)
+
+#if !defined(_MSC_VER)
+
+// __attribute__((constructor)) is supported by GCC and Clang, and
+// declares that a function must be executed as part of library initialization.
+#define ARROW_INITIALIZER_IMPL(NAME, ...) \
+  __attribute__((constructor)) void NAME() __VA_ARGS__
+
+#else
+
+// MSVC has no equivalent of __attribute__((constructor)), so instead
+// specify an object whose constructor executes the required code.
+#define ARROW_INITIALIZER_IMPL(NAME, ...) \
+  __declspec(dllexport) class NAME { NAME() __VA_ARGS__ } NAME
+
+#endif
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/init.h
+++ b/cpp/src/arrow/util/init.h
@@ -45,7 +45,7 @@ namespace internal {
 // MSVC has no equivalent of __attribute__((constructor)), so instead
 // specify an object whose constructor executes the required code.
 #define ARROW_INITIALIZER_IMPL(NAME, ...) \
-  __declspec(dllexport) class NAME { NAME() __VA_ARGS__ } NAME
+  __declspec(dllexport) struct NAME { NAME() __VA_ARGS__ } NAME
 
 #endif
 

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "arrow/result.h"
+#include "arrow/util/init.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/utf8.h"
 #include "arrow/vendored/utfcpp/checked.h"
@@ -84,11 +85,9 @@ ARROW_EXPORT void CheckUTF8Initialized() {
 
 }  // namespace internal
 
-static std::once_flag utf8_initialized;
+void InitializeUTF8() {}
 
-void InitializeUTF8() {
-  std::call_once(utf8_initialized, internal::InitializeLargeTable);
-}
+ARROW_INITIALIZER({ internal::InitializeLargeTable(); });
 
 static const uint8_t kBOM[] = {0xEF, 0xBB, 0xBF};
 


### PR DESCRIPTION
Allows declaring blocks of code to be run at library load time.

For now this is a draft, I'm checking to see if CI accepts this