### PR TITLE
ARROW-13878: [C++] Implement fixed-size-binary support for several kernels

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -223,7 +223,7 @@ std::shared_ptr<DataType> CommonTemporal(const ValueDescr* begin, size_t count) 
 }
 
 std::shared_ptr<DataType> CommonBinary(const ValueDescr* begin, size_t count) {
-  bool all_utf8 = true, all_offset32 = true;
+  bool all_utf8 = true, all_offset32 = true, all_fixed_width = true;
 
   const ValueDescr* end = begin + count;
   for (auto it = begin; it != end; ++it) {
@@ -231,20 +231,32 @@ std::shared_ptr<DataType> CommonBinary(const ValueDescr* begin, size_t count) {
     // a common varbinary type is only possible if all types are binary like
     switch (id) {
       case Type::STRING:
+        all_fixed_width = false;
         continue;
       case Type::BINARY:
+        all_fixed_width = false;
+        all_utf8 = false;
+        continue;
+      case Type::FIXED_SIZE_BINARY:
         all_utf8 = false;
         continue;
       case Type::LARGE_STRING:
         all_offset32 = false;
+        all_fixed_width = false;
         continue;
       case Type::LARGE_BINARY:
         all_offset32 = false;
+        all_fixed_width = false;
         all_utf8 = false;
         continue;
       default:
         return nullptr;
     }
+  }
+
+  if (all_fixed_width) {
+    // At least for the purposes of comparison, no need to cast.
+    return nullptr;
   }
 
   if (all_utf8) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -247,6 +247,26 @@ struct ArrayIterator<Type, enable_if_base_binary<Type>> {
   }
 };
 
+template <>
+struct ArrayIterator<FixedSizeBinaryType> {
+  const ArrayData& arr;
+  const char* data;
+  const int32_t width;
+  int64_t position;
+
+  explicit ArrayIterator(const ArrayData& arr)
+      : arr(arr),
+        data(reinterpret_cast<const char*>(arr.buffers[1]->data())),
+        width(checked_cast<const FixedSizeBinaryType&>(*arr.type).byte_width()),
+        position(arr.offset) {}
+
+  util::string_view operator()() {
+    auto result = util::string_view(data + position * width, width);
+    position++;
+    return result;
+  }
+};
+
 // Iterator over various output array types, taking a GetOutputType<Type>
 
 template <typename Type, typename Enable = void>

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -268,6 +268,13 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name,
         func->AddKernel({InputType(id), InputType(id)}, boolean(), std::move(exec)));
   }
 
+  {
+    auto exec =
+        applicator::ScalarBinaryEqualTypes<BooleanType, FixedSizeBinaryType, Op>::Exec;
+    auto ty = InputType(Type::FIXED_SIZE_BINARY);
+    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
+  }
+
   return func;
 }
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -341,6 +341,8 @@ struct TypeTraits<FixedSizeBinaryType> {
   using ArrayType = FixedSizeBinaryArray;
   using BuilderType = FixedSizeBinaryBuilder;
   using ScalarType = FixedSizeBinaryScalar;
+  // FixedSizeBinary doesn't have offsets per se, but string length is int32 sized
+  using OffsetType = Int32Type;
   constexpr static bool is_parameter_free = false;
 };
 


### PR DESCRIPTION
All kernels listed in the JIRA, plus casting fixed_size_binary to other binary types, are now supported:

- binary_length
- binary_replace_slice
- count_substring
- find_substring
- find_substring_regex
- equal
- greater
- greater_equal
- less
- less_equal
- fixed_size_binary cast to (large_)binary/utf8
- fixed_size_binary cast to fixed_size_binary
  Note that while CanCast for mismatched widths returns true, the kernel will error during execution still.