### PR TITLE
ARROW-14247: [C++] Fix Valgrind errors in parquet-arrow-test

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1338,7 +1338,7 @@ TEST(TestFromParquetSchema, CorruptMetadata) {
 ::arrow::Result<std::deque<LevelInfo>> RootToTreeLeafLevels(
     const SchemaManifest& manifest, int column_number) {
   std::deque<LevelInfo> out;
-  const SchemaField* field;
+  const SchemaField* field = nullptr;
   RETURN_NOT_OK(manifest.GetColumnField(column_number, &field));
   while (field != nullptr) {
     out.push_front(field->level_info);

--- a/cpp/src/parquet/arrow/arrow_statistics_test.cc
+++ b/cpp/src/parquet/arrow/arrow_statistics_test.cc
@@ -48,6 +48,16 @@ struct StatisticsTestParam {
   std::string expected_max;
 };
 
+// Define a custom print since the default Googletest print trips Valgrind
+void PrintTo(const StatisticsTestParam& param, std::ostream* os) {
+  (*os) << "StatisticsTestParam{"
+        << "table.schema=" << param.table->schema()->ToString()
+        << ", expected_null_count=" << param.expected_null_count
+        << ", expected_value_count=" << param.expected_value_count
+        << ", expected_min=" << param.expected_min
+        << ", expected_max=" << param.expected_max << "}";
+}
+
 class ParameterizedStatisticsTest : public ::testing::TestWithParam<StatisticsTestParam> {
 };
 


### PR DESCRIPTION
Googletest prints all test parameter objects up front. When there's no custom printer defined, it just prints the bytes of the struct. This happened to go into uninitialized memory in (apparently) std::string, tripping Valgrind.

See a discussion by Chromium developers on a similar issue: https://bugs.chromium.org/p/chromium/issues/detail?id=64887