### PR TITLE
ARROW-14109: [C++] Fix segfault when parsing JSON with duplicate keys.

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -753,7 +753,13 @@ class HandlerBase : public BlockParser,
     if (ARROW_PREDICT_FALSE(field_index_ == -1)) {
       return false;
     }
-    *duplicate_keys = !absent_fields_stack_[field_index_];
+    if (field_index_ < absent_fields_stack_.TopSize()) {
+      *duplicate_keys = !absent_fields_stack_[field_index_];
+    } else {
+      // When field_index is beyond the range of absent_fields_stack_ we have a duplicated
+      // field that wasn't declared in schema or previous records.
+      *duplicate_keys = true;
+    }
     if (*duplicate_keys) {
       status_ = ParseError("Column(", Path(), ") was specified twice in row ", num_rows_);
       return false;

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -179,6 +179,17 @@ TEST_P(BlockParserTypeError, FailOnDuplicateKeys) {
       testing::StartsWith("JSON parse error: Column(/a) was specified twice in row 0"));
 }
 
+TEST_P(BlockParserTypeError, FailOnDuplicateKeysNoSchema) {
+  std::shared_ptr<Array> parsed;
+  Status error =
+      ParseFromString(ParseOptions::Defaults(), "{\"a\":0, \"a\":1}\n", &parsed);
+
+  ASSERT_RAISES(Invalid, error);
+  EXPECT_THAT(
+      error.message(),
+      testing::StartsWith("JSON parse error: Column(/a) was specified twice in row 0"));
+}
+
 INSTANTIATE_TEST_SUITE_P(BlockParserTypeError, BlockParserTypeError,
                          ::testing::Values(UnexpectedFieldBehavior::Ignore,
                                            UnexpectedFieldBehavior::Error,


### PR DESCRIPTION
When reading a JSON object with duplicate keys, Arrow can crash if the duplicate key was not in schema. In this case, the absent_fields_stack_ will not have an index to represent the duplicated key. When we encounter the duplicated key for a second time, field_index_ will be non-negative and greater than the size of absent_fields_stack_, thus triggering a crash when we attempt to read from absent_fields_stack_.