### PR TITLE
ARROW-11238: [Python] Make SubTreeFileSystem print method more informative

### DIFF
--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -833,11 +833,9 @@ cdef class SubTreeFileSystem(FileSystem):
         FileSystem.init(self, wrapped)
         self.subtreefs = <CSubTreeFileSystem*> wrapped.get()
 
-    def __str__(self):
-        return f'SubTreeFileSystem: file:{self.base_path}'
-
     def __repr__(self):
-        return f'SubTreeFileSystem(base_path={self.base_path}, base_fs={self.base_fs})'
+        txt = 'SubTreeFileSystem(base_path={}, base_fs={}'
+        return txt.format(self.base_path, self.base_fs)
 
     def __reduce__(self):
         return SubTreeFileSystem, (

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -833,6 +833,12 @@ cdef class SubTreeFileSystem(FileSystem):
         FileSystem.init(self, wrapped)
         self.subtreefs = <CSubTreeFileSystem*> wrapped.get()
 
+    def __str__(self):
+        return f'SubTreeFileSystem: file:{self.base_path}'
+
+    def __repr__(self):
+        return f'SubTreeFileSystem(base_path={self.base_path}, base_fs={self.base_fs})'
+
     def __reduce__(self):
         return SubTreeFileSystem, (
             frombytes(self.subtreefs.base_path()),

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -834,8 +834,8 @@ cdef class SubTreeFileSystem(FileSystem):
         self.subtreefs = <CSubTreeFileSystem*> wrapped.get()
 
     def __repr__(self):
-        txt = 'SubTreeFileSystem(base_path={}, base_fs={}'
-        return txt.format(self.base_path, self.base_fs)
+        return ("SubTreeFileSystem(base_path={}, base_fs={}"
+                .format(self.base_path, self.base_fs))
 
     def __reduce__(self):
         return SubTreeFileSystem, (

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -588,13 +588,13 @@ def test_subtree_filesystem():
     assert subfs.base_path == '/base/'
     assert subfs.base_fs == localfs
     assert str(subfs) == 'SubTreeFileSystem: file:/base/'
-    assert repr(subfs) == f'SubTreeFileSystem(base_path=/base/, base_fs={subfs.base_fs})'
+    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/base/, base_fs=<pyarrow._fs.LocalFileSystem object at')
 
     subfs = SubTreeFileSystem('/another/base/', LocalFileSystem())
     assert subfs.base_path == '/another/base/'
     assert subfs.base_fs == localfs
     assert str(subfs) == 'SubTreeFileSystem: file:/another/base/'
-    assert repr(subfs) == f'SubTreeFileSystem(base_path=/another/base/, base_fs={subfs.base_fs})'
+    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/another/base/, base_fs=<pyarrow._fs.LocalFileSystem object at')
 
 def test_filesystem_pickling(fs):
     if fs.type_name.split('::')[-1] == 'mock':

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -587,11 +587,14 @@ def test_subtree_filesystem():
     subfs = SubTreeFileSystem('/base', localfs)
     assert subfs.base_path == '/base/'
     assert subfs.base_fs == localfs
+    assert str(subfs) == 'SubTreeFileSystem: file:/base/'
+    assert repr(subfs) == f'SubTreeFileSystem(base_path=/base/, base_fs={subfs.base_fs})'
 
     subfs = SubTreeFileSystem('/another/base/', LocalFileSystem())
     assert subfs.base_path == '/another/base/'
     assert subfs.base_fs == localfs
-
+    assert str(subfs) == 'SubTreeFileSystem: file:/another/base/'
+    assert repr(subfs) == f'SubTreeFileSystem(base_path=/another/base/, base_fs={subfs.base_fs})'
 
 def test_filesystem_pickling(fs):
     if fs.type_name.split('::')[-1] == 'mock':

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -587,14 +587,15 @@ def test_subtree_filesystem():
     subfs = SubTreeFileSystem('/base', localfs)
     assert subfs.base_path == '/base/'
     assert subfs.base_fs == localfs
-    assert str(subfs) == 'SubTreeFileSystem: file:/base/'
-    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/base/, base_fs=<pyarrow._fs.LocalFileSystem object at')
+    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/base/, '
+                                  'base_fs=<pyarrow._fs.LocalFileSystem')
 
     subfs = SubTreeFileSystem('/another/base/', LocalFileSystem())
     assert subfs.base_path == '/another/base/'
     assert subfs.base_fs == localfs
-    assert str(subfs) == 'SubTreeFileSystem: file:/another/base/'
-    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/another/base/, base_fs=<pyarrow._fs.LocalFileSystem object at')
+    assert repr(subfs).startswith('SubTreeFileSystem(base_path=/another/base/,'
+                                  ' base_fs=<pyarrow._fs.LocalFileSystem')
+
 
 def test_filesystem_pickling(fs):
     if fs.type_name.split('::')[-1] == 'mock':


### PR DESCRIPTION
Added `__str__` and `__repr__` methods for `SubTreeFileSystem` class.