### PR TITLE
ARROW-14352: [IR] Remove schema property from Source

### DIFF
--- a/cpp/src/generated/Relation_generated.h
+++ b/cpp/src/generated/Relation_generated.h
@@ -1327,13 +1327,23 @@ struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_BASE = 4,
     VT_NAME = 6,
-    VT_SCHEMA = 8
+    VT_PROJECTION = 8,
+    VT_SCHEMA = 10
   };
   const org::apache::arrow::computeir::flatbuf::RelBase *base() const {
     return GetPointer<const org::apache::arrow::computeir::flatbuf::RelBase *>(VT_BASE);
   }
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
+  }
+  /// An optional list of field indices indicating which columns should be read
+  /// from the source.
+  ///
+  /// A missing value indicates all columns should be read.
+  ///
+  /// The behavior of an empty list is undefined.
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *projection() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *>(VT_PROJECTION);
   }
   const org::apache::arrow::flatbuf::Schema *schema() const {
     return GetPointer<const org::apache::arrow::flatbuf::Schema *>(VT_SCHEMA);
@@ -1344,6 +1354,9 @@ struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyTable(base()) &&
            VerifyOffsetRequired(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
+           VerifyOffset(verifier, VT_PROJECTION) &&
+           verifier.VerifyVector(projection()) &&
+           verifier.VerifyVectorOfTables(projection()) &&
            VerifyOffsetRequired(verifier, VT_SCHEMA) &&
            verifier.VerifyTable(schema()) &&
            verifier.EndTable();
@@ -1359,6 +1372,9 @@ struct SourceBuilder {
   }
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(Source::VT_NAME, name);
+  }
+  void add_projection(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>> projection) {
+    fbb_.AddOffset(Source::VT_PROJECTION, projection);
   }
   void add_schema(flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema) {
     fbb_.AddOffset(Source::VT_SCHEMA, schema);
@@ -1382,9 +1398,11 @@ inline flatbuffers::Offset<Source> CreateSource(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>> projection = 0,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0) {
   SourceBuilder builder_(_fbb);
   builder_.add_schema(schema);
+  builder_.add_projection(projection);
   builder_.add_name(name);
   builder_.add_base(base);
   return builder_.Finish();
@@ -1394,12 +1412,15 @@ inline flatbuffers::Offset<Source> CreateSourceDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::RelBase> base = 0,
     const char *name = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>> *projection = nullptr,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
+  auto projection__ = projection ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::computeir::flatbuf::FieldIndex>>(*projection) : 0;
   return org::apache::arrow::computeir::flatbuf::CreateSource(
       _fbb,
       base,
       name__,
+      projection__,
       schema);
 }
 

--- a/experimental/computeir/Relation.fbs
+++ b/experimental/computeir/Relation.fbs
@@ -197,6 +197,13 @@ table LiteralRelation {
 table Source {
   base: RelBase (required);
   name: string (required);
+  /// An optional list of field indices indicating which columns should be read
+  /// from the source.
+  ///
+  /// A missing value indicates all columns should be read.
+  ///
+  /// The behavior of an empty list is undefined.
+  projection: [FieldIndex];
   schema: org.apache.arrow.flatbuf.Schema (required);
 }
 


### PR DESCRIPTION
This PR adds support for passing a list of field indices for consumers that
would like to support projection pruning and pushdown.
