### PR TITLE
ARROW-14025: [R][C++] PreBuffer is not enabled when scanning parquet via exec nodes

### DIFF
--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -291,7 +291,7 @@ CsvFragmentScanOptions$create <- function(...,
 ParquetFragmentScanOptions <- R6Class("ParquetFragmentScanOptions", inherit = FragmentScanOptions)
 ParquetFragmentScanOptions$create <- function(use_buffered_stream = FALSE,
                                               buffer_size = 8196,
-                                              pre_buffer = FALSE) {
+                                              pre_buffer = TRUE) {
   dataset___ParquetFragmentScanOptions__Make(use_buffered_stream, buffer_size, pre_buffer)
 }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -335,6 +335,10 @@ dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buf
   }
   options->reader_properties->set_buffer_size(buffer_size);
   options->arrow_reader_properties->set_pre_buffer(pre_buffer);
+  if (pre_buffer) {
+    options->arrow_reader_properties->set_cache_options(
+        arrow::io::CacheOptions::LazyDefaults());
+  }
   return options;
 }
 

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -108,6 +108,17 @@ test_that("CSV scan options", {
     chr = c("foo", NA),
     chr2 = c("bar", "baz")
   ))
+  expect_equal(
+    ds %>%
+      group_by(chr2) %>%
+      summarize(na = all(is.na(chr))) %>%
+      arrange(chr2) %>%
+      collect(),
+    tibble(
+      chr2 = c("bar", "baz"),
+      na = c(FALSE, TRUE)
+    )
+  )
 })
 
 test_that("compressed CSV dataset", {


### PR DESCRIPTION
Also includes an unrelated CSV dataset test, just to confirm that FragmentScanOptions are passed through correctly.