### PR TITLE
MINOR: [R] Fix quantile() test failure in test-r-versions CI task

### DIFF
--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -368,7 +368,7 @@ test_that("quantile()", {
   # with a vector of 2+ probs
   expect_warning(
     Table$create(tbl) %>%
-      summarize(q = quantile(dbl, probs = c(0.2, 0.8), na.rm = FALSE)),
+      summarize(q = quantile(dbl, probs = c(0.2, 0.8), na.rm = TRUE)),
     "quantile() with length(probs) != 1 not supported by Arrow",
     fixed = TRUE
   )


### PR DESCRIPTION
This is a trivially small fix to resolve a test failure on older versions of R following ARROW-13772 (#11018).