### PR TITLE
ARROW-13839: [R] Don't automatically set DuckDB connections to maximum parallelism

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -82,8 +82,6 @@ arrow_duck_connection <- function() {
   con <- getOption("arrow_duck_con")
   if (is.null(con) || !DBI::dbIsValid(con)) {
     con <- DBI::dbConnect(duckdb::duckdb())
-    # Use the same CPU count that the arrow library is set to
-    DBI::dbExecute(con, paste0("PRAGMA threads=", cpu_count()))
     options(arrow_duck_con = con)
   }
   con


### PR DESCRIPTION
We've experienced a number of hangs when using our DuckDB-Arrow integration. This is to test the theory that we're getting these hangs because we're using parallelism in both DuckDB and Arrow's scanning. This PR disables setting DuckDB's parallelism.

Using the taxi parquet dataset, the following query will hang some proportion of the time:
```
library(arrow)
library(dplyr)

ds <- open_dataset("~/repos/ab_store/data/taxi_parquet/", partitioning = c("year", "month"))

ds %>%
    filter(total_amount > 100, year == 2015) %>%
    select(tip_amount, total_amount, passenger_count) %>%
    mutate(tip_pct = 100 * tip_amount / total_amount) %>%
    to_duckdb() %>%
    group_by(passenger_count) %>%
    summarise(
        mean_tip_pct = mean(tip_pct, na.rm = TRUE),
        n = n()
    ) %>% 
    collect()
```

But with this PR, we do not get that same hanging behavior.