### PR TITLE
ARROW-13823 [Java]: Exclude .factorypath

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -2,6 +2,7 @@
 .buildpath
 .classpath
 .checkstyle
+.factorypath
 .settings/
 .idea/
 TAGS

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -128,6 +128,7 @@
             <exclude>**/TAGS</exclude>
             <exclude>**/*.checkstyle</exclude>
             <exclude>**/.classpath</exclude>
+            <exclude>**/.factorypath</exclude>
             <exclude>**/.settings/**</exclude>
             <exclude>.*/**</exclude>
             <exclude>**/*.patch</exclude>


### PR DESCRIPTION
Exclude .factorypath files generated by Eclipse IDE for configuring
annotation processing from Git commit and RAT plugin scans.