### PR TITLE
ARROW-13670: [C++] add virtual destructors

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -290,6 +290,7 @@ void EnsureLookupTablesFilled() {}
 constexpr int64_t kTransformError = -1;
 
 struct StringTransformBase {
+  virtual ~StringTransformBase() = default;
   virtual Status PreExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     return Status::OK();
   }
@@ -1904,6 +1905,7 @@ struct IsUpperAscii : CharacterPredicateAscii<IsUpperAscii> {
 
 template <typename Options>
 struct SplitFinderBase {
+  virtual ~SplitFinderBase() = default;
   virtual Status PreExec(const Options& options) { return Status::OK(); }
 
   // Derived classes should also define these methods:

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1980,6 +1980,7 @@ class PandasBlockCreator {
     }
     column_block_placement_.resize(num_columns_);
   }
+  virtual ~PandasBlockCreator() = default;
 
   virtual Status Convert(PyObject** out) = 0;
 


### PR DESCRIPTION
This prevents warnings for non-virtual destructors in base classes.

