### PR TITLE
ARROW-14044: [R] Handle group_by .drop parameter in summarize

### DIFF
--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -96,6 +96,19 @@ do_arrow_summarize <- function(.data, ..., .groups = NULL) {
     )[c(.data$group_by_vars, names(exprs))]
   }
 
+  # If the object has .drop = FALSE and any group vars are dictionaries,
+  # we can't (currently) preserve the empty rows that dplyr does,
+  # so give a warning about that.
+  if (!dplyr::group_by_drop_default(.data)) {
+    group_by_exprs <- .data$selected_columns[.data$group_by_vars]
+    if (any(map_lgl(group_by_exprs, ~ inherits(.$type(), "DictionaryType")))) {
+      warning(
+        ".drop = FALSE currently not supported in Arrow aggregation",
+        call. = FALSE
+      )
+    }
+  }
+
   # Handle .groups argument
   if (length(.data$group_by_vars)) {
     if (is.null(.groups)) {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -781,3 +781,47 @@ test_that(".groups argument", {
     "NOTVALID"
   )
 })
+
+test_that("summarize() handles group_by .drop", {
+  # Error: Type error: Sorting not supported for type dictionary<values=string, indices=int8, ordered=0>
+  withr::local_options(list(arrow.summarise.sort = FALSE))
+
+  tbl <- tibble(
+    x = 1:10,
+    y = factor(rep(c("a", "c"), each = 5), levels = c("a", "b", "c"))
+  )
+  expect_dplyr_equal(
+    input %>%
+      group_by(y) %>%
+      count() %>%
+      collect() %>%
+      arrange(y),
+    tbl
+  )
+  # Not supported: check message
+  expect_dplyr_equal(
+    input %>%
+      group_by(y, .drop = FALSE) %>%
+      count() %>%
+      collect() %>%
+      # Because it's not supported, we have to filter out the (empty) row
+      # that dplyr keeps, just so we test equal (otherwise)
+      filter(y != "b") %>%
+      arrange(y),
+    tbl,
+    warning = ".drop = FALSE currently not supported in Arrow aggregation"
+  )
+
+  # But this is ok because there is no factor group
+  expect_dplyr_equal(
+    input %>%
+      group_by(y, .drop = FALSE) %>%
+      count() %>%
+      collect() %>%
+      arrange(y),
+    tibble(
+      x = 1:10,
+      y = rep(c("a", "c"), each = 5)
+    )
+  )
+})


### PR DESCRIPTION
Should we add an option to the hash function that keeps groups for all dictionary values, regardless of whether they are present in indices?