### PR TITLE
ARROW-14223: [C++] add missing third-party dependency

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -58,6 +58,7 @@ set(ARROW_THIRDPARTY_DEPENDENCIES
     c-ares
     gflags
     GLOG
+    google_cloud_cpp_storage
     gRPC
     GTest
     LLVM


### PR DESCRIPTION
In #11268 I neglected to add `google_cloud_cpp_storage` to the
third-party dependencies.