### PR TITLE
ARROW-8621: [Release] Add post release step to add tags for Go versioning

### DIFF
--- a/dev/release/post-13-go.sh
+++ b/dev/release/post-13-go.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -ue
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    exit
+fi
+
+version=$1
+go_arrow_tag="go/arrow/v${version}"
+go_parquet_tag="go/parquet/v${version}"
+
+git tag "${go_arrow_tag}"
+git tag "${go_parquet_tag}"
+
+git push origin "${go_arrow_tag}"
+git push origin "${go_parquet_tag}"

--- a/dev/release/post-13-go.sh
+++ b/dev/release/post-13-go.sh
@@ -27,11 +27,12 @@ if [ "$#" -ne 1 ]; then
 fi
 
 version=$1
+version_tag="apache-arrow-${version}"
 go_arrow_tag="go/arrow/v${version}"
 go_parquet_tag="go/parquet/v${version}"
 
-git tag "${go_arrow_tag}"
-git tag "${go_parquet_tag}"
+git tag "${go_arrow_tag}" "${version_tag}"
+git tag "${go_parquet_tag}" "${version_tag}"
 
 git push apache "${go_arrow_tag}"
 git push apache "${go_parquet_tag}"

--- a/dev/release/post-13-go.sh
+++ b/dev/release/post-13-go.sh
@@ -33,5 +33,5 @@ go_parquet_tag="go/parquet/v${version}"
 git tag "${go_arrow_tag}"
 git tag "${go_parquet_tag}"
 
-git push origin "${go_arrow_tag}"
-git push origin "${go_parquet_tag}"
+git push apache "${go_arrow_tag}"
+git push apache "${go_parquet_tag}"


### PR DESCRIPTION
Adding a new post script for adding the tags needed for pkg.go.dev to recognize the package versioning for the Golang modules for arrow and parquet