### PR TITLE
ARROW-14449: [Python] RecordBatch in Cython is missing column_data method

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -759,6 +759,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CArray] column(int i)
         const c_string& column_name(int i)
 
+        shared_ptr[CArrayData] column_data(int i)
+        const vector[shared_ptr[CArrayData]]& column_data()
+
         const vector[shared_ptr[CArray]]& columns()
 
         int num_columns()


### PR DESCRIPTION
Adds API for column_data() methods to Cython's `CRecordBatch` but not to Python's RecordBatch because ArrayData is not exposed in Python, only in Cython.