### PR TITLE
ARROW-14350: [IR] Add filter expression to Source node

### DIFF
--- a/experimental/computeir/Relation.fbs
+++ b/experimental/computeir/Relation.fbs
@@ -197,6 +197,13 @@ table LiteralRelation {
 table Source {
   base: RelBase (required);
   name: string (required);
+  /// An optional expression used to filter out rows directly from the source.
+  ///
+  /// Useful for consumers that implement predicate pushdown.
+  ///
+  /// A missing filter value indicates no filter, i.e., all rows are
+  /// returned from the source.
+  filter: Expression;
   schema: org.apache.arrow.flatbuf.Schema (required);
 }
 


### PR DESCRIPTION
This PR adds a `filter` expression to `Source` nodes to support
consumers that implement predicate pushdown.
