### PR TITLE
ARROW-13859: [Java] Add code coverage support

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -93,17 +93,4 @@
 
     </dependencies>
 
-    <build>	
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <user.timezone>UTC</user.timezone>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -109,16 +109,5 @@
                 </includes>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <user.timezone>UTC</user.timezone>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/java/memory/memory-core/pom.xml
+++ b/java/memory/memory-core/pom.xml
@@ -37,22 +37,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        <configuration>
-          <enableAssertions>true</enableAssertions>
-          <childDelegation>true</childDelegation>
-          <forkCount>${forkCount}</forkCount>
-          <reuseForks>true</reuseForks>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-            <user.timezone>UTC</user.timezone>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/java/memory/memory-netty/pom.xml
+++ b/java/memory/memory-netty/pom.xml
@@ -45,27 +45,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        <configuration>
-          <enableAssertions>true</enableAssertions>
-          <childDelegation>true</childDelegation>
-          <forkCount>${forkCount}</forkCount>
-          <reuseForks>true</reuseForks>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-            <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
-            <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
-            <user.timezone>UTC</user.timezone>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <!-- This profile turns on integration testing. It activates the failsafe plugin and will run any tests
@@ -77,14 +56,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-                <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
-                <user.timezone>UTC</user.timezone>
-              </systemPropertyVariables>
-              <argLine />
-            </configuration>
             <executions>
               <execution>
                 <goals>

--- a/java/memory/memory-unsafe/pom.xml
+++ b/java/memory/memory-unsafe/pom.xml
@@ -30,23 +30,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        <configuration>
-          <enableAssertions>true</enableAssertions>
-          <childDelegation>true</childDelegation>
-          <forkCount>${forkCount}</forkCount>
-          <reuseForks>true</reuseForks>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-            <user.timezone>UTC</user.timezone>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
   <url>https://arrow.apache.org/</url>
 
   <properties>
-    <target.gen.source.path>${project.basedir}/target/generated-sources</target.gen.source.path>
+    <target.gen.source.path>${project.build.directory}/generated-sources</target.gen.source.path>
     <dep.junit.platform.version>1.4.0</dep.junit.platform.version>
     <dep.junit.jupiter.version>5.4.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
@@ -394,13 +394,28 @@
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
               <user.timezone>UTC</user.timezone>
+              <!-- Note: changing the below configuration might increase the max allocation size for a vector
+              which in turn can cause OOM. -->
+              <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
             </systemPropertyVariables>
-            <!-- Note: changing the below configuration might increase the max allocation size for a vector
-            which in turn can cause OOM. -->
-            <argLine>-Darrow.vector.max_allocation_bytes=1048576</argLine>
           </configuration>
         </plugin>
-
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M3</version>
+          <configuration>
+            <systemPropertyVariables>
+              <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+              <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
+              <user.timezone>UTC</user.timezone>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.7</version>
+        </plugin>
 
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
@@ -757,6 +772,57 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>code-coverage</id>
+      <!--
+        Use `mvn -Pcode-coverage install site` to capture and generate the code coverage report
+        Alternatively, if you do not want to generate the full set of reports, use:
+        `mvn -Pcode-coverage install org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-integration`
+
+        Add `-Pintegration-tests` to the previous commandline to also capture integration tests coverage
+      -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-prepare-agent-integration</id>
+                <goals>
+                  <goal>prepare-agent-integration</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.7</version>
+            <reportSets>
+              <reportSet>
+                <inherited>false</inherited><!-- don't run aggregate in child modules -->
+                <reports>
+                  <!-- select non-aggregate reports -->
+                  <report>report</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
 
   </profiles>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -105,20 +105,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <enableAssertions>true</enableAssertions>
-          <childDelegation>true</childDelegation>
-          <forkCount>${forkCount}</forkCount>
-          <reuseForks>true</reuseForks>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-            <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
-            <user.timezone>UTC</user.timezone>
-          </systemPropertyVariables>
-          <!-- Note: changing the below configuration might increase the max allocation size for a vector
-          which in turn can cause OOM. -->
-          <argLine>-Darrow.vector.max_allocation_bytes=1048576</argLine>
-        </configuration>
         <executions>
           <execution>
             <id>default-test</id>
@@ -139,6 +125,7 @@
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>org.apache.arrow:arrow-memory-netty</classpathDependencyExclude>
               </classpathDependencyExcludes>
+              <reportNameSuffix>netty</reportNameSuffix>
             </configuration>
           </execution>
         </executions>
@@ -267,12 +254,8 @@
             <configuration>
               <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
               <systemPropertyVariables>
-                <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-                <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
                 <arrow.memory.debug.allocator>false</arrow.memory.debug.allocator>
-                <user.timezone>UTC</user.timezone>
               </systemPropertyVariables>
-              <argLine />
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Add optional code coverage support to the Maven build configuration
using the JaCoCo plugin.

Code coverage reporting is enabled when using the `code-coverage`
profile.