### PR TITLE
ARROW-14584: [Python][CI] Python sdist installation fails with latest setuptools 58.5

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,8 @@
 [build-system]
 requires = [
     "cython >= 0.29",
-    "numpy>=1.16.6; python_version<'3.9'",
+    "numpy==1.16.6; python_version<'3.8'",
+    "numpy==1.17.3; python_version=='3.8'",
     "numpy>=1.19.4; python_version=='3.9'",
     "numpy>=1.21.3; python_version>'3.9'",
     "setuptools < 58.5",  # ARROW-14584

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,9 +18,9 @@
 [build-system]
 requires = [
     "cython >= 0.29",
-    "numpy==1.16.6; python_version<'3.9'",
-    "numpy==1.19.4; python_version=='3.9'",
-    "numpy==1.21.3; python_version>'3.9'",
+    "numpy>=1.16.6; python_version<'3.9'",
+    "numpy>=1.19.4; python_version=='3.9'",
+    "numpy>=1.21.3; python_version>'3.9'",
     "setuptools < 58.5",  # ARROW-14584
     "setuptools_scm",
     "wheel"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "numpy==1.16.6; python_version<'3.9'",
     "numpy==1.19.4; python_version=='3.9'",
     "numpy==1.21.3; python_version>'3.9'",
-    "setuptools",
+    "setuptools < 58.5",  # ARROW-14584
     "setuptools_scm",
     "wheel"
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,8 +20,8 @@ requires = [
     "cython >= 0.29",
     "numpy==1.16.6; python_version<'3.8'",
     "numpy==1.17.3; python_version=='3.8'",
-    "numpy>=1.19.4; python_version=='3.9'",
-    "numpy>=1.21.3; python_version>'3.9'",
+    "numpy==1.19.4; python_version=='3.9'",
+    "numpy==1.21.3; python_version>'3.9'",
     "setuptools < 58.5",  # ARROW-14584
     "setuptools_scm",
     "wheel"

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -23,6 +23,4 @@ pandas<1.1.0;  platform_system == "Darwin"  and platform_machine != "arm64"   an
 pandas;        platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.8"
 pandas;        platform_system == "Darwin"  and platform_machine == "arm64"
 pandas<1.1.0;  platform_system == "Windows"                                   and python_version <  "3.8"
-pandas;        platform_system == "Windows"                                   and python_version >= "3.8" and python_version <= "3.9"
-
-# TODO(kszucs): remove the python_version <= "3.9" constraint once https://github.com/scipy/oldest-supported-numpy/pull/27 gets merged
+pandas;        platform_system == "Windows"                                   and python_version >= "3.8"


### PR DESCRIPTION
This patch should go to the 6.0.1 release.