### PR TITLE
ARROW-13784: [Python] Table.from_arrays should raise an error when array is empty but names is not

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -571,6 +571,10 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     if metadata is not None:
         c_meta = KeyValueMetadata(metadata).unwrap()
 
+    if names is None:
+        raise ValueError('Must pass names or schema when constructing '
+                         'Table or RecordBatch.')
+
     if len(names) != K:
         raise ValueError('Length of names ({}) does not match '
                          'length of arrays ({})'.format(len(names), K))
@@ -580,10 +584,6 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
         return arrays
 
     c_fields.resize(K)
-
-    if names is None:
-        raise ValueError('Must pass names or schema when constructing '
-                         'Table or RecordBatch.')
 
     converted_arrays = []
     for i in range(K):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -571,6 +571,10 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     if metadata is not None:
         c_meta = KeyValueMetadata(metadata).unwrap()
 
+    if len(names) != K:
+        raise ValueError('Length of names ({}) does not match '
+                         'length of arrays ({})'.format(len(names), K))
+
     if K == 0:
         schema.reset(new CSchema(c_fields, c_meta))
         return arrays
@@ -580,10 +584,6 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     if names is None:
         raise ValueError('Must pass names or schema when constructing '
                          'Table or RecordBatch.')
-
-    if len(names) != K:
-        raise ValueError('Length of names ({}) does not match '
-                         'length of arrays ({})'.format(len(names), K))
 
     converted_arrays = []
     for i in range(K):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -571,6 +571,16 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     if metadata is not None:
         c_meta = KeyValueMetadata(metadata).unwrap()
 
+    if K == 0:
+        if names is None or len(names) == 0:
+            schema.reset(new CSchema(c_fields, c_meta))
+            return arrays
+        else:
+            raise ValueError('Length of names ({}) does not match '
+                             'length of arrays ({})'.format(len(names), K))
+
+    c_fields.resize(K)
+
     if names is None:
         raise ValueError('Must pass names or schema when constructing '
                          'Table or RecordBatch.')
@@ -578,12 +588,6 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     if len(names) != K:
         raise ValueError('Length of names ({}) does not match '
                          'length of arrays ({})'.format(len(names), K))
-
-    if K == 0:
-        schema.reset(new CSchema(c_fields, c_meta))
-        return arrays
-
-    c_fields.resize(K)
 
     converted_arrays = []
     for i in range(K):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1021,6 +1021,13 @@ def test_table_remove_column_empty():
     t3.validate()
     assert t3.equals(table)
 
+def test_empty_table_with_names():
+    # ARROW-13784
+    data = []
+    names = ["a", "b"]
+    message = ('Length of names [(]2[)] does not match length of arrays [(]0[)]')
+    with pytest.raises(ValueError, match=message):
+        table = pa.Table.from_arrays(data, names=names)
 
 def test_table_rename_columns():
     data = [

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1021,13 +1021,16 @@ def test_table_remove_column_empty():
     t3.validate()
     assert t3.equals(table)
 
+
 def test_empty_table_with_names():
     # ARROW-13784
     data = []
     names = ["a", "b"]
-    message = ('Length of names [(]2[)] does not match length of arrays [(]0[)]')
+    message = (
+        'Length of names [(]2[)] does not match length of arrays [(]0[)]')
     with pytest.raises(ValueError, match=message):
-        table = pa.Table.from_arrays(data, names=names)
+        pa.Table.from_arrays(data, names=names)
+
 
 def test_table_rename_columns():
     data = [

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1032,6 +1032,13 @@ def test_empty_table_with_names():
         pa.Table.from_arrays(data, names=names)
 
 
+def test_empty_table():
+    table = pa.table([])
+
+    assert table.column_names == []
+    assert table.equals(pa.Table.from_arrays([], []))
+
+
 def test_table_rename_columns():
     data = [
         pa.array(range(5)),


### PR DESCRIPTION
We already check that the list of arrays and list of names should have the same length in `table.pxi`.
For a special case when a list of arrays is of length 0 but length of list of names is greater than 0 the check fails.
I changed the ordering of checks in `table.pxi` and added a test to `test_table.py`.