### PR TITLE
ARROW-14051 [R] Handle conditionals enclosing aggregate expressions

### DIFF
--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -218,8 +218,16 @@ summarize_eval <- function(name, quosure, ctx, hash, recurse = FALSE) {
   } else if (all(inner_agg_exprs)) {
     # Something like: fun(agg(x), agg(y))
     # So based on the aggregations that have been extracted, mutate after
+    agg_field_refs <- make_field_refs(names(ctx$aggregations))
+    agg_field_types <- lapply(ctx$aggregations, function(x) x$data$type())
+
     mutate_mask <- arrow_mask(
-      list(selected_columns = make_field_refs(names(ctx$aggregations)))
+      list(
+        selected_columns = agg_field_refs,
+        .data = list(
+          schema = schema(!!! agg_field_types)
+        )
+      )
     )
     ctx$post_mutate[[name]] <- arrow_eval_or_stop(
       as_quosure(expr, ctx$quo_env),

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -879,3 +879,20 @@ test_that("summarize() handles group_by .drop", {
     )
   )
 })
+
+test_that("summarise() passes through type information for temporary columns", {
+  # applies to ifelse and case_when(), in which argument types are checked
+  # within a translated function (previously this failed because the appropriate
+  # schema was not available for n() > 1, mean(y), and mean(z))
+  compare_dplyr_binding(
+    .input %>%
+      group_by(x) %>%
+      summarise(r = ifelse(n() > 1, mean(y), mean(z))) %>%
+      collect(),
+    tibble(
+      x = c(0, 1, 1),
+      y = c(2, 3, 5),
+      z = c(8, 13, 21)
+    )
+  )
+})

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -887,7 +887,7 @@ test_that("summarise() passes through type information for temporary columns", {
   compare_dplyr_binding(
     .input %>%
       group_by(x) %>%
-      summarise(r = ifelse(n() > 1, mean(y), mean(z))) %>%
+      summarise(r = if_else(n() > 1, mean(y), mean(z))) %>%
       collect(),
     tibble(
       x = c(0, 1, 1),


### PR DESCRIPTION
This PR more correctly passes on type information for the temporary columns that are created when nested expressions exist. This isn't needed often, but occasionally the expression type is checked for the purposes of erroring or warning. The two examples where this happens are `ifelse()` and `case_when()`, which resulted in the following (valid) code pulling data into R with a confusing message:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

# motvating example
RecordBatch$create(x = c(0, 1, 1), y = c(2, 3, 5), z = c(8, 13, 21)) %>%
  group_by(x) %>%
  summarise(r = ifelse(n() > 1, mean(y), mean(z))) %>% 
  collect()
#> Warning: Error : Expression ifelse(..temp0 > 1, ..temp1, ..temp2) not supported
#> in Arrow; pulling data into R
#> # A tibble: 2 × 2
#>       x     r
#>   <dbl> <dbl>
#> 1     0     8
#> 2     1     4
```

After this PR, the above works without warning:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

# motvating example
RecordBatch$create(x = c(0, 1, 1), y = c(2, 3, 5), z = c(8, 13, 21)) %>%
  group_by(x) %>%
  summarise(r = ifelse(n() > 1, mean(y), mean(z))) %>% 
  collect()
#> # A tibble: 2 × 2
#>       x     r
#>   <dbl> <dbl>
#> 1     0     8
#> 2     1     4
```

I imagine I'm missing some of the complexity here...feel free to let me know!