### PR TITLE
ARROW-14483: [Release] Add missing download targets

### DIFF
--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -126,7 +126,13 @@ def parallel_map_terminate_early(f, iterable, num_parallel):
                 raise e
 
 
-ARROW_REPOSITORY_PACKAGE_TYPES = ['centos', 'debian', 'ubuntu']
+ARROW_REPOSITORY_PACKAGE_TYPES = [
+    'almalinux',
+    'amazon-linux',
+    'centos',
+    'debian',
+    'ubuntu',
+]
 ARROW_STANDALONE_PACKAGE_TYPES = ['nuget', 'python']
 ARROW_PACKAGE_TYPES = \
     ARROW_REPOSITORY_PACKAGE_TYPES + \


### PR DESCRIPTION
Packages for AlmaLinux and Amazon Linux aren't downloaded.