### PR TITLE
ARROW-14074: [C++][Compute] C++ consumer of compute IR

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -2352,7 +2352,7 @@ garrow_sort_key_get_property(GObject *object,
 
   switch (prop_id) {
   case PROP_SORT_KEY_NAME:
-    if (auto name = priv->sort_key.target().name()) {
+    if (auto name = priv->sort_key.target).name()) {
       g_value_set_string(value, name->c_str());
     } else {
       g_value_set_string(value, "");

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -106,7 +106,7 @@ namespace {
   garrow_sort_key_equal_raw(const arrow::compute::SortKey &sort_key,
                             const arrow::compute::SortKey &other_sort_key) {
     return
-      (sort_key.name == other_sort_key.name) &&
+      (sort_key.target == other_sort_key.target) &&
       (sort_key.order == other_sort_key.order);
 
   }
@@ -2330,7 +2330,7 @@ garrow_sort_key_set_property(GObject *object,
 
   switch (prop_id) {
   case PROP_SORT_KEY_NAME:
-    priv->sort_key.name = g_value_get_string(value);
+    priv->sort_key.target = g_value_get_string(value);
     break;
   case PROP_SORT_KEY_ORDER:
     priv->sort_key.order =
@@ -2352,7 +2352,11 @@ garrow_sort_key_get_property(GObject *object,
 
   switch (prop_id) {
   case PROP_SORT_KEY_NAME:
-    g_value_set_string(value, priv->sort_key.name.c_str());
+    if (auto name = priv->sort_key.target().name()) {
+      g_value_set_string(value, name->c_str());
+    } else {
+      g_value_set_string(value, "");
+    }
     break;
   case PROP_SORT_KEY_ORDER:
     g_value_set_enum(value, static_cast<GArrowSortOrder>(priv->sort_key.order));
@@ -2531,9 +2535,8 @@ garrow_sort_options_get_sort_keys(GArrowSortOptions *options)
   auto arrow_options = garrow_sort_options_get_raw(options);
   GList *sort_keys = NULL;
   for (const auto &arrow_sort_key : arrow_options->sort_keys) {
-    auto sort_key =
-      garrow_sort_key_new(arrow_sort_key.name.c_str(),
-                          static_cast<GArrowSortOrder>(arrow_sort_key.order));
+    auto sort_key = g_object_new(GARROW_TYPE_SORT_KEY, NULL);
+    GARROW_SORT_KEY_GET_PRIVATE(sort_key)->sort_key = arrow_sort_key;
     sort_keys = g_list_prepend(sort_keys, sort_key);
   }
   return g_list_reverse(sort_keys);

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -2352,7 +2352,7 @@ garrow_sort_key_get_property(GObject *object,
 
   switch (prop_id) {
   case PROP_SORT_KEY_NAME:
-    if (auto name = priv->sort_key.target).name()) {
+    if (auto name = priv->sort_key.target.name()) {
       g_value_set_string(value, name->c_str());
     } else {
       g_value_set_string(value, "");

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -40,3 +40,4 @@ snappy
 thrift-cpp>=0.11.0
 zlib
 zstd
+flatbuffers

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -737,9 +737,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
                  --num-callers=500 --leak-check=full --leak-check-heuristics=stdstring \
                  --error-exitcode=1 ${TEST_PATH} ${ARG_TEST_ARGUMENTS}")
   elseif(WIN32)
-    add_test(${TEST_NAME}
-             ${TEST_PATH}
-             ${ARG_TEST_ARGUMENTS})
+    add_test(${TEST_NAME} ${TEST_PATH} ${ARG_TEST_ARGUMENTS})
   else()
     add_test(${TEST_NAME}
              ${BUILD_SUPPORT_DIR}/run-test.sh

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -652,6 +652,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
       EXTRA_DEPENDENCIES
       LABELS
       EXTRA_LABELS
+      TEST_ARGUMENTS
       PREFIX)
   cmake_parse_arguments(ARG
                         "${options}"
@@ -723,6 +724,10 @@ function(ADD_TEST_CASE REL_TEST_NAME)
     add_dependencies(${TEST_NAME} ${ARG_EXTRA_DEPENDENCIES})
   endif()
 
+  if(ARG_ENVIRONMENT)
+    message(STATUS "WTF ${ARG_ENVIRONMENT}")
+  endif()
+
   if(ARROW_TEST_MEMCHECK AND NOT ARG_NO_VALGRIND)
     add_test(${TEST_NAME}
              bash
@@ -730,15 +735,18 @@ function(ADD_TEST_CASE REL_TEST_NAME)
              "cd '${CMAKE_SOURCE_DIR}'; \
                valgrind --suppressions=valgrind.supp --tool=memcheck --gen-suppressions=all \
                  --num-callers=500 --leak-check=full --leak-check-heuristics=stdstring \
-                 --error-exitcode=1 ${TEST_PATH}")
+                 --error-exitcode=1 ${TEST_PATH} ${ARG_TEST_ARGUMENTS}")
   elseif(WIN32)
-    add_test(${TEST_NAME} ${TEST_PATH})
+    add_test(${TEST_NAME}
+             ${TEST_PATH}
+             ${ARG_TEST_ARGUMENTS})
   else()
     add_test(${TEST_NAME}
              ${BUILD_SUPPORT_DIR}/run-test.sh
              ${CMAKE_BINARY_DIR}
              test
-             ${TEST_PATH})
+             ${TEST_PATH}
+             ${ARG_TEST_ARGUMENTS})
   endif()
 
   # Add test as dependency of relevant targets

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -724,10 +724,6 @@ function(ADD_TEST_CASE REL_TEST_NAME)
     add_dependencies(${TEST_NAME} ${ARG_EXTRA_DEPENDENCIES})
   endif()
 
-  if(ARG_ENVIRONMENT)
-    message(STATUS "WTF ${ARG_ENVIRONMENT}")
-  endif()
-
   if(ARROW_TEST_MEMCHECK AND NOT ARG_NO_VALGRIND)
     add_test(${TEST_NAME}
              bash

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -376,6 +376,7 @@ if(ARROW_COMPUTE)
        compute/exec/exec_plan.cc
        compute/exec/expression.cc
        compute/exec/filter_node.cc
+       compute/exec/ir_consumer.cc
        compute/exec/project_node.cc
        compute/exec/source_node.cc
        compute/exec/sink_node.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -380,7 +380,6 @@ if(ARROW_COMPUTE)
        compute/exec/project_node.cc
        compute/exec/source_node.cc
        compute/exec/sink_node.cc
-       compute/exec/options.cc
        compute/exec/order_by_impl.cc
        compute/function.cc
        compute/function_internal.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -380,6 +380,7 @@ if(ARROW_COMPUTE)
        compute/exec/project_node.cc
        compute/exec/source_node.cc
        compute/exec/sink_node.cc
+       compute/exec/options.cc
        compute/exec/order_by_impl.cc
        compute/function.cc
        compute/function_internal.cc

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -97,11 +97,11 @@ namespace compute {
 // Function options
 
 bool SortKey::Equals(const SortKey& other) const {
-  return name == other.name && order == other.order;
+  return target == other.target && order == other.order;
 }
 std::string SortKey::ToString() const {
   std::stringstream ss;
-  ss << name << ' ';
+  ss << target.ToString() << ' ';
   switch (order) {
     case SortOrder::Ascending:
       ss << "ASC";

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -98,8 +98,8 @@ enum class NullPlacement {
 /// \brief One sort key for PartitionNthIndices (TODO) and SortIndices
 class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
  public:
-  explicit SortKey(std::string name, SortOrder order = SortOrder::Ascending)
-      : name(std::move(name)), order(order) {}
+  explicit SortKey(FieldRef target, SortOrder order = SortOrder::Ascending)
+      : target(std::move(target)), order(order) {}
 
   using util::EqualityComparable<SortKey>::Equals;
   using util::EqualityComparable<SortKey>::operator==;
@@ -107,8 +107,8 @@ class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
   bool Equals(const SortKey& other) const;
   std::string ToString() const;
 
-  /// The name of the sort column.
-  std::string name;
+  /// A FieldRef targetting the sort column.
+  FieldRef target;
   /// How to order by this sort key.
   SortOrder order;
 };

--- a/cpp/src/arrow/compute/exec/CMakeLists.txt
+++ b/cpp/src/arrow/compute/exec/CMakeLists.txt
@@ -38,4 +38,4 @@ add_arrow_compute_test(ir_test
                        EXTRA_LINK_LIBS
                        ${GFLAGS_LIBRARIES}
                        TEST_ARGUMENTS
-                       "-computeir_dir=${CMAKE_SOURCE_DIR}/../experimental/computeir")
+                       "--computeir_dir=${CMAKE_SOURCE_DIR}/../experimental/computeir")

--- a/cpp/src/arrow/compute/exec/CMakeLists.txt
+++ b/cpp/src/arrow/compute/exec/CMakeLists.txt
@@ -25,6 +25,7 @@ add_arrow_compute_test(expression_test
                        subtree_test.cc)
 
 add_arrow_compute_test(plan_test PREFIX "arrow-compute")
+add_arrow_compute_test(ir_test PREFIX "arrow-compute")
 add_arrow_compute_test(hash_join_node_test PREFIX "arrow-compute")
 add_arrow_compute_test(union_node_test PREFIX "arrow-compute")
 

--- a/cpp/src/arrow/compute/exec/CMakeLists.txt
+++ b/cpp/src/arrow/compute/exec/CMakeLists.txt
@@ -25,10 +25,17 @@ add_arrow_compute_test(expression_test
                        subtree_test.cc)
 
 add_arrow_compute_test(plan_test PREFIX "arrow-compute")
-add_arrow_compute_test(ir_test PREFIX "arrow-compute")
 add_arrow_compute_test(hash_join_node_test PREFIX "arrow-compute")
 add_arrow_compute_test(union_node_test PREFIX "arrow-compute")
 
 add_arrow_compute_test(util_test PREFIX "arrow-compute")
 
 add_arrow_benchmark(expression_benchmark PREFIX "arrow-compute")
+
+add_arrow_compute_test(ir_test
+                       PREFIX
+                       "arrow-compute"
+                       EXTRA_LINK_LIBS
+                       ${GFLAGS_LIBRARIES}
+                       TEST_ARGUMENTS
+                       "-computeir_dir=${CMAKE_SOURCE_DIR}/../experimental/computeir")

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -23,6 +23,7 @@
 
 #include "arrow/compute/exec.h"
 #include "arrow/compute/exec/expression.h"
+#include "arrow/compute/exec/options.h"
 #include "arrow/compute/exec_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/datum.h"
@@ -518,6 +519,24 @@ Result<std::function<Future<util::optional<ExecBatch>>()>> MakeReaderGenerator(
 
   return MakeBackgroundGenerator(std::move(batch_it), io_executor, max_q, q_restart);
 }
-}  // namespace compute
 
+bool Declaration::operator==(const Declaration& other) const {
+  if (factory_name != other.factory_name) return false;
+  if (inputs != other.inputs) return false;
+  if (label != other.label) return false;
+
+  return options == other.options || options->Equals(*other.options);
+}
+
+void PrintTo(const Declaration& decl, std::ostream* os) {
+  *os << decl.factory_name << "{";
+  for (const auto& input : decl.inputs) {
+    if (auto decl = util::get_if<Declaration>(&input)) {
+      PrintTo(*decl, os);
+    }
+  }
+  *os << "}";
+}
+
+}  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -251,27 +251,41 @@ Status ExecNode::Validate() const {
 
 std::string ExecNode::ToString() const {
   std::stringstream ss;
-  ss << kind_name() << "{\"" << label_ << '"';
+
+  auto PrintLabelAndKind = [&](const ExecNode* node) {
+    ss << node->label() << ":" << node->kind_name();
+  };
+
+  PrintLabelAndKind(this);
+  ss << "{";
+
   if (!inputs_.empty()) {
-    ss << ", inputs=[";
+    ss << "inputs=[";
     for (size_t i = 0; i < inputs_.size(); i++) {
       if (i > 0) ss << ", ";
-      ss << input_labels_[i] << ": \"" << inputs_[i]->label() << '"';
+      ss << input_labels_[i] << "=";
+      PrintLabelAndKind(inputs_[i]);
     }
     ss << ']';
   }
 
   if (!outputs_.empty()) {
-    ss << ", outputs=[";
+    if (!inputs_.empty()) {
+      ss << ", ";
+    }
+
+    ss << "outputs=[";
     for (size_t i = 0; i < outputs_.size(); i++) {
       if (i > 0) ss << ", ";
-      ss << "\"" << outputs_[i]->label() << "\"";
+      PrintLabelAndKind(outputs_[i]);
     }
     ss << ']';
   }
 
   const std::string extra = ToStringExtra();
-  if (!extra.empty()) ss << ", " << extra;
+  if (!extra.empty()) {
+    ss << ", " << extra;
+  }
 
   ss << '}';
   return ss.str();

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -520,23 +520,5 @@ Result<std::function<Future<util::optional<ExecBatch>>()>> MakeReaderGenerator(
   return MakeBackgroundGenerator(std::move(batch_it), io_executor, max_q, q_restart);
 }
 
-bool Declaration::operator==(const Declaration& other) const {
-  if (factory_name != other.factory_name) return false;
-  if (inputs != other.inputs) return false;
-  if (label != other.label) return false;
-
-  return options == other.options || options->Equals(*other.options);
-}
-
-void PrintTo(const Declaration& decl, std::ostream* os) {
-  *os << decl.factory_name << "{";
-  for (const auto& input : decl.inputs) {
-    if (auto decl = util::get_if<Declaration>(&input)) {
-      PrintTo(*decl, os);
-    }
-  }
-  *os << "}";
-}
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -352,11 +352,26 @@ struct ARROW_EXPORT Declaration {
         label{this->factory_name} {}
 
   template <typename Options>
+  Declaration(std::string factory_name, std::vector<Input> inputs, Options options,
+              std::string label)
+      : factory_name{std::move(factory_name)},
+        inputs{std::move(inputs)},
+        options{std::make_shared<Options>(std::move(options))},
+        label{std::move(label)} {}
+
+  template <typename Options>
   Declaration(std::string factory_name, Options options)
       : factory_name{std::move(factory_name)},
         inputs{},
         options{std::make_shared<Options>(std::move(options))},
         label{this->factory_name} {}
+
+  template <typename Options>
+  Declaration(std::string factory_name, Options options, std::string label)
+      : factory_name{std::move(factory_name)},
+        inputs{},
+        options{std::make_shared<Options>(std::move(options))},
+        label{std::move(label)} {}
 
   /// \brief Convenience factory for the common case of a simple sequence of nodes.
   ///

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -393,10 +393,6 @@ struct ARROW_EXPORT Declaration {
   Result<ExecNode*> AddToPlan(ExecPlan* plan, ExecFactoryRegistry* registry =
                                                   default_exec_factory_registry()) const;
 
-  bool operator==(const Declaration& other) const;
-
-  friend void PrintTo(const Declaration& decl, std::ostream* os);
-
   std::string factory_name;
   std::vector<Input> inputs;
   std::shared_ptr<ExecNodeOptions> options;

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -345,33 +345,25 @@ struct ARROW_EXPORT Declaration {
         label{std::move(label)} {}
 
   template <typename Options>
-  Declaration(std::string factory_name, std::vector<Input> inputs, Options options)
-      : factory_name{std::move(factory_name)},
-        inputs{std::move(inputs)},
-        options{std::make_shared<Options>(std::move(options))},
-        label{this->factory_name} {}
-
-  template <typename Options>
   Declaration(std::string factory_name, std::vector<Input> inputs, Options options,
               std::string label)
-      : factory_name{std::move(factory_name)},
-        inputs{std::move(inputs)},
-        options{std::make_shared<Options>(std::move(options))},
-        label{std::move(label)} {}
+      : Declaration{std::move(factory_name), std::move(inputs),
+                    std::shared_ptr<ExecNodeOptions>(
+                        std::make_shared<Options>(std::move(options))),
+                    std::move(label)} {}
+
+  template <typename Options>
+  Declaration(std::string factory_name, std::vector<Input> inputs, Options options)
+      : Declaration{std::move(factory_name), std::move(inputs), std::move(options),
+                    /*label=*/""} {}
 
   template <typename Options>
   Declaration(std::string factory_name, Options options)
-      : factory_name{std::move(factory_name)},
-        inputs{},
-        options{std::make_shared<Options>(std::move(options))},
-        label{this->factory_name} {}
+      : Declaration{std::move(factory_name), {}, std::move(options), /*label=*/""} {}
 
   template <typename Options>
   Declaration(std::string factory_name, Options options, std::string label)
-      : factory_name{std::move(factory_name)},
-        inputs{},
-        options{std::make_shared<Options>(std::move(options))},
-        label{std::move(label)} {}
+      : Declaration{std::move(factory_name), {}, std::move(options), std::move(label)} {}
 
   /// \brief Convenience factory for the common case of a simple sequence of nodes.
   ///

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -393,6 +393,10 @@ struct ARROW_EXPORT Declaration {
   Result<ExecNode*> AddToPlan(ExecPlan* plan, ExecFactoryRegistry* registry =
                                                   default_exec_factory_registry()) const;
 
+  bool operator==(const Declaration& other) const;
+
+  friend void PrintTo(const Declaration& decl, std::ostream* os);
+
   std::string factory_name;
   std::vector<Input> inputs;
   std::shared_ptr<ExecNodeOptions> options;

--- a/cpp/src/arrow/compute/exec/ir_consumer.cc
+++ b/cpp/src/arrow/compute/exec/ir_consumer.cc
@@ -457,16 +457,5 @@ Result<Declaration> Convert(const ir::Relation& rel) {
   return Status::NotImplemented("RelationImpl::", EnumNameRelationImpl(rel.impl_type()));
 }
 
-using ::arrow::internal::DataMember;
-auto kCatalogSourceNodeOptions = ::arrow::internal::MakeProperties(
-    DataMember("name", &CatalogSourceNodeOptions::name));
-
-bool CatalogSourceNodeOptions::Equals(const ExecNodeOptions& other) const {
-  using Options = CatalogSourceNodeOptions;
-  const auto& lhs = checked_cast<const Options&>(*this);
-  const auto& rhs = checked_cast<const Options&>(other);
-  return internal::CompareImpl<Options>(lhs, rhs, kCatalogSourceNodeOptions).equal_;
-}
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/ir_consumer.cc
+++ b/cpp/src/arrow/compute/exec/ir_consumer.cc
@@ -79,7 +79,7 @@ Result<std::shared_ptr<Buffer>> BufferFromFlatbufferByteVector(
   if (!vec->data()) return UnexpectedNullField("Vector<int8_t>.data");
   std::memcpy(buf->mutable_data(), vec->data(), vec->size());
 
-  return buf;
+  return std::move(buf);
 }
 
 Result<Datum> Convert(const ir::Literal& lit);

--- a/cpp/src/arrow/compute/exec/ir_consumer.cc
+++ b/cpp/src/arrow/compute/exec/ir_consumer.cc
@@ -1,0 +1,431 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/exec/ir_consumer.h"
+
+#include "arrow/array/array_nested.h"
+#include "arrow/array/builder_base.h"
+#include "arrow/compute/cast.h"
+#include "arrow/compute/exec/exec_plan.h"
+#include "arrow/compute/exec/expression.h"
+#include "arrow/ipc/metadata_internal.h"
+#include "arrow/util/unreachable.h"
+#include "arrow/visitor_inline.h"
+
+#include "generated/Plan_generated.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace compute {
+
+static inline Status UnexpectedNullField(const char* name) {
+  return Status::IOError("Unexpected null field ", name, " in flatbuffer-encoded IR");
+}
+
+Result<std::shared_ptr<Field>> Convert(const flatbuf::Field& f) {
+  std::string name = ipc::internal::StringFromFlatbuffers(f.name());
+
+  FieldVector fields;
+  if (auto children = f.children()) {
+    fields.resize(children->size());
+    int i = 0;
+    for (const flatbuf::Field* child : *children) {
+      ARROW_ASSIGN_OR_RAISE(fields[i++], Convert(*child));
+    }
+  }
+
+  if (!f.type()) return UnexpectedNullField("Field.type");
+
+  std::shared_ptr<DataType> type;
+  RETURN_NOT_OK(ipc::internal::ConcreteTypeFromFlatbuffer(f.type_type(), f.type(),
+                                                          std::move(fields), &type));
+
+  std::shared_ptr<KeyValueMetadata> metadata;
+  RETURN_NOT_OK(ipc::internal::GetKeyValueMetadata(f.custom_metadata(), &metadata));
+
+  return field(std::move(name), std::move(type), f.nullable(), std::move(metadata));
+}
+
+Result<std::shared_ptr<Buffer>> BufferFromFlatbufferByteVector(
+    const flatbuffers::Vector<int8_t>* vec) {
+  if (!vec) return nullptr;
+
+  ARROW_ASSIGN_OR_RAISE(auto buf, AllocateBuffer(vec->size()));
+  std::memcpy(buf->mutable_data(), vec->data(), vec->size());
+  return buf;
+}
+
+Result<Datum> Convert(const ir::Literal& lit);
+
+struct ConvertLiteralImpl {
+  Result<Datum> Convert(const BooleanType& t) { return ValueOf<ir::BooleanLiteral>(t); }
+
+  Result<Datum> Convert(const Int8Type& t) { return ValueOf<ir::Int8Literal>(t); }
+  Result<Datum> Convert(const Int16Type& t) { return ValueOf<ir::Int16Literal>(t); }
+  Result<Datum> Convert(const Int32Type& t) { return ValueOf<ir::Int32Literal>(t); }
+  Result<Datum> Convert(const Int64Type& t) { return ValueOf<ir::Int64Literal>(t); }
+
+  Result<Datum> Convert(const UInt8Type& t) { return ValueOf<ir::UInt8Literal>(t); }
+  Result<Datum> Convert(const UInt16Type& t) { return ValueOf<ir::UInt16Literal>(t); }
+  Result<Datum> Convert(const UInt32Type& t) { return ValueOf<ir::UInt32Literal>(t); }
+  Result<Datum> Convert(const UInt64Type& t) { return ValueOf<ir::UInt64Literal>(t); }
+
+  Result<Datum> Convert(const HalfFloatType& t) { return ValueOf<ir::Float16Literal>(t); }
+  Result<Datum> Convert(const FloatType& t) { return ValueOf<ir::Float32Literal>(t); }
+  Result<Datum> Convert(const DoubleType& t) { return ValueOf<ir::Float64Literal>(t); }
+
+  Result<Datum> Convert(const Date32Type& t) { return ValueOf<ir::DateLiteral>(t); }
+  Result<Datum> Convert(const Date64Type& t) { return ValueOf<ir::DateLiteral>(t); }
+  Result<Datum> Convert(const Time32Type& t) { return ValueOf<ir::TimeLiteral>(t); }
+  Result<Datum> Convert(const Time64Type& t) { return ValueOf<ir::TimeLiteral>(t); }
+  Result<Datum> Convert(const DurationType& t) { return ValueOf<ir::DurationLiteral>(t); }
+  Result<Datum> Convert(const TimestampType& t) {
+    return ValueOf<ir::TimestampLiteral>(t);
+  }
+
+  Result<Datum> Convert(const IntervalType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::IntervalLiteral>());
+    if (!lit->value()) return UnexpectedNullField("IntervalLiteral.value");
+
+    switch (t.interval_type()) {
+      case IntervalType::MONTHS:
+        if (auto value = lit->value_as<ir::IntervalLiteralMonths>()) {
+          return Datum(std::make_shared<MonthIntervalScalar>(value->months()));
+        }
+        break;
+
+      case IntervalType::DAY_TIME:
+        if (auto value = lit->value_as<ir::IntervalLiteralDaysMilliseconds>()) {
+          DayTimeIntervalType::DayMilliseconds day_ms{value->days(),
+                                                      value->milliseconds()};
+          return Datum(std::make_shared<DayTimeIntervalScalar>(day_ms));
+        }
+        break;
+
+      case IntervalType::MONTH_DAY_NANO:
+        return Status::NotImplemented(
+            "IntervalLiteral with interval_type=MONTH_DAY_NANO");
+    }
+
+    return Status::IOError("IntervalLiteral.type was ", t.ToString(),
+                           " but IntervalLiteral.value had value_type ",
+                           ir::EnumNameIntervalLiteralImpl(lit->value_type()));
+  }
+
+  Result<Datum> Convert(const DecimalType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::DecimalLiteral>());
+    if (!lit->value()) return UnexpectedNullField("DecimalLiteral.value");
+
+    if (static_cast<int>(lit->value()->size()) != t.byte_width()) {
+      return Status::IOError("DecimalLiteral.type was ", t.ToString(),
+                             " (expected byte width ", t.byte_width(), ")",
+                             " but DecimalLiteral.value had size ", lit->value()->size());
+    }
+
+    switch (t.id()) {
+      case Type::DECIMAL128: {
+        std::array<uint64_t, 2> little_endian;
+        std::memcpy(little_endian.data(), lit->value(), lit->value()->size());
+        Decimal128 value{BasicDecimal128::LittleEndianArray, little_endian};
+        return Datum(std::make_shared<Decimal128Scalar>(value, type_));
+      }
+
+      case Type::DECIMAL256: {
+        std::array<uint64_t, 4> little_endian;
+        std::memcpy(little_endian.data(), lit->value(), lit->value()->size());
+        Decimal256 value{BasicDecimal256::LittleEndianArray, little_endian};
+        return Datum(std::make_shared<Decimal256Scalar>(value, type_));
+      }
+
+      default:
+        break;
+    }
+
+    Unreachable();
+  }
+
+  Result<Datum> Convert(const ListType&) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::ListLiteral>());
+    if (!lit->values()) return UnexpectedNullField("ListLiteral.values");
+
+    ScalarVector values{lit->values()->size()};
+    int i = 0;
+    for (const ir::Literal* v : *lit->values()) {
+      ARROW_ASSIGN_OR_RAISE(Datum value, arrow::compute::Convert(*v));
+      values[i++] = value.scalar();
+    }
+
+    std::unique_ptr<ArrayBuilder> builder;
+    RETURN_NOT_OK(MakeBuilder(default_memory_pool(), type_, &builder));
+    RETURN_NOT_OK(builder->AppendScalars(std::move(values)));
+    ARROW_ASSIGN_OR_RAISE(auto arr, builder->Finish());
+    return Datum(std::make_shared<ListScalar>(std::move(arr), type_));
+  }
+
+  Result<Datum> Convert(const MapType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::MapLiteral>());
+    if (!lit->values()) return UnexpectedNullField("MapLiteral.values");
+
+    ScalarVector keys{lit->values()->size()}, values{lit->values()->size()};
+    int i = 0;
+    for (const ir::KeyValue* kv : *lit->values()) {
+      ARROW_ASSIGN_OR_RAISE(Datum key, arrow::compute::Convert(*kv->value()));
+      ARROW_ASSIGN_OR_RAISE(Datum value, arrow::compute::Convert(*kv->value()));
+      keys[i] = key.scalar();
+      values[i] = value.scalar();
+      ++i;
+    }
+
+    ArrayVector kv_arrays(2);
+    std::unique_ptr<ArrayBuilder> builder;
+    RETURN_NOT_OK(MakeBuilder(default_memory_pool(), t.key_type(), &builder));
+    RETURN_NOT_OK(builder->AppendScalars(std::move(keys)));
+    ARROW_ASSIGN_OR_RAISE(kv_arrays[0], builder->Finish());
+
+    RETURN_NOT_OK(MakeBuilder(default_memory_pool(), t.value_type(), &builder));
+    RETURN_NOT_OK(builder->AppendScalars(std::move(values)));
+    ARROW_ASSIGN_OR_RAISE(kv_arrays[1], builder->Finish());
+
+    ARROW_ASSIGN_OR_RAISE(auto item_arr,
+                          StructArray::Make(kv_arrays, t.value_type()->fields()));
+    return Datum(std::make_shared<MapScalar>(std::move(item_arr), type_));
+  }
+
+  Result<Datum> Convert(const StructType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::StructLiteral>());
+    if (!lit->values()) return UnexpectedNullField("StructLiteral.values");
+    if (static_cast<int>(lit->values()->size()) != t.num_fields()) {
+      return Status::IOError(
+          "StructLiteral.type was ", t.ToString(), "(expected ", t.num_fields(),
+          " fields)", " but StructLiteral.values has size ", lit->values()->size());
+    }
+
+    ScalarVector values{lit->values()->size()};
+    int i = 0;
+    for (const ir::Literal* v : *lit->values()) {
+      ARROW_ASSIGN_OR_RAISE(Datum value, arrow::compute::Convert(*v));
+      if (!value.type()->Equals(*t.field(i)->type())) {
+        return Status::IOError("StructLiteral.type was ", t.ToString(), " but value ", i,
+                               " had type ", value.type()->ToString(), "(expected ",
+                               t.field(i)->type()->ToString(), ")");
+      }
+      values[i++] = value.scalar();
+    }
+
+    return Datum(std::make_shared<StructScalar>(std::move(values), type_));
+  }
+
+  Result<Datum> Convert(const StringType&) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::StringLiteral>());
+    if (!lit->value()) return UnexpectedNullField("StringLiteral.value");
+
+    return Datum(ipc::internal::StringFromFlatbuffers(lit->value()));
+  }
+
+  Result<Datum> Convert(const BinaryType&) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::BinaryLiteral>());
+    if (!lit->value()) return UnexpectedNullField("BinaryLiteral.value");
+
+    ARROW_ASSIGN_OR_RAISE(auto buf, BufferFromFlatbufferByteVector(lit->value()));
+    return Datum(std::make_shared<BinaryScalar>(std::move(buf)));
+  }
+
+  Result<Datum> Convert(const FixedSizeBinaryType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<ir::FixedSizeBinaryLiteral>());
+    if (!lit->value()) return UnexpectedNullField("FixedSizeBinaryLiteral.value");
+
+    if (static_cast<int>(lit->value()->size()) != t.byte_width()) {
+      return Status::IOError("FixedSizeBinaryLiteral.type was ", t.ToString(),
+                             " but FixedSizeBinaryLiteral.value had size ",
+                             lit->value()->size());
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto buf, BufferFromFlatbufferByteVector(lit->value()));
+    return Datum(std::make_shared<FixedSizeBinaryScalar>(std::move(buf), type_));
+  }
+
+  Status Visit(const NullType&) { Unreachable(); }
+
+  Status NotImplemented() {
+    return Status::NotImplemented("Literals of type ", type_->ToString());
+  }
+  Status Visit(const ExtensionType& t) { return NotImplemented(); }
+  Status Visit(const SparseUnionType& t) { return NotImplemented(); }
+  Status Visit(const DenseUnionType& t) { return NotImplemented(); }
+  Status Visit(const FixedSizeListType& t) { return NotImplemented(); }
+  Status Visit(const DictionaryType& t) { return NotImplemented(); }
+  Status Visit(const LargeStringType& t) { return NotImplemented(); }
+  Status Visit(const LargeBinaryType& t) { return NotImplemented(); }
+  Status Visit(const LargeListType& t) { return NotImplemented(); }
+
+  template <typename T>
+  Status Visit(const T& t) {
+    ARROW_ASSIGN_OR_RAISE(out_, Convert(t));
+    return Status::OK();
+  }
+
+  template <typename Lit>
+  Result<const Lit*> GetLiteral() {
+    if (const Lit* l = lit_.impl_as<Lit>()) return l;
+
+    return Status::IOError(
+        "Literal.type was ", type_->ToString(), " but got ",
+        ir::EnumNameLiteralImpl(ir::LiteralImplTraits<Lit>::enum_value), " Literal.impl");
+  }
+
+  template <typename Lit, typename T,
+            typename ScalarType = typename TypeTraits<T>::ScalarType,
+            typename ValueType = typename ScalarType::ValueType>
+  Result<Datum> ValueOf(const T&) {
+    ARROW_ASSIGN_OR_RAISE(auto lit, GetLiteral<Lit>());
+    auto scalar =
+        std::make_shared<ScalarType>(static_cast<ValueType>(lit->value()), type_);
+    return Datum(std::move(scalar));
+  }
+
+  Datum out_;
+  const std::shared_ptr<DataType>& type_;
+  const ir::Literal& lit_;
+};
+
+Result<Datum> Convert(const ir::Literal& lit) {
+  if (!lit.type()) return UnexpectedNullField("Literal.type");
+  if (lit.type()->name()) {
+    return Status::IOError("Literal.type should have null Field.name");
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto field, Convert(*lit.type()));
+  if (!lit.impl()) return MakeNullScalar(field->type());
+
+  if (field->type()->id() == Type::NA) {
+    return Status::IOError("Literal of type null had non-null Literal.impl");
+  }
+
+  ConvertLiteralImpl visitor{{}, field->type(), lit};
+  RETURN_NOT_OK(VisitTypeInline(*field->type(), &visitor));
+  return std::move(visitor.out_);
+}
+
+Result<FieldRef> Convert(const ir::FieldRef& ref) {
+  switch (ref.ref_type()) {
+    case ir::Deref::StructField:
+      return FieldRef(ref.ref_as<ir::StructField>()->position());
+
+    case ir::Deref::FieldIndex:
+      return FieldRef(ref.ref_as<ir::FieldIndex>()->position());
+
+    case ir::Deref::MapKey:
+    case ir::Deref::ArraySubscript:
+    case ir::Deref::ArraySlice:
+    case ir::Deref::NONE:
+      break;
+  }
+  return Status::NotImplemented("Deref::", EnumNameDeref(ref.ref_type()));
+}
+
+Result<Expression> Convert(const ir::Expression& expr);
+
+Result<std::pair<std::vector<Expression>, std::vector<Expression>>> Convert(
+    const flatbuffers::Vector<flatbuffers::Offset<ir::CaseFragment>>& cases) {
+  std::vector<Expression> conditions(cases.size()), arguments(cases.size());
+
+  int i = 0;
+  for (const ir::CaseFragment* c : cases) {
+    ARROW_ASSIGN_OR_RAISE(conditions[i], Convert(*c->match()));
+    ARROW_ASSIGN_OR_RAISE(arguments[i], Convert(*c->result()));
+    ++i;
+  }
+
+  return std::make_pair(std::move(conditions), std::move(arguments));
+}
+
+Expression CaseWhen(std::vector<Expression> conditions, std::vector<Expression> arguments,
+                    Expression default_value) {
+  arguments.insert(arguments.begin(), call("make_struct", std::move(conditions)));
+  arguments.push_back(std::move(default_value));
+  return call("case_when", std::move(arguments));
+}
+
+Result<Expression> Convert(const ir::Expression& expr) {
+  switch (expr.impl_type()) {
+    case ir::ExpressionImpl::Literal: {
+      ARROW_ASSIGN_OR_RAISE(Datum value, Convert(*expr.impl_as<ir::Literal>()));
+      return literal(std::move(value));
+    }
+
+    case ir::ExpressionImpl::FieldRef: {
+      ARROW_ASSIGN_OR_RAISE(FieldRef ref, Convert(*expr.impl_as<ir::FieldRef>()));
+      return field_ref(std::move(ref));
+    }
+
+    case ir::ExpressionImpl::Call: {
+      auto call = expr.impl_as<ir::Call>();
+
+      auto name = call->name()->str();
+
+      std::vector<Expression> arguments(call->arguments()->size());
+      int i = 0;
+      for (const ir::Expression* a : *call->arguments()) {
+        ARROW_ASSIGN_OR_RAISE(arguments[i++], Convert(*a));
+      }
+
+      // What about options...?
+      return arrow::compute::call(std::move(name), std::move(arguments));
+    }
+
+    case ir::ExpressionImpl::Cast: {
+      auto cast = expr.impl_as<ir::Cast>();
+
+      ARROW_ASSIGN_OR_RAISE(Expression arg, Convert(*cast->operand()));
+      ARROW_ASSIGN_OR_RAISE(auto to, Convert(*cast->to()));
+
+      return call("cast", {std::move(arg)}, CastOptions::Safe(to->type()));
+    }
+
+    case ir::ExpressionImpl::ConditionalCase: {
+      auto conditional_case = expr.impl_as<ir::ConditionalCase>();
+      ARROW_ASSIGN_OR_RAISE(auto cases, Convert(*conditional_case->conditions()));
+      ARROW_ASSIGN_OR_RAISE(auto default_value, Convert(*conditional_case->else_()));
+      return CaseWhen(std::move(cases.first), std::move(cases.second),
+                      std::move(default_value));
+    }
+
+    case ir::ExpressionImpl::SimpleCase: {
+      auto simple_case = expr.impl_as<ir::SimpleCase>();
+      ARROW_ASSIGN_OR_RAISE(auto expression, Convert(*simple_case->expression()));
+      ARROW_ASSIGN_OR_RAISE(auto cases, Convert(*simple_case->matches()));
+      for (auto& condition : cases.first) {
+        condition = equal(std::move(condition), expression);
+      }
+      ARROW_ASSIGN_OR_RAISE(auto default_value, Convert(*simple_case->else_()));
+      return CaseWhen(std::move(cases.first), std::move(cases.second),
+                      std::move(default_value));
+    }
+
+    case ir::ExpressionImpl::WindowCall:
+    case ir::ExpressionImpl::NONE:
+      break;
+  }
+
+  return Status::NotImplemented("ExpressionImpl::",
+                                EnumNameExpressionImpl(expr.impl_type()));
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/exec/ir_consumer.h
+++ b/cpp/src/arrow/compute/exec/ir_consumer.h
@@ -19,7 +19,9 @@
 
 #include <flatbuffers/flatbuffers.h>
 
+#include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
+#include "arrow/compute/exec/options.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/util/visibility.h"
@@ -34,11 +36,25 @@ namespace compute {
 
 namespace ir = org::apache::arrow::computeir::flatbuf;
 
+class ARROW_EXPORT CatalogSourceNodeOptions : public ExecNodeOptions {
+ public:
+  CatalogSourceNodeOptions(std::string name, std::shared_ptr<Schema> schema)
+      : name(std::move(name)), schema(std::move(schema)) {}
+
+  bool Equals(const ExecNodeOptions& other) const override;
+
+  std::string name;
+  std::shared_ptr<Schema> schema;
+};
+
 ARROW_EXPORT
 Result<Datum> Convert(const ir::Literal& lit);
 
 ARROW_EXPORT
 Result<Expression> Convert(const ir::Expression& lit);
+
+ARROW_EXPORT
+Result<Declaration> Convert(const ir::Relation& rel);
 
 template <typename Ir>
 auto ConvertRoot(const Buffer& buf) -> decltype(Convert(std::declval<Ir>())) {

--- a/cpp/src/arrow/compute/exec/ir_consumer.h
+++ b/cpp/src/arrow/compute/exec/ir_consumer.h
@@ -61,4 +61,3 @@ auto ConvertRoot(const Buffer& buf) -> decltype(Convert(std::declval<Ir>())) {
 
 }  // namespace compute
 }  // namespace arrow
-

--- a/cpp/src/arrow/compute/exec/ir_consumer.h
+++ b/cpp/src/arrow/compute/exec/ir_consumer.h
@@ -41,8 +41,6 @@ class ARROW_EXPORT CatalogSourceNodeOptions : public ExecNodeOptions {
   CatalogSourceNodeOptions(std::string name, std::shared_ptr<Schema> schema)
       : name(std::move(name)), schema(std::move(schema)) {}
 
-  bool Equals(const ExecNodeOptions& other) const override;
-
   std::string name;
   std::shared_ptr<Schema> schema;
 };

--- a/cpp/src/arrow/compute/exec/ir_consumer.h
+++ b/cpp/src/arrow/compute/exec/ir_consumer.h
@@ -38,11 +38,18 @@ namespace ir = org::apache::arrow::computeir::flatbuf;
 
 class ARROW_EXPORT CatalogSourceNodeOptions : public ExecNodeOptions {
  public:
-  CatalogSourceNodeOptions(std::string name, std::shared_ptr<Schema> schema)
-      : name(std::move(name)), schema(std::move(schema)) {}
+  CatalogSourceNodeOptions(std::string name, std::shared_ptr<Schema> schema,
+                           Expression filter = literal(true),
+                           std::vector<FieldRef> projection = {})
+      : name(std::move(name)),
+        schema(std::move(schema)),
+        filter(std::move(filter)),
+        projection(std::move(projection)) {}
 
   std::string name;
   std::shared_ptr<Schema> schema;
+  Expression filter;
+  std::vector<FieldRef> projection;
 };
 
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/exec/ir_consumer.h
+++ b/cpp/src/arrow/compute/exec/ir_consumer.h
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+
+#include "arrow/compute/exec/expression.h"
+#include "arrow/datum.h"
+#include "arrow/result.h"
+#include "arrow/util/visibility.h"
+
+#include "generated/Plan_generated.h"
+
+namespace arrow {
+
+namespace flatbuf = org::apache::arrow::flatbuf;
+
+namespace compute {
+
+namespace ir = org::apache::arrow::computeir::flatbuf;
+
+ARROW_EXPORT
+Result<Datum> Convert(const ir::Literal& lit);
+
+ARROW_EXPORT
+Result<Expression> Convert(const ir::Expression& lit);
+
+template <typename Ir>
+auto ConvertRoot(const Buffer& buf) -> decltype(Convert(std::declval<Ir>())) {
+  return Convert(*flatbuffers::GetRoot<Ir>(buf.data()));
+}
+
+}  // namespace compute
+}  // namespace arrow
+

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/exec/ir_consumer.h"
+
+#include <unistd.h>
+#include <fstream>
+
+#include "arrow/io/file.h"
+#include "arrow/testing/matchers.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/string_view.h"
+
+#include "generated/Plan_generated.h"
+
+using testing::ElementsAre;
+using testing::ElementsAreArray;
+using testing::Eq;
+using testing::HasSubstr;
+using testing::Optional;
+using testing::UnorderedElementsAreArray;
+
+namespace ir = org::apache::arrow::computeir::flatbuf;
+namespace flatbuf = org::apache::arrow::flatbuf;
+
+namespace arrow {
+namespace compute {
+
+std::shared_ptr<Buffer> FlatbufferFromJSON(util::string_view json,
+                                           std::string schema_path) {
+  static std::unique_ptr<arrow::internal::TemporaryDir> dir;
+  if (!dir) {
+    dir = *arrow::internal::TemporaryDir::Make("ir_json_");
+    chdir(dir->path().ToString().c_str());
+  }
+
+  std::ofstream{"ir.json"} << json;
+
+  std::string cmd = "flatc --binary " + schema_path + " ir.json";
+  if (int err = std::system(cmd.c_str())) {
+    std::cerr << cmd << " failed with error code: " << err;
+    std::abort();
+  }
+
+  auto bin = *io::MemoryMappedFile::Open("ir.bin", io::FileMode::READ);
+  return *bin->Read(*bin->GetSize());
+}
+
+TEST(FromJSON, Basic) {
+  auto buf = FlatbufferFromJSON(R"({
+    type: {
+      type_type: "Int",
+      type: { bitWidth: 64, is_signed: true }
+    },
+    impl_type: "Int64Literal",
+    impl: { value: 42 }
+  })",
+                                "~/arrow/experimental/computeir/Literal.fbs");
+
+  ASSERT_THAT(ConvertRoot<ir::Literal>(*buf), ResultWith(DataEq<int64_t>(42)));
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -47,6 +47,12 @@ DEFINE_string(computeir_dir, "",
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (std::system("flatc --version") != 0) {
+    std::cout << "flatc not available, skipping tests" << std::endl;
+    return 0;
+  }
+
   int ret = RUN_ALL_TESTS();
   gflags::ShutDownCommandLineFlags();
   return ret;
@@ -54,8 +60,6 @@ int main(int argc, char** argv) {
 
 namespace arrow {
 namespace compute {
-
-bool HaveFlatbufferCompiler() { return std::system("flatc --version") == 0; }
 
 std::shared_ptr<Buffer> FlatbufferFromJSON(std::string root_type,
                                            util::string_view json) {
@@ -108,8 +112,6 @@ auto ConvertJSON(util::string_view json) -> decltype(Convert(std::declval<Ir>())
 }
 
 TEST(Literal, Int64) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(ConvertJSON<ir::Literal>(R"({
     type: {
       type_type: "Int",
@@ -130,8 +132,6 @@ TEST(Literal, Int64) {
 }
 
 TEST(Expression, Comparison) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(ConvertJSON<ir::Expression>(R"({
     impl_type: "Call",
     impl: {
@@ -164,23 +164,13 @@ TEST(Expression, Comparison) {
 }
 
 TEST(Relation, Filter) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
     impl_type: "Filter",
     impl: {
-      base: {
-        output_mapping_type: "PassThrough",
-        output_mapping: {}
-      },
       rel: {
         impl_type: "Source",
         impl: {
-          base: {
-            output_mapping_type: "PassThrough",
-            output_mapping: {}
-          },
           name: "test source",
           schema: {
             endianness: "Little",
@@ -257,15 +247,9 @@ TEST(Relation, Filter) {
 }
 
 TEST(Relation, AggregateSimple) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
-                "base": {
-                    "output_mapping": {},
-                    "output_mapping_type": "PassThrough"
-                },
                 "groupings": [
                     {
                         "keys": [
@@ -322,10 +306,6 @@ TEST(Relation, AggregateSimple) {
                 ],
                 "rel": {
                     "impl": {
-                        "base": {
-                            "output_mapping": {},
-                            "output_mapping_type": "PassThrough"
-                        },
                         "name": "tbl",
                         "schema": {
                             "endianness": "Little",
@@ -385,15 +365,9 @@ TEST(Relation, AggregateSimple) {
 }
 
 TEST(Relation, AggregateWithHaving) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
-                "base": {
-                    "output_mapping": {},
-                    "output_mapping_type": "PassThrough"
-                },
                 "predicate": {
                     "impl": {
                         "arguments": [
@@ -431,10 +405,6 @@ TEST(Relation, AggregateWithHaving) {
                 },
                 "rel": {
                     "impl": {
-                        "base": {
-                            "output_mapping": {},
-                            "output_mapping_type": "PassThrough"
-                        },
                         "groupings": [
                             {
                                 "keys": [
@@ -491,10 +461,6 @@ TEST(Relation, AggregateWithHaving) {
                         ],
                         "rel": {
                             "impl": {
-                                "base": {
-                                    "output_mapping": {},
-                                    "output_mapping_type": "PassThrough"
-                                },
                                 "predicate": {
                                     "impl": {
                                         "arguments": [
@@ -532,10 +498,6 @@ TEST(Relation, AggregateWithHaving) {
                                 },
                                 "rel": {
                                     "impl": {
-                                        "base": {
-                                            "output_mapping": {},
-                                            "output_mapping_type": "PassThrough"
-                                        },
                                         "name": "tbl",
                                         "schema": {
                                             "endianness": "Little",
@@ -603,15 +565,9 @@ TEST(Relation, AggregateWithHaving) {
 }
 
 TEST(Relation, ProjectionWithFilter) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
-                "base": {
-                    "output_mapping": {},
-                    "output_mapping_type": "PassThrough"
-                },
                 "predicate": {
                     "impl": {
                         "arguments": [
@@ -649,10 +605,6 @@ TEST(Relation, ProjectionWithFilter) {
                 },
                 "rel": {
                     "impl": {
-                        "base": {
-                            "output_mapping": {},
-                            "output_mapping_type": "PassThrough"
-                        },
                         "expressions": [
                             {
                                 "impl": {
@@ -677,10 +629,6 @@ TEST(Relation, ProjectionWithFilter) {
                         ],
                         "rel": {
                             "impl": {
-                                "base": {
-                                    "output_mapping": {},
-                                    "output_mapping_type": "PassThrough"
-                                },
                                 "name": "tbl",
                                 "schema": {
                                     "endianness": "Little",
@@ -734,15 +682,9 @@ TEST(Relation, ProjectionWithFilter) {
 }
 
 TEST(Relation, ProjectionWithSort) {
-  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
-
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
-                "base": {
-                    "output_mapping": {},
-                    "output_mapping_type": "PassThrough"
-                },
                 "keys": [
                     {
                         "expression": {
@@ -773,10 +715,6 @@ TEST(Relation, ProjectionWithSort) {
                 ],
                 "rel": {
                     "impl": {
-                        "base": {
-                            "output_mapping": {},
-                            "output_mapping_type": "PassThrough"
-                        },
                         "expressions": [
                             {
                                 "impl": {
@@ -811,10 +749,6 @@ TEST(Relation, ProjectionWithSort) {
                         ],
                         "rel": {
                             "impl": {
-                                "base": {
-                                    "output_mapping": {},
-                                    "output_mapping_type": "PassThrough"
-                                },
                                 "name": "tbl",
                                 "schema": {
                                     "endianness": "Little",

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -714,10 +714,147 @@ TEST(Relation, ProjectionWithFilter) {
                                                                  field("bar", int64()),
                                                                  field("baz", float64()),
                                                              })}},
-          {"project", ProjectNodeOptions{
-                          /*expressions=*/{field_ref(1), field_ref(2)},
-                      }},
+          {"project", ProjectNodeOptions{/*expressions=*/{field_ref(1), field_ref(2)}}},
           {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}},
+      }))));
+}
+
+TEST(Relation, ProjectionWithSort) {
+  ASSERT_THAT(
+      ConvertJSON<ir::Relation>(R"({
+            "impl": {
+                "base": {
+                    "output_mapping": {},
+                    "output_mapping_type": "PassThrough"
+                },
+                "keys": [
+                    {
+                        "expression": {
+                            "impl": {
+                                "ref": {
+                                    "position": 0
+                                },
+                                "ref_type": "FieldIndex",
+                                "relation_index": 0
+                            },
+                            "impl_type": "FieldRef"
+                        },
+                        "ordering": "NULLS_THEN_ASCENDING"
+                    },
+                    {
+                        "expression": {
+                            "impl": {
+                                "ref": {
+                                    "position": 1
+                                },
+                                "ref_type": "FieldIndex",
+                                "relation_index": 0
+                            },
+                            "impl_type": "FieldRef"
+                        },
+                        "ordering": "NULLS_THEN_DESCENDING"
+                    }
+                ],
+                "rel": {
+                    "impl": {
+                        "base": {
+                            "output_mapping": {},
+                            "output_mapping_type": "PassThrough"
+                        },
+                        "expressions": [
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 0
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            },
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 1
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            },
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 2
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            }
+                        ],
+                        "rel": {
+                            "impl": {
+                                "base": {
+                                    "output_mapping": {},
+                                    "output_mapping_type": "PassThrough"
+                                },
+                                "name": "tbl",
+                                "schema": {
+                                    "endianness": "Little",
+                                    "fields": [
+                                        {
+                                            "name": "foo",
+                                            "nullable": true,
+                                            "type": {
+                                                "bitWidth": 32,
+                                                "is_signed": true
+                                            },
+                                            "type_type": "Int"
+                                        },
+                                        {
+                                            "name": "bar",
+                                            "nullable": true,
+                                            "type": {
+                                                "bitWidth": 64,
+                                                "is_signed": true
+                                            },
+                                            "type_type": "Int"
+                                        },
+                                        {
+                                            "name": "baz",
+                                            "nullable": true,
+                                            "type": {
+                                                "precision": "DOUBLE"
+                                            },
+                                            "type_type": "FloatingPoint"
+                                        }
+                                    ]
+                                }
+                            },
+                            "impl_type": "Source"
+                        }
+                    },
+                    "impl_type": "Project"
+                }
+            },
+            "impl_type": "OrderBy"
+})"),
+      ResultWith(Eq(Declaration::Sequence({
+          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
+                                                                 field("foo", int32()),
+                                                                 field("bar", int64()),
+                                                                 field("baz", float64()),
+                                                             })}},
+          {"project", ProjectNodeOptions{
+                          /*expressions=*/{field_ref(0), field_ref(1), field_ref(2)}}},
+          {"order_by_sink",
+           OrderBySinkNodeOptions{SortOptions{{
+                                                  SortKey{0, SortOrder::Ascending},
+                                                  SortKey{1, SortOrder::Descending},
+                                              },
+                                              NullPlacement::AtStart},
+                                  nullptr}},
       }))));
 }
 

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -55,6 +55,13 @@ int main(int argc, char** argv) {
 namespace arrow {
 namespace compute {
 
+bool HaveFlatbufferCompiler() {
+  if (int err = std::system("flatc --version")) {
+    return false;
+  }
+  return true;
+}
+
 std::shared_ptr<Buffer> FlatbufferFromJSON(std::string root_type,
                                            util::string_view json) {
   static std::unique_ptr<arrow::internal::TemporaryDir> dir;
@@ -106,6 +113,8 @@ auto ConvertJSON(util::string_view json) -> decltype(Convert(std::declval<Ir>())
 }
 
 TEST(Literal, Int64) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(ConvertJSON<ir::Literal>(R"({
     type: {
       type_type: "Int",
@@ -126,6 +135,8 @@ TEST(Literal, Int64) {
 }
 
 TEST(Expression, Comparison) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(ConvertJSON<ir::Expression>(R"({
     impl_type: "Call",
     impl: {
@@ -158,6 +169,8 @@ TEST(Expression, Comparison) {
 }
 
 TEST(Relation, Filter) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
     impl_type: "Filter",
@@ -249,6 +262,8 @@ TEST(Relation, Filter) {
 }
 
 TEST(Relation, AggregateSimple) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
@@ -375,6 +390,8 @@ TEST(Relation, AggregateSimple) {
 }
 
 TEST(Relation, AggregateWithHaving) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
@@ -591,6 +608,8 @@ TEST(Relation, AggregateWithHaving) {
 }
 
 TEST(Relation, ProjectionWithFilter) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
@@ -720,6 +739,8 @@ TEST(Relation, ProjectionWithFilter) {
 }
 
 TEST(Relation, ProjectionWithSort) {
+  if (!HaveFlatbufferCompiler()) GTEST_SKIP() << "flatc unavailable";
+
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -168,9 +168,11 @@ TEST(Relation, Filter) {
       ConvertJSON<ir::Relation>(R"({
     impl_type: "Filter",
     impl: {
+      id: { id: 1 },
       rel: {
         impl_type: "Source",
         impl: {
+          id: { id: 0 },
           name: "test source",
           schema: {
             endianness: "Little",
@@ -241,15 +243,16 @@ TEST(Relation, Filter) {
                                                        field("i32", int32()),
                                                        field("f64", float64()),
                                                        field("i64", int64()),
-                                                   })}},
-          {"filter", FilterNodeOptions{equal(field_ref(2), literal<int64_t>(42))}},
+                                                   })},
+           "0"},
+          {"filter", FilterNodeOptions{equal(field_ref(2), literal<int64_t>(42))}, "1"},
       }))));
 }
 
 TEST(Relation, AggregateSimple) {
-  ASSERT_THAT(
-      ConvertJSON<ir::Relation>(R"({
+  ASSERT_THAT(ConvertJSON<ir::Relation>(R"({
             "impl": {
+                id: {id: 1},
                 "groupings": [
                     {
                         "keys": [
@@ -306,6 +309,7 @@ TEST(Relation, AggregateSimple) {
                 ],
                 "rel": {
                     "impl": {
+                        id: {id: 0},
                         "name": "tbl",
                         "schema": {
                             "endianness": "Little",
@@ -344,30 +348,35 @@ TEST(Relation, AggregateSimple) {
             },
             "impl_type": "Aggregate"
 })"),
-      ResultWith(Eq(Declaration::Sequence({
-          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
-                                                                 field("foo", int32()),
-                                                                 field("bar", int64()),
-                                                                 field("baz", float64()),
-                                                             })}},
-          {"aggregate", AggregateNodeOptions{/*aggregates=*/{
-                                                 {"sum", nullptr},
-                                                 {"mean", nullptr},
-                                             },
-                                             /*targets=*/{1, 2},
-                                             /*names=*/
-                                             {
-                                                 "sum FieldRef.FieldPath(1)",
-                                                 "mean FieldRef.FieldPath(2)",
-                                             },
-                                             /*keys=*/{0}}},
-      }))));
+              ResultWith(Eq(Declaration::Sequence({
+                  {"catalog_source",
+                   CatalogSourceNodeOptions{"tbl", schema({
+                                                       field("foo", int32()),
+                                                       field("bar", int64()),
+                                                       field("baz", float64()),
+                                                   })},
+                   "0"},
+                  {"aggregate",
+                   AggregateNodeOptions{/*aggregates=*/{
+                                            {"sum", nullptr},
+                                            {"mean", nullptr},
+                                        },
+                                        /*targets=*/{1, 2},
+                                        /*names=*/
+                                        {
+                                            "sum FieldRef.FieldPath(1)",
+                                            "mean FieldRef.FieldPath(2)",
+                                        },
+                                        /*keys=*/{0}},
+                   "1"},
+              }))));
 }
 
 TEST(Relation, AggregateWithHaving) {
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
+                id: {id: 3},
                 "predicate": {
                     "impl": {
                         "arguments": [
@@ -405,6 +414,7 @@ TEST(Relation, AggregateWithHaving) {
                 },
                 "rel": {
                     "impl": {
+                        id: {id: 2},
                         "groupings": [
                             {
                                 "keys": [
@@ -461,6 +471,7 @@ TEST(Relation, AggregateWithHaving) {
                         ],
                         "rel": {
                             "impl": {
+                                id: {id: 1},
                                 "predicate": {
                                     "impl": {
                                         "arguments": [
@@ -498,6 +509,7 @@ TEST(Relation, AggregateWithHaving) {
                                 },
                                 "rel": {
                                     "impl": {
+                                        id: {id: 0},
                                         "name": "tbl",
                                         "schema": {
                                             "endianness": "Little",
@@ -543,24 +555,28 @@ TEST(Relation, AggregateWithHaving) {
             "impl_type": "Filter"
 })"),
       ResultWith(Eq(Declaration::Sequence({
-          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
-                                                                 field("foo", int32()),
-                                                                 field("bar", int64()),
-                                                                 field("baz", float64()),
-                                                             })}},
-          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}},
-          {"aggregate", AggregateNodeOptions{/*aggregates=*/{
-                                                 {"sum", nullptr},
-                                                 {"mean", nullptr},
-                                             },
-                                             /*targets=*/{1, 2},
-                                             /*names=*/
-                                             {
-                                                 "sum FieldRef.FieldPath(1)",
-                                                 "mean FieldRef.FieldPath(2)",
-                                             },
-                                             /*keys=*/{0}}},
-          {"filter", FilterNodeOptions{greater(field_ref(0), literal<int8_t>(10))}},
+          {"catalog_source",
+           CatalogSourceNodeOptions{"tbl", schema({
+                                               field("foo", int32()),
+                                               field("bar", int64()),
+                                               field("baz", float64()),
+                                           })},
+           "0"},
+          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}, "1"},
+          {"aggregate",
+           AggregateNodeOptions{/*aggregates=*/{
+                                    {"sum", nullptr},
+                                    {"mean", nullptr},
+                                },
+                                /*targets=*/{1, 2},
+                                /*names=*/
+                                {
+                                    "sum FieldRef.FieldPath(1)",
+                                    "mean FieldRef.FieldPath(2)",
+                                },
+                                /*keys=*/{0}},
+           "2"},
+          {"filter", FilterNodeOptions{greater(field_ref(0), literal<int8_t>(10))}, "3"},
       }))));
 }
 
@@ -568,6 +584,7 @@ TEST(Relation, ProjectionWithFilter) {
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
+                id: {id:2},
                 "predicate": {
                     "impl": {
                         "arguments": [
@@ -605,6 +622,7 @@ TEST(Relation, ProjectionWithFilter) {
                 },
                 "rel": {
                     "impl": {
+                        id: {id:1},
                         "expressions": [
                             {
                                 "impl": {
@@ -629,6 +647,7 @@ TEST(Relation, ProjectionWithFilter) {
                         ],
                         "rel": {
                             "impl": {
+                                id: {id:0},
                                 "name": "tbl",
                                 "schema": {
                                     "endianness": "Little",
@@ -671,13 +690,16 @@ TEST(Relation, ProjectionWithFilter) {
             "impl_type": "Filter"
 })"),
       ResultWith(Eq(Declaration::Sequence({
-          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
-                                                                 field("foo", int32()),
-                                                                 field("bar", int64()),
-                                                                 field("baz", float64()),
-                                                             })}},
-          {"project", ProjectNodeOptions{/*expressions=*/{field_ref(1), field_ref(2)}}},
-          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}},
+          {"catalog_source",
+           CatalogSourceNodeOptions{"tbl", schema({
+                                               field("foo", int32()),
+                                               field("bar", int64()),
+                                               field("baz", float64()),
+                                           })},
+           "0"},
+          {"project", ProjectNodeOptions{/*expressions=*/{field_ref(1), field_ref(2)}},
+           "1"},
+          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}, "2"},
       }))));
 }
 
@@ -685,6 +707,7 @@ TEST(Relation, ProjectionWithSort) {
   ASSERT_THAT(
       ConvertJSON<ir::Relation>(R"({
             "impl": {
+                id: {id:2},
                 "keys": [
                     {
                         "expression": {
@@ -715,6 +738,7 @@ TEST(Relation, ProjectionWithSort) {
                 ],
                 "rel": {
                     "impl": {
+                        id: {id:1},
                         "expressions": [
                             {
                                 "impl": {
@@ -749,6 +773,7 @@ TEST(Relation, ProjectionWithSort) {
                         ],
                         "rel": {
                             "impl": {
+                                id: {id: 0},
                                 "name": "tbl",
                                 "schema": {
                                     "endianness": "Little",
@@ -791,20 +816,24 @@ TEST(Relation, ProjectionWithSort) {
             "impl_type": "OrderBy"
 })"),
       ResultWith(Eq(Declaration::Sequence({
-          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
-                                                                 field("foo", int32()),
-                                                                 field("bar", int64()),
-                                                                 field("baz", float64()),
-                                                             })}},
-          {"project", ProjectNodeOptions{
-                          /*expressions=*/{field_ref(0), field_ref(1), field_ref(2)}}},
+          {"catalog_source",
+           CatalogSourceNodeOptions{"tbl", schema({
+                                               field("foo", int32()),
+                                               field("bar", int64()),
+                                               field("baz", float64()),
+                                           })},
+           "0"},
+          {"project",
+           ProjectNodeOptions{/*expressions=*/{field_ref(0), field_ref(1), field_ref(2)}},
+           "1"},
           {"order_by_sink",
            OrderBySinkNodeOptions{SortOptions{{
                                                   SortKey{0, SortOrder::Ascending},
                                                   SortKey{1, SortOrder::Descending},
                                               },
                                               NullPlacement::AtStart},
-                                  nullptr}},
+                                  nullptr},
+           "2"},
       }))));
 }
 

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -74,14 +74,13 @@ std::shared_ptr<Buffer> FlatbufferFromJSON(std::string root_type,
     dir = *arrow::internal::TemporaryDir::Make("ir_json_");
   }
 
-  auto st = SetWorkingDir(dir->path());
-  if (!st.ok()) st.Abort();
-
-  std::ofstream{"ir.json"} << json;
+  auto json_path = dir->path().ToString() + "ir.json";
+  std::ofstream{json_path} << json;
 
   std::string cmd = "flatc --binary " + FLAGS_computeir_dir + "/Plan.fbs" +
-                    " --root-type org.apache.arrow.computeir.flatbuf." + root_type +
-                    " ir.json";
+                    " --root-type org.apache.arrow.computeir.flatbuf." + root_type + " " +
+                    " -o " + dir->path().ToString() + " " + json_path;
+
   if (int err = std::system(cmd.c_str())) {
     std::cerr << cmd << " failed with error code: " << err;
     std::abort();

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -55,12 +55,7 @@ int main(int argc, char** argv) {
 namespace arrow {
 namespace compute {
 
-bool HaveFlatbufferCompiler() {
-  if (int err = std::system("flatc --version")) {
-    return false;
-  }
-  return true;
-}
+bool HaveFlatbufferCompiler() { return std::system("flatc --version") == 0; }
 
 std::shared_ptr<Buffer> FlatbufferFromJSON(std::string root_type,
                                            util::string_view json) {

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -79,7 +79,7 @@ std::shared_ptr<Buffer> FlatbufferFromJSON(std::string root_type,
 
   std::string cmd = "flatc --binary " + FLAGS_computeir_dir + "/Plan.fbs" +
                     " --root-type org.apache.arrow.computeir.flatbuf." + root_type + " " +
-                    " -o " + dir->path().ToString() + " " + json_path;
+                    json_path;
 
   if (int err = std::system(cmd.c_str())) {
     std::cerr << cmd << " failed with error code: " << err;

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -248,5 +248,478 @@ TEST(Relation, Filter) {
       }))));
 }
 
+TEST(Relation, AggregateSimple) {
+  ASSERT_THAT(
+      ConvertJSON<ir::Relation>(R"({
+            "impl": {
+                "base": {
+                    "output_mapping": {},
+                    "output_mapping_type": "PassThrough"
+                },
+                "groupings": [
+                    {
+                        "keys": [
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 0
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            }
+                        ]
+                    }
+                ],
+                "measures": [
+                    {
+                        "impl": {
+                            "arguments": [
+                                {
+                                    "impl": {
+                                        "ref": {
+                                            "position": 1
+                                        },
+                                        "ref_type": "FieldIndex",
+                                        "relation_index": 0
+                                    },
+                                    "impl_type": "FieldRef"
+                                }
+                            ],
+                            "name": "sum"
+                        },
+                        "impl_type": "Call"
+                    },
+                    {
+                        "impl": {
+                            "arguments": [
+                                {
+                                    "impl": {
+                                        "ref": {
+                                            "position": 2
+                                        },
+                                        "ref_type": "FieldIndex",
+                                        "relation_index": 0
+                                    },
+                                    "impl_type": "FieldRef"
+                                }
+                            ],
+                            "name": "mean"
+                        },
+                        "impl_type": "Call"
+                    }
+                ],
+                "rel": {
+                    "impl": {
+                        "base": {
+                            "output_mapping": {},
+                            "output_mapping_type": "PassThrough"
+                        },
+                        "name": "tbl",
+                        "schema": {
+                            "endianness": "Little",
+                            "fields": [
+                                {
+                                    "name": "foo",
+                                    "nullable": true,
+                                    "type": {
+                                        "bitWidth": 32,
+                                        "is_signed": true
+                                    },
+                                    "type_type": "Int"
+                                },
+                                {
+                                    "name": "bar",
+                                    "nullable": true,
+                                    "type": {
+                                        "bitWidth": 64,
+                                        "is_signed": true
+                                    },
+                                    "type_type": "Int"
+                                },
+                                {
+                                    "name": "baz",
+                                    "nullable": true,
+                                    "type": {
+                                        "precision": "DOUBLE"
+                                    },
+                                    "type_type": "FloatingPoint"
+                                }
+                            ]
+                        }
+                    },
+                    "impl_type": "Source"
+                }
+            },
+            "impl_type": "Aggregate"
+})"),
+      ResultWith(Eq(Declaration::Sequence({
+          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
+                                                                 field("foo", int32()),
+                                                                 field("bar", int64()),
+                                                                 field("baz", float64()),
+                                                             })}},
+          {"aggregate", AggregateNodeOptions{/*aggregates=*/{
+                                                 {"sum", nullptr},
+                                                 {"mean", nullptr},
+                                             },
+                                             /*targets=*/{1, 2},
+                                             /*names=*/
+                                             {
+                                                 "sum FieldRef.FieldPath(1)",
+                                                 "mean FieldRef.FieldPath(2)",
+                                             },
+                                             /*keys=*/{0}}},
+      }))));
+}
+
+TEST(Relation, AggregateWithHaving) {
+  ASSERT_THAT(
+      ConvertJSON<ir::Relation>(R"({
+            "impl": {
+                "base": {
+                    "output_mapping": {},
+                    "output_mapping_type": "PassThrough"
+                },
+                "predicate": {
+                    "impl": {
+                        "arguments": [
+                            {
+                                            "impl": {
+                                                "ref": {
+                                                    "position": 0
+                                                },
+                                                "ref_type": "FieldIndex",
+                                                "relation_index": 0
+                                            },
+                                            "impl_type": "FieldRef"
+                            },
+                            {
+                                "impl": {
+                                    "impl": {
+                                        "value": 10
+                                    },
+                                    "impl_type": "Int8Literal",
+                                    "type": {
+                                        "nullable": true,
+                                        "type": {
+                                            "bitWidth": 8,
+                                            "is_signed": true
+                                        },
+                                        "type_type": "Int"
+                                    }
+                                },
+                                "impl_type": "Literal"
+                            }
+                        ],
+                        "name": "greater"
+                    },
+                    "impl_type": "Call"
+                },
+                "rel": {
+                    "impl": {
+                        "base": {
+                            "output_mapping": {},
+                            "output_mapping_type": "PassThrough"
+                        },
+                        "groupings": [
+                            {
+                                "keys": [
+                                    {
+                                        "impl": {
+                                            "ref": {
+                                                "position": 0
+                                            },
+                                            "ref_type": "FieldIndex",
+                                            "relation_index": 0
+                                        },
+                                        "impl_type": "FieldRef"
+                                    }
+                                ]
+                            }
+                        ],
+                        "measures": [
+                            {
+                                "impl": {
+                                    "arguments": [
+                                        {
+                                            "impl": {
+                                                "ref": {
+                                                    "position": 1
+                                                },
+                                                "ref_type": "FieldIndex",
+                                                "relation_index": 0
+                                            },
+                                            "impl_type": "FieldRef"
+                                        }
+                                    ],
+                                    "name": "sum"
+                                },
+                                "impl_type": "Call"
+                            },
+                            {
+                                "impl": {
+                                    "arguments": [
+                                        {
+                                            "impl": {
+                                                "ref": {
+                                                    "position": 2
+                                                },
+                                                "ref_type": "FieldIndex",
+                                                "relation_index": 0
+                                            },
+                                            "impl_type": "FieldRef"
+                                        }
+                                    ],
+                                    "name": "mean"
+                                },
+                                "impl_type": "Call"
+                            }
+                        ],
+                        "rel": {
+                            "impl": {
+                                "base": {
+                                    "output_mapping": {},
+                                    "output_mapping_type": "PassThrough"
+                                },
+                                "predicate": {
+                                    "impl": {
+                                        "arguments": [
+                                            {
+                                                "impl": {
+                                                    "ref": {
+                                                        "position": 0
+                                                    },
+                                                    "ref_type": "FieldIndex",
+                                                    "relation_index": 0
+                                                },
+                                                "impl_type": "FieldRef"
+                                            },
+                                            {
+                                                "impl": {
+                                                    "impl": {
+                                                        "value": 3
+                                                    },
+                                                    "impl_type": "Int8Literal",
+                                                    "type": {
+                                                        "nullable": true,
+                                                        "type": {
+                                                            "bitWidth": 8,
+                                                            "is_signed": true
+                                                        },
+                                                        "type_type": "Int"
+                                                    }
+                                                },
+                                                "impl_type": "Literal"
+                                            }
+                                        ],
+                                        "name": "less"
+                                    },
+                                    "impl_type": "Call"
+                                },
+                                "rel": {
+                                    "impl": {
+                                        "base": {
+                                            "output_mapping": {},
+                                            "output_mapping_type": "PassThrough"
+                                        },
+                                        "name": "tbl",
+                                        "schema": {
+                                            "endianness": "Little",
+                                            "fields": [
+                                                {
+                                                    "name": "foo",
+                                                    "nullable": true,
+                                                    "type": {
+                                                        "bitWidth": 32,
+                                                        "is_signed": true
+                                                    },
+                                                    "type_type": "Int"
+                                                },
+                                                {
+                                                    "name": "bar",
+                                                    "nullable": true,
+                                                    "type": {
+                                                        "bitWidth": 64,
+                                                        "is_signed": true
+                                                    },
+                                                    "type_type": "Int"
+                                                },
+                                                {
+                                                    "name": "baz",
+                                                    "nullable": true,
+                                                    "type": {
+                                                        "precision": "DOUBLE"
+                                                    },
+                                                    "type_type": "FloatingPoint"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "impl_type": "Source"
+                                }
+                            },
+                            "impl_type": "Filter"
+                        }
+                    },
+                    "impl_type": "Aggregate"
+                }
+            },
+            "impl_type": "Filter"
+})"),
+      ResultWith(Eq(Declaration::Sequence({
+          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
+                                                                 field("foo", int32()),
+                                                                 field("bar", int64()),
+                                                                 field("baz", float64()),
+                                                             })}},
+          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}},
+          {"aggregate", AggregateNodeOptions{/*aggregates=*/{
+                                                 {"sum", nullptr},
+                                                 {"mean", nullptr},
+                                             },
+                                             /*targets=*/{1, 2},
+                                             /*names=*/
+                                             {
+                                                 "sum FieldRef.FieldPath(1)",
+                                                 "mean FieldRef.FieldPath(2)",
+                                             },
+                                             /*keys=*/{0}}},
+          {"filter", FilterNodeOptions{greater(field_ref(0), literal<int8_t>(10))}},
+      }))));
+}
+
+TEST(Relation, ProjectionWithFilter) {
+  ASSERT_THAT(
+      ConvertJSON<ir::Relation>(R"({
+            "impl": {
+                "base": {
+                    "output_mapping": {},
+                    "output_mapping_type": "PassThrough"
+                },
+                "predicate": {
+                    "impl": {
+                        "arguments": [
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 0
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            },
+                            {
+                                "impl": {
+                                    "impl": {
+                                        "value": 3
+                                    },
+                                    "impl_type": "Int8Literal",
+                                    "type": {
+                                        "nullable": true,
+                                        "type": {
+                                            "bitWidth": 8,
+                                            "is_signed": true
+                                        },
+                                        "type_type": "Int"
+                                    }
+                                },
+                                "impl_type": "Literal"
+                            }
+                        ],
+                        "name": "less"
+                    },
+                    "impl_type": "Call"
+                },
+                "rel": {
+                    "impl": {
+                        "base": {
+                            "output_mapping": {},
+                            "output_mapping_type": "PassThrough"
+                        },
+                        "expressions": [
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 1
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            },
+                            {
+                                "impl": {
+                                    "ref": {
+                                        "position": 2
+                                    },
+                                    "ref_type": "FieldIndex",
+                                    "relation_index": 0
+                                },
+                                "impl_type": "FieldRef"
+                            }
+                        ],
+                        "rel": {
+                            "impl": {
+                                "base": {
+                                    "output_mapping": {},
+                                    "output_mapping_type": "PassThrough"
+                                },
+                                "name": "tbl",
+                                "schema": {
+                                    "endianness": "Little",
+                                    "fields": [
+                                        {
+                                            "name": "foo",
+                                            "nullable": true,
+                                            "type": {
+                                                "bitWidth": 32,
+                                                "is_signed": true
+                                            },
+                                            "type_type": "Int"
+                                        },
+                                        {
+                                            "name": "bar",
+                                            "nullable": true,
+                                            "type": {
+                                                "bitWidth": 64,
+                                                "is_signed": true
+                                            },
+                                            "type_type": "Int"
+                                        },
+                                        {
+                                            "name": "baz",
+                                            "nullable": true,
+                                            "type": {
+                                                "precision": "DOUBLE"
+                                            },
+                                            "type_type": "FloatingPoint"
+                                        }
+                                    ]
+                                }
+                            },
+                            "impl_type": "Source"
+                        }
+                    },
+                    "impl_type": "Project"
+                }
+            },
+            "impl_type": "Filter"
+})"),
+      ResultWith(Eq(Declaration::Sequence({
+          {"catalog_source", CatalogSourceNodeOptions{"tbl", schema({
+                                                                 field("foo", int32()),
+                                                                 field("bar", int64()),
+                                                                 field("baz", float64()),
+                                                             })}},
+          {"project", ProjectNodeOptions{
+                          /*expressions=*/{field_ref(1), field_ref(2)},
+                      }},
+          {"filter", FilterNodeOptions{less(field_ref(0), literal<int8_t>(3))}},
+      }))));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/ir_test.cc
+++ b/cpp/src/arrow/compute/exec/ir_test.cc
@@ -22,6 +22,7 @@
 #include <gflags/gflags.h>
 
 #include "arrow/compute/exec/options.h"
+#include "arrow/compute/exec/test_util.h"
 #include "arrow/io/file.h"
 #include "arrow/testing/matchers.h"
 #include "arrow/util/io_util.h"
@@ -182,14 +183,16 @@ TEST(Relation, Filter) {
                 type: {
                   bitWidth: 32,
                   is_signed: true
-                }
+                },
+                nullable: true
               },
               {
                 name: "f64",
                 type_type: "FloatingPoint",
                 type: {
                   precision: "DOUBLE"
-                }
+                },
+                nullable: true
               },
               {
                 name: "i64",
@@ -197,7 +200,8 @@ TEST(Relation, Filter) {
                 type: {
                   bitWidth: 64,
                   is_signed: true
-                }
+                },
+                nullable: true
               }
             ]
           }

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -36,6 +36,8 @@ namespace compute {
 class ARROW_EXPORT ExecNodeOptions {
  public:
   virtual ~ExecNodeOptions() = default;
+
+  virtual bool Equals(const ExecNodeOptions& other) const { return false; }
 };
 
 /// \brief Adapt an AsyncGenerator<ExecBatch> as a source node
@@ -61,6 +63,8 @@ class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
  public:
   explicit FilterNodeOptions(Expression filter_expression, bool async_mode = true)
       : filter_expression(std::move(filter_expression)), async_mode(async_mode) {}
+
+  bool Equals(const ExecNodeOptions& other) const override;
 
   Expression filter_expression;
   bool async_mode;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -36,8 +36,6 @@ namespace compute {
 class ARROW_EXPORT ExecNodeOptions {
  public:
   virtual ~ExecNodeOptions() = default;
-
-  virtual bool Equals(const ExecNodeOptions& other) const { return false; }
 };
 
 /// \brief Adapt an AsyncGenerator<ExecBatch> as a source node
@@ -63,8 +61,6 @@ class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
  public:
   explicit FilterNodeOptions(Expression filter_expression, bool async_mode = true)
       : filter_expression(std::move(filter_expression)), async_mode(async_mode) {}
-
-  bool Equals(const ExecNodeOptions& other) const override;
 
   Expression filter_expression;
   bool async_mode;

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -301,12 +301,11 @@ TEST(ExecPlan, ToString) {
                     {"sink", SinkNodeOptions{&sink_gen}},
                 })
                 .AddToPlan(plan.get()));
-  EXPECT_EQ(plan->sources()[0]->ToString(), R"(SourceNode{"source", outputs=["sink"]})");
-  EXPECT_EQ(plan->sinks()[0]->ToString(),
-            R"(SinkNode{"sink", inputs=[collected: "source"]})");
+  EXPECT_EQ(plan->sources()[0]->ToString(), R"(:SourceNode{outputs=[:SinkNode]})");
+  EXPECT_EQ(plan->sinks()[0]->ToString(), R"(:SinkNode{inputs=[collected=:SourceNode]})");
   EXPECT_EQ(plan->ToString(), R"(ExecPlan with 2 nodes:
-SourceNode{"source", outputs=["sink"]}
-SinkNode{"sink", inputs=[collected: "source"]}
+:SourceNode{outputs=[:SinkNode]}
+:SinkNode{inputs=[collected=:SourceNode]}
 )");
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());
@@ -316,7 +315,8 @@ SinkNode{"sink", inputs=[collected: "source"]}
           {
               {"source",
                SourceNodeOptions{basic_data.schema,
-                                 basic_data.gen(/*parallel=*/false, /*slow=*/false)}},
+                                 basic_data.gen(/*parallel=*/false, /*slow=*/false)},
+               "custom_source_label"},
               {"filter", FilterNodeOptions{greater_equal(field_ref("i32"), literal(0))}},
               {"project", ProjectNodeOptions{{
                               field_ref("bool"),
@@ -333,22 +333,24 @@ SinkNode{"sink", inputs=[collected: "source"]}
               {"order_by_sink",
                OrderBySinkNodeOptions{
                    SortOptions({SortKey{"sum(multiply(i32, 2))", SortOrder::Ascending}}),
-                   &sink_gen}},
+                   &sink_gen},
+               "custom_sink_label"},
           })
           .AddToPlan(plan.get()));
   EXPECT_EQ(plan->ToString(), R"a(ExecPlan with 6 nodes:
-SourceNode{"source", outputs=["filter"]}
-FilterNode{"filter", inputs=[target: "source"], outputs=["project"], filter=(i32 >= 0)}
-ProjectNode{"project", inputs=[target: "filter"], outputs=["aggregate"], projection=[bool, multiply(i32, 2)]}
-GroupByNode{"aggregate", inputs=[groupby: "project"], outputs=["filter"], keys=["bool"], aggregates=[
+custom_source_label:SourceNode{outputs=[:FilterNode]}
+:FilterNode{inputs=[target=custom_source_label:SourceNode], outputs=[:ProjectNode], filter=(i32 >= 0)}
+:ProjectNode{inputs=[target=:FilterNode], outputs=[:GroupByNode], projection=[bool, multiply(i32, 2)]}
+:GroupByNode{inputs=[groupby=:ProjectNode], outputs=[:FilterNode], keys=["bool"], aggregates=[
 	hash_sum(multiply(i32, 2)),
 	hash_count(multiply(i32, 2), {mode=NON_NULL}),
 ]}
-FilterNode{"filter", inputs=[target: "aggregate"], outputs=["order_by_sink"], filter=(sum(multiply(i32, 2)) > 10)}
-OrderBySinkNode{"order_by_sink", inputs=[collected: "filter"], by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
+:FilterNode{inputs=[target=:GroupByNode], outputs=[custom_sink_label:OrderBySinkNode], filter=(sum(multiply(i32, 2)) > 10)}
+custom_sink_label:OrderBySinkNode{inputs=[collected=:FilterNode], by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
 )a");
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());
+
   Declaration union_node{"union", ExecNodeOptions{}};
   Declaration lhs{"source",
                   SourceNodeOptions{basic_data.schema,
@@ -372,13 +374,13 @@ OrderBySinkNode{"order_by_sink", inputs=[collected: "filter"], by={sort_keys=[Fi
           })
           .AddToPlan(plan.get()));
   EXPECT_EQ(plan->ToString(), R"a(ExecPlan with 5 nodes:
-SourceNode{"lhs", outputs=["union"]}
-SourceNode{"rhs", outputs=["union"]}
-UnionNode{"union", inputs=[input_0_label: "lhs", input_1_label: "rhs"], outputs=["aggregate"]}
-ScalarAggregateNode{"aggregate", inputs=[target: "union"], outputs=["sink"], aggregates=[
+lhs:SourceNode{outputs=[:UnionNode]}
+rhs:SourceNode{outputs=[:UnionNode]}
+:UnionNode{inputs=[input_0_label=lhs:SourceNode, input_1_label=rhs:SourceNode], outputs=[:ScalarAggregateNode]}
+:ScalarAggregateNode{inputs=[target=:UnionNode], outputs=[:SinkNode], aggregates=[
 	count(i32, {mode=NON_NULL}),
 ]}
-SinkNode{"sink", inputs=[collected: "aggregate"]}
+:SinkNode{inputs=[collected=:ScalarAggregateNode]}
 )a");
 }
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -345,7 +345,7 @@ GroupByNode{"aggregate", inputs=[groupby: "project"], outputs=["filter"], keys=[
 	hash_count(multiply(i32, 2), {mode=NON_NULL}),
 ]}
 FilterNode{"filter", inputs=[target: "aggregate"], outputs=["order_by_sink"], filter=(sum(multiply(i32, 2)) > 10)}
-OrderBySinkNode{"order_by_sink", inputs=[collected: "filter"], by={sort_keys=[sum(multiply(i32, 2)) ASC], null_placement=AtEnd}}
+OrderBySinkNode{"order_by_sink", inputs=[collected: "filter"], by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
 )a");
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -241,7 +241,7 @@ void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
 
 template <typename T>
 static const T& OptionsAs(const ExecNodeOptions& opts) {
-  const auto& ptr = dynamic_cast<const T&>(opts);
+  const auto& ptr = checked_cast<const T&>(opts);
   return ptr;
 }
 

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -293,6 +293,14 @@ bool operator==(const Declaration& l, const Declaration& r) {
            l_opts->keys == r_opts->keys;
   }
 
+  if (l.factory_name == "order_by_sink") {
+    auto l_opts = &OptionsAs<OrderBySinkNodeOptions>(l);
+    auto r_opts = &OptionsAs<OrderBySinkNodeOptions>(r);
+
+    return l_opts->generator == r_opts->generator &&
+           l_opts->sort_options == r_opts->sort_options;
+  }
+
   Unreachable("equality comparison is not supported for all ExecNodeOptions");
 }
 
@@ -358,6 +366,14 @@ static inline void PrintToImpl(const std::string& factory_name,
       *os << "}";
     }
     return;
+  }
+
+  if (factory_name == "order_by_sink") {
+    auto o = &OptionsAs<OrderBySinkNodeOptions>(opts);
+    if (o->generator) {
+      *os << "NON_NULL_GENERATOR,";
+    }
+    return PrintTo(o->sort_options, os);
   }
 
   Unreachable("debug printing is not supported for all ExecNodeOptions");

--- a/cpp/src/arrow/compute/exec/test_util.h
+++ b/cpp/src/arrow/compute/exec/test_util.h
@@ -105,5 +105,11 @@ void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
                             const std::vector<ExecBatch>& exp,
                             const std::vector<ExecBatch>& act);
 
+ARROW_TESTING_EXPORT
+bool operator==(const Declaration&, const Declaration&);
+
+ARROW_TESTING_EXPORT
+void PrintTo(const Declaration& decl, std::ostream* os);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -1232,7 +1232,12 @@ class SortIndicesMetaFunction : public MetaFunction {
       return Status::Invalid("Must specify one or more sort keys");
     }
     if (n_sort_keys == 1) {
-      ARROW_ASSIGN_OR_RAISE(auto array, options.sort_keys[0].target.GetOne(batch));
+      auto maybe_array = options.sort_keys[0].target.GetOne(batch);
+      if (!maybe_array.ok()) {
+        return maybe_array.status().WithMessage("Invalid sort key column: ",
+                                                maybe_array.status().message());
+      }
+      ARROW_ASSIGN_OR_RAISE(auto array, maybe_array);
       return SortIndices(*array, options, ctx);
     }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -51,6 +51,13 @@ struct SortField {
   SortOrder order;
 };
 
+Status CheckNonNested(const FieldRef& ref) {
+  if (ref.IsNested()) {
+    return Status::KeyError("Nested keys not supported for SortKeys");
+  }
+  return Status::OK();
+}
+
 // Return the field indices of the sort keys, deduplicating them along the way
 Result<std::vector<SortField>> FindSortKeys(const Schema& schema,
                                             const std::vector<SortKey>& sort_keys) {
@@ -60,12 +67,11 @@ Result<std::vector<SortField>> FindSortKeys(const Schema& schema,
   seen.reserve(sort_keys.size());
 
   for (const auto& sort_key : sort_keys) {
-    const auto r = schema.GetFieldIndex(sort_key.name);
-    if (r < 0) {
-      return Status::KeyError("Nonexistent sort key column: ", sort_key.name);
-    }
-    if (seen.insert(r).second) {
-      fields.push_back({r, sort_key.order});
+    RETURN_NOT_OK(CheckNonNested(sort_key.target));
+
+    ARROW_ASSIGN_OR_RAISE(auto match, sort_key.target.FindOne(schema));
+    if (seen.insert(match[0]).second) {
+      fields.push_back({match[0], sort_key.order});
     }
   }
   return fields;
@@ -89,6 +95,18 @@ Result<std::vector<ResolvedSortKey>> ResolveSortKeys(
       *table_or_batch.schema(), sort_keys, [&](const SortField& f) {
         return ResolvedSortKey{table_or_batch.column(f.field_index), f.order};
       });
+}
+
+std::shared_ptr<ChunkedArray> GetTableColumn(const Table& table, const FieldRef& ref) {
+  if (ref.IsNested()) return nullptr;
+
+  if (auto name = ref.name()) {
+    return table.GetColumnByName(*name);
+  }
+
+  auto index = ref.field_path()->indices()[0];
+  if (index >= table.num_columns()) return nullptr;
+  return table.column(index);
 }
 
 // We could try to reproduce the concrete Array classes' facilities
@@ -1214,11 +1232,7 @@ class SortIndicesMetaFunction : public MetaFunction {
       return Status::Invalid("Must specify one or more sort keys");
     }
     if (n_sort_keys == 1) {
-      auto array = batch.GetColumnByName(options.sort_keys[0].name);
-      if (!array) {
-        return Status::Invalid("Nonexistent sort key column: ",
-                               options.sort_keys[0].name);
-      }
+      ARROW_ASSIGN_OR_RAISE(auto array, options.sort_keys[0].target.GetOne(batch));
       return SortIndices(*array, options, ctx);
     }
 
@@ -1254,10 +1268,10 @@ class SortIndicesMetaFunction : public MetaFunction {
       return Status::Invalid("Must specify one or more sort keys");
     }
     if (n_sort_keys == 1) {
-      auto chunked_array = table.GetColumnByName(options.sort_keys[0].name);
+      auto chunked_array = GetTableColumn(table, options.sort_keys[0].target);
       if (!chunked_array) {
         return Status::Invalid("Nonexistent sort key column: ",
-                               options.sort_keys[0].name);
+                               options.sort_keys[0].target.ToString());
       }
       return SortIndices(*chunked_array, options, ctx);
     }
@@ -1562,7 +1576,7 @@ class RecordBatchSelecter : public TypeVisitor {
       const RecordBatch& batch, const std::vector<SortKey>& sort_keys) {
     std::vector<ResolvedSortKey> resolved;
     for (const auto& key : sort_keys) {
-      auto array = batch.GetColumnByName(key.name);
+      auto array = key.target.GetOne(batch).ValueOr(nullptr);
       resolved.emplace_back(array, key.order);
     }
     return resolved;
@@ -1698,7 +1712,7 @@ class TableSelecter : public TypeVisitor {
       const Table& table, const std::vector<SortKey>& sort_keys) {
     std::vector<ResolvedSortKey> resolved;
     for (const auto& key : sort_keys) {
-      auto chunked_array = table.GetColumnByName(key.name);
+      auto chunked_array = GetTableColumn(table, key.target);
       resolved.emplace_back(chunked_array, key.order);
     }
     return resolved;
@@ -1808,10 +1822,8 @@ class TableSelecter : public TypeVisitor {
 static Status CheckConsistency(const Schema& schema,
                                const std::vector<SortKey>& sort_keys) {
   for (const auto& key : sort_keys) {
-    auto field = schema.GetFieldByName(key.name);
-    if (!field) {
-      return Status::Invalid("Nonexistent sort key column: ", key.name);
-    }
+    RETURN_NOT_OK(CheckNonNested(key.target));
+    RETURN_NOT_OK(key.target.FindOne(schema));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -104,6 +104,8 @@ Result<std::vector<ResolvedSortKey>> ResolveSortKeys(
       });
 }
 
+// Returns nullptr if no column matching `ref` is found, or if the FieldRef is
+// a nested reference.
 std::shared_ptr<ChunkedArray> GetTableColumn(const Table& table, const FieldRef& ref) {
   if (ref.IsNested()) return nullptr;
 

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -146,10 +146,13 @@ struct ARROW_EXPORT Datum {
   explicit Datum(const RecordBatch& value);
   explicit Datum(const Table& value);
 
-  // Cast from subtypes of Array to Datum
-  template <typename T, typename = enable_if_t<std::is_base_of<Array, T>::value>>
+  // Cast from subtypes of Array or Scalar to Datum
+  template <typename T, bool IsArray = std::is_base_of<Array, T>::value,
+            bool IsScalar = std::is_base_of<Scalar, T>::value,
+            typename = enable_if_t<IsArray || IsScalar>>
   Datum(const std::shared_ptr<T>& value)  // NOLINT implicit conversion
-      : Datum(std::shared_ptr<Array>(value)) {}
+      : Datum(std::shared_ptr<typename std::conditional<IsArray, Array, Scalar>::type>(
+            value)) {}
 
   // Convenience constructors
   explicit Datum(bool value);

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -216,8 +216,9 @@ flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit) {
     case TimeUnit::NANO:
       return flatbuf::TimeUnit::NANOSECOND;
     default:
-      Unreachable();
+      break;
   }
+  return flatbuf::TimeUnit::MIN;
 }
 
 TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
@@ -231,8 +232,10 @@ TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
     case flatbuf::TimeUnit::NANOSECOND:
       return TimeUnit::NANO;
     default:
-      Unreachable();
+      break;
   }
+  // cannot reach
+  return TimeUnit::SECOND;
 }
 
 Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -203,7 +203,9 @@ Status UnionFromFlatbuffer(const flatbuf::Union* union_data,
   *offset = IntToFlatbuffer(fbb, BIT_WIDTH, IS_SIGNED); \
   break;
 
-static inline flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit) {
+}  // namespace
+
+flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit) {
   switch (unit) {
     case TimeUnit::SECOND:
       return flatbuf::TimeUnit::SECOND;
@@ -214,12 +216,11 @@ static inline flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit) {
     case TimeUnit::NANO:
       return flatbuf::TimeUnit::NANOSECOND;
     default:
-      break;
+      Unreachable();
   }
-  return flatbuf::TimeUnit::MIN;
 }
 
-static inline TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
+TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
   switch (unit) {
     case flatbuf::TimeUnit::SECOND:
       return TimeUnit::SECOND;
@@ -230,15 +231,12 @@ static inline TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
     case flatbuf::TimeUnit::NANOSECOND:
       return TimeUnit::NANO;
     default:
-      break;
+      Unreachable();
   }
-  // cannot reach
-  return TimeUnit::SECOND;
 }
 
 Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
-                                  const std::vector<std::shared_ptr<Field>>& children,
-                                  std::shared_ptr<DataType>* out) {
+                                  FieldVector children, std::shared_ptr<DataType>* out) {
   switch (type) {
     case flatbuf::Type::NONE:
       return Status::Invalid("Type metadata cannot be none");
@@ -389,6 +387,8 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
                              std::to_string(static_cast<int>(type)));
   }
 }
+
+namespace {
 
 Status TensorTypeToFlatbuffer(FBB& fbb, const DataType& type, flatbuf::Type* out_type,
                               Offset* offset) {
@@ -778,8 +778,8 @@ Status FieldFromFlatbuffer(const flatbuf::Field* field, FieldPosition field_pos,
   // 2. Top-level concrete data type
   auto type_data = field->type();
   CHECK_FLATBUFFERS_NOT_NULL(type_data, "Field.type");
-  RETURN_NOT_OK(
-      ConcreteTypeFromFlatbuffer(field->type_type(), type_data, child_fields, &type));
+  RETURN_NOT_OK(ConcreteTypeFromFlatbuffer(field->type_type(), type_data,
+                                           std::move(child_fields), &type));
 
   // 3. Is it a dictionary type?
   int64_t dictionary_id = -1;

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -36,6 +36,7 @@
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/unreachable.h"
 #include "arrow/util/visibility.h"
 
 #include "generated/Message_generated.h"
@@ -125,23 +126,28 @@ inline std::string StringFromFlatbuffers(const flatbuffers::String* s) {
 // dictionary-encoded fields to a DictionaryMemo instance. May be
 // expensive for very large schemas if you are only interested in a
 // few fields
+ARROW_EXPORT
 Status GetSchema(const void* opaque_schema, DictionaryMemo* dictionary_memo,
                  std::shared_ptr<Schema>* out);
 
+ARROW_EXPORT
 Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
                          std::vector<int64_t>* shape, std::vector<int64_t>* strides,
                          std::vector<std::string>* dim_names);
 
 // EXPERIMENTAL: Extracting metadata of a SparseCOOIndex from the message
+ARROW_EXPORT
 Status GetSparseCOOIndexMetadata(const flatbuf::SparseTensorIndexCOO* sparse_index,
                                  std::shared_ptr<DataType>* indices_type);
 
 // EXPERIMENTAL: Extracting metadata of a SparseCSXIndex from the message
+ARROW_EXPORT
 Status GetSparseCSXIndexMetadata(const flatbuf::SparseMatrixIndexCSX* sparse_index,
                                  std::shared_ptr<DataType>* indptr_type,
                                  std::shared_ptr<DataType>* indices_type);
 
 // EXPERIMENTAL: Extracting metadata of a SparseCSFIndex from the message
+ARROW_EXPORT
 Status GetSparseCSFIndexMetadata(const flatbuf::SparseTensorIndexCSF* sparse_index,
                                  std::vector<int64_t>* axis_order,
                                  std::vector<int64_t>* indices_size,
@@ -149,13 +155,19 @@ Status GetSparseCSFIndexMetadata(const flatbuf::SparseTensorIndexCSF* sparse_ind
                                  std::shared_ptr<DataType>* indices_type);
 
 // EXPERIMENTAL: Extracting metadata of a sparse tensor from the message
+ARROW_EXPORT
 Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
                                std::vector<int64_t>* shape,
                                std::vector<std::string>* dim_names, int64_t* length,
                                SparseTensorFormat::type* sparse_tensor_format_id);
 
+ARROW_EXPORT
 Status GetKeyValueMetadata(const KVVector* fb_metadata,
                            std::shared_ptr<KeyValueMetadata>* out);
+
+ARROW_EXPORT
+Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
+                                  FieldVector children, std::shared_ptr<DataType>* out);
 
 template <typename RootType>
 bool VerifyFlatbuffers(const uint8_t* data, int64_t size) {
@@ -180,6 +192,7 @@ static inline Status VerifyMessage(const uint8_t* data, int64_t size,
 }
 
 // Serialize arrow::Schema as a Flatbuffer
+ARROW_EXPORT
 Status WriteSchemaMessage(const Schema& schema, const DictionaryFieldMapper& mapper,
                           const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);
 
@@ -191,19 +204,23 @@ Status WriteRecordBatchMessage(
     const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
     const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);
 
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
                                                    const int64_t buffer_start_offset,
                                                    const IpcWriteOptions& options);
 
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> WriteSparseTensorMessage(
     const SparseTensor& sparse_tensor, int64_t body_length,
     const std::vector<BufferMetadata>& buffers, const IpcWriteOptions& options);
 
+ARROW_EXPORT
 Status WriteFileFooter(const Schema& schema, const std::vector<FileBlock>& dictionaries,
                        const std::vector<FileBlock>& record_batches,
                        const std::shared_ptr<const KeyValueMetadata>& metadata,
                        io::OutputStream* out);
 
+ARROW_EXPORT
 Status WriteDictionaryMessage(
     const int64_t id, const bool is_delta, const int64_t length,
     const int64_t body_length,
@@ -222,6 +239,12 @@ static inline Result<std::shared_ptr<Buffer>> WriteFlatbufferBuilder(
   memcpy(dst, fbb.GetBufferPointer(), size);
   return std::move(result);
 }
+
+ARROW_EXPORT
+flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit);
+
+ARROW_EXPORT
+TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit);
 
 }  // namespace internal
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -36,7 +36,6 @@
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
-#include "arrow/util/unreachable.h"
 #include "arrow/util/visibility.h"
 
 #include "generated/Message_generated.h"

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -302,11 +302,8 @@ struct TemporalScalar : internal::PrimitiveScalar<T> {
   using internal::PrimitiveScalar<T>::PrimitiveScalar;
   using ValueType = typename TemporalScalar<T>::ValueType;
 
-  explicit TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
+  TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
       : internal::PrimitiveScalar<T>(std::move(value), type) {}
-
-  explicit TemporalScalar(ValueType value, TimeUnit::type unit)
-      : TemporalScalar(std::move(value), std::make_shared<T>(unit)) {}
 };
 
 template <typename T>
@@ -330,6 +327,9 @@ struct ARROW_EXPORT Date64Scalar : public DateScalar<Date64Type> {
 template <typename T>
 struct ARROW_EXPORT TimeScalar : public TemporalScalar<T> {
   using TemporalScalar<T>::TemporalScalar;
+
+  TimeScalar(typename TemporalScalar<T>::ValueType value, TimeUnit::type unit)
+      : TimeScalar(std::move(value), std::make_shared<T>(unit)) {}
 };
 
 struct ARROW_EXPORT Time32Scalar : public TimeScalar<Time32Type> {
@@ -342,6 +342,10 @@ struct ARROW_EXPORT Time64Scalar : public TimeScalar<Time64Type> {
 
 struct ARROW_EXPORT TimestampScalar : public TemporalScalar<TimestampType> {
   using TemporalScalar<TimestampType>::TemporalScalar;
+
+  TimestampScalar(typename TemporalScalar<TimestampType>::ValueType value,
+                  TimeUnit::type unit)
+      : TimestampScalar(std::move(value), timestamp(unit)) {}
 };
 
 template <typename T>
@@ -369,6 +373,10 @@ struct ARROW_EXPORT MonthDayNanoIntervalScalar
 
 struct ARROW_EXPORT DurationScalar : public TemporalScalar<DurationType> {
   using TemporalScalar<DurationType>::TemporalScalar;
+
+  DurationScalar(typename TemporalScalar<DurationType>::ValueType value,
+                 TimeUnit::type unit)
+      : DurationScalar(std::move(value), duration(unit)) {}
 };
 
 struct ARROW_EXPORT Decimal128Scalar : public internal::PrimitiveScalarBase {

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -304,6 +304,9 @@ struct TemporalScalar : internal::PrimitiveScalar<T> {
 
   explicit TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
       : internal::PrimitiveScalar<T>(std::move(value), type) {}
+
+  explicit TemporalScalar(ValueType value, TimeUnit::type unit)
+      : TemporalScalar(std::move(value), std::make_shared<T>(unit)) {}
 };
 
 template <typename T>

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1170,6 +1170,30 @@ Result<FieldRef> FieldRef::FromDotPath(const std::string& dot_path_arg) {
   return out;
 }
 
+std::string FieldRef::ToDotPath() const {
+  struct Visitor {
+    std::string operator()(const FieldPath& path) {
+      std::string out;
+      for (int i : path.indices()) {
+        out += "[" + std::to_string(i) + "]";
+      }
+      return out;
+    }
+
+    std::string operator()(const std::string& name) { return "." + name; }
+
+    std::string operator()(const std::vector<FieldRef>& children) {
+      std::string out;
+      for (const auto& child : children) {
+        out += child.ToDotPath();
+      }
+      return out;
+    }
+  };
+
+  return util::visit(Visitor{}, impl_);
+}
+
 size_t FieldRef::hash() const {
   struct Visitor : std::hash<std::string> {
     using std::hash<std::string>::operator();

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -188,6 +188,9 @@ class ARROW_EXPORT DataType : public detail::Fingerprintable {
 ARROW_EXPORT
 std::ostream& operator<<(std::ostream& os, const DataType& type);
 
+inline bool operator==(const DataType& l, const DataType& r) { return l.Equals(r); }
+inline bool operator!=(const DataType& l, const DataType& r) { return !l.Equals(r); }
+
 /// \brief Return the compatible physical data type
 ///
 /// Some types may have distinct logical meanings but the exact same physical

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -188,8 +188,12 @@ class ARROW_EXPORT DataType : public detail::Fingerprintable {
 ARROW_EXPORT
 std::ostream& operator<<(std::ostream& os, const DataType& type);
 
-inline bool operator==(const DataType& l, const DataType& r) { return l.Equals(r); }
-inline bool operator!=(const DataType& l, const DataType& r) { return !l.Equals(r); }
+inline bool operator==(const DataType& lhs, const DataType& rhs) {
+  return lhs.Equals(rhs);
+}
+inline bool operator!=(const DataType& lhs, const DataType& rhs) {
+  return !lhs.Equals(rhs);
+}
 
 /// \brief Return the compatible physical data type
 ///

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1622,6 +1622,7 @@ class ARROW_EXPORT FieldRef {
   /// the resulting name. Therefore if a name must contain the characters '.', '\', or '['
   /// those must be escaped with a preceding '\'.
   static Result<FieldRef> FromDotPath(const std::string& dot_path);
+  std::string ToDotPath() const;
 
   bool Equals(const FieldRef& other) const { return impl_ == other.impl_; }
   bool operator==(const FieldRef& other) const { return Equals(other); }

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -607,19 +607,6 @@ Result<std::vector<PlatformFilename>> ListDir(const PlatformFilename& dir_path) 
 
 #endif
 
-Status SetWorkingDir(const PlatformFilename& dir_path) {
-#ifdef _WIN32
-  if (_wchdir(dir_path.ToNative().c_str()) == 0) return Status::OK();
-
-  return IOErrorFromWinError(GetLastError(), "Cannot set working directory '",
-                             dir_path.ToString(), "'");
-#else
-  if (chdir(dir_path.ToNative().c_str()) == 0) return Status::OK();
-  return IOErrorFromErrno(errno, "Cannot set working directory '", dir_path.ToString(),
-                          "'");
-#endif
-}
-
 namespace {
 
 #ifdef _WIN32

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -34,6 +34,7 @@
 #include "arrow/util/windows_compatibility.h"  // IWYU pragma: keep
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <climits>
 #include <cstdint>
@@ -313,18 +314,18 @@ namespace {
 
 Result<NativePathString> NativeReal(const NativePathString& path) {
 #if _WIN32
-  std::array<char, _MAX_PATH> resolved;
-  if (_wfullpath(path.c_str(), resolved.data(), resolved.size()) == nullptr) {
+  std::array<wchar_t, _MAX_PATH> resolved;
+  if (_wfullpath(const_cast<wchar_t*>(path.c_str()), resolved.data(), resolved.size()) ==
+      nullptr) {
     return IOErrorFromWinError(errno, "Failed to resolve real path");
   }
-  return {resolved.data()};
 #else
   std::array<char, PATH_MAX + 1> resolved;
   if (realpath(path.c_str(), resolved.data()) == nullptr) {
     return IOErrorFromErrno(errno, "Failed to resolve real path");
   }
-  return {resolved.data()};
 #endif
+  return NativePathString{resolved.data()};
 }
 
 }  // namespace

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -57,13 +57,14 @@ class ARROW_EXPORT PlatformFilename {
   PlatformFilename(PlatformFilename&&);
   PlatformFilename& operator=(const PlatformFilename&);
   PlatformFilename& operator=(PlatformFilename&&);
-  explicit PlatformFilename(const NativePathString& path);
+  explicit PlatformFilename(NativePathString path);
   explicit PlatformFilename(const NativePathString::value_type* path);
 
   const NativePathString& ToNative() const;
   std::string ToString() const;
 
   PlatformFilename Parent() const;
+  Result<PlatformFilename> Real() const;
 
   // These functions can fail for character encoding reasons.
   static Result<PlatformFilename> FromString(const std::string& file_name);
@@ -112,6 +113,10 @@ Result<bool> DeleteDirTree(const PlatformFilename& dir_path, bool allow_not_foun
 // The returned names are the children's base names, not including dir_path.
 ARROW_EXPORT
 Result<std::vector<PlatformFilename>> ListDir(const PlatformFilename& dir_path);
+
+/// Set the process' current working directory.
+ARROW_EXPORT
+Status SetWorkingDir(const PlatformFilename& dir_path);
 
 /// Delete a file if it exists.
 ///

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -114,10 +114,6 @@ Result<bool> DeleteDirTree(const PlatformFilename& dir_path, bool allow_not_foun
 ARROW_EXPORT
 Result<std::vector<PlatformFilename>> ListDir(const PlatformFilename& dir_path);
 
-/// Set the process' current working directory.
-ARROW_EXPORT
-Status SetWorkingDir(const PlatformFilename& dir_path);
-
 /// Delete a file if it exists.
 ///
 /// Return whether the file existed.

--- a/cpp/src/arrow/util/unreachable.h
+++ b/cpp/src/arrow/util/unreachable.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
+#include "arrow/util/visibility.h"
+
 namespace arrow {
 
-[[noreturn]] void Unreachable(const char* message = "Unreachable");
+[[noreturn]] ARROW_EXPORT void Unreachable(const char* message = "Unreachable");
 
 }  // namespace arrow

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1974,7 +1974,8 @@ def test_select_k_table():
     with pytest.raises(ValueError, match="not a valid sort order"):
         pc.select_k_unstable(table, k=k, sort_keys=[("a", "nonscending")])
 
-    with pytest.raises(ValueError, match="Nonexistent sort key column"):
+    with pytest.raises(ValueError,
+                       match="Invalid sort key column: No match for.*unknown"):
         pc.select_k_unstable(table, k=k, sort_keys=[("unknown", "ascending")])
 
 


### PR DESCRIPTION
Provide a consumer for compute IR.

The consumer produces `Declaration` objects from buffers of Compute IR. This allows us to specify mappings from IR to ExecNode graphs without needing those specific nodes in the registry or requiring the registered factories to support all features declared in IR.

This is tested by using the flatbuffer compiler to convert JSON into the corresponding binary representation.