### PR TITLE
ARROW-14203: [C++] Fix description of ExecBatch.length for Scalars in aggregate kernels

### DIFF
--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -200,10 +200,12 @@ struct ARROW_EXPORT ExecBatch {
   Expression guarantee = literal(true);
 
   /// The semantic length of the ExecBatch. When the values are all scalars,
-  /// the length should be set to 1, otherwise the length is taken from the
-  /// array values, except when there is a selection vector. When there is a
-  /// selection vector set, the length of the batch is the length of the
-  /// selection.
+  /// the length should be set to 1 for non-aggregate kernels, otherwise the
+  /// length is taken from the array values, except when there is a selection
+  /// vector. When there is a selection vector set, the length of the batch is
+  /// the length of the selection. Aggregate kernels can have an ExecBatch
+  /// formed by projecting just the partition columns from a batch in which
+  /// case, it would have scalar rows with length greater than 1.
   ///
   /// If the array values are of length 0 then the length is 0 regardless of
   /// whether any values are Scalar. In general ExecBatch objects are produced


### PR DESCRIPTION
This PR updates the comment describing the `length` data member of ExecBatch to clarify its possible values when operating on Scalars in (non-)aggregate kernels.