### PR TITLE
ARROW-14539: [C++] Dataset scanner test failing a DCHECK

### DIFF
--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -43,8 +43,8 @@ void AsyncDestroyable::Destroy() {
 
 Status AsyncTaskGroup::AddTask(std::function<Result<Future<>>()> task) {
   auto guard = mutex_.Lock();
-  if (all_tasks_done_.is_finished()) {
-    return Status::Invalid("Attempt to add a task after the task group has completed");
+  if (finished_adding_) {
+    return Status::Cancelled("Ignoring task added after the task group has been ended");
   }
   if (!err_.ok()) {
     return err_;
@@ -80,8 +80,8 @@ Status AsyncTaskGroup::AddTaskUnlocked(const Future<>& task_fut,
 
 Status AsyncTaskGroup::AddTask(const Future<>& task_fut) {
   auto guard = mutex_.Lock();
-  if (all_tasks_done_.is_finished()) {
-    return Status::Invalid("Attempt to add a task after the task group has completed");
+  if (finished_adding_) {
+    return Status::Cancelled("Ignoring task added after the task group has been ended");
   }
   if (!err_.ok()) {
     return err_;

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -106,8 +106,8 @@ SerializedAsyncTaskGroup::SerializedAsyncTaskGroup() : on_finished_(Future<>::Ma
 Status SerializedAsyncTaskGroup::AddTask(std::function<Result<Future<>>()> task) {
   util::Mutex::Guard guard = mutex_.Lock();
   ARROW_RETURN_NOT_OK(err_);
-  if (on_finished_.is_finished()) {
-    return Status::Invalid("Attempt to add a task after a task group has finished");
+  if (ended_) {
+    return Status::Cancelled("Ignoring task added after the task group has been ended");
   }
   tasks_.push(std::move(task));
   if (!processing_.is_valid()) {


### PR DESCRIPTION
If the exec plan ends early (either through a failure or user cancellation) it is possible for `AsyncTaskGroup::AddTask` to be called after `AsyncTaskGroup::End`.  This led to `AsyncTaskGroup` trying to mark its future finished twice.

I modified `AsyncTaskGroup` so that it won't mark the future twice if this condition occurs.  Instead it returns a cancelled status.  There is no good way to prevent this condition in `MapNode` without introducing a mutex / more synchronization so instead I just modified `MapNode` to expect a potential cancelled status return from `AddTask`.