### PR TITLE
ARROW-13982: [C++] Don't stall in async scanner if a fragment generates no batches

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -775,9 +775,8 @@ Result<int64_t> AsyncScanner::CountRows() {
               if (fast_count) {
                 // fast path: got row count directly; skip scanning this fragment
                 total += *fast_count;
-                return std::make_shared<OneShotFragment>(
-                    options->dataset_schema,
-                    MakeEmptyIterator<std::shared_ptr<RecordBatch>>());
+                return std::make_shared<InMemoryFragment>(options->dataset_schema,
+                                                          RecordBatchVector{});
               }
 
               // slow path: actually filter this fragment's batches

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -455,7 +455,7 @@ Result<EnumeratedRecordBatchGenerator> FragmentToBatches(
                           MakeArrayOfNull(field->type(), /*length=*/0, options->pool));
     columns.push_back(std::move(array));
   }
-  batch_gen = MakeOrGenerator(
+  batch_gen = MakeDefaultIfEmptyGenerator(
       std::move(batch_gen),
       RecordBatch::Make(options->dataset_schema, /*num_rows=*/0, std::move(columns)));
   auto enumerated_batch_gen = MakeEnumeratedGenerator(std::move(batch_gen));

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1612,9 +1612,9 @@ AsyncGenerator<T> MakeCancellable(AsyncGenerator<T> source, StopToken stop_token
 }
 
 template <typename T>
-class OrGenerator {
+class DefaultIfEmptyGenerator {
  public:
-  OrGenerator(AsyncGenerator<T> source, T or_value)
+  DefaultIfEmptyGenerator(AsyncGenerator<T> source, T or_value)
       : state_(std::make_shared<State>(std::move(source), std::move(or_value))) {}
 
   Future<T> operator()() {
@@ -1652,7 +1652,7 @@ class OrGenerator {
 ///
 /// This generator is async-reentrant.
 template <typename T>
-AsyncGenerator<T> MakeOrGenerator(AsyncGenerator<T> source, T or_value) {
-  return OrGenerator<T>(std::move(source), std::move(or_value));
+AsyncGenerator<T> MakeDefaultIfEmptyGenerator(AsyncGenerator<T> source, T or_value) {
+  return DefaultIfEmptyGenerator<T>(std::move(source), std::move(or_value));
 }
 }  // namespace arrow

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -1479,4 +1479,16 @@ TEST(FailingGenerator, Basics) {
   ASSERT_FINISHES_OK_AND_EQ(std::vector<TestInt>{}, collect_fut);
 }
 
+TEST(OrGenerator, Basics) {
+  std::vector<TestInt> values{1, 2, 3, 4};
+  auto gen = MakeVectorGenerator(values);
+  ASSERT_FINISHES_OK_AND_ASSIGN(auto actual,
+                                CollectAsyncGenerator(MakeOrGenerator(gen, TestInt(42))));
+  EXPECT_EQ(values, actual);
+
+  gen = MakeVectorGenerator<TestInt>({});
+  ASSERT_FINISHES_OK_AND_ASSIGN(actual,
+                                CollectAsyncGenerator(MakeOrGenerator(gen, TestInt(42))));
+  EXPECT_EQ(std::vector<TestInt>{42}, actual);
+}
 }  // namespace arrow

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -1479,16 +1479,16 @@ TEST(FailingGenerator, Basics) {
   ASSERT_FINISHES_OK_AND_EQ(std::vector<TestInt>{}, collect_fut);
 }
 
-TEST(OrGenerator, Basics) {
+TEST(DefaultIfEmptyGenerator, Basics) {
   std::vector<TestInt> values{1, 2, 3, 4};
   auto gen = MakeVectorGenerator(values);
-  ASSERT_FINISHES_OK_AND_ASSIGN(auto actual,
-                                CollectAsyncGenerator(MakeOrGenerator(gen, TestInt(42))));
+  ASSERT_FINISHES_OK_AND_ASSIGN(
+      auto actual, CollectAsyncGenerator(MakeDefaultIfEmptyGenerator(gen, TestInt(42))));
   EXPECT_EQ(values, actual);
 
   gen = MakeVectorGenerator<TestInt>({});
-  ASSERT_FINISHES_OK_AND_ASSIGN(actual,
-                                CollectAsyncGenerator(MakeOrGenerator(gen, TestInt(42))));
+  ASSERT_FINISHES_OK_AND_ASSIGN(
+      actual, CollectAsyncGenerator(MakeDefaultIfEmptyGenerator(gen, TestInt(42))));
   EXPECT_EQ(std::vector<TestInt>{42}, actual);
 }
 }  // namespace arrow


### PR DESCRIPTION
Since reordering uses metadata on the batches, we have to emit at least one batch for every fragment, else we'll wait forever for a batch that never arrives. This adds a utility generator to emit an empty batch if the underlying generator is empty (that way we don't need to fix each file format individually).