### PR TITLE
ARROW-13558: [C++] Validate decimal arrays/scalars

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -230,12 +230,20 @@ struct ScalarValidateImpl {
   }
 
   Status Visit(const Decimal128Scalar& s) {
-    // XXX validate precision?
+    const auto& ty = checked_cast<const DecimalType&>(*s.type);
+    if (!s.value.FitsInPrecision(ty.precision())) {
+      return Status::Invalid("Decimal value ", s.value.ToIntegerString(),
+                             " does not fit in precision of ", ty);
+    }
     return Status::OK();
   }
 
   Status Visit(const Decimal256Scalar& s) {
-    // XXX validate precision?
+    const auto& ty = checked_cast<const DecimalType&>(*s.type);
+    if (!s.value.FitsInPrecision(ty.precision())) {
+      return Status::Invalid("Decimal value ", s.value.ToIntegerString(),
+                             " does not fit in precision of ", ty);
+    }
     return Status::OK();
   }
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "arrow/buffer.h"
@@ -407,6 +408,11 @@ class TestDecimalScalar : public ::testing::Test {
     ASSERT_FALSE(first->Equals(pi));
     ASSERT_TRUE(second->Equals(pi));
     ASSERT_FALSE(second->Equals(null));
+
+    auto invalid = ScalarType(ValueType::GetMaxValue(6), std::make_shared<T>(5, 2));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                    ::testing::HasSubstr("does not fit in precision of"),
+                                    invalid.ValidateFull());
   }
 };
 

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -247,6 +247,7 @@ class RandomDecimalArrayTest : public ::testing::Test {
     ASSERT_LE(over_half, non_nulls * 0.7);
     ASSERT_GE(negative, non_nulls * 0.3);
     ASSERT_LE(negative, non_nulls * 0.7);
+    ASSERT_OK(values.ValidateFull());
   }
 };
 

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -247,7 +247,6 @@ class RandomDecimalArrayTest : public ::testing::Test {
     ASSERT_LE(over_half, non_nulls * 0.7);
     ASSERT_GE(negative, non_nulls * 0.3);
     ASSERT_LE(negative, non_nulls * 0.7);
-    ASSERT_OK(values.ValidateFull());
   }
 };
 

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -82,20 +82,6 @@ std::string random_string(int64_t n, uint32_t seed) {
   return s;
 }
 
-void random_decimals(int64_t n, uint32_t seed, int32_t precision, uint8_t* out) {
-  auto gen = random::RandomArrayGenerator(seed);
-  std::shared_ptr<Array> decimals;
-  int32_t byte_width = 0;
-  if (precision <= Decimal128Type::kMaxPrecision) {
-    decimals = gen.Decimal128(decimal128(precision, 0), n);
-    byte_width = Decimal128Type::kByteWidth;
-  } else {
-    decimals = gen.Decimal256(decimal256(precision, 0), n);
-    byte_width = Decimal256Type::kByteWidth;
-  }
-  std::memcpy(out, decimals->data()->GetValues<uint8_t>(1, 0), byte_width * n);
-}
-
 void random_ascii(int64_t n, uint32_t seed, uint8_t* out) {
   rand_uniform_int(n, seed, static_cast<int32_t>('A'), static_cast<int32_t>('z'), out);
 }

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -63,8 +63,6 @@ ARROW_TESTING_EXPORT void random_is_valid(int64_t n, double pct_null,
 ARROW_TESTING_EXPORT void random_bytes(int64_t n, uint32_t seed, uint8_t* out);
 ARROW_TESTING_EXPORT std::string random_string(int64_t n, uint32_t seed);
 ARROW_TESTING_EXPORT int32_t DecimalSize(int32_t precision);
-ARROW_TESTING_EXPORT void random_decimals(int64_t n, uint32_t seed, int32_t precision,
-                                          uint8_t* out);
 ARROW_TESTING_EXPORT void random_ascii(int64_t n, uint32_t seed, uint8_t* out);
 ARROW_TESTING_EXPORT int64_t CountNulls(const std::vector<uint8_t>& valid_bytes);
 

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -303,8 +303,9 @@ inline Result<int32_t> MaxDecimalDigitsForInteger(Type::type type_id) {
     case Type::UINT32:
       return 10;
     case Type::INT64:
-    case Type::UINT64:
       return 19;
+    case Type::UINT64:
+      return 20;
     default:
       break;
   }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -594,6 +594,28 @@ class DecimalFromIntegerTest : public ::testing::Test {
       AssertArrayBits(value.little_endian_array(), 0, 0);
     }
   }
+
+  void TestNumericLimits() {
+    TestNumericLimit<Int8Type>();
+    TestNumericLimit<UInt8Type>();
+    TestNumericLimit<Int16Type>();
+    TestNumericLimit<UInt16Type>();
+    TestNumericLimit<Int32Type>();
+    TestNumericLimit<UInt32Type>();
+    TestNumericLimit<Int64Type>();
+    TestNumericLimit<UInt64Type>();
+  }
+
+  template <typename ArrowType>
+  void TestNumericLimit() {
+    using c_type = typename ArrowType::c_type;
+    ASSERT_OK_AND_ASSIGN(const int32_t precision,
+                         MaxDecimalDigitsForInteger(ArrowType::type_id));
+    DecimalType min_value(std::numeric_limits<c_type>::min());
+    ASSERT_TRUE(min_value.FitsInPrecision(precision));
+    DecimalType max_value(std::numeric_limits<c_type>::max());
+    ASSERT_TRUE(max_value.FitsInPrecision(precision));
+  }
 };
 
 TYPED_TEST_SUITE(DecimalFromIntegerTest, DecimalTypes);
@@ -605,6 +627,8 @@ TYPED_TEST(DecimalFromIntegerTest, ConstructibleFromAnyIntegerType) {
 TYPED_TEST(DecimalFromIntegerTest, ConstructibleFromBool) {
   this->TestConstructibleFromBool();
 }
+
+TYPED_TEST(DecimalFromIntegerTest, TestNumericLimits) { this->TestNumericLimits(); }
 
 TEST(Decimal128Test, Division) {
   const std::string expected_string_value("-23923094039234029");

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -703,7 +703,7 @@ def _set_default(opt, default):
 @click.option('--with-rust', type=bool, default=False,
               help='Include Rust in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_RUST")
-@click.option('--write_generated_json', default=False,
+@click.option('--write_generated_json', default="",
               help='Generate test JSON to indicated path')
 @click.option('--run-flight', is_flag=True, default=False,
               help='Run Flight integration tests')

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -431,23 +431,10 @@ class FloatingPointField(PrimitiveField):
         return PrimitiveColumn(name, size, is_valid, values)
 
 
-DECIMAL_PRECISION_TO_VALUE = {
-    key: (1 << (8 * i - 1)) - 1 for i, key in enumerate(
-        [1, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24, 27, 29, 32, 34, 36,
-         40, 42, 44, 50, 60, 70],
-        start=1,
-    )
-}
-
-
 def decimal_range_from_precision(precision):
     assert 1 <= precision <= 76
-    try:
-        max_value = DECIMAL_PRECISION_TO_VALUE[precision]
-    except KeyError:
-        return decimal_range_from_precision(precision - 1)
-    else:
-        return ~max_value, max_value
+    max_value = (10 ** precision) - 1
+    return ~max_value, max_value
 
 
 class DecimalField(PrimitiveField):
@@ -1138,7 +1125,7 @@ class RecordBatch(object):
 class File(object):
 
     def __init__(self, name, schema, batches, dictionaries=None,
-                 skip=None, path=None):
+                 skip=None, path=None, quirks=None):
         self.name = name
         self.schema = schema
         self.dictionaries = dictionaries or []
@@ -1147,6 +1134,11 @@ class File(object):
         self.path = path
         if skip:
             self.skip.update(skip)
+        # For tracking flags like whether to validate decimal values
+        # fit into the given precision (ARROW-13558).
+        self.quirks = set()
+        if quirks:
+            self.quirks.update(quirks)
 
     def get_json(self):
         entries = [

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -434,7 +434,7 @@ class FloatingPointField(PrimitiveField):
 def decimal_range_from_precision(precision):
     assert 1 <= precision <= 76
     max_value = (10 ** precision) - 1
-    return ~max_value, max_value
+    return -max_value, max_value
 
 
 class DecimalField(PrimitiveField):

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -150,6 +150,8 @@ class IntegrationRunner(object):
             quirks = set()
             if prefix in {'0.14.1', '0.17.1',
                           '1.0.0-bigendian', '1.0.0-littleendian'}:
+                # ARROW-13558: older versions generated decimal values that
+                # were out of range for the given precision.
                 quirks.add("no_decimal_validate")
 
             yield datagen.File(name, None, None, skip=skip, path=out_path,

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -147,7 +147,13 @@ class IntegrationRunner(object):
                 skip.add("C#")
                 skip.add("Go")
 
-            yield datagen.File(name, None, None, skip=skip, path=out_path)
+            quirks = set()
+            if prefix in {'0.14.1', '0.17.1',
+                          '1.0.0-bigendian', '1.0.0-littleendian'}:
+                quirks.add("no_decimal_validate")
+
+            yield datagen.File(name, None, None, skip=skip, path=out_path,
+                               quirks=quirks)
 
     def _run_test_cases(self, producer, consumer, case_runner,
                         test_cases):
@@ -254,7 +260,8 @@ class IntegrationRunner(object):
         log('-- Validating file')
         producer_file_path = os.path.join(
             gold_dir, "generated_" + test_case.name + ".arrow_file")
-        consumer.validate(json_path, producer_file_path)
+        consumer.validate(json_path, producer_file_path,
+                          quirks=test_case.quirks)
 
         log('-- Validating stream')
         consumer_stream_path = os.path.join(
@@ -266,7 +273,8 @@ class IntegrationRunner(object):
                                           name + '.consumer_stream_as_file')
 
         consumer.stream_to_file(consumer_stream_path, consumer_file_path)
-        consumer.validate(json_path, consumer_file_path)
+        consumer.validate(json_path, consumer_file_path,
+                          quirks=test_case.quirks)
 
     def _compare_flight_implementations(self, producer, consumer):
         log('##########################################################')

--- a/dev/archery/archery/integration/tester.py
+++ b/dev/archery/archery/integration/tester.py
@@ -47,7 +47,7 @@ class Tester(object):
     def file_to_stream(self, file_path, stream_path):
         raise NotImplementedError
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         raise NotImplementedError
 
     def flight_server(self, scenario_name=None):

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -59,7 +59,7 @@ class CPPTester(Tester):
 
         if quirks:
             if "no_decimal_validate" in quirks:
-                cmd.append("--no_decimal_validate")
+                cmd.append("--validate_decimals=false")
 
         if self.debug:
             log(' '.join(cmd))

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -45,7 +45,8 @@ class CPPTester(Tester):
 
     name = 'C++'
 
-    def _run(self, arrow_path=None, json_path=None, command='VALIDATE'):
+    def _run(self, arrow_path=None, json_path=None, command='VALIDATE',
+             quirks=None):
         cmd = [self.CPP_INTEGRATION_EXE, '--integration']
 
         if arrow_path is not None:
@@ -56,13 +57,17 @@ class CPPTester(Tester):
 
         cmd.append('--mode=' + command)
 
+        if quirks:
+            if "no_decimal_validate" in quirks:
+                cmd.append("--no_decimal_validate")
+
         if self.debug:
             log(' '.join(cmd))
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
-        return self._run(arrow_path, json_path, 'VALIDATE')
+    def validate(self, json_path, arrow_path, quirks=None):
+        return self._run(arrow_path, json_path, 'VALIDATE', quirks=quirks)
 
     def json_to_file(self, json_path, arrow_path):
         return self._run(arrow_path, json_path, 'JSON_TO_ARROW')

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -48,7 +48,7 @@ class CSharpTester(Tester):
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         return self._run(json_path, arrow_path, 'validate')
 
     def json_to_file(self, json_path, arrow_path):

--- a/dev/archery/archery/integration/tester_go.py
+++ b/dev/archery/archery/integration/tester_go.py
@@ -62,7 +62,7 @@ class GoTester(Tester):
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         return self._run(arrow_path, json_path, 'VALIDATE')
 
     def json_to_file(self, json_path, arrow_path):

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -75,7 +75,7 @@ class JavaTester(Tester):
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         return self._run(arrow_path, json_path, 'VALIDATE')
 
     def json_to_file(self, json_path, arrow_path):

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -50,7 +50,7 @@ class JSTester(Tester):
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         return self._run(self.VALIDATE, arrow_path, json_path, 'VALIDATE')
 
     def json_to_file(self, json_path, arrow_path):

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -60,7 +60,7 @@ class RustTester(Tester):
 
         run_cmd(cmd)
 
-    def validate(self, json_path, arrow_path):
+    def validate(self, json_path, arrow_path, quirks=None):
         return self._run(arrow_path, json_path, 'VALIDATE')
 
     def json_to_file(self, json_path, arrow_path):


### PR DESCRIPTION
Split out of ARROW-13130. This also adjusts various tests generating random decimals, though in a very imprecise way (such that we aren't generating the full range of possible decimals for a given precision).