### PR TITLE
ARROW-13804: [Go] Add Interval type Month, Day, Nano

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.6'
+      - name: Install pygit2 binary wheel
+        run: pip install pygit2 --only-binary pygit2
       - name: Install Archery, Crossbow- and Test Dependencies
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1589,7 +1589,7 @@ def get_generated_json_files(tempdir=None):
         .skip_category('Rust'),
 
         generate_month_day_nano_interval_case()
-        .skip_category('C#')        
+        .skip_category('C#')
         .skip_category('JS')
         .skip_category('Rust'),
 

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1562,8 +1562,7 @@ def get_generated_json_files(tempdir=None):
         .skip_category('JS'),
 
         generate_null_case([10, 0])
-        .skip_category('C#')
-        .skip_category('Go')    # TODO(ARROW-7901)
+        .skip_category('C#')        
         .skip_category('Go')    # TODO(ARROW-7901)
         .skip_category('JS'),   # TODO(ARROW-7900)
 

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1589,8 +1589,7 @@ def get_generated_json_files(tempdir=None):
         .skip_category('Rust'),
 
         generate_month_day_nano_interval_case()
-        .skip_category('C#')
-        .skip_category('Go')
+        .skip_category('C#')        
         .skip_category('JS')
         .skip_category('Rust'),
 

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1562,7 +1562,7 @@ def get_generated_json_files(tempdir=None):
         .skip_category('JS'),
 
         generate_null_case([10, 0])
-        .skip_category('C#')        
+        .skip_category('C#')
         .skip_category('Go')    # TODO(ARROW-7901)
         .skip_category('JS'),   # TODO(ARROW-7900)
 

--- a/go/arrow/array/array.go
+++ b/go/arrow/array/array.go
@@ -207,10 +207,10 @@ func init() {
 		arrow.LARGE_STRING:            unsupportedArrayType,
 		arrow.LARGE_BINARY:            unsupportedArrayType,
 		arrow.LARGE_LIST:              unsupportedArrayType,
-		arrow.INTERVAL_MONTH_DAY_NANO: unsupportedArrayType,
 		arrow.INTERVAL:                func(data *Data) Interface { return NewIntervalData(data) },
+		arrow.INTERVAL_MONTH_DAY_NANO: func(data *Data) Interface { return NewMonthDayNanoIntervalData(data) },
 
-		// invalid data types to fill out array size 2⁵-1
+		// invalid data types to fill out array to size 2^6 - 1
 		63: invalidDataType,
 	}
 }

--- a/go/arrow/array/array_test.go
+++ b/go/arrow/array/array_test.go
@@ -68,7 +68,8 @@ func TestMakeFromData(t *testing.T) {
 		{name: "time64", d: &testDataType{arrow.TIME64}},
 		{name: "month_interval", d: arrow.FixedWidthTypes.MonthInterval},
 		{name: "day_time_interval", d: arrow.FixedWidthTypes.DayTimeInterval},
-		{name: "decimal", d: &testDataType{arrow.DECIMAL128}},
+		{name: "decimal128", d: &testDataType{arrow.DECIMAL128}},
+		{name: "month_day_nano_interval", d: arrow.FixedWidthTypes.MonthDayNanoInterval},
 
 		{name: "list", d: &testDataType{arrow.LIST}, child: []*array.Data{
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),

--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -266,12 +266,15 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 			return NewDayTimeIntervalBuilder(mem)
 		case *arrow.MonthIntervalType:
 			return NewMonthIntervalBuilder(mem)
+		case *arrow.MonthDayNanoIntervalType:
+			return NewMonthDayNanoIntervalBuilder(mem)
 		}
 	case arrow.INTERVAL_MONTHS:
 		return NewMonthIntervalBuilder(mem)
 	case arrow.INTERVAL_DAY_TIME:
 		return NewDayTimeIntervalBuilder(mem)
 	case arrow.INTERVAL_MONTH_DAY_NANO:
+		return NewMonthDayNanoIntervalBuilder(mem)
 	case arrow.DECIMAL128:
 		if typ, ok := dtype.(*arrow.Decimal128Type); ok {
 			return NewDecimal128Builder(mem, typ)

--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -161,6 +161,9 @@ func ArrayEqual(left, right Interface) bool {
 	case *DayTimeInterval:
 		r := right.(*DayTimeInterval)
 		return arrayEqualDayTimeInterval(l, r)
+	case *MonthDayNanoInterval:
+		r := right.(*MonthDayNanoInterval)
+		return arrayEqualMonthDayNanoInterval(l, r)
 	case *Duration:
 		r := right.(*Duration)
 		return arrayEqualDuration(l, r)
@@ -355,6 +358,9 @@ func arrayApproxEqual(left, right Interface, opt equalOption) bool {
 	case *DayTimeInterval:
 		r := right.(*DayTimeInterval)
 		return arrayEqualDayTimeInterval(l, r)
+	case *MonthDayNanoInterval:
+		r := right.(*MonthDayNanoInterval)
+		return arrayEqualMonthDayNanoInterval(l, r)
 	case *Duration:
 		r := right.(*Duration)
 		return arrayEqualDuration(l, r)

--- a/go/arrow/array/interval_test.go
+++ b/go/arrow/array/interval_test.go
@@ -274,3 +274,128 @@ func TestDayTimeIntervalBuilder_Empty(t *testing.T) {
 	assert.Equal(t, want, dtValues(arr))
 	arr.Release()
 }
+
+func TestMonthDayNanoArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	var (
+		want   = []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}}
+		valids = []bool{true, true, false, true}
+	)
+
+	b := array.NewMonthDayNanoIntervalBuilder(mem)
+	defer b.Release()
+
+	b.Retain()
+	b.Release()
+
+	b.AppendValues(want[:2], nil)
+	b.AppendNull()
+	b.Append(want[3])
+
+	if got, want := b.Len(), len(want); got != want {
+		t.Fatalf("invalid len: got=%d, want=%d", got, want)
+	}
+
+	if got, want := b.NullN(), 1; got != want {
+		t.Fatalf("invalid nulls: got=%d, want=%d", got, want)
+	}
+
+	arr := b.NewMonthDayNanoIntervalArray()
+	defer arr.Release()
+
+	arr.Retain()
+	arr.Release()
+
+	if got, want := arr.Len(), len(want); got != want {
+		t.Fatalf("invalid len: got=%d, want=%d", got, want)
+	}
+
+	if got, want := arr.NullN(), 1; got != want {
+		t.Fatalf("invalid nulls: got=%d, want=%d", got, want)
+	}
+
+	for i := range want {
+		if arr.IsNull(i) != !valids[i] {
+			t.Fatalf("arr[%d]-validity: got=%v want=%v", i, !arr.IsNull(i), valids[i])
+		}
+		switch {
+		case arr.IsNull(i):
+		default:
+			got := arr.Value(i)
+			if got != want[i] {
+				t.Fatalf("arr[%d]: got=%q, want=%q", i, got, want[i])
+			}
+		}
+	}
+
+	sub := array.MakeFromData(arr.Data())
+	defer sub.Release()
+
+	if sub.DataType().ID() != arrow.INTERVAL_MONTH_DAY_NANO {
+		t.Fatalf("invalid type: got=%q, want=interval", sub.DataType().Name())
+	}
+
+	if _, ok := sub.(*array.MonthDayNanoInterval); !ok {
+		t.Fatalf("could not type-assert to array.MonthDayNanoInterval")
+	}
+
+	if got, want := arr.String(), `[{1 1 1000} {2 2 2000} (null) {4 4 4000}]`; got != want {
+		t.Fatalf("got=%q, want=%q", got, want)
+	}
+	slice := array.NewSliceData(arr.Data(), 2, 4)
+	defer slice.Release()
+
+	sub1 := array.MakeFromData(slice)
+	defer sub1.Release()
+
+	v, ok := sub1.(*array.MonthDayNanoInterval)
+	if !ok {
+		t.Fatalf("could not type-assert to array.MonthDayNanoInterval")
+	}
+
+	if got, want := v.String(), `[(null) {4 4 4000}]`; got != want {
+		t.Fatalf("got=%q, want=%q", got, want)
+	}
+}
+
+func TestMonthDayNanoIntervalBuilder_Empty(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	want := []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}}
+
+	b := array.NewMonthDayNanoIntervalBuilder(mem)
+	defer b.Release()
+
+	dtValues := func(a *array.MonthDayNanoInterval) []arrow.MonthDayNanoInterval {
+		vs := make([]arrow.MonthDayNanoInterval, a.Len())
+		for i := range vs {
+			vs[i] = a.Value(i)
+		}
+		return vs
+	}
+
+	b.AppendValues([]arrow.MonthDayNanoInterval{}, nil)
+	arr := b.NewMonthDayNanoIntervalArray()
+	assert.Zero(t, arr.Len())
+	arr.Release()
+
+	b.AppendValues(nil, nil)
+	arr = b.NewMonthDayNanoIntervalArray()
+	assert.Zero(t, arr.Len())
+	arr.Release()
+
+	b.AppendValues([]arrow.MonthDayNanoInterval{}, nil)
+	b.AppendValues(want, nil)
+	arr = b.NewMonthDayNanoIntervalArray()
+	assert.Equal(t, want, dtValues(arr))
+	arr.Release()
+
+	b.AppendValues(want, nil)
+	b.AppendValues([]arrow.MonthDayNanoInterval{}, nil)
+	arr = b.NewMonthDayNanoIntervalArray()
+	assert.Equal(t, want, dtValues(arr))
+	arr.Release()
+}

--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -87,6 +87,7 @@ var formatToSimpleType = map[string]arrow.DataType{
 	"tDn": arrow.FixedWidthTypes.Duration_ns,
 	"tiM": arrow.FixedWidthTypes.MonthInterval,
 	"tiD": arrow.FixedWidthTypes.DayTimeInterval,
+	"tin": arrow.FixedWidthTypes.MonthDayNanoInterval,
 }
 
 // decode metadata from C which is encoded as

--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -208,6 +208,8 @@ func (exp *schemaExporter) exportFormat(dt arrow.DataType) string {
 		return "tiM"
 	case *arrow.DayTimeIntervalType:
 		return "tiD"
+	case *arrow.MonthDayNanoIntervalType:
+		return "tin"
 	case *arrow.ListType:
 		return "+l"
 	case *arrow.FixedSizeListType:

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -149,7 +149,7 @@ func TestImportTemporalSchema(t *testing.T) {
 		{arrow.FixedWidthTypes.Duration_ns, "tDn"},
 		{arrow.FixedWidthTypes.MonthInterval, "tiM"},
 		{arrow.FixedWidthTypes.DayTimeInterval, "tiD"},
-		{arrow.FixedWidthTypes.MonthDayNanoInterval, "tin"}
+		{arrow.FixedWidthTypes.MonthDayNanoInterval, "tin"},
 		{arrow.FixedWidthTypes.Timestamp_s, "tss:"},
 		{&arrow.TimestampType{Unit: arrow.Second, TimeZone: "Europe/Paris"}, "tss:Europe/Paris"},
 		{arrow.FixedWidthTypes.Timestamp_ms, "tsm:"},

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -149,6 +149,7 @@ func TestImportTemporalSchema(t *testing.T) {
 		{arrow.FixedWidthTypes.Duration_ns, "tDn"},
 		{arrow.FixedWidthTypes.MonthInterval, "tiM"},
 		{arrow.FixedWidthTypes.DayTimeInterval, "tiD"},
+		{arrow.FixedWidthTypes.MonthDayNanoInterval, "tin"}
 		{arrow.FixedWidthTypes.Timestamp_s, "tss:"},
 		{&arrow.TimestampType{Unit: arrow.Second, TimeZone: "Europe/Paris"}, "tss:Europe/Paris"},
 		{arrow.FixedWidthTypes.Timestamp_ms, "tsm:"},

--- a/go/arrow/datatype_fixedwidth.go
+++ b/go/arrow/datatype_fixedwidth.go
@@ -150,7 +150,7 @@ type Decimal128Type struct {
 	Scale     int32
 }
 
-func (*Decimal128Type) ID() Type      { return DECIMAL }
+func (*Decimal128Type) ID() Type      { return DECIMAL128 }
 func (*Decimal128Type) Name() string  { return "decimal" }
 func (*Decimal128Type) BitWidth() int { return 128 }
 func (t *Decimal128Type) String() string {
@@ -193,45 +193,69 @@ func (*DayTimeIntervalType) Fingerprint() string { return typeIDFingerprint(INTE
 // BitWidth returns the number of bits required to store a single element of this data type in memory.
 func (t *DayTimeIntervalType) BitWidth() int { return 64 }
 
+// MonthDayNanoInterval represents a number of months, days and nanoseconds (fraction of day).
+type MonthDayNanoInterval struct {
+	Months      int32 `json:"months"`
+	Days        int32 `json:"days"`
+	Nanoseconds int64 `json:"nanoseconds"`
+}
+
+// MonthDayNanoIntervalType is encoded as two signed 32-bit integers representing
+// a number of months and a number of days, followed by a 64-bit integer representing
+// the number of nanoseconds since midnight for fractions of a day.
+type MonthDayNanoIntervalType struct{}
+
+func (*MonthDayNanoIntervalType) ID() Type       { return INTERVAL_MONTH_DAY_NANO }
+func (*MonthDayNanoIntervalType) Name() string   { return "month_day_nano_interval" }
+func (*MonthDayNanoIntervalType) String() string { return "month_day_nano_interval" }
+func (*MonthDayNanoIntervalType) Fingerprint() string {
+	return typeIDFingerprint(INTERVAL_MONTH_DAY_NANO) + "N"
+}
+
+// BitWidth returns the number of bits required to store a single element of this data type in memory.
+func (*MonthDayNanoIntervalType) BitWidth() int { return 128 }
+
 var (
 	FixedWidthTypes = struct {
-		Boolean         FixedWidthDataType
-		Date32          FixedWidthDataType
-		Date64          FixedWidthDataType
-		DayTimeInterval FixedWidthDataType
-		Duration_s      FixedWidthDataType
-		Duration_ms     FixedWidthDataType
-		Duration_us     FixedWidthDataType
-		Duration_ns     FixedWidthDataType
-		Float16         FixedWidthDataType
-		MonthInterval   FixedWidthDataType
-		Time32s         FixedWidthDataType
-		Time32ms        FixedWidthDataType
-		Time64us        FixedWidthDataType
-		Time64ns        FixedWidthDataType
-		Timestamp_s     FixedWidthDataType
-		Timestamp_ms    FixedWidthDataType
-		Timestamp_us    FixedWidthDataType
-		Timestamp_ns    FixedWidthDataType
+		Boolean              FixedWidthDataType
+		Date32               FixedWidthDataType
+		Date64               FixedWidthDataType
+		DayTimeInterval      FixedWidthDataType
+		Duration_s           FixedWidthDataType
+		Duration_ms          FixedWidthDataType
+		Duration_us          FixedWidthDataType
+		Duration_ns          FixedWidthDataType
+		Float16              FixedWidthDataType
+		MonthInterval        FixedWidthDataType
+		Time32s              FixedWidthDataType
+		Time32ms             FixedWidthDataType
+		Time64us             FixedWidthDataType
+		Time64ns             FixedWidthDataType
+		Timestamp_s          FixedWidthDataType
+		Timestamp_ms         FixedWidthDataType
+		Timestamp_us         FixedWidthDataType
+		Timestamp_ns         FixedWidthDataType
+		MonthDayNanoInterval FixedWidthDataType
 	}{
-		Boolean:         &BooleanType{},
-		Date32:          &Date32Type{},
-		Date64:          &Date64Type{},
-		DayTimeInterval: &DayTimeIntervalType{},
-		Duration_s:      &DurationType{Unit: Second},
-		Duration_ms:     &DurationType{Unit: Millisecond},
-		Duration_us:     &DurationType{Unit: Microsecond},
-		Duration_ns:     &DurationType{Unit: Nanosecond},
-		Float16:         &Float16Type{},
-		MonthInterval:   &MonthIntervalType{},
-		Time32s:         &Time32Type{Unit: Second},
-		Time32ms:        &Time32Type{Unit: Millisecond},
-		Time64us:        &Time64Type{Unit: Microsecond},
-		Time64ns:        &Time64Type{Unit: Nanosecond},
-		Timestamp_s:     &TimestampType{Unit: Second, TimeZone: "UTC"},
-		Timestamp_ms:    &TimestampType{Unit: Millisecond, TimeZone: "UTC"},
-		Timestamp_us:    &TimestampType{Unit: Microsecond, TimeZone: "UTC"},
-		Timestamp_ns:    &TimestampType{Unit: Nanosecond, TimeZone: "UTC"},
+		Boolean:              &BooleanType{},
+		Date32:               &Date32Type{},
+		Date64:               &Date64Type{},
+		DayTimeInterval:      &DayTimeIntervalType{},
+		Duration_s:           &DurationType{Unit: Second},
+		Duration_ms:          &DurationType{Unit: Millisecond},
+		Duration_us:          &DurationType{Unit: Microsecond},
+		Duration_ns:          &DurationType{Unit: Nanosecond},
+		Float16:              &Float16Type{},
+		MonthInterval:        &MonthIntervalType{},
+		Time32s:              &Time32Type{Unit: Second},
+		Time32ms:             &Time32Type{Unit: Millisecond},
+		Time64us:             &Time64Type{Unit: Microsecond},
+		Time64ns:             &Time64Type{Unit: Nanosecond},
+		Timestamp_s:          &TimestampType{Unit: Second, TimeZone: "UTC"},
+		Timestamp_ms:         &TimestampType{Unit: Millisecond, TimeZone: "UTC"},
+		Timestamp_us:         &TimestampType{Unit: Microsecond, TimeZone: "UTC"},
+		Timestamp_ns:         &TimestampType{Unit: Nanosecond, TimeZone: "UTC"},
+		MonthDayNanoInterval: &MonthDayNanoIntervalType{},
 	}
 
 	_ FixedWidthDataType = (*FixedSizeBinaryType)(nil)

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -553,6 +553,7 @@ func makeIntervalsRecords() []array.Record {
 		[]arrow.Field{
 			arrow.Field{Name: "months", Type: arrow.FixedWidthTypes.MonthInterval, Nullable: true},
 			arrow.Field{Name: "days", Type: arrow.FixedWidthTypes.DayTimeInterval, Nullable: true},
+			arrow.Field{Name: "nanos", Type: arrow.FixedWidthTypes.MonthDayNanoInterval, Nullable: true},
 		}, nil,
 	)
 

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -561,14 +561,17 @@ func makeIntervalsRecords() []array.Record {
 		[]array.Interface{
 			arrayOf(mem, []arrow.MonthInterval{1, 2, 3, 4, 5}, mask),
 			arrayOf(mem, []arrow.DayTimeInterval{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}, mask),
+			arrayOf(mem, []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}, {5, 5, 5000}}, mask),
 		},
 		[]array.Interface{
 			arrayOf(mem, []arrow.MonthInterval{11, 12, 13, 14, 15}, mask),
 			arrayOf(mem, []arrow.DayTimeInterval{{11, 11}, {12, 12}, {13, 13}, {14, 14}, {15, 15}}, mask),
+			arrayOf(mem, []arrow.MonthDayNanoInterval{{11, 11, 11000}, {12, 12, 12000}, {13, 13, 13000}, {14, 14, 14000}, {15, 15, 15000}}, mask),
 		},
 		[]array.Interface{
 			arrayOf(mem, []arrow.MonthInterval{21, 22, 23, 24, 25}, mask),
 			arrayOf(mem, []arrow.DayTimeInterval{{21, 21}, {22, 22}, {23, 23}, {24, 24}, {25, 25}}, mask),
+			arrayOf(mem, []arrow.MonthDayNanoInterval{{21, 21, 21000}, {22, 22, 22000}, {23, 23, 23000}, {24, 24, 24000}, {25, 25, 25000}}, mask),
 		},
 	}
 
@@ -1148,6 +1151,13 @@ func arrayOf(mem memory.Allocator, a interface{}, valids []bool) array.Interface
 
 	case []arrow.DayTimeInterval:
 		bldr := array.NewDayTimeIntervalBuilder(mem)
+		defer bldr.Release()
+
+		bldr.AppendValues(a, valids)
+		return bldr.NewArray()
+
+	case []arrow.MonthDayNanoInterval:
+		bldr := array.NewMonthDayNanoIntervalBuilder(mem)
 		defer bldr.Release()
 
 		bldr.AppendValues(a, valids)

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -565,14 +565,14 @@ func makeIntervalsRecords() []array.Record {
 			arrayOf(mem, []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}, {5, 5, 5000}}, mask),
 		},
 		[]array.Interface{
-			arrayOf(mem, []arrow.MonthInterval{11, 12, 13, 14, 15}, mask),
-			arrayOf(mem, []arrow.DayTimeInterval{{11, 11}, {12, 12}, {13, 13}, {14, 14}, {15, 15}}, mask),
-			arrayOf(mem, []arrow.MonthDayNanoInterval{{11, 11, 11000}, {12, 12, 12000}, {13, 13, 13000}, {14, 14, 14000}, {15, 15, 15000}}, mask),
+			arrayOf(mem, []arrow.MonthInterval{-11, -12, -13, -14, -15}, mask),
+			arrayOf(mem, []arrow.DayTimeInterval{{-11, -11}, {-12, -12}, {-13, -13}, {-14, -14}, {-15, -15}}, mask),
+			arrayOf(mem, []arrow.MonthDayNanoInterval{{-11, -11, -11000}, {-12, -12, -12000}, {-13, -13, -13000}, {-14, -14, -14000}, {-15, -15, -15000}}, mask),
 		},
 		[]array.Interface{
-			arrayOf(mem, []arrow.MonthInterval{21, 22, 23, 24, 25}, mask),
-			arrayOf(mem, []arrow.DayTimeInterval{{21, 21}, {22, 22}, {23, 23}, {24, 24}, {25, 25}}, mask),
-			arrayOf(mem, []arrow.MonthDayNanoInterval{{21, 21, 21000}, {22, 22, 22000}, {23, 23, 23000}, {24, 24, 24000}, {25, 25, 25000}}, mask),
+			arrayOf(mem, []arrow.MonthInterval{21, 22, 23, 24, 25, 0}, append(mask, true)),
+			arrayOf(mem, []arrow.DayTimeInterval{{21, 21}, {22, 22}, {23, 23}, {24, 24}, {25, 25}, {0, 0}}, append(mask, true)),
+			arrayOf(mem, []arrow.MonthDayNanoInterval{{21, 21, 21000}, {22, 22, 22000}, {23, 23, 23000}, {24, 24, 24000}, {25, 25, 25000}, {0, 0, 0}}, append(mask, true)),
 		},
 	}
 

--- a/go/arrow/internal/arrjson/arrjson_test.go
+++ b/go/arrow/internal/arrjson/arrjson_test.go
@@ -2673,6 +2673,15 @@ func makeIntervalsWantJSONs() string {
         },
         "nullable": true,
         "children": []
+      },
+      {
+        "name": "nanos",
+        "type": {
+          "name": "interval",
+          "unit": "MONTH_DAY_NANO"
+        },
+        "nullable": true,
+        "children": []
       }
     ]
   },
@@ -2728,6 +2737,44 @@ func makeIntervalsWantJSONs() string {
             {
               "days": 5,
               "milliseconds": 5
+            }
+          ]
+        },
+        {
+          "name": "nanos",
+          "count": 5,
+          "VALIDITY": [
+            1,
+            0,
+            0,
+            1,
+            1
+          ],
+          "DATA": [
+            {
+              "months": 1,
+              "days": 1,
+              "nanoseconds": 1000
+            },
+            {
+              "months": 2,
+              "days": 2,
+              "nanoseconds": 2000
+            },
+            {
+              "months": 3,
+              "days": 3,
+              "nanoseconds": 3000
+            },
+            {
+              "months": 4,
+              "days": 4,
+              "nanoseconds": 4000
+            },
+            {
+              "months": 5,
+              "days": 5,
+              "nanoseconds": 5000
             }
           ]
         }
@@ -2786,6 +2833,44 @@ func makeIntervalsWantJSONs() string {
               "milliseconds": 15
             }
           ]
+        },
+        {
+          "name": "nanos",
+          "count": 5,
+          "VALIDITY": [
+            1,
+            0,
+            0,
+            1,
+            1
+          ],
+          "DATA": [
+            {
+              "months": 11,
+              "days": 11,
+              "nanoseconds": 11000
+            },
+            {
+              "months": 12,
+              "days": 12,
+              "nanoseconds": 12000
+            },
+            {
+              "months": 13,
+              "days": 13,
+              "nanoseconds": 13000
+            },
+            {
+              "months": 14,
+              "days": 14,
+              "nanoseconds": 14000
+            },
+            {
+              "months": 15,
+              "days": 15,
+              "nanoseconds": 15000
+            }
+          ]
         }
       ]
     },
@@ -2840,6 +2925,44 @@ func makeIntervalsWantJSONs() string {
             {
               "days": 25,
               "milliseconds": 25
+            }
+          ]
+        },
+        {
+          "name": "nanos",
+          "count": 5,
+          "VALIDITY": [
+            1,
+            0,
+            0,
+            1,
+            1
+          ],
+          "DATA": [
+            {
+              "months": 21,
+              "days": 21,
+              "nanoseconds": 21000
+            },
+            {
+              "months": 22,
+              "days": 22,
+              "nanoseconds": 22000
+            },
+            {
+              "months": 23,
+              "days": 23,
+              "nanoseconds": 23000
+            },
+            {
+              "months": 24,
+              "days": 24,
+              "nanoseconds": 24000
+            },
+            {
+              "months": 25,
+              "days": 25,
+              "nanoseconds": 25000
             }
           ]
         }

--- a/go/arrow/internal/arrjson/arrjson_test.go
+++ b/go/arrow/internal/arrjson/arrjson_test.go
@@ -2794,11 +2794,11 @@ func makeIntervalsWantJSONs() string {
             1
           ],
           "DATA": [
-            11,
-            12,
-            13,
-            14,
-            15
+            -11,
+            -12,
+            -13,
+            -14,
+            -15
           ]
         },
         {
@@ -2813,24 +2813,24 @@ func makeIntervalsWantJSONs() string {
           ],
           "DATA": [
             {
-              "days": 11,
-              "milliseconds": 11
+              "days": -11,
+              "milliseconds": -11
             },
             {
-              "days": 12,
-              "milliseconds": 12
+              "days": -12,
+              "milliseconds": -12
             },
             {
-              "days": 13,
-              "milliseconds": 13
+              "days": -13,
+              "milliseconds": -13
             },
             {
-              "days": 14,
-              "milliseconds": 14
+              "days": -14,
+              "milliseconds": -14
             },
             {
-              "days": 15,
-              "milliseconds": 15
+              "days": -15,
+              "milliseconds": -15
             }
           ]
         },
@@ -2846,44 +2846,45 @@ func makeIntervalsWantJSONs() string {
           ],
           "DATA": [
             {
-              "months": 11,
-              "days": 11,
-              "nanoseconds": 11000
+              "months": -11,
+              "days": -11,
+              "nanoseconds": -11000
             },
             {
-              "months": 12,
-              "days": 12,
-              "nanoseconds": 12000
+              "months": -12,
+              "days": -12,
+              "nanoseconds": -12000
             },
             {
-              "months": 13,
-              "days": 13,
-              "nanoseconds": 13000
+              "months": -13,
+              "days": -13,
+              "nanoseconds": -13000
             },
             {
-              "months": 14,
-              "days": 14,
-              "nanoseconds": 14000
+              "months": -14,
+              "days": -14,
+              "nanoseconds": -14000
             },
             {
-              "months": 15,
-              "days": 15,
-              "nanoseconds": 15000
+              "months": -15,
+              "days": -15,
+              "nanoseconds": -15000
             }
           ]
         }
       ]
     },
     {
-      "count": 5,
+      "count": 6,
       "columns": [
         {
           "name": "months",
-          "count": 5,
+          "count": 6,
           "VALIDITY": [
             1,
             0,
             0,
+            1,
             1,
             1
           ],
@@ -2892,16 +2893,18 @@ func makeIntervalsWantJSONs() string {
             22,
             23,
             24,
-            25
+            25,
+            0
           ]
         },
         {
           "name": "days",
-          "count": 5,
+          "count": 6,
           "VALIDITY": [
             1,
             0,
             0,
+            1,
             1,
             1
           ],
@@ -2925,16 +2928,21 @@ func makeIntervalsWantJSONs() string {
             {
               "days": 25,
               "milliseconds": 25
+            },
+            {
+              "days": 0,
+              "milliseconds": 0
             }
           ]
         },
         {
           "name": "nanos",
-          "count": 5,
+          "count": 6,
           "VALIDITY": [
             1,
             0,
             0,
+            1,
             1,
             1
           ],
@@ -2963,6 +2971,11 @@ func makeIntervalsWantJSONs() string {
               "months": 25,
               "days": 25,
               "nanoseconds": 25000
+            },
+            {
+              "months": 0,
+              "days": 0,
+              "nanoseconds": 0
             }
           ]
         }

--- a/go/arrow/internal/flight_integration/cmd/arrow-flight-integration-server/main.go
+++ b/go/arrow/internal/flight_integration/cmd/arrow-flight-integration-server/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	s := flight_integration.GetScenario(*scenario)
 	srv := s.MakeServer(*port)
-	srv.Init(fmt.Sprintf("0.0.0.0:%d", *port))
 	srv.SetShutdownOnSignals(syscall.SIGTERM, os.Interrupt)
 	_, p, _ := net.SplitHostPort(srv.Addr().String())
 	fmt.Printf("Server listening on localhost:%s\n", p)

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -430,7 +430,7 @@ func (ctx *arrayLoaderContext) loadArray(dt arrow.DataType) array.Interface {
 		*arrow.Time32Type, *arrow.Time64Type,
 		*arrow.TimestampType,
 		*arrow.Date32Type, *arrow.Date64Type,
-		*arrow.MonthIntervalType, *arrow.DayTimeIntervalType,
+		*arrow.MonthIntervalType, *arrow.DayTimeIntervalType, *arrow.MonthDayNanoIntervalType,
 		*arrow.DurationType:
 		return ctx.loadPrimitive(dt)
 

--- a/go/arrow/ipc/metadata.go
+++ b/go/arrow/ipc/metadata.go
@@ -370,6 +370,12 @@ func (fv *fieldVisitor) visit(field arrow.Field) {
 		flatbuf.IntervalAddUnit(fv.b, flatbuf.IntervalUnitDAY_TIME)
 		fv.offset = flatbuf.IntervalEnd(fv.b)
 
+	case *arrow.MonthDayNanoIntervalType:
+		fv.dtype = flatbuf.TypeInterval
+		flatbuf.IntervalStart(fv.b)
+		flatbuf.IntervalAddUnit(fv.b, flatbuf.IntervalUnitMONTH_DAY_NANO)
+		fv.offset = flatbuf.IntervalEnd(fv.b)
+
 	case *arrow.DurationType:
 		fv.dtype = flatbuf.TypeDuration
 		unit := unitToFB(dt.Unit)
@@ -806,6 +812,8 @@ func intervalFromFB(data flatbuf.Interval) (arrow.DataType, error) {
 		return arrow.FixedWidthTypes.MonthInterval, nil
 	case flatbuf.IntervalUnitDAY_TIME:
 		return arrow.FixedWidthTypes.DayTimeInterval, nil
+	case flatbuf.IntervalUnitMONTH_DAY_NANO:
+		return arrow.FixedWidthTypes.MonthDayNanoInterval, nil
 	}
 	return nil, xerrors.Errorf("arrow/ipc: Interval type with %d unit not implemented", data.Unit())
 }

--- a/go/arrow/scalar/parse.go
+++ b/go/arrow/scalar/parse.go
@@ -150,6 +150,8 @@ func MakeScalar(val interface{}) Scalar {
 		return NewMonthIntervalScalar(v)
 	case arrow.DayTimeInterval:
 		return NewDayTimeIntervalScalar(v)
+	case arrow.MonthDayNanoInterval:
+		return NewMonthDayNanoIntervalScalar(v)
 	case arrow.DataType:
 		return MakeNullScalar(v)
 	}

--- a/go/arrow/scalar/scalar.go
+++ b/go/arrow/scalar/scalar.go
@@ -777,6 +777,8 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 		out ^= Hash(seed, s.Value)
 	case *DayTimeInterval:
 		return valueHash(s.Value.Days) & valueHash(s.Value.Milliseconds)
+	case *MonthDayNanoInterval:
+		return valueHash(s.Value.Months) & valueHash(s.Value.Days) & valueHash(s.Value.Nanoseconds)
 	case PrimitiveScalar:
 		h.Write(s.Data())
 		hash()

--- a/go/arrow/scalar/scalar.go
+++ b/go/arrow/scalar/scalar.go
@@ -295,7 +295,7 @@ func (s *Decimal128) CastTo(to arrow.DataType) (Scalar, error) {
 	}
 
 	switch to.ID() {
-	case arrow.DECIMAL:
+	case arrow.DECIMAL128:
 		return NewDecimal128Scalar(s.Value, to), nil
 	case arrow.STRING:
 		dt := s.Type.(*arrow.Decimal128Type)
@@ -431,10 +431,14 @@ func init() {
 			if arrow.TypeEqual(dt, arrow.FixedWidthTypes.MonthInterval) {
 				return &MonthInterval{scalar: scalar{dt, false}}
 			}
+			if arrow.TypeEqual(dt, arrow.FixedWidthTypes.MonthDayNanoInterval) {
+				return &MonthDayNanoInterval{scalar: scalar{dt, false}}
+			}
 			return &DayTimeInterval{scalar: scalar{dt, false}}
 		},
 		arrow.INTERVAL_MONTHS:         func(dt arrow.DataType) Scalar { return &MonthInterval{scalar: scalar{dt, false}} },
 		arrow.INTERVAL_DAY_TIME:       func(dt arrow.DataType) Scalar { return &DayTimeInterval{scalar: scalar{dt, false}} },
+		arrow.INTERVAL_MONTH_DAY_NANO: func(dt arrow.DataType) Scalar { return &MonthDayNanoInterval{scalar: scalar{dt, false}} },
 		arrow.DECIMAL128:              func(dt arrow.DataType) Scalar { return &Decimal128{scalar: scalar{dt, false}} },
 		arrow.LIST:                    func(dt arrow.DataType) Scalar { return &List{scalar: scalar{dt, false}} },
 		arrow.STRUCT:                  func(dt arrow.DataType) Scalar { return &Struct{scalar: scalar{dt, false}} },
@@ -449,9 +453,7 @@ func init() {
 		arrow.EXTENSION:               func(dt arrow.DataType) Scalar { return &Extension{scalar: scalar{dt, false}} },
 		arrow.FIXED_SIZE_LIST:         func(dt arrow.DataType) Scalar { return &FixedSizeList{&List{scalar: scalar{dt, false}}} },
 		arrow.DURATION:                func(dt arrow.DataType) Scalar { return &Duration{scalar: scalar{dt, false}} },
-		arrow.INTERVAL_MONTH_DAY_NANO: unsupportedScalarType,
-
-		// invalid data types to fill out array size 2⁵-1
+		// invalid data types to fill out array size 2^6 - 1
 		63: invalidScalarType,
 	}
 
@@ -530,6 +532,8 @@ func GetScalar(arr array.Interface, idx int) (Scalar, error) {
 		return NewMapScalar(slice), nil
 	case *array.MonthInterval:
 		return NewMonthIntervalScalar(arr.Value(idx)), nil
+	case *array.MonthDayNanoInterval:
+		return NewMonthDayNanoIntervalScalar(arr.Value(idx)), nil
 	case *array.Null:
 		return ScalarNull, nil
 	case *array.String:

--- a/go/arrow/scalar/scalar_test.go
+++ b/go/arrow/scalar/scalar_test.go
@@ -493,6 +493,31 @@ func TestDayTimeIntervalScalarBasics(t *testing.T) {
 	assert.False(t, scalar.Equals(tsNull, tsVal2))
 }
 
+func TestMonthDayNanoIntervalScalarBasics(t *testing.T) {
+	typ := arrow.FixedWidthTypes.MonthDayNanoInterval
+
+	val1 := arrow.MonthDayNanoInterval{Months: 1, Days: 2, Nanoseconds: 3000}
+	val2 := arrow.MonthDayNanoInterval{Months: 2, Days: 3, Nanoseconds: 4000}
+	tsVal1 := scalar.NewMonthDayNanoIntervalScalar(val1)
+	tsVal2 := scalar.NewMonthDayNanoIntervalScalar(val2)
+	tsNull := scalar.MakeNullScalar(typ)
+	assert.NoError(t, tsVal1.ValidateFull())
+	assert.NoError(t, tsVal2.ValidateFull())
+	assert.NoError(t, tsNull.ValidateFull())
+
+	assert.Equal(t, val1, tsVal1.Value)
+
+	assert.True(t, arrow.TypeEqual(tsVal1.Type, typ))
+	assert.True(t, arrow.TypeEqual(tsVal2.DataType(), typ))
+	assert.True(t, tsVal1.Valid)
+	assert.False(t, tsNull.IsValid())
+	assert.True(t, arrow.TypeEqual(typ, tsNull.DataType()))
+
+	assert.False(t, scalar.Equals(tsVal1, tsVal2))
+	assert.False(t, scalar.Equals(tsVal1, tsNull))
+	assert.False(t, scalar.Equals(tsNull, tsVal2))
+}
+
 func TestNumericScalarCasts(t *testing.T) {
 	tests := []arrow.DataType{
 		arrow.PrimitiveTypes.Int8,
@@ -793,6 +818,7 @@ func TestStructScalarValidateErrors(t *testing.T) {
 func getScalars(mem memory.Allocator) []scalar.Scalar {
 	hello := memory.NewBufferBytes([]byte("hello"))
 	daytime := arrow.DayTimeInterval{Days: 1, Milliseconds: 100}
+	monthdaynano := arrow.MonthDayNanoInterval{Months: 5, Days: 4, Nanoseconds: 100}
 
 	int8Bldr := array.NewInt8Builder(mem)
 	defer int8Bldr.Release()
@@ -828,6 +854,7 @@ func getScalars(mem memory.Allocator) []scalar.Scalar {
 		scalar.NewTimestampScalar(111, arrow.FixedWidthTypes.Timestamp_ms),
 		scalar.NewMonthIntervalScalar(1),
 		scalar.NewDayTimeIntervalScalar(daytime),
+		scalar.NewMonthDayNanoIntervalScalar(monthdaynano),
 		scalar.NewDurationScalar(60, arrow.FixedWidthTypes.Duration_s),
 		scalar.NewBinaryScalar(hello, arrow.BinaryTypes.Binary),
 		scalar.NewFixedSizeBinaryScalar(hello, &arrow.FixedSizeBinaryType{ByteWidth: hello.Len()}),

--- a/go/arrow/scalar/temporal.go
+++ b/go/arrow/scalar/temporal.go
@@ -464,6 +464,48 @@ func NewDayTimeIntervalScalar(val arrow.DayTimeInterval) *DayTimeInterval {
 	return &DayTimeInterval{scalar{arrow.FixedWidthTypes.DayTimeInterval, true}, val}
 }
 
+type MonthDayNanoInterval struct {
+	scalar
+	Value arrow.MonthDayNanoInterval
+}
+
+func (MonthDayNanoInterval) temporal()             {}
+func (MonthDayNanoInterval) interval()             {}
+func (s *MonthDayNanoInterval) value() interface{} { return s.Value }
+func (s *MonthDayNanoInterval) Data() []byte {
+	return (*[arrow.MonthDayNanoIntervalSizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
+}
+func (s *MonthDayNanoInterval) String() string {
+	if !s.Valid {
+		return "null"
+	}
+	val, err := s.CastTo(arrow.BinaryTypes.String)
+	if err != nil {
+		return "..."
+	}
+	return string(val.(*String).Value.Bytes())
+}
+
+func (s *MonthDayNanoInterval) CastTo(to arrow.DataType) (Scalar, error) {
+	if !s.Valid {
+		return MakeNullScalar(to), nil
+	}
+
+	if !arrow.TypeEqual(s.DataType(), to) {
+		return nil, xerrors.Errorf("non-null month_day_nano_interval scalar cannot be cast to anything other than monthinterval")
+	}
+
+	return s, nil
+}
+
+func (s *MonthDayNanoInterval) equals(rhs Scalar) bool {
+	return s.Value == rhs.(*MonthDayNanoInterval).Value
+}
+
+func NewMonthDayNanoIntervalScalar(val arrow.MonthDayNanoInterval) *MonthDayNanoInterval {
+	return &MonthDayNanoInterval{scalar{arrow.FixedWidthTypes.MonthDayNanoInterval, true}, val}
+}
+
 var (
 	_ Scalar = (*Date32)(nil)
 )

--- a/go/arrow/type_traits_interval.go
+++ b/go/arrow/type_traits_interval.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	MonthIntervalTraits   monthTraits
-	DayTimeIntervalTraits daytimeTraits
+	MonthIntervalTraits        monthTraits
+	DayTimeIntervalTraits      daytimeTraits
+	MonthDayNanoIntervalTraits monthDayNanoTraits
 )
 
 // MonthInterval traits
@@ -124,3 +125,53 @@ func (daytimeTraits) CastToBytes(b []DayTimeInterval) []byte {
 
 // Copy copies src to dst.
 func (daytimeTraits) Copy(dst, src []DayTimeInterval) { copy(dst, src) }
+
+// DayTimeInterval traits
+
+const (
+	// MonthDayNanoIntervalSizeBytes specifies the number of bytes required to store a single DayTimeInterval in memory
+	MonthDayNanoIntervalSizeBytes = int(unsafe.Sizeof(MonthDayNanoInterval{}))
+)
+
+type monthDayNanoTraits struct{}
+
+// BytesRequired returns the number of bytes required to store n elements in memory.
+func (monthDayNanoTraits) BytesRequired(n int) int { return MonthDayNanoIntervalSizeBytes * n }
+
+// PutValue
+func (monthDayNanoTraits) PutValue(b []byte, v MonthDayNanoInterval) {
+	endian.Native.PutUint32(b[0:4], uint32(v.Months))
+	endian.Native.PutUint32(b[4:8], uint32(v.Days))
+	endian.Native.PutUint64(b[8:], uint64(v.Nanoseconds))
+}
+
+// CastFromBytes reinterprets the slice b to a slice of type MonthDayNanoInterval.
+//
+// NOTE: len(b) must be a multiple of MonthDayNanoIntervalSizeBytes.
+func (monthDayNanoTraits) CastFromBytes(b []byte) []MonthDayNanoInterval {
+	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+
+	var res []MonthDayNanoInterval
+	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
+	s.Data = h.Data
+	s.Len = h.Len / MonthDayNanoIntervalSizeBytes
+	s.Cap = h.Cap / MonthDayNanoIntervalSizeBytes
+
+	return res
+}
+
+// CastToBytes reinterprets the slice b to a slice of bytes.
+func (monthDayNanoTraits) CastToBytes(b []MonthDayNanoInterval) []byte {
+	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+
+	var res []byte
+	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
+	s.Data = h.Data
+	s.Len = h.Len * MonthDayNanoIntervalSizeBytes
+	s.Cap = h.Cap * MonthDayNanoIntervalSizeBytes
+
+	return res
+}
+
+// Copy copies src to dst.
+func (monthDayNanoTraits) Copy(dst, src []MonthDayNanoInterval) { copy(dst, src) }

--- a/go/arrow/type_traits_interval.go
+++ b/go/arrow/type_traits_interval.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/apache/arrow/go/arrow/endian"
+	"github.com/apache/arrow/go/arrow/internal/debug"
 )
 
 var (
@@ -28,6 +29,12 @@ var (
 	DayTimeIntervalTraits      daytimeTraits
 	MonthDayNanoIntervalTraits monthDayNanoTraits
 )
+
+func init() {
+	debug.Assert(MonthIntervalSizeBytes == 4, "MonthIntervalSizeBytes should be 4")
+	debug.Assert(DayTimeIntervalSizeBytes == 8, "DayTimeIntervalSizeBytes should be 8")
+	debug.Assert(MonthDayNanoIntervalSizeBytes == 16, "MonthDayNanoIntervalSizeBytes should be 16")
+}
 
 // MonthInterval traits
 

--- a/go/arrow/type_traits_test.go
+++ b/go/arrow/type_traits_test.go
@@ -199,3 +199,37 @@ func TestDayTimeIntervalTraits(t *testing.T) {
 		t.Fatalf("invalid values:\nv1=%v\nv2=%v\n", v1, v2)
 	}
 }
+
+func TestMonthDayNanoIntervalTraits(t *testing.T) {
+	const N = 10
+	b1 := arrow.MonthDayNanoIntervalTraits.CastToBytes([]arrow.MonthDayNanoInterval{
+		{0, 0, 0}, {1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}, {5, 5, 5000}, {6, 6, 6000}, {7, 7, 7000}, {8, 8, 8000}, {9, 9, 9000},
+	})
+
+	b2 := make([]byte, arrow.MonthDayNanoIntervalTraits.BytesRequired(N))
+	for i := 0; i < N; i++ {
+		beg := i * arrow.MonthDayNanoIntervalSizeBytes
+		end := (i + 1) * arrow.MonthDayNanoIntervalSizeBytes
+		arrow.MonthDayNanoIntervalTraits.PutValue(b2[beg:end], arrow.MonthDayNanoInterval{int32(i), int32(i), int64(i) * 1000})
+	}
+
+	if !reflect.DeepEqual(b1, b2) {
+		v1 := arrow.MonthDayNanoIntervalTraits.CastFromBytes(b1)
+		v2 := arrow.MonthDayNanoIntervalTraits.CastFromBytes(b2)
+		t.Fatalf("invalid values:\nb1=%v\nb2=%v\nv1=%v\nv2=%v\n", b1, b2, v1, v2)
+	}
+
+	v1 := arrow.MonthDayNanoIntervalTraits.CastFromBytes(b1)
+	for i, v := range v1 {
+		if got, want := v, (arrow.MonthDayNanoInterval{int32(i), int32(i), int64(i) * 1000}); got != want {
+			t.Fatalf("invalid value[%d]. got=%v, want=%v", i, got, want)
+		}
+	}
+
+	v2 := make([]arrow.MonthDayNanoInterval, N)
+	arrow.MonthDayNanoIntervalTraits.Copy(v2, v1)
+
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("invalid values:\nv1=%v\nv2=%v\n", v1, v2)
+	}
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -427,7 +427,7 @@ public class FlightStream implements AutoCloseable {
           }
 
           synchronized (completed) {
-            if (!completed.isDone()) {              
+            if (!completed.isDone()) {
               fulfilledRoot = VectorSchemaRoot.create(schema, allocator);
               loader = new VectorLoader(fulfilledRoot);
               if (msg.getDescriptor() != null) {


### PR DESCRIPTION
#10177 Added the interval type Month, Day, Nano to the flatbuffer and C++/Java, this updates the flatbuffer generated files and adds support for the type to Go.