### PR TITLE
ARROW-8379: [R] Investigate/fix thread safety issues (esp. Windows)

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -36,6 +36,7 @@ If you have the [duckdb](https://duckdb.org/) package installed, you can hand of
 
 * `dplyr::summarize()` on an in-memory Arrow Table or RecordBatch no longer eagerly evaluates. Call `compute()` or `collect()` to evaluate the query.
 * Row order of data from a Dataset query is no longer deterministic. If you need a stable sort order, you should explicitly `arrange()` the query result. For calls to `summarize()`, you can set `options(arrow.summarise.sort = TRUE)` to match the current `dplyr` behavior of sorting on the grouping columns.
+* Datasets are officially no longer supported on 32-bit Windows on R < 4.0 (Rtools 3.5). 32-bit Windows users should upgrade to a newer version of R in order to use datasets.
 
 ## Installation on Linux
 

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -135,6 +135,9 @@ open_dataset <- function(sources,
                          unify_schemas = NULL,
                          format = c("parquet", "arrow", "ipc", "feather", "csv", "tsv", "text"),
                          ...) {
+  if (!arrow_with_dataset()) {
+    stop("This build of the arrow package does not support Datasets", call. = FALSE)
+  }
   if (is_list_of(sources, "Dataset")) {
     if (is.null(schema)) {
       if (is.null(unify_schemas) || isTRUE(unify_schemas)) {
@@ -309,6 +312,9 @@ UnionDataset <- R6Class("UnionDataset",
 #' @export
 InMemoryDataset <- R6Class("InMemoryDataset", inherit = Dataset)
 InMemoryDataset$create <- function(x) {
+  if (!arrow_with_dataset()) {
+    stop("This build of the arrow package does not support Datasets", call. = FALSE)
+  }
   if (!inherits(x, "Table")) {
     x <- Table$create(x)
   }

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -18,12 +18,6 @@
 # Wrap testthat::test_that with a check for the C++ library
 options(..skip.tests = !arrow:::arrow_available())
 
-if (tolower(Sys.info()[["sysname"]]) == "windows") {
-  # For now, disable multithreading by default on Windows
-  # See https://issues.apache.org/jira/browse/ARROW-8379
-  options(arrow.use_threads = FALSE)
-}
-
 set.seed(1)
 
 MAX_INT <- 2147483647L

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -25,10 +25,6 @@ skip_if_not_available <- function(feature) {
   if (feature == "re2") {
     # RE2 does not support valgrind (on purpose): https://github.com/google/re2/issues/177
     skip_on_valgrind()
-  } else if (feature == "dataset") {
-    # These tests often hang on 32-bit windows rtools35, and we haven't been
-    # able to figure out how to make them work safely
-    skip_if_multithreading_disabled()
   }
 
   yes <- feature %in% names(build_features) && build_features[feature]
@@ -70,15 +66,6 @@ skip_on_valgrind <- function() {
 
   if (linux_dev) {
     skip_on_cran()
-  }
-}
-
-skip_if_multithreading_disabled <- function() {
-  is_32bit <- .Machine$sizeof.pointer < 8
-  is_old_r <- getRversion() < "4.0.0"
-  is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
-  if (is_32bit && is_old_r && is_windows) {
-    skip("Multithreading does not work properly on this system")
   }
 }
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -1029,9 +1029,6 @@ test_that("Scanner$ScanBatches", {
   table <- Table$create(!!!batches)
   expect_equal(as.data.frame(table), rbind(df1, df2))
 
-  # use_async will always use the thread pool (even if it only uses
-  # one thread) and RTools 3.5 on Windows doesn't support this
-  skip_on_os("windows")
   batches <- ds$NewScan()$UseAsync(TRUE)$Finish()$ScanBatches()
   table <- Table$create(!!!batches)
   expect_equal(as.data.frame(table), rbind(df1, df2))
@@ -1301,7 +1298,6 @@ test_that("Assembling multiple DatasetFactories with DatasetFactory", {
 })
 
 test_that("Writing a dataset: CSV->IPC", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   dst_dir <- make_temp_dir()
   write_dataset(ds, dst_dir, format = "feather", partitioning = "int")
@@ -1333,7 +1329,6 @@ test_that("Writing a dataset: CSV->IPC", {
 
 test_that("Writing a dataset: Parquet->IPC", {
   skip_if_not_available("parquet")
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(hive_dir)
   dst_dir <- make_temp_dir()
   write_dataset(ds, dst_dir, format = "feather", partitioning = "int")
@@ -1357,7 +1352,6 @@ test_that("Writing a dataset: Parquet->IPC", {
 
 test_that("Writing a dataset: CSV->Parquet", {
   skip_if_not_available("parquet")
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   dst_dir <- make_temp_dir()
   write_dataset(ds, dst_dir, format = "parquet", partitioning = "int")
@@ -1381,7 +1375,6 @@ test_that("Writing a dataset: CSV->Parquet", {
 
 test_that("Writing a dataset: Parquet->Parquet (default)", {
   skip_if_not_available("parquet")
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(hive_dir)
   dst_dir <- make_temp_dir()
   write_dataset(ds, dst_dir, partitioning = "int")
@@ -1404,7 +1397,6 @@ test_that("Writing a dataset: Parquet->Parquet (default)", {
 })
 
 test_that("Writing a dataset: no format specified", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   dst_dir <- make_temp_dir()
   write_dataset(example_data, dst_dir)
   new_ds <- open_dataset(dst_dir)
@@ -1423,7 +1415,6 @@ test_that("Writing a dataset: no format specified", {
 
 test_that("Dataset writing: dplyr methods", {
   skip_if_not_available("parquet")
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(hive_dir)
   dst_dir <- tempfile()
   # Specify partition vars by group_by
@@ -1473,7 +1464,6 @@ test_that("Dataset writing: dplyr methods", {
 })
 
 test_that("Dataset writing: non-hive", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   skip_if_not_available("parquet")
   ds <- open_dataset(hive_dir)
   dst_dir <- tempfile()
@@ -1483,7 +1473,6 @@ test_that("Dataset writing: non-hive", {
 })
 
 test_that("Dataset writing: no partitioning", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   skip_if_not_available("parquet")
   ds <- open_dataset(hive_dir)
   dst_dir <- tempfile()
@@ -1493,7 +1482,6 @@ test_that("Dataset writing: no partitioning", {
 })
 
 test_that("Dataset writing: partition on null", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(hive_dir)
 
   dst_dir <- tempfile()
@@ -1523,7 +1511,6 @@ test_that("Dataset writing: partition on null", {
 })
 
 test_that("Dataset writing: from data.frame", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   dst_dir <- tempfile()
   stacked <- rbind(df1, df2)
   stacked %>%
@@ -1548,7 +1535,6 @@ test_that("Dataset writing: from data.frame", {
 })
 
 test_that("Dataset writing: from RecordBatch", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   dst_dir <- tempfile()
   stacked <- record_batch(rbind(df1, df2))
   stacked %>%
@@ -1573,7 +1559,6 @@ test_that("Dataset writing: from RecordBatch", {
 })
 
 test_that("Writing a dataset: Ipc format options & compression", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   dst_dir <- make_temp_dir()
 
@@ -1600,7 +1585,6 @@ test_that("Writing a dataset: Ipc format options & compression", {
 })
 
 test_that("Writing a dataset: Parquet format options", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
   skip_if_not_available("parquet")
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   dst_dir <- make_temp_dir()

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -445,8 +445,6 @@ test_that("mutate and write_dataset", {
   skip_if_not_available("dataset")
   # See related test in test-dataset.R
 
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-9651
-
   first_date <- lubridate::ymd_hms("2015-04-29 03:12:39")
   df1 <- tibble(
     int = 1:10,


### PR DESCRIPTION
One side effect of this change is that it actually re-enables lots of dataset tests on Windows, just not for 32-bit rtools35