### PR TITLE
ARROW-13879: [C++] Mixed support for binary types in regex functions

### DIFF
--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -324,7 +324,7 @@ class TestStringArray : public ::testing::Test {
   std::shared_ptr<ArrayType> strings_;
 };
 
-TYPED_TEST_SUITE(TestStringArray, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestStringArray, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestStringArray, TestArrayBasics) { this->TestArrayBasics(); }
 
@@ -661,7 +661,7 @@ class TestStringBuilder : public TestBuilder {
   std::shared_ptr<ArrayType> result_;
 };
 
-TYPED_TEST_SUITE(TestStringBuilder, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestStringBuilder, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestStringBuilder, TestScalarAppend) { this->TestScalarAppend(); }
 
@@ -863,7 +863,7 @@ struct BinaryAppender {
 };
 
 template <typename T>
-class TestBinaryDataVisitor : public ::testing::Test {
+class TestBaseBinaryDataVisitor : public ::testing::Test {
  public:
   using TypeClass = T;
 
@@ -891,10 +891,10 @@ class TestBinaryDataVisitor : public ::testing::Test {
   std::shared_ptr<DataType> type_;
 };
 
-TYPED_TEST_SUITE(TestBinaryDataVisitor, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestBaseBinaryDataVisitor, BaseBinaryArrowTypes);
 
-TYPED_TEST(TestBinaryDataVisitor, Basics) { this->TestBasics(); }
+TYPED_TEST(TestBaseBinaryDataVisitor, Basics) { this->TestBasics(); }
 
-TYPED_TEST(TestBinaryDataVisitor, Sliced) { this->TestSliced(); }
+TYPED_TEST(TestBaseBinaryDataVisitor, Sliced) { this->TestSliced(); }
 
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1647,7 +1647,7 @@ TEST(TestNullMinMaxKernel, Basics) {
 
 template <typename ArrowType>
 class TestBaseBinaryMinMaxKernel : public ::testing::Test {};
-TYPED_TEST_SUITE(TestBaseBinaryMinMaxKernel, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestBaseBinaryMinMaxKernel, BaseBinaryArrowTypes);
 TYPED_TEST(TestBaseBinaryMinMaxKernel, Basics) {
   std::vector<std::string> chunked_input1 = {R"(["cc", "", "aa", "b", "c"])",
                                              R"(["d", "", null, "b", "c"])"};
@@ -2249,7 +2249,7 @@ TYPED_TEST(TestBooleanIndexKernel, Basics) {
 
 template <typename ArrowType>
 class TestStringIndexKernel : public TestIndexKernel<ArrowType> {};
-TYPED_TEST_SUITE(TestStringIndexKernel, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestStringIndexKernel, BaseBinaryArrowTypes);
 TYPED_TEST(TestStringIndexKernel, Basics) {
   auto buffer = Buffer::FromString("foo");
   auto value = std::make_shared<typename TestFixture::ScalarType>(buffer);

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1234,7 +1234,7 @@ ArrayKernelExec GenerateVarBinaryToVarBinary(detail::GetTypeId get_id) {
 }
 
 // Generate a kernel given a templated functor for base binary types. Generates
-// a single kernel for [Large]BinaryType and [Large]StringType. If your kernel
+// a single kernel for binary/string and large binary/large string. If your kernel
 // implementation needs access to the specific type at compile time, please use
 // BaseBinarySpecific.
 //

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1217,7 +1217,7 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
 
 // similar to GenerateTypeAgnosticPrimitive, but for variable binary and string types
 template <template <typename...> class Generator, typename... Args>
-ArrayKernelExec GenerateTypeAgnosticVarBinary(detail::GetTypeId get_id) {
+ArrayKernelExec GenerateIsomorphicVarBinary(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::BINARY:
       return Generator<BinaryType, Args...>::Exec;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1199,7 +1199,7 @@ ArrayKernelExec GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
   }
 }
 
-// similar to GenerateTypeAgnosticPrimitive, but for variable types
+// similar to GenerateTypeAgnosticPrimitive, but for base variable binary types
 template <template <typename...> class Generator, typename... Args>
 ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
   switch (get_id.id) {
@@ -1215,6 +1215,7 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
   }
 }
 
+// similar to GenerateTypeAgnosticPrimitive, but for variable binary and string types
 template <template <typename...> class Generator, typename... Args>
 ArrayKernelExec GenerateTypeAgnosticVarBinary(detail::GetTypeId get_id) {
   switch (get_id.id) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1215,6 +1215,23 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
   }
 }
 
+template <template <typename...> class Generator, typename... Args>
+ArrayKernelExec GenerateTypeAgnosticVarBinary(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::BINARY:
+      return Generator<BinaryType, Args...>::Exec;
+    case Type::STRING:
+      return Generator<StringType, Args...>::Exec;
+    case Type::LARGE_BINARY:
+      return Generator<LargeBinaryType, Args...>::Exec;
+    case Type::LARGE_STRING:
+      return Generator<LargeStringType, Args...>::Exec;
+    default:
+      DCHECK(false);
+      return ExecFail;
+  }
+}
+
 // Generate a kernel given a templated functor for base binary types. Generates
 // a single kernel for binary/string and large binary / large string. If your
 // kernel implementation needs access to the specific type at compile time,

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1215,7 +1215,7 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
   }
 }
 
-// similar to GenerateTypeAgnosticPrimitive, but for variable binary and string types
+// Generate a kernel given a templated functor for binary and string types
 template <template <typename...> class Generator, typename... Args>
 ArrayKernelExec GenerateVarBinaryToVarBinary(detail::GetTypeId get_id) {
   switch (get_id.id) {
@@ -1234,9 +1234,9 @@ ArrayKernelExec GenerateVarBinaryToVarBinary(detail::GetTypeId get_id) {
 }
 
 // Generate a kernel given a templated functor for base binary types. Generates
-// a single kernel for binary/string and large binary / large string. If your
-// kernel implementation needs access to the specific type at compile time,
-// please use BaseBinarySpecific.
+// a single kernel for [Large]BinaryType and [Large]StringType. If your kernel
+// implementation needs access to the specific type at compile time, please use
+// BaseBinarySpecific.
 //
 // See "Numeric" above for description of the generator functor
 template <template <typename...> class Generator, typename Type0, typename... Args>

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1217,7 +1217,7 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
 
 // similar to GenerateTypeAgnosticPrimitive, but for variable binary and string types
 template <template <typename...> class Generator, typename... Args>
-ArrayKernelExec GenerateIsomorphicVarBinary(detail::GetTypeId get_id) {
+ArrayKernelExec GenerateVarBinaryToVarBinary(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::BINARY:
       return Generator<BinaryType, Args...>::Exec;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -389,7 +389,7 @@ TEST_F(TestIfElseKernel, IfElseDispatchBest) {
 template <typename Type>
 class TestIfElseBaseBinary : public ::testing::Test {};
 
-TYPED_TEST_SUITE(TestIfElseBaseBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestIfElseBaseBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestIfElseBaseBinary, IfElseBaseBinary) {
   auto type = TypeTraits<TypeParam>::type_singleton();
@@ -1488,7 +1488,7 @@ TEST(TestCaseWhen, FixedSizeBinary) {
 template <typename Type>
 class TestCaseWhenBinary : public ::testing::Test {};
 
-TYPED_TEST_SUITE(TestCaseWhenBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestCaseWhenBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestCaseWhenBinary, Basics) {
   auto type = default_type_instance<TypeParam>();
@@ -2129,7 +2129,7 @@ template <typename Type>
 class TestCoalesceList : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TestCoalesceNumeric, NumericBasedTypes);
-TYPED_TEST_SUITE(TestCoalesceBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestCoalesceBinary, BaseBinaryArrowTypes);
 TYPED_TEST_SUITE(TestCoalesceList, ListArrowTypes);
 
 TYPED_TEST(TestCoalesceNumeric, Basics) {
@@ -2724,7 +2724,7 @@ template <typename Type>
 class TestChooseBinary : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TestChooseNumeric, NumericBasedTypes);
-TYPED_TEST_SUITE(TestChooseBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestChooseBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestChooseNumeric, FixedSize) {
   auto type = default_type_instance<TypeParam>();

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -219,7 +219,7 @@ TEST_F(TestIsInKernel, Boolean) {
             "[false, true, false, false, true]", /*skip_nulls=*/true);
 }
 
-TYPED_TEST_SUITE(TestIsInKernelBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestIsInKernelBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestIsInKernelBinary, Binary) {
   auto type = TypeTraits<TypeParam>::type_singleton();
@@ -678,7 +678,7 @@ TEST_F(TestIndexInKernel, Boolean) {
 template <typename Type>
 class TestIndexInKernelBinary : public TestIndexInKernel {};
 
-TYPED_TEST_SUITE(TestIndexInKernelBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestIndexInKernelBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestIndexInKernelBinary, Binary) {
   auto type = TypeTraits<TypeParam>::type_singleton();

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1342,9 +1342,7 @@ struct FindSubstringRegex {
     regex.reserve(options.pattern.length() + 2);
     regex += literal ? RE2::QuoteMeta(options.pattern) : options.pattern;
     regex += ")";
-    regex_match_.reset(
-        new RE2(std::move(regex),
-                MakeRE2Options(is_utf8, options.ignore_case, /*literal=*/false)));
+    regex_match_.reset(new RE2(regex, MakeRE2Options(is_utf8, options.ignore_case, /*literal=*/false)));
   }
 
   template <typename OutValue, typename... Ignored>
@@ -4232,11 +4230,6 @@ void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* regi
 }
 
 #endif
-
-// NOTE: Predicate should only populate 'status' with errors,
-//       leave it unmodified to indicate Status::OK()
-using StringPredicate =
-    std::function<bool(KernelContext*, const uint8_t*, size_t, Status*)>;
 
 template <typename Type, typename Predicate>
 struct StringPredicateFunctor {

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -2948,8 +2948,8 @@ struct ExtractRegexData {
       // No input type specified => propagate shape
       return args[0];
     }
-    // Input type is [Large]Binary or [Large]String and is also the type of each
-    // field in the output struct type.
+    // Input type is either [Large]Binary or [Large]String and is also the type
+    // of each field in the output struct type.
     DCHECK(is_base_binary_like(input_type->id()));
     FieldVector fields;
     fields.reserve(group_names.size());

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1214,17 +1214,21 @@ struct MatchLike {
     std::string pattern;
     bool matched = false;
     if (!original_options.ignore_case) {
-      if ((matched = re2::RE2::FullMatch(original_options.pattern, kLikePatternIsSubstringMatch, &pattern))) {
+      if ((matched = re2::RE2::FullMatch(original_options.pattern,
+                                         kLikePatternIsSubstringMatch, &pattern))) {
         MatchSubstringOptions converted_options{pattern, original_options.ignore_case};
         MatchSubstringState converted_state(converted_options);
         ctx->SetState(&converted_state);
         status = MatchSubstring<StringType, PlainSubstringMatcher>::Exec(ctx, batch, out);
-      } else if ((matched = re2::RE2::FullMatch(original_options.pattern, kLikePatternIsStartsWith, &pattern))) {
+      } else if ((matched = re2::RE2::FullMatch(original_options.pattern,
+                                                kLikePatternIsStartsWith, &pattern))) {
         MatchSubstringOptions converted_options{pattern, original_options.ignore_case};
         MatchSubstringState converted_state(converted_options);
         ctx->SetState(&converted_state);
-        status = MatchSubstring<StringType, PlainStartsWithMatcher>::Exec(ctx, batch, out);
-      } else if ((matched = re2::RE2::FullMatch(original_options.pattern, kLikePatternIsEndsWith, &pattern))) {
+        status =
+            MatchSubstring<StringType, PlainStartsWithMatcher>::Exec(ctx, batch, out);
+      } else if ((matched = re2::RE2::FullMatch(original_options.pattern,
+                                                kLikePatternIsEndsWith, &pattern))) {
         MatchSubstringOptions converted_options{pattern, original_options.ignore_case};
         MatchSubstringState converted_state(converted_options);
         ctx->SetState(&converted_state);

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1743,7 +1743,7 @@ void AddSlice(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("utf8_slice_codeunits", Arity::Unary(),
                                                &utf8_slice_codeunits_doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<SliceCodeunits>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<SliceCodeunits>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec, SliceCodeunitsTransform::State::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2260,7 +2260,7 @@ void AddSplitPattern(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern", Arity::Unary(),
                                                &split_pattern_doc);
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<SplitPatternExec, ListType>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<SplitPatternExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2318,7 +2318,7 @@ void AddSplitWhitespaceAscii(FunctionRegistry* registry) {
                                        &ascii_split_whitespace_doc, &default_options);
 
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2388,7 +2388,7 @@ void AddSplitWhitespaceUTF8(FunctionRegistry* registry) {
       std::make_shared<ScalarFunction>("utf8_split_whitespace", Arity::Unary(),
                                        &utf8_split_whitespace_doc, &default_options);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2454,7 +2454,7 @@ void AddSplitRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern_regex", Arity::Unary(),
                                                &split_pattern_regex_doc);
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<SplitRegexExec, ListType>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<SplitRegexExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2857,7 +2857,7 @@ void AddReplaceSlice(FunctionRegistry* registry) {
                                                  &utf8_replace_slice_doc);
 
     for (const auto& ty : StringTypes()) {
-      auto exec = GenerateIsomorphicVarBinary<Utf8ReplaceSlice>(ty);
+      auto exec = GenerateVarBinaryToVarBinary<Utf8ReplaceSlice>(ty);
       DCHECK_OK(func->AddKernel({ty}, ty, exec, ReplaceSliceTransformBase::State::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -3039,7 +3039,7 @@ void AddExtractRegex(FunctionRegistry* registry) {
   for (const auto& ty : BaseBinaryTypes()) {
     ScalarKernel kernel{{ty},
                         out_ty,
-                        GenerateIsomorphicVarBinary<ExtractRegex>(ty),
+                        GenerateVarBinaryToVarBinary<ExtractRegex>(ty),
                         ExtractRegexState::Init};
     // Null values will be computed based on regex match or not
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
@@ -3561,7 +3561,7 @@ void AddStrptime(FunctionRegistry* registry) {
 
   OutputType out_ty(ResolveStrptimeOutput);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<StrptimeExec>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<StrptimeExec>(ty);
     DCHECK_OK(func->AddKernel({ty}, out_ty, exec, StrptimeState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -4117,7 +4117,7 @@ void MakeUnaryStringBatchKernel(
     MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<ExecFunctor>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<ExecFunctor>(ty);
     ScalarKernel kernel{{ty}, ty, exec};
     kernel.mem_allocation = mem_allocation;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
@@ -4152,7 +4152,7 @@ void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* regi
                                         const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<Transformer>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<Transformer>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -4206,7 +4206,7 @@ void AddUnaryStringPredicate(std::string name, FunctionRegistry* registry,
                              const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateIsomorphicVarBinary<StringPredicateFunctor, Predicate>(ty);
+    auto exec = GenerateVarBinaryToVarBinary<StringPredicateFunctor, Predicate>(ty);
     DCHECK_OK(func->AddKernel({ty}, boolean(), exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1245,32 +1245,32 @@ void AddMatchSubstring(FunctionRegistry* registry) {
   {
     auto func = std::make_shared<ScalarFunction>("starts_with", Arity::Unary(),
                                                  &match_substring_doc);
-    auto exec_32 = MatchSubstring<StringType, PlainStartsWithMatcher>::Exec;
-    auto exec_64 = MatchSubstring<LargeStringType, PlainStartsWithMatcher>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, boolean(), exec_32, MatchSubstringState::Init));
-    DCHECK_OK(
-        func->AddKernel({large_utf8()}, boolean(), exec_64, MatchSubstringState::Init));
+    for (const auto& ty : BaseBinaryTypes()) {
+      auto exec =
+          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainStartsWithMatcher>(ty);
+      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
   {
     auto func = std::make_shared<ScalarFunction>("ends_with", Arity::Unary(),
                                                  &match_substring_doc);
-    auto exec_32 = MatchSubstring<StringType, PlainEndsWithMatcher>::Exec;
-    auto exec_64 = MatchSubstring<LargeStringType, PlainEndsWithMatcher>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, boolean(), exec_32, MatchSubstringState::Init));
-    DCHECK_OK(
-        func->AddKernel({large_utf8()}, boolean(), exec_64, MatchSubstringState::Init));
+    for (const auto& ty : BaseBinaryTypes()) {
+      auto exec =
+          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainEndsWithMatcher>(ty);
+      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 #ifdef ARROW_WITH_RE2
   {
     auto func = std::make_shared<ScalarFunction>("match_substring_regex", Arity::Unary(),
                                                  &match_substring_regex_doc);
-    auto exec_32 = MatchSubstring<StringType, RegexSubstringMatcher>::Exec;
-    auto exec_64 = MatchSubstring<LargeStringType, RegexSubstringMatcher>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, boolean(), exec_32, MatchSubstringState::Init));
-    DCHECK_OK(
-        func->AddKernel({large_utf8()}, boolean(), exec_64, MatchSubstringState::Init));
+    for (const auto& ty : BaseBinaryTypes()) {
+      auto exec =
+          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, RegexSubstringMatcher>(ty);
+      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
   {

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1276,11 +1276,10 @@ void AddMatchSubstring(FunctionRegistry* registry) {
   {
     auto func =
         std::make_shared<ScalarFunction>("match_like", Arity::Unary(), &match_like_doc);
-    auto exec_32 = MatchLike<StringType>::Exec;
-    auto exec_64 = MatchLike<LargeStringType>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, boolean(), exec_32, MatchSubstringState::Init));
-    DCHECK_OK(
-        func->AddKernel({large_utf8()}, boolean(), exec_64, MatchSubstringState::Init));
+    for (const auto& ty : BaseBinaryTypes()) {
+      auto exec = GenerateTypeAgnosticVarBinaryBase<MatchLike>(ty);
+      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 #endif

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1276,7 +1276,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
   }
   {
     auto func = std::make_shared<ScalarFunction>("starts_with", Arity::Unary(),
-                                                 &match_substring_doc);
+                                                 &starts_with_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec =
           GenerateVarBinaryToVarBinary<MatchSubstring, PlainStartsWithMatcher>(ty);
@@ -1287,7 +1287,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
   }
   {
     auto func = std::make_shared<ScalarFunction>("ends_with", Arity::Unary(),
-                                                 &match_substring_doc);
+                                                 &ends_with_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainEndsWithMatcher>(ty);
       DCHECK_OK(

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1032,6 +1032,7 @@ struct MatchSubstring {
   }
 };
 
+#ifdef ARROW_WITH_RE2
 template <typename Type>
 struct MatchSubstring<Type, RegexSubstringMatcher> {
   static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
@@ -1043,6 +1044,7 @@ struct MatchSubstring<Type, RegexSubstringMatcher> {
                                                                  matcher.get());
   }
 };
+#endif
 
 template <typename Type>
 struct MatchSubstring<Type, PlainSubstringMatcher> {
@@ -1360,8 +1362,9 @@ struct FindSubstringExec {
           kernel{FindSubstringRegex(options, /*is_utf8=*/InputType::is_utf8,
                                     /*literal=*/true)};
       return kernel.Exec(ctx, batch, out);
-#endif
+#else
       return Status::NotImplemented("ignore_case requires RE2");
+#endif
     }
     applicator::ScalarUnaryNotNullStateful<OffsetType, InputType, FindSubstring> kernel{
         FindSubstring(PlainSubstringMatcher(options))};

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1235,11 +1235,11 @@ void AddMatchSubstring(FunctionRegistry* registry) {
   {
     auto func = std::make_shared<ScalarFunction>("match_substring", Arity::Unary(),
                                                  &match_substring_doc);
-    auto exec_32 = MatchSubstring<StringType, PlainSubstringMatcher>::Exec;
-    auto exec_64 = MatchSubstring<LargeStringType, PlainSubstringMatcher>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, boolean(), exec_32, MatchSubstringState::Init));
-    DCHECK_OK(
-        func->AddKernel({large_utf8()}, boolean(), exec_64, MatchSubstringState::Init));
+    for (const auto& ty : BaseBinaryTypes()) {
+      auto exec =
+          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainSubstringMatcher>(ty);
+      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
   {

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -2312,8 +2312,10 @@ template <typename Type, typename ListType>
 using SplitWhitespaceAsciiExec = SplitExec<Type, ListType, SplitWhitespaceAsciiFinder>;
 
 void AddSplitWhitespaceAscii(FunctionRegistry* registry) {
-  auto func = std::make_shared<ScalarFunction>("ascii_split_whitespace", Arity::Unary(),
-                                               &ascii_split_whitespace_doc);
+  static const SplitOptions default_options{};
+  auto func =
+      std::make_shared<ScalarFunction>("ascii_split_whitespace", Arity::Unary(),
+                                       &ascii_split_whitespace_doc, &default_options);
 
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateTypeAgnosticVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
@@ -2381,8 +2383,10 @@ template <typename Type, typename ListType>
 using SplitWhitespaceUtf8Exec = SplitExec<Type, ListType, SplitWhitespaceUtf8Finder>;
 
 void AddSplitWhitespaceUTF8(FunctionRegistry* registry) {
-  auto func = std::make_shared<ScalarFunction>("utf8_split_whitespace", Arity::Unary(),
-                                               &utf8_split_whitespace_doc);
+  static const SplitOptions default_options{};
+  auto func =
+      std::make_shared<ScalarFunction>("utf8_split_whitespace", Arity::Unary(),
+                                       &utf8_split_whitespace_doc, &default_options);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateTypeAgnosticVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1743,7 +1743,7 @@ void AddSlice(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("utf8_slice_codeunits", Arity::Unary(),
                                                &utf8_slice_codeunits_doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<SliceCodeunits>(ty);
+    auto exec = GenerateIsomorphicVarBinary<SliceCodeunits>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec, SliceCodeunitsTransform::State::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2260,7 +2260,7 @@ void AddSplitPattern(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern", Arity::Unary(),
                                                &split_pattern_doc);
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<SplitPatternExec, ListType>(ty);
+    auto exec = GenerateIsomorphicVarBinary<SplitPatternExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2318,7 +2318,7 @@ void AddSplitWhitespaceAscii(FunctionRegistry* registry) {
                                        &ascii_split_whitespace_doc, &default_options);
 
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
+    auto exec = GenerateIsomorphicVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2388,7 +2388,7 @@ void AddSplitWhitespaceUTF8(FunctionRegistry* registry) {
       std::make_shared<ScalarFunction>("utf8_split_whitespace", Arity::Unary(),
                                        &utf8_split_whitespace_doc, &default_options);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
+    auto exec = GenerateIsomorphicVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2454,7 +2454,7 @@ void AddSplitRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern_regex", Arity::Unary(),
                                                &split_pattern_regex_doc);
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<SplitRegexExec, ListType>(ty);
+    auto exec = GenerateIsomorphicVarBinary<SplitRegexExec, ListType>(ty);
     DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -2857,7 +2857,7 @@ void AddReplaceSlice(FunctionRegistry* registry) {
                                                  &utf8_replace_slice_doc);
 
     for (const auto& ty : StringTypes()) {
-      auto exec = GenerateTypeAgnosticVarBinary<Utf8ReplaceSlice>(ty);
+      auto exec = GenerateIsomorphicVarBinary<Utf8ReplaceSlice>(ty);
       DCHECK_OK(func->AddKernel({ty}, ty, exec, ReplaceSliceTransformBase::State::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -3039,7 +3039,7 @@ void AddExtractRegex(FunctionRegistry* registry) {
   for (const auto& ty : BaseBinaryTypes()) {
     ScalarKernel kernel{{ty},
                         out_ty,
-                        GenerateTypeAgnosticVarBinary<ExtractRegex>(ty),
+                        GenerateIsomorphicVarBinary<ExtractRegex>(ty),
                         ExtractRegexState::Init};
     // Null values will be computed based on regex match or not
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
@@ -3561,7 +3561,7 @@ void AddStrptime(FunctionRegistry* registry) {
 
   OutputType out_ty(ResolveStrptimeOutput);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<StrptimeExec>(ty);
+    auto exec = GenerateIsomorphicVarBinary<StrptimeExec>(ty);
     DCHECK_OK(func->AddKernel({ty}, out_ty, exec, StrptimeState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -4117,7 +4117,7 @@ void MakeUnaryStringBatchKernel(
     MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<ExecFunctor>(ty);
+    auto exec = GenerateIsomorphicVarBinary<ExecFunctor>(ty);
     ScalarKernel kernel{{ty}, ty, exec};
     kernel.mem_allocation = mem_allocation;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
@@ -4152,7 +4152,7 @@ void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* regi
                                         const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<Transformer>(ty);
+    auto exec = GenerateIsomorphicVarBinary<Transformer>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -4206,7 +4206,7 @@ void AddUnaryStringPredicate(std::string name, FunctionRegistry* registry,
                              const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinary<StringPredicateFunctor, Predicate>(ty);
+    auto exec = GenerateIsomorphicVarBinary<StringPredicateFunctor, Predicate>(ty);
     DCHECK_OK(func->AddKernel({ty}, boolean(), exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -3009,7 +3009,7 @@ struct ExtractRegex : public ExtractRegexBase {
         result->value.reserve(group_count);
         for (int i = 0; i < group_count; i++) {
           result->value.push_back(std::make_shared<ScalarType>(
-              std::make_shared<Buffer>(ToStringView(found_values[i]))));
+              Buffer::FromString(found_values[i].as_string())));
         }
         result->is_valid = true;
       } else {

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1252,8 +1252,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     auto func = std::make_shared<ScalarFunction>("match_substring", Arity::Unary(),
                                                  &match_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
-      auto exec =
-          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainSubstringMatcher>(ty);
+      auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainSubstringMatcher>(ty);
       DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -1263,7 +1262,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
                                                  &match_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec =
-          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainStartsWithMatcher>(ty);
+          GenerateVarBinaryToVarBinary<MatchSubstring, PlainStartsWithMatcher>(ty);
       DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -1272,8 +1271,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     auto func = std::make_shared<ScalarFunction>("ends_with", Arity::Unary(),
                                                  &match_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
-      auto exec =
-          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, PlainEndsWithMatcher>(ty);
+      auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainEndsWithMatcher>(ty);
       DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -1283,8 +1281,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     auto func = std::make_shared<ScalarFunction>("match_substring_regex", Arity::Unary(),
                                                  &match_substring_regex_doc);
     for (const auto& ty : BaseBinaryTypes()) {
-      auto exec =
-          GenerateTypeAgnosticVarBinaryBase<MatchSubstring, RegexSubstringMatcher>(ty);
+      auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, RegexSubstringMatcher>(ty);
       DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -1293,7 +1290,7 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     auto func =
         std::make_shared<ScalarFunction>("match_like", Arity::Unary(), &match_like_doc);
     for (const auto& ty : BaseBinaryTypes()) {
-      auto exec = GenerateTypeAgnosticVarBinaryBase<MatchLike>(ty);
+      auto exec = GenerateVarBinaryToVarBinary<MatchLike>(ty);
       DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -1397,7 +1394,7 @@ void AddFindSubstring(FunctionRegistry* registry) {
     for (const auto& ty : BaseBinaryTypes()) {
       auto offset_type = offset_bit_width(ty->id()) == 64 ? int64() : int32();
       DCHECK_OK(func->AddKernel({ty}, offset_type,
-                                GenerateTypeAgnosticVarBinaryBase<FindSubstringExec>(ty),
+                                GenerateVarBinaryToVarBinary<FindSubstringExec>(ty),
                                 MatchSubstringState::Init));
     }
     DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_BINARY)}, int32(),
@@ -1411,10 +1408,9 @@ void AddFindSubstring(FunctionRegistry* registry) {
                                                  &find_substring_regex_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto offset_type = offset_bit_width(ty->id()) == 64 ? int64() : int32();
-      DCHECK_OK(
-          func->AddKernel({ty}, offset_type,
-                          GenerateTypeAgnosticVarBinaryBase<FindSubstringRegexExec>(ty),
-                          MatchSubstringState::Init));
+      DCHECK_OK(func->AddKernel({ty}, offset_type,
+                                GenerateVarBinaryToVarBinary<FindSubstringRegexExec>(ty),
+                                MatchSubstringState::Init));
     }
     DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_BINARY)}, int32(),
                               FindSubstringRegexExec<FixedSizeBinaryType>::Exec,
@@ -1547,7 +1543,7 @@ void AddCountSubstring(FunctionRegistry* registry) {
     for (const auto& ty : BaseBinaryTypes()) {
       auto offset_type = offset_bit_width(ty->id()) == 64 ? int64() : int32();
       DCHECK_OK(func->AddKernel({ty}, offset_type,
-                                GenerateTypeAgnosticVarBinaryBase<CountSubstringExec>(ty),
+                                GenerateVarBinaryToVarBinary<CountSubstringExec>(ty),
                                 MatchSubstringState::Init));
     }
     DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_BINARY)}, int32(),
@@ -1561,10 +1557,9 @@ void AddCountSubstring(FunctionRegistry* registry) {
                                                  &count_substring_regex_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto offset_type = offset_bit_width(ty->id()) == 64 ? int64() : int32();
-      DCHECK_OK(
-          func->AddKernel({ty}, offset_type,
-                          GenerateTypeAgnosticVarBinaryBase<CountSubstringRegexExec>(ty),
-                          MatchSubstringState::Init));
+      DCHECK_OK(func->AddKernel({ty}, offset_type,
+                                GenerateVarBinaryToVarBinary<CountSubstringRegexExec>(ty),
+                                MatchSubstringState::Init));
     }
     DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_BINARY)}, int32(),
                               CountSubstringRegexExec<FixedSizeBinaryType>::Exec,
@@ -3060,7 +3055,7 @@ void AddExtractRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("extract_regex", Arity::Unary(),
                                                &extract_regex_doc);
   OutputType out_ty(ResolveExtractRegexOutput);
-  for (const auto& ty : BaseBinaryTypes()) {
+  for (const auto& ty : StringTypes()) {
     ScalarKernel kernel{{ty},
                         out_ty,
                         GenerateVarBinaryToVarBinary<ExtractRegex>(ty),

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -2846,7 +2846,7 @@ struct Utf8ReplaceSliceTransform : ReplaceSliceTransformBase {
           return kTransformError;
         }
       } else {
-        // zero-length slice
+        // Zero-length slice
         end_sliced = begin_sliced;
       }
     }

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1036,7 +1036,8 @@ struct MatchSubstring<Type, PlainSubstringMatcher> {
     auto options = MatchSubstringState::Get(ctx);
     if (options.ignore_case) {
       if (!Type::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
 #ifdef ARROW_WITH_RE2
       ARROW_ASSIGN_OR_RAISE(auto matcher,
@@ -1059,7 +1060,8 @@ struct MatchSubstring<Type, PlainStartsWithMatcher> {
     auto options = MatchSubstringState::Get(ctx);
     if (options.ignore_case) {
       if (!Type::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
 #ifdef ARROW_WITH_RE2
       MatchSubstringOptions converted_options = options;
@@ -1083,7 +1085,8 @@ struct MatchSubstring<Type, PlainEndsWithMatcher> {
     auto options = MatchSubstringState::Get(ctx);
     if (options.ignore_case) {
       if (!Type::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
 #ifdef ARROW_WITH_RE2
       MatchSubstringOptions converted_options = options;
@@ -1219,7 +1222,8 @@ struct MatchLike {
       status = MatchSubstring<StringType, PlainEndsWithMatcher>::Exec(ctx, batch, out);
     } else {
       if (original_options.ignore_case && !StringType::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
       MatchSubstringOptions converted_options{MakeLikeRegex(original_options),
                                               original_options.ignore_case};
@@ -1343,7 +1347,8 @@ struct FindSubstringExec {
     const MatchSubstringOptions& options = MatchSubstringState::Get(ctx);
     if (options.ignore_case) {
       if (!InputType::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
 #ifdef ARROW_WITH_RE2
       applicator::ScalarUnaryNotNullStateful<OffsetType, InputType, FindSubstringRegex>
@@ -1500,7 +1505,8 @@ struct CountSubstringExec {
     const MatchSubstringOptions& options = MatchSubstringState::Get(ctx);
     if (options.ignore_case) {
       if (!InputType::is_utf8) {
-        return Status::NotImplemented("ignore_case is not supported for non-encoded binary types");
+        return Status::NotImplemented(
+            "ignore_case is not supported for non-encoded binary types");
       }
 #ifdef ARROW_WITH_RE2
       ARROW_ASSIGN_OR_RAISE(auto counter,

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1275,8 +1275,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
   {
-    auto func = std::make_shared<ScalarFunction>("starts_with", Arity::Unary(),
-                                                 &starts_with_doc);
+    auto func =
+        std::make_shared<ScalarFunction>("starts_with", Arity::Unary(), &starts_with_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec =
           GenerateVarBinaryToVarBinary<MatchSubstring, PlainStartsWithMatcher>(ty);
@@ -1286,8 +1286,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
   {
-    auto func = std::make_shared<ScalarFunction>("ends_with", Arity::Unary(),
-                                                 &ends_with_doc);
+    auto func =
+        std::make_shared<ScalarFunction>("ends_with", Arity::Unary(), &ends_with_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainEndsWithMatcher>(ty);
       DCHECK_OK(
@@ -1342,7 +1342,8 @@ struct FindSubstringRegex {
     regex.reserve(options.pattern.length() + 2);
     regex += literal ? RE2::QuoteMeta(options.pattern) : options.pattern;
     regex += ")";
-    regex_match_.reset(new RE2(regex, MakeRE2Options(is_utf8, options.ignore_case, /*literal=*/false)));
+    regex_match_.reset(
+        new RE2(regex, MakeRE2Options(is_utf8, options.ignore_case, /*literal=*/false)));
   }
 
   template <typename OutValue, typename... Ignored>

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1259,7 +1259,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
                                                  &match_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainSubstringMatcher>(ty);
-      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+      DCHECK_OK(
+          func->AddKernel({ty}, boolean(), std::move(exec), MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -1269,7 +1270,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec =
           GenerateVarBinaryToVarBinary<MatchSubstring, PlainStartsWithMatcher>(ty);
-      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+      DCHECK_OK(
+          func->AddKernel({ty}, boolean(), std::move(exec), MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -1278,7 +1280,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
                                                  &match_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, PlainEndsWithMatcher>(ty);
-      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+      DCHECK_OK(
+          func->AddKernel({ty}, boolean(), std::move(exec), MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -1288,7 +1291,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
                                                  &match_substring_regex_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchSubstring, RegexSubstringMatcher>(ty);
-      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+      DCHECK_OK(
+          func->AddKernel({ty}, boolean(), std::move(exec), MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -1297,7 +1301,8 @@ void AddMatchSubstring(FunctionRegistry* registry) {
         std::make_shared<ScalarFunction>("match_like", Arity::Unary(), &match_like_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<MatchLike>(ty);
-      DCHECK_OK(func->AddKernel({ty}, boolean(), exec, MatchSubstringState::Init));
+      DCHECK_OK(
+          func->AddKernel({ty}, boolean(), std::move(exec), MatchSubstringState::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -1766,7 +1771,8 @@ void AddSlice(FunctionRegistry* registry) {
                                                &utf8_slice_codeunits_doc);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SliceCodeunits>(ty);
-    DCHECK_OK(func->AddKernel({ty}, ty, exec, SliceCodeunitsTransform::State::Init));
+    DCHECK_OK(
+        func->AddKernel({ty}, ty, std::move(exec), SliceCodeunitsTransform::State::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2283,7 +2289,8 @@ void AddSplitPattern(FunctionRegistry* registry) {
                                                &split_pattern_doc);
   for (const auto& ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitPatternExec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
+    DCHECK_OK(
+        func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2341,7 +2348,7 @@ void AddSplitWhitespaceAscii(FunctionRegistry* registry) {
 
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2411,7 +2418,7 @@ void AddSplitWhitespaceUTF8(FunctionRegistry* registry) {
                                        &utf8_split_whitespace_doc, &default_options);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2479,7 +2486,8 @@ void AddSplitRegex(FunctionRegistry* registry) {
                                                &split_pattern_regex_doc);
   for (const auto& ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitRegexExec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, exec, SplitPatternState::Init));
+    DCHECK_OK(
+        func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2885,7 +2893,8 @@ void AddReplaceSlice(FunctionRegistry* registry) {
 
     for (const auto& ty : StringTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<Utf8ReplaceSlice>(ty);
-      DCHECK_OK(func->AddKernel({ty}, ty, exec, ReplaceSliceTransformBase::State::Init));
+      DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec),
+                                ReplaceSliceTransformBase::State::Init));
     }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
@@ -3590,7 +3599,7 @@ void AddStrptime(FunctionRegistry* registry) {
   OutputType out_ty(ResolveStrptimeOutput);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<StrptimeExec>(ty);
-    DCHECK_OK(func->AddKernel({ty}, out_ty, exec, StrptimeState::Init));
+    DCHECK_OK(func->AddKernel({ty}, out_ty, std::move(exec), StrptimeState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -3602,13 +3611,13 @@ void AddBinaryLength(FunctionRegistry* registry) {
     auto exec =
         GenerateVarBinaryBase<applicator::ScalarUnaryNotNull, Int32Type, BinaryLength>(
             ty);
-    DCHECK_OK(func->AddKernel({ty}, int32(), exec));
+    DCHECK_OK(func->AddKernel({ty}, int32(), std::move(exec)));
   }
   for (const auto& ty : {large_binary(), large_utf8()}) {
     auto exec =
         GenerateVarBinaryBase<applicator::ScalarUnaryNotNull, Int64Type, BinaryLength>(
             ty);
-    DCHECK_OK(func->AddKernel({ty}, int64(), exec));
+    DCHECK_OK(func->AddKernel({ty}, int64(), std::move(exec)));
   }
   DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_BINARY)}, int32(),
                             BinaryLength::FixedSizeExec));
@@ -3620,12 +3629,12 @@ void AddUtf8Length(FunctionRegistry* registry) {
       std::make_shared<ScalarFunction>("utf8_length", Arity::Unary(), &utf8_length_doc);
   {
     auto exec = applicator::ScalarUnaryNotNull<Int32Type, StringType, Utf8Length>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, int32(), exec));
+    DCHECK_OK(func->AddKernel({utf8()}, int32(), std::move(exec)));
   }
   {
     auto exec =
         applicator::ScalarUnaryNotNull<Int64Type, LargeStringType, Utf8Length>::Exec;
-    DCHECK_OK(func->AddKernel({large_utf8()}, int64(), exec));
+    DCHECK_OK(func->AddKernel({large_utf8()}, int64(), std::move(exec)));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -4111,7 +4120,7 @@ void AddBinaryJoinForListType(ScalarFunction* func) {
   for (const auto& ty : BaseBinaryTypes()) {
     auto exec = GenerateTypeAgnosticVarBinaryBase<BinaryJoin, ListType>(*ty);
     auto list_ty = std::make_shared<ListType>(ty);
-    DCHECK_OK(func->AddKernel({InputType(list_ty), InputType(ty)}, ty, exec));
+    DCHECK_OK(func->AddKernel({InputType(list_ty), InputType(ty)}, ty, std::move(exec)));
   }
 }
 
@@ -4146,7 +4155,7 @@ void MakeUnaryStringBatchKernel(
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<ExecFunctor>(ty);
-    ScalarKernel kernel{{ty}, ty, exec};
+    ScalarKernel kernel{{ty}, ty, std::move(exec)};
     kernel.mem_allocation = mem_allocation;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
@@ -4179,7 +4188,7 @@ void AddReplaceSubstring(FunctionRegistry* registry) {
                                                  &replace_substring_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<ReplaceSubstringPlain>(ty);
-      ScalarKernel kernel{{ty}, ty, exec, ReplaceState::Init};
+      ScalarKernel kernel{{ty}, ty, std::move(exec), ReplaceState::Init};
       kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
       DCHECK_OK(func->AddKernel(std::move(kernel)));
     }
@@ -4191,7 +4200,7 @@ void AddReplaceSubstring(FunctionRegistry* registry) {
         "replace_substring_regex", Arity::Unary(), &replace_substring_regex_doc);
     for (const auto& ty : BaseBinaryTypes()) {
       auto exec = GenerateVarBinaryToVarBinary<ReplaceSubstringRegex>(ty);
-      ScalarKernel kernel{{ty}, ty, exec, ReplaceState::Init};
+      ScalarKernel kernel{{ty}, ty, std::move(exec), ReplaceState::Init};
       kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
       DCHECK_OK(func->AddKernel(std::move(kernel)));
     }
@@ -4208,7 +4217,7 @@ void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* regi
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<Transformer>(ty);
-    DCHECK_OK(func->AddKernel({ty}, ty, exec));
+    DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec)));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -4262,7 +4271,7 @@ void AddUnaryStringPredicate(std::string name, FunctionRegistry* registry,
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<StringPredicateFunctor, Predicate>(ty);
-    DCHECK_OK(func->AddKernel({ty}, boolean(), exec));
+    DCHECK_OK(func->AddKernel({ty}, boolean(), std::move(exec)));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1360,7 +1360,7 @@ TYPED_TEST(TestStringKernels, ReplaceSubstringRegexInvalid) {
       CallFunction("replace_substring_regex", {input}, &options));
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegex) {
+TYPED_TEST(TestBinaryKernels, ExtractRegex) {
   ExtractRegexOptions options{"(?P<letter>[ab])(?P<digit>\\d)"};
   auto type = struct_({field("letter", this->type()), field("digit", this->type())});
   this->CheckUnary("extract_regex", R"([])", type, R"([])", &options);
@@ -1380,7 +1380,7 @@ TYPED_TEST(TestStringKernels, ExtractRegex) {
                    &options);
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexNoCapture) {
+TYPED_TEST(TestBinaryKernels, ExtractRegexNoCapture) {
   // XXX Should we accept this or is it a user error?
   ExtractRegexOptions options{"foo"};
   auto type = struct_({});
@@ -1388,12 +1388,12 @@ TYPED_TEST(TestStringKernels, ExtractRegexNoCapture) {
                    R"([{}, null, null])", &options);
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexNoOptions) {
+TYPED_TEST(TestBinaryKernels, ExtractRegexNoOptions) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ASSERT_RAISES(Invalid, CallFunction("extract_regex", {input}));
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexInvalid) {
+TYPED_TEST(TestBinaryKernels, ExtractRegexInvalid) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ExtractRegexOptions options{"invalid["};
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -150,21 +150,24 @@ TYPED_TEST(TestBinaryBaseKernels, NonUtf8) {
         this->MakeArray({"\xf7\xfc\x40\xab", "\xff\xfc\x40\xc3\xbb"}), &options);
   }
   {
-    for (auto ignore_case : { true, false } ) {
+    for (auto ignore_case : {true, false}) {
       MatchSubstringOptions options{std::string("\xfc\x40", 2), ignore_case};
-      this->CheckUnary("find_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
-                       this->offset_type(), "[0, 2, -1]", &options);
+      this->CheckUnary(
+          "find_substring",
+          this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
+          this->offset_type(), "[0, 2, -1]", &options);
 
       // @ = \x40
       options.pattern = "@";
-      this->CheckUnary("find_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
-                       this->offset_type(), "[1, 3, -1]", &options);
+      this->CheckUnary(
+          "find_substring",
+          this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
+          this->offset_type(), "[1, 3, -1]", &options);
 
       options.pattern = std::string("\xfc\x40", 2);
       this->CheckUnary("count_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
+                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
                        this->offset_type(), "[1, 1, 0, 2]", &options);
 
       options.pattern = "@";

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1133,7 +1133,7 @@ TYPED_TEST(TestBinaryKernels, MatchLikeEscaping) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, SplitBasics) {
+TYPED_TEST(TestBinaryKernels, SplitBasics) {
   SplitPatternOptions options{" "};
   // basics
   this->CheckUnary("split_pattern", R"(["foo bar", "foo"])", list(this->type()),
@@ -1155,7 +1155,7 @@ TYPED_TEST(TestStringKernels, SplitBasics) {
                    &options_long_reverse);
 }
 
-TYPED_TEST(TestStringKernels, SplitMax) {
+TYPED_TEST(TestBinaryKernels, SplitMax) {
   SplitPatternOptions options{"---", 2};
   SplitPatternOptions options_reverse{"---", 2, /*reverse=*/true};
   this->CheckUnary("split_pattern", R"(["foo---bar", "foo", "foo---bar------ar"])",
@@ -1216,7 +1216,7 @@ TYPED_TEST(TestStringKernels, SplitWhitespaceUTF8Reverse) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, SplitRegex) {
+TYPED_TEST(TestBinaryKernels, SplitRegex) {
   SplitPatternOptions options{"a+|b"};
 
   this->CheckUnary(
@@ -1233,7 +1233,7 @@ TYPED_TEST(TestStringKernels, SplitRegex) {
       &options);
 }
 
-TYPED_TEST(TestStringKernels, SplitRegexReverse) {
+TYPED_TEST(TestBinaryKernels, SplitRegexReverse) {
   SplitPatternOptions options{"a+|b", /*max_splits=*/1, /*reverse=*/true};
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
 

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -918,7 +918,7 @@ TYPED_TEST(TestStringKernels, IsUpperAscii) {
                    "[false, null, false, true, true, false, false]");
 }
 
-TYPED_TEST(TestStringKernels, MatchSubstring) {
+TYPED_TEST(TestBinaryKernels, MatchSubstring) {
   MatchSubstringOptions options{"ab"};
   this->CheckUnary("match_substring", "[]", boolean(), "[]", &options);
   this->CheckUnary("match_substring", R"(["abc", "acb", "cab", null, "bac", "AB"])",
@@ -944,14 +944,14 @@ TYPED_TEST(TestStringKernels, MatchSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchSubstringIgnoreCase) {
   MatchSubstringOptions options_insensitive{"aé(", /*ignore_case=*/true};
   this->CheckUnary("match_substring", R"(["abc", "aEb", "baÉ(", "aé(", "ae(", "Aé("])",
                    boolean(), "[false, false, true, true, false, true]",
                    &options_insensitive);
 }
 #else
-TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchSubstringIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -147,17 +147,7 @@ TYPED_TEST(TestBinaryBaseKernels, BinaryNonUtf8Tests) {
     this->CheckUnary("find_substring",
                      this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\xff"}),
                      this->offset_type(), "[0, 2, -1]", &options);
-  }
-#ifdef ARROW_WITH_RE2
-  {
-    MatchSubstringOptions options{"\xfc\x40"};
-    this->CheckUnary("find_substring",
-                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\xff"}),
-                     this->offset_type(), "[0, 2, -1]", &options);
-  }
-#endif
-  {
-    MatchSubstringOptions options{"\xfc\x40", /*ignore_case=*/true};
+    options.ignore_case = true;
     auto input = Datum(this->MakeArray({"\xfc\x40\xab"}));
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         NotImplemented,
@@ -240,7 +230,7 @@ TYPED_TEST(TestBinaryKernels, FindSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestBinaryKernels, FindSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
   MatchSubstringOptions options{"?AB)", /*ignore_case=*/true};
   this->CheckUnary("find_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary("find_substring",
@@ -248,7 +238,7 @@ TYPED_TEST(TestBinaryKernels, FindSubstringIgnoreCase) {
                    this->offset_type(), "[0, -1, 1, null, -1, -1]", &options);
 }
 
-TYPED_TEST(TestBinaryKernels, FindSubstringRegex) {
+TYPED_TEST(TestStringKernels, FindSubstringRegex) {
   MatchSubstringOptions options{"a+", /*ignore_case=*/false};
   this->CheckUnary("find_substring_regex", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary("find_substring_regex", R"(["a", "A", "baaa", null, "", "AaaA"])",
@@ -260,7 +250,7 @@ TYPED_TEST(TestBinaryKernels, FindSubstringRegex) {
                    this->offset_type(), "[0, 0, 1, null, -1, 0]", &options);
 }
 #else
-TYPED_TEST(TestBinaryKernels, FindSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
   MatchSubstringOptions options{"a+", /*ignore_case=*/true};
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -313,7 +303,7 @@ TYPED_TEST(TestBinaryKernels, CountSubstringRegex) {
                    this->offset_type(), "[0, 1, 1, 2, 0]", &options_repeated);
 }
 
-TYPED_TEST(TestBinaryKernels, CountSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
   MatchSubstringOptions options{"aba", /*ignore_case=*/true};
   this->CheckUnary("count_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary(
@@ -326,7 +316,7 @@ TYPED_TEST(TestBinaryKernels, CountSubstringIgnoreCase) {
                    "[1, null, 4]", &options_empty);
 }
 
-TYPED_TEST(TestBinaryKernels, CountSubstringRegexIgnoreCase) {
+TYPED_TEST(TestStringKernels, CountSubstringRegexIgnoreCase) {
   MatchSubstringOptions options_as{"a+", /*ignore_case=*/true};
   this->CheckUnary("count_substring_regex", R"(["", "bacAaAdaAaA", "c", "AAA"])",
                    this->offset_type(), "[0, 3, 0, 1]", &options_as);
@@ -336,7 +326,7 @@ TYPED_TEST(TestBinaryKernels, CountSubstringRegexIgnoreCase) {
                    this->offset_type(), "[1, 7, 2, 2]", &options_empty_match);
 }
 #else
-TYPED_TEST(TestBinaryKernels, CountSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1010,14 +1000,14 @@ TYPED_TEST(TestBinaryKernels, MatchSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestBinaryKernels, MatchSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
   MatchSubstringOptions options_insensitive{"aé(", /*ignore_case=*/true};
   this->CheckUnary("match_substring", R"(["abc", "aEb", "baÉ(", "aé(", "ae(", "Aé("])",
                    boolean(), "[false, false, true, true, false, true]",
                    &options_insensitive);
 }
 #else
-TYPED_TEST(TestBinaryKernels, MatchSubstringIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1045,7 +1035,7 @@ TYPED_TEST(TestBinaryKernels, MatchEndsWith) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("starts_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("starts_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1054,7 +1044,7 @@ TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
                    boolean(), "[true, false, true, false, true]", &options);
 }
 
-TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("ends_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("ends_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1063,7 +1053,7 @@ TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
                    boolean(), "[true, true, false, true, false]", &options);
 }
 #else
-TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1071,7 +1061,7 @@ TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
                                   CallFunction("starts_with", {input}, &options));
 }
 
-TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1081,7 +1071,7 @@ TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
 #endif
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestBinaryKernels, MatchSubstringRegex) {
+TYPED_TEST(TestStringKernels, MatchSubstringRegex) {
   MatchSubstringOptions options{"ab"};
   this->CheckUnary("match_substring_regex", "[]", boolean(), "[]", &options);
   this->CheckUnary("match_substring_regex", R"(["abc", "acb", "cab", null, "bac", "AB"])",
@@ -1124,7 +1114,7 @@ TYPED_TEST(TestBinaryKernels, MatchSubstringRegexInvalid) {
       CallFunction("match_substring_regex", {input}, &options));
 }
 
-TYPED_TEST(TestBinaryKernels, MatchLike) {
+TYPED_TEST(TestStringKernels, MatchLike) {
   auto inputs = R"(["foo", "bar", "foobar", "barfoo", "o", "\nfoo", "foo\n", null])";
 
   MatchSubstringOptions prefix_match{"foo%"};
@@ -1421,7 +1411,7 @@ TYPED_TEST(TestStringKernels, ReplaceSubstringRegexInvalid) {
       CallFunction("replace_substring_regex", {input}, &options));
 }
 
-TYPED_TEST(TestBinaryKernels, ExtractRegex) {
+TYPED_TEST(TestStringKernels, ExtractRegex) {
   ExtractRegexOptions options{"(?P<letter>[ab])(?P<digit>\\d)"};
   auto type = struct_({field("letter", this->type()), field("digit", this->type())});
   this->CheckUnary("extract_regex", R"([])", type, R"([])", &options);
@@ -1441,7 +1431,7 @@ TYPED_TEST(TestBinaryKernels, ExtractRegex) {
                    &options);
 }
 
-TYPED_TEST(TestBinaryKernels, ExtractRegexNoCapture) {
+TYPED_TEST(TestStringKernels, ExtractRegexNoCapture) {
   // XXX Should we accept this or is it a user error?
   ExtractRegexOptions options{"foo"};
   auto type = struct_({});
@@ -1449,12 +1439,12 @@ TYPED_TEST(TestBinaryKernels, ExtractRegexNoCapture) {
                    R"([{}, null, null])", &options);
 }
 
-TYPED_TEST(TestBinaryKernels, ExtractRegexNoOptions) {
+TYPED_TEST(TestStringKernels, ExtractRegexNoOptions) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ASSERT_RAISES(Invalid, CallFunction("extract_regex", {input}));
 }
 
-TYPED_TEST(TestBinaryKernels, ExtractRegexInvalid) {
+TYPED_TEST(TestStringKernels, ExtractRegexInvalid) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ExtractRegexOptions options{"invalid["};
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -111,14 +111,14 @@ class BaseTestStringKernels : public ::testing::Test {
 };
 
 template <typename TestType>
-class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
-
-TYPED_TEST_SUITE(TestBinaryKernels, BinaryArrowTypes);
-
-template <typename TestType>
 class TestBaseBinaryKernels : public BaseTestStringKernels<TestType> {};
 
 TYPED_TEST_SUITE(TestBaseBinaryKernels, BaseBinaryArrowTypes);
+
+template <typename TestType>
+class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
+
+TYPED_TEST_SUITE(TestBinaryKernels, BinaryArrowTypes);
 
 template <typename TestType>
 class TestStringKernels : public BaseTestStringKernels<TestType> {};
@@ -140,97 +140,146 @@ TYPED_TEST(TestBaseBinaryKernels, BinaryLength) {
                    this->offset_type(), "[3, 4, 2]");
 }
 
+// The NonUtf8XXX tests use kernels that do not accept invalid UTF-8 when
+// processing [Large]StringType data. These tests use invalid UTF-8 inputs.
 TYPED_TEST(TestBinaryKernels, NonUtf8) {
-  // These kernels do not accept invalid UTF-8 when processing
-  // [Large]StringType data. These tests use invalid UTF-8 inputs.
-  {
-    ReplaceSliceOptions options{1, 2, std::string("\xfc\x40", 2)};
+#ifdef ARROW_WITH_RE2
+  for (auto ignore_case : {true, false}) {
+#else
+  for (auto ignore_case : {false}) {
+#endif
+    MatchSubstringOptions options("\xfc\x40", ignore_case);
     this->CheckUnary(
-        "binary_replace_slice", this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}),
-        this->MakeArray({"\xf7\xfc\x40\xab", "\xff\xfc\x40\xc3\xbb"}), &options);
-  }
-  {
-    for (auto ignore_case : {true, false}) {
-      MatchSubstringOptions options{std::string("\xfc\x40", 2), ignore_case};
-      this->CheckUnary(
-          "find_substring",
-          this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
-          this->offset_type(), "[0, 2, -1]", &options);
+        "find_substring",
+        this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
+        this->offset_type(), "[0, 2, -1]", &options);
 
-      // @ = \x40
-      options.pattern = "@";
-      this->CheckUnary(
-          "find_substring",
-          this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
-          this->offset_type(), "[1, 3, -1]", &options);
+    // @ = \x40
+    options.pattern = "@";
+    this->CheckUnary(
+        "find_substring",
+        this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
+        this->offset_type(), "[1, 3, -1]", &options);
 
-      options.pattern = std::string("\xfc\x40", 2);
-      this->CheckUnary("count_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
-                       this->offset_type(), "[1, 1, 0, 2]", &options);
+    options.pattern = "\xfc\x40";
+    this->CheckUnary("count_substring",
+                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
+                     this->offset_type(), "[1, 1, 0, 2]", &options);
 
-      options.pattern = "@";
-      this->CheckUnary("count_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
-                       this->offset_type(), "[1, 1, 0, 3]", &options);
+    options.pattern = "@";
+    this->CheckUnary("count_substring",
+                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
+                     this->offset_type(), "[1, 1, 0, 3]", &options);
 
-      options.pattern = std::string("\xfc\x40", 2);
-      this->CheckUnary("match_substring",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
-                       boolean(), "[true, true, false, true]", &options);
+    options.pattern = "\xfc\x40";
+    this->CheckUnary("match_substring",
+                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
+                     boolean(), "[true, true, false, true]", &options);
 
-      options.pattern = std::string("\xfc\x40", 2);
-      this->CheckUnary("starts_with",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
-                       boolean(), "[true, false, false, false]", &options);
+    options.pattern = "\xfc\x40";
+    this->CheckUnary("starts_with",
+                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
+                     boolean(), "[true, false, false, false]", &options);
 
-      options.pattern = std::string("\xfc\x40", 2);
-      this->CheckUnary("ends_with",
-                       this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                        "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40"}),
-                       boolean(), "[false, false, false, true]", &options);
-    }
+    options.pattern = "\xfc\x40";
+    this->CheckUnary("ends_with",
+                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
+                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40"}),
+                     boolean(), "[false, false, false, true]", &options);
   }
   {
     // "foo<non-UTF8>bar" = \x66\x6f\x6f\xfc\x62\x61\x72
-    SplitPatternOptions options{"\xfc"};
+    SplitPatternOptions options("\xfc");
     this->CheckUnary("split_pattern",
                      this->MakeArray({"\x66\x6f\x6f\xfc\x62\x61\x72", "foo"}),
                      list(this->type()), R"([["foo", "bar"], ["foo"]])", &options);
   }
   {
-    ReplaceSubstringOptions options{"\xfc\x40", "bazz", 1};
+    ReplaceSubstringOptions options("\xfc\x40", "bazz", 1);
     this->CheckUnary("replace_substring",
                      this->MakeArray({"\xfc\x40", "this \xfc\x40 that \xfc\x40"}),
                      this->MakeArray({"bazz", "this bazz that \xfc\x40"}), &options);
   }
+  {
+    ReplaceSliceOptions options(1, 2, "\xfc\x40");
+    this->CheckUnary(
+        "binary_replace_slice", this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}),
+        this->MakeArray({"\xf7\xfc\x40\xab", "\xff\xfc\x40\xc3\xbb"}), &options);
+  }
 }
 
 TYPED_TEST(TestBinaryKernels, NonUtf8WithNull) {
-  // These kernels do not accept invalid UTF-8 when processing
-  // [Large]StringType data. These tests use invalid UTF-8 inputs.
+#ifdef ARROW_WITH_RE2
   for (auto ignore_case : {true, false}) {
-    MatchSubstringOptions options{std::string("\xfc\x00", 2), ignore_case};
+#else
+  for (auto ignore_case : {false}) {
+#endif
+    MatchSubstringOptions options{std::string("\x00\x40", 2), ignore_case};
+    this->CheckUnary(
+        "find_substring",
+        this->template MakeArray<std::string>(
+            {{"\x00\x40\xab", 3}, {"\x00\x9b\x00\x40\xab", 5}, {"\x40\x00\x41", 3}}),
+        this->offset_type(), "[0, 2, -1]", &options);
+
     this->CheckUnary(
         "count_substring",
-        this->template MakeArray<std::string>({{"\xfc\x00\xab", 3},
-                                               {"\xff\x9b\xfc\x00\xab", 5},
+        this->template MakeArray<std::string>({{"\x00\x40\xab", 3},
                                                {"\x01\xfc\x41", 3},
-                                               {"\x01\xfc\x00\x40\xfc\x00\xab", 7}}),
-        this->offset_type(), "[1, 1, 0, 2]", &options);
+                                               {"\x01\x00\x00\x40\x00\x40\xab", 7}}),
+        this->offset_type(), "[1, 0, 2]", &options);
+
+    this->CheckUnary(
+        "match_substring",
+        this->template MakeArray<std::string>({{"\x00\x40\xab", 3},
+                                               {"\x00\xfc\x41", 3},
+                                               {"\x01\xfc\x00\x40\x00\x40\xab", 7}}),
+        boolean(), "[true, false, true]", &options);
+
+    this->CheckUnary(
+        "starts_with",
+        this->template MakeArray<std::string>(
+            {{"\x00\x40\xab", 3}, {"\x01\xfc\x41", 3}, {"\x00\x00\x00\x00\x00\x40", 6}}),
+        boolean(), "[true, false, false]", &options);
+
+    this->CheckUnary(
+        "ends_with",
+        this->template MakeArray<std::string>(
+            {{"\x00\x40\xab", 3}, {"\x01\xfc\x41", 3}, {"\x00\x00\x00\x00\x00\x40", 6}}),
+        boolean(), "[false, false, true]", &options);
+  }
+  {
+    // "foo<non-UTF8>bar" = \x66\x6f\x6f\xfc\x62\x61\x72
+    SplitPatternOptions options(std::string("\xfc\x00", 2));
+    this->CheckUnary(
+        "split_pattern",
+        this->template MakeArray<std::string>({{"\x66\x6f\x6f\xfc\x00\x62\x61\x72", 8}}),
+        list(this->type()), R"([["foo", "bar"]])", &options);
+  }
+  {
+    ReplaceSubstringOptions options(std::string("\x00\x40", 2), "bazz", 1);
+    this->CheckUnary("replace_substring",
+                     this->template MakeArray<std::string>({{"\x00\x40", 2}}),
+                     this->type(), R"(["bazz"])", &options);
+  }
+  {
+    ReplaceSliceOptions options(1, 2, std::string("\x00\x40", 2));
+    this->CheckUnary("binary_replace_slice",
+                     this->template MakeArray<std::string>(
+                         {{"\x00\x0f\xab", 3}, {"\x00\x9b\xc3\xbb", 4}}),
+                     this->template MakeArray<std::string>(
+                         {{"\x00\x00\x40\xab", 4}, {"\x00\x00\x40\xc3\xbb", 5}}),
+                     &options);
   }
 }
 
 #ifdef ARROW_WITH_RE2
 TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
-  // These kernels do not accept invalid UTF-8 when processing
-  // [Large]StringType data. These tests use invalid UTF-8 inputs.
   for (auto ignore_case : {true, false}) {
-    MatchSubstringOptions options{std::string("\xfc\x40", 2), ignore_case};
+    MatchSubstringOptions options("\xfc\x40", ignore_case);
     // @ = \x40
     options.pattern = "@+";
     this->CheckUnary(
@@ -246,19 +295,19 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
                      this->offset_type(), "[0, 1, 2, 2]", &options);
 
     // options.pattern = "@*A";
-    options.pattern = std::string("\x40*\x41", 3);
+    options.pattern = "\x40*\x41";
     this->CheckUnary("match_substring_regex",
                      this->MakeArray({"\xfc\x42\xab", "\xff\x9b\x40\x41\xab",
                                       "\x01\x41\x41", "\x01\x40\x41\x40\x40\x41\xab"}),
                      boolean(), "[false, true, true, true]", &options);
 
-    options.pattern = std::string("\xfc*\xab", 3);
+    options.pattern = "\xfc*\xab";
     this->CheckUnary("match_substring_regex",
                      this->MakeArray({"\xfc\x42\xab", "\xff\x9b\x40\x41\xab",
                                       "\x01\x41\x41", "\x01\x40\x41\x40\x40\x41\xab"}),
                      boolean(), "[true, true, false, true]", &options);
 
-    options.pattern = std::string("%\xfc\x40", 3);
+    options.pattern = "%\xfc\x40";
     this->CheckUnary("match_like",
                      this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
                                       "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40"}),
@@ -266,7 +315,7 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
   }
   {
     // "foo<non-UTF8>bar" = \x66\x6f\x6f\xfc\x62\x61\x72
-    SplitPatternOptions options{"\xfc"};
+    SplitPatternOptions options("\xfc");
     this->CheckUnary("split_pattern_regex",
                      this->MakeArray({"\x66\x6f\x6f\xfc\x62\x61\x72", "foo"}),
                      list(this->type()), R"([["foo", "bar"], ["foo"]])", &options);
@@ -277,13 +326,13 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
                      list(this->type()), R"([["f", "o", "b", "r"], ["bar"]])", &options);
   }
   {
-    ReplaceSubstringOptions options{"\xfc\x40", "bazz", 1};
+    ReplaceSubstringOptions options("\xfc\x40", "bazz", 1);
     this->CheckUnary("replace_substring_regex",
                      this->MakeArray({"\xfc\x40", "this \xfc\x40 that \xfc\x40"}),
                      this->MakeArray({"bazz", "this bazz that \xfc\x40"}), &options);
   }
   {
-    ExtractRegexOptions options{"(?P<letter>[\\xfc])(?P<digit>\\d)"};
+    ExtractRegexOptions options("(?P<letter>[\\xfc])(?P<digit>\\d)");
     auto null_bitmap = std::make_shared<Buffer>("0");
     auto output = StructArray::Make(
         {this->MakeArray({"\xfc", "1"}), this->MakeArray({"\xfc", "2"})},
@@ -294,17 +343,70 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
 }
 
 TYPED_TEST(TestBinaryKernels, NonUtf8WithNullRegex) {
-  // These kernels do not accept invalid UTF-8 when processing
-  // [Large]StringType data. These tests use invalid UTF-8 inputs.
   for (auto ignore_case : {true, false}) {
-    MatchSubstringOptions options{std::string("\xfc\x00", 2), ignore_case};
+    MatchSubstringOptions options{std::string("\x00\x40", 2), ignore_case};
+    this->CheckUnary(
+        "find_substring_regex",
+        this->template MakeArray<std::string>(
+            {{"\x00\x40\xab", 3}, {"\x00\x9b\x00\x40\xab", 5}, {"\x40\x00\x41", 3}}),
+        this->offset_type(), "[0, 2, -1]", &options);
+
     this->CheckUnary(
         "count_substring_regex",
-        this->template MakeArray<std::string>({{"\xfc\x00\xab", 3},
-                                               {"\xff\x9b\xfc\x00\xab", 5},
+        this->template MakeArray<std::string>({{"\x00\x40\xab", 3},
                                                {"\x01\xfc\x41", 3},
-                                               {"\x01\xfc\x00\x40\xfc\x00\xab", 7}}),
-        this->offset_type(), "[1, 1, 0, 2]", &options);
+                                               {"\x01\x00\x00\x40\x00\x40\xab", 7}}),
+        this->offset_type(), "[1, 0, 2]", &options);
+
+    this->CheckUnary(
+        "match_substring_regex",
+        this->template MakeArray<std::string>({{"\x00\x40\xab", 3},
+                                               {"\x00\xfc\x41", 3},
+                                               {"\x01\xfc\x00\x40\x00\x40\xab", 7}}),
+        boolean(), "[true, false, true]", &options);
+
+    options.pattern = std::string("%\x00\x40", 3);
+    this->CheckUnary(
+        "match_like",
+        this->template MakeArray<std::string>({{"\x00\x40\xab", 3},
+                                               {"\xff\x9b\x00\x40\xab", 5},
+                                               {"\xff\xfc\x40\x40\x00\x40", 6}}),
+        boolean(), "[false, false, true]", &options);
+  }
+  {
+    // "foo<non-UTF8>bar" = \x66\x6f\x6f\xfc\x62\x61\x72
+    SplitPatternOptions options(std::string("\xfc\x00", 2));
+    this->CheckUnary(
+        "split_pattern_regex",
+        this->template MakeArray<std::string>({{"\x66\x6f\x6f\xfc\x00\x62\x61\x72", 8}}),
+        list(this->type()), R"([["foo", "bar"]])", &options);
+  }
+  {
+    ReplaceSubstringOptions options(std::string("\x00\x40", 2), "bazz", 1);
+    this->CheckUnary("replace_substring_regex",
+                     this->template MakeArray<std::string>({{"\x00\x40", 2}}),
+                     this->type(), R"(["bazz"])", &options);
+  }
+  {
+    ExtractRegexOptions options("(?P<null>[\\x00])(?P<digit>\\d)");
+    auto null_bitmap = std::make_shared<Buffer>("0");
+    auto output = StructArray::Make(
+        {this->template MakeArray<std::string>({{"\x00", 1}, {"1", 1}}),
+         this->template MakeArray<std::string>({{"\x00", 1}, {"2", 1}})},
+        {field("null", this->type()), field("digit", this->type())}, null_bitmap);
+    this->CheckUnary(
+        "extract_regex",
+        this->template MakeArray<std::string>({{"foo\x00 1bar", 9}, {"\x02\x00\x40", 3}}),
+        std::static_pointer_cast<Array>(*output), &options);
+  }
+  {
+    ReplaceSliceOptions options(1, 2, std::string("\x00\x40", 2));
+    this->CheckUnary("binary_replace_slice",
+                     this->template MakeArray<std::string>(
+                         {{"\x00\x0f\xab", 3}, {"\x00\x9b\xc3\xbb", 4}}),
+                     this->template MakeArray<std::string>(
+                         {{"\x00\x00\x40\xab", 4}, {"\x00\x00\x40\xc3\xbb", 5}}),
+                     &options);
   }
 }
 #endif
@@ -359,7 +461,7 @@ TYPED_TEST(TestBaseBinaryKernels, BinaryReplaceSlice) {
                    &options_neg_flip);
 }
 
-TYPED_TEST(TestStringKernels, FindSubstring) {
+TYPED_TEST(TestBaseBinaryKernels, FindSubstring) {
   MatchSubstringOptions options{"ab"};
   this->CheckUnary("find_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary("find_substring", R"(["abc", "acb", "cab", null, "bac"])",
@@ -383,7 +485,7 @@ TYPED_TEST(TestStringKernels, FindSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, FindSubstringIgnoreCase) {
   MatchSubstringOptions options{"?AB)", /*ignore_case=*/true};
   this->CheckUnary("find_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary("find_substring",
@@ -391,7 +493,7 @@ TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
                    this->offset_type(), "[0, -1, 1, null, -1, -1]", &options);
 }
 
-TYPED_TEST(TestStringKernels, FindSubstringRegex) {
+TYPED_TEST(TestBaseBinaryKernels, FindSubstringRegex) {
   MatchSubstringOptions options{"a+", /*ignore_case=*/false};
   this->CheckUnary("find_substring_regex", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary("find_substring_regex", R"(["a", "A", "baaa", null, "", "AaaA"])",
@@ -403,7 +505,7 @@ TYPED_TEST(TestStringKernels, FindSubstringRegex) {
                    this->offset_type(), "[0, 0, 1, null, -1, 0]", &options);
 }
 #else
-TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, FindSubstringIgnoreCase) {
   MatchSubstringOptions options{"a+", /*ignore_case=*/true};
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -412,7 +514,7 @@ TYPED_TEST(TestStringKernels, FindSubstringIgnoreCase) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, CountSubstring) {
+TYPED_TEST(TestBaseBinaryKernels, CountSubstring) {
   MatchSubstringOptions options{"aba"};
   this->CheckUnary("count_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary(
@@ -430,7 +532,7 @@ TYPED_TEST(TestStringKernels, CountSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, CountSubstringRegex) {
+TYPED_TEST(TestBaseBinaryKernels, CountSubstringRegex) {
   MatchSubstringOptions options{"aba"};
   this->CheckUnary("count_substring_regex", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary(
@@ -456,7 +558,7 @@ TYPED_TEST(TestStringKernels, CountSubstringRegex) {
                    this->offset_type(), "[0, 1, 1, 2, 0]", &options_repeated);
 }
 
-TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, CountSubstringIgnoreCase) {
   MatchSubstringOptions options{"aba", /*ignore_case=*/true};
   this->CheckUnary("count_substring", "[]", this->offset_type(), "[]", &options);
   this->CheckUnary(
@@ -469,7 +571,7 @@ TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
                    "[1, null, 4]", &options_empty);
 }
 
-TYPED_TEST(TestStringKernels, CountSubstringRegexIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, CountSubstringRegexIgnoreCase) {
   MatchSubstringOptions options_as{"a+", /*ignore_case=*/true};
   this->CheckUnary("count_substring_regex", R"(["", "bacAaAdaAaA", "c", "AAA"])",
                    this->offset_type(), "[0, 3, 0, 1]", &options_as);
@@ -479,7 +581,7 @@ TYPED_TEST(TestStringKernels, CountSubstringRegexIgnoreCase) {
                    this->offset_type(), "[1, 7, 2, 2]", &options_empty_match);
 }
 #else
-TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, CountSubstringIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1122,7 +1224,7 @@ TYPED_TEST(TestStringKernels, IsUpperAscii) {
                    "[false, null, false, true, true, false, false]");
 }
 
-TYPED_TEST(TestStringKernels, MatchSubstring) {
+TYPED_TEST(TestBaseBinaryKernels, MatchSubstring) {
   MatchSubstringOptions options{"ab"};
   this->CheckUnary("match_substring", "[]", boolean(), "[]", &options);
   this->CheckUnary("match_substring", R"(["abc", "acb", "cab", null, "bac", "AB"])",
@@ -1155,7 +1257,7 @@ TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
                    &options_insensitive);
 }
 #else
-TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, MatchSubstringIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1164,7 +1266,7 @@ TYPED_TEST(TestStringKernels, MatchSubstringIgnoreCase) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, MatchStartsWith) {
+TYPED_TEST(TestBaseBinaryKernels, MatchStartsWith) {
   MatchSubstringOptions options{"abab"};
   this->CheckUnary("starts_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("starts_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1173,7 +1275,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWith) {
                    boolean(), "[false, false, false, false, false]", &options);
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWith) {
+TYPED_TEST(TestBaseBinaryKernels, MatchEndsWith) {
   MatchSubstringOptions options{"abab"};
   this->CheckUnary("ends_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("ends_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1183,7 +1285,7 @@ TYPED_TEST(TestStringKernels, MatchEndsWith) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, MatchStartsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("starts_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("starts_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1192,7 +1294,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
                    boolean(), "[true, false, true, false, true]", &options);
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, MatchEndsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("ends_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("ends_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -1201,7 +1303,7 @@ TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
                    boolean(), "[true, true, false, true, false]", &options);
 }
 #else
-TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, MatchStartsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1209,7 +1311,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
                                   CallFunction("starts_with", {input}, &options));
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestBaseBinaryKernels, MatchEndsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1298,7 +1400,7 @@ TYPED_TEST(TestStringKernels, MatchLike) {
                    "[false, true, false]", &insensitive_regex);
 }
 
-TYPED_TEST(TestStringKernels, MatchLikeEscaping) {
+TYPED_TEST(TestBaseBinaryKernels, MatchLikeEscaping) {
   auto inputs = R"(["%%foo", "_bar", "({", "\\baz"])";
 
   // N.B. I believe Impala mistakenly optimizes these into substring searches
@@ -1332,7 +1434,7 @@ TYPED_TEST(TestStringKernels, MatchLikeEscaping) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, SplitBasics) {
+TYPED_TEST(TestBaseBinaryKernels, SplitBasics) {
   SplitPatternOptions options{" "};
   // basics
   this->CheckUnary("split_pattern", R"(["foo bar", "foo"])", list(this->type()),
@@ -1354,7 +1456,7 @@ TYPED_TEST(TestStringKernels, SplitBasics) {
                    &options_long_reverse);
 }
 
-TYPED_TEST(TestStringKernels, SplitMax) {
+TYPED_TEST(TestBaseBinaryKernels, SplitMax) {
   SplitPatternOptions options{"---", 2};
   SplitPatternOptions options_reverse{"---", 2, /*reverse=*/true};
   this->CheckUnary("split_pattern", R"(["foo---bar", "foo", "foo---bar------ar"])",
@@ -1415,7 +1517,7 @@ TYPED_TEST(TestStringKernels, SplitWhitespaceUTF8Reverse) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, SplitRegex) {
+TYPED_TEST(TestBaseBinaryKernels, SplitRegex) {
   SplitPatternOptions options{"a+|b"};
 
   this->CheckUnary(
@@ -1432,7 +1534,7 @@ TYPED_TEST(TestStringKernels, SplitRegex) {
       &options);
 }
 
-TYPED_TEST(TestStringKernels, SplitRegexReverse) {
+TYPED_TEST(TestBaseBinaryKernels, SplitRegexReverse) {
   SplitPatternOptions options{"a+|b", /*max_splits=*/1, /*reverse=*/true};
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
 
@@ -1492,7 +1594,7 @@ TYPED_TEST(TestStringKernels, Utf8ReplaceSlice) {
                    &options_neg_flip);
 }
 
-TYPED_TEST(TestStringKernels, ReplaceSubstring) {
+TYPED_TEST(TestBaseBinaryKernels, ReplaceSubstring) {
   ReplaceSubstringOptions options{"foo", "bazz"};
   this->CheckUnary("replace_substring", R"(["foo", "this foo that foo", null])",
                    this->type(), R"(["bazz", "this bazz that bazz", null])", &options);
@@ -1506,7 +1608,7 @@ TYPED_TEST(TestStringKernels, ReplaceSubstring) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, ReplaceSubstringRegex) {
+TYPED_TEST(TestBaseBinaryKernels, ReplaceSubstringRegex) {
   ReplaceSubstringOptions options{"(fo+)\\s*", "\\1-bazz"};
   this->CheckUnary("replace_substring_regex", R"(["foo ", "this foo   that foo", null])",
                    this->type(), R"(["foo-bazz", "this foo-bazzthat foo-bazz", null])",
@@ -1535,7 +1637,7 @@ TYPED_TEST(TestStringKernels, ReplaceSubstringRegex) {
                    &options);
 }
 
-TYPED_TEST(TestStringKernels, ReplaceSubstringRegexInvalid) {
+TYPED_TEST(TestBaseBinaryKernels, ReplaceSubstringRegexInvalid) {
   {
     Datum input = ArrayFromJSON(this->type(), "[]");
     ASSERT_RAISES(Invalid, CallFunction("replace_substring_regex", {input}));
@@ -1555,7 +1657,7 @@ TYPED_TEST(TestStringKernels, ReplaceSubstringRegexInvalid) {
   }
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegex) {
+TYPED_TEST(TestBaseBinaryKernels, ExtractRegex) {
   ExtractRegexOptions options{"(?P<letter>[ab])(?P<digit>\\d)"};
   auto type = struct_({field("letter", this->type()), field("digit", this->type())});
   this->CheckUnary("extract_regex", R"([])", type, R"([])", &options);
@@ -1575,7 +1677,7 @@ TYPED_TEST(TestStringKernels, ExtractRegex) {
                    &options);
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexNoCapture) {
+TYPED_TEST(TestBaseBinaryKernels, ExtractRegexNoCapture) {
   // XXX Should we accept this or is it a user error?
   ExtractRegexOptions options{"foo"};
   auto type = struct_({});
@@ -1583,12 +1685,12 @@ TYPED_TEST(TestStringKernels, ExtractRegexNoCapture) {
                    R"([{}, null, null])", &options);
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexNoOptions) {
+TYPED_TEST(TestBaseBinaryKernels, ExtractRegexNoOptions) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ASSERT_RAISES(Invalid, CallFunction("extract_regex", {input}));
 }
 
-TYPED_TEST(TestStringKernels, ExtractRegexInvalid) {
+TYPED_TEST(TestBaseBinaryKernels, ExtractRegexInvalid) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ExtractRegexOptions options{"invalid["};
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1063,7 +1063,7 @@ TYPED_TEST(TestBinaryKernels, MatchSubstringRegexInvalid) {
       CallFunction("match_substring_regex", {input}, &options));
 }
 
-TYPED_TEST(TestStringKernels, MatchLike) {
+TYPED_TEST(TestBinaryKernels, MatchLike) {
   auto inputs = R"(["foo", "bar", "foobar", "barfoo", "o", "\nfoo", "foo\n", null])";
 
   MatchSubstringOptions prefix_match{"foo%"};
@@ -1099,7 +1099,7 @@ TYPED_TEST(TestStringKernels, MatchLike) {
                    "[false, true, false]", &insensitive_regex);
 }
 
-TYPED_TEST(TestStringKernels, MatchLikeEscaping) {
+TYPED_TEST(TestBinaryKernels, MatchLikeEscaping) {
   auto inputs = R"(["%%foo", "_bar", "({", "\\baz"])";
 
   // N.B. I believe Impala mistakenly optimizes these into substring searches

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -111,21 +111,21 @@ class BaseTestStringKernels : public ::testing::Test {
 };
 
 template <typename TestType>
-class TestBinaryBaseKernels : public BaseTestStringKernels<TestType> {};
-
-TYPED_TEST_SUITE(TestBinaryBaseKernels, BinaryBaseArrowTypes);
-
-template <typename TestType>
 class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
 
 TYPED_TEST_SUITE(TestBinaryKernels, BinaryArrowTypes);
+
+template <typename TestType>
+class TestBaseBinaryKernels : public BaseTestStringKernels<TestType> {};
+
+TYPED_TEST_SUITE(TestBaseBinaryKernels, BaseBinaryArrowTypes);
 
 template <typename TestType>
 class TestStringKernels : public BaseTestStringKernels<TestType> {};
 
 TYPED_TEST_SUITE(TestStringKernels, StringArrowTypes);
 
-TYPED_TEST(TestBinaryKernels, BinaryLength) {
+TYPED_TEST(TestBaseBinaryKernels, BinaryLength) {
   this->CheckUnary("binary_length", R"(["aaa", null, "áéíóú", "", "b"])",
                    this->offset_type(), "[3, null, 10, 0, 1]");
 
@@ -140,7 +140,7 @@ TYPED_TEST(TestBinaryKernels, BinaryLength) {
                    this->offset_type(), "[3, 4, 2]");
 }
 
-TYPED_TEST(TestBinaryBaseKernels, NonUtf8) {
+TYPED_TEST(TestBinaryKernels, NonUtf8) {
   // These kernels do not accept invalid UTF-8 when processing
   // [Large]StringType data. These tests use invalid UTF-8 inputs.
   {
@@ -210,7 +210,7 @@ TYPED_TEST(TestBinaryBaseKernels, NonUtf8) {
   }
 }
 
-TYPED_TEST(TestBinaryBaseKernels, NonUtf8WithNull) {
+TYPED_TEST(TestBinaryKernels, NonUtf8WithNull) {
   // These kernels do not accept invalid UTF-8 when processing
   // [Large]StringType data. These tests use invalid UTF-8 inputs.
   for (auto ignore_case : {true, false}) {
@@ -226,7 +226,7 @@ TYPED_TEST(TestBinaryBaseKernels, NonUtf8WithNull) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestBinaryBaseKernels, NonUtf8Regex) {
+TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
   // These kernels do not accept invalid UTF-8 when processing
   // [Large]StringType data. These tests use invalid UTF-8 inputs.
   for (auto ignore_case : {true, false}) {
@@ -293,7 +293,7 @@ TYPED_TEST(TestBinaryBaseKernels, NonUtf8Regex) {
   }
 }
 
-TYPED_TEST(TestBinaryBaseKernels, NonUtf8WithNullRegex) {
+TYPED_TEST(TestBinaryKernels, NonUtf8WithNullRegex) {
   // These kernels do not accept invalid UTF-8 when processing
   // [Large]StringType data. These tests use invalid UTF-8 inputs.
   for (auto ignore_case : {true, false}) {
@@ -309,7 +309,7 @@ TYPED_TEST(TestBinaryBaseKernels, NonUtf8WithNullRegex) {
 }
 #endif
 
-TYPED_TEST(TestBinaryKernels, BinaryReplaceSlice) {
+TYPED_TEST(TestBaseBinaryKernels, BinaryReplaceSlice) {
   ReplaceSliceOptions options{0, 1, "XX"};
   this->CheckUnary("binary_replace_slice", "[]", this->type(), "[]", &options);
   this->CheckUnary("binary_replace_slice", R"([null, "", "a", "ab", "abc"])",
@@ -488,7 +488,7 @@ TYPED_TEST(TestStringKernels, CountSubstringIgnoreCase) {
 }
 #endif
 
-TYPED_TEST(TestBinaryKernels, BinaryJoinElementWise) {
+TYPED_TEST(TestBaseBinaryKernels, BinaryJoinElementWise) {
   const auto ty = this->type();
   JoinOptions options;
   JoinOptions options_skip(JoinOptions::SKIP);
@@ -1249,12 +1249,12 @@ TYPED_TEST(TestStringKernels, MatchSubstringRegex) {
                    "[true, true, false, false]", &options_unicode);
 }
 
-TYPED_TEST(TestBinaryKernels, MatchSubstringRegexNoOptions) {
+TYPED_TEST(TestBaseBinaryKernels, MatchSubstringRegexNoOptions) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ASSERT_RAISES(Invalid, CallFunction("match_substring_regex", {input}));
 }
 
-TYPED_TEST(TestBinaryKernels, MatchSubstringRegexInvalid) {
+TYPED_TEST(TestBaseBinaryKernels, MatchSubstringRegexInvalid) {
   Datum input = ArrayFromJSON(this->type(), "[null]");
   MatchSubstringOptions options{"invalid["};
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -59,7 +59,7 @@ class BaseTestStringKernels : public ::testing::Test {
   }
 
   void CheckUnary(std::string func_name, const std::shared_ptr<Array>& input,
-                  const std::shared_ptr<Array> expected,
+                  const std::shared_ptr<Array>& expected,
                   const FunctionOptions* options = nullptr) {
     CheckScalar(func_name, {Datum(input)}, Datum(expected), options);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -154,8 +154,7 @@ TYPED_TEST(TestBinaryKernels, NonUtf8) {
         this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
         this->offset_type(), "[0, 2, -1]", &options);
 
-    // @ = \x40
-    options.pattern = "@";
+    options.pattern = "\x40";
     this->CheckUnary(
         "find_substring",
         this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
@@ -166,12 +165,6 @@ TYPED_TEST(TestBinaryKernels, NonUtf8) {
                      this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
                                       "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
                      this->offset_type(), "[1, 1, 0, 2]", &options);
-
-    options.pattern = "@";
-    this->CheckUnary("count_substring",
-                     this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab",
-                                      "\x01\xfc\x41", "\x01\xfc\x40\x40\xfc\x40\xab"}),
-                     this->offset_type(), "[1, 1, 0, 3]", &options);
 
     options.pattern = "\xfc\x40";
     this->CheckUnary("match_substring",
@@ -280,26 +273,17 @@ TYPED_TEST(TestBinaryKernels, NonUtf8WithNull) {
 TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
   for (auto ignore_case : {true, false}) {
     MatchSubstringOptions options("\xfc\x40", ignore_case);
-    // @ = \x40
-    options.pattern = "@+";
+    options.pattern = "\x40+";
     this->CheckUnary(
         "find_substring_regex",
         this->MakeArray({"\xfc\x40\xab", "\xff\x9b\xfc\x40\xab", "\x01\xfc\x41"}),
         this->offset_type(), "[1, 3, -1]", &options);
 
-    // @ = \x40, A = \x41
-    options.pattern = "@*A";
+    options.pattern = "\x40*\x41";
     this->CheckUnary("count_substring_regex",
                      this->MakeArray({"\xfc\x42\xab", "\xff\x9b\x40\x41\xab",
                                       "\x01\x41\x41", "\x01\x40\x41\x40\x40\x41\xab"}),
                      this->offset_type(), "[0, 1, 2, 2]", &options);
-
-    // options.pattern = "@*A";
-    options.pattern = "\x40*\x41";
-    this->CheckUnary("match_substring_regex",
-                     this->MakeArray({"\xfc\x42\xab", "\xff\x9b\x40\x41\xab",
-                                      "\x01\x41\x41", "\x01\x40\x41\x40\x40\x41\xab"}),
-                     boolean(), "[false, true, true, true]", &options);
 
     options.pattern = "\xfc*\xab";
     this->CheckUnary("match_substring_regex",

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -91,6 +91,11 @@ class BaseTestStringKernels : public ::testing::Test {
 };
 
 template <typename TestType>
+class TestStringKernels : public BaseTestStringKernels<TestType> {};
+
+TYPED_TEST_SUITE(TestStringKernels, StringArrowTypes);
+
+template <typename TestType>
 class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
 
 TYPED_TEST_SUITE(TestBinaryKernels, BinaryArrowTypes);
@@ -960,7 +965,7 @@ TYPED_TEST(TestBinaryKernels, MatchSubstringIgnoreCase) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, MatchStartsWith) {
+TYPED_TEST(TestBinaryKernels, MatchStartsWith) {
   MatchSubstringOptions options{"abab"};
   this->CheckUnary("starts_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("starts_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -969,7 +974,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWith) {
                    boolean(), "[false, false, false, false, false]", &options);
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWith) {
+TYPED_TEST(TestBinaryKernels, MatchEndsWith) {
   MatchSubstringOptions options{"abab"};
   this->CheckUnary("ends_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("ends_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -979,7 +984,7 @@ TYPED_TEST(TestStringKernels, MatchEndsWith) {
 }
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("starts_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("starts_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -988,7 +993,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
                    boolean(), "[true, false, true, false, true]", &options);
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
   MatchSubstringOptions options{"aBAb", /*ignore_case=*/true};
   this->CheckUnary("ends_with", "[]", boolean(), "[]", &options);
   this->CheckUnary("ends_with", R"([null, "", "ab", "abab", "$abab", "abab$"])",
@@ -997,7 +1002,7 @@ TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
                    boolean(), "[true, true, false, true, false]", &options);
 }
 #else
-TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchStartsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1005,7 +1010,7 @@ TYPED_TEST(TestStringKernels, MatchStartsWithIgnoreCase) {
                                   CallFunction("starts_with", {input}, &options));
 }
 
-TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
+TYPED_TEST(TestBinaryKernels, MatchEndsWithIgnoreCase) {
   Datum input = ArrayFromJSON(this->type(), R"(["a"])");
   MatchSubstringOptions options{"a", /*ignore_case=*/true};
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
@@ -1015,7 +1020,7 @@ TYPED_TEST(TestStringKernels, MatchEndsWithIgnoreCase) {
 #endif
 
 #ifdef ARROW_WITH_RE2
-TYPED_TEST(TestStringKernels, MatchSubstringRegex) {
+TYPED_TEST(TestBinaryKernels, MatchSubstringRegex) {
   MatchSubstringOptions options{"ab"};
   this->CheckUnary("match_substring_regex", "[]", boolean(), "[]", &options);
   this->CheckUnary("match_substring_regex", R"(["abc", "acb", "cab", null, "bac", "AB"])",
@@ -1045,12 +1050,12 @@ TYPED_TEST(TestStringKernels, MatchSubstringRegex) {
                    "[true, true, false, false]", &options_unicode);
 }
 
-TYPED_TEST(TestStringKernels, MatchSubstringRegexNoOptions) {
+TYPED_TEST(TestBinaryKernels, MatchSubstringRegexNoOptions) {
   Datum input = ArrayFromJSON(this->type(), "[]");
   ASSERT_RAISES(Invalid, CallFunction("match_substring_regex", {input}));
 }
 
-TYPED_TEST(TestStringKernels, MatchSubstringRegexInvalid) {
+TYPED_TEST(TestBinaryKernels, MatchSubstringRegexInvalid) {
   Datum input = ArrayFromJSON(this->type(), "[null]");
   MatchSubstringOptions options{"invalid["};
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1128,25 +1128,6 @@ TYPED_TEST(TestStringKernels, MatchLikeEscaping) {
 }
 #endif
 
-TYPED_TEST(TestStringKernels, FindSubstring) {
-  MatchSubstringOptions options{"ab"};
-  this->CheckUnary("find_substring", "[]", this->offset_type(), "[]", &options);
-  this->CheckUnary("find_substring", R"(["abc", "acb", "cab", null, "bac"])",
-                   this->offset_type(), "[0, -1, 1, null, -1]", &options);
-
-  MatchSubstringOptions options_repeated{"abab"};
-  this->CheckUnary("find_substring", R"(["abab", "ab", "cababc", null, "bac"])",
-                   this->offset_type(), "[0, -1, 1, null, -1]", &options_repeated);
-
-  MatchSubstringOptions options_double_char{"aab"};
-  this->CheckUnary("find_substring", R"(["aacb", "aab", "ab", "aaab"])",
-                   this->offset_type(), "[-1, 0, -1, 1]", &options_double_char);
-
-  MatchSubstringOptions options_double_char_2{"bbcaa"};
-  this->CheckUnary("find_substring", R"(["abcbaabbbcaabccabaab"])", this->offset_type(),
-                   "[7]", &options_double_char_2);
-}
-
 TYPED_TEST(TestStringKernels, SplitBasics) {
   SplitPatternOptions options{" "};
   // basics

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -51,14 +51,15 @@ class BaseTestStringKernels : public ::testing::Test {
   }
 
   void CheckUnary(std::string func_name, const std::shared_ptr<Array>& input,
-                    std::shared_ptr<DataType> out_ty, std::string json_expected,
-                    const FunctionOptions* options = nullptr) {
-    CheckScalar(func_name, {Datum(input)}, Datum(ArrayFromJSON(out_ty, json_expected)), options);
+                  std::shared_ptr<DataType> out_ty, std::string json_expected,
+                  const FunctionOptions* options = nullptr) {
+    CheckScalar(func_name, {Datum(input)}, Datum(ArrayFromJSON(out_ty, json_expected)),
+                options);
   }
 
   void CheckUnary(std::string func_name, const std::shared_ptr<Array>& input,
-                    const std::shared_ptr<Array> expected,
-                    const FunctionOptions* options = nullptr) {
+                  const std::shared_ptr<Array> expected,
+                  const FunctionOptions* options = nullptr) {
     CheckScalar(func_name, {Datum(input)}, Datum(expected), options);
   }
 
@@ -102,7 +103,8 @@ class BaseTestStringKernels : public ::testing::Test {
   }
 
   template <typename CType = const char*>
-  std::shared_ptr<Array> MakeArray(const std::vector<CType>& values, const std::vector<bool>& is_valid = {}) {
+  std::shared_ptr<Array> MakeArray(const std::vector<CType>& values,
+                                   const std::vector<bool>& is_valid = {}) {
     return _MakeArray<TestType, CType>(type(), values, is_valid);
   }
 };
@@ -127,8 +129,8 @@ TYPED_TEST(TestBinaryKernels, BinaryLength) {
                    this->offset_type(), "[3, null, 10, 0, 1]");
 
   // Binary non-UTF8 inputs
-  this->CheckUnary("binary_length",
-                   this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}), this->offset_type(), "[3, 4]");
+  this->CheckUnary("binary_length", this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}),
+                   this->offset_type(), "[3, 4]");
 }
 
 TYPED_TEST(TestBinaryBaseKernels, BinaryNonUtf8Tests) {
@@ -136,9 +138,9 @@ TYPED_TEST(TestBinaryBaseKernels, BinaryNonUtf8Tests) {
   // [Large]StringType data. These tests use binary non-encoded inputs.
   {
     ReplaceSliceOptions options{1, 2, "\xfc\x40"};
-    this->CheckUnary("binary_replace_slice",
-                     this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}),
-                     this->MakeArray({"\xf7\xfc\x40\xab", "\xff\xfc\x40\xc3\xbb"}), &options);
+    this->CheckUnary(
+        "binary_replace_slice", this->MakeArray({"\xf7\x0f\xab", "\xff\x9b\xc3\xbb"}),
+        this->MakeArray({"\xf7\xfc\x40\xab", "\xff\xfc\x40\xc3\xbb"}), &options);
   }
   {
     MatchSubstringOptions options{"\xfc\x40"};
@@ -157,9 +159,10 @@ TYPED_TEST(TestBinaryBaseKernels, BinaryNonUtf8Tests) {
   {
     MatchSubstringOptions options{"\xfc\x40", /*ignore_case=*/true};
     auto input = Datum(this->MakeArray({"\xfc\x40\xab"}));
-    EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented,
-                                    ::testing::HasSubstr("ignore_case is not supported for non-encoded binary types"),
-                                    CallFunction("find_substring", {input}, &options));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        NotImplemented,
+        ::testing::HasSubstr("ignore_case is not supported for non-encoded binary types"),
+        CallFunction("find_substring", {input}, &options));
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -40,7 +40,7 @@ namespace {
 
 template <typename T>
 DatumVector GetDatums(const std::vector<T>& inputs) {
-  std::vector<Datum> datums;
+  DatumVector datums;
   for (const auto& input : inputs) {
     datums.emplace_back(input);
   }
@@ -250,7 +250,7 @@ void CheckDictionary(const std::string& func_name, const DatumVector& args,
 
 void CheckScalarUnary(std::string func_name, Datum input, Datum expected,
                       const FunctionOptions* options) {
-  std::vector<Datum> input_vector = {std::move(input)};
+  DatumVector input_vector = {std::move(input)};
   CheckScalar(std::move(func_name), input_vector, expected, options);
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -364,7 +364,7 @@ class TestHashKernelBinaryTypes : public TestHashKernel {
   }
 };
 
-TYPED_TEST_SUITE(TestHashKernelBinaryTypes, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestHashKernelBinaryTypes, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestHashKernelBinaryTypes, ZeroChunks) {
   auto type = this->type();

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -162,7 +162,7 @@ using NumericBasedTypes =
 
 TYPED_TEST_SUITE(TestReplaceNumeric, NumericBasedTypes);
 TYPED_TEST_SUITE(TestReplaceDecimal, DecimalArrowTypes);
-TYPED_TEST_SUITE(TestReplaceBinary, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestReplaceBinary, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestReplaceNumeric, ReplaceWithMask) {
   this->Assert(ReplaceWithMask, this->array("[]"), this->mask_scalar(false),

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -518,7 +518,7 @@ class TestFilterKernelWithString : public TestFilterKernel {
   }
 };
 
-TYPED_TEST_SUITE(TestFilterKernelWithString, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestFilterKernelWithString, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestFilterKernelWithString, FilterString) {
   this->AssertFilter(R"(["a", "b", "c"])", "[0, 1, 0]", R"(["b"])");
@@ -1156,7 +1156,7 @@ class TestTakeKernelWithString : public TestTakeKernelTyped<TypeClass> {
   }
 };
 
-TYPED_TEST_SUITE(TestTakeKernelWithString, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestTakeKernelWithString, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestTakeKernelWithString, TakeString) {
   this->AssertTake(R"(["a", "b", "c"])", "[0, 1, 0]", R"(["a", "b", "a"])");
@@ -1917,7 +1917,7 @@ class TestDropNullKernelWithString : public TestDropNullKernelTyped<TypeClass> {
   }
 };
 
-TYPED_TEST_SUITE(TestDropNullKernelWithString, BinaryArrowTypes);
+TYPED_TEST_SUITE(TestDropNullKernelWithString, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestDropNullKernelWithString, DropNullString) {
   this->AssertDropNull(R"(["a", "b", "c"])", R"(["a", "b", "c"])");

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -175,10 +175,10 @@ using TemporalArrowTypes =
 
 using DecimalArrowTypes = ::testing::Types<Decimal128Type, Decimal256Type>;
 
-using BinaryBaseArrowTypes = ::testing::Types<BinaryType, LargeBinaryType>;
-
-using BinaryArrowTypes =
+using BaseBinaryArrowTypes =
     ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
+
+using BinaryArrowTypes = ::testing::Types<BinaryType, LargeBinaryType>;
 
 using StringArrowTypes = ::testing::Types<StringType, LargeStringType>;
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -175,6 +175,8 @@ using TemporalArrowTypes =
 
 using DecimalArrowTypes = ::testing::Types<Decimal128Type, Decimal256Type>;
 
+using BinaryBaseArrowTypes = ::testing::Types<BinaryType, LargeBinaryType>;
+
 using BinaryArrowTypes =
     ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -826,7 +826,7 @@ String transforms
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
 | binary_length           | Unary | Binary- or String-like | Int32 or Int64         |                                   | \(3)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
-| binary_replace_slice    | Unary | String-like            | Binary- or String-like | :struct:`ReplaceSliceOptions`     | \(4)  |
+| binary_replace_slice    | Unary | Binary- or String-like | Binary- or String-like | :struct:`ReplaceSliceOptions`     | \(4)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
 | replace_substring       | Unary | String-like            | String-like            | :struct:`ReplaceSubstringOptions` | \(5)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
@@ -856,7 +856,7 @@ String transforms
   are present, ``Invalid`` :class:`Status` will be returned.
 
 * \(3) Output is the physical length in bytes of each input element.  Output
-  type is Int32 for Binary / String, Int64 for LargeBinary / LargeString.
+  type is Int32 for Binary/String, Int64 for LargeBinary/LargeString.
 
 * \(4) Replace the slice of the substring from :member:`ReplaceSliceOptions::start`
   (inclusive) to :member:`ReplaceSliceOptions::stop` (exclusive) by
@@ -967,9 +967,9 @@ when a positive ``max_splits`` is given.
 +==========================+============+=========================+===================+==================================+=========+
 | ascii_split_whitespace   | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(1)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
-| split_pattern            | Unary      | String-like             | List-like         | :struct:`SplitPatternOptions`    | \(2)    |
+| split_pattern            | Unary      | Binary- or String-like  | List-like         | :struct:`SplitPatternOptions`    | \(2)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
-| split_pattern_regex      | Unary      | String-like             | List-like         | :struct:`SplitPatternOptions`    | \(3)    |
+| split_pattern_regex      | Unary      | Binary- or String-like  | List-like         | :struct:`SplitPatternOptions`    | \(3)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
 | utf8_split_whitespace    | Unary      | String-like             | List-like         | :struct:`SplitOptions`           | \(4)    |
 +--------------------------+------------+-------------------------+-------------------+----------------------------------+---------+
@@ -990,11 +990,11 @@ when a positive ``max_splits`` is given.
 String component extraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+---------------+-------+-------------+-------------+-------------------------------+-------+
-| Function name | Arity | Input types | Output type | Options class                 | Notes |
-+===============+=======+=============+=============+===============================+=======+
-| extract_regex | Unary | String-like | Struct      | :struct:`ExtractRegexOptions` | \(1)  |
-+---------------+-------+-------------+-------------+-------------------------------+-------+
++---------------+-------+------------------------+-------------+-------------------------------+-------+
+| Function name | Arity | Input types            | Output type | Options class                 | Notes |
++===============+=======+========================+=============+===============================+=======+
+| extract_regex | Unary | Binary- or String-like | Struct      | :struct:`ExtractRegexOptions` | \(1)  |
++---------------+-------+------------------------+-------------+-------------------------------+-------+
 
 * \(1) Extract substrings defined by a regular expression using the Google RE2
   library.  The output struct field names refer to the named capture groups,
@@ -1006,13 +1006,13 @@ String joining
 
 These functions do the inverse of string splitting.
 
-+--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
-| Function name            | Arity     | Input type 1          | Input type 2   | Output type       | Options class         | Notes   |
-+==========================+===========+=======================+================+===================+=======================+=========+
-| binary_join              | Binary    | List of string-like   | String-like    | String-like       |                       | \(1)    |
-+--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
-| binary_join_element_wise | Varargs   | String-like (varargs) | String-like    | String-like       | :struct:`JoinOptions` | \(2)    |
-+--------------------------+-----------+-----------------------+----------------+-------------------+-----------------------+---------+
++--------------------------+---------+----------------------------------+------------------------+------------------------+-----------------------+---------+
+| Function name            | Arity   | Input type 1                     | Input type 2           | Output type            | Options class         | Notes   |
++==========================+=========+==================================+========================+========================+=======================+=========+
+| binary_join              | Binary  | List of Binary- or String-like   | String-like            | String-like            |                       | \(1)    |
++--------------------------+---------+----------------------------------+------------------------+------------------------+-----------------------+---------+
+| binary_join_element_wise | Varargs | Binary- or String-like (varargs) | Binary- or String-like | Binary- or String-like | :struct:`JoinOptions` | \(2)    |
++--------------------------+---------+----------------------------------+------------------------+------------------------+-----------------------+---------+
 
 * \(1) The first input must be an array, while the second can be a scalar or array.
   Each list of values in the first input is joined using each second input
@@ -1319,7 +1319,6 @@ null input value is converted into a null output value.
   input value type to the output value type (if a conversion is
   available).
 
-
 Temporal component extraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1457,7 +1456,6 @@ An error is returned if the timestamps already have the timezone metadata set.
 * \(1) In addition to the timezone value, :struct:`AssumeTimezoneOptions`
   allows choosing the behaviour when a timestamp is ambiguous or nonexistent
   in the given timezone (because of DST shifts).
-
 
 Array-wise ("vector") functions
 -------------------------------

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -828,9 +828,9 @@ String transforms
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
 | binary_replace_slice    | Unary | Binary- or String-like | Binary- or String-like | :struct:`ReplaceSliceOptions`     | \(4)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
-| replace_substring       | Unary | String-like            | String-like            | :struct:`ReplaceSubstringOptions` | \(5)  |
+| replace_substring       | Unary | Binary- or String-like | Binary- or String-like | :struct:`ReplaceSubstringOptions` | \(5)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
-| replace_substring_regex | Unary | String-like            | String-like            | :struct:`ReplaceSubstringOptions` | \(6)  |
+| replace_substring_regex | Unary | Binary- or String-like | Binary- or String-like | :struct:`ReplaceSubstringOptions` | \(6)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
 | utf8_capitalize         | Unary | String-like            | String-like            |                                   | \(8)  |
 +-------------------------+-------+------------------------+------------------------+-----------------------------------+-------+
@@ -1049,11 +1049,11 @@ Containment tests
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | Function name         | Arity | Input types                       | Output type    | Options class                   | Notes |
 +=======================+=======+===================================+================+=================================+=======+
-| count_substring       | Unary | String-like                       | Int32 or Int64 | :struct:`MatchSubstringOptions` | \(1)  |
+| count_substring       | Unary | Binary- or String-like            | Int32 or Int64 | :struct:`MatchSubstringOptions` | \(1)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| count_substring_regex | Unary | String-like                       | Int32 or Int64 | :struct:`MatchSubstringOptions` | \(1)  |
+| count_substring_regex | Unary | Binary- or String-like            | Int32 or Int64 | :struct:`MatchSubstringOptions` | \(1)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| ends_with             | Unary | String-like                       | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
+| ends_with             | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | find_substring        | Unary | Binary- and String-like           | Int32 or Int64 | :struct:`MatchSubstringOptions` | \(3)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
@@ -1065,13 +1065,13 @@ Containment tests
 | is_in                 | Unary | Boolean, Null, Numeric, Temporal, | Boolean        | :struct:`SetLookupOptions`      | \(5)  |
 |                       |       | Binary- and String-like           |                |                                 |       |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| match_like            | Unary | String-like                       | Boolean        | :struct:`MatchSubstringOptions` | \(6)  |
+| match_like            | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(6)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| match_substring       | Unary | String-like                       | Boolean        | :struct:`MatchSubstringOptions` | \(7)  |
+| match_substring       | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(7)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| match_substring_regex | Unary | String-like                       | Boolean        | :struct:`MatchSubstringOptions` | \(8)  |
+| match_substring_regex | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(8)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| starts_with           | Unary | String-like                       | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
+| starts_with           | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 * \(1) Output is the number of occurrences of


### PR DESCRIPTION
This PR extends variable-width binary types support for string functions:
* find_substring[_regex]
* count_substring[_regex]
* match_substring[_regex]
* split_pattern[_regex]
* replace_substring[_regex]
* match_like
* starts/ends_with
* extract_regex

Also, updates several scalar string kernel/function registrations.