### PR TITLE
ARROW-14003: [C++][Python] Not providing a sort_key in the "select_k_unstable" kernel crashes

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -2337,8 +2337,11 @@ class SelectKUnstableMetaFunction : public MetaFunction {
                             const FunctionOptions* options, ExecContext* ctx) const {
     const SelectKOptions& select_k_options = static_cast<const SelectKOptions&>(*options);
     if (select_k_options.k < 0) {
-      return Status::Invalid("SelectK requires a nonnegative `k`, got ",
+      return Status::Invalid("select_k_unstable requires a nonnegative `k`, got ",
                              select_k_options.k);
+    }
+    if (select_k_options.sort_keys.size() == 0) {
+      return Status::Invalid("select_k_unstable requires a non-empty `sort_keys`");
     }
     switch (args[0].kind()) {
       case Datum::ARRAY: {

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -643,3 +643,85 @@ def fill_null(values, fill_value):
         fill_value = pa.scalar(fill_value.as_py(), type=values.type)
 
     return call_function("coalesce", [values, fill_value])
+
+
+def top_k_unstable(values, k, sort_keys=None, memory_pool=None):
+    """
+    Select the indices of the top-k ordered elements from array- or table-like
+    data.
+
+    This is a specialization for :func:`select_k_unstable`. Output is not
+    guaranteed to be stable.
+
+    Parameters
+    ----------
+    values : Array, ChunkedArray, RecordBatch, or Table
+    k :  The number of `k` elements to keep.
+    sort_keys : Column key names to order by when input is table-like data.
+
+    Returns
+    -------
+    result : Array of indices
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr = pa.array(["a", "b", "c", None, "e", "f"])
+    >>> pc.top_k_unstable(arr, k=3)
+    <pyarrow.lib.UInt64Array object at 0x7fdcb19d7f30>
+    [
+      5,
+      4,
+      2
+    ]
+    """
+    if sort_keys is None:
+        sort_keys = []
+    if isinstance(values, (pa.Array, pa.ChunkedArray)):
+        sort_keys.append(("dummy", "descending"))
+    else:
+        sort_keys = map(lambda key_name: (key_name, "descending"), sort_keys)
+    options = SelectKOptions(k=k, sort_keys=sort_keys)
+    return call_function("select_k_unstable", [values], options, memory_pool)
+
+
+def bottom_k_unstable(values, k, sort_keys=None, memory_pool=None):
+    """
+    Select the indices of the bottom-k ordered elements from
+    array- or table-like data.
+
+    This is a specialization for :func:`select_k_unstable`. Output is not
+    guaranteed to be stable.
+
+    Parameters
+    ----------
+    values : Array, ChunkedArray, RecordBatch, or Table
+    k :  The number of `k` elements to keep.
+    sort_keys : Column key names to order by when input is table-like data.
+
+    Returns
+    -------
+    result : Array of indices
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr = pa.array(["a", "b", "c", None, "e", "f"])
+    >>> pc.bottom_k_unstable(arr, k=3)
+    <pyarrow.lib.UInt64Array object at 0x7fdcb19d7fa0>
+    [
+      0,
+      1,
+      2
+    ]
+    """
+    if sort_keys is None:
+        sort_keys = []
+    if isinstance(values, (pa.Array, pa.ChunkedArray)):
+        sort_keys.append(("dummy", "ascending"))
+    else:
+        sort_keys = map(lambda key_name: (key_name, "ascending"), sort_keys)
+    options = SelectKOptions(k=k, sort_keys=sort_keys)
+    return call_function("select_k_unstable", [values], options, memory_pool)


### PR DESCRIPTION
This is a minor fix for issue ARROW-14003. Moreover I added some function (topK/bottomK) specialization  in arrow/compute.py. 
@jorisvandenbossche 