### PR TITLE
ARROW-13785: [C++] Add methods to print exec nodes/plans

### DIFF
--- a/cpp/examples/arrow/compute_register_example.cc
+++ b/cpp/examples/arrow/compute_register_example.cc
@@ -85,7 +85,7 @@ class ExampleNode : public cp::ExecNode {
                  /*input_labels=*/{"ignored"},
                  /*output_schema=*/input->output_schema(), /*num_outputs=*/1) {}
 
-  const char* kind_name() override { return "ExampleNode"; }
+  const char* kind_name() const override { return "ExampleNode"; }
 
   arrow::Status StartProducing() override {
     outputs_[0]->InputFinished(this, 0);

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -18,6 +18,7 @@
 #include "arrow/compute/exec/exec_plan.h"
 
 #include <mutex>
+#include <sstream>
 #include <thread>
 #include <unordered_map>
 
@@ -92,14 +93,18 @@ class ScalarAggregateNode : public ExecNode {
   ScalarAggregateNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
                       std::shared_ptr<Schema> output_schema,
                       std::vector<int> target_field_ids,
+                      std::vector<internal::Aggregate> aggs,
                       std::vector<const ScalarAggregateKernel*> kernels,
-                      std::vector<std::vector<std::unique_ptr<KernelState>>> states)
+                      std::vector<std::vector<std::unique_ptr<KernelState>>> states,
+                      std::vector<std::unique_ptr<FunctionOptions>> owned_options)
       : ExecNode(plan, std::move(inputs), {"target"},
                  /*output_schema=*/std::move(output_schema),
                  /*num_outputs=*/1),
         target_field_ids_(std::move(target_field_ids)),
+        aggs_(std::move(aggs)),
         kernels_(std::move(kernels)),
-        states_(std::move(states)) {}
+        states_(std::move(states)),
+        owned_options_(std::move(owned_options)) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -116,6 +121,7 @@ class ScalarAggregateNode : public ExecNode {
     FieldVector fields(kernels.size());
     const auto& field_names = aggregate_options.names;
     std::vector<int> target_field_ids(kernels.size());
+    std::vector<std::unique_ptr<FunctionOptions>> owned_options(aggregates.size());
 
     for (size_t i = 0; i < kernels.size(); ++i) {
       ARROW_ASSIGN_OR_RAISE(auto match,
@@ -138,6 +144,10 @@ class ScalarAggregateNode : public ExecNode {
       if (aggregates[i].options == nullptr) {
         aggregates[i].options = function->default_options();
       }
+      if (aggregates[i].options) {
+        owned_options[i] = aggregates[i].options->Copy();
+        aggregates[i].options = owned_options[i].get();
+      }
 
       KernelContext kernel_ctx{exec_ctx};
       states[i].resize(ThreadIndexer::Capacity());
@@ -159,10 +169,11 @@ class ScalarAggregateNode : public ExecNode {
 
     return plan->EmplaceNode<ScalarAggregateNode>(
         plan, std::move(inputs), schema(std::move(fields)), std::move(target_field_ids),
-        std::move(kernels), std::move(states));
+        std::move(aggregates), std::move(kernels), std::move(states),
+        std::move(owned_options));
   }
 
-  const char* kind_name() override { return "ScalarAggregateNode"; }
+  const char* kind_name() const override { return "ScalarAggregateNode"; }
 
   Status DoConsume(const ExecBatch& batch, size_t thread_index) {
     for (size_t i = 0; i < kernels_.size(); ++i) {
@@ -225,6 +236,23 @@ class ScalarAggregateNode : public ExecNode {
 
   Future<> finished() override { return finished_; }
 
+ protected:
+  std::string ToStringExtra() const override {
+    std::stringstream ss;
+    const auto input_schema = inputs_[0]->output_schema();
+    ss << "aggregates=[" << std::endl;
+    for (size_t i = 0; i < aggs_.size(); i++) {
+      ss << '\t' << aggs_[i].function << '('
+         << input_schema->field(target_field_ids_[i])->name();
+      if (owned_options_[i]) {
+        ss << ", " << owned_options_[i]->ToString();
+      }
+      ss << ")," << std::endl;
+    }
+    ss << ']';
+    return ss.str();
+  }
+
  private:
   Status Finish() {
     ExecBatch batch{{}, 1};
@@ -244,9 +272,11 @@ class ScalarAggregateNode : public ExecNode {
 
   Future<> finished_ = Future<>::MakeFinished();
   const std::vector<int> target_field_ids_;
+  const std::vector<internal::Aggregate> aggs_;
   const std::vector<const ScalarAggregateKernel*> kernels_;
 
   std::vector<std::vector<std::unique_ptr<KernelState>>> states_;
+  const std::vector<std::unique_ptr<FunctionOptions>> owned_options_;
 
   ThreadIndexer get_thread_index_;
   AtomicCounter input_counter_;
@@ -345,7 +375,7 @@ class GroupByNode : public ExecNode {
         std::move(owned_options));
   }
 
-  const char* kind_name() override { return "GroupByNode"; }
+  const char* kind_name() const override { return "GroupByNode"; }
 
   Status Consume(ExecBatch batch) {
     size_t thread_index = get_thread_index_();
@@ -526,6 +556,28 @@ class GroupByNode : public ExecNode {
   void StopProducing() override { StopProducing(outputs_[0]); }
 
   Future<> finished() override { return finished_; }
+
+ protected:
+  std::string ToStringExtra() const override {
+    std::stringstream ss;
+    const auto input_schema = inputs_[0]->output_schema();
+    ss << "keys=[";
+    for (size_t i = 0; i < key_field_ids_.size(); i++) {
+      if (i > 0) ss << ", ";
+      ss << '"' << input_schema->field(key_field_ids_[i])->name() << '"';
+    }
+    ss << "], aggregates=[" << std::endl;
+    for (size_t i = 0; i < aggs_.size(); i++) {
+      ss << '\t' << aggs_[i].function << '('
+         << input_schema->field(agg_src_field_ids_[i])->name();
+      if (owned_options_[i]) {
+        ss << ", " << owned_options_[i]->ToString();
+      }
+      ss << ")," << std::endl;
+    }
+    ss << ']';
+    return ss.str();
+  }
 
  private:
   struct ThreadLocalState {

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -76,6 +76,8 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
   /// \brief A future which will be marked finished when all nodes have stopped producing.
   Future<> finished();
 
+  std::string ToString() const;
+
  protected:
   ExecContext* exec_context_;
   explicit ExecPlan(ExecContext* exec_context) : exec_context_(exec_context) {}
@@ -87,7 +89,7 @@ class ARROW_EXPORT ExecNode {
 
   virtual ~ExecNode() = default;
 
-  virtual const char* kind_name() = 0;
+  virtual const char* kind_name() const = 0;
 
   // The number of inputs/outputs expected by this node
   int num_inputs() const { return static_cast<int>(inputs_.size()); }
@@ -217,6 +219,8 @@ class ARROW_EXPORT ExecNode {
   /// \brief A future which will be marked finished when this node has stopped producing.
   virtual Future<> finished() = 0;
 
+  std::string ToString() const;
+
  protected:
   ExecNode(ExecPlan* plan, NodeVector inputs, std::vector<std::string> input_labels,
            std::shared_ptr<Schema> output_schema, int num_outputs);
@@ -224,6 +228,9 @@ class ARROW_EXPORT ExecNode {
   // A helper method to send an error status to all outputs.
   // Returns true if the status was an error.
   bool ErrorIfNotOk(Status status);
+
+  /// Provide extra info to include in the string representation.
+  virtual std::string ToStringExtra() const;
 
   ExecPlan* plan_;
   std::string label_;

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -66,7 +66,7 @@ class FilterNode : public ExecNode {
                                          std::move(filter_expression));
   }
 
-  const char* kind_name() override { return "FilterNode"; }
+  const char* kind_name() const override { return "FilterNode"; }
 
   Result<ExecBatch> DoFilter(const ExecBatch& target) {
     ARROW_ASSIGN_OR_RAISE(Expression simplified_filter,
@@ -130,6 +130,9 @@ class FilterNode : public ExecNode {
   void StopProducing() override { inputs_[0]->StopProducing(this); }
 
   Future<> finished() override { return inputs_[0]->finished(); }
+
+ protected:
+  std::string ToStringExtra() const override { return "filter=" + filter_.ToString(); }
 
  private:
   Expression filter_;

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -128,7 +128,7 @@ class ProjectNode : public ExecNode {
   std::string ToStringExtra() const override {
     std::stringstream ss;
     ss << "projection=[";
-    for (int64_t i = 0; static_cast<size_t>(i) < exprs_.size(); i++) {
+    for (int i = 0; static_cast<size_t>(i) < exprs_.size(); i++) {
       if (i > 0) ss << ", ";
       auto repr = exprs_[i].ToString();
       if (repr != output_schema_->field(i)->name()) {

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -128,7 +128,7 @@ class ProjectNode : public ExecNode {
   std::string ToStringExtra() const override {
     std::stringstream ss;
     ss << "projection=[";
-    for (size_t i = 0; i < exprs_.size(); i++) {
+    for (int64_t i = 0; static_cast<size_t>(i) < exprs_.size(); i++) {
       if (i > 0) ss << ", ";
       auto repr = exprs_[i].ToString();
       if (repr != output_schema_->field(i)->name()) {

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -17,6 +17,8 @@
 
 #include "arrow/compute/exec/exec_plan.h"
 
+#include <sstream>
+
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/exec/expression.h"
@@ -73,7 +75,7 @@ class ProjectNode : public ExecNode {
                                           schema(std::move(fields)), std::move(exprs));
   }
 
-  const char* kind_name() override { return "ProjectNode"; }
+  const char* kind_name() const override { return "ProjectNode"; }
 
   Result<ExecBatch> DoProject(const ExecBatch& target) {
     std::vector<Datum> values{exprs_.size()};
@@ -121,6 +123,22 @@ class ProjectNode : public ExecNode {
   void StopProducing() override { inputs_[0]->StopProducing(this); }
 
   Future<> finished() override { return inputs_[0]->finished(); }
+
+ protected:
+  std::string ToStringExtra() const override {
+    std::stringstream ss;
+    ss << "projection=[";
+    for (size_t i = 0; i < exprs_.size(); i++) {
+      if (i > 0) ss << ", ";
+      auto repr = exprs_[i].ToString();
+      if (repr != output_schema_->field(i)->name()) {
+        ss << '"' << output_schema_->field(i)->name() << "\": ";
+      }
+      ss << repr;
+    }
+    ss << ']';
+    return ss.str();
+  }
 
  private:
   std::vector<Expression> exprs_;

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -83,7 +83,7 @@ class SinkNode : public ExecNode {
     return out;
   }
 
-  const char* kind_name() override { return "SinkNode"; }
+  const char* kind_name() const override { return "SinkNode"; }
 
   Status StartProducing() override {
     finished_ = Future<>::Make();
@@ -153,7 +153,7 @@ struct OrderBySinkNode final : public SinkNode {
       : SinkNode(plan, std::move(inputs), generator),
         sort_options_(std::move(sort_options)) {}
 
-  const char* kind_name() override { return "OrderBySinkNode"; }
+  const char* kind_name() const override { return "OrderBySinkNode"; }
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -212,6 +212,9 @@ struct OrderBySinkNode final : public SinkNode {
     }
     SinkNode::Finish();
   }
+
+ protected:
+  std::string ToStringExtra() const override { return "by=" + sort_options_.ToString(); }
 
  private:
   SortOptions sort_options_;

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -56,7 +56,7 @@ struct SourceNode : ExecNode {
                                          source_options.generator);
   }
 
-  const char* kind_name() override { return "SourceNode"; }
+  const char* kind_name() const override { return "SourceNode"; }
 
   [[noreturn]] static void NoInputs() {
     Unreachable("no inputs; this should never be called");

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -62,7 +62,7 @@ struct DummyNode : ExecNode {
     }
   }
 
-  const char* kind_name() override { return "Dummy"; }
+  const char* kind_name() const override { return "Dummy"; }
 
   void InputReceived(ExecNode* input, ExecBatch batch) override {}
 

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -54,7 +54,7 @@ class UnionNode : public ExecNode {
     ARROW_DCHECK(counter_completed == false);
   }
 
-  const char* kind_name() override { return "UnionNode"; }
+  const char* kind_name() const override { return "UnionNode"; }
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {


### PR DESCRIPTION
Example output:

```
ExecPlan with 6 nodes:
SourceNode{"source", outputs=["filter"]}
FilterNode{"filter", inputs=[target: "source"], outputs=["project"], filter=(i32 >= 0)}
ProjectNode{"project", inputs=[target: "filter"], outputs=["aggregate"], projection=[bool, multiply(i32, 2)]}
GroupByNode{"aggregate", inputs=[groupby: "project"], outputs=["filter"], keys=["bool"], aggregates=[
	hash_sum(multiply(i32, 2)),
	hash_count(multiply(i32, 2), {mode=NON_NULL}),
]}
FilterNode{"filter", inputs=[target: "aggregate"], outputs=["order_by_sink"], filter=(sum(multiply(i32, 2)) > 10)}
OrderBySinkNode{"order_by_sink", inputs=[collected: "filter"], by={sort_keys=[sum(multiply(i32, 2)) ASC]}}
```

This prints nodes in the order of the topological sort. Since this is a graph and not necessarily a tree, I didn't try to indent the nodes themselves or anything.