### PR TITLE
ARROW-13794: [C++] Deprecate PARQUET_VERSION_2_0

### DIFF
--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -22,6 +22,7 @@
 #include <mach-o/dyld.h>
 #endif
 
+#include <algorithm>
 #include <cstdlib>
 #include <sstream>
 

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -128,8 +128,6 @@
 #else
 # if defined(__GNUC__) && __GNUC__ >= 6
 #  define ARROW_DEPRECATED_ENUM_VALUE(...) __attribute__((deprecated(__VA_ARGS__)))
-# elif defined(_MSC_VER)
-#  define ARROW_DEPRECATED_ENUM_VALUE(...) __declspec(deprecated(__VA_ARGS__))
 # else
 #  define ARROW_DEPRECATED_ENUM_VALUE(...)
 # endif

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -120,6 +120,21 @@
 #  define ARROW_DEPRECATED_USING(...)
 # endif
 #endif
+
+#ifdef __COVERITY__
+#  define ARROW_DEPRECATED_ENUM_VALUE(...)
+#elif __cplusplus > 201103L
+#  define ARROW_DEPRECATED_ENUM_VALUE(...) [[deprecated(__VA_ARGS__)]]
+#else
+# if defined(__GNUC__) && __GNUC__ >= 6
+#  define ARROW_DEPRECATED_ENUM_VALUE(...) __attribute__((deprecated(__VA_ARGS__)))
+# elif defined(_MSC_VER)
+#  define ARROW_DEPRECATED_ENUM_VALUE(...) __declspec(deprecated(__VA_ARGS__))
+# else
+#  define ARROW_DEPRECATED_ENUM_VALUE(...)
+# endif
+#endif
+
 // clang-format on
 
 // Macros to disable deprecation warnings

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1805,7 +1805,7 @@ Status WriteTimestamps(const ::arrow::Array& values, int64_t num_levels,
         maybe_parent_nulls);
   };
 
-  const auto version = writer->properties()->version();
+  const ParquetVersion::type version = writer->properties()->version();
 
   if (ctx->properties->coerce_timestamps_enabled()) {
     // User explicitly requested coercion to specific unit

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1805,6 +1805,8 @@ Status WriteTimestamps(const ::arrow::Array& values, int64_t num_levels,
         maybe_parent_nulls);
   };
 
+  const auto version = writer->properties()->version();
+
   if (ctx->properties->coerce_timestamps_enabled()) {
     // User explicitly requested coercion to specific unit
     if (source_type.unit() == ctx->properties->coerce_timestamps_unit()) {
@@ -1814,9 +1816,10 @@ Status WriteTimestamps(const ::arrow::Array& values, int64_t num_levels,
     } else {
       return WriteCoerce(ctx->properties);
     }
-  } else if (writer->properties()->version() == ParquetVersion::PARQUET_1_0 &&
+  } else if ((version == ParquetVersion::PARQUET_1_0 ||
+              version == ParquetVersion::PARQUET_2_4) &&
              source_type.unit() == ::arrow::TimeUnit::NANO) {
-    // Absent superseding user instructions, when writing Parquet version 1.0 files,
+    // Absent superseding user instructions, when writing Parquet version <= 2.4 files,
     // timestamps in nanoseconds are coerced to microseconds
     std::shared_ptr<ArrowWriterProperties> properties =
         (ArrowWriterProperties::Builder())

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -613,7 +613,7 @@ TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion1_0) {
 }
 
 TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion2_0) {
-  this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_0);
+  this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_4);
 }
 
 TEST(TestWriter, NullValuesBuffer) {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -62,8 +62,14 @@ std::string ParquetVersionToString(ParquetVersion::type ver) {
   switch (ver) {
     case ParquetVersion::PARQUET_1_0:
       return "1.0";
+      ARROW_SUPPRESS_DEPRECATION_WARNING
     case ParquetVersion::PARQUET_2_0:
-      return "2.0";
+      return "pseudo-2.0";
+      ARROW_UNSUPPRESS_DEPRECATION_WARNING
+    case ParquetVersion::PARQUET_2_4:
+      return "2.4";
+    case ParquetVersion::PARQUET_2_6:
+      return "2.6";
   }
 
   // This should be unreachable
@@ -815,7 +821,7 @@ ParquetVersion::type FileMetaData::version() const {
     case 1:
       return ParquetVersion::PARQUET_1_0;
     case 2:
-      return ParquetVersion::PARQUET_2_0;
+      return ParquetVersion::PARQUET_2_LATEST;
     default:
       // Improperly set version, assuming Parquet 1.0
       break;
@@ -1670,10 +1676,8 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
       case ParquetVersion::PARQUET_1_0:
         file_version = 1;
         break;
-      case ParquetVersion::PARQUET_2_0:
-        file_version = 2;
-        break;
       default:
+        file_version = 2;
         break;
     }
     metadata_->__set_version(file_version);

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -278,9 +278,10 @@ class PARQUET_EXPORT FileMetaData {
 
   /// \brief Return the "version" of the file
   ///
-  /// The Parquet file metadata stores the version as a single integer,
-  /// therefore the returned value can only be an approximation of the
-  /// Parquet format version actually supported by the producer of the file.
+  /// WARNING: The value returned by this method is unreliable as 1) the Parquet
+  /// file metadata stores the version as a single integer and 2) some producers
+  /// are known to always write a hardcoded value.  Therefore, you cannot use
+  /// this value to know which features are used in the file.
   ParquetVersion::type version() const;
 
   /// \brief Return the application's user-agent string of the writer.

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -276,7 +276,11 @@ class PARQUET_EXPORT FileMetaData {
   /// \throws ParquetException if the index is out of bound.
   std::unique_ptr<RowGroupMetaData> RowGroup(int index) const;
 
-  /// \brief Return the version of the file.
+  /// \brief Return the "version" of the file
+  ///
+  /// The Parquet file metadata stores the version as a single integer,
+  /// therefore the returned value can only be an approximation of the
+  /// Parquet format version actually supported by the producer of the file.
   ParquetVersion::type version() const;
 
   /// \brief Return the application's user-agent string of the writer.

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -83,7 +83,7 @@ TEST(Metadata, TestBuildAccess) {
   WriterProperties::Builder prop_builder;
 
   std::shared_ptr<WriterProperties> props =
-      prop_builder.version(ParquetVersion::PARQUET_2_0)->build();
+      prop_builder.version(ParquetVersion::PARQUET_2_6)->build();
 
   fields.push_back(parquet::schema::Int32("int_col", Repetition::REQUIRED));
   fields.push_back(parquet::schema::Float("float_col", Repetition::REQUIRED));
@@ -126,7 +126,7 @@ TEST(Metadata, TestBuildAccess) {
     ASSERT_EQ(nrows, f_accessors[loop_index]->num_rows());
     ASSERT_LE(0, static_cast<int>(f_accessors[loop_index]->size()));
     ASSERT_EQ(2, f_accessors[loop_index]->num_row_groups());
-    ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessors[loop_index]->version());
+    ASSERT_EQ(ParquetVersion::PARQUET_2_6, f_accessors[loop_index]->version());
     ASSERT_EQ(DEFAULT_CREATED_BY, f_accessors[loop_index]->created_by());
     ASSERT_EQ(3, f_accessors[loop_index]->num_schema_elements());
 
@@ -213,7 +213,7 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(4, f_accessor->num_row_groups());
   ASSERT_EQ(nrows * 2, f_accessor->num_rows());
   ASSERT_LE(0, static_cast<int>(f_accessor->size()));
-  ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessor->version());
+  ASSERT_EQ(ParquetVersion::PARQUET_2_6, f_accessor->version());
   ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
   ASSERT_EQ(3, f_accessor->num_schema_elements());
 

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -36,18 +36,6 @@
 
 namespace parquet {
 
-/// Determines use of Parquet Format version >= 2.0.0 logical types. For
-/// example, when writing from Arrow data structures, PARQUET_2_0 will enable
-/// use of INT_* and UINT_* converted types as well as nanosecond timestamps
-/// stored physically as INT64. Since some Parquet implementations do not
-/// support the logical types added in the 2.0.0 format version, if you want to
-/// maximize compatibility of your files you may want to use PARQUET_1_0.
-///
-/// Note that the 2.x format version series also introduced new serialized
-/// data page metadata and on disk data page layout. To enable this, use
-/// ParquetDataPageVersion.
-struct ParquetVersion;
-
 /// Controls serialization format of data pages.  parquet-format v2.0.0
 /// introduced a new data page metadata type DataPageV2 and serialized page
 /// structure (for example, encoded levels are no longer compressed). Prior to

--- a/cpp/src/parquet/type_fwd.h
+++ b/cpp/src/parquet/type_fwd.h
@@ -31,9 +31,11 @@ namespace parquet {
 /// ArrowWriterProperties.
 struct ParquetVersion {
   enum type : int {
-    /// Enable only pre-2.0 Parquet format features when writing
+    /// Enable only pre-2.2 Parquet format features when writing
     ///
     /// This setting is useful for maximum compatibility with legacy readers.
+    /// Note that logical types may still be emitted, as long they have a
+    /// corresponding converted type.
     PARQUET_1_0,
 
     /// DEPRECATED: Enable Parquet format 2.6 features
@@ -44,7 +46,8 @@ struct ParquetVersion {
 
     /// Enable Parquet format 2.4 and earlier features when writing
     ///
-    /// This enables logical types and UINT32.
+    /// This enables UINT32 as well as logical types which don't have
+    /// a corresponding converted type.
     ///
     /// Note: Parquet format 2.4.0 was released in October 2017.
     PARQUET_2_4,

--- a/cpp/src/parquet/type_fwd.h
+++ b/cpp/src/parquet/type_fwd.h
@@ -19,8 +19,50 @@
 
 namespace parquet {
 
+/// \brief Feature selection when writing Parquet files
+///
+/// `ParquetVersion::type` governs which data types are allowed and how they
+/// are represented. For example, uint32_t data will be written differently
+/// depending on this value (as INT64 for PARQUET_1_0, as UINT32 for other
+/// versions).
+///
+/// However, some features - such as compression algorithms, encryption,
+/// or the improved "v2" data page format - must be enabled separately in
+/// ArrowWriterProperties.
 struct ParquetVersion {
-  enum type { PARQUET_1_0, PARQUET_2_0 };
+  enum type : int {
+    /// Enable only pre-2.0 Parquet format features when writing
+    ///
+    /// This setting is useful for maximum compatibility with legacy readers.
+    PARQUET_1_0,
+
+    /// DEPRECATED: Enable Parquet format 2.6 features
+    ///
+    /// This misleadingly named enum value is roughly similar to PARQUET_2_6.
+    PARQUET_2_0 ARROW_DEPRECATED_ENUM_VALUE("use PARQUET_2_4 or PARQUET_2_6 "
+                                            "for fine-grained feature selection"),
+
+    /// Enable Parquet format 2.4 and earlier features when writing
+    ///
+    /// This enables logical types and UINT32.
+    ///
+    /// Note: Parquet format 2.4.0 was released in October 2017.
+    PARQUET_2_4,
+
+    /// Enable Parquet format 2.6 and earlier features when writing
+    ///
+    /// This enables the NANOS time unit in addition to the PARQUET_2_4
+    /// features.
+    ///
+    /// Note: Parquet format 2.6.0 was released in September 2018.
+    PARQUET_2_6,
+
+    /// Enable latest Parquet format 2.x features
+    ///
+    /// This value is equal to the greatest 2.x version supported by
+    /// this library.
+    PARQUET_2_LATEST = PARQUET_2_6
+  };
 };
 
 class FileMetaData;

--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -99,7 +99,7 @@ Encodings
 * \(1) Only supported for encoding definition and repetition levels, not values.
 
 * \(2) On the write path, RLE_DICTIONARY is only enabled if Parquet format version
-  2.0 (or potentially greater) is selected in :func:`WriterProperties::version`.
+  2.4 or greater is selected in :func:`WriterProperties::version`.
 
 *Unsupported encodings:* DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY,
 DELTA_BYTE_ARRAY.

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -141,11 +141,11 @@ Parquet file writing options
 :func:`~pyarrow.parquet.write_table()` has a number of options to
 control various settings when writing a Parquet file.
 
-* ``version``, the Parquet format version to use, whether ``'1.0'``
-  for compatibility with older readers, or ``'2.0'`` to unlock more
-  recent features.
+* ``version``, the Parquet format version to use.  ``'1.0'`` ensures
+  compatibility with older readers, while ``'2.4'`` and greater values
+  enable more Parquet types and encodings.
 * ``data_page_size``, to control the approximate size of encoded data
-  pages within a column chunk. This currently defaults to 1MB
+  pages within a column chunk. This currently defaults to 1MB.
 * ``flavor``, to set compatibility options particular to a Parquet
   consumer like ``'spark'`` for Apache Spark.
 
@@ -292,11 +292,11 @@ an exception will be raised. This can be suppressed by passing
                   allow_truncated_timestamps=True)
 
 Timestamps with nanoseconds can be stored without casting when using the
-more recent Parquet format version 2.0:
+more recent Parquet format version 2.6:
 
 .. code-block:: python
 
-   pq.write_table(table, where, version='2.0')
+   pq.write_table(table, where, version='2.6')
 
 However, many Parquet readers do not yet support this newer format version, and
 therefore the default is to write version 1.0 files. When compatibility across

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -133,7 +133,9 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
 
     enum ParquetVersion" parquet::ParquetVersion::type":
         ParquetVersion_V1" parquet::ParquetVersion::PARQUET_1_0"
-        ParquetVersion_V2" parquet::ParquetVersion::PARQUET_2_0"
+        ParquetVersion_V2_0" parquet::ParquetVersion::PARQUET_2_0"
+        ParquetVersion_V2_4" parquet::ParquetVersion::PARQUET_2_4"
+        ParquetVersion_V2_6" parquet::ParquetVersion::PARQUET_2_6"
 
     enum ParquetSortOrder" parquet::SortOrder::type":
         ParquetSortOrder_SIGNED" parquet::SortOrder::SIGNED"

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -579,8 +579,12 @@ cdef class FileMetaData(_Weakrefable):
         cdef ParquetVersion version = self._metadata.version()
         if version == ParquetVersion_V1:
             return '1.0'
-        if version == ParquetVersion_V2:
-            return '2.0'
+        elif version == ParquetVersion_V2_0:
+            return 'pseudo-2.0'
+        elif version == ParquetVersion_V2_4:
+            return '2.4'
+        elif version == ParquetVersion_V2_6:
+            return '2.6'
         else:
             warnings.warn('Unrecognized file version, assuming 1.0: {}'
                           .format(version))
@@ -1214,8 +1218,16 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     if version is not None:
         if version == "1.0":
             props.version(ParquetVersion_V1)
-        elif version == "2.0":
-            props.version(ParquetVersion_V2)
+        elif version in ("2.0", "pseudo-2.0"):
+            warnings.warn(
+                "Parquet format '2.0' pseudo version is deprecated, use "
+                "'2.4' or '2.6' for fine-grained feature selection",
+                FutureWarning, stacklevel=2)
+            props.version(ParquetVersion_V2_0)
+        elif version == "2.4":
+            props.version(ParquetVersion_V2_4)
+        elif version == "2.6":
+            props.version(ParquetVersion_V2_6)
         else:
             raise ValueError("Unsupported Parquet format version: {0}"
                              .format(version))

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -492,16 +492,18 @@ def _sanitize_table(table, new_schema, flavor):
         return table
 
 
-_parquet_writer_arg_docs = """version : {"1.0", "2.0"}, default "1.0"
+_parquet_writer_arg_docs = """version : {"1.0", "2.4", "2.6"}, default "1.0"
     Determine which Parquet logical types are available for use, whether the
     reduced set from the Parquet 1.x.x format or the expanded logical types
-    added in format version 2.0.0 and after. Note that files written with
-    version='2.0' may not be readable in all Parquet implementations, so
-    version='1.0' is likely the choice that maximizes file compatibility. Some
-    features, such as lossless storage of nanosecond timestamps as INT64
-    physical storage, are only available with version='2.0'. The Parquet 2.0.0
-    format version also introduced a new serialized data page format; this can
-    be enabled separately using the data_page_version option.
+    added in later format versions.
+    Files written with version='2.4' or '2.6' may not be readable in all
+    Parquet implementations, so version='1.0' is likely the choice that
+    maximizes file compatibility.
+    Logical types and UINT32 are only available with version '2.4'.
+    Nanosecond timestamps are only available with version '2.6'.
+    Other features such as compression algorithms or the new serialized
+    data page format must be enabled separately (see 'compression' and
+    'data_page_version').
 use_dictionary : bool or list
     Specify if we should use dictionary encoding in general or only for
     some columns.
@@ -511,11 +513,12 @@ use_deprecated_int96_timestamps : bool, default None
 coerce_timestamps : str, default None
     Cast timestamps a particular resolution. The defaults depends on `version`.
     For ``version='1.0'`` (the default), nanoseconds will be cast to
-    microseconds ('us'), and seconds to milliseconds ('ms') by default. For
-    ``version='2.0'``, the original resolution is preserved and no casting
-    is done by default. The casting might result in loss of data, in which
-    case ``allow_truncated_timestamps=True`` can be used to suppress the
-    raised exception.
+    microseconds ('us'), and seconds to milliseconds ('ms') by default.
+    For ``version='2.4'``, nanoseconds will be cast to microseconds.
+    For ``version='2.6'``, the original resolution is always preserved.
+    The casting might result in loss of data, in which case
+    ``allow_truncated_timestamps=True`` can be used to suppress the raised
+    exception.
     Valid values: {None, 'ms', 'us'}
 data_page_size : int, default None
     Set a target threshold for the approximate encoded size of data

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -499,7 +499,7 @@ _parquet_writer_arg_docs = """version : {"1.0", "2.4", "2.6"}, default "1.0"
     Files written with version='2.4' or '2.6' may not be readable in all
     Parquet implementations, so version='1.0' is likely the choice that
     maximizes file compatibility.
-    Logical types and UINT32 are only available with version '2.4'.
+    UINT32 and some logical types are only available with version '2.4'.
     Nanosecond timestamps are only available with version '2.6'.
     Other features such as compression algorithms or the new serialized
     data page format must be enabled separately (see 'compression' and
@@ -511,14 +511,14 @@ use_deprecated_int96_timestamps : bool, default None
     Write timestamps to INT96 Parquet format. Defaults to False unless enabled
     by flavor argument. This take priority over the coerce_timestamps option.
 coerce_timestamps : str, default None
-    Cast timestamps a particular resolution. The defaults depends on `version`.
-    For ``version='1.0'`` (the default), nanoseconds will be cast to
-    microseconds ('us'), and seconds to milliseconds ('ms') by default.
-    For ``version='2.4'``, nanoseconds will be cast to microseconds.
-    For ``version='2.6'``, the original resolution is always preserved.
-    The casting might result in loss of data, in which case
-    ``allow_truncated_timestamps=True`` can be used to suppress the raised
-    exception.
+    Cast timestamps to a particular resolution. If omitted, defaults are chosen
+    depending on `version`. By default, for ``version='1.0'`` (the default)
+    and ``version='2.4'``, nanoseconds are cast to microseconds ('us'), while
+    for other `version` values, they are written natively without loss
+    of resolution.  Seconds are always cast to milliseconds ('ms') by default,
+    as Parquet does not have any temporal type with seconds resolution.
+    If the casting results in loss of data, it will raise an exception
+    unless ``allow_truncated_timestamps=True`` is given.
     Valid values: {None, 'ms', 'us'}
 data_page_size : int, default None
     Set a target threshold for the approximate encoded size of data

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -139,7 +139,7 @@ def make_sample_file(table_or_df):
         a_table = pa.Table.from_pandas(table_or_df)
 
     buf = io.BytesIO()
-    _write_table(a_table, buf, compression='SNAPPY', version='2.0',
+    _write_table(a_table, buf, compression='SNAPPY', version='2.6',
                  coerce_timestamps='ms')
 
     buf.seek(0)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -85,7 +85,7 @@ def test_chunked_table_write(use_legacy_dataset):
         for use_dictionary in [True, False]:
             for table in tables:
                 _check_roundtrip(
-                    table, version='2.0',
+                    table, version='2.6',
                     use_legacy_dataset=use_legacy_dataset,
                     data_page_version=data_page_version,
                     use_dictionary=use_dictionary)
@@ -98,11 +98,11 @@ def test_memory_map(tempdir, use_legacy_dataset):
 
     table = pa.Table.from_pandas(df)
     _check_roundtrip(table, read_table_kwargs={'memory_map': True},
-                     version='2.0', use_legacy_dataset=use_legacy_dataset)
+                     version='2.6', use_legacy_dataset=use_legacy_dataset)
 
     filename = str(tempdir / 'tmp_file')
     with open(filename, 'wb') as f:
-        _write_table(table, f, version='2.0')
+        _write_table(table, f, version='2.6')
     table_read = pq.read_pandas(filename, memory_map=True,
                                 use_legacy_dataset=use_legacy_dataset)
     assert table_read.equals(table)
@@ -115,11 +115,11 @@ def test_enable_buffered_stream(tempdir, use_legacy_dataset):
 
     table = pa.Table.from_pandas(df)
     _check_roundtrip(table, read_table_kwargs={'buffer_size': 1025},
-                     version='2.0', use_legacy_dataset=use_legacy_dataset)
+                     version='2.6', use_legacy_dataset=use_legacy_dataset)
 
     filename = str(tempdir / 'tmp_file')
     with open(filename, 'wb') as f:
-        _write_table(table, f, version='2.0')
+        _write_table(table, f, version='2.6')
     table_read = pq.read_pandas(filename, buffer_size=4096,
                                 use_legacy_dataset=use_legacy_dataset)
     assert table_read.equals(table)
@@ -176,7 +176,7 @@ def test_empty_table_roundtrip(use_legacy_dataset):
     assert table.schema.field('null').type == pa.null()
     assert table.schema.field('null_list').type == pa.list_(pa.null())
     _check_roundtrip(
-        table, version='2.0', use_legacy_dataset=use_legacy_dataset)
+        table, version='2.6', use_legacy_dataset=use_legacy_dataset)
 
 
 @pytest.mark.pandas
@@ -413,7 +413,7 @@ def test_multithreaded_read(use_legacy_dataset):
     table = pa.Table.from_pandas(df)
 
     buf = io.BytesIO()
-    _write_table(table, buf, compression='SNAPPY', version='2.0')
+    _write_table(table, buf, compression='SNAPPY', version='2.6')
 
     buf.seek(0)
     table1 = _read_table(

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -71,7 +71,7 @@ def test_write_compliant_nested_type_enable(tempdir,
     path = str(tempdir / 'data.parquet')
     with pq.ParquetWriter(path, table.schema,
                           use_compliant_nested_type=True,
-                          version='2.0') as writer:
+                          version='2.6') as writer:
         writer.write_table(table)
     # Read back as a table
     new_table = _read_table(path)
@@ -100,7 +100,7 @@ def test_write_compliant_nested_type_disable(tempdir,
     # Write to a parquet file while disabling compliant nested type
     table = pa.Table.from_pandas(df, preserve_index=False)
     path = str(tempdir / 'data.parquet')
-    with pq.ParquetWriter(path, table.schema, version='2.0') as writer:
+    with pq.ParquetWriter(path, table.schema, version='2.6') as writer:
         writer.write_table(table)
     new_table = _read_table(path)
 

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -61,7 +61,7 @@ def test_parquet_2_0_roundtrip(tempdir, chunk_size, use_legacy_dataset):
     arrow_table = pa.Table.from_pandas(df)
     assert arrow_table.schema.pandas_metadata is not None
 
-    _write_table(arrow_table, filename, version="2.0",
+    _write_table(arrow_table, filename, version='2.6',
                  coerce_timestamps='ms', chunk_size=chunk_size)
     table_read = pq.read_pandas(
         filename, use_legacy_dataset=use_legacy_dataset)
@@ -328,7 +328,7 @@ def test_column_of_arrays(tempdir):
 
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df, schema=schema)
-    _write_table(arrow_table, filename, version="2.0", coerce_timestamps='ms')
+    _write_table(arrow_table, filename, version='2.6', coerce_timestamps='ms')
     table_read = _read_table(filename)
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
@@ -340,7 +340,7 @@ def test_column_of_lists(tempdir):
 
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df, schema=schema)
-    _write_table(arrow_table, filename, version='2.0')
+    _write_table(arrow_table, filename, version='2.6')
     table_read = _read_table(filename)
     df_read = table_read.to_pandas()
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -55,7 +55,7 @@ def test_parquet_piece_read(tempdir):
     table = pa.Table.from_pandas(df)
 
     path = tempdir / 'parquet_piece_read.parquet'
-    _write_table(table, path, version='2.0')
+    _write_table(table, path, version='2.6')
 
     with pytest.warns(DeprecationWarning):
         piece1 = pq.ParquetDatasetPiece(path)
@@ -70,7 +70,7 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     table = pa.Table.from_pandas(df)
 
     path = tempdir / 'parquet_piece_read.parquet'
-    _write_table(table, path, version='2.0')
+    _write_table(table, path, version='2.6')
 
     with pytest.warns(DeprecationWarning):
         piece = pq.ParquetDatasetPiece(path)
@@ -997,7 +997,7 @@ def test_dataset_memory_map(tempdir, use_legacy_dataset):
     df = _test_dataframe(10, seed=0)
     path = dirpath / '{}.parquet'.format(0)
     table = pa.Table.from_pandas(df)
-    _write_table(table, path, version='2.0')
+    _write_table(table, path, version='2.6')
 
     dataset = pq.ParquetDataset(
         dirpath, memory_map=True, use_legacy_dataset=use_legacy_dataset)
@@ -1015,7 +1015,7 @@ def test_dataset_enable_buffered_stream(tempdir, use_legacy_dataset):
     df = _test_dataframe(10, seed=0)
     path = dirpath / '{}.parquet'.format(0)
     table = pa.Table.from_pandas(df)
-    _write_table(table, path, version='2.0')
+    _write_table(table, path, version='2.6')
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(
@@ -1038,7 +1038,7 @@ def test_dataset_enable_pre_buffer(tempdir, use_legacy_dataset):
     df = _test_dataframe(10, seed=0)
     path = dirpath / '{}.parquet'.format(0)
     table = pa.Table.from_pandas(df)
-    _write_table(table, path, version='2.0')
+    _write_table(table, path, version='2.6')
 
     for pre_buffer in (True, False):
         dataset = pq.ParquetDataset(

--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -108,7 +108,7 @@ def test_coerce_timestamps(tempdir):
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df, schema=schema)
 
-    _write_table(arrow_table, filename, version="2.0", coerce_timestamps='us')
+    _write_table(arrow_table, filename, version='2.6', coerce_timestamps='us')
     table_read = _read_table(filename)
     df_read = table_read.to_pandas()
 
@@ -120,7 +120,7 @@ def test_coerce_timestamps(tempdir):
     tm.assert_frame_equal(df_expected, df_read)
 
     with pytest.raises(ValueError):
-        _write_table(arrow_table, filename, version='2.0',
+        _write_table(arrow_table, filename, version='2.6',
                      coerce_timestamps='unknown')
 
 
@@ -144,7 +144,7 @@ def test_coerce_timestamps_truncated(tempdir):
     filename = tempdir / 'pandas_truncated.parquet'
     table_us = pa.Table.from_pandas(df_us, schema=schema_us)
 
-    _write_table(table_us, filename, version="2.0", coerce_timestamps='ms',
+    _write_table(table_us, filename, version='2.6', coerce_timestamps='ms',
                  allow_truncated_timestamps=True)
     table_ms = _read_table(filename)
     df_ms = table_ms.to_pandas()
@@ -202,7 +202,7 @@ def test_date_time_types(tempdir):
                                      'time32_from64[s]',
                                      'timestamp[ns]'])
 
-    _check_roundtrip(table, expected=expected, version='2.0')
+    _check_roundtrip(table, expected=expected, version='2.6')
 
     t0 = pa.timestamp('ms')
     data0 = np.arange(4, dtype='int64')
@@ -223,7 +223,7 @@ def test_date_time_types(tempdir):
 
     # int64 for all timestamps supported by default
     filename = tempdir / 'int64_timestamps.parquet'
-    _write_table(table, filename, version='2.0')
+    _write_table(table, filename, version='2.6')
     parquet_schema = pq.ParquetFile(filename).schema
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT64'
@@ -243,7 +243,7 @@ def test_date_time_types(tempdir):
 
     # int96 nanosecond timestamps produced upon request
     filename = tempdir / 'explicit_int96_timestamps.parquet'
-    _write_table(table, filename, version='2.0',
+    _write_table(table, filename, version='2.6',
                  use_deprecated_int96_timestamps=True)
     parquet_schema = pq.ParquetFile(filename).schema
     for i in range(3):
@@ -253,7 +253,7 @@ def test_date_time_types(tempdir):
 
     # int96 nanosecond timestamps implied by flavor 'spark'
     filename = tempdir / 'spark_int96_timestamps.parquet'
-    _write_table(table, filename, version='2.0',
+    _write_table(table, filename, version='2.6',
                  flavor='spark')
     parquet_schema = pq.ParquetFile(filename).schema
     for i in range(3):
@@ -288,7 +288,7 @@ def test_coerce_int96_timestamp_unit(unit):
     _check_roundtrip(table, expected,
                      read_table_kwargs=read_table_kwargs,
                      use_deprecated_int96_timestamps=True)
-    _check_roundtrip(table, expected, version='2.0',
+    _check_roundtrip(table, expected, version='2.6',
                      read_table_kwargs=read_table_kwargs,
                      use_deprecated_int96_timestamps=True)
 
@@ -382,7 +382,7 @@ def test_parquet_version_timestamp_differences():
     # Using Parquet version 2.0, seconds should be coerced to milliseconds
     # and nanoseconds should be retained by default
     expected = pa.Table.from_arrays([a_ms, a_ms, a_us, a_ns], names)
-    _check_roundtrip(table, expected, version='2.0')
+    _check_roundtrip(table, expected, version='2.6')
 
     # Using Parquet version 1.0, coercing to milliseconds or microseconds
     # is allowed
@@ -392,7 +392,7 @@ def test_parquet_version_timestamp_differences():
     # Using Parquet version 2.0, coercing to milliseconds or microseconds
     # is allowed
     expected = pa.Table.from_arrays([a_us, a_us, a_us, a_us], names)
-    _check_roundtrip(table, expected, version='2.0', coerce_timestamps='us')
+    _check_roundtrip(table, expected, version='2.6', coerce_timestamps='us')
 
     # TODO: after pyarrow allows coerce_timestamps='ns', tests like the
     # following should pass ...
@@ -404,14 +404,14 @@ def test_parquet_version_timestamp_differences():
 
     # Using Parquet version 2.0, coercing to nanoseconds is allowed
     # expected = pa.Table.from_arrays([a_ns, a_ns, a_ns, a_ns], names)
-    # _check_roundtrip(table, expected, version='2.0', coerce_timestamps='ns')
+    # _check_roundtrip(table, expected, version='2.6', coerce_timestamps='ns')
 
     # For either Parquet version, coercing to nanoseconds is allowed
     # if Int96 storage is used
     expected = pa.Table.from_arrays([a_ns, a_ns, a_ns, a_ns], names)
     _check_roundtrip(table, expected,
                      use_deprecated_int96_timestamps=True)
-    _check_roundtrip(table, expected, version='2.0',
+    _check_roundtrip(table, expected, version='2.6',
                      use_deprecated_int96_timestamps=True)
 
 
@@ -426,7 +426,7 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
 
     filename = tempdir / 'written.parquet'
     try:
-        pq.write_table(tb, filename, version='2.0')
+        pq.write_table(tb, filename, version='2.6')
     except Exception:
         pass
     assert filename.exists()
@@ -437,4 +437,4 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     # Loss of data through coercion (without explicit override) still an error
     filename = tempdir / 'not_written.parquet'
     with pytest.raises(ValueError):
-        pq.write_table(tb, filename, coerce_timestamps='ms', version='2.0')
+        pq.write_table(tb, filename, coerce_timestamps='ms', version='2.6')

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -57,7 +57,7 @@ def test_pandas_parquet_custom_metadata(tempdir):
     arrow_table = pa.Table.from_pandas(df)
     assert b'pandas' in arrow_table.schema.metadata
 
-    _write_table(arrow_table, filename, version='2.0', coerce_timestamps='ms')
+    _write_table(arrow_table, filename, version='2.6', coerce_timestamps='ms')
 
     metadata = pq.read_metadata(filename).metadata
     assert b'pandas' in metadata
@@ -111,7 +111,7 @@ def test_pandas_parquet_column_multiindex(tempdir, use_legacy_dataset):
     arrow_table = pa.Table.from_pandas(df)
     assert arrow_table.schema.pandas_metadata is not None
 
-    _write_table(arrow_table, filename, version='2.0', coerce_timestamps='ms')
+    _write_table(arrow_table, filename, version='2.6', coerce_timestamps='ms')
 
     table_read = pq.read_pandas(
         filename, use_legacy_dataset=use_legacy_dataset)
@@ -134,7 +134,7 @@ def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(
     # While index_columns should be empty, columns needs to be filled still.
     assert js['columns']
 
-    _write_table(arrow_table, filename, version='2.0', coerce_timestamps='ms')
+    _write_table(arrow_table, filename, version='2.6', coerce_timestamps='ms')
     table_read = pq.read_pandas(
         filename, use_legacy_dataset=use_legacy_dataset)
 
@@ -183,7 +183,7 @@ def test_pandas_parquet_native_file_roundtrip(tempdir, use_legacy_dataset):
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
-    _write_table(arrow_table, imos, version="2.0")
+    _write_table(arrow_table, imos, version='2.6')
     buf = imos.getvalue()
     reader = pa.BufferReader(buf)
     df_read = _read_table(
@@ -197,7 +197,7 @@ def test_read_pandas_column_subset(tempdir, use_legacy_dataset):
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
-    _write_table(arrow_table, imos, version="2.0")
+    _write_table(arrow_table, imos, version='2.6')
     buf = imos.getvalue()
     reader = pa.BufferReader(buf)
     df_read = pq.read_pandas(
@@ -213,7 +213,7 @@ def test_pandas_parquet_empty_roundtrip(tempdir, use_legacy_dataset):
     df = _test_dataframe(0)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
-    _write_table(arrow_table, imos, version="2.0")
+    _write_table(arrow_table, imos, version='2.6')
     buf = imos.getvalue()
     reader = pa.BufferReader(buf)
     df_read = _read_table(
@@ -285,7 +285,7 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
     arrow_table = pa.Table.from_pandas(df)
 
     for use_dictionary in [True, False]:
-        _write_table(arrow_table, filename, version='2.0',
+        _write_table(arrow_table, filename, version='2.6',
                      use_dictionary=use_dictionary)
         table_read = _read_table(
             filename, use_legacy_dataset=use_legacy_dataset)
@@ -293,7 +293,7 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
         tm.assert_frame_equal(df, df_read)
 
     for write_statistics in [True, False]:
-        _write_table(arrow_table, filename, version='2.0',
+        _write_table(arrow_table, filename, version='2.6',
                      write_statistics=write_statistics)
         table_read = _read_table(filename,
                                  use_legacy_dataset=use_legacy_dataset)
@@ -304,7 +304,7 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
         if (compression != 'NONE' and
                 not pa.lib.Codec.is_available(compression)):
             continue
-        _write_table(arrow_table, filename, version='2.0',
+        _write_table(arrow_table, filename, version='2.6',
                      compression=compression)
         table_read = _read_table(
             filename, use_legacy_dataset=use_legacy_dataset)
@@ -524,7 +524,7 @@ def test_pandas_categorical_na_type_row_groups(use_legacy_dataset):
     buf = pa.BufferOutputStream()
 
     # it works
-    pq.write_table(table_cat, buf, version="2.0", chunk_size=10)
+    pq.write_table(table_cat, buf, version='2.6', chunk_size=10)
     result = pq.read_table(
         buf.getvalue(), use_legacy_dataset=use_legacy_dataset)
 

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -47,7 +47,7 @@ def test_pass_separate_metadata():
     a_table = pa.Table.from_pandas(df)
 
     buf = io.BytesIO()
-    _write_table(a_table, buf, compression='snappy', version='2.0')
+    _write_table(a_table, buf, compression='snappy', version='2.6')
 
     buf.seek(0)
     metadata = pq.read_metadata(buf)
@@ -69,7 +69,7 @@ def test_read_single_row_group():
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
 
@@ -90,7 +90,7 @@ def test_read_single_row_group_with_column_subset():
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
     pf = pq.ParquetFile(buf)
@@ -116,7 +116,7 @@ def test_read_multiple_row_groups():
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
 
@@ -136,7 +136,7 @@ def test_read_multiple_row_groups_with_column_subset():
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
     pf = pq.ParquetFile(buf)
@@ -159,7 +159,7 @@ def test_scan_contents():
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
     pf = pq.ParquetFile(buf)
@@ -200,7 +200,7 @@ def test_iter_batches_columns_reader(tempdir, batch_size):
 
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df)
-    _write_table(arrow_table, filename, version="2.0",
+    _write_table(arrow_table, filename, version='2.6',
                  coerce_timestamps='ms', chunk_size=chunk_size)
 
     file_ = pq.ParquetFile(filename)
@@ -224,7 +224,7 @@ def test_iter_batches_reader(tempdir, chunk_size):
     arrow_table = pa.Table.from_pandas(df)
     assert arrow_table.schema.pandas_metadata is not None
 
-    _write_table(arrow_table, filename, version="2.0",
+    _write_table(arrow_table, filename, version='2.6',
                  coerce_timestamps='ms', chunk_size=chunk_size)
 
     file_ = pq.ParquetFile(filename)
@@ -269,7 +269,7 @@ def test_pre_buffer(pre_buffer):
 
     buf = io.BytesIO()
     _write_table(a_table, buf, row_group_size=N / K,
-                 compression='snappy', version='2.0')
+                 compression='snappy', version='2.6')
 
     buf.seek(0)
     pf = pq.ParquetFile(buf, pre_buffer=pre_buffer)

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -48,7 +48,7 @@ def test_parquet_incremental_file_build(tempdir, use_legacy_dataset):
     arrow_table = pa.Table.from_pandas(df, preserve_index=False)
     out = pa.BufferOutputStream()
 
-    writer = pq.ParquetWriter(out, arrow_table.schema, version='2.0')
+    writer = pq.ParquetWriter(out, arrow_table.schema, version='2.6')
 
     frames = []
     for i in range(10):
@@ -84,7 +84,7 @@ def test_validate_schema_write_table(tempdir):
     path = tempdir / 'simple_validate_schema.parquet'
 
     with pq.ParquetWriter(path, simple_schema,
-                          version='2.0',
+                          version='2.6',
                           compression='snappy', flavor='spark') as w:
         with pytest.raises(ValueError):
             w.write_table(simple_table)
@@ -99,7 +99,7 @@ def test_parquet_writer_context_obj(tempdir, use_legacy_dataset):
     arrow_table = pa.Table.from_pandas(df, preserve_index=False)
     out = pa.BufferOutputStream()
 
-    with pq.ParquetWriter(out, arrow_table.schema, version='2.0') as writer:
+    with pq.ParquetWriter(out, arrow_table.schema, version='2.6') as writer:
 
         frames = []
         for i in range(10):
@@ -132,7 +132,7 @@ def test_parquet_writer_context_obj_with_exception(
     try:
         with pq.ParquetWriter(out,
                               arrow_table.schema,
-                              version='2.0') as writer:
+                              version='2.6') as writer:
 
             frames = []
             for i in range(10):
@@ -165,7 +165,7 @@ def test_parquet_writer_filesystem_local(tempdir, filesystem):
     path = str(tempdir / 'data.parquet')
 
     with pq.ParquetWriter(
-        path, table.schema, filesystem=filesystem, version='2.0'
+        path, table.schema, filesystem=filesystem, version='2.6'
     ) as writer:
         writer.write_table(table)
 
@@ -182,7 +182,7 @@ def test_parquet_writer_filesystem_s3(s3_example_fs):
     fs, uri, path = s3_example_fs
 
     with pq.ParquetWriter(
-        path, table.schema, filesystem=fs, version='2.0'
+        path, table.schema, filesystem=fs, version='2.6'
     ) as writer:
         writer.write_table(table)
 
@@ -198,7 +198,7 @@ def test_parquet_writer_filesystem_s3_uri(s3_example_fs):
 
     fs, uri, path = s3_example_fs
 
-    with pq.ParquetWriter(uri, table.schema, version='2.0') as writer:
+    with pq.ParquetWriter(uri, table.schema, version='2.6') as writer:
         writer.write_table(table)
 
     result = _read_table(path, filesystem=fs).to_pandas()
@@ -215,7 +215,7 @@ def test_parquet_writer_filesystem_s3fs(s3_example_s3fs):
     path = directory + "/test.parquet"
 
     with pq.ParquetWriter(
-        path, table.schema, filesystem=fs, version='2.0'
+        path, table.schema, filesystem=fs, version='2.6'
     ) as writer:
         writer.write_table(table)
 
@@ -256,7 +256,7 @@ def test_parquet_writer_with_caller_provided_filesystem(use_legacy_dataset):
     df = _test_dataframe(100)
     table = pa.Table.from_pandas(df, preserve_index=False)
 
-    with pq.ParquetWriter(fname, table.schema, filesystem=fs, version='2.0') \
+    with pq.ParquetWriter(fname, table.schema, filesystem=fs, version='2.6') \
             as writer:
         writer.write_table(table)
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3500,13 +3500,14 @@ def test_write_dataset_parquet(tempdir):
     assert result.equals(table)
 
     # using custom options
-    for version in ["1.0", "2.0"]:
+    for version in ["1.0", "2.4", "2.6"]:
         format = ds.ParquetFileFormat()
         opts = format.make_write_options(version=version)
         base_dir = tempdir / 'parquet_dataset_version{0}'.format(version)
         ds.write_dataset(table, base_dir, format=format, file_options=opts)
         meta = pq.read_metadata(base_dir / "part-0.parquet")
-        assert meta.format_version == version
+        expected_version = "1.0" if version == "1.0" else "2.6"
+        assert meta.format_version == expected_version
 
 
 def test_write_dataset_csv(tempdir):


### PR DESCRIPTION
Introduce PARQUET_VERSION_2_4 and PARQUET_VERSION_2_6 which allow fine-grained selection of post-1.0 Parquet format features.