### PR TITLE
ARROW-14968: [Python] Pin numpy build dependency using oldest-supported-numpy

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,6 @@
 [build-system]
 requires = [
     "cython >= 0.29",
-    "numpy >= 1.16.6",
     "oldest-supported-numpy",
     "setuptools_scm",
     "setuptools",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,6 +20,6 @@ requires = [
     "cython >= 0.29",
     "oldest-supported-numpy",
     "setuptools_scm",
-    "setuptools",
+    "setuptools >= 38.6.0",
     "wheel"
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,11 +18,8 @@
 [build-system]
 requires = [
     "cython >= 0.29",
-    "numpy==1.16.6; python_version<'3.8'",
-    "numpy==1.17.3; python_version=='3.8'",
-    "numpy==1.19.4; python_version=='3.9'",
-    "numpy==1.21.3; python_version>'3.9'",
-    "setuptools < 58.5",  # ARROW-14584
+    "oldest-supported-numpy",
     "setuptools_scm",
+    "setuptools",
     "wheel"
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,7 @@
 [build-system]
 requires = [
     "cython >= 0.29",
+    "numpy >= 1.16.6",
     "oldest-supported-numpy",
     "setuptools_scm",
     "setuptools",

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
 cython>=0.29
-numpy>=1.16.6
-setuptools>=38.6.0
+oldest-supported-numpy
 setuptools_scm
+setuptools>=38.6.0

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,5 +1,4 @@
 cython>=0.29
-numpy>=1.16.6
 oldest-supported-numpy
 setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,5 @@
 cython>=0.29
+numpy>=1.16.6
 oldest-supported-numpy
 setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,16 +1,5 @@
 cython>=0.29.11
-setuptools>=58
+oldest-supported-numpy
 setuptools_scm
+setuptools>=58
 wheel
-numpy==1.19.4; platform_system == "Linux"   and platform_machine == "aarch64" and python_version <= "3.9"
-numpy==1.21.3; platform_system == "Linux"   and platform_machine == "aarch64" and python_version >  "3.9"
-numpy==1.16.6; platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.9"
-numpy==1.19.4; platform_system == "Linux"   and platform_machine != "aarch64" and python_version == "3.9"
-numpy==1.21.3; platform_system == "Linux"   and platform_machine != "aarch64" and python_version >  "3.9"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine == "arm64"
-numpy==1.16.6; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version <  "3.8"
-numpy==1.19.4; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.8" and python_version <= "3.9"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >  "3.9"
-numpy==1.16.6; platform_system == "Windows"                                   and python_version <  "3.9"
-numpy==1.19.4; platform_system == "Windows"                                   and python_version == "3.9"
-numpy==1.21.3; platform_system == "Windows"                                   and python_version >  "3.9"

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,5 +1,4 @@
 cython>=0.29.11
-numpy>=1.16.6
 oldest-supported-numpy
 setuptools_scm
 setuptools>=58

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,5 @@
 cython>=0.29.11
+numpy>=1.16.6
 oldest-supported-numpy
 setuptools_scm
 setuptools>=58

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -6,16 +6,6 @@ pytest
 pytest-lazy-fixture
 pytz
 
-numpy==1.19.5; platform_system == "Linux"   and platform_machine == "aarch64" and python_version <  "3.7"
-numpy==1.21.3; platform_system == "Linux"   and platform_machine == "aarch64" and python_version >= "3.7"
-numpy==1.19.5; platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.9"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine == "arm64"
-numpy==1.19.5; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.9"
-numpy==1.19.5; platform_system == "Windows"                                   and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Windows"                                   and python_version >= "3.9"
-
 pandas<1.1.0;  platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.8"
 pandas;        platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.8"
 pandas;        platform_system == "Linux"   and platform_machine == "aarch64"

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -6,6 +6,16 @@ pytest
 pytest-lazy-fixture
 pytz
 
+numpy==1.19.5; platform_system == "Linux"   and platform_machine == "aarch64" and python_version <  "3.7"
+numpy==1.21.3; platform_system == "Linux"   and platform_machine == "aarch64" and python_version >= "3.7"
+numpy==1.19.5; platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.9"
+numpy==1.21.3; platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.9"
+numpy==1.21.3; platform_system == "Darwin"  and platform_machine == "arm64"
+numpy==1.19.5; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version <  "3.9"
+numpy==1.21.3; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.9"
+numpy==1.19.5; platform_system == "Windows"                                   and python_version <  "3.9"
+numpy==1.21.3; platform_system == "Windows"                                   and python_version >= "3.9"
+
 pandas<1.1.0;  platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.8"
 pandas;        platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.8"
 pandas;        platform_system == "Linux"   and platform_machine == "aarch64"


### PR DESCRIPTION
`oldest-supported-numpy` is a meta-package which defines the numpy version pins across platforms and python versions, this should make the python package maintenance easier and more future-proof.

cc @jorisvandenbossche 