### PR TITLE
ARROW-14305: [C++][Compute] Fixing Valgrind errors in hash join node tests

### DIFF
--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -115,6 +115,7 @@ Result<std::shared_ptr<ArrayData>> BooleanKeyEncoder::Decode(uint8_t** encoded_b
   ARROW_ASSIGN_OR_RAISE(auto key_buf, AllocateBitmap(length, pool));
 
   uint8_t* raw_output = key_buf->mutable_data();
+  memset(raw_output, 0, BitUtil::BytesForBits(length));
   for (int32_t i = 0; i < length; ++i) {
     auto& encoded_ptr = encoded_bytes[i];
     BitUtil::SetBitTo(raw_output, i, encoded_ptr[0] != 0);


### PR DESCRIPTION
On verifying contents of the Boolean column output from hash join test, Valgrind reported uninitialized data access.
I added clearing of an output bit vector for Boolean column before decoding.
This seems to have fixed Valgrind errors.