### PR TITLE
MINOR: [C++] Avoid exposing arrow_vendored::date in public headers

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -23,13 +23,12 @@
 #include <string>
 #include <utility>
 
-#include "arrow/compute/exec.h"  // IWYU pragma: keep
 #include "arrow/compute/function.h"
+#include "arrow/compute/type_fwd.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
-#include "arrow/vendored/datetime.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -66,6 +66,10 @@
 #error "xsimd should not be visible from Arrow public headers."
 #endif
 
+#ifdef HAS_CHRONO_ROUNDING
+#error "arrow::vendored::date should not be visible from Arrow public headers."
+#endif
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This may also reduce compilation cost slightly.