### PR TITLE
ARROW-14008: [R][Compute] Running an ExecPlan should yield Reader instead of Table

### DIFF
--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -18,7 +18,7 @@
 do_exec_plan <- function(.data) {
   plan <- ExecPlan$create()
   final_node <- plan$Build(.data)
-  tab <- plan$Run(final_node)
+  tab <- plan$Run(final_node)$read_table()
 
   # If arrange() created $temp_columns, make sure to omit them from the result
   # We can't currently handle this in the ExecPlan itself because sorting

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1094,7 +1094,7 @@ extern "C" SEXP _arrow_ExecPlan_create(SEXP use_threads_sexp){
 
 // compute-exec.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::Table> ExecPlan_run(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<compute::ExecNode>& final_node, cpp11::list sort_options);
+std::shared_ptr<arrow::RecordBatchReader> ExecPlan_run(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<compute::ExecNode>& final_node, cpp11::list sort_options);
 extern "C" SEXP _arrow_ExecPlan_run(SEXP plan_sexp, SEXP final_node_sexp, SEXP sort_options_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::ExecPlan>&>::type plan(plan_sexp);


### PR DESCRIPTION
This only modifies the binding (c++) so that returning a RecordBatchReader is possible; the R API continues to collect the stream of batches into a Table. 