### PR TITLE
ARROW-14009: [C++] Seed parallellism in SourceNode

### DIFF
--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -228,10 +228,24 @@ class DatasetFixtureMixin : public ::testing::Test {
                                         bool ensure_drained = true) {
     ASSERT_OK_AND_ASSIGN(auto it, scanner->ScanBatchesUnordered());
 
+    ASSERT_OK_AND_ASSIGN(auto batches, it.ToVector());
+    std::sort(batches.begin(), batches.end(),
+              [](const EnumeratedRecordBatch& left,
+                 const EnumeratedRecordBatch& right) -> bool {
+                if (left.fragment.index < right.fragment.index) {
+                  return true;
+                }
+                if (left.fragment.index > right.fragment.index) {
+                  return false;
+                }
+                return left.record_batch.index < right.record_batch.index;
+              });
+
     int fragment_counter = 0;
     bool saw_last_fragment = false;
     int batch_counter = 0;
-    auto visitor = [&](EnumeratedRecordBatch batch) -> Status {
+
+    for (const auto& batch : batches) {
       if (batch_counter == 0) {
         EXPECT_FALSE(saw_last_fragment);
       }
@@ -245,9 +259,7 @@ class DatasetFixtureMixin : public ::testing::Test {
       }
       saw_last_fragment = batch.fragment.last;
       AssertBatchEquals(expected, *batch.record_batch.value);
-      return Status::OK();
-    };
-    ARROW_EXPECT_OK(it.Visit(visitor));
+    }
 
     if (ensure_drained) {
       EnsureRecordBatchReaderDrained(expected);

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -176,9 +176,10 @@ class Iterator : public util::EqualityComparable<Iterator<T>> {
   /// \brief Move every element of this iterator into a vector.
   Result<std::vector<T>> ToVector() {
     std::vector<T> out;
-    for (auto maybe_element : *this) {
-      ARROW_ASSIGN_OR_RAISE(auto element, maybe_element);
-      out.push_back(std::move(element));
+    for (;;) {
+      ARROW_ASSIGN_OR_RAISE(auto value, Next());
+      if (IsIterationEnd(value)) break;
+      out.push_back(std::move(value));
     }
     // ARROW-8193: On gcc-4.8 without the explicit move it tries to use the
     // copy constructor, which may be deleted on the elements of type T

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -176,10 +176,9 @@ class Iterator : public util::EqualityComparable<Iterator<T>> {
   /// \brief Move every element of this iterator into a vector.
   Result<std::vector<T>> ToVector() {
     std::vector<T> out;
-    for (;;) {
-      ARROW_ASSIGN_OR_RAISE(auto value, Next());
-      if (IsIterationEnd(value)) break;
-      out.push_back(std::move(value));
+    for (auto maybe_element : *this) {
+      ARROW_ASSIGN_OR_RAISE(auto element, maybe_element);
+      out.push_back(std::move(element));
     }
     // ARROW-8193: On gcc-4.8 without the explicit move it tries to use the
     // copy constructor, which may be deleted on the elements of type T


### PR DESCRIPTION
Previously we synchronously called InputReceived in the loop that consumed the source generator. This meant that we only ever processed one batch at a time (barring a pipeline breaker). Instead, submit batches to an executor and use an AsyncTaskGroup to track completion.