### PR TITLE
ARROW-14308: [C++][CI] Use old gcc-libs on MinGW 32 temporary

### DIFF
--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -83,7 +83,7 @@ if [ "${MINGW_PACKAGE_PREFIX}" == "mingw-w64-i686" ]; then
     --location \
     --remote-name \
     --show-error \
-    --silient \
+    --silent \
     https://repo.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
   pacman --noconfirm --upgrade mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
 fi

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -60,7 +60,7 @@ case "${target}" in
     ;;
 esac
 
-case "${target}" in 
+case "${target}" in
   cgo)
     packages+=(${MINGW_PACKAGE_PREFIX}-arrow)
     packages+=(${MINGW_PACKAGE_PREFIX}-gcc)
@@ -74,5 +74,11 @@ pacman \
   --sync \
   "${packages[@]}"
 
-"$(dirname $0)/ccache_setup.sh"
-echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
+# https://issues.apache.org/jira/browse/ARROW-14308
+# https://github.com/msys2/MINGW-packages/issues/9771
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100486
+# Disabled ccache on mingw-w64-i686 temporary because it's crashed.
+if [ "${MINGW_PACKAGE_PREFIX}" != "mingw-w64-i686" ]; then
+  "$(dirname $0)/ccache_setup.sh"
+  echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
+fi

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -79,13 +79,16 @@ pacman \
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100486
 # Use old gcc-libs as workaround.
 if [ "${MINGW_PACKAGE_PREFIX}" == "mingw-w64-i686" ]; then
-  curl \
-    --location \
-    --remote-name \
-    --show-error \
-    --silent \
-    https://repo.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
-  pacman --noconfirm --upgrade mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
+  for package in gcc gcc-libs gcc-libgfortran; do
+    curl \
+      --location \
+      --remote-name \
+      --show-error \
+      --silent \
+      https://repo.msys2.org/mingw/mingw32/mingw-w64-i686-${package}-10.3.0-5-any.pkg.tar.zst
+  done
+  pacman --noconfirm --upgrade *.pkg.tar.zst
+  rm *.pkg.tar.zst
 fi
 "$(dirname $0)/ccache_setup.sh"
 echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -77,8 +77,15 @@ pacman \
 # https://issues.apache.org/jira/browse/ARROW-14308
 # https://github.com/msys2/MINGW-packages/issues/9771
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100486
-# Disabled ccache on mingw-w64-i686 temporary because it's crashed.
-if [ "${MINGW_PACKAGE_PREFIX}" != "mingw-w64-i686" ]; then
-  "$(dirname $0)/ccache_setup.sh"
-  echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
+# Use old gcc-libs as workaround.
+if [ "${MINGW_PACKAGE_PREFIX}" == "mingw-w64-i686" ]; then
+  curl \
+    --location \
+    --remote-name \
+    --show-error \
+    --silient \
+    https://repo.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
+  pacman --noconfirm --upgrade mingw-w64-i686-gcc-libs-10.3.0-5-any.pkg.tar.zst
 fi
+"$(dirname $0)/ccache_setup.sh"
+echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV


### PR DESCRIPTION
See also: https://github.com/msys2/MINGW-packages/issues/9771