### PR TITLE
ARROW-14238: [Python] "could not run mc" error in test_fs.py

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -292,8 +292,7 @@ def _ensure_minio_component_version(component, minimum_year):
     full_args = [component, '--version']
     proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, encoding='utf-8')
-    retval = proc.wait(10)
-    if (retval != 0):
+    if proc.wait(10) != 0:
         return False
     stdout = proc.stdout.read()
     pattern = component + r' version RELEASE\.(\d+)-.*'


### PR DESCRIPTION
The error appears to be due to an older version of mc.  This PR adds a minimum version check to ensure that we are working with a recent version of mc.  If we are not it will skip the test.