### PR TITLE
ARROW-14450: [R] Old macos build error

### DIFF
--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -56,6 +56,8 @@ static std::vector<std::string> UnorderedMapValues(
   return values;
 }
 
+KeyValueMetadata::KeyValueMetadata() {}
+
 KeyValueMetadata::KeyValueMetadata(
     const std::unordered_map<std::string, std::string>& map)
     : keys_(UnorderedMapKeys(map)), values_(UnorderedMapValues(map)) {

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -34,7 +34,7 @@ namespace arrow {
 /// \brief A container for key-value pair type metadata. Not thread-safe
 class ARROW_EXPORT KeyValueMetadata {
  public:
-  KeyValueMetadata() = default;
+  KeyValueMetadata();
   KeyValueMetadata(std::vector<std::string> keys, std::vector<std::string> values);
   explicit KeyValueMetadata(const std::unordered_map<std::string, std::string>& map);
 


### PR DESCRIPTION
It appears that Clang 8 on MacOS 10.11.6 has a bug recognizing when a struct without a user provided constructor can be default initialized in a const context.

Related issue: https://sourceware.org/bugzilla/show_bug.cgi?id=24937

There is some discussion in the issue and a link to more discussion on the SO post (and eventually a reference to a defect in the spec)