### PR TITLE
ARROW-10094: [Python][Doc] Document missing pandas to arrow conversions

### DIFF
--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -299,6 +299,7 @@ each offset in the selected child array it can be found:
    union_arr.type
    union_arr
 
+.. _data.dictionary:
 
 Dictionary Arrays
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -199,7 +199,6 @@ use the ``datetime64[ns]`` type in Pandas and are converted to an Arrow
 
    table = pa.Table.from_pandas(df)
    table
-   table[0]
 
 In this example the Pandas Timestamp is time zone aware
 (``UTC`` on this case), and this information is used to create the Arrow

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -161,8 +161,8 @@ Categorical types
 ~~~~~~~~~~~~~~~~~
 
 `Pandas categorical <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_
-columns are converted to :ref:`Arrow array dictionaries <data.dictionary>`,
-an special array type optimized to handle repeated, limited, and fixed,
+columns are converted to :ref:`Arrow dictionary arrays <data.dictionary>`,
+a special array type optimized to handle repeated and limited
 number of possible values.
 
 .. ipython:: python

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -201,8 +201,8 @@ use the ``datetime64[ns]`` type in Pandas and are converted to an Arrow
    table
    table[0]
 
-On this example the Pandas Timestamp is time zone aware
-(``UTC`` on this case) information that is used to create the Arrow
+In this example the Pandas Timestamp is time zone aware
+(``UTC`` on this case), and this information is used to create the Arrow
 :class:`~.TimestampArray`.
 
 Date types

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -160,12 +160,50 @@ Arrow -> pandas Conversion
 Categorical types
 ~~~~~~~~~~~~~~~~~
 
-TODO
+`Pandas categorical <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_
+columns are converted to :ref:`Arrow array dictionaries <data.dictionary>`,
+an special array type optimized to handle repeated, limited, and fixed,
+number of possible values.
+
+.. ipython:: python
+
+   df = pd.DataFrame({"cat": pd.Categorical(["a", "b", "c", "a", "b", "c"])})
+   df.cat.dtype.categories
+   df
+
+   table = pa.Table.from_pandas(df)
+   table
+
+We can inspect the :class:`~.ChunkedArray` of the created table and see the
+same categories of the Pandas DataFrame.
+
+.. ipython:: python
+
+   column = table[0]
+   chunk = column.chunk(0)
+   chunk.dictionary
+   chunk.indices
 
 Datetime (Timestamp) types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+`Pandas Timestamps <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html>`_
+use the ``datetime64[ns]`` type in Pandas and are converted to an Arrow
+:class:`~.TimestampArray`.
+
+.. ipython:: python
+
+   df = pd.DataFrame({"datetime": pd.date_range("2020-01-01T00:00:00Z", freq="H", periods=3)})
+   df.dtypes
+   df
+
+   table = pa.Table.from_pandas(df)
+   table
+   table[0]
+
+On this example the Pandas Timestamp is time zone aware
+(``UTC`` on this case) information that is used to create the Arrow
+:class:`~.TimestampArray`.
 
 Date types
 ~~~~~~~~~~
@@ -220,7 +258,24 @@ If you want to use NumPy's ``datetime64`` dtype instead, pass
 Time types
 ~~~~~~~~~~
 
-TODO
+The builtin ``datetime.time`` objects inside Pandas data structures will be
+converted to an Arrow ``time64`` and :class:`~.Time64Array` respectively.
+
+.. ipython:: python
+
+   from datetime import time
+   s = pd.Series([time(1, 1, 1), time(2, 2, 2)])
+   s
+
+   arr = pa.array(s)
+   arr.type
+   arr
+
+When converting to pandas, arrays of ``datetime.time`` objects are returned:
+
+.. ipython:: python
+
+   arr.to_pandas()
 
 Memory Usage and Zero Copy
 --------------------------


### PR DESCRIPTION
Just adding a couple of example to some of the missing converstion types.