### PR TITLE
ARROW-14024: [C++] Test that batch size is respected for IPC/CSV

### DIFF
--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -139,7 +139,7 @@ class FragmentDataset : public Dataset {
 // reentrant pulls, so apply readahead before using this helper.
 inline RecordBatchGenerator MakeChunkedBatchGenerator(RecordBatchGenerator gen,
                                                       int64_t batch_size) {
-  return MakeConcatenatedGenerator(MakeMappedGenerator(
+  return MakeFlatMappedGenerator(
       std::move(gen),
       [batch_size](const std::shared_ptr<RecordBatch>& batch)
           -> ::arrow::AsyncGenerator<std::shared_ptr<::arrow::RecordBatch>> {
@@ -153,7 +153,7 @@ inline RecordBatchGenerator MakeChunkedBatchGenerator(RecordBatchGenerator gen,
           slices.push_back(batch->Slice(i, batch_size));
         }
         return ::arrow::MakeVectorGenerator(std::move(slices));
-      }));
+      });
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -28,6 +28,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/scalar.h"
 #include "arrow/type.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/iterator.h"
 
@@ -131,6 +132,29 @@ class FragmentDataset : public Dataset {
   FragmentVector fragments_;
   AsyncGenerator<std::shared_ptr<Fragment>> fragment_gen_;
 };
+
+// Given a record batch generator, creates a new generator that slices
+// batches so individual batches have at most batch_size rows. The
+// resulting generator is async-reentrant, but does not forward
+// reentrant pulls, so apply readahead before using this helper.
+inline RecordBatchGenerator MakeChunkedBatchGenerator(RecordBatchGenerator gen,
+                                                      int64_t batch_size) {
+  return MakeConcatenatedGenerator(MakeMappedGenerator(
+      std::move(gen),
+      [batch_size](const std::shared_ptr<RecordBatch>& batch)
+          -> ::arrow::AsyncGenerator<std::shared_ptr<::arrow::RecordBatch>> {
+        const int64_t rows = batch->num_rows();
+        if (rows <= batch_size) {
+          return ::arrow::MakeVectorGenerator<std::shared_ptr<RecordBatch>>({batch});
+        }
+        std::vector<std::shared_ptr<RecordBatch>> slices;
+        slices.reserve(rows / batch_size + (rows % batch_size != 0));
+        for (int64_t i = 0; i < rows; i += batch_size) {
+          slices.push_back(batch->Slice(i, batch_size));
+        }
+        return ::arrow::MakeVectorGenerator(std::move(slices));
+      }));
+}
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -387,6 +387,7 @@ INSTANTIATE_TEST_SUITE_P(TestZSTDCsv, TestCsvFileFormat,
 class TestCsvFileFormatScan : public FileFormatScanMixin<CsvFormatHelper> {};
 
 TEST_P(TestCsvFileFormatScan, ScanRecordBatchReader) { TestScan(); }
+TEST_P(TestCsvFileFormatScan, ScanBatchSize) { TestScanBatchSize(); }
 TEST_P(TestCsvFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
   TestScanWithVirtualColumn();
 }

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -134,6 +134,7 @@ TEST_F(TestIpcFileSystemDataset, WriteExceedsMaxPartitions) {
 class TestIpcFileFormatScan : public FileFormatScanMixin<IpcFormatHelper> {};
 
 TEST_P(TestIpcFileFormatScan, ScanRecordBatchReader) { TestScan(); }
+TEST_P(TestIpcFileFormatScan, ScanBatchSize) { TestScanBatchSize(); }
 TEST_P(TestIpcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
   TestScanWithVirtualColumn();
 }

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -591,6 +591,7 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
   }
   // Ensure batch_size is respected
   void TestScanBatchSize() {
+    constexpr int kBatchSize = 17;
     auto reader = GetRecordBatchReader(schema({field("f64", float64())}));
     auto source = this->GetFileSource(reader.get());
 
@@ -598,10 +599,10 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
     auto fragment = this->MakeFragment(*source);
 
     int64_t row_count = 0;
-    opts_->batch_size = 16;
+    opts_->batch_size = kBatchSize;
     for (auto maybe_batch : Batches(fragment)) {
       ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
-      ASSERT_LE(batch->num_rows(), 16);
+      ASSERT_LE(batch->num_rows(), kBatchSize);
       row_count += batch->num_rows();
     }
     ASSERT_EQ(row_count, GetParam().expected_rows());

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -221,6 +221,9 @@ class MappingGenerator {
       bool should_trigger;
       {
         auto guard = state->mutex.Lock();
+        // A MappedCallback may have purged or be purging the queue;
+        // we shouldn't do anything here.
+        if (state->finished) return;
         if (end) {
           should_purge = !state->finished;
           state->finished = true;


### PR DESCRIPTION
This wraps the IPC/CSV generators in a sub-generator that will re-slice the batches to respect the batch_size parameter. For Parquet, see #11189.