### PR TITLE
ARROW-14517: [Python] Missing ampersand in CIpcReadOptions of CFeatherReader

### DIFF
--- a/python/pyarrow/includes/libarrow_feather.pxd
+++ b/python/pyarrow/includes/libarrow_feather.pxd
@@ -41,7 +41,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         @staticmethod
         CResult[shared_ptr[CFeatherReader]] Open(
             const shared_ptr[CRandomAccessFile]& file,
-            const CIpcReadOptions options)
+            const CIpcReadOptions& options)
         int version()
         shared_ptr[CSchema] schema()
 


### PR DESCRIPTION
Add a missing ampersand (&) for `CIpcReadOptions` in `libarrow_feather.pxd`.