### PR TITLE
ARROW-13921: [Python][Packaging] Pin minimum setuptools version for the macos wheels

### DIFF
--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -53,6 +53,7 @@ export PIP_SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[
 export PIP_TARGET_PLATFORM="macosx_${MACOSX_DEPLOYMENT_TARGET//./_}_${arch}"
 
 pip install \
+  --upgrade \
   --only-binary=:all: \
   --target $PIP_SITE_PACKAGES \
   --platform $PIP_TARGET_PLATFORM \

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,5 @@
 cython>=0.29.11
+setuptools>=58.0.1
 setuptools_scm
 wheel
 numpy==1.19.4; platform_system == "Linux"   and platform_machine == "aarch64"

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,5 +1,5 @@
 cython>=0.29.11
-setuptools>=58.0.1
+setuptools>=58
 setuptools_scm
 wheel
 numpy==1.19.4; platform_system == "Linux"   and platform_machine == "aarch64"


### PR DESCRIPTION
There was a bug in setuptools which caused the recent nightly failures: https://github.com/ursacomputing/crossbow/runs/3521607291#step:10:269