### PR TITLE
ARROW-14140: [R] skip arrow_binary/arrow_large_binary class from R metadata

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -118,8 +118,10 @@ arrow_attributes <- function(x, only_top_level = FALSE) {
     removed_attributes <- c("row.names", "names")
   } else if (inherits(x, "factor")) {
     removed_attributes <- c("class", "levels")
-  } else if (inherits(x, "integer64") || inherits(x, "Date")) {
+  } else if (inherits(x, c("integer64", "Date", "arrow_binary", "arrow_large_binary"))) {
     removed_attributes <- c("class")
+  } else if (inherits(x, "arrow_fixed_size_binary")) {
+    removed_attributes <- c("class", "byte_width")
   } else if (inherits(x, "POSIXct")) {
     removed_attributes <- c("class", "tzone")
   } else if (inherits(x, "hms") || inherits(x, "difftime")) {

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -65,6 +65,22 @@ test_that("R metadata is not stored for types that map to Arrow types (factor, D
   expect_null(Table$create(example_with_times[1:3])$metadata$r)
 })
 
+test_that("classes are not stored for arrow_binary/arrow_large_binary/arrow_fixed_size_binary (ARROW-14140)", {
+  raws <- charToRaw("bonjour")
+
+  binary <- Array$create(list(raws), binary())
+  large_binary <- Array$create(list(raws), large_binary())
+  fixed_size_binary <- Array$create(list(raws), fixed_size_binary(7L))
+
+  expect_null(RecordBatch$create(b = binary)$metadata$r)
+  expect_null(RecordBatch$create(b = large_binary)$metadata$r)
+  expect_null(RecordBatch$create(b = fixed_size_binary)$metadata$r)
+
+  expect_null(Table$create(b = binary)$metadata$r)
+  expect_null(Table$create(b = large_binary)$metadata$r)
+  expect_null(Table$create(b = fixed_size_binary)$metadata$r)
+})
+
 test_that("Garbage R metadata doesn't break things", {
   tab <- Table$create(example_data[1:6])
   tab$metadata$r <- "garbage"


### PR DESCRIPTION
``` r
library(arrow, warn.conflicts = FALSE)
#> See arrow_info() for available features

raws <- charToRaw("bonjour")

RecordBatch$create(b = Array$create(list(raws), binary()))$metadata$r
#> NULL
RecordBatch$create(lb = Array$create(list(raws), large_binary()))$metadata$r
#> NULL
RecordBatch$create(fsb = Array$create(list(raws), fixed_size_binary(7L)))$metadata$r
#> NULL
```

<sup>Created on 2021-09-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>