### PR TITLE
ARROW-13317: [Python] Improve documentation on what 'use_threads' does in 'read_feather'

### DIFF
--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -206,7 +206,9 @@ def read_feather(source, columns=None, use_threads=True, memory_map=True):
         Only read a specific set of columns. If not provided, all columns are
         read.
     use_threads : bool, default True
-        Whether to parallelize reading using multiple threads.
+        Whether to parallelize reading using multiple threads. If false the
+        restriction is only used in the conversion to Pandas and not in the
+        reading from Feather format.
     memory_map : boolean, default True
         Use memory mapping when opening file on disk
 


### PR DESCRIPTION
Add to the documentation of [read_feather](https://arrow.apache.org/docs/_modules/pyarrow/feather.html#read_feather) info about `use_threads` in case it is set to `false`.