### PR TITLE
ARROW-12683: [C++] Enable fine-grained I/O (coalescing) in IPC reader

### DIFF
--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -441,6 +442,10 @@ class ARROW_EXPORT MessageReader {
   virtual Result<std::unique_ptr<Message>> ReadNextMessage() = 0;
 };
 
+// the first parameter of the function should be a pointer to metadata (aka.
+// org::apache::arrow::flatbuf::RecordBatch*)
+using FieldsLoaderFunction = std::function<Status(const void*, io::RandomAccessFile*)>;
+
 /// \brief Read encapsulated RPC message from position in file
 ///
 /// Read a length-prefixed message flatbuffer starting at the indicated file
@@ -453,11 +458,13 @@ class ARROW_EXPORT MessageReader {
 /// first 4 bytes after the offset are the message length
 /// \param[in] metadata_length the total number of bytes to read from file
 /// \param[in] file the seekable file interface to read from
+/// \param[in] fields_loader the function for loading subset of fields from the given file
 /// \return the message read
+
 ARROW_EXPORT
-Result<std::unique_ptr<Message>> ReadMessage(const int64_t offset,
-                                             const int32_t metadata_length,
-                                             io::RandomAccessFile* file);
+Result<std::unique_ptr<Message>> ReadMessage(
+    const int64_t offset, const int32_t metadata_length, io::RandomAccessFile* file,
+    const FieldsLoaderFunction& fields_loader = {});
 
 ARROW_EXPORT
 Future<std::shared_ptr<Message>> ReadMessageAsync(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -36,6 +36,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/ipc/message.h"
 #include "arrow/ipc/metadata_internal.h"
+#include "arrow/ipc/reader_internal.h"
 #include "arrow/ipc/util.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
@@ -967,8 +968,9 @@ static inline FileBlock FileBlockFromFlatbuffer(const flatbuf::Block* block) {
   return FileBlock{block->offset(), block->metaDataLength(), block->bodyLength()};
 }
 
-static Result<std::unique_ptr<Message>> ReadMessageFromBlock(const FileBlock& block,
-                                                             io::RandomAccessFile* file) {
+static Result<std::unique_ptr<Message>> ReadMessageFromBlock(
+    const FileBlock& block, io::RandomAccessFile* file,
+    const FieldsLoaderFunction& fields_loader) {
   if (!BitUtil::IsMultipleOf8(block.offset) ||
       !BitUtil::IsMultipleOf8(block.metadata_length) ||
       !BitUtil::IsMultipleOf8(block.body_length)) {
@@ -978,8 +980,8 @@ static Result<std::unique_ptr<Message>> ReadMessageFromBlock(const FileBlock& bl
   // TODO(wesm): this breaks integration tests, see ARROW-3256
   // DCHECK_EQ((*out)->body_length(), block.body_length);
 
-  ARROW_ASSIGN_OR_RAISE(auto message,
-                        ReadMessage(block.offset, block.metadata_length, file));
+  ARROW_ASSIGN_OR_RAISE(auto message, ReadMessage(block.offset, block.metadata_length,
+                                                  file, fields_loader));
   return std::move(message);
 }
 
@@ -1061,6 +1063,31 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
     return internal::GetMetadataVersion(footer_->version());
   }
 
+  static Status LoadFieldsSubset(const flatbuf::RecordBatch* metadata,
+                                 const IpcReadOptions& options,
+                                 io::RandomAccessFile* file,
+                                 const std::shared_ptr<Schema>& schema,
+                                 const std::vector<bool>* inclusion_mask,
+                                 MetadataVersion metadata_version = MetadataVersion::V5) {
+    ArrayLoader loader(metadata, metadata_version, options, file);
+    for (int i = 0; i < schema->num_fields(); ++i) {
+      const Field& field = *schema->field(i);
+      if (!inclusion_mask || (*inclusion_mask)[i]) {
+        // Read field
+        ArrayData column;
+        RETURN_NOT_OK(loader.Load(&field, &column));
+        if (metadata->length() != column.length) {
+          return Status::IOError("Array length did not match record batch length");
+        }
+      } else {
+        // Skip field. This logic must be executed to advance the state of the
+        // loader to the next field
+        RETURN_NOT_OK(loader.SkipField(&field));
+      }
+    }
+    return Status::OK();
+  }
+
   Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) override {
     DCHECK_GE(i, 0);
     DCHECK_LT(i, num_record_batches());
@@ -1070,7 +1097,19 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
       read_dictionaries_ = true;
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto message, ReadMessageFromBlock(GetRecordBatchBlock(i)));
+    FieldsLoaderFunction fields_loader = {};
+    if (!field_inclusion_mask_.empty()) {
+      auto& schema = schema_;
+      auto& inclusion_mask = field_inclusion_mask_;
+      auto& read_options = options_;
+      fields_loader = [schema, inclusion_mask, read_options](const void* metadata,
+                                                             io::RandomAccessFile* file) {
+        return LoadFieldsSubset(static_cast<const flatbuf::RecordBatch*>(metadata),
+                                read_options, file, schema, &inclusion_mask);
+      };
+    }
+    ARROW_ASSIGN_OR_RAISE(auto message,
+                          ReadMessageFromBlock(GetRecordBatchBlock(i), fields_loader));
 
     CHECK_HAS_BODY(*message);
     ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
@@ -1193,8 +1232,10 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
     return FileBlockFromFlatbuffer(footer_->dictionaries()->Get(i));
   }
 
-  Result<std::unique_ptr<Message>> ReadMessageFromBlock(const FileBlock& block) {
-    ARROW_ASSIGN_OR_RAISE(auto message, arrow::ipc::ReadMessageFromBlock(block, file_));
+  Result<std::unique_ptr<Message>> ReadMessageFromBlock(
+      const FileBlock& block, const FieldsLoaderFunction& fields_loader = {}) {
+    ARROW_ASSIGN_OR_RAISE(auto message,
+                          arrow::ipc::ReadMessageFromBlock(block, file_, fields_loader));
     ++stats_.num_messages;
     return std::move(message);
   }
@@ -1529,7 +1570,6 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
   }
 
   Status OnRecordBatchMessageDecoded(std::unique_ptr<Message> message) {
-    IpcReadContext context(&dictionary_memo_, options_, swap_endian_);
     if (message->type() == MessageType::DICTIONARY_BATCH) {
       return ReadDictionary(*message);
     } else {
@@ -2088,6 +2128,67 @@ Status FuzzIpcTensorStream(const uint8_t* data, int64_t size) {
   }
 
   return Status::OK();
+}
+
+Result<int64_t> IoRecordedRandomAccessFile::GetSize() { return file_size_; }
+
+Result<int64_t> IoRecordedRandomAccessFile::ReadAt(int64_t position, int64_t nbytes,
+                                                   void* out) {
+  auto num_bytes_read = std::min(file_size_, position + nbytes) - position;
+
+  if (!read_ranges_.empty() &&
+      position == read_ranges_.back().offset + read_ranges_.back().length) {
+    // merge continuous IOs into one if possible
+    read_ranges_.back().length += num_bytes_read;
+  } else {
+    // no real IO is performed, it is only saved into a vector for replaying later
+    read_ranges_.emplace_back(io::ReadRange{position, num_bytes_read});
+  }
+  return num_bytes_read;
+}
+
+Result<std::shared_ptr<Buffer>> IoRecordedRandomAccessFile::ReadAt(int64_t position,
+                                                                   int64_t nbytes) {
+  std::shared_ptr<Buffer> out;
+  auto result = ReadAt(position, nbytes, &out);
+  return out;
+}
+
+Status IoRecordedRandomAccessFile::Close() {
+  closed_ = true;
+  return Status::OK();
+}
+
+Status IoRecordedRandomAccessFile::Abort() { return Status::OK(); }
+
+Result<int64_t> IoRecordedRandomAccessFile::Tell() const { return position_; }
+
+bool IoRecordedRandomAccessFile::closed() const { return closed_; }
+
+Status IoRecordedRandomAccessFile::Seek(int64_t position) {
+  position_ = position;
+  return Status::OK();
+}
+
+Result<int64_t> IoRecordedRandomAccessFile::Read(int64_t nbytes, void* out) {
+  ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(position_, nbytes, out));
+  position_ += bytes_read;
+  return bytes_read;
+}
+
+Result<std::shared_ptr<Buffer>> IoRecordedRandomAccessFile::Read(int64_t nbytes) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> buffer, ReadAt(position_, nbytes));
+  auto num_bytes_read = std::min(file_size_, position_ + nbytes) - position_;
+  position_ += num_bytes_read;
+  return std::move(buffer);
+}
+
+const io::IOContext& IoRecordedRandomAccessFile::io_context() const {
+  return io_context_;
+}
+
+const std::vector<io::ReadRange>& IoRecordedRandomAccessFile::GetReadRanges() const {
+  return read_ranges_;
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/ipc/reader_internal.h
+++ b/cpp/src/arrow/ipc/reader_internal.h
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "arrow/io/type_fwd.h"
+#include "arrow/result.h"
+#include "arrow/type_fwd.h"
+
+namespace arrow {
+namespace io {
+struct ReadRange;
+}
+
+namespace ipc {
+
+namespace internal {
+/// \class IoRecordedRandomAccessFile
+/// \brief An RandomAccessFile that doesn't perform real IO, but only save all the IO
+/// operations it receives, including read operation's <offset, length>, for replaying
+/// later
+class ARROW_EXPORT IoRecordedRandomAccessFile : public io::RandomAccessFile {
+ public:
+  explicit IoRecordedRandomAccessFile(const int64_t file_size)
+      : file_size_(file_size), position_(0) {}
+
+  Status Close() override;
+
+  Status Abort() override;
+
+  /// \brief Return the position in this stream
+  Result<int64_t> Tell() const override;
+
+  /// \brief Return whether the stream is closed
+  bool closed() const override;
+
+  Status Seek(int64_t position) override;
+
+  Result<int64_t> GetSize() override;
+
+  Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+
+  Result<std::shared_ptr<Buffer>> ReadAt(int64_t position, int64_t nbytes) override;
+
+  Result<int64_t> Read(int64_t nbytes, void* out) override;
+
+  Result<std::shared_ptr<Buffer>> Read(int64_t nbytes) override;
+
+  const io::IOContext& io_context() const override;
+
+  /// \brief Return a vector containing all the read operations this file receives, each
+  /// read operation is represented as an arrow::io::ReadRange
+  ///
+  /// \return a vector
+  const std::vector<io::ReadRange>& GetReadRanges() const;
+
+ private:
+  const int64_t file_size_;
+  std::vector<io::ReadRange> read_ranges_;
+  int64_t position_;
+  bool closed_ = false;
+  io::IOContext io_context_;
+};
+
+}  // namespace internal
+}  // namespace ipc
+}  // namespace arrow

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -83,6 +83,16 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
   return Status::OK();
 }
 
+Status MakeRandomInt64Array(int64_t length, bool include_nulls, MemoryPool* pool,
+                            std::shared_ptr<Array>* out, uint32_t seed) {
+  random::RandomArrayGenerator rand(seed);
+  const double null_probability = include_nulls ? 0.5 : 0.0;
+
+  *out = rand.Int64(length, 0, 1000, null_probability);
+
+  return Status::OK();
+}
+
 namespace {
 
 template <typename ArrayType>

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -45,6 +45,10 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
                             std::shared_ptr<Array>* out, uint32_t seed = 0);
 
 ARROW_TESTING_EXPORT
+Status MakeRandomInt64Array(int64_t length, bool include_nulls, MemoryPool* pool,
+                            std::shared_ptr<Array>* out, uint32_t seed = 0);
+
+ARROW_TESTING_EXPORT
 Status MakeRandomListArray(const std::shared_ptr<Array>& child_array, int num_lists,
                            bool include_nulls, MemoryPool* pool,
                            std::shared_ptr<Array>* out);


### PR DESCRIPTION
This PR tries to fix https://issues.apache.org/jira/browse/ARROW-12683 ([C++] Enable fine-grained I/O (coalescing) in IPC reader)

This is my first PR for arrow, please forgive my ignorance and let me know the issues for code format/convention/etc. 
And probably I chose a wrong issue as the first problem I want to contribute since after investigating this issue for a while, I realize it is more difficult than I expected :(

Currently I chose an approach that can re-use the current code as much as possible in `ArrayLoader`, to do that, I use a no-op random access file to record the IO and replay only the necessary read operation later. But I am not certain if this is the best approach for solving this issue, and if this kind of approach doesn't fit, feel free to reject this PR, and please let me know how this should be done and I can give it another try.

Besides passing the unit tests, I verified the IO behavior under Linux manually by watching the file pages loaded in page cache, and it works largely as I expected, and the IO saving varies depending on the specific field to be accessed.

