### PR TITLE
ARROW-14246: [C++] Fix wrong find_package() usage in build_google_cloud_cpp_storage()

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3590,7 +3590,7 @@ macro(build_google_cloud_cpp_storage)
 
   # Curl is required on all platforms, but building it internally might also trip over S3's copy.
   # For now, force its inclusion from the underlying system or fail.
-  find_package(CURL REQUIRED 7.47.0)
+  find_package(CURL 7.47.0 REQUIRED)
 
   # Build google-cloud-cpp, with only storage_client
 


### PR DESCRIPTION
Error message:

    CMake Error at /usr/share/cmake-3.18/Modules/FindCURL.cmake:163 (message):
      CURL: Required feature 7.47.0 is not found
    Call Stack (most recent call first):
      cmake_modules/ThirdpartyToolchain.cmake:3585 (find_package)
      cmake_modules/ThirdpartyToolchain.cmake:156 (build_google_cloud_cpp_storage)
      cmake_modules/ThirdpartyToolchain.cmake:232 (build_dependency)
      cmake_modules/ThirdpartyToolchain.cmake:3697 (resolve_dependency)
      CMakeLists.txt:535 (include)

find_package() signature:

https://cmake.org/cmake/help/latest/command/find_package.html

    find_package(<PackageName> [version] [EXACT] [QUIET] [MODULE]
                 [REQUIRED] [[COMPONENTS] [components...]]
                 [OPTIONAL_COMPONENTS components...]
                 [NO_POLICY_SCOPE])