### PR TITLE
ARROW-12846: [Release] Reduce download/upload bandwidth for APT/Yum repositories

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -117,5 +117,6 @@ docker_run \
     ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \
+    STAGING=${STAGING:-no} \
     VERSION=${version} \
     YUM_TARGETS=$(IFS=,; echo "${yum_targets[*]}")

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -65,16 +65,12 @@ fi
 # To explicitly select one category, set UPLOAD_DEFAULT=0 UPLOAD_X=1.
 : ${UPLOAD_DEFAULT:=1}
 : ${UPLOAD_ALMALINUX:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_AMAZON_LINUX_RPM:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_AMAZON_LINUX_YUM:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_CENTOS_RPM:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_CENTOS_YUM:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_DEBIAN_APT:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_DEBIAN_DEB:=${UPLOAD_DEFAULT}}
+: ${UPLOAD_AMAZON_LINUX:=${UPLOAD_DEFAULT}}
+: ${UPLOAD_CENTOS:=${UPLOAD_DEFAULT}}
+: ${UPLOAD_DEBIAN:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_NUGET:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_PYTHON:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_UBUNTU_APT:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_UBUNTU_DEB:=${UPLOAD_DEFAULT}}
+: ${UPLOAD_UBUNTU:=${UPLOAD_DEFAULT}}
 
 rake_tasks=()
 apt_targets=()
@@ -83,27 +79,15 @@ if [ ${UPLOAD_ALMALINUX} -gt 0 ]; then
   rake_tasks+=(yum:rc)
   yum_targets+=(almalinux)
 fi
-if [ ${UPLOAD_AMAZON_LINUX_RPM} -gt 0 ]; then
-  rake_tasks+=(rpm)
-  yum_targets+=(amazon-linux)
-fi
-if [ ${UPLOAD_AMAZON_LINUX_YUM} -gt 0 ]; then
+if [ ${UPLOAD_AMAZON_LINUX} -gt 0 ]; then
   rake_tasks+=(yum:rc)
   yum_targets+=(amazon-linux)
 fi
-if [ ${UPLOAD_CENTOS_RPM} -gt 0 ]; then
-  rake_tasks+=(rpm)
-  yum_targets+=(centos)
-fi
-if [ ${UPLOAD_CENTOS_YUM} -gt 0 ]; then
+if [ ${UPLOAD_CENTOS} -gt 0 ]; then
   rake_tasks+=(yum:rc)
   yum_targets+=(centos)
 fi
-if [ ${UPLOAD_DEBIAN_DEB} -gt 0 ]; then
-  rake_tasks+=(deb)
-  apt_targets+=(debian)
-fi
-if [ ${UPLOAD_DEBIAN_APT} -gt 0 ]; then
+if [ ${UPLOAD_DEBIAN} -gt 0 ]; then
   rake_tasks+=(apt:rc)
   apt_targets+=(debian)
 fi
@@ -113,11 +97,7 @@ fi
 if [ ${UPLOAD_PYTHON} -gt 0 ]; then
   rake_tasks+=(python:rc)
 fi
-if [ ${UPLOAD_UBUNTU_DEB} -gt 0 ]; then
-  rake_tasks+=(deb)
-  apt_targets+=(ubuntu)
-fi
-if [ ${UPLOAD_UBUNTU_APT} -gt 0 ]; then
+if [ ${UPLOAD_UBUNTU} -gt 0 ]; then
   rake_tasks+=(apt:rc)
   apt_targets+=(ubuntu)
 fi

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -24,7 +24,11 @@ require "tempfile"
 require "thread"
 require "time"
 
-require "apt-dists-merge"
+begin
+  require "apt-dists-merge"
+rescue LoadError
+  warn("apt-dists-merge is needed for apt:* tasks")
+end
 
 class BinaryTask
   include Rake::DSL

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1723,13 +1723,13 @@ Success! The release candidate binaries are available here:
       task :release do
         puts(<<-SUMMARY)
 Success! The release binaries are available here:
-  https://apache.jfrog.io/arrow/almalinux/
-  https://apache.jfrog.io/arrow/amazon-linux/
-  https://apache.jfrog.io/arrow/centos/
-  https://apache.jfrog.io/arrow/debian/
-  https://apache.jfrog.io/arrow/nuget/#{version}
-  https://apache.jfrog.io/arrow/python/#{version}
-  https://apache.jfrog.io/arrow/ubuntu/
+  https://apache.jfrog.io/artifactory/arrow/almalinux/
+  https://apache.jfrog.io/artifactory/arrow/amazon-linux/
+  https://apache.jfrog.io/artifactory/arrow/centos/
+  https://apache.jfrog.io/artifactory/arrow/debian/
+  https://apache.jfrog.io/artifactory/arrow/nuget/#{version}
+  https://apache.jfrog.io/artifactory/arrow/python/#{version}
+  https://apache.jfrog.io/artifactory/arrow/ubuntu/
         SUMMARY
       end
     end

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:18.04
+FROM debian:bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -26,7 +26,7 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     apt-utils \
-    createrepo \
+    createrepo-c \
     devscripts \
     gpg \
     locales \
@@ -37,6 +37,8 @@ RUN \
     sudo && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN gem install apt-dists-merge -v ">= 1.0.1"
 
 RUN locale-gen en_US.UTF-8
 

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -38,7 +38,7 @@ RUN \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN gem install apt-dists-merge -v ">= 1.0.1"
+RUN gem install apt-dists-merge -v ">= 1.0.2"
 
 RUN locale-gen en_US.UTF-8
 

--- a/dev/release/post-02-binary.sh
+++ b/dev/release/post-02-binary.sh
@@ -96,5 +96,6 @@ docker_run \
     ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \
+    STAGING=${STAGING:-no} \
     VERSION=${version} \
     YUM_TARGETS=$(IFS=,; echo "${yum_targets[*]}")

--- a/dev/tasks/linux-packages/Rakefile
+++ b/dev/tasks/linux-packages/Rakefile
@@ -174,19 +174,21 @@ class LocalBinaryTask < BinaryTask
     namespace :apt do
       desc "Test deb packages"
       task :test do
-        repositories_dir = "apt/repositories"
-        rm_rf(repositories_dir)
+        incoming_dir = "apt/incoming"
+        rm_rf(incoming_dir)
         @packages.each do |package|
           package_repositories = "#{package}/apt/repositories"
           next unless File.exist?(package_repositories)
-          sh("rsync", "-a", "#{package_repositories}/", repositories_dir)
+          sh("rsync", "-a", "#{package_repositories}/", incoming_dir)
         end
-        Dir.glob("#{repositories_dir}/ubuntu/pool/*") do |code_name_dir|
+        Dir.glob("#{incoming_dir}/ubuntu/pool/*") do |code_name_dir|
           universe_dir = "#{code_name_dir}/universe"
           next unless File.exist?(universe_dir)
           mv(universe_dir, "#{code_name_dir}/main")
         end
-        apt_update(repositories_dir)
+        base_dir = "nonexistent"
+        repositories_dir = "apt/repositories"
+        apt_update(base_dir, incoming_dir, repositories_dir)
         apt_test_targets.each do |target|
           verify(target)
         end
@@ -224,7 +226,8 @@ class LocalBinaryTask < BinaryTask
           sh("rsync", "-a", "#{package_repositories}/", repositories_dir)
         end
         rpm_sign(repositories_dir)
-        yum_update(repositories_dir)
+        base_dir = "nonexistent"
+        yum_update(base_dir, repositories_dir)
         yum_test_targets.each do |target|
           verify(target)
         end

--- a/dev/tasks/linux-packages/Rakefile
+++ b/dev/tasks/linux-packages/Rakefile
@@ -174,21 +174,26 @@ class LocalBinaryTask < BinaryTask
     namespace :apt do
       desc "Test deb packages"
       task :test do
-        incoming_dir = "apt/incoming"
-        rm_rf(incoming_dir)
+        repositories_dir = "apt/repositories"
+        rm_rf(repositories_dir)
         @packages.each do |package|
           package_repositories = "#{package}/apt/repositories"
           next unless File.exist?(package_repositories)
-          sh("rsync", "-a", "#{package_repositories}/", incoming_dir)
+          sh("rsync", "-a", "#{package_repositories}/", repositories_dir)
         end
-        Dir.glob("#{incoming_dir}/ubuntu/pool/*") do |code_name_dir|
+        Dir.glob("#{repositories_dir}/ubuntu/pool/*") do |code_name_dir|
           universe_dir = "#{code_name_dir}/universe"
           next unless File.exist?(universe_dir)
           mv(universe_dir, "#{code_name_dir}/main")
         end
         base_dir = "nonexistent"
-        repositories_dir = "apt/repositories"
-        apt_update(base_dir, incoming_dir, repositories_dir)
+        merged_dir = "apt/merged"
+        apt_update(base_dir, repositories_dir, merged_dir)
+        Dir.glob("#{merged_dir}/*/dists/*") do |dists_code_name_dir|
+          prefix = dists_code_name_dir.split("/")[-3..-1].join("/")
+          mv(Dir.glob("#{dists_code_name_dir}/*Release*"),
+             "#{repositories_dir}/#{prefix}")
+        end
         apt_test_targets.each do |target|
           verify(target)
         end

--- a/dev/tasks/linux-packages/apt/build.sh
+++ b/dev/tasks/linux-packages/apt/build.sh
@@ -106,10 +106,12 @@ repositories="/host/repositories"
 package_initial=$(echo "${PACKAGE}" | sed -e 's/\(.\).*/\1/')
 pool_dir="${repositories}/${distribution}/pool/${code_name}/${component}/${package_initial}/${PACKAGE}"
 run mkdir -p "${pool_dir}/"
-run cp \
-  *.*deb \
-  *.dsc \
-  *.tar.* \
-  "${pool_dir}/"
+run \
+  find . \
+  -maxdepth 1 \
+  -type f \
+  -not -path '*.build' \
+  -not -path '*.buildinfo' \
+  -exec cp '{}' "${pool_dir}/" ';'
 
 run chown -R "$(stat --format "%u:%g" "${repositories}")" "${repositories}"

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -22,14 +22,7 @@
 jobs:
   package:
     name: Package
-    # We can't use Ubuntu 20.04 because it doesn't ship neither
-    # createrepo nor createrepo_c. We'll be able to use Ubuntu
-    # 22.04. It will ship createrepo_c. Or we can build createrepo_c
-    # from source like we do in travis.linux.arm64.yml.
-    #
-    # Note that createrepo or createrepo_c is only needed to test Yum
-    # repository.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
@@ -76,12 +69,14 @@ jobs:
         run: |
           set -e
           sudo apt update
+          # We can install createrepo_c by package with Ubuntu 22.04.
           sudo apt install -y \
             apt-utils \
-            createrepo \
+            # createrepo_c \
             devscripts \
             gpg \
             rpm
+          sudo gem install apt-dists-merge
           (echo "Key-Type: RSA"; \
            echo "Key-Length: 4096"; \
            echo "Name-Real: Test"; \
@@ -91,6 +86,38 @@ jobs:
           GPG_KEY_ID=$(gpg --list-keys --with-colon test@example.com | grep fpr | cut -d: -f10)
           echo "GPG_KEY_ID=${GPG_KEY_ID}" >> ${GITHUB_ENV}
           gpg --export --armor test@example.com > arrow/dev/tasks/linux-packages/KEYS
+      # We can install createrepo_c by package with Ubuntu 22.04.
+      # This is workaround:
+      - name: Install createrepo_c
+        run: |
+          sudo apt install -y \
+            cmake \
+            libbz2-dev \
+            libcurl4-openssl-dev \
+            libglib2.0-dev \
+            liblzma-dev \
+            libmagic-dev \
+            librpm-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libxml2-dev \
+            libzstd-dev \
+            pkg-config \
+            zlib1g-dev
+          git clone --depth 1 https://github.com/rpm-software-management/createrepo_c.git
+          pushd createrepo_c
+          /usr/bin/cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DENABLE_BASHCOMP=OFF \
+            -DENABLE_DRPM=OFF \
+            -DENABLE_PYTHON=OFF \
+            -DWITH_LIBMODULEMD=OFF \
+            -DWITH_ZCHUNK=OFF \
+            .
+          make -j$(nproc)
+          sudo make install
+          popd
+          rm -rf createrepo_c
       - name: Test
         run: |
           set -e

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -70,9 +70,9 @@ jobs:
           set -e
           sudo apt update
           # We can install createrepo_c by package with Ubuntu 22.04.
+          #   createrepo_c \
           sudo apt install -y \
             apt-utils \
-            # createrepo_c \
             devscripts \
             gpg \
             rpm

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -76,7 +76,7 @@ jobs:
             devscripts \
             gpg \
             rpm
-          sudo gem install apt-dists-merge
+          gem install apt-dists-merge
           (echo "Key-Type: RSA"; \
            echo "Key-Length: 4096"; \
            echo "Name-Real: Test"; \

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -131,6 +131,7 @@ script:
       rake docker:push || :
   - popd
   # Test built packages
+  - sudo gem install apt-dists-merge
   - |
       (echo "Key-Type: RSA"; \
        echo "Key-Length: 4096"; \


### PR DESCRIPTION
Summary:

Generating metadata for APT/Yum repositories from all .deb/.rpm
on local from scratch

    ||
    \/

Generating metadata for APT/Yum repositories only for built .deb/.rpm
and merging the generated metadata and existing metadata
(Released .deb/.rpm aren't downloaded.)

Before:

  For RC:
    1. Download built .deb/.rpm for RC
    2. Sign the built .deb/.rpm
    3. Upload the signed built .deb/.rpm to
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc
    3. Download all released .deb/.rpm from
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}
    4. Download the all built and signed .deb/.rpm from
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc
    5. Generate metadata for APT/Yum repositories with local .deb/.rpm
       from scratch
    6. Upload the metadata for APT/Yum repositories to
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc

  For release:
    1. Download the all .deb/.rpm and metadata for APT/Yum repositories from
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc
    2. Upload the downloaded files to
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}

After:

  For RC:
    1. Download the built .deb/.rpm for RC
    2. Sign the built .deb/.rpm
    3. Generate metadata for APT/Yum repositories for the built and
       signed .deb/.rpm
    4. Download metadata for APT/Yum repositories from
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}
    5. Merge metadata of 3. and 4.
    6. Upload the built and signed .deb/.rpm and the merged metadata
       for APT/Yum repositories to
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc

  For release:
    1. Download only uploaded files by 6. for RC from
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}-rc
    2. Upload the downloaded files to
       https://apache.jfrog.io/ui/native/arrow/{debian,centos,...}