### PR TITLE
ARROW-14402: [Release][Yum] Specify gpg path explicitly

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1453,6 +1453,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
       unless signed_rpm?(rpm)
         sh("rpm",
            "-D", "_gpg_name #{gpg_key_id}",
+           "-D", "__gpg /usr/bin/gpg",
            "-D", "__gpg_check_password_cmd /bin/true true",
            "--resign",
            rpm,


### PR DESCRIPTION
The default gpg path is /usr/bin/gpg2 but it doesn't exist. We should
use /usr/bin/gpg.