### PR TITLE
MINOR: [R] Exclude some paths from the cpp rsync

### DIFF
--- a/r/Makefile
+++ b/r/Makefile
@@ -40,11 +40,11 @@ deps:
 # cmake expects .env, NOTICE.txt, and LICENSE.txt to be available one level up from cpp/
 build: doc
 	cp ../NOTICE.txt inst/NOTICE.txt
-	rsync --archive --delete ../cpp tools/
+	rsync --archive --delete --exclude 'build' --exclude 'build-support/boost_*' --exclude 'submodules' ../cpp tools/
 	cp -p ../.env tools/
 	cp -p ../NOTICE.txt tools/
 	cp -p ../LICENSE.txt tools/
-	R CMD build .
+	R CMD build ${args} .
 
 check: build
 	-export _R_CHECK_CRAN_INCOMING_REMOTE_=FALSE && export ARROW_R_DEV=$(ARROW_R_DEV) && export _R_CHECK_TESTS_NLINES_=0 && R CMD check --as-cran --run-donttest arrow_$(VERSION).tar.gz

--- a/r/Makefile
+++ b/r/Makefile
@@ -38,12 +38,14 @@ deps:
 
 # Note: files in tools are available at build time, but not at run time. The thirdparty
 # cmake expects .env, NOTICE.txt, and LICENSE.txt to be available one level up from cpp/
-build: doc
+sync-cpp:
 	cp ../NOTICE.txt inst/NOTICE.txt
 	rsync --archive --delete --exclude 'build' --exclude 'build-support/boost_*' --exclude 'submodules' ../cpp tools/
 	cp -p ../.env tools/
 	cp -p ../NOTICE.txt tools/
 	cp -p ../LICENSE.txt tools/
+
+build: doc sync-cpp
 	R CMD build ${args} .
 
 check: build


### PR DESCRIPTION
Also factors that logic out to its own step so we could call it separately.