### PR TITLE
ARROW-13810: [C++][Compute] Predicate IsAsciiCharacter allows invalid types and values

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -73,9 +73,7 @@ Status RegexStatus(const RE2& regex) {
 
 // IsAlpha/Digit etc
 
-static inline bool IsAsciiCharacter(uint8_t character) {
-  return character < 128;
-}
+static inline bool IsAsciiCharacter(uint8_t character) { return character < 128; }
 
 static inline bool IsLowerCaseCharacterAscii(uint8_t ascii_character) {
   return (ascii_character >= 'a') && (ascii_character <= 'z');
@@ -1745,8 +1743,7 @@ struct IsNumericUnicode : CharacterPredicateUnicode<IsNumericUnicode> {
 struct IsAscii {
   static bool Call(KernelContext*, const uint8_t* input,
                    size_t input_string_nascii_characters, Status*) {
-    return std::all_of(input, input + input_string_nascii_characters,
-                       IsAsciiCharacter);
+    return std::all_of(input, input + input_string_nascii_characters, IsAsciiCharacter);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -73,8 +73,7 @@ Status RegexStatus(const RE2& regex) {
 
 // IsAlpha/Digit etc
 
-template <typename T>
-static inline bool IsAsciiCharacter(T character) {
+static inline bool IsAsciiCharacter(uint8_t character) {
   return character < 128;
 }
 
@@ -1747,7 +1746,7 @@ struct IsAscii {
   static bool Call(KernelContext*, const uint8_t* input,
                    size_t input_string_nascii_characters, Status*) {
     return std::all_of(input, input + input_string_nascii_characters,
-                       IsAsciiCharacter<uint8_t>);
+                       IsAsciiCharacter);
   }
 };
 


### PR DESCRIPTION
Remove template from string predicate IsAsciiCharacter to prevent returning true for invalid types and values.