### PR TITLE
ARROW-14274: [C++] Refine base64 api

### DIFF
--- a/cpp/src/arrow/flight/client_header_internal.cc
+++ b/cpp/src/arrow/flight/client_header_internal.cc
@@ -293,11 +293,8 @@ std::string CookieCache::GetValidCookiesAsString() {
 void AddBasicAuthHeaders(grpc::ClientContext* context, const std::string& username,
                          const std::string& password) {
   const std::string credentials = username + ":" + password;
-  context->AddMetadata(
-      kAuthHeader,
-      kBasicPrefix + arrow::util::base64_encode(
-                         reinterpret_cast<const unsigned char*>(credentials.c_str()),
-                         static_cast<unsigned int>(credentials.size())));
+  context->AddMetadata(kAuthHeader,
+                       kBasicPrefix + arrow::util::base64_encode(credentials));
 }
 
 /// \brief Get bearer token from inbound headers.

--- a/cpp/src/arrow/util/base64.h
+++ b/cpp/src/arrow/util/base64.h
@@ -19,16 +19,17 @@
 
 #include <string>
 
+#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace util {
 
 ARROW_EXPORT
-std::string base64_encode(unsigned char const*, unsigned int len);
+std::string base64_encode(string_view s);
 
 ARROW_EXPORT
-std::string base64_decode(std::string const& s);
+std::string base64_decode(string_view s);
 
 }  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/vendored/base64.cpp
+++ b/cpp/src/arrow/vendored/base64.cpp
@@ -45,7 +45,7 @@ static inline bool is_base64(unsigned char c) {
   return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
+static std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
   std::string ret;
   int i = 0;
   int j = 0;
@@ -87,7 +87,13 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 
 }
 
-std::string base64_decode(std::string const& encoded_string) {
+std::string base64_encode(string_view string_to_encode) {
+  auto bytes_to_encode = reinterpret_cast<const unsigned char*>(string_to_encode.data());
+  auto in_len = static_cast<unsigned int>(string_to_encode.size());
+  return base64_encode(bytes_to_encode, in_len);
+}
+
+std::string base64_decode(string_view encoded_string) {
   size_t in_len = encoded_string.size();
   int i = 0;
   int j = 0;

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -25,6 +25,7 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/double_conversion.h"
 #include "arrow/util/formatting.h"
+#include "arrow/util/string_view.h"
 #include "arrow/util/utf8.h"
 #include "arrow/util/value_parsing.h"
 #include "gandiva/engine.h"
@@ -337,7 +338,7 @@ const char* gdv_fn_base64_encode_binary(int64_t context, const char* in, int32_t
   }
   // use arrow method to encode base64 string
   std::string encoded_str =
-      arrow::util::base64_encode(reinterpret_cast<const unsigned char*>(in), in_len);
+      arrow::util::base64_encode(arrow::util::string_view(in, in_len));
   *out_len = static_cast<int32_t>(encoded_str.length());
   // allocate memory for response
   char* ret = reinterpret_cast<char*>(
@@ -364,7 +365,8 @@ const char* gdv_fn_base64_decode_utf8(int64_t context, const char* in, int32_t i
     return "";
   }
   // use arrow method to decode base64 string
-  std::string decoded_str = arrow::util::base64_decode(std::string(in, in_len));
+  std::string decoded_str =
+      arrow::util::base64_decode(arrow::util::string_view(in, in_len));
   *out_len = static_cast<int32_t>(decoded_str.length());
   // allocate memory for response
   char* ret = reinterpret_cast<char*>(

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -422,9 +422,7 @@ Status GetSchemaMetadata(const ::arrow::Schema& schema, ::arrow::MemoryPool* poo
 
   // The serialized schema is not UTF-8, which is required for Thrift
   std::string schema_as_string = serialized->ToString();
-  std::string schema_base64 = ::arrow::util::base64_encode(
-      reinterpret_cast<const unsigned char*>(schema_as_string.data()),
-      static_cast<unsigned int>(schema_as_string.size()));
+  std::string schema_base64 = ::arrow::util::base64_encode(schema_as_string);
   result->Append(kArrowSchemaKey, schema_base64);
   *out = result;
   return Status::OK();

--- a/cpp/src/parquet/encryption/key_encryption_key.h
+++ b/cpp/src/parquet/encryption/key_encryption_key.h
@@ -33,13 +33,11 @@ namespace encryption {
 // locally, and does not involve an interaction with a KMS server.
 class KeyEncryptionKey {
  public:
-  KeyEncryptionKey(const std::string& kek_bytes, const std::string& kek_id,
-                   const std::string& encoded_wrapped_kek)
+  KeyEncryptionKey(std::string kek_bytes, std::string kek_id,
+                   std::string encoded_wrapped_kek)
       : kek_bytes_(std::move(kek_bytes)),
         kek_id_(std::move(kek_id)),
-        encoded_kek_id_(
-            ::arrow::util::base64_encode(reinterpret_cast<const uint8_t*>(kek_id_.data()),
-                                         static_cast<uint32_t>(kek_id_.size()))),
+        encoded_kek_id_(::arrow::util::base64_encode(kek_id_)),
         encoded_wrapped_kek_(std::move(encoded_wrapped_kek)) {}
 
   const std::string& kek_bytes() const { return kek_bytes_; }

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -43,8 +43,8 @@ std::string EncryptKeyLocally(const std::string& key_bytes, const std::string& m
       static_cast<int>(master_key.size()), reinterpret_cast<const uint8_t*>(aad.data()),
       static_cast<int>(aad.size()), reinterpret_cast<uint8_t*>(&encrypted_key[0]));
 
-  return ::arrow::util::base64_encode(reinterpret_cast<const uint8_t*>(&encrypted_key[0]),
-                                      encrypted_key_len);
+  return ::arrow::util::base64_encode(
+      ::arrow::util::string_view(encrypted_key.data(), encrypted_key_len));
 }
 
 std::string DecryptKeyLocally(const std::string& encoded_encrypted_key,


### PR DESCRIPTION
Passing arguments as string_view simplifies the api significantly.