### PR TITLE
ARROW-13897: [Python] Correct TimestampScalar.as_py() and DurationScalar.as_py() docstrings

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -450,8 +450,9 @@ cdef class TimestampScalar(Scalar):
 
     def as_py(self):
         """
-        Return this value as a Pandas Timestamp instance (if available),
-        otherwise as a Python datetime.timedelta instance.
+        Return this value as a Pandas Timestamp instance (if units are
+        nanoseconds and pandas is available), otherwise as a Python
+        datetime.datetime instance.
         """
         cdef:
             CTimestampScalar* sp = <CTimestampScalar*> self.wrapped.get()
@@ -480,8 +481,9 @@ cdef class DurationScalar(Scalar):
 
     def as_py(self):
         """
-        Return this value as a Pandas Timestamp instance (if available),
-        otherwise as a Python datetime.timedelta instance.
+        Return this value as a Pandas Timedelta instance (if units are
+        nanoseconds and pandas is available), otherwise as a Python
+        datetime.timedelta instance.
         """
         cdef:
             CDurationScalar* sp = <CDurationScalar*> self.wrapped.get()


### PR DESCRIPTION
These methods incorrectly stated that pandas types are always returned if pandas is availabe. Also, TimestampScalar incorrectly stated that it returns a timedelta.