### PR TITLE
MINOR: [C++] Avoid linting files outside of the source tree(s)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -233,17 +233,22 @@ find_program(CPPLINT_BIN
              HINTS ${BUILD_SUPPORT_DIR})
 message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
 
+set(COMMON_LINT_OPTIONS
+    --exclude_globs
+    ${LINT_EXCLUSIONS_FILE}
+    --source_dir
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    --source_dir
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples
+    --source_dir
+    ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+
 add_custom_target(lint
                   ${PYTHON_EXECUTABLE}
                   ${BUILD_SUPPORT_DIR}/run_cpplint.py
                   --cpplint_binary
                   ${CPPLINT_BIN}
-                  --exclude_globs
-                  ${LINT_EXCLUSIONS_FILE}
-                  --source_dir
-                  ${CMAKE_CURRENT_SOURCE_DIR}/src
-                  --source_dir
-                  ${CMAKE_CURRENT_SOURCE_DIR}/examples
+                  ${COMMON_LINT_OPTIONS}
                   ${ARROW_LINT_QUIET})
 
 #
@@ -256,12 +261,7 @@ if(${CLANG_FORMAT_FOUND})
                     ${BUILD_SUPPORT_DIR}/run_clang_format.py
                     --clang_format_binary
                     ${CLANG_FORMAT_BIN}
-                    --exclude_globs
-                    ${LINT_EXCLUSIONS_FILE}
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/src
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
+                    ${COMMON_LINT_OPTIONS}
                     --fix
                     ${ARROW_LINT_QUIET})
 
@@ -271,12 +271,7 @@ if(${CLANG_FORMAT_FOUND})
                     ${BUILD_SUPPORT_DIR}/run_clang_format.py
                     --clang_format_binary
                     ${CLANG_FORMAT_BIN}
-                    --exclude_globs
-                    ${LINT_EXCLUSIONS_FILE}
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/src
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
+                    ${COMMON_LINT_OPTIONS}
                     ${ARROW_LINT_QUIET})
 endif()
 
@@ -300,14 +295,9 @@ if(${CLANG_TIDY_FOUND})
                     ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
                     --clang_tidy_binary
                     ${CLANG_TIDY_BIN}
-                    --exclude_globs
-                    ${LINT_EXCLUSIONS_FILE}
                     --compile_commands
                     ${CMAKE_BINARY_DIR}/compile_commands.json
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/src
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
+                    ${COMMON_LINT_OPTIONS}
                     --fix
                     ${ARROW_LINT_QUIET})
 
@@ -317,14 +307,9 @@ if(${CLANG_TIDY_FOUND})
                     ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
                     --clang_tidy_binary
                     ${CLANG_TIDY_BIN}
-                    --exclude_globs
-                    ${LINT_EXCLUSIONS_FILE}
                     --compile_commands
                     ${CMAKE_BINARY_DIR}/compile_commands.json
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/src
-                    --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
+                    ${COMMON_LINT_OPTIONS}
                     ${ARROW_LINT_QUIET})
 endif()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -241,7 +241,9 @@ add_custom_target(lint
                   --exclude_globs
                   ${LINT_EXCLUSIONS_FILE}
                   --source_dir
-                  ${CMAKE_CURRENT_SOURCE_DIR}
+                  ${CMAKE_CURRENT_SOURCE_DIR}/src
+                  --source_dir
+                  ${CMAKE_CURRENT_SOURCE_DIR}/examples
                   ${ARROW_LINT_QUIET})
 
 #
@@ -257,7 +259,9 @@ if(${CLANG_FORMAT_FOUND})
                     --exclude_globs
                     ${LINT_EXCLUSIONS_FILE}
                     --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
                     --fix
                     ${ARROW_LINT_QUIET})
 
@@ -270,7 +274,9 @@ if(${CLANG_FORMAT_FOUND})
                     --exclude_globs
                     ${LINT_EXCLUSIONS_FILE}
                     --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
                     ${ARROW_LINT_QUIET})
 endif()
 
@@ -299,7 +305,9 @@ if(${CLANG_TIDY_FOUND})
                     --compile_commands
                     ${CMAKE_BINARY_DIR}/compile_commands.json
                     --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
                     --fix
                     ${ARROW_LINT_QUIET})
 
@@ -314,7 +322,9 @@ if(${CLANG_TIDY_FOUND})
                     --compile_commands
                     ${CMAKE_BINARY_DIR}/compile_commands.json
                     --source_dir
-                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/examples
                     ${ARROW_LINT_QUIET})
 endif()
 

--- a/cpp/build-support/lint_exclusions.txt
+++ b/cpp/build-support/lint_exclusions.txt
@@ -1,8 +1,6 @@
 *_generated*
 *.grpc.fb.*
-*apidoc/*
 *arrowExports.cpp*
-*build_support/*
 *parquet_constants.*
 *parquet_types.*
 *pyarrow_api.h

--- a/cpp/build-support/run_clang_format.py
+++ b/cpp/build-support/run_clang_format.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
                         "that should be excluded from the checks")
     parser.add_argument("--source_dir",
                         required=True,
+                        action="append",
                         help="Root directory of the source code")
     parser.add_argument("--fix", default=False,
                         action="store_true",
@@ -78,8 +79,9 @@ if __name__ == "__main__":
             exclude_globs.extend(line.strip() for line in f)
 
     formatted_filenames = []
-    for path in lintutils.get_sources(arguments.source_dir, exclude_globs):
-        formatted_filenames.append(str(path))
+    for source_dir in arguments.source_dir:
+        for path in lintutils.get_sources(source_dir, exclude_globs):
+            formatted_filenames.append(str(path))
 
     if arguments.fix:
         if not arguments.quiet:

--- a/cpp/build-support/run_clang_tidy.py
+++ b/cpp/build-support/run_clang_tidy.py
@@ -83,6 +83,7 @@ if __name__ == "__main__":
                         help="compile_commands.json to pass clang-tidy")
     parser.add_argument("--source_dir",
                         required=True,
+                        action="append",
                         help="Root directory of the source code")
     parser.add_argument("--fix", default=False,
                         action="store_true",
@@ -100,8 +101,9 @@ if __name__ == "__main__":
             exclude_globs.append(line.strip())
 
     linted_filenames = []
-    for path in lintutils.get_sources(arguments.source_dir, exclude_globs):
-        linted_filenames.append(path)
+    for source_dir in arguments.source_dir:
+        for path in lintutils.get_sources(source_dir, exclude_globs):
+            linted_filenames.append(path)
 
     if not arguments.quiet:
         msg = 'Tidying {}' if arguments.fix else 'Checking {}'

--- a/cpp/build-support/run_cpplint.py
+++ b/cpp/build-support/run_cpplint.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
                         "that should be excluded from the checks")
     parser.add_argument("--source_dir",
                         required=True,
+                        action="append",
                         help="Root directory of the source code")
     parser.add_argument("--quiet", default=False,
                         action="store_true",
@@ -79,8 +80,9 @@ if __name__ == "__main__":
             exclude_globs.extend(line.strip() for line in f)
 
     linted_filenames = []
-    for path in lintutils.get_sources(arguments.source_dir, exclude_globs):
-        linted_filenames.append(str(path))
+    for source_dir in arguments.source_dir:
+        for path in lintutils.get_sources(source_dir, exclude_globs):
+            linted_filenames.append(str(path))
 
     cmd = [
         arguments.cpplint_binary,


### PR DESCRIPTION
The base `cpp` directory can typically contain build directories and other foreign files.
Only lint the C++ source files in `cpp/src` and `cpp/examples`.