### PR TITLE
ARROW-14585: [C++] Find libgrpc++_reflection via pkg-config

### DIFF
--- a/cpp/cmake_modules/FindgRPCAlt.cmake
+++ b/cpp/cmake_modules/FindgRPCAlt.cmake
@@ -68,8 +68,8 @@ if(GRPCPP_PC_FOUND)
   endif()
   find_library(GRPCPP_REFLECTION_IMPORTED_LOCATION
                NAMES grpc++_reflection ${GRPCPP_REFLECTION_LIB_NAME}
-               HINTS ${GRPCPP_IMPORTED_DIRECTORY}
-               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
+               PATHS ${GRPCPP_IMPORTED_DIRECTORY}
+               NO_DEFAULT_PATH)
 else()
   set(gRPCAlt_FOUND FALSE)
 endif()

--- a/cpp/cmake_modules/FindgRPCAlt.cmake
+++ b/cpp/cmake_modules/FindgRPCAlt.cmake
@@ -56,6 +56,20 @@ if(GRPCPP_PC_FOUND)
     list(APPEND gRPCAlt_FIND_PACKAGE_ARGS VERSION_VAR gRPCAlt_VERSION)
   endif()
   find_package_handle_standard_args(${gRPCAlt_FIND_PACKAGE_ARGS})
+
+  # gRPC does not expose the reflection library via pkg-config, but it should be alongside the main library
+  get_filename_component(GRPCPP_IMPORTED_DIRECTORY ${GRPCPP_IMPORTED_LOCATION} DIRECTORY)
+  if(ARROW_GRPC_USE_SHARED)
+    set(GRPCPP_REFLECTION_LIB_NAME
+        "${CMAKE_SHARED_LIBRARY_PREFIX}grpc++_reflection${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  else()
+    set(GRPCPP_REFLECTION_LIB_NAME
+        "${CMAKE_STATIC_LIBRARY_PREFIX}grpc++_reflection${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  endif()
+  find_library(GRPCPP_REFLECTION_IMPORTED_LOCATION
+               NAMES grpc++_reflection ${GRPCPP_REFLECTION_LIB_NAME}
+               HINTS ${GRPCPP_IMPORTED_DIRECTORY}
+               PATH_SUFFIXES ${ARROW_LIBRARY_PATH_SUFFIXES})
 else()
   set(gRPCAlt_FOUND FALSE)
 endif()
@@ -69,6 +83,12 @@ if(gRPCAlt_FOUND)
                                    "${GRPCPP_INCLUDE_DIRECTORIES}"
                                    INTERFACE_LINK_LIBRARIES "${GRPCPP_LINK_LIBRARIES}"
                                    INTERFACE_LINK_OPTIONS "${GRPCPP_LINK_OPTIONS}")
+
+  add_library(gRPC::grpc++_reflection UNKNOWN IMPORTED)
+  set_target_properties(gRPC::grpc++_reflection
+                        PROPERTIES IMPORTED_LOCATION
+                                   "${GRPCPP_REFLECTION_IMPORTED_LOCATION}"
+                                   INTERFACE_LINK_LIBRARIES gRPC::grpc++)
 
   add_executable(gRPC::grpc_cpp_plugin IMPORTED)
   set_target_properties(gRPC::grpc_cpp_plugin PROPERTIES IMPORTED_LOCATION

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -67,6 +67,8 @@ string(REPLACE "-Werror " " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # Probe the version of gRPC being used to see if it supports disabling server
 # verification when using TLS.
+# gRPC's pkg-config file neglects to specify pthreads.
+find_package(Threads REQUIRED)
 function(test_grpc_version DST_VAR DETECT_VERSION TEST_FILE)
   if(NOT DEFINED ${DST_VAR})
     message(STATUS "Checking support for TlsCredentialsOptions (gRPC >= ${DETECT_VERSION})..."
@@ -80,7 +82,7 @@ function(test_grpc_version DST_VAR DETECT_VERSION TEST_FILE)
     try_compile(HAS_GRPC_VERSION ${CMAKE_CURRENT_BINARY_DIR}/try_compile
                 SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/${TEST_FILE}"
                 CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CURRENT_INCLUDE_DIRECTORIES}"
-                LINK_LIBRARIES gRPC::grpc++
+                LINK_LIBRARIES gRPC::grpc++ Threads::Threads
                 OUTPUT_VARIABLE TLS_CREDENTIALS_OPTIONS_CHECK_OUTPUT CXX_STANDARD 11)
     if(HAS_GRPC_VERSION)
       set(${DST_VAR}


### PR DESCRIPTION
gRPC does not ship a pkg-config file for the reflection library, so assume it's next to the discovered gRPC library.

Also, gRPC's pkg-config file neglects to include pthreads, so manually specify that as well, when doing gRPC feature detection. (Otherwise we incorrectly conclude that gRPC doesn't support advanced TLS options.)