### PR TITLE
ARROW-13797: [C++][Python] Column projection pushdown for ORC dataset reading + use liborc for column selection

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -359,10 +359,6 @@ class ORCFileReader::Impl {
   Status SelectNames(liborc::RowReaderOptions* opts,
                        const std::vector<std::string>& include_names) {
     std::list<std::string> include_names_list(include_names.begin(), include_names.end());
-    // for (auto it = include_indices.begin(); it != include_indices.end(); ++it) {
-    //   ARROW_RETURN_IF(*it < 0, Status::Invalid("Negative field index"));
-    //   include_indices_list.push_back(*it);
-    // }
     opts->include(include_names_list);
     return Status::OK();
   }

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -277,7 +277,8 @@ class ORCFileReader::Impl {
     return ReadTable(opts, schema, out);
   }
 
-  Status Read(const std::vector<std::string>& include_names, std::shared_ptr<Table>* out) {
+  Status Read(const std::vector<std::string>& include_names,
+              std::shared_ptr<Table>* out) {
     liborc::RowReaderOptions opts;
     RETURN_NOT_OK(SelectNames(&opts, include_names));
     std::shared_ptr<Schema> schema;
@@ -357,7 +358,7 @@ class ORCFileReader::Impl {
   }
 
   Status SelectNames(liborc::RowReaderOptions* opts,
-                       const std::vector<std::string>& include_names) {
+                     const std::vector<std::string>& include_names) {
     std::list<std::string> include_names_list(include_names.begin(), include_names.end());
     opts->include(include_names_list);
     return Status::OK();

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -277,6 +277,14 @@ class ORCFileReader::Impl {
     return ReadTable(opts, schema, out);
   }
 
+  Status Read(const std::vector<std::string>& include_names, std::shared_ptr<Table>* out) {
+    liborc::RowReaderOptions opts;
+    RETURN_NOT_OK(SelectNames(&opts, include_names));
+    std::shared_ptr<Schema> schema;
+    RETURN_NOT_OK(ReadSchema(opts, &schema));
+    return ReadTable(opts, schema, out);
+  }
+
   Status Read(const std::shared_ptr<Schema>& schema,
               const std::vector<int>& include_indices, std::shared_ptr<Table>* out) {
     liborc::RowReaderOptions opts;
@@ -296,6 +304,16 @@ class ORCFileReader::Impl {
                     std::shared_ptr<RecordBatch>* out) {
     liborc::RowReaderOptions opts;
     RETURN_NOT_OK(SelectIndices(&opts, include_indices));
+    RETURN_NOT_OK(SelectStripe(&opts, stripe));
+    std::shared_ptr<Schema> schema;
+    RETURN_NOT_OK(ReadSchema(opts, &schema));
+    return ReadBatch(opts, schema, stripes_[stripe].num_rows, out);
+  }
+
+  Status ReadStripe(int64_t stripe, const std::vector<std::string>& include_names,
+                    std::shared_ptr<RecordBatch>* out) {
+    liborc::RowReaderOptions opts;
+    RETURN_NOT_OK(SelectNames(&opts, include_names));
     RETURN_NOT_OK(SelectStripe(&opts, stripe));
     std::shared_ptr<Schema> schema;
     RETURN_NOT_OK(ReadSchema(opts, &schema));
@@ -335,6 +353,17 @@ class ORCFileReader::Impl {
       include_indices_list.push_back(*it);
     }
     opts->includeTypes(include_indices_list);
+    return Status::OK();
+  }
+
+  Status SelectNames(liborc::RowReaderOptions* opts,
+                       const std::vector<std::string>& include_names) {
+    std::list<std::string> include_names_list(include_names.begin(), include_names.end());
+    // for (auto it = include_indices.begin(); it != include_indices.end(); ++it) {
+    //   ARROW_RETURN_IF(*it < 0, Status::Invalid("Negative field index"));
+    //   include_indices_list.push_back(*it);
+    // }
+    opts->include(include_names_list);
     return Status::OK();
   }
 
@@ -486,6 +515,13 @@ Result<std::shared_ptr<Table>> ORCFileReader::Read(
   return table;
 }
 
+Result<std::shared_ptr<Table>> ORCFileReader::Read(
+    const std::vector<std::string>& include_names) {
+  std::shared_ptr<Table> table;
+  RETURN_NOT_OK(impl_->Read(include_names, &table));
+  return table;
+}
+
 Status ORCFileReader::Read(const std::shared_ptr<Schema>& schema,
                            const std::vector<int>& include_indices,
                            std::shared_ptr<Table>* out) {
@@ -518,6 +554,13 @@ Result<std::shared_ptr<RecordBatch>> ORCFileReader::ReadStripe(
     int64_t stripe, const std::vector<int>& include_indices) {
   std::shared_ptr<RecordBatch> recordBatch;
   RETURN_NOT_OK(impl_->ReadStripe(stripe, include_indices, &recordBatch));
+  return recordBatch;
+}
+
+Result<std::shared_ptr<RecordBatch>> ORCFileReader::ReadStripe(
+    int64_t stripe, const std::vector<std::string>& include_names) {
+  std::shared_ptr<RecordBatch> recordBatch;
+  RETURN_NOT_OK(impl_->ReadStripe(stripe, include_names, &recordBatch));
   return recordBatch;
 }
 

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -127,6 +127,14 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// The table will be composed of one record batch per stripe.
   ///
+  /// \param[in] include_names the selected field names to read
+  /// \return the returned Table
+  Result<std::shared_ptr<Table>> Read(const std::vector<std::string>& include_names);
+
+  /// \brief Read the file as a Table
+  ///
+  /// The table will be composed of one record batch per stripe.
+  ///
   /// \param[in] schema the Table schema
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned Table
@@ -173,6 +181,14 @@ class ARROW_EXPORT ORCFileReader {
   /// \return the returned RecordBatch
   Result<std::shared_ptr<RecordBatch>> ReadStripe(
       int64_t stripe, const std::vector<int>& include_indices);
+
+  /// \brief Read a single stripe as a RecordBatch
+  ///
+  /// \param[in] stripe the stripe index
+  /// \param[in] include_names the selected field names to read
+  /// \return the returned RecordBatch
+  Result<std::shared_ptr<RecordBatch>> ReadStripe(
+      int64_t stripe, const std::vector<std::string>& include_names);
 
   /// \brief Seek to designated row. Invoke NextStripeReader() after seek
   ///        will return stripe reader starting from designated row.

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -86,7 +86,7 @@ class OrcScanTask : public ScanTask {
         }
 
         return RecordBatchIterator(
-          Impl{std::move(reader), 0, num_stripes, included_fields});
+            Impl{std::move(reader), 0, num_stripes, included_fields});
       }
 
       Result<std::shared_ptr<RecordBatch>> Next() {

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -72,7 +72,21 @@ class OrcScanTask : public ScanTask {
             auto reader,
             OpenORCReader(source, std::make_shared<ScanOptions>(scan_options)));
         int num_stripes = reader->NumberOfStripes();
-        return RecordBatchIterator(Impl{std::move(reader), 0, num_stripes});
+
+        auto materialized_fields = scan_options.MaterializedFields();
+        // filter out virtual columns
+        std::vector<std::string> included_fields;
+        ARROW_ASSIGN_OR_RAISE(auto schema, reader->ReadSchema());
+        for (auto name : materialized_fields) {
+          FieldRef ref(name);
+          ARROW_ASSIGN_OR_RAISE(auto match, ref.FindOneOrNone(*schema));
+          if (match.indices().empty()) continue;
+
+          included_fields.push_back(name);
+        }
+
+        return RecordBatchIterator(
+          Impl{std::move(reader), 0, num_stripes, included_fields});
       }
 
       Result<std::shared_ptr<RecordBatch>> Next() {
@@ -80,19 +94,15 @@ class OrcScanTask : public ScanTask {
           return nullptr;
         }
         std::shared_ptr<RecordBatch> batch;
-        // TODO (https://issues.apache.org/jira/browse/ARROW-13797)
-        // determine included fields from options_->MaterializedFields() to
-        // optimize the column selection (see _column_index_lookup in python
-        // orc.py for custom logic)
-        // std::vector<int> included_fields;
         // TODO (https://issues.apache.org/jira/browse/ARROW-14153)
         // pass scan_options_->batch_size
-        return reader_->ReadStripe(i_++);
+        return reader_->ReadStripe(i_++, included_fields_);
       }
 
       std::unique_ptr<arrow::adapters::orc::ORCFileReader> reader_;
       int i_;
       int num_stripes_;
+      std::vector<std::string> included_fields_;
     };
 
     return Impl::Make(source_, *checked_pointer_cast<FileFragment>(fragment_)->format(),

--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -73,10 +73,10 @@ TEST_P(TestOrcFileFormatScan, ScanRecordBatchReader) { TestScan(); }
 TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
   TestScanWithVirtualColumn();
 }
-// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
-// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
-//   TestScanProjectedMissingCols();
-// }
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
+  TestScanProjectedMissingCols();
+}
 INSTANTIATE_TEST_SUITE_P(TestScan, TestOrcFileFormatScan,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);

--- a/python/pyarrow/_orc.pxd
+++ b/python/pyarrow/_orc.pxd
@@ -45,10 +45,10 @@ cdef extern from "arrow/adapters/orc/adapter.h" \
 
         CResult[shared_ptr[CRecordBatch]] ReadStripe(int64_t stripe)
         CResult[shared_ptr[CRecordBatch]] ReadStripe(
-            int64_t stripe, std_vector[int])
+            int64_t stripe, std_vector[c_string])
 
         CResult[shared_ptr[CTable]] Read()
-        CResult[shared_ptr[CTable]] Read(std_vector[int])
+        CResult[shared_ptr[CTable]] Read(std_vector[c_string])
 
         int64_t NumberOfStripes()
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2663,6 +2663,14 @@ def test_orc_format(tempdir, dataset_reader):
     result.validate(full=True)
     assert result.equals(table.select(["b"]))
 
+    result = dataset_reader.to_table(
+        dataset, columns={"b2": ds.field("b") * 2}
+    )
+    result.validate(full=True)
+    assert result.equals(
+        pa.table({'b2': pa.array([.2, .4, .6], type="float64")})
+    )
+
     assert dataset_reader.count_rows(dataset) == 3
     assert dataset_reader.count_rows(dataset, filter=ds.field("a") > 2) == 1
 

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -260,3 +260,10 @@ def test_column_selection(tempdir):
 
     result3 = orc_file.read(columns=[1, 2, 3])
     assert result3.equals(table.select(["list", "struct", "list-struct"]))
+
+    # error on non-existing name or index
+    with pytest.raises(ValueError):
+        orc_file.read(columns=["wrong"])
+
+    with pytest.raises(ValueError):
+        orc_file.read(columns=[5])

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -262,7 +262,9 @@ def test_column_selection(tempdir):
     assert result3.equals(table.select(["list", "struct", "list-struct"]))
 
     # error on non-existing name or index
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
+        # liborc returns ParseError, which gets translated into IOError
+        # instead of ValueError
         orc_file.read(columns=["wrong"])
 
     with pytest.raises(ValueError):

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -190,3 +190,73 @@ def test_orcfile_readwrite():
     orc_file = orc.ORCFile(buffer_reader)
     output_table = orc_file.read()
     assert table.equals(output_table)
+
+
+def test_column_selection(tempdir):
+    from pyarrow import orc
+
+    # create a table with nested types
+    inner = pa.field('inner', pa.int64())
+    middle = pa.field('middle', pa.struct([inner]))
+    fields = [
+        pa.field('basic', pa.int32()),
+        pa.field(
+            'list', pa.list_(pa.field('item', pa.int32()))
+        ),
+        pa.field(
+            'struct', pa.struct([middle, pa.field('inner2', pa.int64())])
+        ),
+        pa.field(
+            'list-struct', pa.list_(pa.field(
+                'item', pa.struct([
+                    pa.field('inner1', pa.int64()),
+                    pa.field('inner2', pa.int64())
+                ])
+            ))
+        ),
+        pa.field('basic2', pa.int64()),
+    ]
+    arrs = [
+        [0], [[1, 2]], [{"middle": {"inner": 3}, "inner2": 4}],
+        [[{"inner1": 5, "inner2": 6}, {"inner1": 7, "inner2": 8}]], [9]]
+    table = pa.table(arrs, schema=pa.schema(fields))
+
+    path = str(tempdir / 'test.orc')
+    orc.write_table(table, path)
+    orc_file = orc.ORCFile(path)
+
+    # default selecting all columns
+    result1 = orc_file.read()
+    assert result1.equals(table)
+
+    # selecting with columns names
+    result2 = orc_file.read(columns=["basic", "basic2"])
+    assert result2.equals(table.select(["basic", "basic2"]))
+
+    result3 = orc_file.read(columns=["list", "struct", "basic2"])
+    assert result3.equals(table.select(["list", "struct", "basic2"]))
+
+    # using dotted paths
+    result4 = orc_file.read(columns=["struct.middle.inner"])
+    expected4 = pa.table({"struct": [{"middle": {"inner": 3}}]})
+    assert result4.equals(expected4)
+
+    result5 = orc_file.read(columns=["struct.inner2"])
+    expected5 = pa.table({"struct": [{"inner2": 4}]})
+    assert result5.equals(expected5)
+
+    result6 = orc_file.read(
+        columns=["list", "struct.middle.inner", "struct.inner2"]
+    )
+    assert result6.equals(table.select(["list", "struct"]))
+
+    result7 = orc_file.read(columns=["list-struct.inner1"])
+    expected7 = pa.table({"list-struct": [[{"inner1": 5}, {"inner1": 7}]]})
+    assert result7.equals(expected7)
+
+    # selecting with (Arrow-based) field indices
+    result2 = orc_file.read(columns=[0, 4])
+    assert result2.equals(table.select(["basic", "basic2"]))
+
+    result3 = orc_file.read(columns=[1, 2, 3])
+    assert result3.equals(table.select(["list", "struct", "list-struct"]))


### PR DESCRIPTION
I was first trying to port the python logic we have to convert column names to ORC field indices, but it turns out that liborc already supports that. 