### PR TITLE
MINOR: [R] Finesse the empty tzone to reenable tests on Windows

### DIFF
--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -33,7 +33,6 @@ if (tolower(Sys.info()[["sysname"]]) == "windows") {
   test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "Pacific/Marquesas")
 }
 
-skip_on_os("windows")
 
 test_df <- tibble::tibble(
   # test_date + 1 turns the tzone = "" to NULL, which is functionally equivalent

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -28,15 +28,20 @@ withr::local_timezone("UTC")
 
 # TODO: We should test on windows once ARROW-13168 is resolved.
 if (tolower(Sys.info()[["sysname"]]) == "windows") {
-  test_date <- as.POSIXct("2017-01-01 00:00:12.3456789", tz = "")
+  test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "")
 } else {
-  test_date <- as.POSIXct("2017-01-01 00:00:12.3456789", tz = "Pacific/Marquesas")
+  test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "Pacific/Marquesas")
 }
 
-skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13588
+skip_on_os("windows")
 
 test_df <- tibble::tibble(
-  datetime = c(test_date, NA),
+  # test_date + 1 turns the tzone = "" to NULL, which is functionally equivalent
+  # so we can run some tests on Windows, but this skirts around
+  # https://issues.apache.org/jira/browse/ARROW-13588
+  # That issue is tough because in C++, "" is the "no timezone" value
+  # due to static typing, so we can't distinguish a literal "" from NULL
+  datetime = c(test_date, NA) + 1,
   date = c(as.Date("2021-09-09"), NA)
 )
 


### PR DESCRIPTION
Does not solve the original issue (ARROW-13588, which may not be worth solving), just works around it in order to re-enable some tests on Windows