### PR TITLE
ARROW-14384: [Docs] Add documentation for building Sphinx docs without having to build pyarrow

### DIFF
--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -101,3 +101,27 @@ The final output is located under ``docs/_build/html``.
 .. seealso::
 
    :ref:`docker-builds`.
+
+Building a single directory for dev purposes without all the pre-requisites
+----------------------------------------------------------
+
+You can build documentation in a single directory without needing to install
+all of the pre-requisites by first installing `sphinx`:
+
+.. code-block:: shell
+
+   pip install sphinx
+
+and then navigating to the appropriate directory and running:
+
+.. code-block:: shell
+
+   sphinx-quickstart
+
+Follow the prompts (enter any random text for 'Project name' etc), and once this is complete, run:
+
+.. code-block:: shell
+
+   make html
+
+This will build the HTML docs.

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -103,7 +103,7 @@ The final output is located under ``docs/_build/html``.
    :ref:`docker-builds`.
 
 Building a single directory for dev purposes without all the pre-requisites
-----------------------------------------------------------
+---------------------------------------------------------------------------
 
 You can build documentation in a single directory without needing to install
 all of the pre-requisites by installing sphinx, setting up a temporary
@@ -117,11 +117,11 @@ Install ``sphinx``:
 
    pip install sphinx
 
-Create an empty ``temp_index.rst`` file:
+Create an temporary index file ``temp_index.rst`` file in the target directory:
 
 .. code-block:: shell
 
-   touch ./source/developers/temp_index.rst
+   echo $'.. toctree::\n\t:glob:\n\n\t*' > ./source/developers/temp_index.rst
 
 Build the docs in the target directory:
 

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -117,35 +117,23 @@ Install ``sphinx``:
 
    pip install sphinx
 
-After navigating to the ``docs`` directory, back up any existing ``index.rst``
-file in the target directory:
+Create an empty ``temp_index.rst`` file:
 
 .. code-block:: shell
 
-   cd docs
-   mv ./source/developers/index.rst ./source/developers/index_old.rst
-
-Create an empty ``index.rst`` file:
-
-.. code-block:: shell
-
-   touch ./source/developers/index.rst
+   touch ./source/developers/temp_index.rst
 
 Build the docs in the target directory:
 
 .. code-block:: shell
 
-   cd ../..
-   sphinx-build ./source/developers ./source/developers/_build -c ./source
+   sphinx-build ./source/developers ./source/developers/_build -c ./source -D master_doc=temp_index
 
-This builds everything in the target directory (``.``) to a folder inside of it
+This builds everything in the target directory to a folder inside of it
 called ``_build`` using the config file in the `source` directory.
 
-Once you have verified the HTML documents, you can remove the build directory
-and, if necessary, restore any previous ``index.rst`` file:
+Once you have verified the HTML documents, you can remove temporary index file:
 
 .. code-block:: shell
 
-   rm -rf ./source/developers/_build
-   rm ./source/developers/index.rst
-   mv ./source/developers/index_old.rst ./source/developers/index.rst
+   rm ./source/developers/temp_index.rst

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -106,22 +106,44 @@ Building a single directory for dev purposes without all the pre-requisites
 ----------------------------------------------------------
 
 You can build documentation in a single directory without needing to install
-all of the pre-requisites by first installing `sphinx`:
+all of the pre-requisites by installing sphinx, setting up a temporary
+index in the directory you want to build and then building that directory.
+
+The example below shows how to do this in the ``developers`` directory.
+
+Install ``sphinx``:
 
 .. code-block:: shell
 
    pip install sphinx
 
-and then navigating to the appropriate directory and running:
+After navigating to the relevant directory, back up any existing ``index.rst`` file:
 
 .. code-block:: shell
 
-   sphinx-quickstart
+   cd docs/source/developers
+   mv index.rst index_old.rst
 
-Follow the prompts (enter any random text for 'Project name' etc), and once this is complete, run:
+Create an empty index.rst file:
 
 .. code-block:: shell
 
-   make html
+   touch index.rst
 
-This will build the HTML docs.
+Build the current directory
+
+.. code-block:: shell
+
+   sphinx-build . _build -c ..
+
+This builds everything in the current directory (``.``) to a folder called ``_build`` using
+the config file in the parent directory (``..``).
+
+Once you have verified the HTML documents, you can remove the build directory
+and, if necessary, restore any previous ``index.rst`` file:
+
+.. code-block:: shell
+
+   rm -rf _build
+   rm index.rst
+   mv index_old.rst index.rst

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -117,33 +117,35 @@ Install ``sphinx``:
 
    pip install sphinx
 
-After navigating to the relevant directory, back up any existing ``index.rst`` file:
+After navigating to the ``docs`` directory, back up any existing ``index.rst``
+file in the target directory:
 
 .. code-block:: shell
 
-   cd docs/source/developers
-   mv index.rst index_old.rst
+   cd docs
+   mv ./source/developers/index.rst ./source/developers/index_old.rst
 
-Create an empty index.rst file:
-
-.. code-block:: shell
-
-   touch index.rst
-
-Build the current directory
+Create an empty ``index.rst`` file:
 
 .. code-block:: shell
 
-   sphinx-build . _build -c ..
+   touch ./source/developers/index.rst
 
-This builds everything in the current directory (``.``) to a folder called ``_build`` using
-the config file in the parent directory (``..``).
+Build the docs in the target directory:
+
+.. code-block:: shell
+
+   cd ../..
+   sphinx-build ./source/developers ./source/developers/_build -c ./source
+
+This builds everything in the target directory (``.``) to a folder inside of it
+called ``_build`` using the config file in the `source` directory.
 
 Once you have verified the HTML documents, you can remove the build directory
 and, if necessary, restore any previous ``index.rst`` file:
 
 .. code-block:: shell
 
-   rm -rf _build
-   rm index.rst
-   mv index_old.rst index.rst
+   rm -rf ./source/developers/_build
+   rm ./source/developers/index.rst
+   mv ./source/developers/index_old.rst ./source/developers/index.rst


### PR DESCRIPTION
These instructions simplify the process of building individual directories of docs for local development without having to install all the dependencies and build every single directory.