### PR TITLE
ARROW-13820: [R] Rename na.min_count to min_count and na.rm to skip_nulls

### DIFF
--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -120,7 +120,7 @@ max.ArrowDatum <- function(..., na.rm = FALSE) {
   scalar_aggregate("min_max", ..., na.rm = na.rm)$GetFieldByName("max")
 }
 
-scalar_aggregate <- function(FUN, ..., na.rm = FALSE, min_count = 0) {
+scalar_aggregate <- function(FUN, ..., na.rm = FALSE, min_count = 0L) {
   a <- collect_arrays_from_dots(list(...))
   if (FUN == "min_max" && na.rm && a$null_count == length(a)) {
     Array$create(data.frame(min = Inf, max = -Inf))

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -120,7 +120,7 @@ max.ArrowDatum <- function(..., na.rm = FALSE) {
   scalar_aggregate("min_max", ..., na.rm = na.rm)$GetFieldByName("max")
 }
 
-scalar_aggregate <- function(FUN, ..., na.rm = FALSE, na.min_count = 0) {
+scalar_aggregate <- function(FUN, ..., na.rm = FALSE, min_count = 0) {
   a <- collect_arrays_from_dots(list(...))
   if (FUN == "min_max" && na.rm && a$null_count == length(a)) {
     Array$create(data.frame(min = Inf, max = -Inf))
@@ -128,7 +128,7 @@ scalar_aggregate <- function(FUN, ..., na.rm = FALSE, na.min_count = 0) {
     # Inf/-Inf, which are type double. Since Arrow is type-stable
     # and does not do that, we handle this special case here.
   } else {
-    call_function(FUN, a, options = list(na.rm = na.rm, na.min_count = na.min_count))
+    call_function(FUN, a, options = list(skip_nulls = na.rm, min_count = min_count))
   }
 }
 

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -784,44 +784,42 @@ agg_funcs$sum <- function(x, na.rm = FALSE) {
   list(
     fun = "sum",
     data = x,
-    options = list(na.rm = na.rm, na.min_count = 0L)
+    options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
 agg_funcs$any <- function(x, na.rm = FALSE) {
   list(
     fun = "any",
     data = x,
-    options = list(na.rm = na.rm, na.min_count = 0L)
+    options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
 agg_funcs$all <- function(x, na.rm = FALSE) {
   list(
     fun = "all",
     data = x,
-    options = list(na.rm = na.rm, na.min_count = 0L)
+    options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
 agg_funcs$mean <- function(x, na.rm = FALSE) {
   list(
     fun = "mean",
     data = x,
-    options = list(na.rm = na.rm, na.min_count = 0L)
+    options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
-# na.rm not currently passed in due to ARROW-13691
 agg_funcs$sd <- function(x, na.rm = FALSE, ddof = 1) {
   list(
     fun = "stddev",
     data = x,
-    options = list(ddof = ddof)
+    options = list(skip_nulls = na.rm, min_count = 0L, ddof = ddof)
   )
 }
-# na.rm not currently passed in due to ARROW-13691
 agg_funcs$var <- function(x, na.rm = FALSE, ddof = 1) {
   list(
     fun = "variance",
     data = x,
-    options = list(ddof = ddof)
+    options = list(skip_nulls = na.rm, min_count = 0L, ddof = ddof)
   )
 }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -177,11 +177,11 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
       func_name == "hash_all") {
     using Options = arrow::compute::ScalarAggregateOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
-    if (!Rf_isNull(options["na.min_count"])) {
-      out->min_count = cpp11::as_cpp<int>(options["na.min_count"]);
+    if (!Rf_isNull(options["min_count"])) {
+      out->min_count = cpp11::as_cpp<int>(options["min_count"]);
     }
-    if (!Rf_isNull(options["na.rm"])) {
-      out->skip_nulls = cpp11::as_cpp<bool>(options["na.rm"]);
+    if (!Rf_isNull(options["skip_nulls"])) {
+      out->skip_nulls = cpp11::as_cpp<bool>(options["skip_nulls"]);
     }
     return out;
   }
@@ -225,11 +225,11 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
           cpp11::as_cpp<enum arrow::compute::QuantileOptions::Interpolation>(
               interpolation);
     }
-    if (!Rf_isNull(options["na.min_count"])) {
-      out->min_count = cpp11::as_cpp<int64_t>(options["na.min_count"]);
+    if (!Rf_isNull(options["min_count"])) {
+      out->min_count = cpp11::as_cpp<int64_t>(options["min_count"]);
     }
-    if (!Rf_isNull(options["na.rm"])) {
-      out->skip_nulls = cpp11::as_cpp<int64_t>(options["na.rm"]);
+    if (!Rf_isNull(options["skip_nulls"])) {
+      out->skip_nulls = cpp11::as_cpp<int64_t>(options["skip_nulls"]);
     }
     return out;
   }
@@ -392,8 +392,8 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     if (!Rf_isNull(options["min_count"])) {
       out->min_count = cpp11::as_cpp<int64_t>(options["min_count"]);
     }
-    if (!Rf_isNull(options["na.rm"])) {
-      out->skip_nulls = cpp11::as_cpp<int64_t>(options["na.rm"]);
+    if (!Rf_isNull(options["skip_nulls"])) {
+      out->skip_nulls = cpp11::as_cpp<bool>(options["skip_nulls"]);
     }
     return out;
   }

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -134,7 +134,6 @@ test_that("Group by sd on dataset", {
     tbl
   )
 
-  skip("ARROW-13691 - na.rm not yet implemented for VarianceOptions")
   expect_dplyr_equal(
     input %>%
       group_by(some_grouping) %>%
@@ -153,7 +152,6 @@ test_that("Group by var on dataset", {
     tbl
   )
 
-  skip("ARROW-13691 - na.rm not yet implemented for VarianceOptions")
   expect_dplyr_equal(
     input %>%
       group_by(some_grouping) %>%


### PR DESCRIPTION
Also contains ARROW-13821: [R] Handle na.rm in sd, var bindings

The only other place we take nonstandard C++ options in make_compute_options is for a few types (like count) where there is an enum that controls options and we switch off based on a boolean. We can try to clean that up but I'm inclined to wait to see if anyone needs lower-level control.