### PR TITLE
ARROW-14491: [CI] Add Debian 10 C++ nightly build

### DIFF
--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -74,8 +74,6 @@ RUN apt-get update -y -q && \
 
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
-COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_gcs_testbench.sh ${arch} default
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DATASET=ON \

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -906,13 +906,15 @@ tasks:
       flags: -e ARROW_SKYHOOK=ON
       image: ubuntu-cpp
 
-  test-debian-11-cpp:
+{% for debian_version in ["10", "11"] %}
+  test-debian-{{ debian_version }}-cpp:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        DEBIAN: 11
+        DEBIAN: {{ debian_version }}
       image: debian-cpp
+{% endfor %}
 
   test-fedora-33-cpp:
     ci: github


### PR DESCRIPTION
The GCS testbench doesn't currently work on Debian 10, but it was never noticed because Debian 10 builds were disabled. Removing the testbench for now, and re-enabling builds.