### PR TITLE
ARROW-14300: [C++][R][CI] Work around missing include in xsimd

### DIFF
--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -85,10 +85,6 @@ COPY ci/scripts/r_deps.sh /arrow/ci/scripts/
 COPY r/DESCRIPTION /arrow/r/
 RUN /arrow/ci/scripts/r_deps.sh /arrow
 
-COPY ci/scripts/install_minio.sh \
-     /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
-
 # Set up Python 3 and its dependencies
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -85,6 +85,10 @@ COPY ci/scripts/r_deps.sh /arrow/ci/scripts/
 COPY r/DESCRIPTION /arrow/r/
 RUN /arrow/ci/scripts/r_deps.sh /arrow
 
+COPY ci/scripts/install_minio.sh \
+     /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
+
 # Set up Python 3 and its dependencies
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip

--- a/cpp/src/arrow/util/bpacking_simd128_generated.h
+++ b/cpp/src/arrow/util/bpacking_simd128_generated.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>  // missing include in xsimd
 
 #include <xsimd/xsimd.hpp>
 

--- a/cpp/src/arrow/util/bpacking_simd256_generated.h
+++ b/cpp/src/arrow/util/bpacking_simd256_generated.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>  // missing include in xsimd
 
 #include <xsimd/xsimd.hpp>
 

--- a/cpp/src/arrow/util/bpacking_simd512_generated.h
+++ b/cpp/src/arrow/util/bpacking_simd512_generated.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>  // missing include in xsimd
 
 #include <xsimd/xsimd.hpp>
 

--- a/cpp/src/arrow/util/bpacking_simd_codegen.py
+++ b/cpp/src/arrow/util/bpacking_simd_codegen.py
@@ -174,6 +174,7 @@ def main(simd_width):
 
         #include <cstdint>
         #include <cstring>
+        #include <limits>  // missing include in xsimd
 
         #include <xsimd/xsimd.hpp>
 


### PR DESCRIPTION
Upstream issue: https://github.com/xtensor-stack/xsimd/issues/595

Should fix the "test-r-gcc-11" nightly build