### PR TITLE
ARROW-14396: [R][Doc] Remove relic note in write_dataset that columns cannot be renamed

### DIFF
--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -22,11 +22,9 @@
 #' make it much faster to read and query.
 #'
 #' @param dataset [Dataset], [RecordBatch], [Table], `arrow_dplyr_query`, or
-#' `data.frame`. If an `arrow_dplyr_query` or `grouped_df`,
-#' `schema` and `partitioning` will be taken from the result of any `select()`
-#' and `group_by()` operations done on the dataset. `filter()` queries will be
-#' applied to restrict written rows.
-#' Note that `select()`-ed columns may not be renamed.
+#' `data.frame`. If an `arrow_dplyr_query`, the query will be evaluated and
+#' the result will be written, so you can `select()`, `filter()`, `mutate()`,
+#' etc. to transform the data.
 #' @param path string path, URI, or `SubTreeFileSystem` referencing a directory
 #' to write to (directory will be created if it does not exist)
 #' @param format a string identifier of the file format. Default is to use

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -23,8 +23,8 @@
 #'
 #' @param dataset [Dataset], [RecordBatch], [Table], `arrow_dplyr_query`, or
 #' `data.frame`. If an `arrow_dplyr_query`, the query will be evaluated and
-#' the result will be written, so you can `select()`, `filter()`, `mutate()`,
-#' etc. to transform the data.
+#' the result will be written. This means that you can `select()`, `filter()`, `mutate()`,
+#' etc. to transform the data before it is written if you need to.
 #' @param path string path, URI, or `SubTreeFileSystem` referencing a directory
 #' to write to (directory will be created if it does not exist)
 #' @param format a string identifier of the file format. Default is to use

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -6,11 +6,7 @@
 \alias{arrow-package}
 \title{arrow: Integration to 'Apache' 'Arrow'}
 \description{
-'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
-    development platform for in-memory data. It specifies a standardized
-    language-independent columnar memory format for flat and hierarchical data,
-    organized for efficient analytic operations on modern hardware. This
-    package provides an interface to the 'Arrow C++' library.
+'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language development platform for in-memory data. It specifies a standardized language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware. This package provides an interface to the 'Arrow C++' library.
 }
 \seealso{
 Useful links:

--- a/r/man/write_dataset.Rd
+++ b/r/man/write_dataset.Rd
@@ -17,8 +17,8 @@ write_dataset(
 \arguments{
 \item{dataset}{\link{Dataset}, \link{RecordBatch}, \link{Table}, \code{arrow_dplyr_query}, or
 \code{data.frame}. If an \code{arrow_dplyr_query}, the query will be evaluated and
-the result will be written, so you can \code{select()}, \code{filter()}, \code{mutate()},
-etc. to transform the data.}
+the result will be written. This means that you can \code{select()}, \code{filter()}, \code{mutate()},
+etc. to transform the data before it is written if you need to.}
 
 \item{path}{string path, URI, or \code{SubTreeFileSystem} referencing a directory
 to write to (directory will be created if it does not exist)}

--- a/r/man/write_dataset.Rd
+++ b/r/man/write_dataset.Rd
@@ -16,11 +16,9 @@ write_dataset(
 }
 \arguments{
 \item{dataset}{\link{Dataset}, \link{RecordBatch}, \link{Table}, \code{arrow_dplyr_query}, or
-\code{data.frame}. If an \code{arrow_dplyr_query} or \code{grouped_df},
-\code{schema} and \code{partitioning} will be taken from the result of any \code{select()}
-and \code{group_by()} operations done on the dataset. \code{filter()} queries will be
-applied to restrict written rows.
-Note that \code{select()}-ed columns may not be renamed.}
+\code{data.frame}. If an \code{arrow_dplyr_query}, the query will be evaluated and
+the result will be written, so you can \code{select()}, \code{filter()}, \code{mutate()},
+etc. to transform the data.}
 
 \item{path}{string path, URI, or \code{SubTreeFileSystem} referencing a directory
 to write to (directory will be created if it does not exist)}


### PR DESCRIPTION
Removes the note referenced in the issue and more generally updates the docs for the `dataset` argument