### PR TITLE
MINOR: [Release] Fix debian:bookwarm typo in the release verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -148,7 +148,7 @@ test_apt() {
                 "ubuntu:hirsute" \
                 "arm64v8/ubuntu:hirsute"; do \
     case "${target}" in
-      arm64v8/debian:bullseye|arm64v8/debian:bookwarm)
+      arm64v8/debian:bullseye|arm64v8/debian:bookworm)
         # qemu-user-static in Ubuntu 20.04 has a crash bug:
         #   https://bugs.launchpad.net/qemu/+bug/1749393
         continue


### PR DESCRIPTION
Build result is going to be here: https://github.com/apache/arrow/pull/11511#issuecomment-949069537