### PR TITLE
ARROW-14191: [C++][Dataset] Dataset writes should respect backpressure

### DIFF
--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -410,10 +410,12 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
 /// \brief Wraps FileSystemDatasetWriteOptions for consumption as compute::ExecNodeOptions
 class ARROW_DS_EXPORT WriteNodeOptions : public compute::ExecNodeOptions {
  public:
-  explicit WriteNodeOptions(FileSystemDatasetWriteOptions options,
-                            std::shared_ptr<Schema> schema,
-                            std::shared_ptr<util::AsyncToggle> backpressure_toggle = NULLPTR)
-      : write_options(std::move(options)), schema(std::move(schema)), backpressure_toggle(std::move(backpressure_toggle)) {}
+  explicit WriteNodeOptions(
+      FileSystemDatasetWriteOptions options, std::shared_ptr<Schema> schema,
+      std::shared_ptr<util::AsyncToggle> backpressure_toggle = NULLPTR)
+      : write_options(std::move(options)),
+        schema(std::move(schema)),
+        backpressure_toggle(std::move(backpressure_toggle)) {}
 
   FileSystemDatasetWriteOptions write_options;
   std::shared_ptr<Schema> schema;

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -411,11 +411,13 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
 class ARROW_DS_EXPORT WriteNodeOptions : public compute::ExecNodeOptions {
  public:
   explicit WriteNodeOptions(FileSystemDatasetWriteOptions options,
-                            std::shared_ptr<Schema> schema)
-      : write_options(std::move(options)), schema(std::move(schema)) {}
+                            std::shared_ptr<Schema> schema,
+                            std::shared_ptr<util::AsyncToggle> backpressure_toggle = NULLPTR)
+      : write_options(std::move(options)), schema(std::move(schema)), backpressure_toggle(std::move(backpressure_toggle)) {}
 
   FileSystemDatasetWriteOptions write_options;
   std::shared_ptr<Schema> schema;
+  std::shared_ptr<util::AsyncToggle> backpressure_toggle;
 };
 
 /// @}

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -22,6 +22,8 @@ import pathlib
 import pickle
 import textwrap
 import tempfile
+import threading
+import time
 
 import numpy as np
 import pytest
@@ -30,7 +32,8 @@ import pyarrow as pa
 import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
-from pyarrow.tests.util import change_cwd, _filesystem_uri, FSProtocolClass
+from pyarrow.tests.util import (change_cwd, _filesystem_uri,
+                                FSProtocolClass, ProxyHandler)
 
 try:
     import pandas as pd
@@ -3387,6 +3390,73 @@ def test_write_dataset_with_scanner(tempdir):
         load_back_table = load_back.to_table()
         assert dict(load_back_table.to_pydict()
                     ) == table.drop(["a"]).to_pydict()
+
+
+def test_write_dataset_with_backpressure(tempdir):
+    consumer_gate = threading.Semaphore(0)
+
+    class GatingFs(ProxyHandler):
+        def open_output_stream(self, path, metadata):
+            consumer_gate.acquire(1)
+            return self._fs.open_output_stream(path, metadata=metadata)
+    gating_fs = fs.PyFileSystem(GatingFs(fs.LocalFileSystem()))
+
+    schema = pa.schema([pa.field('data', pa.int32())])
+    # By default, the dataset writer will queue up 64Mi rows so
+    # with batches of 1M it should only fit ~67 batches
+    batch = pa.record_batch([pa.array(list(range(1_000_000)))], schema=schema)
+    batches_read = 0
+    min_backpressure = 67
+    end = 200
+
+    def counting_generator():
+        nonlocal batches_read
+        while batches_read < end:
+            time.sleep(0.01)
+            batches_read += 1
+            yield batch
+
+    scanner = ds.Scanner.from_batches(
+            counting_generator(), schema=schema, use_threads=True,
+            use_async=True)
+
+    write_thread = threading.Thread(
+        target=lambda: ds.write_dataset(
+            scanner, str(tempdir), format='parquet', filesystem=gating_fs))
+    write_thread.start()
+
+    try:
+        start = time.time()
+
+        def duration():
+            return time.time() - start
+
+        # This test is timing dependent.  There is no signal from the C++
+        # when backpressure has been hit.  We don't know exactly when
+        # backpressure will be hit because it may take some time for the
+        # signal to get from the sink to the scanner.
+        #
+        # The test may emit false positives on slow systems.  It could
+        # theoretically emit a false negative if the scanner managed to read
+        # and emit all 200 batches before the backpressure signal had a chance
+        # to propagate but the 0.01s delay in the generator should make that
+        # scenario unlikely.
+        last_value = 0
+        backpressure_probably_hit = False
+        while duration() < 10:
+            if batches_read > min_backpressure:
+                if batches_read == last_value:
+                    backpressure_probably_hit = True
+                    break
+                last_value = batches_read
+            time.sleep(0.5)
+
+        assert backpressure_probably_hit
+
+    finally:
+        consumer_gate.release(1)
+        write_thread.join()
+    assert batches_read == end
 
 
 def test_write_dataset_with_dataset(tempdir):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3417,8 +3417,8 @@ def test_write_dataset_with_backpressure(tempdir):
             yield batch
 
     scanner = ds.Scanner.from_batches(
-            counting_generator(), schema=schema, use_threads=True,
-            use_async=True)
+        counting_generator(), schema=schema, use_threads=True,
+        use_async=True)
 
     write_thread = threading.Thread(
         target=lambda: ds.write_dataset(

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3454,7 +3454,7 @@ def test_write_dataset_with_backpressure(tempdir):
         assert backpressure_probably_hit
 
     finally:
-        consumer_gate.release(1)
+        consumer_gate.release()
         write_thread.join()
     assert batches_read == end
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -29,7 +29,7 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri
+from pyarrow.tests.util import _filesystem_uri, ProxyHandler
 from pyarrow.vendored.version import Version
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
@@ -141,67 +141,6 @@ class DummyHandler(FileSystemHandler):
         if "notfound" in path:
             raise FileNotFoundError(path)
         return pa.BufferOutputStream()
-
-
-class ProxyHandler(FileSystemHandler):
-
-    def __init__(self, fs):
-        self._fs = fs
-
-    def __eq__(self, other):
-        if isinstance(other, ProxyHandler):
-            return self._fs == other._fs
-        return NotImplemented
-
-    def __ne__(self, other):
-        if isinstance(other, ProxyHandler):
-            return self._fs != other._fs
-        return NotImplemented
-
-    def get_type_name(self):
-        return "proxy::" + self._fs.type_name
-
-    def normalize_path(self, path):
-        return self._fs.normalize_path(path)
-
-    def get_file_info(self, paths):
-        return self._fs.get_file_info(paths)
-
-    def get_file_info_selector(self, selector):
-        return self._fs.get_file_info(selector)
-
-    def create_dir(self, path, recursive):
-        return self._fs.create_dir(path, recursive=recursive)
-
-    def delete_dir(self, path):
-        return self._fs.delete_dir(path)
-
-    def delete_dir_contents(self, path):
-        return self._fs.delete_dir_contents(path)
-
-    def delete_root_dir_contents(self):
-        return self._fs.delete_dir_contents("", accept_root_dir=True)
-
-    def delete_file(self, path):
-        return self._fs.delete_file(path)
-
-    def move(self, src, dest):
-        return self._fs.move(src, dest)
-
-    def copy_file(self, src, dest):
-        return self._fs.copy_file(src, dest)
-
-    def open_input_stream(self, path):
-        return self._fs.open_input_stream(path)
-
-    def open_input_file(self, path):
-        return self._fs.open_input_file(path)
-
-    def open_output_stream(self, path, metadata):
-        return self._fs.open_output_stream(path, metadata=metadata)
-
-    def open_append_stream(self, path, metadata):
-        return self._fs.open_append_stream(path, metadata=metadata)
 
 
 @pytest.fixture

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -33,6 +33,7 @@ import sys
 import pytest
 
 import pyarrow as pa
+import pyarrow.fs
 
 
 def randsign():
@@ -249,6 +250,71 @@ class FSProtocolClass:
 
     def __fspath__(self):
         return str(self._path)
+
+
+class ProxyHandler(pyarrow.fs.FileSystemHandler):
+    """
+    A dataset handler that proxies to an underlying filesystem.  Useful
+    to partially wrap an existing filesystem with partial changes.
+    """
+
+    def __init__(self, fs):
+        self._fs = fs
+
+    def __eq__(self, other):
+        if isinstance(other, ProxyHandler):
+            return self._fs == other._fs
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, ProxyHandler):
+            return self._fs != other._fs
+        return NotImplemented
+
+    def get_type_name(self):
+        return "proxy::" + self._fs.type_name
+
+    def normalize_path(self, path):
+        return self._fs.normalize_path(path)
+
+    def get_file_info(self, paths):
+        return self._fs.get_file_info(paths)
+
+    def get_file_info_selector(self, selector):
+        return self._fs.get_file_info(selector)
+
+    def create_dir(self, path, recursive):
+        return self._fs.create_dir(path, recursive=recursive)
+
+    def delete_dir(self, path):
+        return self._fs.delete_dir(path)
+
+    def delete_dir_contents(self, path):
+        return self._fs.delete_dir_contents(path)
+
+    def delete_root_dir_contents(self):
+        return self._fs.delete_dir_contents("", accept_root_dir=True)
+
+    def delete_file(self, path):
+        return self._fs.delete_file(path)
+
+    def move(self, src, dest):
+        return self._fs.move(src, dest)
+
+    def copy_file(self, src, dest):
+        return self._fs.copy_file(src, dest)
+
+    def open_input_stream(self, path):
+        return self._fs.open_input_stream(path)
+
+    def open_input_file(self, path):
+        return self._fs.open_input_file(path)
+
+    def open_output_stream(self, path, metadata):
+        return self._fs.open_output_stream(path, metadata=metadata)
+
+    def open_append_stream(self, path, metadata):
+        return self._fs.open_append_stream(path, metadata=metadata)
 
 
 def get_raise_signal():


### PR DESCRIPTION
This PR adds the backpressure feature (introduced in ARROW-13611) to the dataset write node (introduced in ARROW-13542).

To note: The python test here is unfortunately a bit slow for two reasons.  First, we don't make the "how many rows can the dataset writer hold before backpressure applies" option a configurable option (it's not clear in what circumstances a user would ever change it) and it defaults to 64Mi rows.

Second, there is no signal sent from the C++ side when backpressure has been applied.  So we are forced to poll and guess when it seems we have stopped reading from the source.

I'm open to suggestions (e.g. don't include the test, make the test a large memory test or something so it doesn't always run, any ideas we can use to test this better, etc.)