### PR TITLE
ARROW-13930: [Python][C++] Automatically infer/convert uuid.Uuid to an Arrow binary

### DIFF
--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "arrow/buffer.h"
+#include "arrow/python/helpers.h"
 #include "arrow/python/pyarrow.h"
 #include "arrow/python/visibility.h"
 #include "arrow/result.h"
@@ -315,6 +316,10 @@ struct PyBytesView {
       bytes = reinterpret_cast<const char*>(buffer->buf);
       size = buffer->len;
       is_utf8 = false;
+    } else if (internal::IsUuid(obj)) {
+      PyObject* bytes_obj = PyObject_GetAttrString(obj, "bytes");
+      RETURN_IF_PYERROR();
+      return ParseBinary(bytes_obj);
     } else {
       return Status::TypeError("Expected bytes, got a '", Py_TYPE(obj)->tp_name,
                                "' object");

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -98,8 +98,7 @@ ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);
 
 inline bool IsPyBinary(PyObject* obj) {
-  return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj) ||
-         IsUuid(obj);
+  return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);
 }
 
 // \brief Convert a Python integer into a C integer

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -28,6 +28,7 @@
 
 #include <numpy/halffloat.h>
 
+#include "arrow/python/platform.h"
 #include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
@@ -87,12 +88,19 @@ bool IsPandasTimedelta(PyObject* obj);
 // \brief Check that obj is a pandas.Timestamp instance
 bool IsPandasTimestamp(PyObject* obj);
 
+// \brief Import symbols from uuid module needed for uuid type-checking
+void InitUuidStaticData();
+
+// \brief Check that obj is a uuid.UUID instance
+bool IsUuid(PyObject* obj);
+
 // \brief Check whether obj is a floating-point NaN
 ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);
 
 inline bool IsPyBinary(PyObject* obj) {
-  return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);
+  return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj) ||
+         IsUuid(obj);
 }
 
 // \brief Convert a Python integer into a C integer

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -28,7 +28,6 @@
 
 #include <numpy/halffloat.h>
 
-#include "arrow/python/platform.h"
 #include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"

--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -298,6 +298,7 @@ class TypeInferrer {
         timestamp_micro_count_(0),
         duration_count_(0),
         float_count_(0),
+        uuid_count_(0),
         binary_count_(0),
         unicode_count_(0),
         decimal_count_(0),
@@ -346,6 +347,8 @@ class TypeInferrer {
     } else if (PyTime_Check(obj)) {
       ++time_count_;
       *keep_going = make_unions_;
+    } else if (internal::IsUuid(obj)) {
+      uuid_count_++;
     } else if (internal::IsPyBinary(obj)) {
       ++binary_count_;
       *keep_going = make_unions_;
@@ -480,6 +483,8 @@ class TypeInferrer {
       *out = binary();
     } else if (unicode_count_) {
       *out = utf8();
+    } else if (uuid_count_) {
+      *out = fixed_size_binary(16);
     } else {
       *out = null();
     }
@@ -607,6 +612,7 @@ class TypeInferrer {
   std::string timezone_;
   int64_t duration_count_;
   int64_t float_count_;
+  int64_t uuid_count_;
   int64_t binary_count_;
   int64_t unicode_count_;
   int64_t decimal_count_;

--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -636,6 +636,8 @@ Result<std::shared_ptr<DataType>> InferArrowType(PyObject* obj, PyObject* mask,
     internal::InitPandasStaticData();
   }
 
+  internal::InitUuidStaticData();
+
   std::shared_ptr<DataType> out_type;
   TypeInferrer inferrer(pandas_null_sentinels);
   RETURN_NOT_OK(inferrer.VisitSequence(obj, mask));

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1956,7 +1956,16 @@ def test_uuid_to_binary():
     values = [uuid.uuid4() for _ in range(32)]
     values_bytes = [value.bytes for value in values]
     arrow_values = pa.array(values)
+    assert arrow_values.type == pa.binary(16)
     assert arrow_values.to_pylist() == values_bytes
+
+
+def test_uuid_mixed_to_binary():
+    values = [uuid.uuid4() for _ in range(16)] + ['xyz']
+    values_bytes = [value.bytes for value in values[0:16]]
+    arrow_values = pa.array(values)
+    assert arrow_values.type == pa.binary()
+    assert arrow_values.to_pylist()[0:16] == values_bytes
 
 
 def test_binary_string_pandas_null_sentinels():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -25,6 +25,7 @@ import pickle
 import pytest
 import struct
 import sys
+import uuid
 import weakref
 
 import numpy as np
@@ -1949,6 +1950,13 @@ def test_time32_time64_from_integer():
                          datetime.time(microsecond=2), None],
                         type=pa.time64('ns'))
     assert result.equals(expected)
+
+
+def test_uuid_to_binary():
+    values = [uuid.uuid4() for _ in range(32)]
+    values_bytes = [value.bytes for value in values]
+    arrow_values = pa.array(values)
+    assert arrow_values.to_pylist() == values_bytes
 
 
 def test_binary_string_pandas_null_sentinels():


### PR DESCRIPTION
As mentioned in the JIRA, this offers marginal benefit so I'm not certain if it is worth maintaining or not but it was an interesting exercise to learn more about python inference/conversion so I figured I would see if anyone felt it worthwhile.

Also, just to be clear, this is not adding a UUID extension type.  It is simply converting from UUID to a binary value.

Pros:
 * uuid.Uuid is part of the python standard (similar to datetime.datetime)
 * Would solve issues like: https://stackoverflow.com/questions/69067754/handling-uuid-values-in-arrow-with-parquet-files
 * Allows for writing code that would be replaced by something better if a UUID extension type is ever added

Cons:
 * Users can easily convert from uuid to bytes in python (`[value.bytes for value in uuids]`)
 * Minor overhead added to conversion
 * Not round-trippable (that would require a UUID extension type be added)