### PR TITLE
ARROW-14570: [Docs][C++][Python] Suggest using -DARROW_INSTALL_NAME_RPATH=OFF on MacOS

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -283,6 +283,13 @@ environment variable (which requires the `locales` package or equivalent):
    On MacOS it is suggested to use ``-DARROW_INSTALL_NAME_RPATH=OFF`` to
    avoid issues at link time.
 
+   Likely error message that is a result of not setting this option
+   is:
+
+   .. code:: console
+
+      E     Reason: tried: '/opt/homebrew/lib/libarrow.800.dylib' (no such file), '/opt/homebrew/lib/libarrow.800.dylib' (no such file), '/usr/local/lib/libarrow.800.dylib' (no such file), '/usr/lib/libarrow.800.dylib' (no such file)
+
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -278,6 +278,11 @@ environment variable (which requires the `locales` package or equivalent):
 
    $ export LC_ALL="en_US.UTF-8"
 
+.. note::
+
+   On MacOS it is suggested to use ``-DARROW_INSTALL_NAME_RPATH=OFF`` to
+   avoid issues at link time.
+
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -334,6 +334,13 @@ virtualenv) enables cmake to choose the python executable which you are using.
    On MacOS it is suggested to use ``-DARROW_INSTALL_NAME_RPATH=OFF`` to
    avoid issues at link time.
 
+   Likely error message that is a result of not setting this option
+   is:
+
+   .. code:: console
+
+      E     Reason: tried: '/opt/homebrew/lib/libarrow.800.dylib' (no such file), '/opt/homebrew/lib/libarrow.800.dylib' (no such file), '/usr/local/lib/libarrow.800.dylib' (no such file), '/usr/lib/libarrow.800.dylib' (no such file)
+
 For any other C++ build challenges, see :ref:`cpp-development`.
 
 In case you may need to rebuild the C++ part due to errors in the process it is

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -329,6 +329,11 @@ virtualenv) enables cmake to choose the python executable which you are using.
    instead of ``-DPython3_EXECUTABLE``. See `cmake documentation <https://cmake.org/cmake/help/latest/module/FindPython3.html#artifacts-specification>`_
    for more details.
 
+.. note::
+
+   On MacOS it is suggested to use ``-DARROW_INSTALL_NAME_RPATH=OFF`` to
+   avoid issues at link time.
+
 For any other C++ build challenges, see :ref:`cpp-development`.
 
 In case you may need to rebuild the C++ part due to errors in the process it is


### PR DESCRIPTION
Add note to C++ and Python dev doc suggesting the use of `-DARROW_INSTALL_NAME_RPATH=OFF` when doing development on MacOS.