### PR TITLE
MINOR: [Docs] Fix names of compute functions in python/cpp docs

### DIFF
--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1032,7 +1032,7 @@ in reverse order.
 +--------------------------+------------+----------------+-----------------+--------------------------+---------+
 | Function name            | Arity      | Input types    | Output type     | Options class            | Notes   |
 +==========================+============+================+=================+==========================+=========+
-| utf8_slice_codepoints    | Unary      | String-like    | String-like     | :struct:`SliceOptions`   | \(1)    |
+| utf8_slice_codeunits     | Unary      | String-like    | String-like     | :struct:`SliceOptions`   | \(1)    |
 +--------------------------+------------+----------------+-----------------+--------------------------+---------+
 
 * \(1) Slice string into a substring defined by (``start``, ``stop``, ``step``)

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -60,9 +60,11 @@ Grouped Aggregations
    hash_mean
    hash_min
    hash_min_max
-   hash_min_sum
-   hash_min_tdigest
-   hash_min_variance
+   hash_product
+   hash_stddev
+   hash_sum
+   hash_tdigest
+   hash_variance
 
 Arithmetic Functions
 --------------------
@@ -342,7 +344,7 @@ String Slicing
 .. autosummary::
    :toctree: ../generated/
 
-   utf8_slice_codepoints
+   utf8_slice_codeunits
 
 Containment Tests
 -----------------


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow/pull/11237