### PR TITLE
ARROW-14026: [C++] Enable batch parallelism in Parquet scanner

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -382,6 +382,7 @@ class TestParquetFileFormatScan : public FileFormatScanMixin<ParquetFormatHelper
 };
 
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReader) { TestScan(); }
+TEST_P(TestParquetFileFormatScan, ScanBatchSize) { TestScanBatchSize(); }
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
   TestScanProjectedMissingCols();

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -192,7 +192,8 @@ class PARQUET_EXPORT FileReader {
   GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
                           const std::vector<int> row_group_indices,
                           const std::vector<int> column_indices,
-                          ::arrow::internal::Executor* cpu_executor = NULLPTR) = 0;
+                          ::arrow::internal::Executor* cpu_executor = NULLPTR,
+                          int row_group_readahead = 0) = 0;
 
   ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
                                        const std::vector<int>& column_indices,


### PR DESCRIPTION
This creates a new concatenating generator which converts AsyncGenerator<optional<vector<T>>> to AsyncGenerator<T> and supports async-reentrancy. When combined with a readahead generator, this enables us to get parallelism in scanning Parquet files.

This also properly chunks each row group into smaller batches as mentioned in ARROW-14024, though we can add more specific tests in that JIRA (and fix the issue for IPC as well).