### PR TITLE
ARROW-14146: [Dev] Update merge script to specify python3 in shebang line

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
This updates the shebang at the top of `dev/merge_arrow_pr.py` from `python` to `python3`