### PR TITLE
ARROW-13775: [C++] Allow Partitioning objects to be created with a vector of field names

### DIFF
--- a/cpp/examples/arrow/dataset_documentation_example.cc
+++ b/cpp/examples/arrow/dataset_documentation_example.cc
@@ -141,7 +141,7 @@ std::string CreateExampleParquetHivePartitionedDataset(
   // The partition schema determines which fields are part of the partitioning.
   auto partition_schema = arrow::schema({arrow::field("part", arrow::utf8())});
   // We'll use Hive-style partitioning, which creates directories with "key=value" pairs.
-  auto partitioning = std::make_shared<ds::HivePartitioning>(partition_schema);
+  auto partitioning = std::make_shared<ds::HivePartitioning>(*partition_schema);
   // We'll write Parquet files.
   auto format = std::make_shared<ds::ParquetFileFormat>();
   ds::FileSystemDatasetWriteOptions write_options;

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -501,7 +501,7 @@ class TestSchemaUnification : public TestUnionDataset {
       FileSystemFactoryOptions options;
       options.partition_base_dir = base;
       options.partitioning =
-          std::make_shared<HivePartitioning>(SchemaFromNames({"part_ds", "part_df"}));
+          std::make_shared<HivePartitioning>(*SchemaFromNames({"part_ds", "part_df"}));
 
       ARROW_ASSIGN_OR_RAISE(auto factory,
                             FileSystemDatasetFactory::Make(fs_, paths, format, options));
@@ -709,7 +709,7 @@ TEST(TestDictPartitionColumn, SelectPartitionColumnFilterPhysicalColumn) {
 
   FileSystemFactoryOptions options;
   options.partition_base_dir = "/dataset";
-  options.partitioning = std::make_shared<HivePartitioning>(schema({partition_field}),
+  options.partitioning = std::make_shared<HivePartitioning>(*schema({partition_field}),
                                                             ArrayVector{dictionary});
 
   ASSERT_OK_AND_ASSIGN(auto factory,

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -175,7 +175,7 @@ TEST_F(FileSystemDatasetFactoryTest, ExplicitPartition) {
   selector_.base_dir = "a=ignored/base";
   auto part_field = field("a", int32());
   factory_options_.partitioning =
-      std::make_shared<HivePartitioning>(schema({part_field}));
+      std::make_shared<HivePartitioning>(*schema({part_field}));
 
   auto a_1 = "a=ignored/base/a=1";
   MakeFactory({fs::File(a_1)});
@@ -209,7 +209,7 @@ TEST_F(FileSystemDatasetFactoryTest, MissingDirectories) {
 
   factory_options_.partition_base_dir = "base_dir";
   factory_options_.partitioning = std::make_shared<HivePartitioning>(
-      schema({field("a", int32()), field("b", int32())}));
+      *schema({field("a", int32()), field("b", int32())}));
 
   auto paths = std::vector<std::string>{partition_path, unpartition_path};
 
@@ -363,7 +363,7 @@ TEST_F(FileSystemDatasetFactoryTest, FilenameNotPartOfPartitions) {
   // specifically chosen such that parsing would fail given a non-integer
   // string.
   auto s = schema({field("first", utf8()), field("second", int32())});
-  factory_options_.partitioning = std::make_shared<DirectoryPartitioning>(s);
+  factory_options_.partitioning = std::make_shared<DirectoryPartitioning>(*s);
 
   selector_.recursive = true;
   // The file doesn't have a directory component for the second partition
@@ -382,7 +382,7 @@ TEST_F(FileSystemDatasetFactoryTest, FilenameNotPartOfPartitions) {
 
 TEST_F(FileSystemDatasetFactoryTest, UnparseablePartitionExpression) {
   auto s = schema({field("first", int32()), field("second", int32())});
-  factory_options_.partitioning = std::make_shared<HivePartitioning>(s);
+  factory_options_.partitioning = std::make_shared<HivePartitioning>(*s);
   selector_.recursive = true;
 
   for (auto pathlist : {"first=one/file.parquet", "second=one/file.parquet",

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -121,7 +121,7 @@ TEST_F(TestIpcFileSystemDataset, WriteWithEmptyPartitioningSchema) {
 
 TEST_F(TestIpcFileSystemDataset, WriteExceedsMaxPartitions) {
   write_options_.partitioning = std::make_shared<DirectoryPartitioning>(
-      SchemaFromColumnNames(source_schema_, {"model"}));
+      *SchemaFromColumnNames(source_schema_, {"model"}));
 
   // require that no batch be grouped into more than 2 written batches:
   write_options_.max_partitions = 2;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -941,7 +941,9 @@ Result<std::vector<std::shared_ptr<Schema>>> ParquetDatasetFactory::InspectSchem
 
     schemas.push_back(std::move(partition_schema));
   } else {
-    schemas.push_back(options_.partitioning.partitioning()->schema());
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Schema> part_schema,
+                          options_.partitioning.partitioning()->GetSchema());
+    schemas.push_back(std::move(part_schema));
   }
 
   return schemas;

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include "arrow/dataset/api.h"
 #include "arrow/dataset/partition.h"
@@ -307,7 +307,7 @@ TEST_F(TestFileSystemDataset, WriteProjected) {
   write_options.file_write_options = format->DefaultWriteOptions();
   write_options.filesystem = fs;
   write_options.base_dir = "root";
-  write_options.partitioning = std::make_shared<HivePartitioning>(schema({}));
+  write_options.partitioning = std::make_shared<HivePartitioning>(*schema({}));
   write_options.basename_template = "{i}.feather";
 
   auto dataset_schema = schema({field("a", int64())});

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1972,11 +1972,6 @@ cdef class Partitioning(_Weakrefable):
         result = self.partitioning.Parse(tobytes(path))
         return Expression.wrap(GetResultValue(result))
 
-    @property
-    def schema(self):
-        """The arrow Schema attached to the partitioning."""
-        return pyarrow_wrap_schema(self.partitioning.schema())
-
 
 cdef class PartitioningFactory(_Weakrefable):
 
@@ -2068,7 +2063,7 @@ cdef class DirectoryPartitioning(Partitioning):
 
         c_options.segment_encoding = _get_segment_encoding(segment_encoding)
         c_partitioning = make_shared[CDirectoryPartitioning](
-            pyarrow_unwrap_schema(schema),
+            deref(pyarrow_unwrap_schema(schema)),
             _partitioning_dictionaries(schema, dictionaries),
             c_options,
         )
@@ -2223,7 +2218,7 @@ cdef class HivePartitioning(Partitioning):
         c_options.segment_encoding = _get_segment_encoding(segment_encoding)
 
         c_partitioning = make_shared[CHivePartitioning](
-            pyarrow_unwrap_schema(schema),
+            deref(pyarrow_unwrap_schema(schema)),
             _partitioning_dictionaries(schema, dictionaries),
             c_options,
         )

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -345,7 +345,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CPartitioning "arrow::dataset::Partitioning":
         c_string type_name() const
         CResult[CExpression] Parse(const c_string & path) const
-        const shared_ptr[CSchema] & schema()
 
     cdef cppclass CSegmentEncoding" arrow::dataset::SegmentEncoding":
         pass
@@ -382,7 +381,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CDirectoryPartitioning \
             "arrow::dataset::DirectoryPartitioning"(CPartitioning):
-        CDirectoryPartitioning(shared_ptr[CSchema] schema,
+        CDirectoryPartitioning(const CSchema& schema,
                                vector[shared_ptr[CArray]] dictionaries)
 
         @staticmethod
@@ -393,7 +392,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CHivePartitioning \
             "arrow::dataset::HivePartitioning"(CPartitioning):
-        CHivePartitioning(shared_ptr[CSchema] schema,
+        CHivePartitioning(const CSchema& schema,
                           vector[shared_ptr[CArray]] dictionaries,
                           CHivePartitioningOptions options)
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1668,7 +1668,6 @@ def test_directory_partitioning_dictionary_key(mockfs):
     dataset = ds.dataset(
         "subdir", format="parquet", filesystem=mockfs, partitioning=part
     )
-    assert dataset.partitioning.schema == schema
     table = dataset.to_table()
 
     assert table.column('group').type.equals(schema.types[0])
@@ -1688,7 +1687,6 @@ def test_hive_partitioning_dictionary_key(multisourcefs):
     dataset = ds.dataset(
         "hive", format="parquet", filesystem=multisourcefs, partitioning=part
     )
-    assert dataset.partitioning.schema == schema
     table = dataset.to_table()
 
     year_dictionary = list(range(2006, 2011))
@@ -3081,7 +3079,6 @@ def test_dataset_preserved_partitioning(tempdir):
     part = dataset.partitioning
     assert part is not None
     assert isinstance(part, ds.HivePartitioning)
-    assert part.schema == pa.schema([("part", pa.int32())])
     assert len(part.dictionaries) == 1
     assert part.dictionaries[0] == pa.array([0, 1, 2], pa.int32())
 
@@ -3092,7 +3089,6 @@ def test_dataset_preserved_partitioning(tempdir):
     dataset = ds.dataset(path, partitioning=part)
     part = dataset.partitioning
     assert isinstance(part, ds.HivePartitioning)
-    assert part.schema == pa.schema([("part", pa.int32())])
     # TODO is this expected?
     assert part.dictionaries is None
 
@@ -3111,7 +3107,6 @@ def test_dataset_preserved_partitioning(tempdir):
     part = dataset.partitioning
     assert part is not None
     assert isinstance(part, ds.HivePartitioning)
-    assert part.schema == pa.schema([("part", pa.string())])
     assert len(part.dictionaries) == 1
     # will be fixed by ARROW-13153 (order is not preserved at the moment)
     # assert part.dictionaries[0] == pa.array(["a", "b"], pa.string())

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -356,7 +356,7 @@ std::shared_ptr<ds::DirectoryPartitioning> dataset___DirectoryPartitioning(
   ds::KeyValuePartitioningOptions options;
   options.segment_encoding = GetSegmentEncoding(segment_encoding);
   std::vector<std::shared_ptr<arrow::Array>> dictionaries;
-  return std::make_shared<ds::DirectoryPartitioning>(schm, dictionaries, options);
+  return std::make_shared<ds::DirectoryPartitioning>(*schm, dictionaries, options);
 }
 
 // [[dataset::export]]
@@ -375,7 +375,7 @@ std::shared_ptr<ds::HivePartitioning> dataset___HivePartitioning(
   options.null_fallback = null_fallback;
   options.segment_encoding = GetSegmentEncoding(segment_encoding);
   std::vector<std::shared_ptr<arrow::Array>> dictionaries;
-  return std::make_shared<ds::HivePartitioning>(schm, dictionaries, options);
+  return std::make_shared<ds::HivePartitioning>(*schm, dictionaries, options);
 }
 
 // [[dataset::export]]


### PR DESCRIPTION
This PR ended up being fairly extensive but mostly to avoid a single `shared_ptr` copy (due to changing the constructor to take in `const Schema& schema` instead of `std::shared_ptr<Schema>` since I now copy the field names and types out of the schema) and I'm not entirely sure that's worth it over just keeping the old interface.

Otherwise the only potential downside is that `std::shared_ptr<Schema> Partitioning::schema()` became `Result<std::shared_ptr<Schema>> Partitioning::GetSchema()` since it could potentially fail if the partitioning was created without a schema.  I also removed the corresponding accessor from python.

I don't think this is a problem though because `GetSchema` would only work if there was a schema which means...

1. You created the partitioning with a schema in the first place so there is no need to pull it back out.
2. You created the schema with a FileSystemDatasetFactory so you can just get the field types from the dataset schema.