### PR TITLE
ARROW-13916: [C++] Implement strftime on date32/64 types

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal.cc
@@ -1199,7 +1199,7 @@ void RegisterScalarTemporal(FunctionRegistry* registry) {
 
   static const auto default_strftime_options = StrftimeOptions();
   auto strftime = MakeSimpleUnaryTemporal<Strftime>(
-      "strftime", {WithDates, WithTimestamps}, utf8(), &strftime_doc,
+      "strftime", {WithTimes, WithDates, WithTimestamps}, utf8(), &strftime_doc,
       &default_strftime_options, StrftimeState::Init);
   DCHECK_OK(registry->AddFunction(std::move(strftime)));
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal.cc
@@ -1199,7 +1199,7 @@ void RegisterScalarTemporal(FunctionRegistry* registry) {
 
   static const auto default_strftime_options = StrftimeOptions();
   auto strftime = MakeSimpleUnaryTemporal<Strftime>(
-      "strftime", {WithTimes, WithTimestamps}, utf8(), &strftime_doc,
+      "strftime", {WithDates, WithTimestamps}, utf8(), &strftime_doc,
       &default_strftime_options, StrftimeState::Init);
   DCHECK_OK(registry->AddFunction(std::move(strftime)));
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -639,6 +639,7 @@ TEST_F(ScalarTemporalTest, Strftime) {
   CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
                    utf8(), string_nanoseconds, &options);
 
+<<<<<<< HEAD
   auto options_hms = StrftimeOptions("%H:%M:%S");
   auto options_ymdhms = StrftimeOptions("%Y-%m-%dT%H:%M:%S");
 
@@ -693,6 +694,26 @@ TEST_F(ScalarTemporalTest, Strftime) {
       Invalid,
       testing::HasSubstr("Invalid: Timezone not present, cannot convert to string"),
       Strftime(arr_ns, StrftimeOptions("%Y-%m-%dT%H:%M:%S%Z")));
+
+  auto options_ymd = StrftimeOptions("%Y-%m-%d");
+  auto options_ymdhms = StrftimeOptions("%Y-%m-%dT%H:%M:%S");
+
+  const char* date32s = R"([0, 10957, 10958, null])";
+  const char* date64s = R"([0, 946684800000, 946771200000, null])";
+  const char* dates32_ymd = R"(["1970-01-01", "2000-01-01", "2000-01-02", null])";
+  const char* dates64_ymd = R"(["1970-01-01", "2000-01-01", "2000-01-02", null])";
+  const char* dates32_ymdhms =
+      R"(["1970-01-01T00:00:00", "2000-01-01T00:00:00", "2000-01-02T00:00:00", null])";
+  const char* dates64_ymdhms =
+      R"(["1970-01-01T00:00:00.000", "2000-01-01T00:00:00.000",
+          "2000-01-02T00:00:00.000", null])";
+
+  CheckScalarUnary("strftime", date32(), date32s, utf8(), dates32_ymd, &options_ymd);
+  CheckScalarUnary("strftime", date64(), date64s, utf8(), dates64_ymd, &options_ymd);
+  CheckScalarUnary("strftime", date32(), date32s, utf8(), dates32_ymdhms,
+                   &options_ymdhms);
+  CheckScalarUnary("strftime", date64(), date64s, utf8(), dates64_ymdhms,
+                   &options_ymdhms);
 }
 
 TEST_F(ScalarTemporalTest, StrftimeNoTimezone) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -639,7 +639,6 @@ TEST_F(ScalarTemporalTest, Strftime) {
   CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
                    utf8(), string_nanoseconds, &options);
 
-<<<<<<< HEAD
   auto options_hms = StrftimeOptions("%H:%M:%S");
   auto options_ymdhms = StrftimeOptions("%Y-%m-%dT%H:%M:%S");
 
@@ -696,7 +695,6 @@ TEST_F(ScalarTemporalTest, Strftime) {
       Strftime(arr_ns, StrftimeOptions("%Y-%m-%dT%H:%M:%S%Z")));
 
   auto options_ymd = StrftimeOptions("%Y-%m-%d");
-  auto options_ymdhms = StrftimeOptions("%Y-%m-%dT%H:%M:%S");
 
   const char* date32s = R"([0, 10957, 10958, null])";
   const char* date64s = R"([0, 946684800000, 946771200000, null])";

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1215,7 +1215,7 @@ provided by a concrete function :func:`~arrow::compute::Cast`.
 +=================+============+====================+==================+==============================+=======+
 | cast            | Unary      | Many               | Variable         | :struct:`CastOptions`        |       |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+
-| strftime        | Unary      | Timestamp, Time    | String           | :struct:`StrftimeOptions`    | \(1)  |
+| strftime        | Unary      | Temporal           | String           | :struct:`StrftimeOptions`    | \(1)  |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+
 | strptime        | Unary      | String-like        | Timestamp        | :struct:`StrptimeOptions`    |       |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -731,13 +731,15 @@ nse_funcs$round <- function(x, digits = 0) {
   )
 }
 
-nse_funcs$wday <- function(x, label = FALSE, abbr = TRUE, week_start = getOption("lubridate.week.start", 7)) {
-
-  # The "day_of_week" compute function returns numeric days of week and not locale-aware strftime
-  # When the ticket below is resolved, we should be able to support the label argument
-  # https://issues.apache.org/jira/browse/ARROW-13133
+nse_funcs$wday <- function(x, label = FALSE, abbr = TRUE, week_start = getOption("lubridate.week.start", 7),
+                           locale = Sys.getlocale("LC_TIME")) {
   if (label) {
-    arrow_not_supported("Label argument")
+    if (abbr) (
+      format <- "%a"
+    ) else {
+      format <- "%A"
+    }
+    return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
   }
 
   Expression$create("day_of_week", x, options = list(count_from_zero = FALSE, week_start = week_start))

--- a/r/tests/testthat/test-dplyr-lubridate.R
+++ b/r/tests/testthat/test-dplyr-lubridate.R
@@ -125,12 +125,20 @@ test_that("extract wday from timestamp", {
     test_df
   )
 
-  # We should be able to support the label argument after this ticket is resolved:
-  # https://issues.apache.org/jira/browse/ARROW-13133
-  x <- Expression$field_ref("x")
-  expect_error(
-    nse_funcs$wday(x, label = TRUE),
-    "Label argument not supported by Arrow"
+  expect_dplyr_equal(
+    input %>%
+      mutate(x = wday(date, label = TRUE)) %>%
+      mutate(x = as.character(x)) %>%
+      collect(),
+    test_df
+  )
+
+  expect_dplyr_equal(
+    input %>%
+      mutate(x = wday(datetime, label = TRUE, abbr = TRUE)) %>%
+      mutate(x = as.character(x)) %>%
+      collect(),
+    test_df
   )
 })
 
@@ -259,12 +267,20 @@ test_that("extract wday from date", {
     test_df
   )
 
-  # We should be able to support the label argument after this ticket is resolved:
-  # https://issues.apache.org/jira/browse/ARROW-13133
-  x <- Expression$field_ref("x")
-  expect_error(
-    nse_funcs$wday(x, label = TRUE),
-    "Label argument not supported by Arrow"
+  expect_dplyr_equal(
+    input %>%
+      mutate(x = wday(date, label = TRUE, abbr = TRUE)) %>%
+      mutate(x = as.character(x)) %>%
+      collect(),
+    test_df
+  )
+
+  expect_dplyr_equal(
+    input %>%
+      mutate(x = wday(date, label = TRUE)) %>%
+      mutate(x = as.character(x)) %>%
+      collect(),
+    test_df
   )
 })
 

--- a/r/tests/testthat/test-dplyr-lubridate.R
+++ b/r/tests/testthat/test-dplyr-lubridate.R
@@ -125,6 +125,8 @@ test_that("extract wday from timestamp", {
     test_df
   )
 
+  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
+
   expect_dplyr_equal(
     input %>%
       mutate(x = wday(date, label = TRUE)) %>%
@@ -266,6 +268,8 @@ test_that("extract wday from date", {
       collect(),
     test_df
   )
+
+  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
 
   expect_dplyr_equal(
     input %>%


### PR DESCRIPTION
This is to resolve [ARROW-13916](https://issues.apache.org/jira/browse/ARROW-13916).