### PR TITLE
ARROW-14165: [C++] Improve table sort performance

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -127,6 +127,8 @@ struct RecordBatchSortIndicesArgs {
         state_(state) {}
 
   ~RecordBatchSortIndicesArgs() {
+    state_.counters["columns"] = static_cast<double>(num_columns);
+    state_.counters["null_percent"] = null_proportion * 100;
     state_.SetItemsProcessed(state_.iterations() * num_records);
   }
 
@@ -149,6 +151,8 @@ struct TableSortIndicesArgs : public RecordBatchSortIndicesArgs {
   // Extract args
   explicit TableSortIndicesArgs(benchmark::State& state)
       : RecordBatchSortIndicesArgs(state), num_chunks(state.range(3)) {}
+
+  ~TableSortIndicesArgs() { state_.counters["chunks"] = static_cast<double>(num_chunks); }
 };
 
 struct BatchOrTableBenchmarkData {
@@ -266,7 +270,7 @@ BENCHMARK(ChunkedArraySortIndicesInt64Wide)
 BENCHMARK(RecordBatchSortIndicesInt64Narrow)
     ->ArgsProduct({
         {1 << 20},      // the number of records
-        {100, 0},       // inverse null proportion
+        {100, 4, 0},    // inverse null proportion
         {16, 8, 2, 1},  // the number of columns
     })
     ->Unit(benchmark::TimeUnit::kNanosecond);
@@ -274,7 +278,7 @@ BENCHMARK(RecordBatchSortIndicesInt64Narrow)
 BENCHMARK(RecordBatchSortIndicesInt64Wide)
     ->ArgsProduct({
         {1 << 20},      // the number of records
-        {100, 0},       // inverse null proportion
+        {100, 4, 0},    // inverse null proportion
         {16, 8, 2, 1},  // the number of columns
     })
     ->Unit(benchmark::TimeUnit::kNanosecond);
@@ -282,7 +286,7 @@ BENCHMARK(RecordBatchSortIndicesInt64Wide)
 BENCHMARK(TableSortIndicesInt64Narrow)
     ->ArgsProduct({
         {1 << 20},      // the number of records
-        {100, 0},       // inverse null proportion
+        {100, 4, 0},    // inverse null proportion
         {16, 8, 2, 1},  // the number of columns
         {32, 4, 1},     // the number of chunks
     })
@@ -291,7 +295,7 @@ BENCHMARK(TableSortIndicesInt64Narrow)
 BENCHMARK(TableSortIndicesInt64Wide)
     ->ArgsProduct({
         {1 << 20},      // the number of records
-        {100, 0},       // inverse null proportion
+        {100, 4, 0},    // inverse null proportion
         {16, 8, 2, 1},  // the number of columns
         {32, 4, 1},     // the number of chunks
     })

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include <gmock/gmock-matchers.h>
+
 #include "arrow/array/array_decimal.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/api_vector.h"
@@ -1261,6 +1263,45 @@ TEST_F(TestRecordBatchSortIndices, DuplicateSortKeys) {
 // Test basic cases for table.
 class TestTableSortIndices : public ::testing::Test {};
 
+TEST_F(TestTableSortIndices, EmptyTable) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                       SortKey("b", SortOrder::Descending)};
+
+  auto table = TableFromJSON(schema, {"[]"});
+  auto chunked_table = TableFromJSON(schema, {"[]", "[]"});
+
+  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  AssertSortIndices(table, options, "[]");
+  AssertSortIndices(chunked_table, options, "[]");
+  options.null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[]");
+  AssertSortIndices(chunked_table, options, "[]");
+}
+
+TEST_F(TestTableSortIndices, EmptySortKeys) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  const std::vector<SortKey> sort_keys{};
+  const SortOptions options(sort_keys, NullPlacement::AtEnd);
+
+  auto table = TableFromJSON(schema, {R"([{"a": null, "b": 5}])"});
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("Must specify one or more sort keys"),
+      CallFunction("sort_indices", {table}, &options));
+
+  // Several chunks
+  table = TableFromJSON(schema, {R"([{"a": null, "b": 5}])", R"([{"a": 0, "b": 6}])"});
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("Must specify one or more sort keys"),
+      CallFunction("sort_indices", {table}, &options));
+}
+
 TEST_F(TestTableSortIndices, Null) {
   auto schema = ::arrow::schema({
       {field("a", uint8())},
@@ -1516,6 +1557,32 @@ TEST_F(TestTableSortIndices, DuplicateSortKeys) {
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
+TEST_F(TestTableSortIndices, HeterogenousChunking) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+
+  // Same logical data as in "NaNAndNull" test above
+  auto col_a =
+      ChunkedArrayFromJSON(float32(), {"[null, 1]", "[]", "[3, null, NaN, NaN, NaN, 1]"});
+  auto col_b = ChunkedArrayFromJSON(float64(),
+                                    {"[5]", "[3, null, null]", "[null, NaN, 5]", "[5]"});
+  auto table = Table::Make(schema, {col_a, col_b});
+
+  SortOptions options(
+      {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
+  AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
+  options.null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
+
+  options = SortOptions(
+      {SortKey("b", SortOrder::Ascending), SortKey("a", SortOrder::Descending)});
+  AssertSortIndices(table, options, "[1, 7, 6, 0, 5, 2, 4, 3]");
+  options.null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[3, 4, 2, 5, 1, 0, 6, 7]");
+}
+
 // Tests for temporal types
 template <typename ArrowType>
 class TestTableSortIndicesForTemporal : public TestTableSortIndices {
@@ -1712,22 +1779,48 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
       {field("decimal128", decimal128(25, 3))},
       {field("decimal256", decimal256(42, 6))},
   };
-  const auto length = 200;
-  ArrayVector columns = {
-      rng.UInt8(length, 0, 10, null_probability),
-      rng.Int16(length, -1000, 12000, /*null_probability=*/0.0),
-      rng.Int32(length, -123456789, 987654321, null_probability),
-      rng.UInt64(length, 1, 1234567890123456789ULL, /*null_probability=*/0.0),
-      rng.Float32(length, -1.0f, 1.0f, null_probability, nan_probability),
-      rng.Boolean(length, /*true_probability=*/0.3, null_probability),
-      rng.StringWithRepeats(length, /*unique=*/length / 10, /*min_length=*/5,
-                            /*max_length=*/15, null_probability),
-      rng.LargeString(length, /*min_length=*/5, /*max_length=*/15,
-                      /*null_probability=*/0.0),
-      rng.Decimal128(fields[8]->type(), length, null_probability),
-      rng.Decimal256(fields[9]->type(), length, /*null_probability=*/0.0),
+  const auto schema = ::arrow::schema(fields);
+  const int64_t length = 80;
+
+  using ArrayFactory = std::function<std::shared_ptr<Array>(int64_t length)>;
+
+  std::vector<ArrayFactory> column_factories{
+      [&](int64_t length) { return rng.UInt8(length, 0, 10, null_probability); },
+      [&](int64_t length) {
+        return rng.Int16(length, -1000, 12000, /*null_probability=*/0.0);
+      },
+      [&](int64_t length) {
+        return rng.Int32(length, -123456789, 987654321, null_probability);
+      },
+      [&](int64_t length) {
+        return rng.UInt64(length, 1, 1234567890123456789ULL, /*null_probability=*/0.0);
+      },
+      [&](int64_t length) {
+        return rng.Float32(length, -1.0f, 1.0f, null_probability, nan_probability);
+      },
+      [&](int64_t length) {
+        return rng.Boolean(length, /*true_probability=*/0.3, null_probability);
+      },
+      [&](int64_t length) {
+        if (length > 0) {
+          return rng.StringWithRepeats(length, /*unique=*/1 + length / 10,
+                                       /*min_length=*/5,
+                                       /*max_length=*/15, null_probability);
+        } else {
+          return *MakeArrayOfNull(utf8(), 0);
+        }
+      },
+      [&](int64_t length) {
+        return rng.LargeString(length, /*min_length=*/5, /*max_length=*/15,
+                               /*null_probability=*/0.0);
+      },
+      [&](int64_t length) {
+        return rng.Decimal128(fields[8]->type(), length, null_probability);
+      },
+      [&](int64_t length) {
+        return rng.Decimal256(fields[9]->type(), length, /*null_probability=*/0.0);
+      },
   };
-  const auto table = Table::Make(schema(fields), columns, length);
 
   // Generate random sort keys, making sure no column is included twice
   std::default_random_engine engine(seed);
@@ -1758,21 +1851,46 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
 
   SortOptions options(sort_keys);
 
-  // Test with different table chunkings
-  for (const int64_t num_chunks : {1, 2, 20}) {
-    ARROW_SCOPED_TRACE("Table sorting: num_chunks = ", num_chunks);
-    TableBatchReader reader(*table);
-    reader.set_chunksize((length + num_chunks - 1) / num_chunks);
-    ASSERT_OK_AND_ASSIGN(auto chunked_table, Table::FromRecordBatchReader(&reader));
+  // Test with different, heterogenous table chunkings
+  for (const int64_t max_num_chunks : {1, 3, 15}) {
+    ARROW_SCOPED_TRACE("Table sorting: max chunks per column = ", max_num_chunks);
+    std::uniform_int_distribution<int64_t> num_chunk_dist(1 + max_num_chunks / 2,
+                                                          max_num_chunks);
+    ChunkedArrayVector columns;
+    columns.reserve(fields.size());
+
+    // Chunk each column independently
+    for (const auto& factory : column_factories) {
+      const int64_t num_chunks = num_chunk_dist(engine);
+      ArrayVector chunks(num_chunks);
+      const auto offsets =
+          checked_pointer_cast<Int32Array>(rng.Offsets(num_chunks + 1, 0, length));
+      for (int64_t i = 0; i < num_chunks; ++i) {
+        const auto chunk_len = offsets->Value(i + 1) - offsets->Value(i);
+        chunks[i] = factory(chunk_len);
+      }
+      columns.push_back(std::make_shared<ChunkedArray>(std::move(chunks)));
+      ASSERT_EQ(columns.back()->length(), length);
+    }
+
+    auto table = Table::Make(schema, std::move(columns));
     for (auto null_placement : AllNullPlacements()) {
       ARROW_SCOPED_TRACE("null_placement = ", null_placement);
       options.null_placement = null_placement;
-      ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*chunked_table), options));
+      ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*table), options));
       Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
     }
   }
 
   // Also validate RecordBatch sorting
+  ChunkedArrayVector columns;
+  columns.reserve(fields.size());
+  for (const auto& factory : column_factories) {
+    columns.push_back(std::make_shared<ChunkedArray>(factory(length)));
+  }
+  auto table = Table::Make(schema, std::move(columns));
+  ASSERT_OK(table->ValidateFull());
+
   TableBatchReader reader(*table);
   RecordBatchVector batches;
   ASSERT_OK(reader.ReadAll(&batches));


### PR DESCRIPTION
When sorting a table, rechunk it homogeneously as record batches, to pay the price of chunked indexing once for all columns.

This helps performance when cardinality is low in the first sort column, yielding up to a 60% speedup on the set of sorting benchmarks.