### PR TITLE
ARROW-14349: [IR] Remove RelBase

### DIFF
--- a/cpp/src/generated/Relation_generated.h
+++ b/cpp/src/generated/Relation_generated.h
@@ -16,17 +16,8 @@ namespace arrow {
 namespace computeir {
 namespace flatbuf {
 
-struct Remap;
-struct RemapBuilder;
-
-struct PassThrough;
-struct PassThroughBuilder;
-
 struct RelId;
 struct RelIdBuilder;
-
-struct RelBase;
-struct RelBaseBuilder;
 
 struct Filter;
 struct FilterBuilder;
@@ -63,55 +54,6 @@ struct SourceBuilder;
 
 struct Relation;
 struct RelationBuilder;
-
-/// A union for the different colum remapping variants
-enum class Emit : uint8_t {
-  NONE = 0,
-  Remap = 1,
-  PassThrough = 2,
-  MIN = NONE,
-  MAX = PassThrough
-};
-
-inline const Emit (&EnumValuesEmit())[3] {
-  static const Emit values[] = {
-    Emit::NONE,
-    Emit::Remap,
-    Emit::PassThrough
-  };
-  return values;
-}
-
-inline const char * const *EnumNamesEmit() {
-  static const char * const names[4] = {
-    "NONE",
-    "Remap",
-    "PassThrough",
-    nullptr
-  };
-  return names;
-}
-
-inline const char *EnumNameEmit(Emit e) {
-  if (flatbuffers::IsOutRange(e, Emit::NONE, Emit::PassThrough)) return "";
-  const size_t index = static_cast<size_t>(e);
-  return EnumNamesEmit()[index];
-}
-
-template<typename T> struct EmitTraits {
-  static const Emit enum_value = Emit::NONE;
-};
-
-template<> struct EmitTraits<org::apache::arrow::computeir::flatbuf::Remap> {
-  static const Emit enum_value = Emit::Remap;
-};
-
-template<> struct EmitTraits<org::apache::arrow::computeir::flatbuf::PassThrough> {
-  static const Emit enum_value = Emit::PassThrough;
-};
-
-bool VerifyEmit(flatbuffers::Verifier &verifier, const void *obj, Emit type);
-bool VerifyEmitVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
 enum class JoinKind : uint8_t {
   Anti = 0,
@@ -290,97 +232,6 @@ template<> struct RelationImplTraits<org::apache::arrow::computeir::flatbuf::Sou
 bool VerifyRelationImpl(flatbuffers::Verifier &verifier, const void *obj, RelationImpl type);
 bool VerifyRelationImplVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
-/// A data type indicating that a different mapping of columns
-/// should occur in the output.
-///
-/// For example:
-///
-/// Given a query `SELECT b, a FROM t` where `t` has columns a, b, c
-/// the mapping value for the projection would equal [1, 0].
-struct Remap FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef RemapBuilder Builder;
-  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_MAPPING = 4
-  };
-  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *mapping() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *>(VT_MAPPING);
-  }
-  bool Verify(flatbuffers::Verifier &verifier) const {
-    return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_MAPPING) &&
-           verifier.VerifyVector(mapping()) &&
-           verifier.VerifyVectorOfTables(mapping()) &&
-           verifier.EndTable();
-  }
-};
-
-struct RemapBuilder {
-  typedef Remap Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
-  void add_mapping(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>> mapping) {
-    fbb_.AddOffset(Remap::VT_MAPPING, mapping);
-  }
-  explicit RemapBuilder(flatbuffers::FlatBufferBuilder &_fbb)
-        : fbb_(_fbb) {
-    start_ = fbb_.StartTable();
-  }
-  RemapBuilder &operator=(const RemapBuilder &);
-  flatbuffers::Offset<Remap> Finish() {
-    const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<Remap>(end);
-    fbb_.Required(o, Remap::VT_MAPPING);
-    return o;
-  }
-};
-
-inline flatbuffers::Offset<Remap> CreateRemap(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>> mapping = 0) {
-  RemapBuilder builder_(_fbb);
-  builder_.add_mapping(mapping);
-  return builder_.Finish();
-}
-
-inline flatbuffers::Offset<Remap> CreateRemapDirect(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *mapping = nullptr) {
-  auto mapping__ = mapping ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>(*mapping) : 0;
-  return org::apache::arrow::computeir::flatbuf::CreateRemap(
-      _fbb,
-      mapping__);
-}
-
-struct PassThrough FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef PassThroughBuilder Builder;
-  bool Verify(flatbuffers::Verifier &verifier) const {
-    return VerifyTableStart(verifier) &&
-           verifier.EndTable();
-  }
-};
-
-struct PassThroughBuilder {
-  typedef PassThrough Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
-  explicit PassThroughBuilder(flatbuffers::FlatBufferBuilder &_fbb)
-        : fbb_(_fbb) {
-    start_ = fbb_.StartTable();
-  }
-  PassThroughBuilder &operator=(const PassThroughBuilder &);
-  flatbuffers::Offset<PassThrough> Finish() {
-    const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<PassThrough>(end);
-    return o;
-  }
-};
-
-inline flatbuffers::Offset<PassThrough> CreatePassThrough(
-    flatbuffers::FlatBufferBuilder &_fbb) {
-  PassThroughBuilder builder_(_fbb);
-  return builder_.Finish();
-}
-
 /// An identifier for relations in a query.
 ///
 /// A table is used here to allow plan implementations optionality.
@@ -426,101 +277,18 @@ inline flatbuffers::Offset<RelId> CreateRelId(
   return builder_.Finish();
 }
 
-/// Fields common to every relational operator
-struct RelBase FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef RelBaseBuilder Builder;
-  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_OUTPUT_MAPPING_TYPE = 4,
-    VT_OUTPUT_MAPPING = 6,
-    VT_ID = 8
-  };
-  org::apache::arrow::computeir::flatbuf::Emit output_mapping_type() const {
-    return static_cast<org::apache::arrow::computeir::flatbuf::Emit>(GetField<uint8_t>(VT_OUTPUT_MAPPING_TYPE, 0));
-  }
-  /// Output remapping of ordinal columns for a given operation
-  const void *output_mapping() const {
-    return GetPointer<const void *>(VT_OUTPUT_MAPPING);
-  }
-  template<typename T> const T *output_mapping_as() const;
-  const org::apache::arrow::computeir::flatbuf::Remap *output_mapping_as_Remap() const {
-    return output_mapping_type() == org::apache::arrow::computeir::flatbuf::Emit::Remap ? static_cast<const org::apache::arrow::computeir::flatbuf::Remap *>(output_mapping()) : nullptr;
-  }
-  const org::apache::arrow::computeir::flatbuf::PassThrough *output_mapping_as_PassThrough() const {
-    return output_mapping_type() == org::apache::arrow::computeir::flatbuf::Emit::PassThrough ? static_cast<const org::apache::arrow::computeir::flatbuf::PassThrough *>(output_mapping()) : nullptr;
-  }
-  /// An identifiier for a relation. The identifier should be unique over the
-  /// entire plan. Optional.
-  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
-  }
-  bool Verify(flatbuffers::Verifier &verifier) const {
-    return VerifyTableStart(verifier) &&
-           VerifyField<uint8_t>(verifier, VT_OUTPUT_MAPPING_TYPE) &&
-           VerifyOffsetRequired(verifier, VT_OUTPUT_MAPPING) &&
-           VerifyEmit(verifier, output_mapping(), output_mapping_type()) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.VerifyTable(id()) &&
-           verifier.EndTable();
-  }
-};
-
-template<> inline const org::apache::arrow::computeir::flatbuf::Remap *RelBase::output_mapping_as<org::apache::arrow::computeir::flatbuf::Remap>() const {
-  return output_mapping_as_Remap();
-}
-
-template<> inline const org::apache::arrow::computeir::flatbuf::PassThrough *RelBase::output_mapping_as<org::apache::arrow::computeir::flatbuf::PassThrough>() const {
-  return output_mapping_as_PassThrough();
-}
-
-struct RelBaseBuilder {
-  typedef RelBase Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
-  void add_output_mapping_type(org::apache::arrow::computeir::flatbuf::Emit output_mapping_type) {
-    fbb_.AddElement<uint8_t>(RelBase::VT_OUTPUT_MAPPING_TYPE, static_cast<uint8_t>(output_mapping_type), 0);
-  }
-  void add_output_mapping(flatbuffers::Offset<void> output_mapping) {
-    fbb_.AddOffset(RelBase::VT_OUTPUT_MAPPING, output_mapping);
-  }
-  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
-    fbb_.AddOffset(RelBase::VT_ID, id);
-  }
-  explicit RelBaseBuilder(flatbuffers::FlatBufferBuilder &_fbb)
-        : fbb_(_fbb) {
-    start_ = fbb_.StartTable();
-  }
-  RelBaseBuilder &operator=(const RelBaseBuilder &);
-  flatbuffers::Offset<RelBase> Finish() {
-    const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<RelBase>(end);
-    fbb_.Required(o, RelBase::VT_OUTPUT_MAPPING);
-    return o;
-  }
-};
-
-inline flatbuffers::Offset<RelBase> CreateRelBase(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::computeir::flatbuf::Emit output_mapping_type = org::apache::arrow::computeir::flatbuf::Emit::NONE,
-    flatbuffers::Offset<void> output_mapping = 0,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0) {
-  RelBaseBuilder builder_(_fbb);
-  builder_.add_id(id);
-  builder_.add_output_mapping(output_mapping);
-  builder_.add_output_mapping_type(output_mapping_type);
-  return builder_.Finish();
-}
-
 /// Filter operation
 struct Filter FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef FilterBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_REL = 6,
     VT_PREDICATE = 8
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relation
   const org::apache::arrow::computeir::flatbuf::Relation *rel() const {
@@ -534,8 +302,8 @@ struct Filter FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_REL) &&
            verifier.VerifyTable(rel()) &&
            VerifyOffsetRequired(verifier, VT_PREDICATE) &&
@@ -548,8 +316,8 @@ struct FilterBuilder {
   typedef Filter Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Filter::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Filter::VT_ID, id);
   }
   void add_rel(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel) {
     fbb_.AddOffset(Filter::VT_REL, rel);
@@ -565,7 +333,6 @@ struct FilterBuilder {
   flatbuffers::Offset<Filter> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Filter>(end);
-    fbb_.Required(o, Filter::VT_BASE);
     fbb_.Required(o, Filter::VT_REL);
     fbb_.Required(o, Filter::VT_PREDICATE);
     return o;
@@ -574,13 +341,13 @@ struct FilterBuilder {
 
 inline flatbuffers::Offset<Filter> CreateFilter(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression> predicate = 0) {
   FilterBuilder builder_(_fbb);
   builder_.add_predicate(predicate);
   builder_.add_rel(rel);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
@@ -588,13 +355,14 @@ inline flatbuffers::Offset<Filter> CreateFilter(
 struct Project FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ProjectBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_REL = 6,
     VT_EXPRESSIONS = 8
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relation
   const org::apache::arrow::computeir::flatbuf::Relation *rel() const {
@@ -607,8 +375,8 @@ struct Project FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_REL) &&
            verifier.VerifyTable(rel()) &&
            VerifyOffsetRequired(verifier, VT_EXPRESSIONS) &&
@@ -622,8 +390,8 @@ struct ProjectBuilder {
   typedef Project Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Project::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Project::VT_ID, id);
   }
   void add_rel(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel) {
     fbb_.AddOffset(Project::VT_REL, rel);
@@ -639,7 +407,6 @@ struct ProjectBuilder {
   flatbuffers::Offset<Project> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Project>(end);
-    fbb_.Required(o, Project::VT_BASE);
     fbb_.Required(o, Project::VT_REL);
     fbb_.Required(o, Project::VT_EXPRESSIONS);
     return o;
@@ -648,25 +415,25 @@ struct ProjectBuilder {
 
 inline flatbuffers::Offset<Project> CreateProject(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression>>> expressions = 0) {
   ProjectBuilder builder_(_fbb);
   builder_.add_expressions(expressions);
   builder_.add_rel(rel);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Project> CreateProjectDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression>> *expressions = nullptr) {
   auto expressions__ = expressions ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression>>(*expressions) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateProject(
       _fbb,
-      base,
+      id,
       rel,
       expressions__);
 }
@@ -731,14 +498,15 @@ inline flatbuffers::Offset<Grouping> CreateGroupingDirect(
 struct Aggregate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AggregateBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_REL = 6,
     VT_MEASURES = 8,
     VT_GROUPINGS = 10
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relation
   const org::apache::arrow::computeir::flatbuf::Relation *rel() const {
@@ -768,8 +536,8 @@ struct Aggregate FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_REL) &&
            verifier.VerifyTable(rel()) &&
            VerifyOffsetRequired(verifier, VT_MEASURES) &&
@@ -786,8 +554,8 @@ struct AggregateBuilder {
   typedef Aggregate Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Aggregate::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Aggregate::VT_ID, id);
   }
   void add_rel(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel) {
     fbb_.AddOffset(Aggregate::VT_REL, rel);
@@ -806,7 +574,6 @@ struct AggregateBuilder {
   flatbuffers::Offset<Aggregate> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Aggregate>(end);
-    fbb_.Required(o, Aggregate::VT_BASE);
     fbb_.Required(o, Aggregate::VT_REL);
     fbb_.Required(o, Aggregate::VT_MEASURES);
     fbb_.Required(o, Aggregate::VT_GROUPINGS);
@@ -816,7 +583,7 @@ struct AggregateBuilder {
 
 inline flatbuffers::Offset<Aggregate> CreateAggregate(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression>>> measures = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Grouping>>> groupings = 0) {
@@ -824,13 +591,13 @@ inline flatbuffers::Offset<Aggregate> CreateAggregate(
   builder_.add_groupings(groupings);
   builder_.add_measures(measures);
   builder_.add_rel(rel);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Aggregate> CreateAggregateDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression>> *measures = nullptr,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Grouping>> *groupings = nullptr) {
@@ -838,7 +605,7 @@ inline flatbuffers::Offset<Aggregate> CreateAggregateDirect(
   auto groupings__ = groupings ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Grouping>>(*groupings) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateAggregate(
       _fbb,
-      base,
+      id,
       rel,
       measures__,
       groupings__);
@@ -848,15 +615,16 @@ inline flatbuffers::Offset<Aggregate> CreateAggregateDirect(
 struct Join FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef JoinBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_LEFT = 6,
     VT_RIGHT = 8,
     VT_ON_EXPRESSION = 10,
     VT_JOIN_KIND = 12
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Left relation
   const org::apache::arrow::computeir::flatbuf::Relation *left() const {
@@ -878,8 +646,8 @@ struct Join FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_LEFT) &&
            verifier.VerifyTable(left()) &&
            VerifyOffsetRequired(verifier, VT_RIGHT) &&
@@ -895,8 +663,8 @@ struct JoinBuilder {
   typedef Join Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Join::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Join::VT_ID, id);
   }
   void add_left(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> left) {
     fbb_.AddOffset(Join::VT_LEFT, left);
@@ -918,7 +686,6 @@ struct JoinBuilder {
   flatbuffers::Offset<Join> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Join>(end);
-    fbb_.Required(o, Join::VT_BASE);
     fbb_.Required(o, Join::VT_LEFT);
     fbb_.Required(o, Join::VT_RIGHT);
     fbb_.Required(o, Join::VT_ON_EXPRESSION);
@@ -928,7 +695,7 @@ struct JoinBuilder {
 
 inline flatbuffers::Offset<Join> CreateJoin(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> left = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> right = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Expression> on_expression = 0,
@@ -937,7 +704,7 @@ inline flatbuffers::Offset<Join> CreateJoin(
   builder_.add_on_expression(on_expression);
   builder_.add_right(right);
   builder_.add_left(left);
-  builder_.add_base(base);
+  builder_.add_id(id);
   builder_.add_join_kind(join_kind);
   return builder_.Finish();
 }
@@ -946,13 +713,14 @@ inline flatbuffers::Offset<Join> CreateJoin(
 struct OrderBy FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef OrderByBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_REL = 6,
     VT_KEYS = 8
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relation
   const org::apache::arrow::computeir::flatbuf::Relation *rel() const {
@@ -965,8 +733,8 @@ struct OrderBy FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_REL) &&
            verifier.VerifyTable(rel()) &&
            VerifyOffsetRequired(verifier, VT_KEYS) &&
@@ -980,8 +748,8 @@ struct OrderByBuilder {
   typedef OrderBy Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(OrderBy::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(OrderBy::VT_ID, id);
   }
   void add_rel(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel) {
     fbb_.AddOffset(OrderBy::VT_REL, rel);
@@ -997,7 +765,6 @@ struct OrderByBuilder {
   flatbuffers::Offset<OrderBy> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<OrderBy>(end);
-    fbb_.Required(o, OrderBy::VT_BASE);
     fbb_.Required(o, OrderBy::VT_REL);
     fbb_.Required(o, OrderBy::VT_KEYS);
     return o;
@@ -1006,25 +773,25 @@ struct OrderByBuilder {
 
 inline flatbuffers::Offset<OrderBy> CreateOrderBy(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::SortKey>>> keys = 0) {
   OrderByBuilder builder_(_fbb);
   builder_.add_keys(keys);
   builder_.add_rel(rel);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<OrderBy> CreateOrderByDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::SortKey>> *keys = nullptr) {
   auto keys__ = keys ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::SortKey>>(*keys) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateOrderBy(
       _fbb,
-      base,
+      id,
       rel,
       keys__);
 }
@@ -1033,14 +800,15 @@ inline flatbuffers::Offset<OrderBy> CreateOrderByDirect(
 struct Limit FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef LimitBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_REL = 6,
     VT_OFFSET = 8,
     VT_COUNT = 10
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relation
   const org::apache::arrow::computeir::flatbuf::Relation *rel() const {
@@ -1056,8 +824,8 @@ struct Limit FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_REL) &&
            verifier.VerifyTable(rel()) &&
            VerifyField<uint32_t>(verifier, VT_OFFSET) &&
@@ -1070,8 +838,8 @@ struct LimitBuilder {
   typedef Limit Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Limit::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Limit::VT_ID, id);
   }
   void add_rel(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel) {
     fbb_.AddOffset(Limit::VT_REL, rel);
@@ -1090,7 +858,6 @@ struct LimitBuilder {
   flatbuffers::Offset<Limit> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Limit>(end);
-    fbb_.Required(o, Limit::VT_BASE);
     fbb_.Required(o, Limit::VT_REL);
     return o;
   }
@@ -1098,7 +865,7 @@ struct LimitBuilder {
 
 inline flatbuffers::Offset<Limit> CreateLimit(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation> rel = 0,
     uint32_t offset = 0,
     uint32_t count = 0) {
@@ -1106,7 +873,7 @@ inline flatbuffers::Offset<Limit> CreateLimit(
   builder_.add_count(count);
   builder_.add_offset(offset);
   builder_.add_rel(rel);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
@@ -1114,13 +881,14 @@ inline flatbuffers::Offset<Limit> CreateLimit(
 struct SetOperation FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SetOperationBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_RELS = 6,
     VT_SET_OP = 8
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// Child relations
   const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation>> *rels() const {
@@ -1132,8 +900,8 @@ struct SetOperation FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_RELS) &&
            verifier.VerifyVector(rels()) &&
            verifier.VerifyVectorOfTables(rels()) &&
@@ -1146,8 +914,8 @@ struct SetOperationBuilder {
   typedef SetOperation Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(SetOperation::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(SetOperation::VT_ID, id);
   }
   void add_rels(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation>>> rels) {
     fbb_.AddOffset(SetOperation::VT_RELS, rels);
@@ -1163,7 +931,6 @@ struct SetOperationBuilder {
   flatbuffers::Offset<SetOperation> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<SetOperation>(end);
-    fbb_.Required(o, SetOperation::VT_BASE);
     fbb_.Required(o, SetOperation::VT_RELS);
     return o;
   }
@@ -1171,25 +938,25 @@ struct SetOperationBuilder {
 
 inline flatbuffers::Offset<SetOperation> CreateSetOperation(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation>>> rels = 0,
     org::apache::arrow::computeir::flatbuf::SetOpKind set_op = org::apache::arrow::computeir::flatbuf::SetOpKind::Union) {
   SetOperationBuilder builder_(_fbb);
   builder_.add_rels(rels);
-  builder_.add_base(base);
+  builder_.add_id(id);
   builder_.add_set_op(set_op);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<SetOperation> CreateSetOperationDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation>> *rels = nullptr,
     org::apache::arrow::computeir::flatbuf::SetOpKind set_op = org::apache::arrow::computeir::flatbuf::SetOpKind::Union) {
   auto rels__ = rels ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::Relation>>(*rels) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateSetOperation(
       _fbb,
-      base,
+      id,
       rels__,
       set_op);
 }
@@ -1254,12 +1021,13 @@ inline flatbuffers::Offset<LiteralColumn> CreateLiteralColumnDirect(
 struct LiteralRelation FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef LiteralRelationBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_COLUMNS = 6
   };
-  /// Common options
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   /// The columns of this literal relation.
   const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::LiteralColumn>> *columns() const {
@@ -1267,8 +1035,8 @@ struct LiteralRelation FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_COLUMNS) &&
            verifier.VerifyVector(columns()) &&
            verifier.VerifyVectorOfTables(columns()) &&
@@ -1280,8 +1048,8 @@ struct LiteralRelationBuilder {
   typedef LiteralRelation Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(LiteralRelation::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(LiteralRelation::VT_ID, id);
   }
   void add_columns(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::LiteralColumn>>> columns) {
     fbb_.AddOffset(LiteralRelation::VT_COLUMNS, columns);
@@ -1294,7 +1062,6 @@ struct LiteralRelationBuilder {
   flatbuffers::Offset<LiteralRelation> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<LiteralRelation>(end);
-    fbb_.Required(o, LiteralRelation::VT_BASE);
     fbb_.Required(o, LiteralRelation::VT_COLUMNS);
     return o;
   }
@@ -1302,22 +1069,22 @@ struct LiteralRelationBuilder {
 
 inline flatbuffers::Offset<LiteralRelation> CreateLiteralRelation(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::LiteralColumn>>> columns = 0) {
   LiteralRelationBuilder builder_(_fbb);
   builder_.add_columns(columns);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<LiteralRelation> CreateLiteralRelationDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::LiteralColumn>> *columns = nullptr) {
   auto columns__ = columns ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::LiteralColumn>>(*columns) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateLiteralRelation(
       _fbb,
-      base,
+      id,
       columns__);
 }
 
@@ -1325,12 +1092,14 @@ inline flatbuffers::Offset<LiteralRelation> CreateLiteralRelationDirect(
 struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SourceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_BASE = 4,
+    VT_ID = 4,
     VT_NAME = 6,
     VT_SCHEMA = 8
   };
-  const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
-    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  const org::apache::arrow::computeir::flatbuf::RelId *id() const {
+    return GetPointer<const org::apache::arrow::computeir::flatbuf::RelId *>(VT_ID);
   }
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
@@ -1340,8 +1109,8 @@ struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffsetRequired(verifier, VT_BASE) &&
-           verifier.VerifyTable(base()) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.VerifyTable(id()) &&
            VerifyOffsetRequired(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
            VerifyOffsetRequired(verifier, VT_SCHEMA) &&
@@ -1354,8 +1123,8 @@ struct SourceBuilder {
   typedef Source Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_base(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base) {
-    fbb_.AddOffset(Source::VT_BASE, base);
+  void add_id(flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id) {
+    fbb_.AddOffset(Source::VT_ID, id);
   }
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(Source::VT_NAME, name);
@@ -1371,7 +1140,6 @@ struct SourceBuilder {
   flatbuffers::Offset<Source> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Source>(end);
-    fbb_.Required(o, Source::VT_BASE);
     fbb_.Required(o, Source::VT_NAME);
     fbb_.Required(o, Source::VT_SCHEMA);
     return o;
@@ -1380,25 +1148,25 @@ struct SourceBuilder {
 
 inline flatbuffers::Offset<Source> CreateSource(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0) {
   SourceBuilder builder_(_fbb);
   builder_.add_schema(schema);
   builder_.add_name(name);
-  builder_.add_base(base);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Source> CreateSourceDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
+    flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelId> id = 0,
     const char *name = nullptr,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateSource(
       _fbb,
-      base,
+      id,
       name__,
       schema);
 }
@@ -1520,35 +1288,6 @@ inline flatbuffers::Offset<Relation> CreateRelation(
   builder_.add_impl(impl);
   builder_.add_impl_type(impl_type);
   return builder_.Finish();
-}
-
-inline bool VerifyEmit(flatbuffers::Verifier &verifier, const void *obj, Emit type) {
-  switch (type) {
-    case Emit::NONE: {
-      return true;
-    }
-    case Emit::Remap: {
-      auto ptr = reinterpret_cast<const org::apache::arrow::computeir::flatbuf::Remap *>(obj);
-      return verifier.VerifyTable(ptr);
-    }
-    case Emit::PassThrough: {
-      auto ptr = reinterpret_cast<const org::apache::arrow::computeir::flatbuf::PassThrough *>(obj);
-      return verifier.VerifyTable(ptr);
-    }
-    default: return true;
-  }
-}
-
-inline bool VerifyEmitVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types) {
-  if (!values || !types) return !values && !types;
-  if (values->size() != types->size()) return false;
-  for (flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
-    if (!VerifyEmit(
-        verifier,  values->Get(i), types->GetEnum<Emit>(i))) {
-      return false;
-    }
-  }
-  return true;
 }
 
 inline bool VerifyRelationImpl(flatbuffers::Verifier &verifier, const void *obj, RelationImpl type) {

--- a/experimental/computeir/Relation.fbs
+++ b/experimental/computeir/Relation.fbs
@@ -21,26 +21,6 @@ include "Expression.fbs";
 
 namespace org.apache.arrow.computeir.flatbuf;
 
-/// A data type indicating that a different mapping of columns
-/// should occur in the output.
-///
-/// For example:
-///
-/// Given a query `SELECT b, a FROM t` where `t` has columns a, b, c
-/// the mapping value for the projection would equal [1, 0].
-table Remap {
-  mapping: [FieldIndex] (required);
-}
-
-// Pass through indicates that no output remapping should occur.
-table PassThrough {}
-
-/// A union for the different colum remapping variants
-union Emit {
-  Remap,
-  PassThrough,
-}
-
 /// An identifier for relations in a query.
 ///
 /// A table is used here to allow plan implementations optionality.
@@ -48,20 +28,11 @@ table RelId {
   id: uint64;
 }
 
-/// Fields common to every relational operator
-table RelBase {
-  /// Output remapping of ordinal columns for a given operation
-  output_mapping: Emit (required);
-
-  /// An identifiier for a relation. The identifier should be unique over the
-  /// entire plan. Optional.
-  id: RelId;
-}
-
 /// Filter operation
 table Filter {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relation
   rel: Relation (required);
   /// The expression which will be evaluated against input rows
@@ -72,8 +43,9 @@ table Filter {
 
 /// Projection
 table Project {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relation
   rel: Relation (required);
   /// Expressions which will be evaluated to produce to
@@ -89,8 +61,9 @@ table Grouping {
 
 /// Aggregate operation
 table Aggregate {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relation
   rel: Relation (required);
   /// Expressions which will be evaluated to produce to
@@ -125,8 +98,9 @@ enum JoinKind : uint8 {
 
 /// Join between two tables
 table Join {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Left relation
   left: Relation (required);
   /// Right relation
@@ -141,8 +115,9 @@ table Join {
 
 /// Order by relation
 table OrderBy {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relation
   rel: Relation (required);
   /// Define sort order for rows of output.
@@ -152,8 +127,9 @@ table OrderBy {
 
 /// Limit operation
 table Limit {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relation
   rel: Relation (required);
   /// Starting index of rows
@@ -171,8 +147,9 @@ enum SetOpKind : uint8 {
 
 /// A set operation on two or more relations
 table SetOperation {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// Child relations
   rels: [Relation] (required);
   /// The kind of set operation
@@ -187,15 +164,18 @@ table LiteralColumn {
 
 /// Literal relation
 table LiteralRelation {
-  /// Common options
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   /// The columns of this literal relation.
   columns: [LiteralColumn] (required);
 }
 
 /// An external source of tabular data
 table Source {
-  base: RelBase (required);
+  /// An identifiier for the relation. The identifier should be unique over the
+  /// entire plan. Optional.
+  id: RelId;
   name: string (required);
   schema: org.apache.arrow.flatbuf.Schema (required);
 }


### PR DESCRIPTION
This PR removes `RelBase` and associated column (re)mapping types.
Producers/consumers are expected to use projections for reordering for the time
being.
