### PR TITLE
ARROW-14065: [C++] Fixes behaviour of "Advance()" of FixedSizeBinaryBuilder.

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2149,12 +2149,12 @@ TEST_F(TestFWBinaryArray, ReserveThenAdvance) {
   ASSERT_EQ(builder.length(), 100);
   ASSERT_GE(builder.capacity(), 100 * 7);
 
-  std::shared_ptr<Array> array;
+  std::shared_ptr<FixedSizeBinaryArray> array;
   ASSERT_OK(builder.Finish(&array));
 
   ASSERT_EQ(array->length(), 100);
   // check the size of underlying buffer
-  ASSERT_EQ(array->values()->size, 7 * 100);
+  ASSERT_EQ(array->values()->size(), 7 * 100);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2137,6 +2137,26 @@ TEST_F(TestFWBinaryArray, ArrayDataVisitorSliced) {
   ARROW_UNUSED(visitor);  // Workaround weird MSVC warning
 }
 
+TEST_F(TestFWBinaryArray, ReserveThenAdvance) {
+  auto type = fixed_size_binary(7);
+  FixedSizeBinaryBuilder builder(type);
+
+  ASSERT_OK(builder.Reserve(100));
+  ASSERT_EQ(builder.length(), 0);
+  ASSERT_GE(builder.capacity(), 100 * 7);
+
+  ASSERT_OK(builder.Advance(100));
+  ASSERT_EQ(builder.length(), 100);
+  ASSERT_GE(builder.capacity(), 100 * 7);
+
+  std::shared_ptr<Array> array;
+  ASSERT_OK(builder.Finish(&array));
+
+  ASSERT_EQ(array->length(), 100);
+  // check the size of underlying buffer
+  ASSERT_EQ(array->values()->size, 7 * 100);
+}
+
 // ----------------------------------------------------------------------
 // AdaptiveInt tests
 

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2143,11 +2143,11 @@ TEST_F(TestFWBinaryArray, ReserveThenAdvance) {
 
   ASSERT_OK(builder.Reserve(100));
   ASSERT_EQ(builder.length(), 0);
-  ASSERT_GE(builder.capacity(), 100 * 7);
+  ASSERT_GE(builder.capacity(), 100);
 
   ASSERT_OK(builder.Advance(100));
   ASSERT_EQ(builder.length(), 100);
-  ASSERT_GE(builder.capacity(), 100 * 7);
+  ASSERT_GE(builder.capacity(), 100);
 
   std::shared_ptr<FixedSizeBinaryArray> array;
   ASSERT_OK(builder.Finish(&array));

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -134,7 +134,7 @@ class ARROW_EXPORT ArrayBuilder {
   /// For cases where raw data was memcpy'd into the internal buffers, allows us
   /// to advance the length of the builder. It is your responsibility to use
   /// this function responsibly.
-  Status Advance(int64_t elements);
+  virtual Status Advance(int64_t elements);
 
   /// \brief Return result of builder as an internal generic ArrayData
   /// object. Resets builder except for dictionary builder

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -107,9 +107,10 @@ Status FixedSizeBinaryBuilder::Resize(int64_t capacity) {
 }
 
 Status FixedSizeBinaryBuilder::Advance(int64_t elements) {
-  RETURN_NOT_OK(ArrayBuilder::Advance(elements));
+  Status status = ArrayBuilder::Advance(elements);
   // Use UnsafeAdvance: don't zero-out the existing data.
-  return byte_builder_.UnsafeAdvance(elements);
+  byte_builder_.UnsafeAdvance(elements);
+  return status;
 }
 
 Status FixedSizeBinaryBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -109,7 +109,7 @@ Status FixedSizeBinaryBuilder::Resize(int64_t capacity) {
 Status FixedSizeBinaryBuilder::Advance(int64_t elements) {
   Status status = ArrayBuilder::Advance(elements);
   // Use UnsafeAdvance: don't zero-out the existing data.
-  byte_builder_.UnsafeAdvance(elements);
+  byte_builder_.UnsafeAdvance(elements * byte_width_);
   return status;
 }
 

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -106,6 +106,12 @@ Status FixedSizeBinaryBuilder::Resize(int64_t capacity) {
   return ArrayBuilder::Resize(capacity);
 }
 
+Status FixedSizeBinaryBuilder::Advance(int64_t elements) {
+  RETURN_NOT_OK(ArrayBuilder::Advance(elements));
+  // Use UnsafeAdvance: don't zero-out the existing data.
+  return byte_builder_.UnsafeAdvance(elements);
+}
+
 Status FixedSizeBinaryBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   std::shared_ptr<Buffer> data;
   RETURN_NOT_OK(byte_builder_.Finish(&data));

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -565,6 +565,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 
   void Reset() override;
   Status Resize(int64_t capacity) override;
+  Status Advance(int64_t elements) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
   /// \cond FALSE


### PR DESCRIPTION
Advance (unsafely) the extra byte_builder as well, to keep consistent with other type of builders.
