### PR TITLE
ARROW-13979: [Go] Enable -race for go tests

### DIFF
--- a/ci/scripts/go_test.sh
+++ b/ci/scripts/go_test.sh
@@ -21,10 +21,18 @@ set -ex
 
 source_dir=${1}/go
 
+testargs="-race"
+case "$(uname)" in
+    MINGW*)
+        # -race doesn't work on windows currently
+        testargs=""
+        ;;
+esac
+
 pushd ${source_dir}/arrow
 
 for d in $(go list ./... | grep -v vendor); do
-    go test $d
+    go test $testargs -tags "test" $d
 done
 
 popd
@@ -32,7 +40,7 @@ popd
 pushd ${source_dir}/parquet
 
 for d in $(go list ./... | grep -v vendor); do
-    go test $d
+    go test $testargs  $d
 done
 
 popd

--- a/go/parquet/internal/hashing/xxh3_memo_table.go
+++ b/go/parquet/internal/hashing/xxh3_memo_table.go
@@ -192,7 +192,13 @@ func (BinaryMemoTable) valAsByteSlice(val interface{}) []byte {
 	case parquet.FixedLenByteArray:
 		return *(*[]byte)(unsafe.Pointer(&v))
 	case string:
-		return (*(*[]byte)(unsafe.Pointer(&v)))[:len(v):len(v)]
+		var out []byte
+		h := (*reflect.StringHeader)(unsafe.Pointer(&v))
+		s := (*reflect.SliceHeader)(unsafe.Pointer(&out))
+		s.Data = h.Data
+		s.Len = h.Len
+		s.Cap = h.Len
+		return out
 	default:
 		panic("invalid type for binarymemotable")
 	}

--- a/go/parquet/internal/utils/bit_set_run_reader_test.go
+++ b/go/parquet/internal/utils/bit_set_run_reader_test.go
@@ -94,9 +94,6 @@ func TestBitSetRunReader(t *testing.T) {
 
 func (br *BitSetRunReaderSuite) SetupSuite() {
 	br.testOffsets = []int64{0, 1, 6, 7, 8, 33, 63, 64, 65, 71}
-}
-
-func (br *BitSetRunReaderSuite) SetupTest() {
 	br.T().Parallel()
 }
 


### PR DESCRIPTION
the change is trivial in just adding the argument in the `go_test.sh` file, and ended up finding an issue in the parquet encoding and a slight change in how the bit set run tests used the testify suite.