### PR TITLE
ARROW-12820: [C++] Support zone offset in ISO8601, strptime parser

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1945,7 +1945,32 @@ TEST(Cast, StringToTimestamp) {
       }
     }
 
-    // NOTE: timestamp parsing is tested comprehensively in parsing-util-test.cc
+    auto zoned = ArrayFromJSON(string_type,
+                               R"(["2020-02-29T00:00:00Z", "2020-03-02T10:11:12+0102"])");
+    auto mixed = ArrayFromJSON(string_type,
+                               R"(["2020-03-02T10:11:12+0102", "2020-02-29T00:00:00"])");
+
+    // Timestamp with zone offset should not parse as naive
+    CheckCastFails(zoned, CastOptions::Safe(timestamp(TimeUnit::SECOND)));
+
+    // Mixed zoned/unzoned should not parse as naive
+    CheckCastFails(mixed, CastOptions::Safe(timestamp(TimeUnit::SECOND)));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("expected no zone offset"),
+        Cast(mixed, CastOptions::Safe(timestamp(TimeUnit::SECOND))));
+
+    // ...or as timestamp with timezone
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("expected a zone offset"),
+        Cast(mixed, CastOptions::Safe(timestamp(TimeUnit::SECOND, "UTC"))));
+
+    // Timestamp with zone offset can parse as any time zone (since they're unambiguous)
+    CheckCast(zoned, ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"),
+                                   "[1582934400, 1583140152]"));
+    CheckCast(zoned, ArrayFromJSON(timestamp(TimeUnit::SECOND, "America/Phoenix"),
+                                   "[1582934400, 1583140152]"));
+
+    // NOTE: timestamp parsing is tested comprehensively in value_parsing_test.cc
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1964,6 +1964,11 @@ TEST(Cast, StringToTimestamp) {
         Invalid, ::testing::HasSubstr("expected a zone offset"),
         Cast(mixed, CastOptions::Safe(timestamp(TimeUnit::SECOND, "UTC"))));
 
+    // Unzoned should not parse as timestamp with timezone
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("expected a zone offset"),
+        Cast(strings, CastOptions::Safe(timestamp(TimeUnit::SECOND, "UTC"))));
+
     // Timestamp with zone offset can parse as any time zone (since they're unambiguous)
     CheckCast(zoned, ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"),
                                    "[1582934400, 1583140152]"));

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -3634,7 +3634,7 @@ Result<ValueDescr> ResolveStrptimeOutput(KernelContext* ctx,
   std::string zone = "";
   while (cur < options.format.size() - 1) {
     if (options.format[cur] == '%') {
-      if (cur + 1 < options.format.size() && options.format[cur + 1] == 'z') {
+      if (options.format[cur + 1] == 'z') {
         zone = "UTC";
         break;
       }

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -3625,11 +3625,24 @@ struct StrptimeExec {
 
 Result<ValueDescr> ResolveStrptimeOutput(KernelContext* ctx,
                                          const std::vector<ValueDescr>&) {
-  if (ctx->state()) {
-    return ::arrow::timestamp(StrptimeState::Get(ctx).unit);
+  if (!ctx->state()) {
+    return Status::Invalid("strptime does not provide default StrptimeOptions");
   }
-
-  return Status::Invalid("strptime does not provide default StrptimeOptions");
+  const StrptimeOptions& options = StrptimeState::Get(ctx);
+  // Check for use of %z or %Z
+  size_t cur = 0;
+  std::string zone = "";
+  while (cur < options.format.size() - 1) {
+    if (options.format[cur] == '%') {
+      if (cur + 1 < options.format.size() && options.format[cur + 1] == 'z') {
+        zone = "UTC";
+        break;
+      }
+      cur++;
+    }
+    cur++;
+  }
+  return ::arrow::timestamp(options.unit, zone);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/csv/column_builder_test.cc
+++ b/cpp/src/arrow/csv/column_builder_test.cc
@@ -33,6 +33,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
+#include "arrow/util/value_parsing.h"
 
 namespace arrow {
 namespace csv {
@@ -427,6 +428,13 @@ TEST_F(InferringColumnBuilderTest, SingleChunkTimestamp) {
                                         {{false, true, true}}, {{0, 0, 1542129070}},
                                         &expected);
   CheckInferred(tg, {{"", "1970-01-01", "2018-11-13 17:11:10"}}, options, expected);
+
+  options.timestamp_parsers.push_back(TimestampParser::MakeStrptime("%Y/%m/%d"));
+  tg = TaskGroup::MakeSerial();
+  ChunkedArrayFromVector<TimestampType>(timestamp(TimeUnit::SECOND),
+                                        {{false, true, true}}, {{0, 0, 1542067200}},
+                                        &expected);
+  CheckInferred(tg, {{"", "1970/01/01", "2018/11/13"}}, options, expected);
 }
 
 TEST_F(InferringColumnBuilderTest, MultipleChunkTimestamp) {
@@ -438,6 +446,13 @@ TEST_F(InferringColumnBuilderTest, MultipleChunkTimestamp) {
                                         {{false}, {true}, {true}},
                                         {{0}, {0}, {1542129070}}, &expected);
   CheckInferred(tg, {{""}, {"1970-01-01"}, {"2018-11-13 17:11:10"}}, options, expected);
+
+  options.timestamp_parsers.push_back(TimestampParser::MakeStrptime("%Y/%m/%d"));
+  tg = TaskGroup::MakeSerial();
+  ChunkedArrayFromVector<TimestampType>(timestamp(TimeUnit::SECOND),
+                                        {{false}, {true}, {true}},
+                                        {{0}, {0}, {1542067200}}, &expected);
+  CheckInferred(tg, {{""}, {"1970/01/01"}, {"2018/11/13"}}, options, expected);
 }
 
 TEST_F(InferringColumnBuilderTest, SingleChunkTimestampNS) {
@@ -468,6 +483,76 @@ TEST_F(InferringColumnBuilderTest, MultipleChunkTimestampNS) {
                  {"1970-01-01"},
                  {"2018-11-13 17:11:10.123", "2018-11-13 17:11:10.123456",
                   "2018-11-13 17:11:10.123456789"}},
+                options, expected);
+}
+
+TEST_F(InferringColumnBuilderTest, SingleChunkTimestampWithZone) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(timestamp(TimeUnit::SECOND, "UTC"),
+                                        {{false, true, true}}, {{0, 0, 1542129010}},
+                                        &expected);
+  CheckInferred(tg, {{"", "1970-01-01T00:00:00Z", "2018-11-13 17:11:10+0001"}}, options,
+                expected);
+
+  tg = TaskGroup::MakeSerial();
+  expected = ChunkedArrayFromJSON(
+      utf8(), {R"(["", "1970-01-01T00:00:00Z", "2018-11-13 17:11:10"])"});
+  CheckInferred(tg, {{"", "1970-01-01T00:00:00Z", "2018-11-13 17:11:10"}}, options,
+                expected);
+}
+
+TEST_F(InferringColumnBuilderTest, MultipleChunkTimestampWithZone) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(timestamp(TimeUnit::SECOND, "UTC"),
+                                        {{false}, {true}, {true}},
+                                        {{0}, {0}, {1542129010}}, &expected);
+  CheckInferred(tg, {{""}, {"1970-01-01T00:00:00Z"}, {"2018-11-13 17:11:10+0001"}},
+                options, expected);
+
+  tg = TaskGroup::MakeSerial();
+  expected = ChunkedArrayFromJSON(
+      utf8(), {R"([""])", R"(["1970-01-01T00:00:00Z"])", R"(["2018-11-13 17:11:10"])"});
+  CheckInferred(tg, {{""}, {"1970-01-01T00:00:00Z"}, {"2018-11-13 17:11:10"}}, options,
+                expected);
+}
+
+TEST_F(InferringColumnBuilderTest, SingleChunkTimestampWithZoneNS) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(
+      timestamp(TimeUnit::NANO, "UTC"), {{false, true, true, true, true}},
+      {{0, 3660000000000, 1542129070123000000, 1542129070123456000, 1542129070123456789}},
+      &expected);
+  CheckInferred(tg,
+                {{"", "1970-01-01T00:00:00-0101", "2018-11-13 17:11:10.123Z",
+                  "2018-11-13 17:11:10.123456Z", "2018-11-13 17:11:10.123456789Z"}},
+                options, expected);
+}
+
+TEST_F(InferringColumnBuilderTest, MultipleChunkTimestampWithZoneNS) {
+  auto options = ConvertOptions::Defaults();
+  auto tg = TaskGroup::MakeSerial();
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<TimestampType>(
+      timestamp(TimeUnit::NANO, "UTC"), {{false}, {true}, {true, true, true}},
+      {{0},
+       {3660000000000},
+       {1542129070123000000, 1542129070123456000, 1542129070123456789}},
+      &expected);
+  CheckInferred(tg,
+                {{""},
+                 {"1970-01-01T00:00:00-0101"},
+                 {"2018-11-13 17:11:10.123Z", "2018-11-13 17:11:10.123456Z",
+                  "2018-11-13 17:11:10.123456789Z"}},
                 options, expected);
 }
 

--- a/cpp/src/arrow/csv/inference_internal.h
+++ b/cpp/src/arrow/csv/inference_internal.h
@@ -35,6 +35,8 @@ enum class InferKind {
   Time,
   Timestamp,
   TimestampNS,
+  TimestampWithZone,
+  TimestampWithZoneNS,
   TextDict,
   BinaryDict,
   Text,
@@ -67,6 +69,10 @@ class InferStatus {
       case InferKind::Timestamp:
         return SetKind(InferKind::TimestampNS);
       case InferKind::TimestampNS:
+        return SetKind(InferKind::TimestampWithZone);
+      case InferKind::TimestampWithZone:
+        return SetKind(InferKind::TimestampWithZoneNS);
+      case InferKind::TimestampWithZoneNS:
         return SetKind(InferKind::Real);
       case InferKind::Real:
         if (options_.auto_dict_encode) {
@@ -123,6 +129,10 @@ class InferStatus {
         return make_converter(timestamp(TimeUnit::SECOND));
       case InferKind::TimestampNS:
         return make_converter(timestamp(TimeUnit::NANO));
+      case InferKind::TimestampWithZone:
+        return make_converter(timestamp(TimeUnit::SECOND, "UTC"));
+      case InferKind::TimestampWithZoneNS:
+        return make_converter(timestamp(TimeUnit::NANO, "UTC"));
       case InferKind::Real:
         return make_converter(float64());
       case InferKind::Text:

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -503,6 +503,15 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
 
     AssertConversion(type, "1970-01-01 00:00:00", 0);
     AssertConversion(type, "2018-11-13 17", 1542128400);
+    AssertConversion(type, "2018-11-13 17+00", 1542128400);
+    AssertConversion(type, "2018-11-13 17+0000", 1542128400);
+    AssertConversion(type, "2018-11-13 17+00:00", 1542128400);
+    AssertConversion(type, "2018-11-13 17+01", 1542124800);
+    AssertConversion(type, "2018-11-13 17+0117", 1542123780);
+    AssertConversion(type, "2018-11-13 17+01:17", 1542123780);
+    AssertConversion(type, "2018-11-13 17-01", 1542132000);
+    AssertConversion(type, "2018-11-13 17-0117", 1542133020);
+    AssertConversion(type, "2018-11-13 17-01:17", 1542133020);
     AssertConversion(type, "2018-11-13T17", 1542128400);
     AssertConversion(type, "2018-11-13 17Z", 1542128400);
     AssertConversion(type, "2018-11-13T17Z", 1542128400);
@@ -510,10 +519,28 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "2018-11-13T17:11", 1542129060);
     AssertConversion(type, "2018-11-13 17:11Z", 1542129060);
     AssertConversion(type, "2018-11-13T17:11Z", 1542129060);
+    AssertConversion(type, "2018-11-13 17:11+00", 1542129060);
+    AssertConversion(type, "2018-11-13 17:11+0000", 1542129060);
+    AssertConversion(type, "2018-11-13 17:11+00:00", 1542129060);
+    AssertConversion(type, "2018-11-13 17:11+01", 1542125460);
+    AssertConversion(type, "2018-11-13 17:11+0117", 1542124440);
+    AssertConversion(type, "2018-11-13 17:11+01:17", 1542124440);
+    AssertConversion(type, "2018-11-13 17:11-01", 1542132660);
+    AssertConversion(type, "2018-11-13 17:11-0117", 1542133680);
+    AssertConversion(type, "2018-11-13 17:11-01:17", 1542133680);
     AssertConversion(type, "2018-11-13 17:11:10", 1542129070);
     AssertConversion(type, "2018-11-13T17:11:10", 1542129070);
     AssertConversion(type, "2018-11-13 17:11:10Z", 1542129070);
     AssertConversion(type, "2018-11-13T17:11:10Z", 1542129070);
+    AssertConversion(type, "2018-11-13T17:11:10+00", 1542129070);
+    AssertConversion(type, "2018-11-13T17:11:10+0000", 1542129070);
+    AssertConversion(type, "2018-11-13T17:11:10+00:00", 1542129070);
+    AssertConversion(type, "2018-11-13T17:11:10+01", 1542125470);
+    AssertConversion(type, "2018-11-13T17:11:10+0117", 1542124450);
+    AssertConversion(type, "2018-11-13T17:11:10+01:17", 1542124450);
+    AssertConversion(type, "2018-11-13T17:11:10-01", 1542132670);
+    AssertConversion(type, "2018-11-13T17:11:10-0117", 1542133690);
+    AssertConversion(type, "2018-11-13T17:11:10-01:17", 1542133690);
     AssertConversion(type, "1900-02-28 12:34:56", -2203932304LL);
 
     // No subseconds allowed
@@ -530,6 +557,22 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversionFails(type, "1970-01-01 00:00:60");
     AssertConversionFails(type, "1970-01-01 00:00,00");
     AssertConversionFails(type, "1970-01-01 00,00:00");
+    // Invalid zone offsets
+    AssertConversionFails(type, "1970-01-01 00:00+0");
+    AssertConversionFails(type, "1970-01-01 00:00+000");
+    AssertConversionFails(type, "1970-01-01 00:00+00000");
+    AssertConversionFails(type, "1970-01-01 00:00+2400");
+    AssertConversionFails(type, "1970-01-01 00:00+0060");
+    AssertConversionFails(type, "1970-01-01 00-0");
+    AssertConversionFails(type, "1970-01-01 00-000");
+    AssertConversionFails(type, "1970-01-01 00+00000");
+    AssertConversionFails(type, "1970-01-01 00+2400");
+    AssertConversionFails(type, "1970-01-01 00+0060");
+    AssertConversionFails(type, "1970-01-01 00:00:00+0");
+    AssertConversionFails(type, "1970-01-01 00:00:00-000");
+    AssertConversionFails(type, "1970-01-01 00:00:00-00000");
+    AssertConversionFails(type, "1970-01-01 00:00:00+2400");
+    AssertConversionFails(type, "1970-01-01 00:00:00+00:99");
   }
   {
     TimestampType type{TimeUnit::MILLI};
@@ -543,6 +586,13 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "1900-02-28 12:34:56.1", -2203932304000LL + 100LL);
     AssertConversion(type, "1900-02-28 12:34:56.12", -2203932304000LL + 120LL);
     AssertConversion(type, "1900-02-28 12:34:56.123", -2203932304000LL + 123LL);
+
+    AssertConversion(type, "2018-11-13 17:11:10.123+01", 1542129070123LL - 3600000LL);
+    AssertConversion(type, "2018-11-13 17:11:10.123+0117", 1542129070123LL - 4620000LL);
+    AssertConversion(type, "2018-11-13 17:11:10.123+01:17", 1542129070123LL - 4620000LL);
+    AssertConversion(type, "2018-11-13 17:11:10.123-01", 1542129070123LL + 3600000LL);
+    AssertConversion(type, "2018-11-13 17:11:10.123-0117", 1542129070123LL + 4620000LL);
+    AssertConversion(type, "2018-11-13 17:11:10.123-01:17", 1542129070123LL + 4620000LL);
 
     // Invalid subseconds
     AssertConversionFails(type, "1900-02-28 12:34:56.1234");
@@ -568,6 +618,19 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "1900-02-28 12:34:56.1234", -2203932304000000LL + 123400LL);
     AssertConversion(type, "1900-02-28 12:34:56.12345", -2203932304000000LL + 123450LL);
     AssertConversion(type, "1900-02-28 12:34:56.123456", -2203932304000000LL + 123456LL);
+
+    AssertConversion(type, "1900-02-28 12:34:56.123456+01",
+                     -2203932304000000LL + 123456LL - 3600000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456+0117",
+                     -2203932304000000LL + 123456LL - 4620000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456+01:17",
+                     -2203932304000000LL + 123456LL - 4620000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456-01",
+                     -2203932304000000LL + 123456LL + 3600000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456-0117",
+                     -2203932304000000LL + 123456LL + 4620000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456-01:17",
+                     -2203932304000000LL + 123456LL + 4620000000LL);
 
     // Invalid subseconds
     AssertConversionFails(type, "1900-02-28 12:34:56.1234567");
@@ -602,7 +665,21 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "1900-02-28 12:34:56.123456789",
                      -2203932304000000000LL + 123456789LL);
 
+    AssertConversion(type, "1900-02-28 12:34:56.123456789+01",
+                     -2203932304000000000LL + 123456789LL - 3600000000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789+0117",
+                     -2203932304000000000LL + 123456789LL - 4620000000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789+01:17",
+                     -2203932304000000000LL + 123456789LL - 4620000000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789-01",
+                     -2203932304000000000LL + 123456789LL + 3600000000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789-0117",
+                     -2203932304000000000LL + 123456789LL + 4620000000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789-01:17",
+                     -2203932304000000000LL + 123456789LL + 4620000000000LL);
+
     // Invalid subseconds
+    AssertConversionFails(type, "1900-02-28 12:34:56.1234567890");
   }
 }
 
@@ -618,10 +695,7 @@ TEST(TimestampParser, StrptimeParser) {
   std::vector<Case> cases = {{"5/31/2000 12:34:56", "2000-05-31 12:34:56"},
                              {"5/31/2000 00:00:00", "2000-05-31 00:00:00"}};
 
-  std::vector<TimeUnit::type> units = {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO,
-                                       TimeUnit::NANO};
-
-  for (auto unit : units) {
+  for (auto unit : TimeUnit::values()) {
     for (const auto& case_ : cases) {
       int64_t converted, expected;
       ASSERT_TRUE((*parser)(case_.value.c_str(), case_.value.size(), unit, &converted));
@@ -636,6 +710,34 @@ TEST(TimestampParser, StrptimeParser) {
   for (auto& value : unparseables) {
     int64_t dummy;
     ASSERT_FALSE((*parser)(value.c_str(), value.size(), TimeUnit::SECOND, &dummy));
+  }
+}
+
+TEST(TimestampParser, StrptimeZoneOffset) {
+  if (!kStrptimeSupportsZone) {
+    GTEST_SKIP() << "strptime does not support %z on this platform";
+  }
+  std::string format = "%Y-%d-%m %H:%M:%S%z";
+  auto parser = TimestampParser::MakeStrptime(format);
+
+  // N.B. GNU %z supports ISO8601 format while BSD %z supports only
+  // +HHMM or -HHMM and POSIX doesn't appear to define %z at all
+  for (auto unit : TimeUnit::values()) {
+    for (const std::string& value :
+         {"2018-01-01 00:00:00+0000", "2018-01-01 00:00:00+0100",
+          "2018-01-01 00:00:00+0130", "2018-01-01 00:00:00-0117"}) {
+      SCOPED_TRACE(value);
+      int64_t converted = 0;
+      int64_t expected = 0;
+      ASSERT_TRUE((*parser)(value.c_str(), value.size(), unit, &converted));
+      ASSERT_TRUE(ParseTimestampISO8601(value.c_str(), value.size(), unit, &expected));
+      ASSERT_EQ(expected, converted);
+    }
+    for (const std::string& value : {"2018-01-01 00:00:00", "2018-01-01 00:00:00EST"}) {
+      SCOPED_TRACE(value);
+      int64_t converted = 0;
+      ASSERT_FALSE((*parser)(value.c_str(), value.size(), unit, &converted));
+    }
   }
 }
 

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -219,10 +219,10 @@ test_that("read_csv_arrow() can read timestamps", {
   on.exit(unlink(tf))
   write.csv(tbl, tf, row.names = FALSE)
 
-  df <- read_csv_arrow(tf, col_types = schema(time = timestamp(timezone = "UTC")))
-  expect_equal(tbl, df)
-
+  df <- read_csv_arrow(tf, col_types = schema(time = timestamp()))
   # time zones are being read in as time zone-naive, hence ignore_attr = "tzone"
+  expect_equal(tbl, df, ignore_attr = "tzone")
+
   df <- read_csv_arrow(tf, col_types = "T", col_names = "time", skip = 1)
   expect_equal(tbl, df, ignore_attr = "tzone")
 })
@@ -235,10 +235,12 @@ test_that("read_csv_arrow(timestamp_parsers=)", {
 
   df <- read_csv_arrow(
     tf,
-    col_types = schema(time = timestamp(timezone = "UTC")),
+    col_types = schema(time = timestamp()),
     timestamp_parsers = "%d/%m/%Y"
   )
-  expect_equal(df$time, as.POSIXct(tbl$time, format = "%d/%m/%Y", tz = "UTC"))
+  # time zones are being read in as time zone-naive, hence ignore_attr = "tzone"
+  expected <- as.POSIXct(tbl$time, format = "%d/%m/%Y", tz = "UTC")
+  expect_equal(df$time, expected, ignore_attr = "tzone")
 })
 
 test_that("Skipping columns with null()", {


### PR DESCRIPTION
For ISO8601, this seems to have a small (~5%) impact on benchmarks.

For strptime, this is only supported on platforms exposing `tm_gmtoff` in `struct tm`. `%Z` still is ignored; it seems implementations don't really support it anyways. (For instance GNU libc will skip over the time zone, omitting it from the result.)