### PR TITLE
ARROW-14027: [C++] Handle scalars in Grouper

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -279,8 +279,10 @@ template <typename Type>
 struct UnboxScalar<Type, enable_if_has_c_type<Type>> {
   using T = typename Type::c_type;
   static T Unbox(const Scalar& val) {
-    return *reinterpret_cast<const T*>(
-        checked_cast<const ::arrow::internal::PrimitiveScalarBase&>(val).data());
+    util::string_view view =
+        checked_cast<const ::arrow::internal::PrimitiveScalarBase&>(val).view();
+    DCHECK_EQ(view.size(), sizeof(T));
+    return *reinterpret_cast<const T*>(view.data());
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -69,9 +69,9 @@ struct KeyEncoder {
 
   virtual ~KeyEncoder() = default;
 
-  virtual void AddLength(const ArrayData&, int32_t* lengths) = 0;
+  virtual void AddLength(const Datum&, int64_t batch_length, int32_t* lengths) = 0;
 
-  virtual Status Encode(const ArrayData&, uint8_t** encoded_bytes) = 0;
+  virtual Status Encode(const Datum&, int64_t batch_length, uint8_t** encoded_bytes) = 0;
 
   virtual Result<std::shared_ptr<ArrayData>> Decode(uint8_t** encoded_bytes,
                                                     int32_t length, MemoryPool*) = 0;
@@ -112,25 +112,36 @@ struct KeyEncoder {
 struct BooleanKeyEncoder : KeyEncoder {
   static constexpr int kByteWidth = 1;
 
-  void AddLength(const ArrayData& data, int32_t* lengths) override {
-    for (int64_t i = 0; i < data.length; ++i) {
+  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override {
+    for (int64_t i = 0; i < batch_length; ++i) {
       lengths[i] += kByteWidth + kExtraByteForNull;
     }
   }
 
-  Status Encode(const ArrayData& data, uint8_t** encoded_bytes) override {
-    VisitArrayDataInline<BooleanType>(
-        data,
-        [&](bool value) {
-          auto& encoded_ptr = *encoded_bytes++;
-          *encoded_ptr++ = kValidByte;
-          *encoded_ptr++ = value;
-        },
-        [&] {
-          auto& encoded_ptr = *encoded_bytes++;
-          *encoded_ptr++ = kNullByte;
-          *encoded_ptr++ = 0;
-        });
+  Status Encode(const Datum& data, int64_t batch_length,
+                uint8_t** encoded_bytes) override {
+    if (data.is_array()) {
+      VisitArrayDataInline<BooleanType>(
+          *data.array(),
+          [&](bool value) {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kValidByte;
+            *encoded_ptr++ = value;
+          },
+          [&] {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kNullByte;
+            *encoded_ptr++ = 0;
+          });
+    } else {
+      const auto& scalar = data.scalar_as<BooleanScalar>();
+      bool value = scalar.is_valid && scalar.value;
+      for (int64_t i = 0; i < batch_length; i++) {
+        auto& encoded_ptr = *encoded_bytes++;
+        *encoded_ptr++ = kValidByte;
+        *encoded_ptr++ = value;
+      }
+    }
     return Status::OK();
   }
 
@@ -159,30 +170,53 @@ struct FixedWidthKeyEncoder : KeyEncoder {
       : type_(std::move(type)),
         byte_width_(checked_cast<const FixedWidthType&>(*type_).bit_width() / 8) {}
 
-  void AddLength(const ArrayData& data, int32_t* lengths) override {
-    for (int64_t i = 0; i < data.length; ++i) {
+  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override {
+    for (int64_t i = 0; i < batch_length; ++i) {
       lengths[i] += byte_width_ + kExtraByteForNull;
     }
   }
 
-  Status Encode(const ArrayData& data, uint8_t** encoded_bytes) override {
-    ArrayData viewed(fixed_size_binary(byte_width_), data.length, data.buffers,
-                     data.null_count, data.offset);
+  Status Encode(const Datum& data, int64_t batch_length,
+                uint8_t** encoded_bytes) override {
+    if (data.is_array()) {
+      const auto& arr = *data.array();
+      ArrayData viewed(fixed_size_binary(byte_width_), arr.length, arr.buffers,
+                       arr.null_count, arr.offset);
 
-    VisitArrayDataInline<FixedSizeBinaryType>(
-        viewed,
-        [&](util::string_view bytes) {
+      VisitArrayDataInline<FixedSizeBinaryType>(
+          viewed,
+          [&](util::string_view bytes) {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kValidByte;
+            memcpy(encoded_ptr, bytes.data(), byte_width_);
+            encoded_ptr += byte_width_;
+          },
+          [&] {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kNullByte;
+            memset(encoded_ptr, 0, byte_width_);
+            encoded_ptr += byte_width_;
+          });
+    } else {
+      const auto& scalar = data.scalar_as<arrow::internal::PrimitiveScalarBase>();
+      if (scalar.is_valid) {
+        const util::string_view data = scalar.view();
+        DCHECK_EQ(data.size(), static_cast<size_t>(byte_width_));
+        for (int64_t i = 0; i < batch_length; i++) {
           auto& encoded_ptr = *encoded_bytes++;
           *encoded_ptr++ = kValidByte;
-          memcpy(encoded_ptr, bytes.data(), byte_width_);
+          memcpy(encoded_ptr, data.data(), data.size());
           encoded_ptr += byte_width_;
-        },
-        [&] {
+        }
+      } else {
+        for (int64_t i = 0; i < batch_length; i++) {
           auto& encoded_ptr = *encoded_bytes++;
           *encoded_ptr++ = kNullByte;
           memset(encoded_ptr, 0, byte_width_);
           encoded_ptr += byte_width_;
-        });
+        }
+      }
+    }
     return Status::OK();
   }
 
@@ -214,8 +248,12 @@ struct DictionaryKeyEncoder : FixedWidthKeyEncoder {
   DictionaryKeyEncoder(std::shared_ptr<DataType> type, MemoryPool* pool)
       : FixedWidthKeyEncoder(std::move(type)), pool_(pool) {}
 
-  Status Encode(const ArrayData& data, uint8_t** encoded_bytes) override {
-    auto dict = MakeArray(data.dictionary);
+  Status Encode(const Datum& data, int64_t batch_length,
+                uint8_t** encoded_bytes) override {
+    auto dict =
+        data.is_array()
+            ? MakeArray(data.array()->dictionary)
+            : MakeArray(data.scalar_as<DictionaryScalar>().value.dictionary->data());
     if (dictionary_) {
       if (!dictionary_->Equals(dict)) {
         // TODO(bkietz) unify if necessary. For now, just error if any batch's dictionary
@@ -225,7 +263,11 @@ struct DictionaryKeyEncoder : FixedWidthKeyEncoder {
     } else {
       dictionary_ = std::move(dict);
     }
-    return FixedWidthKeyEncoder::Encode(data, encoded_bytes);
+    if (data.is_array()) {
+      return FixedWidthKeyEncoder::Encode(data, batch_length, encoded_bytes);
+    }
+    return FixedWidthKeyEncoder::Encode(data.scalar_as<DictionaryScalar>().value.index,
+                                        batch_length, encoded_bytes);
   }
 
   Result<std::shared_ptr<ArrayData>> Decode(uint8_t** encoded_bytes, int32_t length,
@@ -252,34 +294,67 @@ template <typename T>
 struct VarLengthKeyEncoder : KeyEncoder {
   using Offset = typename T::offset_type;
 
-  void AddLength(const ArrayData& data, int32_t* lengths) override {
-    int64_t i = 0;
-    VisitArrayDataInline<T>(
-        data,
-        [&](util::string_view bytes) {
-          lengths[i++] +=
-              kExtraByteForNull + sizeof(Offset) + static_cast<int32_t>(bytes.size());
-        },
-        [&] { lengths[i++] += kExtraByteForNull + sizeof(Offset); });
+  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override {
+    if (data.is_array()) {
+      int64_t i = 0;
+      VisitArrayDataInline<T>(
+          *data.array(),
+          [&](util::string_view bytes) {
+            lengths[i++] +=
+                kExtraByteForNull + sizeof(Offset) + static_cast<int32_t>(bytes.size());
+          },
+          [&] { lengths[i++] += kExtraByteForNull + sizeof(Offset); });
+    } else {
+      const Scalar& scalar = *data.scalar();
+      const int32_t buffer_size =
+          scalar.is_valid ? static_cast<int32_t>(UnboxScalar<T>::Unbox(scalar).size())
+                          : 0;
+      for (int64_t i = 0; i < batch_length; i++) {
+        lengths[i] += kExtraByteForNull + sizeof(Offset) + buffer_size;
+      }
+    }
   }
 
-  Status Encode(const ArrayData& data, uint8_t** encoded_bytes) override {
-    VisitArrayDataInline<T>(
-        data,
-        [&](util::string_view bytes) {
+  Status Encode(const Datum& data, int64_t batch_length,
+                uint8_t** encoded_bytes) override {
+    if (data.is_array()) {
+      VisitArrayDataInline<T>(
+          *data.array(),
+          [&](util::string_view bytes) {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kValidByte;
+            util::SafeStore(encoded_ptr, static_cast<Offset>(bytes.size()));
+            encoded_ptr += sizeof(Offset);
+            memcpy(encoded_ptr, bytes.data(), bytes.size());
+            encoded_ptr += bytes.size();
+          },
+          [&] {
+            auto& encoded_ptr = *encoded_bytes++;
+            *encoded_ptr++ = kNullByte;
+            util::SafeStore(encoded_ptr, static_cast<Offset>(0));
+            encoded_ptr += sizeof(Offset);
+          });
+    } else {
+      const auto& scalar = data.scalar_as<BaseBinaryScalar>();
+      const auto& bytes = *scalar.value;
+      if (scalar.is_valid) {
+        for (int64_t i = 0; i < batch_length; i++) {
           auto& encoded_ptr = *encoded_bytes++;
           *encoded_ptr++ = kValidByte;
           util::SafeStore(encoded_ptr, static_cast<Offset>(bytes.size()));
           encoded_ptr += sizeof(Offset);
           memcpy(encoded_ptr, bytes.data(), bytes.size());
           encoded_ptr += bytes.size();
-        },
-        [&] {
+        }
+      } else {
+        for (int64_t i = 0; i < batch_length; i++) {
           auto& encoded_ptr = *encoded_bytes++;
           *encoded_ptr++ = kNullByte;
           util::SafeStore(encoded_ptr, static_cast<Offset>(0));
           encoded_ptr += sizeof(Offset);
-        });
+        }
+      }
+    }
     return Status::OK();
   }
 
@@ -373,7 +448,7 @@ struct GrouperImpl : Grouper {
   Result<Datum> Consume(const ExecBatch& batch) override {
     std::vector<int32_t> offsets_batch(batch.length + 1);
     for (int i = 0; i < batch.num_values(); ++i) {
-      encoders_[i]->AddLength(*batch[i].array(), offsets_batch.data());
+      encoders_[i]->AddLength(batch[i], batch.length, offsets_batch.data());
     }
 
     int32_t total_length = 0;
@@ -391,7 +466,7 @@ struct GrouperImpl : Grouper {
     }
 
     for (int i = 0; i < batch.num_values(); ++i) {
-      RETURN_NOT_OK(encoders_[i]->Encode(*batch[i].array(), key_buf_ptrs.data()));
+      RETURN_NOT_OK(encoders_[i]->Encode(batch[i], batch.length, key_buf_ptrs.data()));
     }
 
     TypedBufferBuilder<uint32_t> group_ids_batch(ctx_->memory_pool());
@@ -541,9 +616,27 @@ struct GrouperFastImpl : Grouper {
   ~GrouperFastImpl() { map_.cleanup(); }
 
   Result<Datum> Consume(const ExecBatch& batch) override {
+    // ARROW-14027: expand scalar arguments for now
+    for (int i = 0; i < batch.num_values(); i++) {
+      if (batch.values[i].is_scalar()) {
+        ExecBatch expanded = batch;
+        for (int j = i; j < expanded.num_values(); j++) {
+          if (expanded.values[j].is_scalar()) {
+            ARROW_ASSIGN_OR_RAISE(
+                expanded.values[j],
+                MakeArrayFromScalar(*expanded.values[j].scalar(), expanded.length,
+                                    ctx_->memory_pool()));
+          }
+        }
+        return ConsumeImpl(expanded);
+      }
+    }
+    return ConsumeImpl(batch);
+  }
+
+  Result<Datum> ConsumeImpl(const ExecBatch& batch) {
     int64_t num_rows = batch.length;
     int num_columns = batch.num_values();
-
     // Process dictionaries
     for (int icol = 0; icol < num_columns; ++icol) {
       if (key_types_[icol]->id() == Type::DICTIONARY) {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -250,10 +250,8 @@ struct DictionaryKeyEncoder : FixedWidthKeyEncoder {
 
   Status Encode(const Datum& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override {
-    auto dict =
-        data.is_array()
-            ? MakeArray(data.array()->dictionary)
-            : data.scalar_as<DictionaryScalar>().value.dictionary;
+    auto dict = data.is_array() ? MakeArray(data.array()->dictionary)
+                                : data.scalar_as<DictionaryScalar>().value.dictionary;
     if (dictionary_) {
       if (!dictionary_->Equals(dict)) {
         // TODO(bkietz) unify if necessary. For now, just error if any batch's dictionary

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -253,7 +253,7 @@ struct DictionaryKeyEncoder : FixedWidthKeyEncoder {
     auto dict =
         data.is_array()
             ? MakeArray(data.array()->dictionary)
-            : MakeArray(data.scalar_as<DictionaryScalar>().value.dictionary->data());
+            : data.scalar_as<DictionaryScalar>().value.dictionary;
     if (dictionary_) {
       if (!dictionary_->Equals(dict)) {
         // TODO(bkietz) unify if necessary. For now, just error if any batch's dictionary
@@ -616,7 +616,7 @@ struct GrouperFastImpl : Grouper {
   ~GrouperFastImpl() { map_.cleanup(); }
 
   Result<Datum> Consume(const ExecBatch& batch) override {
-    // ARROW-14027: expand scalar arguments for now
+    // ARROW-14027: broadcast scalar arguments for now
     for (int i = 0; i < batch.num_values(); i++) {
       if (batch.values[i].is_scalar()) {
         ExecBatch expanded = batch;

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -401,7 +401,10 @@ struct TestGrouper {
 
     for (int i = 0; i < key_batch.num_values(); ++i) {
       SCOPED_TRACE(std::to_string(i) + "th key array");
-      auto original = key_batch[i].make_array();
+      auto original =
+          key_batch[i].is_array()
+              ? key_batch[i].make_array()
+              : *MakeArrayFromScalar(*key_batch[i].scalar(), key_batch.length);
       ASSERT_OK_AND_ASSIGN(auto encoded, Take(*uniques_[i].make_array(), *ids));
       AssertArraysEqual(*original, *encoded, /*verbose=*/true,
                         EqualOptions().nans_equal(true));
@@ -637,6 +640,37 @@ TEST(Grouper, MakeGroupings) {
   auto ids = checked_pointer_cast<UInt32Array>(ArrayFromJSON(uint32(), "[0, null, 1]"));
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, HasSubstr("MakeGroupings with null ids"),
                                   internal::Grouper::MakeGroupings(*ids, 5));
+}
+
+TEST(Grouper, ScalarValues) {
+  // large_utf8 forces GrouperImpl over GrouperFastImpl
+  for (const auto& str_type : {utf8(), large_utf8()}) {
+    {
+      TestGrouper g({ValueDescr::Scalar(boolean()), ValueDescr::Scalar(int32()),
+                     ValueDescr::Scalar(decimal128(3, 2)),
+                     ValueDescr::Scalar(decimal256(3, 2)),
+                     ValueDescr::Scalar(fixed_size_binary(2)),
+                     ValueDescr::Scalar(str_type), ValueDescr::Array(int32())});
+      g.ExpectConsume(
+          R"([
+[true, 1, "1.00", "2.00", "ab", "foo", 2],
+[true, 1, "1.00", "2.00", "ab", "foo", 2],
+[true, 1, "1.00", "2.00", "ab", "foo", 3]
+])",
+          "[0, 0, 1]");
+    }
+    {
+      auto dict_type = dictionary(int32(), utf8());
+      TestGrouper g({ValueDescr::Scalar(dict_type), ValueDescr::Scalar(str_type)});
+      const auto dict = R"(["foo", null])";
+      g.ExpectConsume(
+          {DictScalarFromJSON(dict_type, "0", dict), ScalarFromJSON(str_type, R"("")")},
+          ArrayFromJSON(uint32(), "[0]"));
+      g.ExpectConsume(
+          {DictScalarFromJSON(dict_type, "1", dict), ScalarFromJSON(str_type, R"("")")},
+          ArrayFromJSON(uint32(), "[1]"));
+    }
+  }
 }
 
 TEST(GroupBy, Errors) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -63,8 +63,8 @@ struct CastPrimitive {
       // the output
       const auto& in_scalar = input.scalar_as<PrimitiveScalarBase>();
       auto out_scalar = checked_cast<PrimitiveScalarBase*>(out->scalar().get());
-      caster(in_scalar.data(), /*in_offset=*/0, /*length=*/1, /*out_offset=*/0,
-             out_scalar->mutable_data());
+      caster(reinterpret_cast<const void*>(in_scalar.view().data()), /*in_offset=*/0,
+             /*length=*/1, /*out_offset=*/0, out_scalar->mutable_data());
     }
   }
 };
@@ -88,7 +88,7 @@ struct CastPrimitive<OutType, InType, enable_if_t<std::is_same<OutType, InType>:
       const auto& in_scalar = input.scalar_as<PrimitiveScalarBase>();
       auto out_scalar = checked_cast<PrimitiveScalarBase*>(out->scalar().get());
       *reinterpret_cast<T*>(out_scalar->mutable_data()) =
-          *reinterpret_cast<const T*>(in_scalar.data());
+          *reinterpret_cast<const T*>(in_scalar.view().data());
     }
   }
 };

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -542,7 +542,7 @@ Result<std::shared_ptr<Scalar>> StructScalar::field(FieldRef ref) const {
 }
 
 DictionaryScalar::DictionaryScalar(std::shared_ptr<DataType> type)
-    : Scalar(std::move(type)),
+    : internal::PrimitiveScalarBase(std::move(type)),
       value{MakeNullScalar(checked_cast<const DictionaryType&>(*this->type).index_type()),
             MakeArrayOfNull(checked_cast<const DictionaryType&>(*this->type).value_type(),
                             0)

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -170,6 +170,22 @@ class ARROW_EXPORT BasicDecimal128 {
     return {low_bits_, static_cast<uint64_t>(high_bits_)};
   }
 
+  inline const uint8_t* native_endian_bytes() const {
+#if ARROW_LITTLE_ENDIAN
+    return reinterpret_cast<const uint8_t*>(&low_bits_);
+#else
+    return reinterpret_cast<const uint8_t*>(&high_bits_);
+#endif
+  }
+
+  inline uint8_t* mutable_native_endian_bytes() {
+#if ARROW_LITTLE_ENDIAN
+    return reinterpret_cast<uint8_t*>(&low_bits_);
+#else
+    return reinterpret_cast<uint8_t*>(&high_bits_);
+#endif
+  }
+
   /// \brief Return the raw bytes of the value in native-endian byte order.
   std::array<uint8_t, 16> ToBytes() const;
   void ToBytes(uint8_t* out) const;
@@ -337,6 +353,14 @@ class ARROW_EXPORT BasicDecimal256 {
   /// For example, BasicDecimal256(123).little_endian_array() = {123, 0};
   inline const std::array<uint64_t, 4> little_endian_array() const {
     return BitUtil::LittleEndianArray::FromNative(array_);
+  }
+
+  inline const uint8_t* native_endian_bytes() const {
+    return reinterpret_cast<const uint8_t*>(array_.data());
+  }
+
+  inline uint8_t* mutable_native_endian_bytes() {
+    return reinterpret_cast<uint8_t*>(array_.data());
   }
 
   /// \brief Get the lowest bits of the two's complement representation of the number.


### PR DESCRIPTION
This adds basic support for scalar values in the groupers. The non-fast grouper directly supports scalar. GrouperFastImpl will expand scalars to arrays first; this is because the rest of the implementation deals with buffers, which we don't really have with a scalar, so expanding scalars was the most expedient solution at a cost in performance. There's also a bit of refactoring to consistently expose a view method for primitive scalars, which can later be used to simplify some kernel implementations.