### PR TITLE
ARROW-13849: [C++] Wrap min_max with min/max functions

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -98,6 +98,10 @@ struct ScalarAggregator : public KernelState {
 // kernel implementations together
 enum class VarOrStd : bool { Var, Std };
 
+// Helper to differentiate between min/max calculation so we can fold
+// kernel implementations together
+enum class MinOrMax : uint8_t { Min = 0, Max };
+
 void AddAggKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                   ScalarAggregateFunction* func,
                   SimdLevel::type simd_level = SimdLevel::NONE);

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -199,7 +199,11 @@ the input to a single output value.
 +---------------+-------+------------------+------------------------+----------------------------------+-------+
 | index         | Unary | Any              | Scalar Int64           | :struct:`IndexOptions`           |       |
 +---------------+-------+------------------+------------------------+----------------------------------+-------+
+| max           | Unary | Non-nested types | Scalar Input type      | :struct:`ScalarAggregateOptions` |       |
++---------------+-------+------------------+------------------------+----------------------------------+-------+
 | mean          | Unary | Numeric          | Scalar Decimal/Float64 | :struct:`ScalarAggregateOptions` |       |
++---------------+-------+------------------+------------------------+----------------------------------+-------+
+| min           | Unary | Non-nested types | Scalar Input type      | :struct:`ScalarAggregateOptions` |       |
 +---------------+-------+------------------+------------------------+----------------------------------+-------+
 | min_max       | Unary | Non-nested types | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(3)  |
 +---------------+-------+------------------+------------------------+----------------------------------+-------+
@@ -307,7 +311,11 @@ equivalents above and reflects how they are implemented internally.
 +---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+
 | hash_distinct       | Unary | Any                                | Input type      | :struct:`CountOptions`           | \(2)  |
 +---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+
+| hash_max            | Unary | Non-nested, non-binary/string-like | Input type      | :struct:`ScalarAggregateOptions` |       |
++---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+
 | hash_mean           | Unary | Numeric                            | Decimal/Float64 | :struct:`ScalarAggregateOptions` |       |
++---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+
+| hash_min            | Unary | Non-nested, non-binary/string-like | Input type      | :struct:`ScalarAggregateOptions` |       |
 +---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+
 | hash_min_max        | Unary | Non-nested, non-binary/string-like | Struct          | :struct:`ScalarAggregateOptions` | \(3)  |
 +---------------------+-------+------------------------------------+-----------------+----------------------------------+-------+


### PR DESCRIPTION
This is intended to make it easier to use in bindings.