### PR TITLE
MINOR: [CI][C++] Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ jobs:
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
+          -e ARROW_GCS=OFF
           -e ARROW_ORC=OFF
           -e ARROW_USE_GLOG=OFF
           -e CMAKE_UNITY_BUILD=ON
@@ -95,6 +96,7 @@ jobs:
           "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_GCS=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF

--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -37,7 +37,7 @@ COPY ci/scripts/install_conda.sh \
 RUN /arrow/ci/scripts/install_conda.sh ${arch} linux latest ${prefix}
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest ${prefix}
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 # create a conda environment
 ADD ci/conda_env_unix.txt /arrow/ci/

--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update -y -q && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/ci/docker/debian-11-cpp.dockerfile
+++ b/ci/docker/debian-11-cpp.dockerfile
@@ -73,7 +73,7 @@ RUN apt-get update -y -q && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/ci/docker/fedora-33-cpp.dockerfile
+++ b/ci/docker/fedora-33-cpp.dockerfile
@@ -66,7 +66,7 @@ RUN dnf update -y && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DEPENDENCY_SOURCE=SYSTEM \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -88,7 +88,7 @@ RUN /arrow/ci/scripts/r_deps.sh /arrow
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 # Set up Python 3 and its dependencies
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \

--- a/ci/docker/ubuntu-20.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-cpp.dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update -y -q && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 # Prioritize system packages and local installation
 # The following dependencies will be downloaded due to missing/invalid packages

--- a/ci/docker/ubuntu-20.10-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.10-cpp.dockerfile
@@ -100,7 +100,7 @@ RUN apt-get update -y -q && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 # Prioritize system packages and local installation
 # The following dependencies will be downloaded due to missing/invalid packages

--- a/ci/docker/ubuntu-21.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-21.04-cpp.dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update -y -q && \
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 # Prioritize system packages and local installation
 # The following dependencies will be downloaded due to missing/invalid packages

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -19,12 +19,18 @@
 
 set -e
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <storage-testbench version>"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <arch> <storage-testbench version>"
   exit 1
 fi
 
-version=$1
+arch=$1
+if [ "${arch}" != "amd64" ]; then
+  echo "GCS testbench won't install on non-x86 architecture"
+  exit 0
+fi
+
+version=$2
 if [[ "${version}" -eq "default" ]]; then
   version="v0.7.0"
 fi

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -73,7 +73,7 @@ if [ "$ARROW_S3" == "ON" ] || [ "$ARROW_R_DEV" == "TRUE" ]; then
   fi
 
   if [ -f "/arrow/ci/scripts/install_gcs_testbench.sh" ] && [ "`which pip`" ]; then
-    /arrow/ci/scripts/install_gcs_testbench.sh default
+    /arrow/ci/scripts/install_gcs_testbench.sh amd64 default
   fi
 fi
 


### PR DESCRIPTION
The GCS testbench cannot be installed on non-x86 architectures, it seems.