### PR TITLE
ARROW-13151: [C++][Parquet] Propagate schema changes from selection all the way up the stack

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4207,10 +4207,12 @@ TEST_P(TestNestedSchemaFilteredReader, ReadWrite) {
   std::shared_ptr<::arrow::Array> array =
       ArrayFromJSON(GetParam().write_schema, GetParam().write_data);
 
-  
-  ASSERT_OK_NO_THROW(WriteTable(**Table::FromRecordBatches({::arrow::RecordBatch::Make(::arrow::schema({::arrow::field("col", array->type())}), array->length(),{array})}),
-                                ::arrow::default_memory_pool(), sink, /*row_group_size=*/100,
-                                write_props, ArrowWriterProperties::Builder().store_schema()->build()));
+  ASSERT_OK_NO_THROW(
+      WriteTable(**Table::FromRecordBatches({::arrow::RecordBatch::Make(
+                     ::arrow::schema({::arrow::field("col", array->type())}),
+                     array->length(), {array})}),
+                 ::arrow::default_memory_pool(), sink, /*row_group_size=*/100,
+                 write_props, ArrowWriterProperties::Builder().store_schema()->build()));
   std::shared_ptr<::arrow::Buffer> buffer;
   ASSERT_OK_AND_ASSIGN(buffer, sink->Finish());
 
@@ -4236,15 +4238,15 @@ std::vector<NestedFilterTestCase> GenerateListFilterTestCases() {
   std::vector<NestedFilterTestCase> cases;
   auto first_selected_type = ::arrow::struct_({struct_type->field(0)});
   cases.push_back({::arrow::list(struct_type),
-                      /*indices=*/{0}, ::arrow::list(first_selected_type), kWriteData,
-                      kReadData});
+                   /*indices=*/{0}, ::arrow::list(first_selected_type), kWriteData,
+                   kReadData});
   cases.push_back({::arrow::large_list(struct_type),
-                      /*indices=*/{0}, ::arrow::large_list(first_selected_type),
-                      kWriteData, kReadData});
+                   /*indices=*/{0}, ::arrow::large_list(first_selected_type), kWriteData,
+                   kReadData});
   cases.push_back({::arrow::fixed_size_list(struct_type, /*list_size=*/1),
-                      /*indices=*/{0},
-                      ::arrow::fixed_size_list(first_selected_type, /*list_size=*/1),
-                      kWriteData, kReadData});
+                   /*indices=*/{0},
+                   ::arrow::fixed_size_list(first_selected_type, /*list_size=*/1),
+                   kWriteData, kReadData});
   return cases;
 }
 
@@ -4255,19 +4257,17 @@ std::vector<NestedFilterTestCase> GenerateNestedStructFilteredTestCases() {
   using ::arrow::field;
   using ::arrow::struct_;
   auto struct_type = struct_(
-      {field("t1", struct_({field("a", ::arrow::int64()),
-                                            field("b", ::arrow::int64())})),
+      {field("t1", struct_({field("a", ::arrow::int64()), field("b", ::arrow::int64())})),
        field("t2", ::arrow::int64())});
 
   constexpr auto kWriteData = R"([{"t1": {"a": 1, "b":2}, "t2": 3}])";
   constexpr auto kReadData = R"([{"t1": {"a": 1}, "t2": 3}])";
 
   std::vector<NestedFilterTestCase> cases;
-  auto selected_type = ::arrow::struct_({
-    field("t1", struct_({field("a", ::arrow::int64())})),
-                   struct_type->field(1)});
+  auto selected_type = ::arrow::struct_(
+      {field("t1", struct_({field("a", ::arrow::int64())})), struct_type->field(1)});
   cases.push_back({struct_type,
-                      /*indices=*/{0, 2}, selected_type, kWriteData, kReadData});
+                   /*indices=*/{0, 2}, selected_type, kWriteData, kReadData});
   return cases;
 }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4211,8 +4211,8 @@ TEST_P(TestNestedSchemaFilteredReader, ReadWrite) {
       WriteTable(**Table::FromRecordBatches({::arrow::RecordBatch::Make(
                      ::arrow::schema({::arrow::field("col", array->type())}),
                      array->length(), {array})}),
-                 ::arrow::default_memory_pool(), sink, /*chunk_size=*/100,
-                 write_props, ArrowWriterProperties::Builder().store_schema()->build()));
+                 ::arrow::default_memory_pool(), sink, /*chunk_size=*/100, write_props,
+                 ArrowWriterProperties::Builder().store_schema()->build()));
   std::shared_ptr<::arrow::Buffer> buffer;
   ASSERT_OK_AND_ASSIGN(buffer, sink->Finish());
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4211,8 +4211,8 @@ TEST_P(TestNestedSchemaFilteredReader, ReadWrite) {
       WriteTable(**Table::FromRecordBatches({::arrow::RecordBatch::Make(
                      ::arrow::schema({::arrow::field("col", array->type())}),
                      array->length(), {array})}),
-                 ::arrow::default_memory_pool(), sink, /*chunk_size=*/100, write_props,
-                 ArrowWriterProperties::Builder().store_schema()->build()));
+                 ::arrow::default_memory_pool(), sink, /*chunk_size=*/100,
+                 write_props, ArrowWriterProperties::Builder().store_schema()->build()));
   std::shared_ptr<::arrow::Buffer> buffer;
   ASSERT_OK_AND_ASSIGN(buffer, sink->Finish());
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4211,7 +4211,7 @@ TEST_P(TestNestedSchemaFilteredReader, ReadWrite) {
       WriteTable(**Table::FromRecordBatches({::arrow::RecordBatch::Make(
                      ::arrow::schema({::arrow::field("col", array->type())}),
                      array->length(), {array})}),
-                 ::arrow::default_memory_pool(), sink, /*row_group_size=*/100,
+                 ::arrow::default_memory_pool(), sink, /*chunk_size=*/100,
                  write_props, ArrowWriterProperties::Builder().store_schema()->build()));
   std::shared_ptr<::arrow::Buffer> buffer;
   ASSERT_OK_AND_ASSIGN(buffer, sink->Finish());

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -846,6 +846,12 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<Field>& arrow_f
     // These two types might not be equal if there column pruning occurred.
     // further down the stack.
     const std::shared_ptr<DataType> reader_child_type = child_reader->field()->type();
+    // This should really never happen but was raised as a question on the code
+    // review, this should  be pretty cheap check so leave it in.
+    if (ARROW_PREDICT_FALSE(list_field->type()->num_fields() != 1)) {
+      return Status::Invalid("expected exactly one child field for: ",
+                             list_field->ToString());
+    }
     const DataType& schema_child_type = *(list_field->type()->field(0)->type());
     if (type_id == ::arrow::Type::MAP) {
       if (reader_child_type->num_fields() != 2 ||

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -6,11 +6,7 @@
 \alias{arrow-package}
 \title{arrow: Integration to 'Apache' 'Arrow'}
 \description{
-'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
-    development platform for in-memory data. It specifies a standardized
-    language-independent columnar memory format for flat and hierarchical data,
-    organized for efficient analytic operations on modern hardware. This
-    package provides an interface to the 'Arrow C++' library.
+'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language development platform for in-memory data. It specifies a standardized language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware. This package provides an interface to the 'Arrow C++' library.
 }
 \seealso{
 Useful links:

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -6,7 +6,11 @@
 \alias{arrow-package}
 \title{arrow: Integration to 'Apache' 'Arrow'}
 \description{
-'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language development platform for in-memory data. It specifies a standardized language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware. This package provides an interface to the 'Arrow C++' library.
+'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
+    development platform for in-memory data. It specifies a standardized
+    language-independent columnar memory format for flat and hierarchical data,
+    organized for efficient analytic operations on modern hardware. This
+    package provides an interface to the 'Arrow C++' library.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Previously, structs would only work for a single level, and other nested types did not do this at all.  This PR propagates types through lists, large_lists, fixed_sized_lists and multiple nesting of structs.  Maps had some special handling:
1.  If only a partial key is selected it gets converted to list<struct>
2. If only a partial value is selected it maintains the map type.
3. The old behavior of changing to list<struct> is maintained when the entire key or value are removed (but test coverage was added for this)

The example given in the JIRA now works:
```
>>> data = {"root": [[\{"addr": {"this": 3, "that": 3}}]]}
 >>> table = pa.Table.from_pydict(data)
 >>> pq.write_table(table, "/tmp/table.parquet")
 >>> file = pq.ParquetFile("/tmp/table.parquet")
 >>> array = file.read(["root.list.item.addr.that"])
 >>> array
 pyarrow.Table
 root: list<item: struct<addr: struct<that: int64>>>
 child 0, item: struct<addr: struct<that: int64>>
 child 0, addr: struct<that: int64>
 child 0, that: int64
----
root: [[ – is_valid: all not null
 – child 0 type: struct<that: int64>
 – is_valid: all not null
 – child 0 type: int64
 [
 3
 ]]]
```