### PR TITLE
ARROW-14598: [C++][Flight] Fix protoc generation dependency for example

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1470,6 +1470,7 @@ macro(build_protobuf)
 
   add_dependencies(toolchain protobuf_ep)
   add_dependencies(arrow::protobuf::libprotobuf protobuf_ep)
+  add_dependencies(arrow::protobuf::protoc protobuf_ep)
 
   list(APPEND ARROW_BUNDLED_STATIC_LIBS arrow::protobuf::libprotobuf)
 endmacro()

--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -52,18 +52,17 @@ if(ARROW_FLIGHT)
 
   set(FLIGHT_EXAMPLE_PROTO "helloworld.proto")
   set(FLIGHT_EXAMPLE_PROTO_PATH "${CMAKE_CURRENT_LIST_DIR}")
-  set(FLIGHT_EXAMPLE_PROTO_DEPENDS ${FLIGHT_EXAMPLE_PROTO} ${ARROW_PROTOBUF_LIBPROTOBUF}
-                                   gRPC::grpc_cpp_plugin)
+  set(FLIGHT_EXAMPLE_PROTO_DEPENDS ${FLIGHT_EXAMPLE_PROTO} gRPC::grpc_cpp_plugin)
 
   add_custom_command(OUTPUT ${FLIGHT_EXAMPLE_GENERATED_PROTO_FILES}
                      COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${FLIGHT_EXAMPLE_PROTO_PATH}"
                              "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
                              "${FLIGHT_EXAMPLE_PROTO}"
-                     DEPENDS ${PROTO_EXAMPLE_PROTO_DEPENDS} ARGS
                      COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${FLIGHT_EXAMPLE_PROTO_PATH}"
                              "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
                              "--plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
-                             "${FLIGHT_EXAMPLE_PROTO}")
+                             "${FLIGHT_EXAMPLE_PROTO}"
+                     DEPENDS ${FLIGHT_EXAMPLE_PROTO_DEPENDS})
 
   add_custom_target(flight_grpc_example_gen ALL
                     DEPENDS ${FLIGHT_EXAMPLE_GENERATED_PROTO_FILES})


### PR DESCRIPTION
* DEPENDS variable name has a typo.
* ARROW_PROTOBUF_PROTOC doesn't depend on protobuf_ep with bundled Protobuf