### PR TITLE
ARROW-14016: [C++] Wrong type_name used for directory partitioning

### DIFF
--- a/c_glib/test/dataset/test-partitioning.rb
+++ b/c_glib/test/dataset/test-partitioning.rb
@@ -29,6 +29,6 @@ class TestDatasetPartitioning < Test::Unit::TestCase
   def test_directory
     schema = build_schema(year: Arrow::UInt16DataType.new)
     partitioning = ArrowDataset::DirectoryPartitioning.new(schema)
-    assert_equal("schema", partitioning.type_name)
+    assert_equal("directory", partitioning.type_name)
   end
 end

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -503,7 +503,7 @@ class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {
     util::InitializeUTF8();
   }
 
-  std::string type_name() const override { return "schema"; }
+  std::string type_name() const override { return "directory"; }
 
   Result<std::shared_ptr<Schema>> Inspect(
       const std::vector<std::string>& paths) override {

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -210,7 +210,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
                                  ArrayVector dictionaries = {},
                                  KeyValuePartitioningOptions options = {});
 
-  std::string type_name() const override { return "schema"; }
+  std::string type_name() const override { return "directory"; }
 
   /// \brief Create a factory for a directory partitioning.
   ///

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1952,7 +1952,7 @@ cdef class Partitioning(_Weakrefable):
         type_name = frombytes(sp.get().type_name())
 
         classes = {
-            'schema': DirectoryPartitioning,
+            'directory': DirectoryPartitioning,
             'hive': HivePartitioning,
         }
 


### PR DESCRIPTION
Trivial change to fix the type_name provided by DirectoryPartitioning. It appears to have been left from when it was called SchemaPartitioner. See: https://github.com/apache/arrow/pull/6153