### PR TITLE
ARROW-13699: [Python][Docs] Improve filesystem documentation

### DIFF
--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -147,6 +147,8 @@ Example how to write to disk and read it back::
 S3
 --
 
+PyArrow implements natively a S3 filesystem for S3 compatible storage.
+
 The :class:`S3FileSystem` constructor has several options to configure the S3
 connection (e.g. credentials, the region, an endpoint override, etc). In
 addition, the constructor will also inspect configured S3 credentials as

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -183,8 +183,10 @@ Example how you can read contents from a S3 bucket::
    for the different ways to configure the AWS credentials.
 
 
-Hadoop File System (HDFS)
--------------------------
+.. _filesystem-hdfs:
+
+Hadoop Distributed File System (HDFS)
+-------------------------------------
 
 PyArrow comes with bindings to the Hadoop File System (based on C++ bindings
 using ``libhdfs``, a JNI-based interface to the Java Hadoop client). You connect

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -44,8 +44,14 @@ Pyarrow implements natively the following filesystem subclasses:
 
 It is also possible to use your own fsspec-compliant filesystem with pyarrow functionalities as described in the section :ref:`filesystem-fsspec`.
 
+
+.. _filesystem-usage:
+
 Usage
 -----
+
+Instantiating a filesystem
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A FileSystem object can be created with one of the constructors (and check the
 respective constructor for its options)::

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -35,10 +35,14 @@ underlying storage, are automatically dereferenced.  Only basic
 and modification time, is made available.
 
 The core interface is represented by the base class :class:`FileSystem`.
-Concrete subclasses are available for various kinds of storage, such as local
-filesystem access (:class:`LocalFileSystem`), HDFS (:class:`HadoopFileSystem`)
-and Amazon S3-compatible storage (:class:`S3FileSystem`).
 
+Pyarrow implements natively the following filesystem subclasses:
+
+* :ref:`filesystem-localfs` (:class:`LocalFileSystem`)
+* :ref:`filesystem-s3` (:class:`S3FileSystem`)
+* :ref:`filesystem-hdfs` (:class:`HadoopFileSystem`)
+
+It is also possible to use your own fsspec-compliant filesystem with pyarrow functionalities as described in the section :ref:`filesystem-fsspec`.
 
 Usage
 -----

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -240,6 +240,16 @@ For example::
    import pyarrow.dataset as ds
    ds.dataset("data/", filesystem=fs)
 
+::
+
+   # Similarly for Azure Blob Storage
+   import adlfs
+   # ... load your credentials and configure the filesystem
+   fs = adlfs.AzureBlobFileSystem(account_name=account_name, account_key=account_key)
+
+   import pyarrow.dataset as ds
+   ds.dataset("data/", filesystem=fs)
+
 Under the hood, the fsspec filesystem object is wrapped into a python-based
 PyArrow filesystem (:class:`PyFileSystem`) using :class:`FSSpecHandler`.
 You can also manually do this to get an object with the PyArrow FileSystem

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -76,6 +76,8 @@ the filesystem) or an explicit ``filesystem`` argument to specify the filesystem
 to read or write from. For example, the :meth:`pyarrow.parquet.read_table`
 function can be used in the following ways::
 
+   import pyarrow.parquet as pq
+
    # using a URI -> filesystem is inferred
    pq.read_table("s3://my-bucket/data.parquet")
    # using a path and filesystem
@@ -85,6 +87,8 @@ function can be used in the following ways::
 The filesystem interface further allows to open files for reading (input) or
 writing (output) directly, which can be combined with functions that work with
 file-like objects. For example::
+
+   import pyarrow as pa
 
    local = fs.LocalFileSystem()
 

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -122,6 +122,28 @@ paths)::
    >>> local.get_file_info('non_existent')
    <FileInfo for 'non_existent': type=FileType.NotFound>
 
+
+.. _filesystem-localfs:
+
+Local FS
+--------
+
+The :class:`LocalFileSystem` allows you to access files on the local machine.
+
+Example how to write to disk and read it back::
+
+   >>> from pyarrow import fs
+   >>> local = fs.LocalFileSystem()
+   >>> with local.open_output_stream('/tmp/pyarrowtest.dat') as stream:
+           stream.write(b'data')
+   4
+   >>> with local.open_input_stream('/tmp/pyarrowtest.dat') as stream:
+           print(stream.readall())
+   b'data'
+
+
+.. _filesystem-s3:
+
 S3
 --
 

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -239,10 +239,9 @@ For example::
    # using this to read a partitioned dataset
    import pyarrow.dataset as ds
    ds.dataset("data/", filesystem=fs)
+   
+Similarly for Azure Blob Storage::
 
-::
-
-   # Similarly for Azure Blob Storage
    import adlfs
    # ... load your credentials and configure the filesystem
    fs = adlfs.AzureBlobFileSystem(account_name=account_name, account_key=account_key)

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -257,3 +257,17 @@ interface::
 
    from pyarrow.fs import PyFileSystem, FSSpecHandler
    pa_fs = PyFileSystem(FSSpecHandler(fs))
+
+Then all the functionalities of :class:`FileSystem` are accessible::
+
+   # write data
+   with pa_fs.open_output_stream('mycontainer/pyarrowtest.dat') as stream:
+      stream.write(b'data')
+
+   # read data
+   with pa_fs.open_input_stream('mycontainer/pyarrowtest.dat') as stream:
+      print(stream.readall())
+   #b'data'
+
+   # read a partitioned dataset
+   ds.dataset("data/", filesystem=pa_fs)

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -248,7 +248,7 @@ For example::
    fs = adlfs.AzureBlobFileSystem(account_name=account_name, account_key=account_key)
 
    import pyarrow.dataset as ds
-   ds.dataset("data/", filesystem=fs)
+   ds.dataset("mycontainer/data/", filesystem=fs)
 
 Under the hood, the fsspec filesystem object is wrapped into a python-based
 PyArrow filesystem (:class:`PyFileSystem`) using :class:`FSSpecHandler`.


### PR DESCRIPTION
Following https://issues.apache.org/jira/browse/ARROW-13699
Here are small improvement proposals for the python filesystem docs.

The goal is to make it more explicit what filesystem comes natively with PyArrow and what falls under fsspec third party libraries.

- Added sections for each native PyArrow filesystem
- Extended the fsspec section with additional code examples
