### PR TITLE
ARROW-13896: [Python] Print of timestamp with timezone errors

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -395,7 +395,7 @@ def _datetime_from_int(int64_t value, TimeUnit unit, tzinfo=None):
     dt = datetime.datetime(1970, 1, 1) + delta
     # adjust timezone if set to the datatype
     if tzinfo is not None:
-        dt = tzinfo.fromutc(dt)
+        dt = tzinfo.fromutc(dt.replace(tzinfo=tzinfo))
 
     return dt
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -395,7 +395,7 @@ def _datetime_from_int(int64_t value, TimeUnit unit, tzinfo=None):
     dt = datetime.datetime(1970, 1, 1) + delta
     # adjust timezone if set to the datatype
     if tzinfo is not None:
-        dt = tzinfo.fromutc(dt.replace(tzinfo=tzinfo))
+        dt = dt.replace(tzinfo=datetime.timezone.utc).astimezone(tzinfo)
 
     return dt
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -323,6 +323,9 @@ def test_timestamp_no_overflow():
         s = pa.scalar(ts, type=pa.timestamp("us", tz="UTC"))
         assert s.as_py() == ts
 
+def test_timestamp_print():
+    arr = pa.array([0], pa.timestamp('s', tz='+02:00'))
+    assert str(arr[0]) == "1970-01-01 02:00:00+02:00"
 
 def test_duration():
     arr = np.array([0, 3600000000000], dtype='timedelta64[ns]')

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -323,9 +323,12 @@ def test_timestamp_no_overflow():
         s = pa.scalar(ts, type=pa.timestamp("us", tz="UTC"))
         assert s.as_py() == ts
 
-def test_timestamp_print():
+
+def test_timestamp_fixed_offset_print():
+    # ARROW-13896
     arr = pa.array([0], pa.timestamp('s', tz='+02:00'))
     assert str(arr[0]) == "1970-01-01 02:00:00+02:00"
+
 
 def test_duration():
     arr = np.array([0, 3600000000000], dtype='timedelta64[ns]')


### PR DESCRIPTION
The initial commit fixes the issue of printing the value of a pyarrow scalar as it errored due to the mismatch of `tzinfo` between `self` and `dt` in `fromutc`.

What I also want to do is to correct the `__str__` method for array class that uses `to_string()` method and ignores tz info. I don't know how to approach this problem as the `to_string()` is not really clear to me. Will do some more research, ideas are welcome.

Due to the second part this PR is not complete yet.