### PR TITLE
MINOR: [C++][CI] Fix Valgrind error in parquet-arrow-test

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -19,9 +19,14 @@
 
 set -ex
 
-arrow_dir=${1}
-source_dir=${1}/cpp
-build_dir=${2}/cpp
+if [[ $# < 2 ]]; then
+  echo "Usage: $0 <Arrow dir> <build dir> [ctest args ...]"
+  exit 1
+fi
+
+arrow_dir=${1}; shift
+build_dir=${1}/cpp; shift
+source_dir=${arrow_dir}/cpp
 binary_output_dir=${build_dir}/${ARROW_BUILD_TYPE:-debug}
 
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
@@ -79,7 +84,8 @@ ctest \
     --output-on-failure \
     --parallel ${n_jobs} \
     --timeout 300 \
-    "${ctest_options[@]}"
+    "${ctest_options[@]}" \
+    $@
 
 if [ "${ARROW_BUILD_EXAMPLES}" == "ON" ]; then
     examples=$(find ${binary_output_dir} -executable -name "*example")

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4196,6 +4196,12 @@ struct NestedFilterTestCase {
   std::shared_ptr<::arrow::DataType> expected_schema;
   std::string write_data;
   std::string read_data;
+
+  // For Valgrind
+  friend std::ostream& operator<<(std::ostream& os, const NestedFilterTestCase& param) {
+    os << "NestedFilterTestCase{write_schema = " << param.write_schema->ToString() << "}";
+    return os;
+  }
 };
 class TestNestedSchemaFilteredReader
     : public ::testing::TestWithParam<NestedFilterTestCase> {};


### PR DESCRIPTION
The issue is a benign read from uninitialized value when GTest tries to print out a NestedFilterTestCase instance.