### PR TITLE
ARROW-14210: [C++] Add AR and RANLIB flags to bzip2

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2250,6 +2250,14 @@ macro(build_bzip2)
     list(APPEND BZIP2_EXTRA_ARGS "SDKROOT=${CMAKE_OSX_SYSROOT}")
   endif()
 
+  if(CMAKE_AR)
+    list(APPEND BZIP2_EXTRA_ARGS AR=${CMAKE_AR})
+  endif()
+
+  if(CMAKE_RANLIB)
+    list(APPEND BZIP2_EXTRA_ARGS RANLIB=${CMAKE_RANLIB})
+  endif()
+
   externalproject_add(bzip2_ep
                       ${EP_LOG_OPTIONS}
                       CONFIGURE_COMMAND ""


### PR DESCRIPTION
Add `AR` or `RANLIB` flags to bzip2 when it's built as an external dependency and `CMAKE_AR` or `CMAKE_RANLIB` are set.

This happens when running a `BUNDLED` build with the conda compiler tools.