### PR TITLE
ARROW-14327: [Release] Remove conda-* from packaging group

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1666,7 +1666,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                               :python,
                               "#{rc_dir}/python/#{full_version}",
                               "#{release_dir}/python/#{full_version}",
-                              "{conda-*,wheel-*,python-sdist}/**/*")
+                              "{python-sdist,wheel-*}/**/*")
   end
 
   def define_nuget_tasks

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -54,7 +54,6 @@ groups:
     - almalinux-*
     - amazon-linux-*
     - centos-*
-    - conda-*
     - debian-*
     - java-jars
     - nuget


### PR DESCRIPTION
We don't need artifacts of conda-* in release process.