### PR TITLE
ARROW-14216: [R] Disable auto-cleaning of duckdb tables

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -29,7 +29,7 @@
 #' @param table_name a name to use in DuckDB for this object. The default is a
 #' unique string `"arrow_"` followed by numbers.
 #' @param auto_disconnect should the table be automatically cleaned up when the
-#' resulting object is removed (and garbage collected)? Default: `TRUE`
+#' resulting object is removed (and garbage collected)? Default: `FALSE`
 #'
 #' @return A `tbl` of the new table in DuckDB
 #'
@@ -48,7 +48,7 @@
 to_duckdb <- function(.data,
                       con = arrow_duck_connection(),
                       table_name = unique_arrow_tablename(),
-                      auto_disconnect = TRUE) {
+                      auto_disconnect = FALSE) {
   .data <- as_adq(.data)
   duckdb::duckdb_register_arrow(con, table_name, .data)
 

--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -23,6 +23,13 @@
 #'
 #' The result is a dbplyr-compatible object that can be used in d(b)plyr pipelines.
 #'
+#' If `auto_disconnect = TRUE`, the DuckDB table that is created will be configured
+#' to be unregistered when the `tbl` object is garbage collected. This is helpful
+#' if you don't want to have extra table objects in DuckDB after you've finished
+#' using them. Currently, this cleanup can, however, sometimes lead to hangs if
+#' tables are created and deleted in quick succession, hence the default value
+#' of `FALSE`
+#'
 #' @param .data the Arrow object (e.g. Dataset, Table) to use for the DuckDB table
 #' @param con a DuckDB connection to use (default will create one and store it
 #' in `options("arrow_duck_con")`)

--- a/r/man/to_duckdb.Rd
+++ b/r/man/to_duckdb.Rd
@@ -8,7 +8,7 @@ to_duckdb(
   .data,
   con = arrow_duck_connection(),
   table_name = unique_arrow_tablename(),
-  auto_disconnect = TRUE
+  auto_disconnect = FALSE
 )
 }
 \arguments{
@@ -21,7 +21,7 @@ in \code{options("arrow_duck_con")})}
 unique string \code{"arrow_"} followed by numbers.}
 
 \item{auto_disconnect}{should the table be automatically cleaned up when the
-resulting object is removed (and garbage collected)? Default: \code{TRUE}}
+resulting object is removed (and garbage collected)? Default: \code{FALSE}}
 }
 \value{
 A \code{tbl} of the new table in DuckDB

--- a/r/man/to_duckdb.Rd
+++ b/r/man/to_duckdb.Rd
@@ -33,6 +33,13 @@ that is backed by the Arrow object given. No data is copied or modified until
 }
 \details{
 The result is a dbplyr-compatible object that can be used in d(b)plyr pipelines.
+
+If \code{auto_disconnect = TRUE}, the DuckDB table that is created will be configured
+to be unregistered when the \code{tbl} object is garbage collected. This is helpful
+if you don't want to have extra table objects in DuckDB after you've finished
+using them. Currently, this cleanup can, however, sometimes lead to hangs if
+tables are created and deleted in quick succession, hence the default value
+of \code{FALSE}
 }
 \examples{
 \dontshow{if (getFromNamespace("run_duckdb_examples", "arrow")()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -75,13 +75,13 @@ on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
 # write one table to the connection so it is kept open
 DBI::dbWriteTable(con, "mtcars", mtcars)
 
-test_that("Joining, auto-cleanup", {
+test_that("Joining, auto-cleanup enabled", {
   ds <- InMemoryDataset$create(example_data)
 
   table_one_name <- "my_arrow_table_1"
-  table_one <- to_duckdb(ds, con = con, table_name = table_one_name)
+  table_one <- to_duckdb(ds, con = con, table_name = table_one_name, auto_disconnect = TRUE)
   table_two_name <- "my_arrow_table_2"
-  table_two <- to_duckdb(ds, con = con, table_name = table_two_name)
+  table_two <- to_duckdb(ds, con = con, table_name = table_two_name, auto_disconnect = TRUE)
 
   res <- dbGetQuery(
     con,
@@ -100,11 +100,11 @@ test_that("Joining, auto-cleanup", {
   expect_false(any(c(table_one_name, table_two_name) %in% DBI::dbListTables(con)))
 })
 
-test_that("Joining, auto-cleanup disabling", {
+test_that("Joining, auto-cleanup disabled", {
   ds <- InMemoryDataset$create(example_data)
 
   table_three_name <- "my_arrow_table_3"
-  table_three <- to_duckdb(ds, con = con, table_name = table_three_name, auto_disconnect = FALSE)
+  table_three <- to_duckdb(ds, con = con, table_name = table_three_name)
 
   # clean up does *not* clean these tables
   expect_true(table_three_name %in% DBI::dbListTables(con))


### PR DESCRIPTION
Until DuckDB's unregister function can be called without a `SELECT` let's turn this off (but allow people to turn it on if they want)