### PR TITLE
ARROW-13913: [C++] Don't segfault if IndexOptions omitted

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -549,6 +549,9 @@ struct IndexInit {
 
   static Result<std::unique_ptr<KernelState>> Init(KernelContext* ctx,
                                                    const KernelInitArgs& args) {
+    if (!args.options) {
+      return Status::Invalid("Must provide IndexOptions for index kernel");
+    }
     IndexInit visitor(ctx, static_cast<const IndexOptions&>(*args.options),
                       *args.inputs[0].type);
     return visitor.Create();

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1853,6 +1853,10 @@ TYPED_TEST(TestNumericIndexKernel, Basics) {
   this->AssertIndexIs(chunked_input2, value, 4);
   this->AssertIndexIs(chunked_input3, value, -1);
   this->AssertIndexIs(chunked_input4, value, 5);
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("Must provide IndexOptions"),
+      CallFunction("index", {ArrayFromJSON(this->type_singleton(), "[0]")}));
 }
 TYPED_TEST(TestNumericIndexKernel, Random) {
   constexpr auto kChunks = 4;


### PR DESCRIPTION
Unlike the other aggregates, there's no default options to fall back on here.