### PR TITLE
ARROW-14429: [C++] Speed up IPC file reader on high-latency filesystems

### DIFF
--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -456,15 +456,24 @@ using FieldsLoaderFunction = std::function<Status(const void*, io::RandomAccessF
 ///
 /// \param[in] offset the position in the file where the message starts. The
 /// first 4 bytes after the offset are the message length
-/// \param[in] metadata_length the total number of bytes to read from file
+/// \param[in] metadata_length the size of the message header
+/// \param[in] body_length the size of the message body, if known, or
+/// -1 otherwise. When provided, the entire message will be read in
+/// one I/O operation, potentially reducing I/O costs on high-latency
+/// filesystems.
 /// \param[in] file the seekable file interface to read from
 /// \param[in] fields_loader the function for loading subset of fields from the given file
 /// \return the message read
-
 ARROW_EXPORT
 Result<std::unique_ptr<Message>> ReadMessage(
-    const int64_t offset, const int32_t metadata_length, io::RandomAccessFile* file,
-    const FieldsLoaderFunction& fields_loader = {});
+    const int64_t offset, const int32_t metadata_length, const int64_t body_length,
+    io::RandomAccessFile* file, const FieldsLoaderFunction& fields_loader = {});
+
+/// \brief Read encapsulated RPC message from position in file
+ARROW_EXPORT
+Result<std::unique_ptr<Message>> ReadMessage(const int64_t offset,
+                                             const int32_t metadata_length,
+                                             io::RandomAccessFile* file);
 
 ARROW_EXPORT
 Future<std::shared_ptr<Message>> ReadMessageAsync(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -980,8 +980,9 @@ static Result<std::unique_ptr<Message>> ReadMessageFromBlock(
   // TODO(wesm): this breaks integration tests, see ARROW-3256
   // DCHECK_EQ((*out)->body_length(), block.body_length);
 
-  ARROW_ASSIGN_OR_RAISE(auto message, ReadMessage(block.offset, block.metadata_length,
-                                                  file, fields_loader));
+  ARROW_ASSIGN_OR_RAISE(
+      auto message, ReadMessage(block.offset, block.metadata_length, block.body_length,
+                                file, fields_loader));
   return std::move(message);
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1272,7 +1272,6 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
     int file_end_size = static_cast<int>(magic_size + sizeof(int32_t));
     int readahead = std::min<int>(kFooterReadaheadSize,
                                   static_cast<int>(footer_offset_ - file_end_size));
-    file_end_size = file_end_size;
     auto self = std::dynamic_pointer_cast<RecordBatchFileReaderImpl>(shared_from_this());
     auto read_magic = file_->ReadAsync(footer_offset_ - file_end_size - readahead,
                                        file_end_size + readahead);

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1258,9 +1258,9 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
   }
 
   Future<> ReadFooterAsync(arrow::internal::Executor* executor) {
-    // When reading the footer, read this much additional data in an
-    // attempt to avoid a second I/O operation (which can be slow on a
-    // high-latency filesystem like S3)
+    // When reading the footer, read up to this much additional data in
+    // an attempt to avoid a second I/O operation (which can be slow
+    // on a high-latency filesystem like S3)
     constexpr static int kFooterReadaheadSize = 512 * 1024;
 
     const int32_t magic_size = static_cast<int>(strlen(kArrowMagicBytes));


### PR DESCRIPTION
This implements two minor optimizations for the IPC file reader:

- When reading an IPC message, try to read the entire body and header in one call. (This was already implemented for the async reader, but not the regular synchronous reader.)
- Like the Parquet reader, try to avoid a second I/O operation when reading the footer by speculatively reading extra data.