### PR TITLE
ARROW-13792 [Java]: The toString representation is incorrect for unsigned integer vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * UInt1Vector implements a fixed width (1 bytes) vector of
@@ -328,7 +329,10 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
     return this.get(index) & PROMOTION_MASK;
   }
 
-
+  @Override
+  public String toString() {
+    return ValueVectorUtility.getToString(this, 0, getValueCount(), (v, i) -> v.getObjectNoOverflow(i));
+  }
 
   private class TransferImpl implements TransferPair {
     UInt1Vector to;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * UInt2Vector implements a fixed width (2 bytes) vector of
@@ -303,6 +304,12 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public String toString() {
+    return ValueVectorUtility.getToString(this, 0, getValueCount(), (v, i) ->
+      v.isNull(i) ? "null" : Integer.toString(v.get(i) & 0x0000ffff));
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * UInt4Vector implements a fixed width (4 bytes) vector of
@@ -298,6 +299,11 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
   @Override
   public long getValueAsLong(int index) {
     return this.get(index) & PROMOTION_MASK;
+  }
+
+  @Override
+  public String toString() {
+    return ValueVectorUtility.getToString(this, 0, getValueCount(), (v, i) -> v.getObjectNoOverflow(i));
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -31,6 +31,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * UInt8Vector implements a fixed width vector (8 bytes) of
@@ -294,6 +295,11 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public String toString() {
+    return ValueVectorUtility.getToString(this, 0, getValueCount(), (v, i) -> v.getObjectNoOverflow(i));
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2792,6 +2792,38 @@ public class TestValueVector {
   }
 
   @Test
+  public void testUInt1VectorToString() {
+    try (final UInt1Vector uInt1Vector = new UInt1Vector("uInt1Vector", allocator)) {
+      setVector(uInt1Vector, (byte) 0xff);
+      assertEquals("[255]", uInt1Vector.toString());
+    }
+  }
+
+  @Test
+  public void testUInt2VectorToString() {
+    try (final UInt2Vector uInt2Vector = new UInt2Vector("uInt2Vector", allocator)) {
+      setVector(uInt2Vector, (char) 0xffff);
+      assertEquals("[" + new Character((char) 0xffff) + "]", uInt2Vector.toString());
+    }
+  }
+
+  @Test
+  public void testUInt4VectorToString() {
+    try (final UInt4Vector uInt4Vector = new UInt4Vector("uInt4Vector", allocator)) {
+      setVector(uInt4Vector, 0xffffffff);
+      assertEquals("[4294967295]", uInt4Vector.toString());
+    }
+  }
+
+  @Test
+  public void testUInt8VectorToString() {
+    try (final UInt8Vector uInt8Vector = new UInt8Vector("uInt8Vector", allocator)) {
+      setVector(uInt8Vector, 0xffffffffffffffffL);
+      assertEquals("[18446744073709551615]", uInt8Vector.toString());
+    }
+  }
+
+  @Test
   public void testUnloadVariableWidthVector() {
     try (final VarCharVector varCharVector = new VarCharVector("var char", allocator)) {
       varCharVector.allocateNew(5, 2);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2803,7 +2803,7 @@ public class TestValueVector {
   public void testUInt2VectorToString() {
     try (final UInt2Vector uInt2Vector = new UInt2Vector("uInt2Vector", allocator)) {
       setVector(uInt2Vector, (char) 0xffff);
-      assertEquals("[" + new Character((char) 0xffff) + "]", uInt2Vector.toString());
+      assertEquals("[\uffff]", uInt2Vector.toString());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2803,7 +2803,7 @@ public class TestValueVector {
   public void testUInt2VectorToString() {
     try (final UInt2Vector uInt2Vector = new UInt2Vector("uInt2Vector", allocator)) {
       setVector(uInt2Vector, (char) 0xffff);
-      assertEquals("[\uffff]", uInt2Vector.toString());
+      assertEquals("[65535]", uInt2Vector.toString());
     }
   }
 


### PR DESCRIPTION
When adding a byte `0xff` to a UInt1Vector, the toString method produces `[-1]`. Since the vector contains unsinged integers, the correct result should be `[255]`.