### PR TITLE
ARROW-14578: [Format][Documentation] Update union-of-structs doc

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -468,7 +468,7 @@ class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
     std::vector<std::shared_ptr<Field>> fields = {f0};
     auto schema = std::make_shared<Schema>(fields);
 
-    auto batch = RecordBatch::Make(schema, 0, {array});
+    auto batch = RecordBatch::Make(schema, array->length(), {array});
     CheckRoundtrip(*batch, options, IpcReadOptions::Defaults(), buffer_size);
   }
 
@@ -485,15 +485,15 @@ TEST(MetadataVersion, ForwardsCompatCheck) {
 
 class TestWriteRecordBatch : public ::testing::Test, public IpcTestFixture {
  public:
-  void SetUp() { IpcTestFixture::SetUp(); }
-  void TearDown() { IpcTestFixture::TearDown(); }
+  void SetUp() override { IpcTestFixture::SetUp(); }
+  void TearDown() override { IpcTestFixture::TearDown(); }
 };
 
 class TestIpcRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*>,
                          public IpcTestFixture {
  public:
-  void SetUp() { IpcTestFixture::SetUp(); }
-  void TearDown() { IpcTestFixture::TearDown(); }
+  void SetUp() override { IpcTestFixture::SetUp(); }
+  void TearDown() override { IpcTestFixture::TearDown(); }
 
   void TestMetadataVersion(MetadataVersion expected_version) {
     std::shared_ptr<RecordBatch> batch;
@@ -604,6 +604,58 @@ TEST_P(TestIpcRoundTrip, ZeroLengthArrays) {
 
   CheckRoundtrip(bin_array);
   CheckRoundtrip(bin_array2);
+}
+
+TEST_F(TestIpcRoundTrip, SparseUnionOfStructs) {
+  auto storage_type = struct_({
+      field("i", int32()),
+      field("f", float32()),
+      field("s", utf8()),
+  });
+  auto storage =
+      arrow::internal::checked_pointer_cast<StructArray>(ArrayFromJSON(storage_type,
+                                                                       R"([
+    {"i": 0, "f": 0.0, "s": "a"},
+    {"i": 1, "f": 0.5, "s": "b"},
+    {"i": 2, "f": 1.5, "s": "c"},
+    {"i": 3, "f": 3.0, "s": "d"}
+  ])"));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto m01, StructArray::Make({storage->field(0), storage->field(1)},
+                                  {storage_type->field(0), storage_type->field(1)}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto m12, StructArray::Make({storage->field(1), storage->field(2)},
+                                  {storage_type->field(1), storage_type->field(2)}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto m20, StructArray::Make({storage->field(2), storage->field(0)},
+                                  {storage_type->field(2), storage_type->field(0)}));
+
+  auto ids = ArrayFromJSON(int8(), "[1, 12, 20, 1]");
+
+  ASSERT_OK_AND_ASSIGN(
+      auto sparse,
+      SparseUnionArray::Make(*ids, {m01, m12, m20}, {"m01", "m12", "m20"}, {01, 12, 20}));
+
+  auto expected = ArrayFromJSON(sparse_union(
+                                    {
+                                        field("m01", m01->type()),
+                                        field("m12", m12->type()),
+                                        field("m20", m20->type()),
+                                    },
+                                    {01, 12, 20}),
+                                R"([
+    [1,  {"i": 0,   "f": 0.0}],
+    [12, {"f": 0.5, "s": "b"}],
+    [20, {"s": "c", "i": 2  }],
+    [1,  {"i": 3,   "f": 3.0}]
+  ])");
+
+  AssertArraysEqual(*expected, *sparse);
+
+  CheckRoundtrip(sparse);
 }
 
 TEST_F(TestWriteRecordBatch, WriteWithCompression) {

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -607,7 +607,7 @@ TEST_P(TestIpcRoundTrip, ZeroLengthArrays) {
   CheckRoundtrip(bin_array2);
 }
 
-TEST_F(TestIpcRoundTrip, SparseUnionOfStructs) {
+TEST_F(TestIpcRoundTrip, SparseUnionOfStructsWithReusedBuffers) {
   auto storage_type = struct_({
       field("i", int32()),
       field("f", float32()),

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -690,16 +690,6 @@ Only the slot in the array corresponding to the type index is considered. All
 "unselected" values are ignored and could be any semantically correct array
 value.
 
-.. note:: Critically, the sparse union allows shared columns to be reused between union members
-   in the ubiquitous union-of-structs with non-overlapping-fields use case.  For example the union::
-
-       SparseUnion<m1: Struct<i: Int32>,
-                   m2: Struct<i: Int32, f: Float32, s: VarBinary>,
-                   m3: Struct<f: Float32, s: VarBinary>>
-
-   could be backed by just three columns (one for each type) since no union member requires more
-   than one of each.
-
 Null Layout
 -----------
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -557,12 +557,12 @@ each value. Its physical layout is as follows:
   union has a corresponding type id whose values are found in this
   buffer. A union with more than 127 possible types can be modeled as
   a union of unions.
-* Offsets buffer: A buffer of signed int32 values indicating the
+* Offsets buffer: A buffer of signed Int32 values indicating the
   relative offset into the respective child array for the type in a
   given slot. The respective offsets for each child value array must
   be in order / increasing.
 
-**Example Layout: ``DenseUnion<f: float, i: int32>``**
+**Example Layout: ``DenseUnion<f: Float32, i: Int32>``**
 
 For the union array: ::
 
@@ -584,7 +584,7 @@ will have the following layout: ::
       | 0        | 1           | 2          | 0           | unspecified |
 
     * Children arrays:
-      * Field-0 array (f: float):
+      * Field-0 array (f: Float32):
         * Length: 2, Null count: 1
         * Validity bitmap buffer: 00000101
 
@@ -595,7 +595,7 @@ will have the following layout: ::
           | 1.2, null, 3.4 | unspecified |
 
 
-      * Field-1 array (i: int32):
+      * Field-1 array (i: Int32):
         * Length: 1, Null count: 0
         * Validity bitmap buffer: Not required
 
@@ -619,7 +619,7 @@ use cases:
 * A sparse union is more amenable to vectorized expression evaluation in some use cases.
 * Equal-length arrays can be interpreted as a union by only defining the types array.
 
-**Example layout: ``SparseUnion<i: Int32, f: Float, s: VarBinary>``**
+**Example layout: ``SparseUnion<i: Int32, f: Float32, s: VarBinary>``**
 
 For the union array: ::
 
@@ -650,7 +650,7 @@ will have the following layout: ::
           |------------|-------------|-------------|-------------|-------------|--------------|-----------------------|
           | 5          | unspecified | unspecified | unspecified | 4           |  unspecified | unspecified (padding) |
 
-      * f (float):
+      * f (Float32):
         * Length: 6, Null count: 4
         * Validity bitmap buffer:
 
@@ -672,7 +672,7 @@ will have the following layout: ::
           |--------------------------|-----------------------|
           | 00100100                 | 0 (padding)           |
 
-        * Offsets buffer (int32)
+        * Offsets buffer (Int32)
 
           | Bytes 0-3  | Bytes 4-7   | Bytes 8-11  | Bytes 12-15 | Bytes 16-19 | Bytes 20-23 | Bytes 24-27 | Bytes 28-63 |
           |------------|-------------|-------------|-------------|-------------|-------------|-------------|-------------|


### PR DESCRIPTION
Demoted the section on `union-of-structs with non-overlapping-fields` to a `..note` and made it slightly more verbose, also made the doc slightly more consistent between dense and sparse.