### PR TITLE
ARROW-14496: [Docs] Create relative links for R / JS / C/Glib references in the sphinx toctree using stub pages

### DIFF
--- a/docs/source/c_glib/index.rst
+++ b/docs/source/c_glib/index.rst
@@ -15,7 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-C/Glib stub page
-================
+C/Glib docs
+===========
 
 Stub page for the C/Glib docs; actual source is located in c_glib/doc/ sub-directory.

--- a/docs/source/c_glib/index.rst
+++ b/docs/source/c_glib/index.rst
@@ -1,0 +1,21 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+C/Glib stub page
+================
+
+Stub page for the C/Glib docs; actual source is located in c_glib/doc/ sub-directory.

--- a/docs/source/c_glib/index.rst
+++ b/docs/source/c_glib/index.rst
@@ -15,7 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-C/Glib docs
+C/GLib docs
 ===========
 
-Stub page for the C/Glib docs; actual source is located in c_glib/doc/ sub-directory.
+Stub page for the C/GLib docs; actual source is located in c_glib/doc/ sub-directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,16 +41,16 @@ target environment.**
    :maxdepth: 1
    :caption: Supported Environments
 
-   C/GLib <https://arrow.apache.org/docs/c_glib/>
+   C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/master/csharp/README.md>
    Go <https://godoc.org/github.com/apache/arrow/go/arrow>
    Java <java/index>
-   JavaScript <https://arrow.apache.org/docs/js/>
+   JavaScript <js/index>
    Julia <https://github.com/apache/arrow/blob/master/julia/Arrow/README.md>
    MATLAB <https://github.com/apache/arrow/blob/master/matlab/README.md>
    Python <python/index>
-   R <https://arrow.apache.org/docs/r/>
+   R <r/index>
    Ruby <https://github.com/apache/arrow/blob/master/ruby/README.md>
    Rust <https://docs.rs/crate/arrow/>
    status

--- a/docs/source/java/reference/index.rst
+++ b/docs/source/java/reference/index.rst
@@ -15,17 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-Java Implementation
-===================
+Java Reference (javadoc)
+========================
 
-This is the documentation of the Java API of Apache Arrow. For more details
-on the Arrow format and other language bindings see the :doc:`parent documentation <../index>`.
-
-.. toctree::
-   :maxdepth: 2
-
-   vector
-   vector_schema_root
-   ipc
-   algorithm
-   Reference (javadoc) <reference/index>
+Stub page for the Java reference docs; actual source is located in the java/ directory.

--- a/docs/source/js/index.rst
+++ b/docs/source/js/index.rst
@@ -1,0 +1,21 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+JS stub page
+===========
+
+Stub page for the JavaScript docs; actual source is located in js/ sub-directory.

--- a/docs/source/js/index.rst
+++ b/docs/source/js/index.rst
@@ -15,7 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-JS stub page
-===========
+JavaScript docs
+===============
 
 Stub page for the JavaScript docs; actual source is located in js/ sub-directory.

--- a/docs/source/r/index.rst
+++ b/docs/source/r/index.rst
@@ -1,0 +1,21 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+R stub page
+===========
+
+Stub page for the R docs; actual source is located in r/ sub-directory.

--- a/docs/source/r/index.rst
+++ b/docs/source/r/index.rst
@@ -15,7 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-R stub page
-===========
+R docs
+======
 
 Stub page for the R docs; actual source is located in r/ sub-directory.


### PR DESCRIPTION
This will create dummy pages like `/r/index.html` which can be used for sphinx to link to, but which should not be added to the actual hosted files for the arrow site (they have to be overwritten by the index.html files of the respective proper doc builds for R, js and C/Glib).