### PR TITLE
ARROW-12657: [C++] Adding String hex to numeric conversion

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1530,6 +1530,7 @@ TEST(Cast, StringToInt) {
              "0.5",
              "0x",
              "0xfff",
+             "-0xf0",
          }) {
       auto options = CastOptions::Safe(int8());
       CheckCastFails(ArrayFromJSON(string_type, "[\"" + not_int8 + "\"]"), options);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1499,17 +1499,14 @@ TEST(Cast, StringToInt) {
     CheckCast(ArrayFromJSON(string_type,
                             R"(["9223372036854775807", null, "-9223372036854775808", "0", 
                     "0x0", "0x7FFFFFFFFFFFFFFf", "0XF000000000000001"])"),
-               ArrayFromJSON(int64(),
+              ArrayFromJSON(int64(),
                             "[9223372036854775807, null, -9223372036854775808, 0, 0, "
                             "9223372036854775807, -1152921504606846975]"));
-
-
 
     for (auto unsigned_type : {uint8(), uint16(), uint32(), uint64()}) {
       CheckCast(ArrayFromJSON(string_type,
                               R"(["0", null, "127", "255", "0", "0X0", "0xff", "0x7f"])"),
                 ArrayFromJSON(unsigned_type, "[0, null, 127, 255, 0, 0, 255, 127]"));
-
     }
 
     CheckCast(
@@ -1521,10 +1518,9 @@ TEST(Cast, StringToInt) {
     CheckCast(ArrayFromJSON(string_type,
                             R"(["9223372036854775807", null, "18446744073709551615", "0", 
                     "0x0", "0x7FFFFFFFFFFFFFFf", "0xfFFFFFFFFFFFFFFf"])"),
-               ArrayFromJSON(uint64(),
+              ArrayFromJSON(uint64(),
                             "[9223372036854775807, null, 18446744073709551615, 0, 0, "
                             "9223372036854775807, 18446744073709551615]"));
-
 
     for (std::string not_int8 : {
              "z",

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1485,34 +1485,46 @@ TEST(Cast, StringToBoolean) {
 TEST(Cast, StringToInt) {
   for (auto string_type : {utf8(), large_utf8()}) {
     for (auto signed_type : {int8(), int16(), int32(), int64()}) {
-      CheckCast(ArrayFromJSON(string_type, R"(["0", null, "127", "-1", "0"])"),
-                ArrayFromJSON(signed_type, "[0, null, 127, -1, 0]"));
+      CheckCast(
+          ArrayFromJSON(string_type, R"(["0", null, "127", "-1", "0", "0x0", "0x7F"])"),
+          ArrayFromJSON(signed_type, "[0, null, 127, -1, 0, 0, 127]"));
     }
 
-    CheckCast(
-        ArrayFromJSON(string_type, R"(["2147483647", null, "-2147483648", "0", "0"])"),
-        ArrayFromJSON(int32(), "[2147483647, null, -2147483648, 0, 0]"));
+    CheckCast(ArrayFromJSON(string_type, R"(["2147483647", null, "-2147483648", "0", 
+          "0X0", "0x7FFFFFFF", "0XFFFFfFfF", "0Xf0000000"])"),
+              ArrayFromJSON(
+                  int32(),
+                  "[2147483647, null, -2147483648, 0, 0, 2147483647, -1, -268435456]"));
 
-    CheckCast(ArrayFromJSON(
-                  string_type,
-                  R"(["9223372036854775807", null, "-9223372036854775808", "0", "0"])"),
-              ArrayFromJSON(int64(),
-                            "[9223372036854775807, null, -9223372036854775808, 0, 0]"));
+    CheckCast(ArrayFromJSON(string_type,
+                            R"(["9223372036854775807", null, "-9223372036854775808", "0", 
+                    "0x0", "0x7FFFFFFFFFFFFFFf", "0XF000000000000001"])"),
+               ArrayFromJSON(int64(),
+                            "[9223372036854775807, null, -9223372036854775808, 0, 0, "
+                            "9223372036854775807, -1152921504606846975]"));
+
+
 
     for (auto unsigned_type : {uint8(), uint16(), uint32(), uint64()}) {
-      CheckCast(ArrayFromJSON(string_type, R"(["0", null, "127", "255", "0"])"),
-                ArrayFromJSON(unsigned_type, "[0, null, 127, 255, 0]"));
+      CheckCast(ArrayFromJSON(string_type,
+                              R"(["0", null, "127", "255", "0", "0X0", "0xff", "0x7f"])"),
+                ArrayFromJSON(unsigned_type, "[0, null, 127, 255, 0, 0, 255, 127]"));
+
     }
 
     CheckCast(
-        ArrayFromJSON(string_type, R"(["2147483647", null, "4294967295", "0", "0"])"),
-        ArrayFromJSON(uint32(), "[2147483647, null, 4294967295, 0, 0]"));
+        ArrayFromJSON(string_type, R"(["2147483647", null, "4294967295", "0", 
+                                    "0x0", "0x7FFFFFFf", "0xFFFFFFFF"])"),
+        ArrayFromJSON(uint32(),
+                      "[2147483647, null, 4294967295, 0, 0, 2147483647, 4294967295]"));
 
-    CheckCast(ArrayFromJSON(
-                  string_type,
-                  R"(["9223372036854775807", null, "18446744073709551615", "0", "0"])"),
-              ArrayFromJSON(uint64(),
-                            "[9223372036854775807, null, 18446744073709551615, 0, 0]"));
+    CheckCast(ArrayFromJSON(string_type,
+                            R"(["9223372036854775807", null, "18446744073709551615", "0", 
+                    "0x0", "0x7FFFFFFFFFFFFFFf", "0xfFFFFFFFFFFFFFFf"])"),
+               ArrayFromJSON(uint64(),
+                            "[9223372036854775807, null, 18446744073709551615, 0, 0, "
+                            "9223372036854775807, 18446744073709551615]"));
+
 
     for (std::string not_int8 : {
              "z",
@@ -1520,16 +1532,14 @@ TEST(Cast, StringToInt) {
              "128",
              "-129",
              "0.5",
+             "0x",
+             "0xfff",
          }) {
       auto options = CastOptions::Safe(int8());
       CheckCastFails(ArrayFromJSON(string_type, "[\"" + not_int8 + "\"]"), options);
     }
 
-    for (std::string not_uint8 : {
-             "256",
-             "-1",
-             "0.5",
-         }) {
+    for (std::string not_uint8 : {"256", "-1", "0.5", "0x", "0x3wa", "0x123"}) {
       auto options = CastOptions::Safe(uint8());
       CheckCastFails(ArrayFromJSON(string_type, "[\"" + not_uint8 + "\"]"), options);
     }

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -311,7 +311,6 @@ struct StringToUnsignedIntConverterMixin {
       s += 2;
 
       return ARROW_PREDICT_TRUE(ParseHex(s, length, out));
-
     }
     // Skip leading zeros
     while (length > 0 && *s == '0') {

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -273,6 +273,30 @@ inline bool ParseUnsigned(const char* s, size_t length, uint64_t* out) {
 #undef PARSE_UNSIGNED_ITERATION
 #undef PARSE_UNSIGNED_ITERATION_LAST
 
+template <typename T>
+bool ParseHex(const char* s, size_t length, T* out) {
+  // lets make sure that the length of the string is not too big
+  if (!ARROW_PREDICT_TRUE(sizeof(T) * 2 >= length && length > 0)) {
+    return false;
+  }
+  T result = 0;
+  for (size_t i = 0; i < length; i++) {
+    result = static_cast<T>(result << 4);
+    if (s[i] >= '0' && s[i] <= '9') {
+      result = static_cast<T>(result | (s[i] - '0'));
+    } else if (s[i] >= 'A' && s[i] <= 'F') {
+      result = static_cast<T>(result | (s[i] - 'A' + 10));
+    } else if (s[i] >= 'a' && s[i] <= 'f') {
+      result = static_cast<T>(result | (s[i] - 'a' + 10));
+    } else {
+      /* Non-digit */
+      return false;
+    }
+  }
+  *out = result;
+  return true;
+}
+
 template <class ARROW_TYPE>
 struct StringToUnsignedIntConverterMixin {
   using value_type = typename ARROW_TYPE::c_type;
@@ -280,6 +304,16 @@ struct StringToUnsignedIntConverterMixin {
   static bool Convert(const ARROW_TYPE&, const char* s, size_t length, value_type* out) {
     if (ARROW_PREDICT_FALSE(length == 0)) {
       return false;
+    }
+    // If it starts with 0x then its hex
+    if (length > 2 && s[0] == '0' && ((s[1] == 'x') || (s[1] == 'X'))) {
+      length -= 2;
+      s += 2;
+
+      if (!ARROW_PREDICT_TRUE(ParseHex(s, length, out))) {
+        return false;
+      }
+      return true;
     }
     // Skip leading zeros
     while (length > 0 && *s == '0') {
@@ -329,6 +363,18 @@ struct StringToSignedIntConverterMixin {
     if (ARROW_PREDICT_FALSE(length == 0)) {
       return false;
     }
+    // If it starts with 0x then its hex
+    if (length > 2 && s[0] == '0' && ((s[1] == 'x') || (s[1] == 'X'))) {
+      length -= 2;
+      s += 2;
+
+      if (!ARROW_PREDICT_TRUE(ParseHex(s, length, &unsigned_value))) {
+        return false;
+      }
+      *out = static_cast<value_type>(unsigned_value);
+      return true;
+    }
+
     if (*s == '-') {
       negative = true;
       s++;

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -310,10 +310,8 @@ struct StringToUnsignedIntConverterMixin {
       length -= 2;
       s += 2;
 
-      if (!ARROW_PREDICT_TRUE(ParseHex(s, length, out))) {
-        return false;
-      }
-      return true;
+      return ARROW_PREDICT_TRUE(ParseHex(s, length, out));
+
     }
     // Skip leading zeros
     while (length > 0 && *s == '0') {

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -120,6 +120,16 @@ TEST(StringConversion, ToInt8) {
   AssertConversionFails<Int8Type>("-");
   AssertConversionFails<Int8Type>("0.0");
   AssertConversionFails<Int8Type>("e");
+
+  // Hex
+  AssertConversion<Int8Type>("0x0", 0);
+  AssertConversion<Int8Type>("0X1A", 26);
+  AssertConversion<Int8Type>("0xb", 11);
+  AssertConversion<Int8Type>("0x7F", 127);
+  AssertConversion<Int8Type>("0xFF", -1);
+  AssertConversionFails<Int8Type>("0x");
+  AssertConversionFails<Int8Type>("0x100");
+  AssertConversionFails<Int8Type>("0x1g");
 }
 
 TEST(StringConversion, ToUInt8) {
@@ -138,6 +148,16 @@ TEST(StringConversion, ToUInt8) {
   AssertConversionFails<UInt8Type>("-");
   AssertConversionFails<UInt8Type>("0.0");
   AssertConversionFails<UInt8Type>("e");
+
+  // Hex
+  AssertConversion<UInt8Type>("0x0", 0);
+  AssertConversion<UInt8Type>("0x1A", 26);
+  AssertConversion<UInt8Type>("0xb", 11);
+  AssertConversion<UInt8Type>("0x7F", 127);
+  AssertConversion<UInt8Type>("0xFF", 255);
+  AssertConversionFails<UInt8Type>("0x");
+  AssertConversionFails<UInt8Type>("0x100");
+  AssertConversionFails<UInt8Type>("0x1g");
 }
 
 TEST(StringConversion, ToInt16) {
@@ -155,6 +175,16 @@ TEST(StringConversion, ToInt16) {
   AssertConversionFails<Int16Type>("-");
   AssertConversionFails<Int16Type>("0.0");
   AssertConversionFails<Int16Type>("e");
+  
+  // Hex
+  AssertConversion<Int16Type>("0x0", 0);
+  AssertConversion<Int16Type>("0X1aA", 426);
+  AssertConversion<Int16Type>("0xb", 11);
+  AssertConversion<Int16Type>("0x7ffF", 32767);
+  AssertConversion<Int16Type>("0XfffF", -1);
+  AssertConversionFails<Int16Type>("0x");
+  AssertConversionFails<Int16Type>("0x10000");
+  AssertConversionFails<Int16Type>("0x1g");
 }
 
 TEST(StringConversion, ToUInt16) {
@@ -172,6 +202,16 @@ TEST(StringConversion, ToUInt16) {
   AssertConversionFails<UInt16Type>("-");
   AssertConversionFails<UInt16Type>("0.0");
   AssertConversionFails<UInt16Type>("e");
+
+  // Hex
+  AssertConversion<UInt16Type>("0x0", 0);
+  AssertConversion<UInt16Type>("0x1aA", 426);
+  AssertConversion<UInt16Type>("0xb", 11);
+  AssertConversion<UInt16Type>("0x7ffF", 32767);
+  AssertConversion<UInt16Type>("0xFffF", 65535);
+  AssertConversionFails<UInt16Type>("0x");
+  AssertConversionFails<UInt16Type>("0x10000");
+  AssertConversionFails<UInt16Type>("0x1g");
 }
 
 TEST(StringConversion, ToInt32) {
@@ -189,6 +229,18 @@ TEST(StringConversion, ToInt32) {
   AssertConversionFails<Int32Type>("-");
   AssertConversionFails<Int32Type>("0.0");
   AssertConversionFails<Int32Type>("e");
+
+  // Hex
+  AssertConversion<Int32Type>("0x0", 0);
+  AssertConversion<Int32Type>("0x123ABC", 1194684);
+  AssertConversion<Int32Type>("0xA4B35", 674613);
+  AssertConversion<Int32Type>("0x7FFFFFFF", 2147483647);
+  AssertConversion<Int32Type>("0x123abc", 1194684);
+  AssertConversion<Int32Type>("0xA4b35", 674613);
+  AssertConversion<Int32Type>("0x7FFFfFfF", 2147483647);
+  AssertConversion<Int32Type>("0XFFFFfFfF", -1);
+  AssertConversionFails<Int32Type>("0X");
+  AssertConversionFails<Int32Type>("0x23512ak");
 }
 
 TEST(StringConversion, ToUInt32) {
@@ -206,6 +258,18 @@ TEST(StringConversion, ToUInt32) {
   AssertConversionFails<UInt32Type>("-");
   AssertConversionFails<UInt32Type>("0.0");
   AssertConversionFails<UInt32Type>("e");
+
+  // Hex
+  AssertConversion<UInt32Type>("0x0", 0);
+  AssertConversion<UInt32Type>("0x123ABC", 1194684);
+  AssertConversion<UInt32Type>("0xA4B35", 674613);
+  AssertConversion<UInt32Type>("0x7FFFFFFF", 2147483647);
+  AssertConversion<UInt32Type>("0x123abc", 1194684);
+  AssertConversion<UInt32Type>("0xA4b35", 674613);
+  AssertConversion<UInt32Type>("0x7FFFfFfF", 2147483647);
+  AssertConversion<UInt32Type>("0XFFFFfFfF", 4294967295);
+  AssertConversionFails<UInt32Type>("0X");
+  AssertConversionFails<UInt32Type>("0x23512ak");
 }
 
 TEST(StringConversion, ToInt64) {
@@ -223,6 +287,17 @@ TEST(StringConversion, ToInt64) {
   AssertConversionFails<Int64Type>("-");
   AssertConversionFails<Int64Type>("0.0");
   AssertConversionFails<Int64Type>("e");
+
+  // Hex
+  AssertConversion<Int64Type>("0x0", 0);
+  AssertConversion<Int64Type>("0x5415a123ABC123cb", 6058926048274359243);
+  AssertConversion<Int64Type>("0xA4B35", 674613);
+  AssertConversion<Int64Type>("0x7FFFFFFFFFFFFFFf", 9223372036854775807);
+  AssertConversion<Int64Type>("0XF000000000000001", -1152921504606846975);
+  AssertConversion<Int64Type>("0xfFFFFFFFFFFFFFFf", -1);
+  AssertConversionFails<Int64Type>("0X");
+  AssertConversionFails<Int64Type>("0x12345678901234567");
+  AssertConversionFails<Int64Type>("0x23512ak");
 }
 
 TEST(StringConversion, ToUInt64) {
@@ -237,6 +312,17 @@ TEST(StringConversion, ToUInt64) {
   AssertConversionFails<UInt64Type>("-");
   AssertConversionFails<UInt64Type>("0.0");
   AssertConversionFails<UInt64Type>("e");
+
+  // Hex
+  AssertConversion<UInt64Type>("0x0", 0);
+  AssertConversion<UInt64Type>("0x5415a123ABC123cb", 6058926048274359243);
+  AssertConversion<UInt64Type>("0xA4B35", 674613);
+  AssertConversion<UInt64Type>("0x7FFFFFFFFFFFFFFf", 9223372036854775807);
+  AssertConversion<UInt64Type>("0XF000000000000001", 17293822569102704641ULL);
+  AssertConversion<UInt64Type>("0xfFFFFFFFFFFFFFFf", 18446744073709551615ULL);
+  AssertConversionFails<UInt64Type>("0x");
+  AssertConversionFails<UInt64Type>("0x12345678901234567");
+  AssertConversionFails<UInt64Type>("0x23512ak");
 }
 
 TEST(StringConversion, ToDate32) {

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -175,7 +175,7 @@ TEST(StringConversion, ToInt16) {
   AssertConversionFails<Int16Type>("-");
   AssertConversionFails<Int16Type>("0.0");
   AssertConversionFails<Int16Type>("e");
-  
+
   // Hex
   AssertConversion<Int16Type>("0x0", 0);
   AssertConversion<Int16Type>("0X1aA", 426);


### PR DESCRIPTION
This PR adds the ability for the StringConverter to parse hex strings of the form:
0x123abc to an integer.
The strings must start with "0x" case insensitive.
The values ABCDEF are case insensitive.

Note that there was already a Hex Parsing function here:
https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/string.cc#L76
Which was not really flexible enough for what was needed.
Not sure it it would be best to replace it with the new functionality added by this PR. I am open to suggestions

This work was originally done here #11064 but had to create a new PR due to a rebase issue