### PR TITLE
ARROW-14069: [R] By default, filter out hash functions in list_compute_functions()

### DIFF
--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -97,8 +97,13 @@ list_compute_functions <- function(pattern = NULL, ...) {
   if (!is.null(pattern)) {
     funcs <- grep(pattern, funcs, value = TRUE, ...)
   }
-  # TODO: This filtering will already happen in C++ with ARROW-13943
-  funcs <- grep("hash_", funcs, value = TRUE, invert = TRUE)
+  # TODO: Filtering of hash funcs will already happen in C++ with ARROW-13943
+  funcs <- grep(
+    "^hash_|index_in_meta_binary|is_in_meta_binary",
+    funcs,
+    value = TRUE,
+    invert = TRUE
+  )
   funcs
 }
 

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -97,6 +97,7 @@ list_compute_functions <- function(pattern = NULL, ...) {
   if (!is.null(pattern)) {
     funcs <- grep(pattern, funcs, value = TRUE, ...)
   }
+  funcs <- grep("hash_", funcs, value = TRUE, invert = TRUE)
   funcs
 }
 

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -97,6 +97,7 @@ list_compute_functions <- function(pattern = NULL, ...) {
   if (!is.null(pattern)) {
     funcs <- grep(pattern, funcs, value = TRUE, ...)
   }
+  # TODO: This filtering will already happen in C++ with ARROW-13943
   funcs <- grep("hash_", funcs, value = TRUE, invert = TRUE)
   funcs
 }

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -99,7 +99,7 @@ list_compute_functions <- function(pattern = NULL, ...) {
   }
   # TODO: Filtering of hash funcs will already happen in C++ with ARROW-13943
   funcs <- grep(
-    "^hash_|index_in_meta_binary|is_in_meta_binary",
+    "^hash_",
     funcs,
     value = TRUE,
     invert = TRUE

--- a/r/tests/testthat/test-compute-aggregate.R
+++ b/r/tests/testthat/test-compute-aggregate.R
@@ -21,8 +21,8 @@ test_that("list_compute_functions", {
   justmins <- list_compute_functions("^min")
   expect_true(length(justmins) > 0)
   expect_true(all(grepl("min", justmins)))
-  hash_funcs <- list_compute_functions("^hash")
-  expect_true(length(hash_funcs) == 0)
+  no_hash_funcs <- list_compute_functions("^hash")
+  expect_true(length(no_hash_funcs) == 0)
 })
 
 test_that("sum.Array", {

--- a/r/tests/testthat/test-compute-aggregate.R
+++ b/r/tests/testthat/test-compute-aggregate.R
@@ -21,6 +21,8 @@ test_that("list_compute_functions", {
   justmins <- list_compute_functions("^min")
   expect_true(length(justmins) > 0)
   expect_true(all(grepl("min", justmins)))
+  hash_funcs <- list_compute_functions("^hash")
+  expect_true(length(hash_funcs) == 0)
 })
 
 test_that("sum.Array", {


### PR DESCRIPTION
Filter the following functions from `list_compute_functions()`:
* any which start with "hash_"
* `index_in_meta_binary`
* `is_in_meta_binary`