### PR TITLE
ARROW-14433: [Release][APT] Skip arm64 Ubuntu 21.04 verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -148,7 +148,7 @@ test_apt() {
                 "ubuntu:hirsute" \
                 "arm64v8/ubuntu:hirsute"; do \
     case "${target}" in
-      arm64v8/debian:bullseye|arm64v8/debian:bookworm)
+      arm64v8/debian:bullseye|arm64v8/debian:bookworm|arm64v8/ubuntu:hirsute)
         # qemu-user-static in Ubuntu 20.04 has a crash bug:
         #   https://bugs.launchpad.net/qemu/+bug/1749393
         continue


### PR DESCRIPTION
qemu-user-static in Ubuntu 20.04 has a crash bug for it.