### PR TITLE
ARROW-13803: [C++] Don't read past end of buffer in BitUtil::SetBitmap

### DIFF
--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -111,8 +111,10 @@ void SetBitmapImpl(uint8_t* data, int64_t offset, int64_t length) {
 
   // clean up
   DCHECK_LT(length, 8);
-  data[offset / 8] =
-      BitUtil::SpliceWord(static_cast<int32_t>(length), set_byte, data[offset / 8]);
+  if (length > 0) {
+    data[offset / 8] =
+        BitUtil::SpliceWord(static_cast<int32_t>(length), set_byte, data[offset / 8]);
+  }
 }
 
 void SetBitmap(uint8_t* data, int64_t offset, int64_t length) {

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1569,6 +1569,12 @@ TEST(BitUtilTests, TestSetBitmap) {
       uint8_t false_byte = static_cast<uint8_t>(0);
       ASSERT_BYTES_EQ(bitmap, {false_byte, false_byte, false_byte, fill_byte});
     }
+    {
+      // ASAN test against out of bound access (ARROW-13803)
+      uint8_t bitmap[1] = {fill_byte};
+      BitUtil::ClearBitmap(bitmap, 0, 8);
+      ASSERT_EQ(bitmap[0], 0);
+    }
   }
 }
 


### PR DESCRIPTION
I can only get this to actually fail on M1 ARM with optimizations, but what happens here is we read one past the end of a buffer. On M1, this actually ends up in an unmapped region, crashing the program.

On Linux/x64, I tried AddressSanitizer and Valgrind but neither caught the access, oddly enough.