### PR TITLE
ARROW-14368: [CI] Use ubuntu-latest for Azure Pipelines

### DIFF
--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-latest
   timeoutInMinutes: 360
 
   steps:

--- a/dev/tasks/conda-recipes/azure.linux.yml
+++ b/dev/tasks/conda-recipes/azure.linux.yml
@@ -3,7 +3,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   timeoutInMinutes: 360
 
   variables:

--- a/dev/tasks/docker-tests/azure.linux.yml
+++ b/dev/tasks/docker-tests/azure.linux.yml
@@ -18,7 +18,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   timeoutInMinutes: 360
   {% if env is defined %}
   variables:


### PR DESCRIPTION
ubuntu-16.04 isn't available.

https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/pipelines/sprint-193-update

> The removal of the image is planned for October 18th.