### PR TITLE
ARROW-14418: [Java] Fix VectorAppender to correctly append data buffer for BitVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -25,6 +25,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.NullVector;
@@ -83,9 +84,18 @@ class VectorAppender implements VectorVisitor<ValueVector, Void> {
             deltaVector.getValidityBuffer(), deltaVector.getValueCount(), targetVector.getValidityBuffer());
 
     // append data buffer
-    PlatformDependent.copyMemory(deltaVector.getDataBuffer().memoryAddress(),
-            targetVector.getDataBuffer().memoryAddress() + deltaVector.getTypeWidth() * targetVector.getValueCount(),
-            deltaVector.getTypeWidth() * deltaVector.getValueCount());
+    if (deltaVector instanceof BitVector) {
+      // Special handling for Bit vector:
+      // Since Bit vector's type-width is 0, use concatBits() to correctly append the data.
+      BitVectorHelper.concatBits(
+              targetVector.getDataBuffer(), targetVector.getValueCount(),
+              deltaVector.getDataBuffer(), deltaVector.getValueCount(), targetVector.getDataBuffer());
+    } else {
+      PlatformDependent.copyMemory(deltaVector.getDataBuffer().memoryAddress(),
+              targetVector.getDataBuffer().memoryAddress() + deltaVector.getTypeWidth() * targetVector.getValueCount(),
+              deltaVector.getTypeWidth() * deltaVector.getValueCount());
+    }
+
     targetVector.setValueCount(newValueCount);
     return targetVector;
   }


### PR DESCRIPTION
Reference JIRA: https://issues.apache.org/jira/browse/ARROW-14418

VectorAppender uses type-width to copy the data buffer from delta vector to target vector.
But, BitVector's type-width is 0, hence, its data buffer does not get copied to the target vector.
This fix uses concatBits() for BitVector instead of copyMemory() to append the delta data buffer to the target vector.