### PR TITLE
MINOR: [CI] Fix conda-integration GHA job

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -29,6 +29,7 @@ ARG go=1.15
 COPY ci/conda_env_archery.txt /arrow/ci/
 RUN conda install -q \
         --file arrow/ci/conda_env_archery.txt \
+        "python>=3.7" \
         numpy \
         compilers \
         maven=${maven} \


### PR DESCRIPTION
The conda-integration job is currenly failing on Github Actions (but I'm not able to reproduce locally), being unable to find a correct solution when installing the conda dependencies for Archery:
https://github.com/apache/arrow/runs/4107211303?check_suite_focus=true

Log excerpt:
```
#8 [3/6] RUN conda install -q         --file arrow/ci/conda_env_archery.txt         numpy         compilers         maven=3.5         nodejs=14         yarn         openjdk=8 &&     conda clean --all --force-pkgs-dirs
#8 sha256:c96c59f55397d6e90bff7d2897eb1247ddfa19b8ffab8019be5ec0bbfdab7dc8
#8 0.450 mesg: ttyname failed: Inappropriate ioctl for device
#8 2.279 Collecting package metadata (current_repodata.json): ...working... done
#8 10.18 Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
#8 10.19 Collecting package metadata (repodata.json): ...working... done
#8 41.80 Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
#8 79.28 
#8 79.28 PackagesNotFoundError: The following packages are not available from current channels:
#8 79.28 
#8 79.28   - python=3.1
#8 79.28 
```

Work around by forcing a reasonable minimum Python version.