### PR TITLE
ARROW-13872: [Java] ExtensionTypeVector does not work with RangeEqualsVisitor

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -261,6 +261,6 @@ public abstract class ExtensionTypeVector<T extends ValueVector & FieldVector> e
 
   @Override
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
-    return getUnderlyingVector().accept(visitor, value);
+    return visitor.visit(this, value);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -217,7 +217,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
 
   @Override
   public Boolean visit(ExtensionTypeVector<?> left, Range range) {
-    if (!validate(left) || !(right instanceof ExtensionTypeVector<?>)) {
+    if (!(right instanceof ExtensionTypeVector<?>) || !validate(left)) {
       return false;
     }
     ValueVector rightUnderlying = ((ExtensionTypeVector<?>) right).getUnderlyingVector();

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -27,6 +27,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -212,6 +213,18 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       return false;
     }
     return true;
+  }
+
+  @Override
+  public Boolean visit(ExtensionTypeVector<?> left, Range range) {
+    if (!validate(left) || !(right instanceof ExtensionTypeVector<?>)) {
+      return false;
+    }
+    ValueVector rightUnderlying = ((ExtensionTypeVector<?>) right).getUnderlyingVector();
+    TypeEqualsVisitor typeVisitor = new TypeEqualsVisitor(rightUnderlying);
+    RangeEqualsVisitor underlyingVisitor =
+            createInnerVisitor(left.getUnderlyingVector(), rightUnderlying, (l, r) -> typeVisitor.equals(l));
+    return underlyingVisitor.rangeEquals(range);
   }
 
   protected RangeEqualsVisitor createInnerVisitor(

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
@@ -116,6 +117,11 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
 
   @Override
   public Boolean visit(NullVector left, Void value) {
+    return compareField(left.getField(), right.getField());
+  }
+
+  @Override
+  public Boolean visit(ExtensionTypeVector<?> left, Void value) {
     return compareField(left.getField(), right.getField());
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector.compare;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
@@ -54,5 +55,7 @@ public interface VectorVisitor<OUT, IN> {
   OUT visit(DenseUnionVector left, IN value);
 
   OUT visit(NullVector left, IN value);
+
+  OUT visit(ExtensionTypeVector<?> left, IN value);
 }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -26,6 +26,7 @@ import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BitVectorHelper;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.TypeEqualsVisitor;
@@ -528,6 +529,14 @@ class VectorAppender implements VectorVisitor<ValueVector, Void> {
   public ValueVector visit(NullVector deltaVector, Void value) {
     Preconditions.checkArgument(targetVector.getField().getType().equals(deltaVector.getField().getType()),
             "The targetVector to append must have the same type as the targetVector being appended");
+    return targetVector;
+  }
+
+  @Override
+  public ValueVector visit(ExtensionTypeVector<?> deltaVector, Void value) {
+    ValueVector targetUnderlying = ((ExtensionTypeVector<?>) targetVector).getUnderlyingVector();
+    VectorAppender underlyingAppender = new VectorAppender(targetUnderlying);
+    deltaVector.getUnderlyingVector().accept(underlyingAppender, null);
     return targetVector;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -24,6 +24,7 @@ import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.TypeLayout;
@@ -234,6 +235,12 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
 
   @Override
   public Void visit(NullVector vector, Void value) {
+    return null;
+  }
+
+  @Override
+  public Void visit(ExtensionTypeVector<?> vector, Void value) {
+    vector.getUnderlyingVector().accept(this, value);
     return null;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -168,6 +169,12 @@ public class ValidateVectorDataVisitor implements VectorVisitor<Void, Void> {
 
   @Override
   public Void visit(NullVector vector, Void value) {
+    return null;
+  }
+
+  @Override
+  public Void visit(ExtensionTypeVector<?> vector, Void value) {
+    vector.getUnderlyingVector().accept(this, value);
     return null;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
@@ -39,7 +40,7 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
 /**
  * Visitor to validate vector (without validating data).
  * This visitor could be used for {@link ValueVector#accept(VectorVisitor, Object)} API,
- * and also users could simply use {@link ValueVectorUtility#validate(FieldVector)}.
+ * and also users could simply use {@link ValueVectorUtility#validate(ValueVector)}.
  */
 public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
 
@@ -261,6 +262,12 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
 
   @Override
   public Void visit(NullVector vector, Void value) {
+    return null;
+  }
+
+  @Override
+  public Void visit(ExtensionTypeVector<?> vector, Void value) {
+    vector.getUnderlyingVector().accept(this, value);
     return null;
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.types.pojo;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,11 +42,15 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.compare.Range;
+import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.ipc.ArrowFileReader;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+import org.apache.arrow.vector.util.VectorBatchAppender;
+import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -227,6 +233,48 @@ public class TestExtensionType {
           }
         }
       }
+    }
+  }
+
+  @Test
+  public void testVectorCompare() {
+    ExtensionTypeRegistry.register(new UuidType());
+    UuidType uuidType = new UuidType();
+    try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+         UuidVector a1 = (UuidVector) uuidType.getNewVector("a", FieldType.nullable(uuidType), allocator);
+         UuidVector a2 = (UuidVector) uuidType.getNewVector("a", FieldType.nullable(uuidType), allocator);
+         UuidVector bb = (UuidVector) uuidType.getNewVector("a", FieldType.nullable(uuidType), allocator)
+         ) {
+      UUID u1 = UUID.randomUUID();
+      UUID u2 = UUID.randomUUID();
+
+      // Test out type and vector validation visitors for an ExtensionTypeVector
+      ValidateVectorVisitor validateVisitor = new ValidateVectorVisitor();
+      validateVisitor.visit(a1, null);
+
+      a1.setValueCount(2);
+      a1.set(0, u1);
+      a1.set(1, u2);
+
+      a2.setValueCount(2);
+      a2.set(0, u1);
+      a2.set(1, u2);
+
+      bb.setValueCount(2);
+      bb.set(0, u2);
+      bb.set(1, u1);
+
+      Range range = new Range(0, 0, a1.getValueCount());
+      RangeEqualsVisitor visitor = new RangeEqualsVisitor(a1, a2);
+      assertTrue(visitor.rangeEquals(range));
+
+      visitor = new RangeEqualsVisitor(a1, bb);
+      assertFalse(visitor.rangeEquals(range));
+
+      // Test out vector appender
+      VectorBatchAppender.batchAppend(a1, a2, bb);
+      assertEquals(a1.getValueCount(), 6);
+      validateVisitor.visit(a1, null);
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -238,8 +238,8 @@ public class TestExtensionType {
 
   @Test
   public void testVectorCompare() {
-    ExtensionTypeRegistry.register(new UuidType());
     UuidType uuidType = new UuidType();
+    ExtensionTypeRegistry.register(uuidType);
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
          UuidVector a1 = (UuidVector) uuidType.getNewVector("a", FieldType.nullable(uuidType), allocator);
          UuidVector a2 = (UuidVector) uuidType.getNewVector("a", FieldType.nullable(uuidType), allocator);


### PR DESCRIPTION
This adds the ExtensionTypeVector to the VectorVisitor interface and implements that method for the existing visitors. Now when visitor like RangeEqualsVisitor that uses another ExtensionTypeVector, they can both use the visitor on the underlying storage vector.