### PR TITLE
ARROW-13853: [R] String to_title, to_lower, to_upper kernels

### DIFF
--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -338,7 +338,8 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 #   str_to_upper
 #   str_to_title
 .valid_locales_for_string_functions <- list("en", "C", "POSIX")
-arrow_string_function_with_locale_arg <- function(fun, string, locale) {
+
+arrow_string_function_with_locale_arg <- function(func, string, locale) {
   assert_that(
     exists(locale, .valid_locales_for_string_functions),
     msg = paste(
@@ -346,7 +347,7 @@ arrow_string_function_with_locale_arg <- function(fun, string, locale) {
       paste(.valid_locales_for_string_functions, collapse=",")
     )
   )
-  Expression$create(fun, string)
+  Expression$create(func, string)
 }
 
 nse_funcs$str_to_lower <- function(string, locale = "en") {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -338,7 +338,7 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 #   str_to_upper
 #   str_to_title
 .valid_locales_for_string_functions <- list("en", "C", "POSIX")
-arrow_string_function_with_locale_arg <- function(function_name, string, locale) {
+arrow_string_function_with_locale_arg <- function(fun, string, locale) {
   assert_that(
     exists(locale, .valid_locales_for_string_functions),
     msg = paste(
@@ -346,6 +346,7 @@ arrow_string_function_with_locale_arg <- function(function_name, string, locale)
       paste(.valid_locales_for_string_functions, collapse=",")
     )
   )
+  Expression$create(fun, string)
 }
 
 nse_funcs$str_to_lower <- function(string, locale = "en") {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -341,21 +341,24 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 # Arrow locale will be supported with ARROW-14126
 nse_funcs$str_to_lower <- function(string, locale = "en") {
   if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_lower' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+    stop("Providing 'locale' to 'str_to_lower' is not supported in Arrow; ",
+    "to change locale use 'Sys.setlocale()'", call. = FALSE)
   }
   Expression$create("utf8_lower", string)
 }
 
 nse_funcs$str_to_upper <- function(string, locale = "en") {
   if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_upper' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+    stop("Providing 'locale' to 'str_to_upper' is not supported in Arrow; ",
+    "to change locale use 'Sys.setlocale()'", call. = FALSE)
   }
   Expression$create("utf8_upper", string)
 }
 
 nse_funcs$str_to_title <- function(string, locale = "en") {
   if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_title' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+    stop("Providing 'locale' to 'str_to_title' is not supported in Arrow; ",
+    "to change locale use 'Sys.setlocale()'", call. = FALSE)
   }
   Expression$create("utf8_title", string)
 }

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -339,28 +339,24 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 #   str_to_title
 #
 # Arrow locale will be supported with ARROW-14126
-nse_funcs$str_to_lower <- function(string, locale = "en") {
+.arrow_string_function_with_locale_arg <- function(func, string, locale) {
   if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_lower' is not supported in Arrow; ",
-    "to change locale use 'Sys.setlocale()'", call. = FALSE)
+    stop("Providing a value for 'locale' other than the default ('en') is not supported by Arrow. ",
+    "To change locale, use 'Sys.setlocale()'", call. = FALSE)
   }
-  Expression$create("utf8_lower", string)
+  Expression$create(func, string)
+}
+
+nse_funcs$str_to_lower <- function(string, locale = "en") {
+  .arrow_string_function_with_locale_arg("utf8_lower", string, locale)
 }
 
 nse_funcs$str_to_upper <- function(string, locale = "en") {
-  if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_upper' is not supported in Arrow; ",
-    "to change locale use 'Sys.setlocale()'", call. = FALSE)
-  }
-  Expression$create("utf8_upper", string)
+  .arrow_string_function_with_locale_arg("utf8_upper", string, locale)
 }
 
 nse_funcs$str_to_title <- function(string, locale = "en") {
-  if (!identical(locale, "en")) {
-    stop("Providing 'locale' to 'str_to_title' is not supported in Arrow; ",
-    "to change locale use 'Sys.setlocale()'", call. = FALSE)
-  }
-  Expression$create("utf8_title", string)
+  .arrow_string_function_with_locale_arg("utf8_title", string, locale)
 }
 
 nse_funcs$str_trim <- function(string, side = c("both", "left", "right")) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -341,7 +341,7 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 
 arrow_string_function_with_locale_arg <- function(func, string, locale) {
   assert_that(
-    exists(locale, .valid_locales_for_string_functions),
+    locale %in% .valid_locales_for_string_functions,
     msg = paste(
       "`locale` must be any of: ",
       paste(.valid_locales_for_string_functions, collapse=",")

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -330,36 +330,34 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
   }
 }
 
-# Arrow does not supports a locale option for string case conversion functions,
-# contrast to stringr's API, so the `locale` argument is only valid for the
-# standard/default ones: "en", "C", and "POSIX". The following are string
-# functions that take a `locale` option as its second argument:
+# Currently, Arrow does not supports a locale option for string case conversion
+# functions, contrast to stringr's API, so the 'locale' argument is only valid
+# for stringr's default value ("en"). The following are string functions that
+# take a 'locale' option as its second argument:
 #   str_to_lower
 #   str_to_upper
 #   str_to_title
-.valid_locales_for_string_functions <- list("en", "C", "POSIX")
-
-arrow_string_function_with_locale_arg <- function(func, string, locale) {
-  assert_that(
-    locale %in% .valid_locales_for_string_functions,
-    msg = paste(
-      "`locale` must be any of: ",
-      paste(.valid_locales_for_string_functions, collapse=",")
-    )
-  )
-  Expression$create(func, string)
-}
-
+#
+# Arrow locale will be supported with ARROW-14126
 nse_funcs$str_to_lower <- function(string, locale = "en") {
-  arrow_string_function_with_locale_arg("utf8_lower", string, locale)
+  if (!identical(locale, "en")) {
+    stop("Providing 'locale' to 'str_to_lower' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+  }
+  Expression$create("utf8_lower", string)
 }
 
 nse_funcs$str_to_upper <- function(string, locale = "en") {
-  arrow_string_function_with_locale_arg("utf8_upper", string, locale)
+  if (!identical(locale, "en")) {
+    stop("Providing 'locale' to 'str_to_upper' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+  }
+  Expression$create("utf8_upper", string)
 }
 
 nse_funcs$str_to_title <- function(string, locale = "en") {
-  arrow_string_function_with_locale_arg("utf8_title", string, locale)
+  if (!identical(locale, "en")) {
+    stop("Providing 'locale' to 'str_to_title' is not supported in Arrow; to change locale use 'Sys.setlocale()'", call. = FALSE)
+  }
+  Expression$create("utf8_title", string)
 }
 
 nse_funcs$str_trim <- function(string, side = c("both", "left", "right")) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -339,24 +339,26 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
 #   str_to_title
 #
 # Arrow locale will be supported with ARROW-14126
-.arrow_string_function_with_locale_arg <- function(func, string, locale) {
+stop_if_locale_provided <- function(locale) {
   if (!identical(locale, "en")) {
     stop("Providing a value for 'locale' other than the default ('en') is not supported by Arrow. ",
     "To change locale, use 'Sys.setlocale()'", call. = FALSE)
   }
-  Expression$create(func, string)
 }
 
 nse_funcs$str_to_lower <- function(string, locale = "en") {
-  .arrow_string_function_with_locale_arg("utf8_lower", string, locale)
+  stop_if_locale_provided(locale)
+  Expression$create("utf8_lower", string)
 }
 
 nse_funcs$str_to_upper <- function(string, locale = "en") {
-  .arrow_string_function_with_locale_arg("utf8_upper", string, locale)
+  stop_if_locale_provided(locale)
+  Expression$create("utf8_upper", string)
 }
 
 nse_funcs$str_to_title <- function(string, locale = "en") {
-  .arrow_string_function_with_locale_arg("utf8_title", string, locale)
+  stop_if_locale_provided(locale)
+  Expression$create("utf8_title", string)
 }
 
 nse_funcs$str_trim <- function(string, side = c("both", "left", "right")) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -330,6 +330,36 @@ arrow_string_join_function <- function(null_handling, null_replacement = NULL) {
   }
 }
 
+# Arrow does not supports a locale option for string case conversion functions,
+# contrast to stringr's API, so the `locale` argument is only valid for the
+# standard/default ones: "en", "C", and "POSIX". The following are string
+# functions that take a `locale` option as its second argument:
+#   str_to_lower
+#   str_to_upper
+#   str_to_title
+.valid_locales_for_string_functions <- list("en", "C", "POSIX")
+arrow_string_function_with_locale_arg <- function(function_name, string, locale) {
+  assert_that(
+    exists(locale, .valid_locales_for_string_functions),
+    msg = paste(
+      "`locale` must be any of: ",
+      paste(.valid_locales_for_string_functions, collapse=",")
+    )
+  )
+}
+
+nse_funcs$str_to_lower <- function(string, locale = "en") {
+  arrow_string_function_with_locale_arg("utf8_lower", string, locale)
+}
+
+nse_funcs$str_to_upper <- function(string, locale = "en") {
+  arrow_string_function_with_locale_arg("utf8_upper", string, locale)
+}
+
+nse_funcs$str_to_title <- function(string, locale = "en") {
+  arrow_string_function_with_locale_arg("utf8_title", string, locale)
+}
+
 nse_funcs$str_trim <- function(string, side = c("both", "left", "right")) {
   side <- match.arg(side)
   trim_fun <- switch(side,

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -50,9 +50,9 @@
   "str_length" = "utf8_length",
   # str_pad is defined in dplyr-functions.R
   # str_sub is defined in dplyr-functions.R
-  "str_to_lower" = "utf8_lower",
-  "str_to_title" = "utf8_title",
-  "str_to_upper" = "utf8_upper",
+  # str_to_lower is defined in dplyr-functions.R
+  # str_to_title is defined in dplyr-functions.R
+  # str_to_upper is defined in dplyr-functions.R
   # str_trim is defined in dplyr-functions.R
   "stri_reverse" = "utf8_reverse",
   # substr is defined in dplyr-functions.R

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -468,7 +468,7 @@ test_that("strsplit and str_split", {
 })
 
 test_that("str_to_lower, str_to_upper, and str_to_title", {
-  df <- tibble(x = c("1Foo1", " \tB a R\n", "!apACHe aRroW!"))
+  df <- tibble(x = c("foo1", " \tB a R\n", "!apACHe aRroW!"))
   expect_dplyr_equal(
     input %>%
       transmute(

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -469,21 +469,22 @@ test_that("strsplit and str_split", {
 
 test_that("str_to_lower, str_to_upper, and str_to_title", {
   df <- tibble(x = c("1Foo1", " \tB a R\n", "!apACHe aRroW!"))
-  funcs <- c(str_to_lower, str_to_upper, str_to_title)
-  for (func in funcs) {
-    expect_dplyr_equal(
-      input %>%
-        transmute(x = func(x)) %>%
-        collect(),
-      df
-    )
+  expect_dplyr_equal(
+    input %>%
+      transmute(
+        x_lower = str_to_lower(x),
+        x_upper = str_to_upper(x),
+        x_title = str_to_title(x)
+      ) %>%
+      collect(),
+    df
+  )
 
-    funcname = as.character(substitute(func))
-    expect_error(
-      nse_funcs[[funcname]]("Apache Arrow", locale = "sp"),
-      "Providing a value for 'locale' other than the default ('en') is not supported by Arrow"
-    )
-  }
+  # Error checking a single function because they all use the same code path.
+  expect_error(
+    nse_funcs$str_to_lower("Apache Arrow", locale = "sp"),
+    "Providing a value for 'locale' other than the default ('en') is not supported by Arrow"
+  )
 })
 
 test_that("arrow_*_split_whitespace functions", {

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -483,7 +483,8 @@ test_that("str_to_lower, str_to_upper, and str_to_title", {
   # Error checking a single function because they all use the same code path.
   expect_error(
     nse_funcs$str_to_lower("Apache Arrow", locale = "sp"),
-    "Providing a value for 'locale' other than the default ('en') is not supported by Arrow"
+    "Providing a value for 'locale' other than the default ('en') is not supported by Arrow",
+    fixed = TRUE
   )
 })
 

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -467,6 +467,46 @@ test_that("strsplit and str_split", {
   )
 })
 
+test_that("str_to_lower, str_to_upper, and str_to_title", {
+  df <- tibble(x = c("Foo", " B\na R", "ⱭɽⱤoW", "ıI"))
+
+  expect_dplyr_equal(
+    input %>%
+      transmute(x = str_to_lower(x)) %>%
+      collect(),
+    df
+  )
+
+  expect_error(
+    nse_funcs$str_to_lower("Apache Arrow", locale = "sp"),
+    "`locale` must be any of"
+  )
+
+  expect_dplyr_equal(
+    input %>%
+      transmute(x = str_to_upper(x)) %>%
+      collect(),
+    df
+  )
+
+  expect_error(
+    nse_funcs$str_to_upper("Apache Arrow", locale = "sp"),
+    "`locale` must be any of"
+  )
+
+  expect_dplyr_equal(
+    input %>%
+      transmute(x = str_to_title(x)) %>%
+      collect(),
+    df
+  )
+
+  expect_error(
+    nse_funcs$str_to_title("Apache Arrow", locale = "sp"),
+    "`locale` must be any of"
+  )
+})
+
 test_that("arrow_*_split_whitespace functions", {
   # use only ASCII whitespace characters
   df_ascii <- tibble(x = c("Foo\nand bar", "baz\tand qux and quux"))

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -468,43 +468,22 @@ test_that("strsplit and str_split", {
 })
 
 test_that("str_to_lower, str_to_upper, and str_to_title", {
-  df <- tibble(x = c("Foo", " B\na R", "ⱭɽⱤoW", "ıI"))
+  df <- tibble(x = c("1Foo1", " \tB a R\n", "!apACHe aRroW!"))
+  funcs <- c(str_to_lower, str_to_upper, str_to_title)
+  for (func in funcs) {
+    expect_dplyr_equal(
+      input %>%
+        transmute(x = func(x)) %>%
+        collect(),
+      df
+    )
 
-  expect_dplyr_equal(
-    input %>%
-      transmute(x = str_to_lower(x)) %>%
-      collect(),
-    df
-  )
-
-  expect_error(
-    nse_funcs$str_to_lower("Apache Arrow", locale = "sp"),
-    "Providing 'locale' to 'str_to_lower' is not supported in Arrow"
-  )
-
-  expect_dplyr_equal(
-    input %>%
-      transmute(x = str_to_upper(x)) %>%
-      collect(),
-    df
-  )
-
-  expect_error(
-    nse_funcs$str_to_upper("Apache Arrow", locale = "sp"),
-    "Providing 'locale' to 'str_to_upper' is not supported in Arrow"
-  )
-
-  expect_dplyr_equal(
-    input %>%
-      transmute(x = str_to_title(x)) %>%
-      collect(),
-    df
-  )
-
-  expect_error(
-    nse_funcs$str_to_title("Apache Arrow", locale = "sp"),
-    "Providing 'locale' to 'str_to_title' is not supported in Arrow"
-  )
+    funcname = as.character(substitute(func))
+    expect_error(
+      nse_funcs[[funcname]]("Apache Arrow", locale = "sp"),
+      "Providing a value for 'locale' other than the default ('en') is not supported by Arrow"
+    )
+  }
 })
 
 test_that("arrow_*_split_whitespace functions", {

--- a/r/tests/testthat/test-dplyr-string-functions.R
+++ b/r/tests/testthat/test-dplyr-string-functions.R
@@ -479,7 +479,7 @@ test_that("str_to_lower, str_to_upper, and str_to_title", {
 
   expect_error(
     nse_funcs$str_to_lower("Apache Arrow", locale = "sp"),
-    "`locale` must be any of"
+    "Providing 'locale' to 'str_to_lower' is not supported in Arrow"
   )
 
   expect_dplyr_equal(
@@ -491,7 +491,7 @@ test_that("str_to_lower, str_to_upper, and str_to_title", {
 
   expect_error(
     nse_funcs$str_to_upper("Apache Arrow", locale = "sp"),
-    "`locale` must be any of"
+    "Providing 'locale' to 'str_to_upper' is not supported in Arrow"
   )
 
   expect_dplyr_equal(
@@ -503,7 +503,7 @@ test_that("str_to_lower, str_to_upper, and str_to_title", {
 
   expect_error(
     nse_funcs$str_to_title("Apache Arrow", locale = "sp"),
-    "`locale` must be any of"
+    "Providing 'locale' to 'str_to_title' is not supported in Arrow"
   )
 })
 


### PR DESCRIPTION
This PR adds locale validation to string functions matching stringr: str_to_title, str_to_lower, and str_to_upper.
In Arrow C++, these kernels do not support a locale argument so only the default R locale ("en") is currently supported.