### PR TITLE
ARROW-14514: [C++][R] UBSAN error on round kernel

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1071,7 +1071,8 @@ struct RoundOptionsWrapper<RoundToMultipleOptions>
     if (auto options = static_cast<const OptionsType*>(args.options)) {
       state = ::arrow::internal::make_unique<State>(*options);
     } else {
-      return Status::Invalid("Attempted to initialize KernelState from null FunctionOptions");
+      return Status::Invalid(
+          "Attempted to initialize KernelState from null FunctionOptions");
     }
 
     auto options = Get(*state);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -864,7 +864,7 @@ struct RoundUtil {
 };
 
 // Specializations of rounding implementations for round kernels
-template <typename Type, RoundMode>
+template <typename, RoundMode>
 struct RoundImpl;
 
 template <typename Type>
@@ -1031,8 +1031,8 @@ struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
 };
 
 // Specializations of kernel state for round kernels
-template <typename>
-struct RoundOptionsWrapper;
+template <typename T>
+struct RoundOptionsWrapper : public OptionsWrapper<T> {};
 
 template <>
 struct RoundOptionsWrapper<RoundOptions> : public OptionsWrapper<RoundOptions> {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -864,7 +864,7 @@ struct RoundUtil {
 };
 
 // Specializations of rounding implementations for round kernels
-template <typename, RoundMode>
+template <typename Type, RoundMode>
 struct RoundImpl;
 
 template <typename Type>
@@ -1031,7 +1031,7 @@ struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
 };
 
 // Specializations of kernel state for round kernels
-template <typename>
+template <typename OptionsType>
 struct RoundOptionsWrapper;
 
 template <>


### PR DESCRIPTION
Add base class `OptionsWrapper` to primary template of `RoundOptionsWrapper`.