### PR TITLE
ARROW-13948: [C++] Support timestamp with timezone in is_in/index_in

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -532,44 +532,22 @@ Result<Datum> MinElementWise(const std::vector<Datum>& args,
 // ----------------------------------------------------------------------
 // Set-related operations
 
-static Result<Datum> ExecSetLookup(const std::string& func_name, const Datum& data,
-                                   const SetLookupOptions& options, ExecContext* ctx) {
-  if (!options.value_set.is_arraylike()) {
-    return Status::Invalid("Set lookup value set must be Array or ChunkedArray");
-  }
-  std::shared_ptr<DataType> data_type;
-  if (data.type()->id() == Type::DICTIONARY) {
-    data_type =
-        arrow::internal::checked_pointer_cast<DictionaryType>(data.type())->value_type();
-  } else {
-    data_type = data.type();
-  }
-
-  if (options.value_set.length() > 0 && !data_type->Equals(options.value_set.type())) {
-    std::stringstream ss;
-    ss << "Array type didn't match type of values set: " << data_type->ToString()
-       << " vs " << options.value_set.type()->ToString();
-    return Status::Invalid(ss.str());
-  }
-  return CallFunction(func_name, {data}, &options, ctx);
-}
-
 Result<Datum> IsIn(const Datum& values, const SetLookupOptions& options,
                    ExecContext* ctx) {
-  return ExecSetLookup("is_in", values, options, ctx);
+  return CallFunction("is_in", {values}, &options, ctx);
 }
 
 Result<Datum> IsIn(const Datum& values, const Datum& value_set, ExecContext* ctx) {
-  return ExecSetLookup("is_in", values, SetLookupOptions{value_set}, ctx);
+  return IsIn(values, SetLookupOptions{value_set}, ctx);
 }
 
 Result<Datum> IndexIn(const Datum& values, const SetLookupOptions& options,
                       ExecContext* ctx) {
-  return ExecSetLookup("index_in", values, options, ctx);
+  return CallFunction("index_in", {values}, &options, ctx);
 }
 
 Result<Datum> IndexIn(const Datum& values, const Datum& value_set, ExecContext* ctx) {
-  return ExecSetLookup("index_in", values, SetLookupOptions{value_set}, ctx);
+  return IndexIn(values, SetLookupOptions{value_set}, ctx);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -194,7 +194,7 @@ struct InitStateVisitor {
             "Cannot compare timestamp with timezone to timestamp without timezone, got: ",
             ty1, " and ", ty2);
       }
-    } else if (arg_type->id() == Type::STRING &&
+    } else if ((arg_type->id() == Type::STRING || arg_type->id() == Type::LARGE_STRING) &&
                !is_base_binary_like(options.value_set.type()->id())) {
       // This is a bit of a hack, but don't implicitly cast from a non-binary
       // type to string, since most types support casting to string and that

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -194,6 +194,13 @@ struct InitStateVisitor {
             "Cannot compare timestamp with timezone to timestamp without timezone, got: ",
             ty1, " and ", ty2);
       }
+    } else if (arg_type->id() == Type::STRING &&
+               !is_base_binary_like(options.value_set.type()->id())) {
+      // This is a bit of a hack, but don't implicitly cast from a non-binary
+      // type to string, since most types support casting to string and that
+      // may lead to surprises. However, we do want most other implicit casts.
+      return Status::Invalid("Array type didn't match type of values set: ", *arg_type,
+                             " vs ", *options.value_set.type());
     }
     if (!options.value_set.is_arraylike()) {
       return Status::Invalid("Set lookup value set must be Array or ChunkedArray");

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -184,7 +184,20 @@ struct InitStateVisitor {
   }
 
   Result<std::unique_ptr<KernelState>> GetResult() {
-    if (!options.value_set.type()->Equals(arg_type)) {
+    if (arg_type->id() == Type::TIMESTAMP &&
+        options.value_set.type()->id() == Type::TIMESTAMP) {
+      // Other types will fail when casting, so no separate check is needed
+      const auto& ty1 = checked_cast<const TimestampType&>(*arg_type);
+      const auto& ty2 = checked_cast<const TimestampType&>(*options.value_set.type());
+      if (ty1.timezone().empty() ^ ty2.timezone().empty()) {
+        return Status::Invalid(
+            "Cannot compare timestamp with timezone to timestamp without timezone, got: ",
+            ty1, " and ", ty2);
+      }
+    }
+    if (!options.value_set.is_arraylike()) {
+      return Status::Invalid("Set lookup value set must be Array or ChunkedArray");
+    } else if (!options.value_set.type()->Equals(arg_type)) {
       ARROW_ASSIGN_OR_RAISE(
           options.value_set,
           Cast(options.value_set, CastOptions::Safe(arg_type), ctx->exec_context()));
@@ -416,7 +429,7 @@ void AddBasicSetLookupKernels(ScalarKernel kernel,
   AddKernels(TemporalTypes());
   AddKernels({month_day_nano_interval()});
 
-  std::vector<Type::type> other_types = {Type::BOOL, Type::DECIMAL,
+  std::vector<Type::type> other_types = {Type::BOOL, Type::DECIMAL128, Type::DECIMAL256,
                                          Type::FIXED_SIZE_BINARY};
   for (auto ty : other_types) {
     kernel.signature = KernelSignature::Make({InputType::Array(ty)}, out_ty);

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -406,7 +406,7 @@ void AddBasicSetLookupKernels(ScalarKernel kernel,
                               ScalarFunction* func) {
   auto AddKernels = [&](const std::vector<std::shared_ptr<DataType>>& types) {
     for (const std::shared_ptr<DataType>& ty : types) {
-      kernel.signature = KernelSignature::Make({ty}, out_ty);
+      kernel.signature = KernelSignature::Make({InputType(ty->id())}, out_ty);
       DCHECK_OK(func->AddKernel(kernel));
     }
   };

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -125,6 +125,19 @@ TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
   // fails; value_set cannot be cast to int8
   opts = SetLookupOptions{ArrayFromJSON(float32(), "[2.5, 3.1, 5.0]")};
   ASSERT_RAISES(Invalid, CallFunction("is_in", {input}, &opts));
+
+  // Allow implicit casts between binary types...
+  CheckIsIn(ArrayFromJSON(binary(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
+            ArrayFromJSON(fixed_size_binary(3), R"(["aaa", "bbb"])"),
+            "[true, true, false, false, true]");
+  CheckIsIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
+            ArrayFromJSON(large_utf8(), R"(["aaa", "bbb"])"),
+            "[true, true, false, false, true]");
+  // But explicitly deny implicit casts from non-binary to utf8 to
+  // avoid surprises
+  ASSERT_RAISES(Invalid,
+                IsIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
+                     SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -185,7 +185,8 @@ TEST_F(TestIsInKernel, NullType) {
 
 TEST_F(TestIsInKernel, TimeTimestamp) {
   for (const auto& type :
-       {time32(TimeUnit::SECOND), time64(TimeUnit::NANO), timestamp(TimeUnit::MICRO)}) {
+       {time32(TimeUnit::SECOND), time64(TimeUnit::NANO), timestamp(TimeUnit::MICRO),
+        timestamp(TimeUnit::NANO, "UTC")}) {
     CheckIsIn(type, "[1, null, 5, 1, 2]", "[2, 1, null]",
               "[true, true, false, true, true]", /*skip_nulls=*/false);
     CheckIsIn(type, "[1, null, 5, 1, 2]", "[2, 1, null]",
@@ -628,6 +629,9 @@ TEST_F(TestIndexInKernel, TimeTimestamp) {
   CheckIndexIn(time64(TimeUnit::NANO), "[2, null, 2, 1]", "[2, null, 1]", "[0, 1, 0, 2]");
 
   CheckIndexIn(timestamp(TimeUnit::NANO), "[2, null, 2, 1]", "[2, null, 1]",
+               "[0, 1, 0, 2]");
+
+  CheckIndexIn(timestamp(TimeUnit::SECOND, "UTC"), "[2, null, 2, 1]", "[2, null, 1]",
                "[0, 1, 0, 2]");
 
   // Empty input array

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -47,11 +47,9 @@ namespace compute {
 // ----------------------------------------------------------------------
 // IsIn tests
 
-void CheckIsIn(const std::shared_ptr<DataType>& type, const std::string& input_json,
-               const std::string& value_set_json, const std::string& expected_json,
+void CheckIsIn(const std::shared_ptr<Array> input,
+               const std::shared_ptr<Array>& value_set, const std::string& expected_json,
                bool skip_nulls = false) {
-  auto input = ArrayFromJSON(type, input_json);
-  auto value_set = ArrayFromJSON(type, value_set_json);
   auto expected = ArrayFromJSON(boolean(), expected_json);
 
   ASSERT_OK_AND_ASSIGN(Datum actual_datum,
@@ -59,6 +57,14 @@ void CheckIsIn(const std::shared_ptr<DataType>& type, const std::string& input_j
   std::shared_ptr<Array> actual = actual_datum.make_array();
   ValidateOutput(actual_datum);
   AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+}
+
+void CheckIsIn(const std::shared_ptr<DataType>& type, const std::string& input_json,
+               const std::string& value_set_json, const std::string& expected_json,
+               bool skip_nulls = false) {
+  auto input = ArrayFromJSON(type, input_json);
+  auto value_set = ArrayFromJSON(type, value_set_json);
+  CheckIsIn(input, value_set, expected_json, skip_nulls);
 }
 
 void CheckIsInChunked(const std::shared_ptr<ChunkedArray>& input,
@@ -198,6 +204,19 @@ TEST_F(TestIsInKernel, TimeTimestamp) {
     CheckIsIn(type, "[1, null, 5, 1, 2]", "[2, 1, 1, null, 2]",
               "[true, false, false, true, true]", /*skip_nulls=*/true);
   }
+
+  // Disallow mixing timezone-aware and timezone-naive values
+  ASSERT_RAISES(Invalid, IsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
+                              SetLookupOptions(ArrayFromJSON(
+                                  timestamp(TimeUnit::SECOND, "UTC"), "[0, 2]"))));
+  ASSERT_RAISES(
+      Invalid,
+      IsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
+           SetLookupOptions(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 2]"))));
+  // However, mixed timezones are allowed (underlying value is UTC)
+  CheckIsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
+            ArrayFromJSON(timestamp(TimeUnit::SECOND, "America/New_York"), "[0, 2]"),
+            "[true, false, true]");
 }
 
 TEST_F(TestIsInKernel, Boolean) {
@@ -274,34 +293,41 @@ TEST_F(TestIsInKernel, FixedSizeBinary) {
             R"(["aaa", null, "aaa", "bbb", "bbb", null])",
             "[true, true, false, false, true]",
             /*skip_nulls=*/true);
+
+  ASSERT_RAISES(Invalid,
+                IsIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
+                     SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }
 
 TEST_F(TestIsInKernel, Decimal) {
-  auto type = decimal(3, 1);
+  for (auto type : {decimal128(3, 1), decimal256(3, 1)}) {
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])", R"(["12.3", "78.9"])",
+              "[true, false, true, false, true]",
+              /*skip_nulls=*/false);
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])", R"(["12.3", "78.9"])",
+              "[true, false, true, false, true]",
+              /*skip_nulls=*/true);
 
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])", R"(["12.3", "78.9"])",
-            "[true, false, true, false, true]",
-            /*skip_nulls=*/false);
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])", R"(["12.3", "78.9"])",
-            "[true, false, true, false, true]",
-            /*skip_nulls=*/true);
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
+              R"(["12.3", "78.9", null])", "[true, false, true, true, true]",
+              /*skip_nulls=*/false);
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
+              R"(["12.3", "78.9", null])", "[true, false, true, false, true]",
+              /*skip_nulls=*/true);
 
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
-            R"(["12.3", "78.9", null])", "[true, false, true, true, true]",
-            /*skip_nulls=*/false);
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
-            R"(["12.3", "78.9", null])", "[true, false, true, false, true]",
-            /*skip_nulls=*/true);
+    // Duplicates in right array
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
+              R"([null, "12.3", "12.3", "78.9", "78.9", null])",
+              "[true, false, true, true, true]",
+              /*skip_nulls=*/false);
+    CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
+              R"([null, "12.3", "12.3", "78.9", "78.9", null])",
+              "[true, false, true, false, true]",
+              /*skip_nulls=*/true);
 
-  // Duplicates in right array
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
-            R"([null, "12.3", "12.3", "78.9", "78.9", null])",
-            "[true, false, true, true, true]",
-            /*skip_nulls=*/false);
-  CheckIsIn(type, R"(["12.3", "45.6", "78.9", null, "12.3"])",
-            R"([null, "12.3", "12.3", "78.9", "78.9", null])",
-            "[true, false, true, false, true]",
-            /*skip_nulls=*/true);
+    CheckIsIn(ArrayFromJSON(decimal128(4, 2), R"(["12.30", "45.60", "78.90"])"),
+              ArrayFromJSON(type, R"(["12.3", "78.9"])"), "[true, false, true]");
+  }
 }
 
 TEST_F(TestIsInKernel, DictionaryArray) {
@@ -427,11 +453,9 @@ TEST_F(TestIsInKernel, ChunkedArrayInvoke) {
 
 class TestIndexInKernel : public ::testing::Test {
  public:
-  void CheckIndexIn(const std::shared_ptr<DataType>& type, const std::string& input_json,
-                    const std::string& value_set_json, const std::string& expected_json,
-                    bool skip_nulls = false) {
-    std::shared_ptr<Array> input = ArrayFromJSON(type, input_json);
-    std::shared_ptr<Array> value_set = ArrayFromJSON(type, value_set_json);
+  void CheckIndexIn(const std::shared_ptr<Array>& input,
+                    const std::shared_ptr<Array>& value_set,
+                    const std::string& expected_json, bool skip_nulls = false) {
     std::shared_ptr<Array> expected = ArrayFromJSON(int32(), expected_json);
 
     SetLookupOptions options(value_set, skip_nulls);
@@ -439,6 +463,14 @@ class TestIndexInKernel : public ::testing::Test {
     std::shared_ptr<Array> actual = actual_datum.make_array();
     ValidateOutput(actual_datum);
     AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+  }
+
+  void CheckIndexIn(const std::shared_ptr<DataType>& type, const std::string& input_json,
+                    const std::string& value_set_json, const std::string& expected_json,
+                    bool skip_nulls = false) {
+    std::shared_ptr<Array> input = ArrayFromJSON(type, input_json);
+    std::shared_ptr<Array> value_set = ArrayFromJSON(type, value_set_json);
+    return CheckIndexIn(input, value_set, expected_json, skip_nulls);
   }
 
   void CheckIndexInChunked(const std::shared_ptr<ChunkedArray>& input,
@@ -643,6 +675,19 @@ TEST_F(TestIndexInKernel, TimeTimestamp) {
   // Both array are all null
   CheckIndexIn(time32(TimeUnit::SECOND), "[null, null, null, null]", "[null]",
                "[0, 0, 0, 0]");
+
+  // Disallow mixing timezone-aware and timezone-naive values
+  ASSERT_RAISES(Invalid, IndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
+                                 SetLookupOptions(ArrayFromJSON(
+                                     timestamp(TimeUnit::SECOND, "UTC"), "[0, 2]"))));
+  ASSERT_RAISES(
+      Invalid,
+      IndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
+              SetLookupOptions(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 2]"))));
+  // However, mixed timezones are allowed (underlying value is UTC)
+  CheckIndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
+               ArrayFromJSON(timestamp(TimeUnit::SECOND, "America/New_York"), "[0, 2]"),
+               "[0, null, 1]");
 }
 
 TEST_F(TestIndexInKernel, Boolean) {
@@ -805,6 +850,11 @@ TEST_F(TestIndexInKernel, FixedSizeBinary) {
 
   // Empty arrays
   CheckIndexIn(fixed_size_binary(0), R"([])", R"([])", R"([])");
+
+  ASSERT_RAISES(
+      Invalid,
+      IndexIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
+              SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }
 
 TEST_F(TestIndexInKernel, MonthDayNanoInterval) {
@@ -826,41 +876,50 @@ TEST_F(TestIndexInKernel, MonthDayNanoInterval) {
 }
 
 TEST_F(TestIndexInKernel, Decimal) {
-  auto type = decimal(2, 0);
+  for (const auto& type : {decimal128(2, 0), decimal256(2, 0)}) {
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"([null, "11", "12"])",
+                 /*expected=*/R"([2, 0, 1, 2, null])",
+                 /*skip_nulls=*/false);
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"([null, "11", "12"])",
+                 /*expected=*/R"([2, null, 1, 2, null])",
+                 /*skip_nulls=*/true);
 
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"([null, "11", "12"])",
-               /*expected=*/R"([2, 0, 1, 2, null])",
-               /*skip_nulls=*/false);
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"([null, "11", "12"])",
-               /*expected=*/R"([2, null, 1, 2, null])",
-               /*skip_nulls=*/true);
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"(["11", "12"])",
+                 /*expected=*/R"([1, null, 0, 1, null])",
+                 /*skip_nulls=*/false);
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"(["11", "12"])",
+                 /*expected=*/R"([1, null, 0, 1, null])",
+                 /*skip_nulls=*/true);
 
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"(["11", "12"])",
-               /*expected=*/R"([1, null, 0, 1, null])",
-               /*skip_nulls=*/false);
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"(["11", "12"])",
-               /*expected=*/R"([1, null, 0, 1, null])",
-               /*skip_nulls=*/true);
+    // Duplicates in value_set
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"([null, null, "11", "11", "12", "12"])",
+                 /*expected=*/R"([4, 0, 2, 4, null])",
+                 /*skip_nulls=*/false);
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"([null, null, "11", "11", "12", "12"])",
+                 /*expected=*/R"([4, null, 2, 4, null])",
+                 /*skip_nulls=*/true);
+    CheckIndexIn(type,
+                 /*input=*/R"(["12", null, "11", "12", "13"])",
+                 /*value_set=*/R"([null, "11", "12"])",
+                 /*expected=*/R"([2, 0, 1, 2, null])",
+                 /*skip_nulls=*/false);
 
-  // Duplicates in value_set
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"([null, null, "11", "11", "12", "12"])",
-               /*expected=*/R"([4, 0, 2, 4, null])",
-               /*skip_nulls=*/false);
-  CheckIndexIn(type,
-               /*input=*/R"(["12", null, "11", "12", "13"])",
-               /*value_set=*/R"([null, null, "11", "11", "12", "12"])",
-               /*expected=*/R"([4, null, 2, 4, null])",
-               /*skip_nulls=*/true);
+    CheckIndexIn(
+        ArrayFromJSON(decimal256(3, 1), R"(["12.0", null, "11.0", "12.0", "13.0"])"),
+        ArrayFromJSON(type, R"([null, "11", "12"])"), R"([2, 0, 1, 2, null])");
+  }
 }
 
 TEST_F(TestIndexInKernel, DictionaryArray) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -138,6 +138,9 @@ TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
   ASSERT_RAISES(Invalid,
                 IsIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
                      SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
+  ASSERT_RAISES(Invalid,
+                IsIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
+                     SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
 }
 
 template <typename Type>

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -449,7 +449,7 @@ def test_filters_inclusive_set(tempdir, use_legacy_dataset):
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
         filters=[('integer', 'in', [1]), ('string', 'in', ('a', 'b')),
-                 ('boolean', 'not in', {False})],
+                 ('boolean', 'not in', {'False'})],
         use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()


### PR DESCRIPTION
A quick PR to fix a minor oversight in kernel registration.