### PR TITLE
ARROW-14381: [CI][Python] Fix Spark integration failures

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1246,8 +1246,10 @@ tasks:
       image: conda-python-hdfs
 {% endfor %}
 
-{% for python_version, spark_version, test_pyarrow_only in [("3.7", "branch-3.0", "true"),
-                                                            ("3.8", "master", "false")] %}
+{% for python_version, spark_version, test_pyarrow_only in [("3.6", "v3.0.3", "false"),
+                                                            ("3.7", "v3.1.2", "false")
+                                                            ("3.8", "v3.2.0", "false"),
+                                                            ("3.9", "master", "false")] %}
   test-conda-python-{{ python_version }}-spark-{{ spark_version }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1247,7 +1247,7 @@ tasks:
 {% endfor %}
 
 {% for python_version, spark_version, test_pyarrow_only in [("3.6", "v3.0.3", "false"),
-                                                            ("3.7", "v3.1.2", "false")
+                                                            ("3.7", "v3.1.2", "false"),
                                                             ("3.8", "v3.2.0", "false"),
                                                             ("3.9", "master", "false")] %}
   test-conda-python-{{ python_version }}-spark-{{ spark_version }}:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1246,8 +1246,7 @@ tasks:
       image: conda-python-hdfs
 {% endfor %}
 
-{% for python_version, spark_version, test_pyarrow_only in [("3.6", "v3.0.3", "false"),
-                                                            ("3.7", "v3.1.2", "false"),
+{% for python_version, spark_version, test_pyarrow_only in [("3.7", "v3.1.2", "false"),
                                                             ("3.8", "v3.2.0", "false"),
                                                             ("3.9", "master", "false")] %}
   test-conda-python-{{ python_version }}-spark-{{ spark_version }}:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -229,7 +229,11 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         return _handle_arrow_array_protocol(obj, type, mask, size)
     elif _is_array_like(obj):
         if mask is not None:
-            mask = get_values(mask, &is_pandas_object)
+            if _is_array_like(mask):
+                mask = get_values(mask, &is_pandas_object)
+            else:
+                raise TypeError("Mask must be a numpy array "
+                                "when converting numpy arrays")
 
         values = get_values(obj, &is_pandas_object)
         if is_pandas_object and from_pandas is None:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -228,9 +228,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     if hasattr(obj, '__arrow_array__'):
         return _handle_arrow_array_protocol(obj, type, mask, size)
     elif _is_array_like(obj):
-        if mask is not None and not _is_array_like(mask):
-            raise TypeError("Mask must be a numpy array "
-                            "when converting numpy arrays")
+        if mask is not None:
+            mask = get_values(mask, &is_pandas_object)
 
         values = get_values(obj, &is_pandas_object)
         if is_pandas_object and from_pandas is None:


### PR DESCRIPTION
I don't have a small reproducer, but either a pandas series or a dataframe gets passed as mask to `pa.array()`