### PR TITLE
ARROW-14515: [R] Add clang sanitizer to crossbow

### DIFF
--- a/ci/docker/r-fedora-clang-devel-san.dockerfile
+++ b/ci/docker/r-fedora-clang-devel-san.dockerfile
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Fedora-clang-devel with the sanitizer enabled, this should/will
+# be upstreamed to rhub, so separated out like this
+
+# start with the Docker 'base R' Debian-based image
+FROM rhub/fedora-clang:latest
+
+# TODO: rhub maintainer when we upstream
+
+ENV CRAN http://cran.r-project.org
+
+RUN cd /tmp \
+    && svn co https://svn.r-project.org/R/trunk R-devel
+
+ENV RPREFIX /opt/R-devel
+
+ENV ROPTIONS --with-x --with-recommended-packages --enable-R-shlib --enable-R-static-lib
+
+ENV CC /usr/bin/clang
+ENV CXX /usr/bin/clang++
+ENV F77 gfortran
+ENV CPP cpp
+
+RUN yum -y install rsync
+RUN dnf install -y libcxx-devel
+
+RUN cd /tmp/R-devel \
+    && ./tools/rsync-recommended \
+    && R_PAPERSIZE=letter \
+    R_BATCHSAVE="--no-save --no-restore" \
+    CC="clang -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" \
+    CXX="clang++ -stdlib=libc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" \
+    CFLAGS="-g -O3 -Wall -pedantic -mtune=native" \
+    FFLAGS="-g -O2 -mtune=native" \
+    FCFLAGS="-g -O2 -mtune=native" \
+    CXXFLAGS="-g -O3 -Wall -pedantic -mtune=native" \
+    MAIN_LD="clang++ -stdlib=libc++ -fsanitize=undefined,address" \
+    R_OPENMP_CFLAGS=-fopenmp \
+    ./configure --prefix=${RPREFIX} ${ROPTIONS} \
+    && make \
+    && make install
+
+# TODO: re-enable when upstreamed?
+# COPY xvfb-run /usr/local/bin/xvfb-run
+
+# RUN chmod +x /usr/local/bin/xvfb-run && \
+#     rm -f /bin/xvfb-run /usr/bin/xvfb-run
+
+ENV RHUB_PLATFORM linux-x86_64-fedora-clang
+
+# More verbose UBSAN/SAN output (cf #3) -- this is still somewhat speculative
+# Entry copied from Prof Ripley's setup described at http://www.stats.ox.ac.uk/pub/bdr/memtests/README.txt
+ENV ASAN_OPTIONS 'alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0'
+
+ENV PATH=${RPREFIX}/bin:$PATH
+
+RUN cd $RPREFIX/bin \
+	&& mv R Rdevel \
+	&& cp Rscript Rscriptdevel \
+	&& ln -s Rdevel RDsan \
+	&& ln -s Rscriptdevel RDscriptsan

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -34,8 +34,16 @@ unset ARROW_R_DEV
 
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=/arrow/r/tools/ubsan.supp"
 
+# run tests
 pushd tests
 ${R_BIN} < testthat.R > testthat.out 2>&1 || { cat testthat.out; exit 1; }
+
+cat testthat.out
+if grep -q "runtime error" testthat.out; then
+  exit 1
+fi
+
+# run examples
 popd
 ${R_BIN} -e 'library(arrow); testthat::test_examples(".")' >> testthat.out 2>&1 || { cat testthat.out; exit 1; }
 

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -45,10 +45,10 @@ fi
 
 # run examples
 popd
-${R_BIN} -e 'library(arrow); testthat::test_examples(".")' >> testthat.out 2>&1 || { cat testthat.out; exit 1; }
+${R_BIN} -e 'library(arrow); testthat::test_examples(".")' >> examples.out 2>&1 || { cat examples.out; exit 1; }
 
 cat testthat.out
-if grep -q "runtime error" testthat.out; then
+if grep -q "runtime error" examples.out; then
   exit 1
 fi
 popd

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -47,7 +47,7 @@ fi
 popd
 ${R_BIN} -e 'library(arrow); testthat::test_examples(".")' >> examples.out 2>&1 || { cat examples.out; exit 1; }
 
-cat testthat.out
+cat examples.out
 if grep -q "runtime error" examples.out; then
   exit 1
 fi

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1158,6 +1158,12 @@ tasks:
         UBUNTU: 18.04
       run: ubuntu-r-sanitizer
 
+  test-fedora-r-clang-sanitizer:
+    ci: azure
+    template: docker-tests/azure.linux.yml
+    params:
+      run: fedora-r-clang-sanitizer
+
   revdep-r-check:
     ci: github
     template: r/github.linux.revdepcheck.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,8 @@ x-hierarchy:
   - ubuntu-cpp-sanitizer
   - ubuntu-cpp-thread-sanitizer
   - ubuntu-r-sanitizer
+  - r-fedora-clang-devel-san
+  - fedora-r-clang-sanitizer
   - ubuntu-r-valgrind
   - python-sdist
   - r
@@ -271,7 +273,7 @@ services:
       ARROW_USE_LD_GOLD: "ON"
       BUILD_WARNING_LEVEL: "PRODUCTION"
     volumes: *conda-volumes
-    command: 
+    command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"]
 
@@ -1153,6 +1155,40 @@ services:
     command: >
       /bin/bash -c "
         /arrow/ci/scripts/r_sanitize.sh /arrow"
+
+  fedora-r-clang-sanitizer:
+    image: ${REPO}:r-rhub-fedora-clang-devel-latest
+    build:
+      context: .
+      dockerfile: ci/docker/linux-r.dockerfile
+      cache_from:
+        - ${REPO}:r-rhub-fedora-clang-devel-latest
+      args:
+        base: ${REPO}:r-fedora-clang-devel-san
+        r_dev: ${ARROW_R_DEV}
+        devtoolset_version: ${DEVTOOLSET_VERSION}
+        r_bin: RDsan
+        tz: ${TZ}
+    shm_size: *shm-size
+    environment:
+      LIBARROW_DOWNLOAD: "false"
+      ARROW_SOURCE_HOME: "/arrow"
+      ARROW_R_DEV: ${ARROW_R_DEV}
+      # To test for CRAN release, delete ^^ these two env vars so we download the Apache release
+      ARROW_USE_PKG_CONFIG: "false"
+    volumes:
+      - .:/arrow:delegated
+    command: >
+      /bin/bash -c "
+        /arrow/ci/scripts/r_sanitize.sh /arrow"
+
+  r-fedora-clang-devel-san:
+    image: ${REPO}:r-fedora-clang-devel-san
+    build:
+      context: .
+      dockerfile: ci/docker/r-fedora-clang-devel-san.dockerfile
+      cache_from:
+        - ${REPO}:r-fedora-clang-devel-san
 
   ubuntu-r-valgrind:
     # Only 18.04 and amd64 supported

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,8 +136,8 @@ x-hierarchy:
   - ubuntu-cpp-sanitizer
   - ubuntu-cpp-thread-sanitizer
   - ubuntu-r-sanitizer
-  - r-fedora-clang-devel-san
-  - fedora-r-clang-sanitizer
+  - r-fedora-clang-devel-san:
+    - fedora-r-clang-sanitizer
   - ubuntu-r-valgrind
   - python-sdist
   - r


### PR DESCRIPTION
We should upstream r-fedora-clang-devel-san.dockerfile to rhub and use theirs when we do