### PR TITLE
ARROW-14352: [IR] Remove schema property from Source

### DIFF
--- a/cpp/src/generated/Relation_generated.h
+++ b/cpp/src/generated/Relation_generated.h
@@ -1114,6 +1114,7 @@ struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const org::apache::arrow::computeir::flatbuf::Expression *filter() const {
     return GetPointer<const org::apache::arrow::computeir::flatbuf::Expression *>(VT_FILTER);
   }
+  /// Schemas are explicitly optional
   const org::apache::arrow::flatbuf::Schema *schema() const {
     return GetPointer<const org::apache::arrow::flatbuf::Schema *>(VT_SCHEMA);
   }
@@ -1125,7 +1126,7 @@ struct Source FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyString(name()) &&
            VerifyOffset(verifier, VT_FILTER) &&
            verifier.VerifyTable(filter()) &&
-           VerifyOffsetRequired(verifier, VT_SCHEMA) &&
+           VerifyOffset(verifier, VT_SCHEMA) &&
            verifier.VerifyTable(schema()) &&
            verifier.EndTable();
   }
@@ -1156,7 +1157,6 @@ struct SourceBuilder {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Source>(end);
     fbb_.Required(o, Source::VT_NAME);
-    fbb_.Required(o, Source::VT_SCHEMA);
     return o;
   }
 };

--- a/experimental/computeir/Relation.fbs
+++ b/experimental/computeir/Relation.fbs
@@ -184,7 +184,8 @@ table Source {
   /// A missing filter value indicates no filter, i.e., all rows are
   /// returned from the source.
   filter: Expression;
-  schema: org.apache.arrow.flatbuf.Schema (required);
+  /// Schemas are explicitly optional
+  schema: org.apache.arrow.flatbuf.Schema;
 }
 
 /// The varieties of relations


### PR DESCRIPTION
This PR removes the schema field from `Source`s, as it is currently unused by
both the C++ consumer in progress, as well as the DuckDB producer/consumer
(https://github.com/duckdb/duckdb/pull/2331)
