### PR TITLE
ARROW-14227: [R] Implement lubridate is.* methods

### DIFF
--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -749,6 +749,19 @@ contains_regex <- function(string) {
   grepl("[.\\|()[{^$*+?]", string)
 }
 
+nse_funcs$trunc <- function(x, ...) {
+  # accepts and ignores ... for consistency with base::trunc()
+  build_expr("trunc", x)
+}
+
+nse_funcs$round <- function(x, digits = 0) {
+  build_expr(
+    "round",
+    x,
+    options = list(ndigits = digits, round_mode = RoundMode$HALF_TO_EVEN)
+  )
+}
+
 nse_funcs$strptime <- function(x, format = "%Y-%m-%d %H:%M:%S", tz = NULL, unit = "ms") {
   # Arrow uses unit for time parsing, strptime() does not.
   # Arrow has no default option for strptime (format, unit),
@@ -818,19 +831,6 @@ nse_funcs$second <- function(x) {
   Expression$create("add", Expression$create("second", x), Expression$create("subsecond", x))
 }
 
-nse_funcs$trunc <- function(x, ...) {
-  # accepts and ignores ... for consistency with base::trunc()
-  build_expr("trunc", x)
-}
-
-nse_funcs$round <- function(x, digits = 0) {
-  build_expr(
-    "round",
-    x,
-    options = list(ndigits = digits, round_mode = RoundMode$HALF_TO_EVEN)
-  )
-}
-
 nse_funcs$wday <- function(x,
                            label = FALSE,
                            abbr = TRUE,
@@ -846,6 +846,31 @@ nse_funcs$wday <- function(x,
   }
 
   Expression$create("day_of_week", x, options = list(count_from_zero = FALSE, week_start = week_start))
+}
+
+nse_funcs$is.Date <- function(x) {
+  lubridate::is.Date(x) ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32", "DATE64")])
+}
+
+nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
+  lubridate::is.instant(x) ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "DATE32", "DATE64")])
+}
+
+nce_funcs$is.POSIXct <- function(x) {
+  lubridate::is.POSIXct(x) ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
+}
+
+nce_funcs$is.POSIXlt <- function(x) {
+  lubridate::is.POSIXlt(x) ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
+}
+
+nce_funcs$is.POSIXt <- function(x) {
+  lubridate::is.POSIXt(x) ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
 }
 
 nse_funcs$log <- nse_funcs$logb <- function(x, base = exp(1)) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -849,17 +849,28 @@ nse_funcs$wday <- function(x,
 }
 
 nse_funcs$is.Date <- function(x) {
-  lubridate::is.Date(x) ||
+  inherits(x, "Date") ||
     (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32", "DATE64")])
 }
 
 nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
-  lubridate::is.instant(x) ||
+  inherits(x, c("POSIXt", "Date")) ||
     (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP", "DATE32", "DATE64")])
 }
 
+
+nse_funcs$is.POSIXt <- function(x) {
+  inherits(x, "POSIXt") ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
+}
+
 nse_funcs$is.POSIXct <- function(x) {
-  lubridate::is.POSIXct(x) ||
+  inherits(x, "POSIXct") ||
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
+}
+
+nse_funcs$is.POSIXlt <- function(x) {
+  inherits(x, "POSIXlt") ||
     (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
 }
 

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -855,22 +855,12 @@ nse_funcs$is.Date <- function(x) {
 
 nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
   lubridate::is.instant(x) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "DATE32", "DATE64")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP", "DATE32", "DATE64")])
 }
 
-nce_funcs$is.POSIXct <- function(x) {
+nse_funcs$is.POSIXct <- function(x) {
   lubridate::is.POSIXct(x) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
-}
-
-nce_funcs$is.POSIXlt <- function(x) {
-  lubridate::is.POSIXlt(x) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
-}
-
-nce_funcs$is.POSIXt <- function(x) {
-  lubridate::is.POSIXt(x) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
 }
 
 nse_funcs$log <- nse_funcs$logb <- function(x, base = exp(1)) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -850,7 +850,7 @@ nse_funcs$is.Date <- function(x) {
 }
 
 nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
-  inherits(x, c("POSIXt", "Date")) ||
+  inherits(x, c("POSIXt", "POSIXct", "POSIXlt", "Date")) ||
     (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP", "DATE32")])
 }
 

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -255,10 +255,6 @@ nse_funcs$is_logical <- function(x, n = NULL) {
   assert_that(is.null(n))
   nse_funcs$is.logical(x)
 }
-nse_funcs$is_timestamp <- function(x, n = NULL) {
-  assert_that(is.null(n))
-  inherits(x, "POSIXt") || (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP")])
-}
 
 # String functions
 nse_funcs$nchar <- function(x, type = "chars", allowNA = FALSE, keepNA = NA) {
@@ -788,7 +784,7 @@ nse_funcs$strftime <- function(x, format = "", tz = "", usetz = FALSE) {
   }
   # Arrow's strftime prints in timezone of the timestamp. To match R's strftime behavior we first
   # cast the timestamp to desired timezone. This is a metadata only change.
-  if (nse_funcs$is_timestamp(x)) {
+  if (nse_funcs$is.POSIXct(x)) {
     ts <- Expression$create("cast", x, options = list(to_type = timestamp(x$type()$unit(), tz)))
   } else {
     ts <- x
@@ -850,28 +846,17 @@ nse_funcs$wday <- function(x,
 
 nse_funcs$is.Date <- function(x) {
   inherits(x, "Date") ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32", "DATE64")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32")])
 }
 
 nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
   inherits(x, c("POSIXt", "Date")) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP", "DATE32", "DATE64")])
-}
-
-
-nse_funcs$is.POSIXt <- function(x) {
-  inherits(x, "POSIXt") ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP", "DATE32")])
 }
 
 nse_funcs$is.POSIXct <- function(x) {
   inherits(x, "POSIXct") ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
-}
-
-nse_funcs$is.POSIXlt <- function(x) {
-  inherits(x, "POSIXlt") ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIME32", "TIME64", "TIMESTAMP")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP")])
 }
 
 nse_funcs$log <- nse_funcs$logb <- function(x, base = exp(1)) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -846,12 +846,12 @@ nse_funcs$wday <- function(x,
 
 nse_funcs$is.Date <- function(x) {
   inherits(x, "Date") ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("DATE32", "DATE64")])
 }
 
 nse_funcs$is.instant <- nse_funcs$is.timepoint <- function(x) {
   inherits(x, c("POSIXt", "POSIXct", "POSIXlt", "Date")) ||
-    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP", "DATE32")])
+    (inherits(x, "Expression") && x$type_id() %in% Type[c("TIMESTAMP", "DATE32", "DATE64")])
 }
 
 nse_funcs$is.POSIXct <- function(x) {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -44,6 +44,38 @@ test_df <- tibble::tibble(
   date = c(as.Date("2021-09-09"), NA)
 )
 
+# These tests test detection of dates and times
+
+test_that("is.* functions from lubridate", {
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = is.POSIXct(datetime)) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = is.Date(date)) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = is.instant(datetime)) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = is.timepoint(datetime)) %>%
+      collect(),
+    test_df
+  )
+})
+
 # These tests test component extraction from timestamp objects
 
 test_that("extract year from timestamp", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -41,36 +41,46 @@ test_df <- tibble::tibble(
   # That issue is tough because in C++, "" is the "no timezone" value
   # due to static typing, so we can't distinguish a literal "" from NULL
   datetime = c(test_date, NA) + 1,
-  date = c(as.Date("2021-09-09"), NA)
+  date = c(as.Date("2021-09-09"), NA),
+  integer = 1:2
 )
 
 # These tests test detection of dates and times
 
 test_that("is.* functions from lubridate", {
+  # make sure all true and at least one false value is considered
   compare_dplyr_binding(
     .input %>%
-      mutate(x = is.POSIXct(datetime)) %>%
+      mutate(x = is.POSIXct(datetime), y = is.POSIXct(integer)) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(x = is.Date(date)) %>%
+      mutate(x = is.Date(date), y = is.Date(integer)) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(x = is.instant(datetime)) %>%
+      mutate(
+        x = is.instant(datetime),
+        y = is.instant(date),
+        z = is.instant(integer)
+      ) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(x = is.timepoint(datetime)) %>%
+      mutate(
+        x = is.timepoint(datetime),
+        y = is.instant(date),
+        z = is.timepoint(integer)
+      ) %>%
       collect(),
     test_df
   )


### PR DESCRIPTION
Implements `is.Date()`, `is.POSIXct()`, `is.timepoint()`, and `is.instant()` from the lubridate package.

There is also `lubridate::is.POSIXt()` and `lubridate::is.POSIXlt()`...these are a bit more niche and I thought they might be confusing if implemented here.

Another question I had while implementing this...can/should these return an `Expression$scalar()`? This isn't how the other `is.*()` functions are done but maybe this makes a difference?

``` r
library(arrow, warn.conflicts = FALSE)
library(lubridate, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "Pacific/Marquesas")

test_df <- tibble::tibble(
  datetime = c(test_date, NA) + 1,
  date = c(as.Date("2021-09-09"), NA)
)

RecordBatch$create(test_df) %>% 
  mutate(is.POSIXct(datetime), is.POSIXct(date)) %>% 
  collect()
#> # A tibble: 2 × 4
#>   datetime            date       `is.POSIXct(datetime)` `is.POSIXct(date)`
#>   <dttm>              <date>     <lgl>                  <lgl>             
#> 1 2017-01-01 00:00:12 2021-09-09 TRUE                   FALSE             
#> 2 NA                  NA         TRUE                   FALSE

RecordBatch$create(test_df) %>% 
  mutate(is.Date(datetime), is.Date(date)) %>% 
  collect()
#> # A tibble: 2 × 4
#>   datetime            date       `is.Date(datetime)` `is.Date(date)`
#>   <dttm>              <date>     <lgl>               <lgl>          
#> 1 2017-01-01 00:00:12 2021-09-09 FALSE               TRUE           
#> 2 NA                  NA         FALSE               TRUE

RecordBatch$create(test_df) %>% 
  mutate(is.instant(datetime), is.instant(date)) %>% 
  collect()
#> # A tibble: 2 × 4
#>   datetime            date       `is.instant(datetime)` `is.instant(date)`
#>   <dttm>              <date>     <lgl>                  <lgl>             
#> 1 2017-01-01 00:00:12 2021-09-09 TRUE                   TRUE              
#> 2 NA                  NA         TRUE                   TRUE

RecordBatch$create(test_df) %>% 
  mutate(is.timepoint(datetime), is.timepoint(date)) %>% 
  collect()
#> # A tibble: 2 × 4
#>   datetime            date       `is.timepoint(datetime)` `is.timepoint(date)`
#>   <dttm>              <date>     <lgl>                    <lgl>               
#> 1 2017-01-01 00:00:12 2021-09-09 TRUE                     TRUE                
#> 2 NA                  NA         TRUE                     TRUE
```

<sup>Created on 2021-11-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>