### PR TITLE
ARROW-14226: [R] Handle n_distinct() (and others) with args != 1

### DIFF
--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -938,24 +938,24 @@ nse_funcs$case_when <- function(...) {
 # So to see a list of available hash aggregation functions,
 # you can use list_compute_functions("^hash_")
 agg_funcs <- list()
-agg_funcs$sum <- function(x, na.rm = FALSE) {
+agg_funcs$sum <- function(..., na.rm = FALSE) {
   list(
     fun = "sum",
-    data = x,
+    data = ensure_one_arg(list2(...), "sum"),
     options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
-agg_funcs$any <- function(x, na.rm = FALSE) {
+agg_funcs$any <- function(..., na.rm = FALSE) {
   list(
     fun = "any",
-    data = x,
+    data = ensure_one_arg(list2(...), "any"),
     options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
-agg_funcs$all <- function(x, na.rm = FALSE) {
+agg_funcs$all <- function(..., na.rm = FALSE) {
   list(
     fun = "all",
-    data = x,
+    data = ensure_one_arg(list2(...), "all"),
     options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
@@ -1012,16 +1012,9 @@ agg_funcs$median <- function(x, na.rm = FALSE) {
   )
 }
 agg_funcs$n_distinct <- function(..., na.rm = FALSE) {
-  args <- list2(...)
-  if (length(args) == 0) {
-    arrow_not_supported("n_distinct() with 0 arguments")
-  } else if (length(args) > 1) {
-    arrow_not_supported("Multiple arguments to n_distinct()")
-  }
-
   list(
     fun = "count_distinct",
-    data = args[[1]],
+    data = ensure_one_arg(list2(...), "n_distinct"),
     options = list(na.rm = na.rm)
   )
 }
@@ -1033,26 +1026,27 @@ agg_funcs$n <- function() {
   )
 }
 agg_funcs$min <- function(..., na.rm = FALSE) {
-  args <- list2(...)
-  if (length(args) > 1) {
-    arrow_not_supported("Multiple arguments to min()")
-  }
   list(
     fun = "min",
-    data = args[[1]],
+    data = ensure_one_arg(list2(...), "min"),
     options = list(skip_nulls = na.rm, min_count = 0L)
   )
 }
 agg_funcs$max <- function(..., na.rm = FALSE) {
-  args <- list2(...)
-  if (length(args) > 1) {
-    arrow_not_supported("Multiple arguments to max()")
-  }
   list(
     fun = "max",
-    data = args[[1]],
+    data = ensure_one_arg(list2(...), "max"),
     options = list(skip_nulls = na.rm, min_count = 0L)
   )
+}
+
+ensure_one_arg <- function(args, fun) {
+  if (length(args) == 0) {
+    arrow_not_supported(paste0(fun, "() with 0 arguments"))
+  } else if (length(args) > 1) {
+    arrow_not_supported(paste0("Multiple arguments to ", fun, "()"))
+  }
+  args[[1]]
 }
 
 output_type <- function(fun, input_type, hash) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -1011,10 +1011,17 @@ agg_funcs$median <- function(x, na.rm = FALSE) {
     options = list(skip_nulls = na.rm)
   )
 }
-agg_funcs$n_distinct <- function(x, na.rm = FALSE) {
+agg_funcs$n_distinct <- function(..., na.rm = FALSE) {
+  args <- list2(...)
+  if (length(args) == 0) {
+    arrow_not_supported("n_distinct() with 0 arguments")
+  } else if (length(args) > 1) {
+    arrow_not_supported("Multiple arguments to n_distinct()")
+  }
+
   list(
     fun = "count_distinct",
-    data = x,
+    data = args[[1]],
     options = list(na.rm = na.rm)
   )
 }

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -242,23 +242,31 @@ test_that("n_distinct() on dataset", {
     tbl
   )
 
-  # We don't handle nargs != 1
   expect_dplyr_equal(
     input %>%
-      summarize(distinct = n_distinct()) %>%
+      summarize(distinct = n_distinct(int, lgl)) %>%
       collect(),
     tbl,
-    warning = "0 arguments"
+    warning = "Multiple arguments"
   )
   expect_dplyr_equal(
     input %>%
       group_by(some_grouping) %>%
-      summarize(distinct = n_distinct()) %>%
+      summarize(distinct = n_distinct(int, lgl)) %>%
       collect(),
     tbl,
-    warning = "0 arguments"
+    warning = "Multiple arguments"
   )
+})
 
+test_that("Functions that take ... but we only accept a single arg", {
+  expect_dplyr_equal(
+    input %>%
+      summarize(distinct = n_distinct()) %>%
+      collect(),
+    tbl,
+    warning = "0 arguments"
+  )
   expect_dplyr_equal(
     input %>%
       summarize(distinct = n_distinct(int, lgl)) %>%
@@ -266,14 +274,20 @@ test_that("n_distinct() on dataset", {
     tbl,
     warning = "Multiple arguments"
   )
-  expect_dplyr_equal(
-    input %>%
-      group_by(some_grouping) %>%
-      summarize(distinct = n_distinct(int, lgl)) %>%
-      collect(),
-    tbl,
-    warning = "Multiple arguments"
-  )
+  # Now that we've demonstrated that the whole machinery works, let's test
+  # the agg_funcs directly
+  expect_error(agg_funcs$n_distinct(), "n_distinct() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$sum(), "sum() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$any(), "any() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$all(), "all() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$min(), "min() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$max(), "max() with 0 arguments", fixed = TRUE)
+  expect_error(agg_funcs$n_distinct(1, 2), "Multiple arguments to n_distinct()")
+  expect_error(agg_funcs$sum(1, 2), "Multiple arguments to sum")
+  expect_error(agg_funcs$any(1, 2), "Multiple arguments to any()")
+  expect_error(agg_funcs$all(1, 2), "Multiple arguments to all()")
+  expect_error(agg_funcs$min(1, 2), "Multiple arguments to min()")
+  expect_error(agg_funcs$max(1, 2), "Multiple arguments to max()")
 })
 
 test_that("median()", {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -241,6 +241,39 @@ test_that("n_distinct() on dataset", {
       collect(),
     tbl
   )
+
+  # We don't handle nargs != 1
+  expect_dplyr_equal(
+    input %>%
+      summarize(distinct = n_distinct()) %>%
+      collect(),
+    tbl,
+    warning = "0 arguments"
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(some_grouping) %>%
+      summarize(distinct = n_distinct()) %>%
+      collect(),
+    tbl,
+    warning = "0 arguments"
+  )
+
+  expect_dplyr_equal(
+    input %>%
+      summarize(distinct = n_distinct(int, lgl)) %>%
+      collect(),
+    tbl,
+    warning = "Multiple arguments"
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(some_grouping) %>%
+      summarize(distinct = n_distinct(int, lgl)) %>%
+      collect(),
+    tbl,
+    warning = "Multiple arguments"
+  )
 })
 
 test_that("median()", {
@@ -248,6 +281,10 @@ test_that("median()", {
   # type integer, whereas whereas the Arrow approx_median kernels always return
   # output of type float64. The calls to median(int, ...) in the tests below
   # are enclosed in as.double() to work around this known difference.
+
+  # Use old testthat behavior here so we don't have to assert the same warning
+  # over and over
+  local_edition(2)
 
   # with groups
   expect_dplyr_equal(
@@ -290,6 +327,7 @@ test_that("median()", {
     tbl,
     warning = "median\\(\\) currently returns an approximate median in Arrow"
   )
+  local_edition(3)
 })
 
 test_that("quantile()", {
@@ -315,6 +353,7 @@ test_that("quantile()", {
   # return output of type float64. The calls to quantile(int, ...) in the tests
   # below are enclosed in as.double() to work around this known difference.
 
+  local_edition(2)
   # with groups
   expect_warning(
     expect_equal(
@@ -378,6 +417,7 @@ test_that("quantile()", {
     "quantile() currently returns an approximate quantile in Arrow",
     fixed = TRUE
   )
+  local_edition(3)
 
   # with a vector of 2+ probs
   expect_warning(


### PR DESCRIPTION
Turns out that we had a bunch of other aggregation functions that needed the same validation