### PR TITLE
ARROW-13898: [C++][Compute] Add support for string binary transforms

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -307,9 +307,13 @@ struct StringTransformBase {
     return Status::Invalid("Invalid UTF8 sequence in input");
   }
 
-  // Derived classes should also define this method:
+  // Unary derived classes should define this method:
   //   int64_t Transform(const uint8_t* input, int64_t input_string_ncodeunits,
   //                     uint8_t* output);
+
+  // Binary derived classes should define this method:
+  //   int64_t Transform(const uint8_t* input, int64_t input_string_ncodeunits, const
+  //   std::shared_ptr<Scalar>& input2, uint8_t* output);
 };
 
 template <typename Type, typename StringTransform>
@@ -429,6 +433,8 @@ struct StringTransformExecWithState
 ///   * Array, Scalar - scalar is broadcasted and paired with all values of array
 ///   * Array, Array - arrays are processed element-wise
 ///   * Scalar, Array - not supported by default
+// TODO(edponce): For when second parameter is an array, need to specify a corresponding
+// iterator/visitor.
 template <typename Type1, typename Type2, typename StringTransform>
 struct StringBinaryTransformExecBase {
   using offset_type = typename Type1::offset_type;


### PR DESCRIPTION
This PR provides a kernel executors for string binary functions (StringBinaryTransformExecBase) that always expect the first parameter to be of string type and the second parameter is generic. It supports the following shapes for the binary parameters:
* Scalar, Scalar
* Array, Scalar - scalar is broadcasted and paired with all values from array
* Array, Array - process arrays element-wise