### PR TITLE
ARROW-14548: [C++] Add madvise random support for memory mapped file

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -26,6 +26,7 @@
 
 #include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
+#include "arrow/util/io_util.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -136,6 +137,8 @@ class ARROW_EXPORT ReadableFile
   std::unique_ptr<ReadableFileImpl> impl_;
 };
 
+using ::arrow::internal::MemoryRegion;
+
 /// \brief A file interface that uses memory-mapped files for memory interactions
 ///
 /// This implementation supports zero-copy reads. The same class is used
@@ -190,6 +193,8 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   Status WillNeed(const std::vector<ReadRange>& ranges) override;
 
+  Status AdviseRandom(const std::vector<ReadRange>& ranges);
+
   bool supports_zero_copy() const override;
 
   /// Write data at the current position in the file. Thread-safe
@@ -215,6 +220,11 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   class ARROW_NO_EXPORT MemoryMap;
   std::shared_ptr<MemoryMap> memory_map_;
+
+  Status ReadRangesToMemoryRegions(
+      const std::vector<ReadRange>& ranges,
+      std::shared_ptr<MemoryMappedFile::MemoryMap>& memory_map,
+      std::vector<MemoryRegion>& regions);
 };
 
 }  // namespace io

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -689,6 +689,21 @@ TEST_F(TestMemoryMappedFile, WillNeed) {
   ASSERT_RAISES(IOError, mmap->WillNeed({{1025, 1}}));  // Out of bounds
 }
 
+TEST_F(TestMemoryMappedFile, AdviseRandom) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  random_bytes(1024, 0, buffer.data());
+
+  std::string path = TempFile("io-memory-map-advise-random-test");
+  ASSERT_OK_AND_ASSIGN(auto mmap, InitMemoryMap(buffer_size, path));
+  ASSERT_OK(mmap->Write(buffer.data(), buffer_size));
+
+  ASSERT_OK(mmap->AdviseRandom({}));
+  ASSERT_OK(mmap->AdviseRandom({{0, 4}, {100, 924}}));
+  ASSERT_OK(mmap->AdviseRandom({{1024, 0}}));
+  ASSERT_RAISES(IOError, mmap->AdviseRandom({{1025, 1}}));  // Out of bounds
+}
+
 TEST_F(TestMemoryMappedFile, InvalidReads) {
   std::string path = TempFile("io-memory-map-invalid-reads-test");
   ASSERT_OK_AND_ASSIGN(auto result, InitMemoryMap(4096, path));

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -179,6 +179,9 @@ ARROW_EXPORT
 Status MemoryAdviseWillNeed(const std::vector<MemoryRegion>& regions);
 
 ARROW_EXPORT
+Status MemoryAdviseRandom(const std::vector<MemoryRegion>& regions);
+
+ARROW_EXPORT
 Result<std::string> GetEnvVar(const char* name);
 ARROW_EXPORT
 Result<std::string> GetEnvVar(const std::string& name);


### PR DESCRIPTION
Add advise random memory API for MemoryMappedFile so that client can advise OS about its memory usage if it uses random access