### PR TITLE
ARROW-14014: [Java] Fix Flight parseTrailers for :status keys

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
@@ -26,6 +26,7 @@ import org.apache.arrow.flight.ErrorFlightMetadata;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStatusCode;
 
+import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -161,7 +162,7 @@ public class StatusUtils {
       } else {
         metadata.insert(key,
                      Objects.requireNonNull(
-                     trailers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER))).getBytes()
+                     trailers.get(InternalMetadata.keyOf(key, Metadata.ASCII_STRING_MARSHALLER))).getBytes()
         );
       }
     }
@@ -209,7 +210,7 @@ public class StatusUtils {
       if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
         trailers.put(Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER), metadata.getByte(key));
       } else {
-        trailers.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), metadata.get(key));
+        trailers.put(InternalMetadata.keyOf(key, Metadata.ASCII_STRING_MARSHALLER), metadata.get(key));
       }
     }
     return trailers;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
@@ -123,12 +123,12 @@ public class StatusUtils {
   }
 
   /** Create Metadata Key for binary metadata. */
-  public static Metadata.Key<byte[]> keyOfBinary(String name) {
+  static Metadata.Key<byte[]> keyOfBinary(String name) {
     return Metadata.Key.of(name, Metadata.BINARY_BYTE_MARSHALLER);
   }
 
   /** Create Metadata Key for ascii metadata. */
-  public static Metadata.Key<String> keyOfAscii(String name) {
+  static Metadata.Key<String> keyOfAscii(String name) {
     // Use InternalMetadata for keys that start with ":", e.g. ":status". See ARROW-14014.
     return InternalMetadata.keyOf(name, Metadata.ASCII_STRING_MARSHALLER);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
@@ -122,6 +122,17 @@ public class StatusUtils {
     }
   }
 
+  /** Create Metadata Key for binary metadata. */
+  public static Metadata.Key<byte[]> keyOfBinary(String name) {
+    return Metadata.Key.of(name, Metadata.BINARY_BYTE_MARSHALLER);
+  }
+
+  /** Create Metadata Key for ascii metadata. */
+  public static Metadata.Key<String> keyOfAscii(String name) {
+    // Use InternalMetadata for keys that start with ":", e.g. ":status". See ARROW-14014.
+    return InternalMetadata.keyOf(name, Metadata.ASCII_STRING_MARSHALLER);
+  }
+
   /** Convert from a gRPC Status & trailers to a Flight status. */
   public static CallStatus fromGrpcStatusAndTrailers(Status status, Metadata trailers) {
     // gRPC may not always have trailers - this happens when the server internally generates an error, which is rare,
@@ -153,17 +164,14 @@ public class StatusUtils {
     return fromGrpcStatusAndTrailers(sre.getStatus(), sre.getTrailers()).toRuntimeException();
   }
 
-  /** Convert gRPC trailers into Flight error metadata.  */
+  /** Convert gRPC trailers into Flight error metadata. */
   private static ErrorFlightMetadata parseTrailers(Metadata trailers) {
     ErrorFlightMetadata metadata = new ErrorFlightMetadata();
     for (String key : trailers.keys()) {
       if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        metadata.insert(key, trailers.get(Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER)));
+        metadata.insert(key, trailers.get(keyOfBinary(key)));
       } else {
-        metadata.insert(key,
-                     Objects.requireNonNull(
-                     trailers.get(InternalMetadata.keyOf(key, Metadata.ASCII_STRING_MARSHALLER))).getBytes()
-        );
+        metadata.insert(key, Objects.requireNonNull(trailers.get(keyOfAscii(key))).getBytes());
       }
     }
     return metadata;
@@ -208,9 +216,9 @@ public class StatusUtils {
     final Metadata trailers = new Metadata();
     for (final String key : metadata.keys()) {
       if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        trailers.put(Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER), metadata.getByte(key));
+        trailers.put(keyOfBinary(key), metadata.getByte(key));
       } else {
-        trailers.put(InternalMetadata.keyOf(key, Metadata.ASCII_STRING_MARSHALLER), metadata.get(key));
+        trailers.put(keyOfAscii(key), metadata.get(key));
       }
     }
     return trailers;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
@@ -22,7 +22,6 @@ import org.apache.arrow.flight.FlightStatusCode;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.Status;
 
@@ -35,9 +34,9 @@ public class TestStatusUtils {
 
     // gRPC can have trailers with certain metadata keys beginning with ":", such as ":status".
     // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
-    trailers.put(InternalMetadata.keyOf(":status", Metadata.ASCII_STRING_MARSHALLER), "502");
-    trailers.put(Metadata.Key.of("date", Metadata.ASCII_STRING_MARSHALLER), "Fri, 13 Sep 2015 11:23:58 GMT");
-    trailers.put(Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER), "text/html");
+    trailers.put(StatusUtils.keyOfAscii(":status"), "502");
+    trailers.put(StatusUtils.keyOfAscii("date"), "Fri, 13 Sep 2015 11:23:58 GMT");
+    trailers.put(StatusUtils.keyOfAscii("content-type"), "text/html");
 
     CallStatus callStatus = StatusUtils.fromGrpcStatusAndTrailers(status, trailers);
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.grpc;
+
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightStatusCode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.grpc.InternalMetadata;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+public class TestStatusUtils {
+
+  @Test
+  public void testParseTrailers() {
+    Status status = Status.CANCELLED;
+    Metadata trailers = new Metadata();
+
+    // gRPC can have trailers with certain metadata keys beginning with ":", such as ":status".
+    // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+    trailers.put(InternalMetadata.keyOf(":status", Metadata.ASCII_STRING_MARSHALLER), "502");
+    trailers.put(Metadata.Key.of("date", Metadata.ASCII_STRING_MARSHALLER), "Fri, 13 Sep 2015 11:23:58 GMT");
+    trailers.put(Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER), "text/html");
+
+    CallStatus callStatus = StatusUtils.fromGrpcStatusAndTrailers(status, trailers);
+
+    Assert.assertEquals(FlightStatusCode.CANCELLED, callStatus.code());
+    Assert.assertTrue(callStatus.metadata().containsKey(":status"));
+    Assert.assertEquals("502", callStatus.metadata().get(":status"));
+    Assert.assertTrue(callStatus.metadata().containsKey("date"));
+    Assert.assertEquals("Fri, 13 Sep 2015 11:23:58 GMT", callStatus.metadata().get("date"));
+    Assert.assertTrue(callStatus.metadata().containsKey("content-type"));
+    Assert.assertEquals("text/html", callStatus.metadata().get("content-type"));
+  }
+}


### PR DESCRIPTION
In Flight Java, the parseTrailers can sometimes receive Metadata with keys that start with ":", such as ":status". Attempting to access the metadata with this type of key causes an error because gRPC-Java rejects these keys as having an invalid prefix. This fixes that by using `InternalMetadata` to create the Key, which checks if the key starts with a ":" and internally labels it as "psuedo" and accepts it as valid.