### PR TITLE
ARROW-14111: [C++] Add extraction function support for time32/time64

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -34,43 +34,28 @@ namespace compute {
 class ScalarTemporalTest : public ::testing::Test {
  public:
   const char* date32s =
-      R"([0,
-      11016,
-      -25932,
-      23148,
-      18262,
-      18261,
-      18260,
-      14609,
-      14610,
-      14612,
-      14613,
-      13149,
-      13148,
-      14241,
-      14242,
-      15340,
-      null])";
-
+      R"([0, 11016, -25932, 23148, 18262, 18261, 18260, 14609, 14610, 14612,
+          14613, 13149, 13148, 14241, 14242, 15340, null])";
   const char* date64s =
-      R"([0,
-      951782400000,
-      -2240524800000,
-      1999987200000,
-      1577836800000,
-      1577750400000,
-      1577664000000,
-      1262217600000,
-      1262304000000,
-      1262476800000,
-      1262563200000,
-      1136073600000,
-      1135987200000,
-      1230422400000,
-      1230508800000,
-      1325376000000,
-      null])";
-
+      R"([0, 951782400000, -2240524800000, 1999987200000, 1577836800000,
+          1577750400000, 1577664000000, 1262217600000, 1262304000000, 1262476800000,
+          1262563200000, 1136073600000, 1135987200000, 1230422400000, 1230508800000,
+          1325376000000, null])";
+  const char* times_s =
+      R"([59, 84203, 3560, 12800, 3905, 7810, 11715, 15620, 19525, 23430, 27335,
+          31240, 35145, 0, 0, 3723, null])";
+  const char* times_ms =
+      R"([59123, 84203999, 3560001, 12800000, 3905001, 7810002, 11715003, 15620004,
+          19525005, 23430006, 27335000, 31240000, 35145000, 0, 0, 3723000, null])";
+  const char* times_us =
+      R"([59123456, 84203999999, 3560001001, 12800000000, 3905001000, 7810002000,
+          11715003000, 15620004132, 19525005321, 23430006163, 27335000000,
+          31240000000, 35145000000, 0, 0, 3723000000, null])";
+  const char* times_ns =
+      R"([59123456789, 84203999999999, 3560001001001, 12800000000000, 3905001000000,
+          7810002000000, 11715003000000, 15620004132000, 19525005321000,
+          23430006163000, 27335000000000, 31240000000000, 35145000000000, 0, 0,
+          3723000000000, null])";
   const char* times =
       R"(["1970-01-01T00:00:59.123456789","2000-02-29T23:23:23.999999999",
           "1899-01-01T00:59:20.001001001","2033-05-18T03:33:20.000000000",
@@ -136,6 +121,12 @@ class ScalarTemporalTest : public ::testing::Test {
   std::string subsecond =
       "[0.123456789, 0.999999999, 0.001001001, 0, 0.001, 0.002, 0.003, 0.004132, "
       "0.005321, 0.006163, 0, 0, 0, 0, 0, 0, null]";
+  std::string subsecond_ms =
+      "[0.123, 0.999, 0.001, 0, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0, 0, 0, "
+      "0, 0, 0, null]";
+  std::string subsecond_us =
+      "[0.123456, 0.999999, 0.001001, 0, 0.001, 0.002, 0.003, 0.004132, 0.005321, "
+      "0.006163, 0, 0, 0, 0, 0, 0, null]";
   std::string zeros = "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null]";
 };
 
@@ -166,6 +157,43 @@ TEST_F(ScalarTemporalTest, TestTemporalComponentExtractionAllTemporalTypes) {
       CheckScalarUnary("subsecond", unit, sample, float64(), subsecond);
     }
   }
+
+  CheckScalarUnary("hour", time32(TimeUnit::SECOND), times_s, int64(), hour);
+  CheckScalarUnary("minute", time32(TimeUnit::SECOND), times_s, int64(), minute);
+  CheckScalarUnary("second", time32(TimeUnit::SECOND), times_s, int64(), second);
+  CheckScalarUnary("millisecond", time32(TimeUnit::SECOND), times_s, int64(), zeros);
+  CheckScalarUnary("microsecond", time32(TimeUnit::SECOND), times_s, int64(), zeros);
+  CheckScalarUnary("nanosecond", time32(TimeUnit::SECOND), times_s, int64(), zeros);
+  CheckScalarUnary("subsecond", time32(TimeUnit::SECOND), times_s, float64(), zeros);
+
+  CheckScalarUnary("hour", time32(TimeUnit::MILLI), times_ms, int64(), hour);
+  CheckScalarUnary("minute", time32(TimeUnit::MILLI), times_ms, int64(), minute);
+  CheckScalarUnary("second", time32(TimeUnit::MILLI), times_ms, int64(), second);
+  CheckScalarUnary("millisecond", time32(TimeUnit::MILLI), times_ms, int64(),
+                   millisecond);
+  CheckScalarUnary("microsecond", time32(TimeUnit::MILLI), times_ms, int64(), zeros);
+  CheckScalarUnary("nanosecond", time32(TimeUnit::MILLI), times_ms, int64(), zeros);
+  CheckScalarUnary("subsecond", time32(TimeUnit::MILLI), times_ms, float64(),
+                   subsecond_ms);
+
+  CheckScalarUnary("hour", time64(TimeUnit::MICRO), times_us, int64(), hour);
+  CheckScalarUnary("minute", time64(TimeUnit::MICRO), times_us, int64(), minute);
+  CheckScalarUnary("second", time64(TimeUnit::MICRO), times_us, int64(), second);
+  CheckScalarUnary("millisecond", time64(TimeUnit::MICRO), times_us, int64(),
+                   millisecond);
+  CheckScalarUnary("microsecond", time64(TimeUnit::MICRO), times_us, int64(),
+                   microsecond);
+  CheckScalarUnary("nanosecond", time64(TimeUnit::MICRO), times_us, int64(), zeros);
+  CheckScalarUnary("subsecond", time64(TimeUnit::MICRO), times_us, float64(),
+                   subsecond_us);
+
+  CheckScalarUnary("hour", time64(TimeUnit::NANO), times_ns, int64(), hour);
+  CheckScalarUnary("minute", time64(TimeUnit::NANO), times_ns, int64(), minute);
+  CheckScalarUnary("second", time64(TimeUnit::NANO), times_ns, int64(), second);
+  CheckScalarUnary("millisecond", time64(TimeUnit::NANO), times_ns, int64(), millisecond);
+  CheckScalarUnary("microsecond", time64(TimeUnit::NANO), times_ns, int64(), microsecond);
+  CheckScalarUnary("nanosecond", time64(TimeUnit::NANO), times_ns, int64(), nanosecond);
+  CheckScalarUnary("subsecond", time64(TimeUnit::NANO), times_ns, float64(), subsecond);
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalComponentExtractionWithDifferentUnits) {
@@ -566,6 +594,25 @@ TEST_F(ScalarTemporalTest, Strftime) {
                    utf8(), string_microseconds, &options);
   CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
                    utf8(), string_nanoseconds, &options);
+
+  auto options_hms = StrftimeOptions("%H:%M:%S");
+  const char* times_s = R"([59, null])";
+  const char* times_ms = R"([59123, null])";
+  const char* times_us = R"([59123456, null])";
+  const char* times_ns = R"([59123456789, null])";
+  const char* strftime_ns = R"(["00:00:59.123456789", null])";
+  const char* strftime_us = R"(["00:00:59.123456", null])";
+  const char* strftime_ms = R"(["00:00:59.123", null])";
+  const char* strftime_s = R"(["00:00:59", null])";
+
+  CheckScalarUnary("strftime", time64(TimeUnit::NANO), times_ns, utf8(), strftime_ns,
+                   &options_hms);
+  CheckScalarUnary("strftime", time64(TimeUnit::MICRO), times_us, utf8(), strftime_us,
+                   &options_hms);
+  CheckScalarUnary("strftime", time32(TimeUnit::MILLI), times_ms, utf8(), strftime_ms,
+                   &options_hms);
+  CheckScalarUnary("strftime", time32(TimeUnit::SECOND), times_s, utf8(), strftime_s,
+                   &options_hms);
 }
 
 TEST_F(ScalarTemporalTest, StrftimeNoTimezone) {

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1211,7 +1211,7 @@ provided by a concrete function :func:`~arrow::compute::Cast`.
 +=================+============+====================+==================+==============================+=======+
 | cast            | Unary      | Many               | Variable         | :struct:`CastOptions`        |       |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+
-| strftime        | Unary      | Timestamp          | String           | :struct:`StrftimeOptions`    | \(1)  |
+| strftime        | Unary      | Timestamp, Time    | String           | :struct:`StrftimeOptions`    | \(1)  |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+
 | strptime        | Unary      | String-like        | Timestamp        | :struct:`StrptimeOptions`    |       |
 +-----------------+------------+--------------------+------------------+------------------------------+-------+
@@ -1338,19 +1338,19 @@ For timestamps inputs with non-empty timezone, localized timestamp components wi
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
 | quarter            | Unary      | Temporal          | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| hour               | Unary      | Timestamp         | Int64         |                            |       |
+| hour               | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| minute             | Unary      | Timestamp         | Int64         |                            |       |
+| minute             | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| second             | Unary      | Timestamp         | Int64         |                            |       |
+| second             | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| millisecond        | Unary      | Timestamp         | Int64         |                            |       |
+| millisecond        | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| microsecond        | Unary      | Timestamp         | Int64         |                            |       |
+| microsecond        | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| nanosecond         | Unary      | Timestamp         | Int64         |                            |       |
+| nanosecond         | Unary      | Timestamp, Time   | Int64         |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
-| subsecond          | Unary      | Timestamp         | Double        |                            |       |
+| subsecond          | Unary      | Timestamp, Time   | Double        |                            |       |
 +--------------------+------------+-------------------+---------------+----------------------------+-------+
 
 * \(1) Outputs the number of the day of the week. By default week begins on Monday


### PR DESCRIPTION
This is to resolve [ARROW-14111](https://issues.apache.org/jira/browse/ARROW-14111)