### PR TITLE
ARROW-13987: [C++] Support nested field refs

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -545,13 +545,14 @@ Result<ArrayVector> StructArray::Flatten(MemoryPool* pool) const {
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
   for (int i = 0; static_cast<size_t>(i) < data_->child_data.size(); i++) {
-    ARROW_ASSIGN_OR_RAISE(flattened[i], Flatten(i, pool));
+    ARROW_ASSIGN_OR_RAISE(flattened[i], GetFlattenedField(i, pool));
   }
 
   return flattened;
 }
 
-Result<std::shared_ptr<Array>> StructArray::Flatten(int index, MemoryPool* pool) const {
+Result<std::shared_ptr<Array>> StructArray::GetFlattenedField(int index,
+                                                              MemoryPool* pool) const {
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
   auto child_data = data_->child_data[index]->Copy();

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -541,56 +541,62 @@ std::shared_ptr<Array> StructArray::GetFieldByName(const std::string& name) cons
 
 Result<ArrayVector> StructArray::Flatten(MemoryPool* pool) const {
   ArrayVector flattened;
-  flattened.reserve(data_->child_data.size());
+  flattened.resize(data_->child_data.size());
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
-  for (const auto& child_data_ptr : data_->child_data) {
-    auto child_data = child_data_ptr->Copy();
-
-    std::shared_ptr<Buffer> flattened_null_bitmap;
-    int64_t flattened_null_count = kUnknownNullCount;
-
-    // Need to adjust for parent offset
-    if (data_->offset != 0 || data_->length != child_data->length) {
-      child_data = child_data->Slice(data_->offset, data_->length);
-    }
-    std::shared_ptr<Buffer> child_null_bitmap = child_data->buffers[0];
-    const int64_t child_offset = child_data->offset;
-
-    // The validity of a flattened datum is the logical AND of the struct
-    // element's validity and the individual field element's validity.
-    if (null_bitmap && child_null_bitmap) {
-      ARROW_ASSIGN_OR_RAISE(
-          flattened_null_bitmap,
-          BitmapAnd(pool, child_null_bitmap->data(), child_offset, null_bitmap_data_,
-                    data_->offset, data_->length, child_offset));
-    } else if (child_null_bitmap) {
-      flattened_null_bitmap = child_null_bitmap;
-      flattened_null_count = child_data->null_count;
-    } else if (null_bitmap) {
-      if (child_offset == data_->offset) {
-        flattened_null_bitmap = null_bitmap;
-      } else {
-        // If the child has an offset, need to synthesize a validity
-        // buffer with an offset too
-        ARROW_ASSIGN_OR_RAISE(flattened_null_bitmap,
-                              AllocateEmptyBitmap(child_offset + data_->length, pool));
-        CopyBitmap(null_bitmap_data_, data_->offset, data_->length,
-                   flattened_null_bitmap->mutable_data(), child_offset);
-      }
-      flattened_null_count = data_->null_count;
-    } else {
-      flattened_null_count = 0;
-    }
-
-    auto flattened_data = child_data->Copy();
-    flattened_data->buffers[0] = flattened_null_bitmap;
-    flattened_data->null_count = flattened_null_count;
-
-    flattened.push_back(MakeArray(flattened_data));
+  for (int i = 0; static_cast<size_t>(i) < data_->child_data.size(); i++) {
+    ARROW_ASSIGN_OR_RAISE(flattened[i], Flatten(i, pool));
   }
 
   return flattened;
+}
+
+Result<std::shared_ptr<Array>> StructArray::Flatten(int index, MemoryPool* pool) const {
+  std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
+
+  auto child_data = data_->child_data[index]->Copy();
+
+  std::shared_ptr<Buffer> flattened_null_bitmap;
+  int64_t flattened_null_count = kUnknownNullCount;
+
+  // Need to adjust for parent offset
+  if (data_->offset != 0 || data_->length != child_data->length) {
+    child_data = child_data->Slice(data_->offset, data_->length);
+  }
+  std::shared_ptr<Buffer> child_null_bitmap = child_data->buffers[0];
+  const int64_t child_offset = child_data->offset;
+
+  // The validity of a flattened datum is the logical AND of the struct
+  // element's validity and the individual field element's validity.
+  if (null_bitmap && child_null_bitmap) {
+    ARROW_ASSIGN_OR_RAISE(
+        flattened_null_bitmap,
+        BitmapAnd(pool, child_null_bitmap->data(), child_offset, null_bitmap_data_,
+                  data_->offset, data_->length, child_offset));
+  } else if (child_null_bitmap) {
+    flattened_null_bitmap = child_null_bitmap;
+    flattened_null_count = child_data->null_count;
+  } else if (null_bitmap) {
+    if (child_offset == data_->offset) {
+      flattened_null_bitmap = null_bitmap;
+    } else {
+      // If the child has an offset, need to synthesize a validity
+      // buffer with an offset too
+      ARROW_ASSIGN_OR_RAISE(flattened_null_bitmap,
+                            AllocateEmptyBitmap(child_offset + data_->length, pool));
+      CopyBitmap(null_bitmap_data_, data_->offset, data_->length,
+                 flattened_null_bitmap->mutable_data(), child_offset);
+    }
+    flattened_null_count = data_->null_count;
+  } else {
+    flattened_null_count = 0;
+  }
+
+  auto flattened_data = child_data->Copy();
+  flattened_data->buffers[0] = flattened_null_bitmap;
+  flattened_data->null_count = flattened_null_count;
+
+  return MakeArray(flattened_data);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -370,8 +370,9 @@ class ARROW_EXPORT StructArray : public Array {
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
   Result<ArrayVector> Flatten(MemoryPool* pool = default_memory_pool()) const;
 
-  /// \brief Get one of the child arrays, with the null bitmap adjusted if necessary.
+  /// \brief Get one of the child arrays, adjusting the null bitmap if necessary.
   ///
+  /// \param[in] index Which child array to get
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
   Result<std::shared_ptr<Array>> Flatten(int index,
                                          MemoryPool* pool = default_memory_pool()) const;

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -370,12 +370,13 @@ class ARROW_EXPORT StructArray : public Array {
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
   Result<ArrayVector> Flatten(MemoryPool* pool = default_memory_pool()) const;
 
-  /// \brief Get one of the child arrays, adjusting the null bitmap if necessary.
+  /// \brief Get one of the child arrays, combining its null bitmap
+  /// with the parent struct array's bitmap.
   ///
   /// \param[in] index Which child array to get
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
-  Result<std::shared_ptr<Array>> Flatten(int index,
-                                         MemoryPool* pool = default_memory_pool()) const;
+  Result<std::shared_ptr<Array>> GetFlattenedField(
+      int index, MemoryPool* pool = default_memory_pool()) const;
 
  private:
   // For caching boxed child data

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -370,6 +370,12 @@ class ARROW_EXPORT StructArray : public Array {
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
   Result<ArrayVector> Flatten(MemoryPool* pool = default_memory_pool()) const;
 
+  /// \brief Get one of the child arrays, with the null bitmap adjusted if necessary.
+  ///
+  /// \param[in] pool The pool to allocate null bitmaps from, if necessary
+  Result<std::shared_ptr<Array>> Flatten(int index,
+                                         MemoryPool* pool = default_memory_pool()) const;
+
  private:
   // For caching boxed child data
   // XXX This is not handled in a thread-safe manner.

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -63,7 +63,7 @@ Expression::Expression(Parameter parameter)
 Expression literal(Datum lit) { return Expression(std::move(lit)); }
 
 Expression field_ref(FieldRef ref) {
-  return Expression(Expression::Parameter{std::move(ref), ValueDescr{}, -1});
+  return Expression(Expression::Parameter{std::move(ref), ValueDescr{}, {-1}});
 }
 
 Expression call(std::string function, std::vector<Expression> arguments,
@@ -394,14 +394,13 @@ Result<Expression> BindImpl(Expression expr, const TypeOrSchema& in,
   if (expr.literal()) return expr;
 
   if (auto ref = expr.field_ref()) {
-    if (ref->IsNested()) {
-      return Status::NotImplemented("nested field references");
-    }
-
     ARROW_ASSIGN_OR_RAISE(auto path, ref->FindOne(in));
 
     auto bound = *expr.parameter();
-    bound.index = path[0];
+    bound.indices.resize(path.indices().size());
+    for (size_t i = 0; i < path.indices().size(); ++i) {
+      bound.indices[i] = path.indices()[i];
+    }
     ARROW_ASSIGN_OR_RAISE(auto field, path.Get(in));
     bound.descr.type = field->type();
     bound.descr.shape = shape;
@@ -512,7 +511,31 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
       return MakeNullScalar(null());
     }
 
-    const Datum& field = input[param->index];
+    Datum field = input[param->indices[0]];
+    for (auto it = param->indices.begin() + 1; it != param->indices.end(); ++it) {
+      if (field.type()->id() != Type::STRUCT) {
+        return Status::Invalid("Nested field reference into a non-struct: ",
+                               *field.type());
+      }
+      const int index = *it;
+      if (index < 0 || index >= field.type()->num_fields()) {
+        return Status::Invalid("Out of bounds field reference: ", index, " but type has ",
+                               field.type()->num_fields(), " fields");
+      }
+      if (field.is_scalar()) {
+        const auto& struct_scalar = field.scalar_as<StructScalar>();
+        if (!struct_scalar.is_valid) {
+          return MakeNullScalar(param->descr.type);
+        }
+        field = struct_scalar.value[index];
+      } else if (field.is_array()) {
+        const auto& struct_array = field.array_as<StructArray>();
+        ARROW_ASSIGN_OR_RAISE(field,
+                              struct_array->Flatten(index, exec_context->memory_pool()));
+      } else {
+        return Status::NotImplemented("Nested field reference into a ", field.ToString());
+      }
+    }
     if (!field.type()->Equals(param->descr.type)) {
       return Status::Invalid("Referenced field ", expr.ToString(), " was ",
                              field.type()->ToString(), " but should have been ",

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -398,9 +398,7 @@ Result<Expression> BindImpl(Expression expr, const TypeOrSchema& in,
 
     auto bound = *expr.parameter();
     bound.indices.resize(path.indices().size());
-    for (size_t i = 0; i < path.indices().size(); ++i) {
-      bound.indices[i] = path.indices()[i];
-    }
+    std::copy(path.indices().begin(), path.indices().end(), bound.indices.begin());
     ARROW_ASSIGN_OR_RAISE(auto field, path.Get(in));
     bound.descr.type = field->type();
     bound.descr.shape = shape;
@@ -530,8 +528,8 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
         field = struct_scalar.value[index];
       } else if (field.is_array()) {
         const auto& struct_array = field.array_as<StructArray>();
-        ARROW_ASSIGN_OR_RAISE(field,
-                              struct_array->Flatten(index, exec_context->memory_pool()));
+        ARROW_ASSIGN_OR_RAISE(
+            field, struct_array->GetFlattenedField(index, exec_context->memory_pool()));
       } else {
         return Status::NotImplemented("Nested field reference into a ", field.ToString());
       }

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -27,6 +27,7 @@
 #include "arrow/compute/type_fwd.h"
 #include "arrow/datum.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/small_vector.h"
 #include "arrow/util/variant.h"
 
 namespace arrow {
@@ -112,7 +113,7 @@ class ARROW_EXPORT Expression {
 
     // post-bind properties
     ValueDescr descr;
-    int index;
+    internal::SmallVector<int, 2> indices;
   };
   const Parameter* parameter() const;
 

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -476,15 +476,16 @@ TEST(Expression, BindLiteral) {
 }
 
 void ExpectBindsTo(Expression expr, util::optional<Expression> expected,
-                   Expression* bound_out = nullptr) {
+                   Expression* bound_out = nullptr,
+                   Schema* schema = kBoringSchema.get()) {
   if (!expected) {
     expected = expr;
   }
 
-  ASSERT_OK_AND_ASSIGN(auto bound, expr.Bind(*kBoringSchema));
+  ASSERT_OK_AND_ASSIGN(auto bound, expr.Bind(*schema));
   EXPECT_TRUE(bound.IsBound());
 
-  ASSERT_OK_AND_ASSIGN(expected, expected->Bind(*kBoringSchema));
+  ASSERT_OK_AND_ASSIGN(expected, expected->Bind(*schema));
   EXPECT_EQ(bound, *expected) << " unbound: " << expr.ToString();
 
   if (bound_out) {
@@ -508,11 +509,24 @@ TEST(Expression, BindFieldRef) {
   // in the input schema
   ASSERT_RAISES(Invalid, field_ref("alpha").Bind(Schema(
                              {field("alpha", int32()), field("alpha", float32())})));
+}
 
-  // referencing nested fields is not supported
-  ASSERT_RAISES(NotImplemented,
-                field_ref(FieldRef("a", "b"))
-                    .Bind(Schema({field("a", struct_({field("b", int32())}))})));
+TEST(Expression, BindNestedFieldRef) {
+  Expression expr;
+  auto schema = Schema({field("a", struct_({field("b", int32())}))});
+
+  ExpectBindsTo(field_ref(FieldRef("a", "b")), no_change, &expr, &schema);
+  EXPECT_TRUE(expr.IsBound());
+  EXPECT_EQ(expr.descr(), ValueDescr::Array(int32()));
+
+  ExpectBindsTo(field_ref(FieldRef(FieldPath({0, 0}))), no_change, &expr, &schema);
+  EXPECT_TRUE(expr.IsBound());
+  EXPECT_EQ(expr.descr(), ValueDescr::Array(int32()));
+
+  ASSERT_RAISES(Invalid, field_ref(FieldPath({0, 1})).Bind(schema));
+  ASSERT_RAISES(Invalid, field_ref(FieldRef("a", "b"))
+                             .Bind(Schema({field("a", struct_({field("b", int32()),
+                                                               field("b", int64())}))})));
 }
 
 TEST(Expression, BindCall) {
@@ -614,6 +628,45 @@ TEST(Expression, ExecuteFieldRef) {
     {"a": -1,    "b": 4.0}
   ])"),
               ArrayFromJSON(float64(), R"([7.5, 2.125, 4.0])"));
+
+  ExpectRefIs(FieldRef(FieldPath({0, 0})),
+              ArrayFromJSON(struct_({field("a", struct_({field("b", float64())}))}), R"([
+    {"a": {"b": 6.125}},
+    {"a": {"b": 0.0}},
+    {"a": {"b": -1}}
+  ])"),
+              ArrayFromJSON(float64(), R"([6.125, 0.0, -1])"));
+
+  ExpectRefIs(FieldRef("a", "b"),
+              ArrayFromJSON(struct_({field("a", struct_({field("b", float64())}))}), R"([
+    {"a": {"b": 6.125}},
+    {"a": {"b": 0.0}},
+    {"a": {"b": -1}}
+  ])"),
+              ArrayFromJSON(float64(), R"([6.125, 0.0, -1])"));
+
+  ExpectRefIs(FieldRef("a", "b"),
+              ArrayFromJSON(struct_({field("a", struct_({field("b", float64())}))}), R"([
+    {"a": {"b": 6.125}},
+    {"a": null},
+    {"a": {"b": null}}
+  ])"),
+              ArrayFromJSON(float64(), R"([6.125, null, null])"));
+
+  ExpectRefIs(
+      FieldRef("a", "b"),
+      ScalarFromJSON(struct_({field("a", struct_({field("b", float64())}))}), "[[64.0]]"),
+      ScalarFromJSON(float64(), "64.0"));
+
+  ExpectRefIs(
+      FieldRef("a", "b"),
+      ScalarFromJSON(struct_({field("a", struct_({field("b", float64())}))}), "[[null]]"),
+      ScalarFromJSON(float64(), "null"));
+
+  ExpectRefIs(
+      FieldRef("a", "b"),
+      ScalarFromJSON(struct_({field("a", struct_({field("b", float64())}))}), "[null]"),
+      ScalarFromJSON(float64(), "null"));
 }
 
 Result<Datum> NaiveExecuteScalarExpression(const Expression& expr, const Datum& input) {
@@ -696,6 +749,18 @@ TEST(Expression, ExecuteCall) {
     {"a": 6.125},
     {"a": 0.0},
     {"a": -1}
+  ])"));
+
+  ExpectExecute(
+      call("add", {field_ref(FieldRef("a", "a")), field_ref(FieldRef("a", "b"))}),
+      ArrayFromJSON(struct_({field("a", struct_({
+                                            field("a", float64()),
+                                            field("b", float64()),
+                                        }))}),
+                    R"([
+    {"a": {"a": 6.125, "b": 3.375}},
+    {"a": {"a": 0.0,   "b": 1}},
+    {"a": {"a": -1,    "b": 4.75}}
   ])"));
 }
 

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -477,15 +477,15 @@ TEST(Expression, BindLiteral) {
 
 void ExpectBindsTo(Expression expr, util::optional<Expression> expected,
                    Expression* bound_out = nullptr,
-                   Schema* schema = kBoringSchema.get()) {
+                   const Schema& schema = *kBoringSchema) {
   if (!expected) {
     expected = expr;
   }
 
-  ASSERT_OK_AND_ASSIGN(auto bound, expr.Bind(*schema));
+  ASSERT_OK_AND_ASSIGN(auto bound, expr.Bind(schema));
   EXPECT_TRUE(bound.IsBound());
 
-  ASSERT_OK_AND_ASSIGN(expected, expected->Bind(*schema));
+  ASSERT_OK_AND_ASSIGN(expected, expected->Bind(schema));
   EXPECT_EQ(bound, *expected) << " unbound: " << expr.ToString();
 
   if (bound_out) {
@@ -515,11 +515,11 @@ TEST(Expression, BindNestedFieldRef) {
   Expression expr;
   auto schema = Schema({field("a", struct_({field("b", int32())}))});
 
-  ExpectBindsTo(field_ref(FieldRef("a", "b")), no_change, &expr, &schema);
+  ExpectBindsTo(field_ref(FieldRef("a", "b")), no_change, &expr, schema);
   EXPECT_TRUE(expr.IsBound());
   EXPECT_EQ(expr.descr(), ValueDescr::Array(int32()));
 
-  ExpectBindsTo(field_ref(FieldRef(FieldPath({0, 0}))), no_change, &expr, &schema);
+  ExpectBindsTo(field_ref(FieldRef(FieldPath({0, 0}))), no_change, &expr, schema);
   EXPECT_TRUE(expr.IsBound());
   EXPECT_EQ(expr.descr(), ValueDescr::Array(int32()));
 


### PR DESCRIPTION
This implements nested field refs in C++ only, using a SmallVector to hold the FieldPath. This only lets us extract from a struct (I'm not so sure it makes sense for other types?).

The JIRA also requests being able to extract a field as an expression. I think this could be done by implementing a small kernel that we could call. (Or otherwise I think we'd have to add a new case to the Expression variant, which maybe isn't a big deal.) If that sounds reasonable it can be added here.

A microbenchmark was added to see if this impacts the common case of a non-nested field ref. On my local machine it does not appear to (~10-20ns difference).