### PR TITLE
ARROW-14259: [R] converting from R vector to Array when the R vector is altrep

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -4,6 +4,10 @@ test_SET_STRING_ELT <- function(s) {
   invisible(.Call(`_arrow_test_SET_STRING_ELT`, s))
 }
 
+test_same_Array <- function(x, y) {
+  .Call(`_arrow_test_same_Array`, x, y)
+}
+
 Array__Slice1 <- function(array, offset) {
   .Call(`_arrow_Array__Slice1`, array, offset)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -8,6 +8,10 @@ test_same_Array <- function(x, y) {
   .Call(`_arrow_test_same_Array`, x, y)
 }
 
+is_arrow_altrep <- function(x) {
+  .Call(`_arrow_is_arrow_altrep`, x)
+}
+
 Array__Slice1 <- function(array, offset) {
   .Call(`_arrow_Array__Slice1`, array, offset)
 }

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -72,6 +72,11 @@ R_xlen_t Standard_Get_region<int>(SEXP data2, R_xlen_t i, R_xlen_t n, int* buf) 
 void DeleteArray(std::shared_ptr<Array>* ptr) { delete ptr; }
 using Pointer = cpp11::external_pointer<std::shared_ptr<Array>, DeleteArray>;
 
+// the Array that is being wrapped by the altrep object
+static const std::shared_ptr<Array>& GetArray(SEXP alt) {
+  return *Pointer(R_altrep_data1(alt));
+}
+
 // base class for all altrep vectors
 //
 // data1: the Array as an external pointer.
@@ -87,11 +92,6 @@ struct AltrepVectorBase {
     MARK_NOT_MUTABLE(alt);
 
     return alt;
-  }
-
-  // the Array that is being wrapped by the altrep object
-  static const std::shared_ptr<Array>& GetArray(SEXP alt) {
-    return *Pointer(R_altrep_data1(alt));
   }
 
   // Is the vector materialized, i.e. does the data2 slot contain a
@@ -176,7 +176,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     }
 
     // the Array has no nulls, we can directly return the start of its data
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     if (array->null_count() == 0) {
       return reinterpret_cast<const void*>(array->data()->template GetValues<c_type>(1));
     }
@@ -190,7 +190,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     // If the object hasn't been materialized, and the array has no
     // nulls we can directly point to the array data.
     if (!Base::IsMaterialized(alt)) {
-      const auto& array = Base::GetArray(alt);
+      const auto& array = GetArray(alt);
 
       if (array->null_count() == 0) {
         return reinterpret_cast<void*>(
@@ -215,7 +215,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
 
   // The value at position i
   static c_type Elt(SEXP alt, R_xlen_t i) {
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     return array->IsNull(i) ? cpp11::na<c_type>()
                             : array->data()->template GetValues<c_type>(1)[i];
   }
@@ -237,7 +237,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     // array has nulls
     //
     // This only materialize the region, into buf. Not the entire vector.
-    auto slice = Base::GetArray(alt)->Slice(i, n);
+    auto slice = GetArray(alt)->Slice(i, n);
     R_xlen_t ncopy = slice->length();
 
     // first copy the data buffer
@@ -273,7 +273,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     using scalar_type =
         typename std::conditional<sexp_type == INTSXP, Int32Scalar, DoubleScalar>::type;
 
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     bool na_rm = narm == TRUE;
     auto n = array->length();
     auto null_count = array->null_count();
@@ -303,7 +303,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
   static SEXP Sum(SEXP alt, Rboolean narm) {
     using data_type = typename std::conditional<sexp_type == REALSXP, double, int>::type;
 
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     bool na_rm = narm == TRUE;
     auto null_count = array->null_count();
 
@@ -436,7 +436,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
 
     BEGIN_CPP11
 
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     RStringViewer r_string_viewer(array);
 
     // r_string_viewer.Convert(i) might jump so it's wrapped
@@ -463,7 +463,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
 
     BEGIN_CPP11
 
-    const auto& array = Base::GetArray(alt);
+    const auto& array = GetArray(alt);
     R_xlen_t n = array->length();
     SEXP data2 = PROTECT(Rf_allocVector(STRSXP, n));
     MARK_NOT_MUTABLE(data2);
@@ -629,6 +629,24 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
   return R_NilValue;
 }
 
+// borrowed from
+// https://github.com/r-devel/r-svn/blob/6418faeb6f5d87d3d9b92b8978773bc3856b4b6f/src/main/altrep.c#L37
+#define ALTREP_CLASS_SERIALIZED_CLASS(x) ATTRIB(x)
+#define ALTREP_SERIALIZED_CLASS_PKGSYM(x) CADR(x)
+
+std::shared_ptr<Array> vec_to_arrow_altrep_bypass(SEXP x) {
+  if (ALTREP(x)) {
+    SEXP info = ALTREP_CLASS_SERIALIZED_CLASS(ALTREP_CLASS(x));
+    SEXP pkg = ALTREP_SERIALIZED_CLASS_PKGSYM(info);
+
+    if (pkg == symbols::arrow) {
+      return GetArray(x);
+    }
+  }
+
+  return nullptr;
+}
+
 }  // namespace altrep
 }  // namespace r
 }  // namespace arrow
@@ -644,6 +662,8 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
   return R_NilValue;
 }
 
+std::shared_ptr<Array> vec_to_arrow_altrep_bypass(SEXP x) { return nullptr; }
+
 }  // namespace altrep
 }  // namespace r
 }  // namespace arrow
@@ -652,5 +672,13 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
 
 // [[arrow::export]]
 void test_SET_STRING_ELT(SEXP s) { SET_STRING_ELT(s, 0, Rf_mkChar("forbidden")); }
+
+// [[arrow::export]]
+bool test_same_Array(SEXP x, SEXP y) {
+  auto* p_x = reinterpret_cast<std::shared_ptr<arrow::Array>*>(x);
+  auto* p_y = reinterpret_cast<std::shared_ptr<arrow::Array>*>(y);
+
+  return p_x->get() == p_y->get();
+}
 
 #endif

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -629,15 +629,15 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
   return R_NilValue;
 }
 
-// borrowed from
+// For context, see
 // https://github.com/r-devel/r-svn/blob/6418faeb6f5d87d3d9b92b8978773bc3856b4b6f/src/main/altrep.c#L37
 #define ALTREP_CLASS_SERIALIZED_CLASS(x) ATTRIB(x)
 #define ALTREP_SERIALIZED_CLASS_PKGSYM(x) CADR(x)
 
 std::shared_ptr<Array> vec_to_arrow_altrep_bypass(SEXP x) {
   if (ALTREP(x)) {
-    SEXP info = ALTREP_CLASS_SERIALIZED_CLASS(ALTREP_CLASS(x));
-    SEXP pkg = ALTREP_SERIALIZED_CLASS_PKGSYM(info);
+    SEXP info = ATTRIB(ALTREP_CLASS(x));
+    SEXP pkg = CADR(info);
 
     if (pkg == symbols::arrow) {
       return GetArray(x);

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -20,6 +20,22 @@ extern "C" SEXP _arrow_test_SET_STRING_ELT(SEXP s_sexp){
 }
 #endif
 
+// altrep.cpp
+#if defined(ARROW_R_WITH_ARROW)
+bool test_same_Array(SEXP x, SEXP y);
+extern "C" SEXP _arrow_test_same_Array(SEXP x_sexp, SEXP y_sexp){
+BEGIN_CPP11
+	arrow::r::Input<SEXP>::type x(x_sexp);
+	arrow::r::Input<SEXP>::type y(y_sexp);
+	return cpp11::as_sexp(test_same_Array(x, y));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_test_same_Array(SEXP x_sexp, SEXP y_sexp){
+	Rf_error("Cannot call test_same_Array(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // array.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::Array> Array__Slice1(const std::shared_ptr<arrow::Array>& array, R_xlen_t offset);
@@ -7090,6 +7106,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
 		{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
+		{ "_arrow_test_same_Array", (DL_FUNC) &_arrow_test_same_Array, 2}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 
 		{ "_arrow_Array__Slice2", (DL_FUNC) &_arrow_Array__Slice2, 3}, 
 		{ "_arrow_Array__IsNull", (DL_FUNC) &_arrow_Array__IsNull, 2}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -36,6 +36,21 @@ extern "C" SEXP _arrow_test_same_Array(SEXP x_sexp, SEXP y_sexp){
 }
 #endif
 
+// altrep.cpp
+#if defined(ARROW_R_WITH_ARROW)
+bool is_arrow_altrep(SEXP x);
+extern "C" SEXP _arrow_is_arrow_altrep(SEXP x_sexp){
+BEGIN_CPP11
+	arrow::r::Input<SEXP>::type x(x_sexp);
+	return cpp11::as_sexp(is_arrow_altrep(x));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_is_arrow_altrep(SEXP x_sexp){
+	Rf_error("Cannot call is_arrow_altrep(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // array.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::Array> Array__Slice1(const std::shared_ptr<arrow::Array>& array, R_xlen_t offset);
@@ -7107,6 +7122,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
 		{ "_arrow_test_same_Array", (DL_FUNC) &_arrow_test_same_Array, 2}, 
+		{ "_arrow_is_arrow_altrep", (DL_FUNC) &_arrow_is_arrow_altrep, 1}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 
 		{ "_arrow_Array__Slice2", (DL_FUNC) &_arrow_Array__Slice2, 3}, 
 		{ "_arrow_Array__IsNull", (DL_FUNC) &_arrow_Array__IsNull, 2}, 

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -121,6 +121,7 @@ struct symbols {
   static SEXP arrow_attributes;
   static SEXP new_;
   static SEXP create;
+  static SEXP arrow;
 };
 
 struct data {

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -35,6 +35,11 @@
 #define IS_ASCII(x) (LEVELS(x) & ASCII_MASK)
 #define IS_UTF8(x) (LEVELS(x) & UTF8_MASK)
 
+// For context, see:
+// https://github.com/r-devel/r-svn/blob/6418faeb6f5d87d3d9b92b8978773bc3856b4b6f/src/main/altrep.c#L37
+#define ALTREP_CLASS_SERIALIZED_CLASS(x) ATTRIB(x)
+#define ALTREP_SERIALIZED_CLASS_PKGSYM(x) CADR(x)
+
 namespace arrow {
 namespace r {
 

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -183,7 +183,7 @@ arrow::Status AddMetadataFromDots(SEXP lst, int num_fields,
 namespace altrep {
 
 void Init_Altrep_classes(DllInfo* dll);
-SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& array);
+SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array);
 
 }  // namespace altrep
 #endif

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -1157,12 +1157,22 @@ std::shared_ptr<arrow::Array> vec_to_arrow__reuse_memory(SEXP x) {
   cpp11::stop("Unreachable: you might need to fix can_reuse_memory()");
 }
 
+namespace altrep {
+std::shared_ptr<Array> vec_to_arrow_altrep_bypass(SEXP);  // in altrep.cpp
+}
+
 std::shared_ptr<arrow::Array> vec_to_arrow(SEXP x,
                                            const std::shared_ptr<arrow::DataType>& type,
                                            bool type_inferred) {
   // short circuit if `x` is already an Array
   if (Rf_inherits(x, "Array")) {
     return cpp11::as_cpp<std::shared_ptr<arrow::Array>>(x);
+  }
+
+  // short circuit if `x` is an altrep vector that shells an Array
+  auto maybe = altrep::vec_to_arrow_altrep_bypass(x);
+  if (maybe.get()) {
+    return maybe;
   }
 
   RConversionOptions options;

--- a/r/src/symbols.cpp
+++ b/r/src/symbols.cpp
@@ -33,6 +33,7 @@ SEXP symbols::list_size = Rf_install("list_size");
 SEXP symbols::arrow_attributes = Rf_install("arrow_attributes");
 SEXP symbols::new_ = Rf_install("new");
 SEXP symbols::create = Rf_install("create");
+SEXP symbols::arrow = Rf_install("arrow");
 
 // persistently protect `x` and return it
 SEXP precious(SEXP x) {

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -227,3 +227,17 @@ test_that("columns of struct types may be altrep", {
   expect_true(is_altrep(df$x))
   expect_true(is_altrep(df$y))
 })
+
+test_that("Conversion from altrep R vector to Array uses the existing Array", {
+  a_int <- Array$create(c(1L, 2L, 3L))
+  b_int <- Array$create(a_int$as_vector())
+  expect_true(test_same_Array(a_int$pointer(), b_int$pointer()))
+
+  a_dbl <- Array$create(c(1, 2, 3))
+  b_dbl <- Array$create(a_dbl$as_vector())
+  expect_true(test_same_Array(a_dbl$pointer(), b_dbl$pointer()))
+
+  a_str <- Array$create(c("un", "deux", "trois"))
+  b_str <- Array$create(a_str$as_vector())
+  expect_true(test_same_Array(a_str$pointer(), b_str$pointer()))
+})

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -17,9 +17,9 @@
 
 skip_if(getRversion() <= "3.5.0")
 
-is_altrep <- function(x) {
-  !is.null(.Internal(altrep_class(x)))
-}
+test_that("is_arrow_altrep() does not include base altrep", {
+  expect_false(is_arrow_altrep(1:10))
+})
 
 test_that("altrep vectors from int32 and dbl arrays with no nulls", {
   withr::local_options(list(arrow.use_altrep = TRUE))
@@ -28,30 +28,30 @@ test_that("altrep vectors from int32 and dbl arrays with no nulls", {
   c_int <- ChunkedArray$create(1:1000)
   c_dbl <- ChunkedArray$create(as.numeric(1:1000))
 
-  expect_true(is_altrep(as.vector(v_int)))
-  expect_true(is_altrep(as.vector(v_int$Slice(1))))
-  expect_true(is_altrep(as.vector(v_dbl)))
-  expect_true(is_altrep(as.vector(v_dbl$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_int)))
+  expect_true(is_arrow_altrep(as.vector(v_int$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_dbl)))
+  expect_true(is_arrow_altrep(as.vector(v_dbl$Slice(1))))
 
   expect_equal(c_int$num_chunks, 1L)
-  expect_true(is_altrep(as.vector(c_int)))
-  expect_true(is_altrep(as.vector(c_int$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(c_int)))
+  expect_true(is_arrow_altrep(as.vector(c_int$Slice(1))))
 
   expect_equal(c_dbl$num_chunks, 1L)
-  expect_true(is_altrep(as.vector(c_dbl)))
-  expect_true(is_altrep(as.vector(c_dbl$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(c_dbl)))
+  expect_true(is_arrow_altrep(as.vector(c_dbl$Slice(1))))
 
   withr::local_options(list(arrow.use_altrep = NULL))
-  expect_true(is_altrep(as.vector(v_int)))
-  expect_true(is_altrep(as.vector(v_int$Slice(1))))
-  expect_true(is_altrep(as.vector(v_dbl)))
-  expect_true(is_altrep(as.vector(v_dbl$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_int)))
+  expect_true(is_arrow_altrep(as.vector(v_int$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_dbl)))
+  expect_true(is_arrow_altrep(as.vector(v_dbl$Slice(1))))
 
   withr::local_options(list(arrow.use_altrep = FALSE))
-  expect_false(is_altrep(as.vector(v_int)))
-  expect_false(is_altrep(as.vector(v_int$Slice(1))))
-  expect_false(is_altrep(as.vector(v_dbl)))
-  expect_false(is_altrep(as.vector(v_dbl$Slice(1))))
+  expect_false(is_arrow_altrep(as.vector(v_int)))
+  expect_false(is_arrow_altrep(as.vector(v_int$Slice(1))))
+  expect_false(is_arrow_altrep(as.vector(v_dbl)))
+  expect_false(is_arrow_altrep(as.vector(v_dbl$Slice(1))))
 })
 
 test_that("altrep vectors from int32 and dbl arrays with nulls", {
@@ -61,19 +61,19 @@ test_that("altrep vectors from int32 and dbl arrays with nulls", {
   c_int <- ChunkedArray$create(c(1L, NA, 3L))
   c_dbl <- ChunkedArray$create(c(1, NA, 3))
 
-  expect_true(is_altrep(as.vector(v_int)))
-  expect_true(is_altrep(as.vector(v_int$Slice(1))))
-  expect_true(is_altrep(as.vector(v_dbl)))
-  expect_true(is_altrep(as.vector(v_dbl$Slice(1))))
-  expect_true(is_altrep(as.vector(c_int)))
-  expect_true(is_altrep(as.vector(c_int$Slice(1))))
-  expect_true(is_altrep(as.vector(c_dbl)))
-  expect_true(is_altrep(as.vector(c_dbl$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_int)))
+  expect_true(is_arrow_altrep(as.vector(v_int$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(v_dbl)))
+  expect_true(is_arrow_altrep(as.vector(v_dbl$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(c_int)))
+  expect_true(is_arrow_altrep(as.vector(c_int$Slice(1))))
+  expect_true(is_arrow_altrep(as.vector(c_dbl)))
+  expect_true(is_arrow_altrep(as.vector(c_dbl$Slice(1))))
 
-  expect_true(is_altrep(as.vector(v_int$Slice(2))))
-  expect_true(is_altrep(as.vector(v_dbl$Slice(2))))
-  expect_true(is_altrep(as.vector(c_int$Slice(2))))
-  expect_true(is_altrep(as.vector(c_dbl$Slice(2))))
+  expect_true(is_arrow_altrep(as.vector(v_int$Slice(2))))
+  expect_true(is_arrow_altrep(as.vector(v_dbl$Slice(2))))
+  expect_true(is_arrow_altrep(as.vector(c_int$Slice(2))))
+  expect_true(is_arrow_altrep(as.vector(c_dbl$Slice(2))))
 
   # chunked array with 2 chunks cannot be altrep
   c_int <- ChunkedArray$create(0L, c(1L, NA, 3L))
@@ -81,10 +81,10 @@ test_that("altrep vectors from int32 and dbl arrays with nulls", {
   expect_equal(c_int$num_chunks, 2L)
   expect_equal(c_dbl$num_chunks, 2L)
 
-  expect_false(is_altrep(as.vector(c_int)))
-  expect_false(is_altrep(as.vector(c_dbl)))
-  expect_true(is_altrep(as.vector(c_int$Slice(3))))
-  expect_true(is_altrep(as.vector(c_dbl$Slice(3))))
+  expect_false(is_arrow_altrep(as.vector(c_int)))
+  expect_false(is_arrow_altrep(as.vector(c_dbl)))
+  expect_true(is_arrow_altrep(as.vector(c_int$Slice(3))))
+  expect_true(is_arrow_altrep(as.vector(c_dbl$Slice(3))))
 })
 
 test_that("empty vectors are not altrep", {
@@ -92,8 +92,8 @@ test_that("empty vectors are not altrep", {
   v_int <- Array$create(integer())
   v_dbl <- Array$create(numeric())
 
-  expect_false(is_altrep(as.vector(v_int)))
-  expect_false(is_altrep(as.vector(v_dbl)))
+  expect_false(is_arrow_altrep(as.vector(v_int)))
+  expect_false(is_arrow_altrep(as.vector(v_dbl)))
 })
 
 test_that("as.data.frame(<Table>, <RecordBatch>) can create altrep vectors", {
@@ -101,23 +101,23 @@ test_that("as.data.frame(<Table>, <RecordBatch>) can create altrep vectors", {
 
   table <- Table$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3), str = c("un", "deux", "trois"))
   df_table <- as.data.frame(table)
-  expect_true(is_altrep(df_table$int))
-  expect_true(is_altrep(df_table$dbl))
-  expect_true(is_altrep(df_table$str))
+  expect_true(is_arrow_altrep(df_table$int))
+  expect_true(is_arrow_altrep(df_table$dbl))
+  expect_true(is_arrow_altrep(df_table$str))
 
   batch <- RecordBatch$create(int = c(1L, 2L, 3L), dbl = c(1, 2, 3), str = c("un", "deux", "trois"))
   df_batch <- as.data.frame(batch)
-  expect_true(is_altrep(df_batch$int))
-  expect_true(is_altrep(df_batch$dbl))
-  expect_true(is_altrep(df_batch$str))
+  expect_true(is_arrow_altrep(df_batch$int))
+  expect_true(is_arrow_altrep(df_batch$dbl))
+  expect_true(is_arrow_altrep(df_batch$str))
 })
 
 expect_altrep_rountrip <- function(x, fn, ...) {
   alt <- Array$create(x)$as_vector()
 
-  expect_true(is_altrep(alt))
+  expect_true(is_arrow_altrep(alt))
   expect_identical(fn(x, ...), fn(alt, ...))
-  expect_true(is_altrep(alt))
+  expect_true(is_arrow_altrep(alt))
 }
 
 test_that("altrep min/max/sum identical to R versions for double", {
@@ -224,8 +224,8 @@ test_that("columns of struct types may be altrep", {
   st <- Array$create(data.frame(x = 1:10, y = runif(10)))
   df <- st$as_vector()
 
-  expect_true(is_altrep(df$x))
-  expect_true(is_altrep(df$y))
+  expect_true(is_arrow_altrep(df$x))
+  expect_true(is_arrow_altrep(df$y))
 })
 
 test_that("Conversion from altrep R vector to Array uses the existing Array", {


### PR DESCRIPTION
``` r
library(arrow, warn.conflicts = FALSE)
#> See arrow_info() for available features

a <- Array$create(c(1, 2, 3))
b <- Array$create(a$as_vector())

# different shared_ptr
a$pointer()
#> <pointer: 0x7f9617c99040>
b$pointer()
#> <pointer: 0x7f9617cf9b50>

# but they both point to the same underlying Array*
arrow:::test_same_Array(a$pointer(), b$pointer())
#> [1] TRUE
```

<sup>Created on 2021-10-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>