### PR TITLE
ARROW-14440: [C++][FlightRPC] Add gRPC + Flight example

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -798,7 +798,12 @@ endfunction()
 function(ADD_ARROW_EXAMPLE REL_EXAMPLE_NAME)
   set(options)
   set(one_value_args)
-  set(multi_value_args EXTRA_LINK_LIBS DEPENDENCIES PREFIX)
+  set(multi_value_args
+      EXTRA_INCLUDES
+      EXTRA_LINK_LIBS
+      EXTRA_SOURCES
+      DEPENDENCIES
+      PREFIX)
   cmake_parse_arguments(ARG
                         "${options}"
                         "${one_value_args}"
@@ -820,7 +825,7 @@ function(ADD_ARROW_EXAMPLE REL_EXAMPLE_NAME)
   if(EXISTS ${CMAKE_SOURCE_DIR}/examples/arrow/${REL_EXAMPLE_NAME}.cc)
     # This example has a corresponding .cc file, set it up as an executable.
     set(EXAMPLE_PATH "${EXECUTABLE_OUTPUT_PATH}/${EXAMPLE_NAME}")
-    add_executable(${EXAMPLE_NAME} "${REL_EXAMPLE_NAME}.cc")
+    add_executable(${EXAMPLE_NAME} "${REL_EXAMPLE_NAME}.cc" ${ARG_EXTRA_SOURCES})
     target_link_libraries(${EXAMPLE_NAME} ${ARROW_EXAMPLE_LINK_LIBS})
     add_dependencies(runexample ${EXAMPLE_NAME})
     set(NO_COLOR "--color_print=false")
@@ -832,6 +837,10 @@ function(ADD_ARROW_EXAMPLE REL_EXAMPLE_NAME)
 
   if(ARG_DEPENDENCIES)
     add_dependencies(${EXAMPLE_NAME} ${ARG_DEPENDENCIES})
+  endif()
+
+  if(ARG_EXTRA_INCLUDES)
+    target_include_directories(${EXAMPLE_NAME} SYSTEM PUBLIC ${ARG_EXTRA_INCLUDES})
   endif()
 
   add_test(${EXAMPLE_NAME} ${EXAMPLE_PATH})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3306,6 +3306,9 @@ macro(build_grpc)
   set(GRPC_STATIC_LIBRARY_ADDRESS_SORTING
       "${GRPC_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}address_sorting${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
+  set(GRPC_STATIC_LIBRARY_GRPCPP_REFLECTION
+      "${GRPC_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}grpc++_reflection${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  )
   set(GRPC_STATIC_LIBRARY_UPB
       "${GRPC_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}upb${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
@@ -3400,6 +3403,7 @@ macro(build_grpc)
                                        ${GRPC_STATIC_LIBRARY_GRPC}
                                        ${GRPC_STATIC_LIBRARY_GRPCPP}
                                        ${GRPC_STATIC_LIBRARY_ADDRESS_SORTING}
+                                       ${GRPC_STATIC_LIBRARY_GRPCPP_REFLECTION}
                                        ${GRPC_STATIC_LIBRARY_UPB}
                                        ${GRPC_CPP_PLUGIN}
                       CMAKE_ARGS ${GRPC_CMAKE_ARGS} ${EP_LOG_OPTIONS}
@@ -3431,6 +3435,12 @@ macro(build_grpc)
   set_target_properties(gRPC::address_sorting
                         PROPERTIES IMPORTED_LOCATION
                                    "${GRPC_STATIC_LIBRARY_ADDRESS_SORTING}"
+                                   INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
+
+  add_library(gRPC::grpc++_reflection STATIC IMPORTED)
+  set_target_properties(gRPC::grpc++_reflection
+                        PROPERTIES IMPORTED_LOCATION
+                                   "${GRPC_STATIC_LIBRARY_GRPCPP_REFLECTION}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${GRPC_INCLUDE_DIR}")
 
   add_library(gRPC::grpc STATIC IMPORTED)
@@ -3512,6 +3522,8 @@ if(ARROW_WITH_GRPC)
 
   if(GRPC_VENDORED)
     set(GRPCPP_PP_INCLUDE TRUE)
+    # Examples need to link to static Arrow if we're using static gRPC
+    set(ARROW_GRPC_USE_SHARED OFF)
   else()
     # grpc++ headers may reside in ${GRPC_INCLUDE_DIR}/grpc++ or ${GRPC_INCLUDE_DIR}/grpcpp
     # depending on the gRPC version.

--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -15,30 +15,80 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ADD_ARROW_EXAMPLE(row_wise_conversion_example)
+add_arrow_example(row_wise_conversion_example)
 
-if (ARROW_COMPUTE)
-  ADD_ARROW_EXAMPLE(compute_register_example)
+if(ARROW_COMPUTE)
+  add_arrow_example(compute_register_example)
 endif()
 
-if (ARROW_COMPUTE AND ARROW_CSV)
-  ADD_ARROW_EXAMPLE(compute_and_write_csv_example)
+if(ARROW_COMPUTE AND ARROW_CSV)
+  add_arrow_example(compute_and_write_csv_example)
 endif()
 
-if (ARROW_PARQUET AND ARROW_DATASET)
-  if (ARROW_BUILD_SHARED)
+if(ARROW_FLIGHT)
+  if(ARROW_BUILD_SHARED)
+    set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_shared)
+  else()
+    set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_static)
+  endif()
+
+  set(FLIGHT_EXAMPLE_GENERATED_PROTO_FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.cc"
+      "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc"
+      "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
+  set_source_files_properties(${FLIGHT_EXAMPLE_GENERATED_PROTO_FILES} PROPERTIES GENERATED
+                                                                                 TRUE)
+
+  set(FLIGHT_EXAMPLE_PROTO "helloworld.proto")
+  set(FLIGHT_EXAMPLE_PROTO_PATH "${CMAKE_CURRENT_LIST_DIR}")
+  set(FLIGHT_EXAMPLE_PROTO_DEPENDS ${FLIGHT_EXAMPLE_PROTO} ${ARROW_PROTOBUF_LIBPROTOBUF}
+                                   gRPC::grpc_cpp_plugin)
+
+  add_custom_command(OUTPUT ${FLIGHT_EXAMPLE_GENERATED_PROTO_FILES}
+                     COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${FLIGHT_EXAMPLE_PROTO_PATH}"
+                             "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
+                             "${FLIGHT_EXAMPLE_PROTO}"
+                     DEPENDS ${PROTO_EXAMPLE_PROTO_DEPENDS} ARGS
+                     COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${FLIGHT_EXAMPLE_PROTO_PATH}"
+                             "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
+                             "--plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
+                             "${FLIGHT_EXAMPLE_PROTO}")
+
+  add_custom_target(flight_grpc_example_gen ALL
+                    DEPENDS ${FLIGHT_EXAMPLE_GENERATED_PROTO_FILES})
+
+  add_arrow_example(flight_grpc_example
+                    DEPENDENCIES
+                    flight_grpc_example_gen
+                    # Not CMAKE_CURRENT_BINARY_DIR so we can #include
+                    # "examples/arrow/helloworld.pb.h" instead of
+                    # "helloworld.pb.h" (which fails lint)
+                    EXTRA_INCLUDES
+                    ${CMAKE_BINARY_DIR}
+                    EXTRA_LINK_LIBS
+                    ${FLIGHT_EXAMPLES_LINK_LIBS}
+                    gRPC::grpc++
+                    gRPC::grpc++_reflection
+                    ${ARROW_PROTOBUF_LIBPROTOBUF}
+                    ${GFLAGS_LIBRARIES}
+                    EXTRA_SOURCES
+                    "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.cc"
+                    "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
+endif()
+
+if(ARROW_PARQUET AND ARROW_DATASET)
+  if(ARROW_BUILD_SHARED)
     set(DATASET_EXAMPLES_LINK_LIBS arrow_dataset_shared)
   else()
     set(DATASET_EXAMPLES_LINK_LIBS arrow_dataset_static)
   endif()
 
-  ADD_ARROW_EXAMPLE(dataset_parquet_scan_example
-    EXTRA_LINK_LIBS
-    ${DATASET_EXAMPLES_LINK_LIBS})
+  add_arrow_example(dataset_parquet_scan_example EXTRA_LINK_LIBS
+                    ${DATASET_EXAMPLES_LINK_LIBS})
   add_dependencies(dataset_parquet_scan_example parquet)
 
-  ADD_ARROW_EXAMPLE(dataset_documentation_example
-    EXTRA_LINK_LIBS
-    ${DATASET_EXAMPLES_LINK_LIBS})
+  add_arrow_example(dataset_documentation_example EXTRA_LINK_LIBS
+                    ${DATASET_EXAMPLES_LINK_LIBS})
   add_dependencies(dataset_documentation_example parquet)
 endif()

--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -26,8 +26,12 @@ if(ARROW_COMPUTE AND ARROW_CSV)
 endif()
 
 if(ARROW_FLIGHT)
-  if(ARROW_BUILD_SHARED)
+  # Static gRPC means we cannot linked to shared Arrow, since then
+  # we'll violate ODR for gRPC symbols
+  if(ARROW_GRPC_USE_SHARED)
     set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_shared)
+  elseif(NOT ARROW_BUILD_STATIC)
+    message(FATAL_ERROR "Statically built gRPC requires ARROW_BUILD_STATIC=ON")
   else()
     set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_static)
   endif()

--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -30,10 +30,16 @@ if(ARROW_FLIGHT)
   # we'll violate ODR for gRPC symbols
   if(ARROW_GRPC_USE_SHARED)
     set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_shared)
+    # We don't directly use symbols from the reflection library, so
+    # ensure the linker still links to it
+    set(GRPC_REFLECTION_LINK_LIBS -Wl,--no-as-needed gRPC::grpc++_reflection
+                                  -Wl,--as-needed)
   elseif(NOT ARROW_BUILD_STATIC)
     message(FATAL_ERROR "Statically built gRPC requires ARROW_BUILD_STATIC=ON")
   else()
     set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_static)
+    set(GRPC_REFLECTION_LINK_LIBS -Wl,--whole-archive gRPC::grpc++_reflection
+                                  -Wl,--no-whole-archive)
   endif()
 
   set(FLIGHT_EXAMPLE_GENERATED_PROTO_FILES
@@ -73,7 +79,7 @@ if(ARROW_FLIGHT)
                     EXTRA_LINK_LIBS
                     ${FLIGHT_EXAMPLES_LINK_LIBS}
                     gRPC::grpc++
-                    gRPC::grpc++_reflection
+                    ${GRPC_REFLECTION_LINK_LIBS}
                     ${ARROW_PROTOBUF_LIBPROTOBUF}
                     ${GFLAGS_LIBRARIES}
                     EXTRA_SOURCES

--- a/cpp/examples/arrow/flight_grpc_example.cc
+++ b/cpp/examples/arrow/flight_grpc_example.cc
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <signal.h>
+#include <cstdlib>
+#include <iostream>
+
+#include <arrow/api.h>
+#include <arrow/flight/api.h>
+#include <gflags/gflags.h>
+#include <grpc++/grpc++.h>
+
+#include "examples/arrow/helloworld.grpc.pb.h"
+#include "examples/arrow/helloworld.pb.h"
+
+// Demonstrate registering a gRPC service alongside a Flight service
+//
+// The gRPC service can be accessed with a gRPC client, on the same
+// port as the Flight service. Additionally, the CMake config for this
+// example links against the gRPC reflection library, enabling tools
+// like grpc_cli and grpcurl to list and call RPCs on the server
+// without needing local copies of the Protobuf definitions.
+// For example, with grpcurl (https://github.com/fullstorydev/grpcurl):
+//
+// grpcurl -d '{"name": "Rakka"}' -plaintext localhost:31337 HelloWorldService/SayHello
+
+DEFINE_string(server_host, "localhost", "Host where the server is running on");
+DEFINE_int32(port, 31337, "Server port to listen on");
+
+namespace flight = ::arrow::flight;
+
+#define ABORT_ON_FAILURE(expr)                     \
+  do {                                             \
+    arrow::Status status_ = (expr);                \
+    if (!status_.ok()) {                           \
+      std::cerr << status_.message() << std::endl; \
+      abort();                                     \
+    }                                              \
+  } while (0);
+
+// Flight service
+class SimpleFlightServer : public flight::FlightServerBase {};
+
+// gRPC service
+class HelloWorldServiceImpl : public HelloWorldService::Service {
+  grpc::Status SayHello(grpc::ServerContext* ctx, const HelloRequest* request,
+                        HelloResponse* reply) override {
+    const std::string& name = request->name();
+    if (name.empty()) {
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Must provide a name!");
+    }
+    reply->set_reply("Hello, " + name);
+    return grpc::Status::OK;
+  }
+};
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  std::unique_ptr<flight::FlightServerBase> server;
+  server.reset(new SimpleFlightServer());
+
+  flight::Location bind_location;
+  ABORT_ON_FAILURE(flight::Location::ForGrpcTcp("0.0.0.0", FLAGS_port, &bind_location));
+  flight::FlightServerOptions options(bind_location);
+
+  HelloWorldServiceImpl grpc_service;
+  int extra_port = 0;
+
+  options.builder_hook = [&](void* raw_builder) {
+    auto* builder = reinterpret_cast<grpc::ServerBuilder*>(raw_builder);
+    builder->AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials(),
+                              &extra_port);
+    builder->RegisterService(&grpc_service);
+  };
+  ABORT_ON_FAILURE(server->Init(options));
+  std::cout << "Listening on ports " << FLAGS_port << " and " << extra_port << std::endl;
+  ABORT_ON_FAILURE(server->SetShutdownOnSignals({SIGTERM}));
+  ABORT_ON_FAILURE(server->Serve());
+  return EXIT_SUCCESS;
+}

--- a/cpp/examples/arrow/flight_grpc_example.cc
+++ b/cpp/examples/arrow/flight_grpc_example.cc
@@ -38,8 +38,7 @@
 //
 // grpcurl -d '{"name": "Rakka"}' -plaintext localhost:31337 HelloWorldService/SayHello
 
-DEFINE_string(server_host, "localhost", "Host where the server is running on");
-DEFINE_int32(port, 31337, "Server port to listen on");
+DEFINE_int32(port, -1, "Server port to listen on");
 
 namespace flight = ::arrow::flight;
 
@@ -70,6 +69,12 @@ class HelloWorldServiceImpl : public HelloWorldService::Service {
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_port < 0) {
+    // For CI
+    std::cout << "Must specify a port with -port" << std::endl;
+    return EXIT_SUCCESS;
+  }
 
   std::unique_ptr<flight::FlightServerBase> server;
   server.reset(new SimpleFlightServer());

--- a/cpp/examples/arrow/helloworld.proto
+++ b/cpp/examples/arrow/helloworld.proto
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+service HelloWorldService {
+  rpc SayHello(HelloRequest) returns (HelloResponse);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloResponse {
+  string reply = 1;
+}

--- a/cpp/examples/minimal_build/CMakeLists.txt
+++ b/cpp/examples/minimal_build/CMakeLists.txt
@@ -31,7 +31,7 @@ message(STATUS "Arrow SO version: ${ARROW_FULL_SO_VERSION}")
 
 add_executable(arrow_example example.cc)
 
-if (ARROW_LINK_SHARED)
+if(ARROW_LINK_SHARED)
   target_link_libraries(arrow_example PRIVATE arrow_shared)
 else()
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/cpp/examples/parquet/CMakeLists.txt
+++ b/cpp/examples/parquet/CMakeLists.txt
@@ -23,33 +23,33 @@ target_include_directories(parquet_low_level_example PRIVATE low_level_api/)
 target_include_directories(parquet_low_level_example2 PRIVATE low_level_api/)
 
 # The variables in these files are for illustration purposes
-set(PARQUET_EXAMPLES_WARNING_SUPPRESSIONS
-  low_level_api/reader_writer.cc
-  low_level_api/reader_writer2.cc)
+set(PARQUET_EXAMPLES_WARNING_SUPPRESSIONS low_level_api/reader_writer.cc
+                                          low_level_api/reader_writer2.cc)
 
-if (PARQUET_REQUIRE_ENCRYPTION)
+if(PARQUET_REQUIRE_ENCRYPTION)
   add_executable(parquet_encryption_example low_level_api/encryption_reader_writer.cc)
-  add_executable(parquet_encryption_example_all_crypto_options low_level_api/encryption_reader_writer_all_crypto_options.cc)
+  add_executable(parquet_encryption_example_all_crypto_options
+                 low_level_api/encryption_reader_writer_all_crypto_options.cc)
   target_include_directories(parquet_encryption_example PRIVATE low_level_api/)
-  target_include_directories(parquet_encryption_example_all_crypto_options PRIVATE low_level_api/)
+  target_include_directories(parquet_encryption_example_all_crypto_options
+                             PRIVATE low_level_api/)
 
   set(PARQUET_EXAMPLES_WARNING_SUPPRESSIONS
-    ${PARQUET_EXAMPLES_WARNING_SUPPRESSIONS}
-    low_level_api/encryption_reader_writer.cc
-    low_level_api/encryption_reader_writer_all_crypto_options.cc)
+      ${PARQUET_EXAMPLES_WARNING_SUPPRESSIONS} low_level_api/encryption_reader_writer.cc
+      low_level_api/encryption_reader_writer_all_crypto_options.cc)
 
 endif()
 
 if(UNIX)
   foreach(FILE ${PARQUET_EXAMPLES_WARNING_SUPPRESSIONS})
     set_property(SOURCE ${FILE}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS "-Wno-unused-variable")
+                 APPEND_STRING
+                 PROPERTY COMPILE_FLAGS "-Wno-unused-variable")
   endforeach()
 endif()
 
 # Prefer shared linkage but use static if shared build is deactivated
-if (ARROW_BUILD_SHARED)
+if(ARROW_BUILD_SHARED)
   set(PARQUET_EXAMPLE_LINK_LIBS parquet_shared)
 else()
   set(PARQUET_EXAMPLE_LINK_LIBS parquet_static)
@@ -62,17 +62,17 @@ target_link_libraries(parquet_stream_api_example ${PARQUET_EXAMPLE_LINK_LIBS})
 
 if(PARQUET_REQUIRE_ENCRYPTION)
   target_link_libraries(parquet_encryption_example ${PARQUET_EXAMPLE_LINK_LIBS})
-  target_link_libraries(parquet_encryption_example_all_crypto_options ${PARQUET_EXAMPLE_LINK_LIBS})
+  target_link_libraries(parquet_encryption_example_all_crypto_options
+                        ${PARQUET_EXAMPLE_LINK_LIBS})
 endif()
 
 add_dependencies(parquet
-  parquet_low_level_example
-  parquet_low_level_example2
-  parquet_arrow_example
-  parquet_stream_api_example)
+                 parquet_low_level_example
+                 parquet_low_level_example2
+                 parquet_arrow_example
+                 parquet_stream_api_example)
 
-if (PARQUET_REQUIRE_ENCRYPTION)
-  add_dependencies(parquet
-    parquet_encryption_example
-    parquet_encryption_example_all_crypto_options)
+if(PARQUET_REQUIRE_ENCRYPTION)
+  add_dependencies(parquet parquet_encryption_example
+                   parquet_encryption_example_all_crypto_options)
 endif()

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -149,6 +149,7 @@ def cmake_linter(src, fix=False):
             'ci/**/*.cmake',
             'cpp/CMakeLists.txt',
             'cpp/src/**/CMakeLists.txt',
+            'cpp/examples/**/CMakeLists.txt',
             'cpp/cmake_modules/*.cmake',
             'go/**/CMakeLists.txt',
             'java/**/CMakeLists.txt',


### PR DESCRIPTION
This demonstrates how to register a normal gRPC service on a Flight server, allowing you to use all of gRPC's features and ecosystem while still serving Flight, all on the same port. This can be helpful for when DoAction is too limited/inconvenient an extension point and you are already using gRPC.