### PR TITLE
ARROW-13655: [C++][Parquet] Disable Thrift message size protections

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1332,6 +1332,11 @@ if(ARROW_WITH_THRIFT)
   endif()
   # TODO: Don't use global includes but rather target_include_directories
   include_directories(SYSTEM ${THRIFT_INCLUDE_DIR})
+
+  string(REPLACE "." ";" VERSION_LIST ${THRIFT_VERSION})
+  list(GET VERSION_LIST 0 THRIFT_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 THRIFT_VERSION_MINOR)
+  list(GET VERSION_LIST 2 THRIFT_VERSION_PATCH)
 endif()
 
 # ----------------------------------------------------------------------

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -282,6 +282,9 @@ endif()
 
 add_dependencies(parquet ${PARQUET_LIBRARIES} thrift::thrift)
 
+add_definitions(-DPARQUET_THRIFT_VERSION_MAJOR=${THRIFT_VERSION_MAJOR})
+add_definitions(-DPARQUET_THRIFT_VERSION_MINOR=${THRIFT_VERSION_MINOR})
+
 # Thrift requires these definitions for some types that we use
 foreach(LIB_TARGET ${PARQUET_LIBRARIES})
   target_compile_definitions(${LIB_TARGET}

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -20,6 +20,7 @@
 #include "arrow/util/windows_compatibility.h"
 
 #include <cstdint>
+#include <limits>
 
 // Check if thrift version < 0.11.0
 // or if FORCE_BOOST_SMART_PTR is defined. Ref: https://thrift.apache.org/lib/cpp
@@ -386,9 +387,8 @@ using configuration_type =
 // Overload with TConfiguration available
 template <typename T = ThriftBuffer, typename C = configuration_type<T>>
 void CreateReadOnlyMemoryBuffer(uint8_t* buf, uint32_t len, std::shared_ptr<T>* out) {
-  auto conf = std::make_shared<C>();
-  conf->setMaxMessageSize(std::numeric_limits<int>::max());
-  *out = std::make_shared<T>(buf, len, ThriftBuffer::OBSERVE, std::move(conf));
+  auto conf = std::make_shared<C>(/*maxMessageSize=*/std::numeric_limits<int>::max());
+  *out = std::make_shared<T>(buf, len, ThriftBuffer::OBSERVE, conf);
 }
 
 // Overload without TConfiguration available

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -368,43 +368,22 @@ using ThriftBuffer = apache::thrift::transport::TMemoryBuffer;
 // limit (ARROW-13655).  If we wanted to protect against huge messages, we could
 // do it ourselves since we know the message size up front.
 
-// We use an elaborate SFINAE hack to check for the existence of TConfiguration
-// since Thrift doesn't expose version macros (THRIFT-5462):
-// - define two potential CreateReadOnlyMemoryBuffer overloads,
-//   one taking a `uint8_t*` buffer, the other a `void*`
-// - if both overloads are available, the `uint8_t*` one will be preferred
-//   as it is more specific
-// - however, the `uint8_t*` overload is conditional on the existence of
-//   the configuration type (obtained by inspecting the return type
-//   of ThriftBuffer::getConfiguration).
-// - therefore, if TConfiguration is not available, the `void*` overload
-//   is selected.
-
-template <typename T>
-using configuration_type =
-    typename std::remove_reference<decltype(*std::declval<T>().getConfiguration())>::type;
-
-// Overload with TConfiguration available
-template <typename T = ThriftBuffer, typename C = configuration_type<T>>
-void CreateReadOnlyMemoryBuffer(uint8_t* buf, uint32_t len, std::shared_ptr<T>* out) {
-  auto conf = std::make_shared<C>(/*maxMessageSize=*/std::numeric_limits<int>::max());
-  *out = std::make_shared<T>(buf, len, ThriftBuffer::OBSERVE, conf);
-}
-
-// Overload without TConfiguration available
-template <typename T = ThriftBuffer>
-void CreateReadOnlyMemoryBuffer(void* buf, uint32_t len, std::shared_ptr<T>* out) {
-  *out = std::make_shared<T>(reinterpret_cast<uint8_t*>(buf), len);
+inline std::shared_ptr<ThriftBuffer> CreateReadOnlyMemoryBuffer(uint8_t* buf,
+                                                                uint32_t len) {
+#if PARQUET_THRIFT_VERSION_MAJOR > 0 || PARQUET_THRIFT_VERSION_MINOR >= 14
+  auto conf = std::make_shared<apache::thrift::TConfiguration>();
+  conf->setMaxMessageSize(std::numeric_limits<int>::max());
+  return std::make_shared<ThriftBuffer>(buf, len, ThriftBuffer::OBSERVE, conf);
+#else
+  return std::make_shared<ThriftBuffer>(buf, len);
+#endif
 }
 
 template <class T>
 inline void DeserializeThriftUnencryptedMsg(const uint8_t* buf, uint32_t* len,
                                             T* deserialized_msg) {
   // Deserialize msg bytes into c++ thrift msg using memory transport.
-
-  shared_ptr<ThriftBuffer> tmem_transport;
-  CreateReadOnlyMemoryBuffer(const_cast<uint8_t*>(buf), *len, &tmem_transport);
-
+  auto tmem_transport = CreateReadOnlyMemoryBuffer(const_cast<uint8_t*>(buf), *len);
   apache::thrift::protocol::TCompactProtocolFactoryT<ThriftBuffer> tproto_factory;
   // Protect against CPU and memory bombs
   tproto_factory.setStringSizeLimit(100 * 1000 * 1000);


### PR DESCRIPTION
In Thrift 0.14+, the maximum message size is capped by default and attempts to read larger messages will error out.

The maximum message size doesn't really make sense in our case since we read the whole message buffer in memory anyway.
Also, it produces regressions on files with large metadata, which can be found in the real world.