### PR TITLE
ARROW-13112: [R] altrep vectors for strings and other types

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -4,6 +4,10 @@ is_altrep <- function(x) {
   .Call(`_arrow_is_altrep`, x)
 }
 
+test_SET_STRING_ELT <- function(s) {
+  invisible(.Call(`_arrow_test_SET_STRING_ELT`, s))
+}
+
 Array__Slice1 <- function(array, offset) {
   .Call(`_arrow_Array__Slice1`, array, offset)
 }
@@ -1771,3 +1775,4 @@ SetIOThreadPoolCapacity <- function(threads) {
 Array__infer_type <- function(x) {
   .Call(`_arrow_Array__infer_type`, x)
 }
+

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -26,9 +26,6 @@
 #include <cpp11/altrep.hpp>
 #if defined(HAS_ALTREP)
 
-// defined in array_to_vector.cpp
-SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array);
-
 #if R_VERSION < R_Version(3, 6, 0)
 
 // workaround because R's <R_ext/Altrep.h> not so conveniently uses `class`

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -124,6 +124,10 @@ struct AltrepArrayPrimitive : public AltrepArrayBase {
 
   using c_type = typename std::conditional<sexp_type == REALSXP, double, int>::type;
 
+  static SEXP Make(const std::shared_ptr<Array>& array) {
+    return AltrepArrayBase::Make(class_t, array);
+  }
+
   // Is the vector materialized, i.e. does the data2 slot contain a
   // standard R vector with the same data as the array.
   static bool IsMaterialized(SEXP alt_) { return !Rf_isNull(R_altrep_data2(alt_)); }
@@ -660,15 +664,13 @@ void Init_Altrep_classes(DllInfo* dll) {
 }
 
 // return an altrep R vector that shadows the array if possible
-SEXP MakeAltrepArrayPrimitive(const std::shared_ptr<Array>& array) {
+SEXP MakeAltrepVector(const std::shared_ptr<Array>& array) {
   switch (array->type()->id()) {
     case arrow::Type::DOUBLE:
-      return altrep::AltrepArrayBase::Make(altrep::AltrepArrayPrimitive<REALSXP>::class_t,
-                                           array);
+      return altrep::AltrepArrayPrimitive<REALSXP>::Make(array);
 
     case arrow::Type::INT32:
-      return altrep::AltrepArrayBase::Make(altrep::AltrepArrayPrimitive<INTSXP>::class_t,
-                                           array);
+      return altrep::AltrepArrayPrimitive<INTSXP>::Make(array);
 
     case arrow::Type::STRING:
       return altrep::AltrepArrayString::Make(array);

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -664,7 +664,8 @@ void Init_Altrep_classes(DllInfo* dll) {
   InitAltIntegerClass<AltrepVectorPrimitive<INTSXP>>(dll, "arrow::array_int_vector");
 
   InitAltStringClass<AltrepVectorString<StringType>>(dll, "arrow::array_string_vector");
-  InitAltStringClass<AltrepVectorString<LargeStringType>>(dll, "arrow::array_large_string_vector");
+  InitAltStringClass<AltrepVectorString<LargeStringType>>(
+      dll, "arrow::array_large_string_vector");
 }
 
 // return an altrep R vector that shadows the array if possible

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -73,7 +73,7 @@ class Converter {
       // - the arrow.use_altrep is set to TRUE or unset (implicit TRUE)
       // - the array has at least one element
       if (arrow::r::GetBoolOption("arrow.use_altrep", true) && array->length() > 0) {
-        SEXP alt = altrep::MakeAltrepArrayPrimitive(array);
+        SEXP alt = altrep::MakeAltrepVector(array);
         if (!Rf_isNull(alt)) {
           return alt;
         }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -19,6 +19,22 @@ extern "C" SEXP _arrow_is_altrep(SEXP x_sexp){
 }
 #endif
 
+// altrep.cpp
+#if defined(ARROW_R_WITH_ARROW)
+void test_SET_STRING_ELT(SEXP s);
+extern "C" SEXP _arrow_test_SET_STRING_ELT(SEXP s_sexp){
+BEGIN_CPP11
+	arrow::r::Input<SEXP>::type s(s_sexp);
+	test_SET_STRING_ELT(s);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_test_SET_STRING_ELT(SEXP s_sexp){
+	Rf_error("Cannot call test_SET_STRING_ELT(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // array.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::Array> Array__Slice1(const std::shared_ptr<arrow::Array>& array, R_xlen_t offset);
@@ -7053,6 +7069,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
 		{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_is_altrep", (DL_FUNC) &_arrow_is_altrep, 1}, 
+		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 
 		{ "_arrow_Array__Slice2", (DL_FUNC) &_arrow_Array__Slice2, 3}, 
 		{ "_arrow_Array__IsNull", (DL_FUNC) &_arrow_Array__IsNull, 2}, 

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -183,7 +183,7 @@ arrow::Status AddMetadataFromDots(SEXP lst, int num_fields,
 namespace altrep {
 
 void Init_Altrep_classes(DllInfo* dll);
-SEXP MakeAltrepArrayPrimitive(const std::shared_ptr<Array>& array);
+SEXP MakeAltrepVector(const std::shared_ptr<Array>& array);
 
 }  // namespace altrep
 #endif

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -515,14 +515,25 @@ test_that("Handling string data with embedded nuls", {
   )
   batch_with_nul <- record_batch(a = 1:5, b = raws)
   batch_with_nul$b <- batch_with_nul$b$cast(utf8())
+
+  df <- as.data.frame(batch_with_nul)
+
+  # expect_error(
+  #   df[],
+  #   paste0(
+  #     "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
+  #     "set options(arrow.skip_nul = TRUE)"
+  #   ),
+  #   fixed = TRUE
+  # )
   expect_error(
-    as.data.frame(batch_with_nul),
-    paste0(
-      "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
-      "set options(arrow.skip_nul = TRUE)"
-    ),
+    df$b[],
+    "embedded nul in string: 'ma\\0n'",
     fixed = TRUE
   )
+
+  batch_with_nul <- record_batch(a = 1:5, b = raws)
+  batch_with_nul$b <- batch_with_nul$b$cast(utf8())
 
   withr::with_options(list(arrow.skip_nul = TRUE), {
     expect_warning(

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -193,15 +193,24 @@ test_that("altrep min/max/sum identical to R versions for int", {
 test_that("altrep vectors handle serialization", {
   ints <- c(1L, 2L, NA_integer_)
   dbls <- c(1, 2, NA_real_)
+  strs <- c("un", "deux" , NA_character_)
 
   expect_identical(ints, unserialize(serialize(Array$create(ints)$as_vector(), NULL)))
   expect_identical(dbls, unserialize(serialize(Array$create(dbls)$as_vector(), NULL)))
+  expect_identical(strs, unserialize(serialize(Array$create(strs)$as_vector(), NULL)))
 })
 
 test_that("altrep vectors handle coercion", {
   ints <- c(1L, 2L, NA_integer_)
   dbls <- c(1, 2, NA_real_)
+  strs <- c("1", "2" , NA_character_)
 
   expect_identical(ints, as.integer(Array$create(dbls)$as_vector()))
+  expect_identical(ints, as.integer(Array$create(strs)$as_vector()))
+
   expect_identical(dbls, as.numeric(Array$create(ints)$as_vector()))
+  expect_identical(dbls, as.numeric(Array$create(strs)$as_vector()))
+
+  expect_identical(strs, as.character(Array$create(ints)$as_vector()))
+  expect_identical(strs, as.character(Array$create(dbls)$as_vector()))
 })

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -97,15 +97,17 @@ test_that("empty vectors are not altrep", {
 test_that("as.data.frame(<Table>, <RecordBatch>) can create altrep vectors", {
   withr::local_options(list(arrow.use_altrep = TRUE))
 
-  table <- Table$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3))
+  table <- Table$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3), str = c("un", "deux", "trois"))
   df_table <- as.data.frame(table)
   expect_true(is_altrep(df_table$int))
   expect_true(is_altrep(df_table$dbl))
+  expect_true(is_altrep(df_table$str))
 
-  batch <- RecordBatch$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3))
+  batch <- RecordBatch$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3), str = c("un", "deux", "trois"))
   df_batch <- as.data.frame(batch)
   expect_true(is_altrep(df_batch$int))
   expect_true(is_altrep(df_batch$dbl))
+  expect_true(is_altrep(df_batch$str))
 })
 
 expect_altrep_rountrip <- function(x, fn, ...) {
@@ -198,6 +200,7 @@ test_that("altrep vectors handle serialization", {
   expect_identical(ints, unserialize(serialize(Array$create(ints)$as_vector(), NULL)))
   expect_identical(dbls, unserialize(serialize(Array$create(dbls)$as_vector(), NULL)))
   expect_identical(strs, unserialize(serialize(Array$create(strs)$as_vector(), NULL)))
+  expect_identical(strs, unserialize(serialize(Array$create(strs, large_utf8())$as_vector(), NULL)))
 })
 
 test_that("altrep vectors handle coercion", {

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -432,21 +432,29 @@ test_that("Handling string data with embedded nuls", {
   class = c("arrow_binary", "vctrs_vctr", "list")
   )
   chunked_array_with_nul <- ChunkedArray$create(raws)$cast(utf8())
+  v <- expect_error(as.vector(chunked_array_with_nul), NA)
+
+  # TODO: when we figure out how to promote the error internally in altrep
+  #
+  # expect_error(
+  #   v[],
+  #   paste0(
+  #     "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
+  #     "set options(arrow.skip_nul = TRUE)"
+  #   ),
+  #   fixed = TRUE
+  # )
+
   expect_error(
-    as.vector(chunked_array_with_nul),
-    paste0(
-      "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
-      "set options(arrow.skip_nul = TRUE)"
-    ),
+    v[3],
+    "embedded nul in string: 'ma\\0n'",
     fixed = TRUE
   )
 
   withr::with_options(list(arrow.skip_nul = TRUE), {
+    v <- expect_warning(as.vector(chunked_array_with_nul), NA)
     expect_warning(
-      expect_identical(
-        as.vector(chunked_array_with_nul),
-        c("person", "woman", "man", "fan", "camera", "tv")
-      ),
+      expect_identical(v[3], "man"),
       "Stripping '\\0' (nul) from character vector",
       fixed = TRUE
     )

--- a/r/tests/testthat/test-scalar.R
+++ b/r/tests/testthat/test-scalar.R
@@ -85,19 +85,25 @@ test_that("Handling string data with embedded nuls", {
     fixed = TRUE
   )
   scalar_with_nul <- Scalar$create(raws, binary())$cast(utf8())
+
+  v <- expect_error(as.vector(scalar_with_nul), NA)
+  # expect_error(
+  #   v[1],
+  #   paste0(
+  #     "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
+  #     "set options(arrow.skip_nul = TRUE)"
+  #   ),
+  #   fixed = TRUE
+  # )
   expect_error(
-    as.vector(scalar_with_nul),
-    paste0(
-      "embedded nul in string: 'ma\\0n'; to strip nuls when converting from Arrow to R, ",
-      "set options(arrow.skip_nul = TRUE)"
-    ),
+    v[], "embedded nul in string: 'ma\\0n'",
     fixed = TRUE
   )
 
   withr::with_options(list(arrow.skip_nul = TRUE), {
     expect_warning(
       expect_identical(
-        as.vector(scalar_with_nul),
+        as.vector(scalar_with_nul)[],
         "man"
       ),
       "Stripping '\\0' (nul) from character vector",


### PR DESCRIPTION
Currently work in progress to deal with converting string Arrays into R altrep vectors. 

This needs more work, and other altrep vectors perhaps need to change as well. The string implementation is mostly inspired from the `R_deferred_string_class` in base R. 

This uses static methods because things like `Dataptr()` or even `Elt()` might jump and so we need to correctly unwind. This right now creates a dissymmetry. Perhaps all classes should just use static methods, like it used to be, and like things are usually done. 

Once this experiment is finished, we can start being more ambitious about converting more things to altrep, i.e. have altrep classes that uses the (potentially redesigned `Converter` code from `array_to_vector.cpp`). 
