### PR TITLE
ARROW-14577: [C++] Enable fine grained IO for async IPC reader 

### DIFF
--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -144,7 +144,8 @@ struct RangeCacheEntry {
 };
 
 struct ReadRangeCache::Impl {
-  std::shared_ptr<RandomAccessFile> file;
+  std::shared_ptr<RandomAccessFile> owned_file;
+  RandomAccessFile* file;
   IOContext ctx;
   CacheOptions options;
 
@@ -289,10 +290,12 @@ struct ReadRangeCache::LazyImpl : public ReadRangeCache::Impl {
   }
 };
 
-ReadRangeCache::ReadRangeCache(std::shared_ptr<RandomAccessFile> file, IOContext ctx,
+ReadRangeCache::ReadRangeCache(std::shared_ptr<RandomAccessFile> owned_file,
+                               RandomAccessFile* file, IOContext ctx,
                                CacheOptions options)
     : impl_(options.lazy ? new LazyImpl() : new Impl()) {
-  impl_->file = std::move(file);
+  impl_->owned_file = std::move(owned_file);
+  impl_->file = file;
   impl_->ctx = std::move(ctx);
   impl_->options = options;
 }

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -104,11 +104,17 @@ class ARROW_EXPORT ReadRangeCache {
 
   /// Construct a read cache with default
   explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, IOContext ctx)
-      : ReadRangeCache(file, std::move(ctx), CacheOptions::Defaults()) {}
+      : ReadRangeCache(file, file.get(), std::move(ctx), CacheOptions::Defaults()) {}
 
   /// Construct a read cache with given options
   explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, IOContext ctx,
-                          CacheOptions options);
+                          CacheOptions options)
+      : ReadRangeCache(file, file.get(), ctx, options) {}
+
+  /// Construct a read cache with an unowned file
+  ReadRangeCache(RandomAccessFile* file, IOContext ctx, CacheOptions options)
+      : ReadRangeCache(NULLPTR, file, ctx, options) {}
+
   ~ReadRangeCache();
 
   /// \brief Cache the given ranges in the background.
@@ -129,6 +135,9 @@ class ARROW_EXPORT ReadRangeCache {
  protected:
   struct Impl;
   struct LazyImpl;
+
+  ReadRangeCache(std::shared_ptr<RandomAccessFile> owned_file, RandomAccessFile* file,
+                 IOContext ctx, CacheOptions options);
 
   std::unique_ptr<Impl> impl_;
 };

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -311,6 +311,50 @@ Status ReadFieldsSubset(int64_t offset, int32_t metadata_length,
   return Status::OK();
 }
 
+Result<std::unique_ptr<Message>> ReadMessage(std::shared_ptr<Buffer> metadata,
+                                             std::shared_ptr<Buffer> body) {
+  std::unique_ptr<Message> result;
+  auto listener = std::make_shared<AssignMessageDecoderListener>(&result);
+  // If the user does not pass in a body buffer then we assume they are skipping it
+  MessageDecoder decoder(listener, default_memory_pool(), body == nullptr);
+
+  if (metadata->size() < decoder.next_required_size()) {
+    return Status::Invalid("metadata_length should be at least ",
+                           decoder.next_required_size());
+  }
+
+  ARROW_RETURN_NOT_OK(decoder.Consume(metadata));
+
+  switch (decoder.state()) {
+    case MessageDecoder::State::INITIAL:
+      // Metadata did not request a body so we better not have provided one
+      DCHECK_EQ(body, nullptr);
+      return std::move(result);
+    case MessageDecoder::State::METADATA_LENGTH:
+      return Status::Invalid("metadata length is missing from the metadata buffer");
+    case MessageDecoder::State::METADATA:
+      return Status::Invalid("flatbuffer size ", decoder.next_required_size(),
+                             " invalid. Buffer size: ", metadata->size());
+    case MessageDecoder::State::BODY: {
+      if (body == nullptr) {
+        // Caller didn't give a body so just give them a message without body
+        return std::move(result);
+      }
+      if (body->size() != decoder.next_required_size()) {
+        return Status::IOError("Expected body buffer to be ",
+                               decoder.next_required_size(),
+                               " bytes for message body, got ", body->size());
+      }
+      RETURN_NOT_OK(decoder.Consume(body));
+      return std::move(result);
+    }
+    case MessageDecoder::State::EOS:
+      return Status::Invalid("Unexpected empty message in IPC file format");
+    default:
+      return Status::Invalid("Unexpected state: ", decoder.state());
+  }
+}
+
 Result<std::unique_ptr<Message>> ReadMessage(int64_t offset, int32_t metadata_length,
                                              io::RandomAccessFile* file,
                                              const FieldsLoaderFunction& fields_loader) {
@@ -560,14 +604,15 @@ class MessageDecoder::MessageDecoderImpl {
  public:
   explicit MessageDecoderImpl(std::shared_ptr<MessageDecoderListener> listener,
                               State initial_state, int64_t initial_next_required_size,
-                              MemoryPool* pool)
+                              MemoryPool* pool, bool skip_body)
       : listener_(std::move(listener)),
         pool_(pool),
         state_(initial_state),
         next_required_size_(initial_next_required_size),
         chunks_(),
         buffered_size_(0),
-        metadata_(nullptr) {}
+        metadata_(nullptr),
+        skip_body_(skip_body) {}
 
   Status ConsumeData(const uint8_t* data, int64_t size) {
     if (buffered_size_ == 0) {
@@ -798,7 +843,7 @@ class MessageDecoder::MessageDecoderImpl {
     RETURN_NOT_OK(CheckMetadataAndGetBodyLength(*metadata_, &body_length));
 
     state_ = State::BODY;
-    next_required_size_ = body_length;
+    next_required_size_ = skip_body_ ? 0 : body_length;
     RETURN_NOT_OK(listener_->OnBody());
     if (next_required_size_ == 0) {
       ARROW_ASSIGN_OR_RAISE(auto body, AllocateBuffer(0, pool_));
@@ -894,19 +939,21 @@ class MessageDecoder::MessageDecoderImpl {
   std::vector<std::shared_ptr<Buffer>> chunks_;
   int64_t buffered_size_;
   std::shared_ptr<Buffer> metadata_;  // Must be CPU buffer
+  bool skip_body_;
 };
 
 MessageDecoder::MessageDecoder(std::shared_ptr<MessageDecoderListener> listener,
-                               MemoryPool* pool) {
+                               MemoryPool* pool, bool skip_body) {
   impl_.reset(new MessageDecoderImpl(std::move(listener), State::INITIAL,
-                                     kMessageDecoderNextRequiredSizeInitial, pool));
+                                     kMessageDecoderNextRequiredSizeInitial, pool,
+                                     skip_body));
 }
 
 MessageDecoder::MessageDecoder(std::shared_ptr<MessageDecoderListener> listener,
                                State initial_state, int64_t initial_next_required_size,
-                               MemoryPool* pool) {
+                               MemoryPool* pool, bool skip_body) {
   impl_.reset(new MessageDecoderImpl(std::move(listener), initial_state,
-                                     initial_next_required_size, pool));
+                                     initial_next_required_size, pool, skip_body));
 }
 
 MessageDecoder::~MessageDecoder() {}

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "arrow/io/caching.h"
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -147,6 +148,11 @@ struct ARROW_EXPORT IpcReadOptions {
   /// Endianness conversion is achieved by the RecordBatchFileReader,
   /// RecordBatchStreamReader and StreamDecoder classes.
   bool ensure_native_endian = true;
+
+  /// \brief Options to control caching behavior when pre-buffering is requested
+  ///
+  /// The lazy property will always be reset to true to deliver the expected behavior
+  io::CacheOptions pre_buffer_cache_options = io::CacheOptions::LazyDefaults();
 
   static IpcReadOptions Defaults();
 };

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -51,7 +51,6 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/make_unique.h"
 
 #include "generated/Message_generated.h"  // IWYU pragma: keep
 
@@ -60,7 +59,6 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::GetByteWidth;
-using internal::make_unique;
 using internal::TemporaryDir;
 
 namespace ipc {
@@ -2801,7 +2799,7 @@ class PreBufferingTest : public ::testing::TestWithParam<bool> {
   }
 
   void OpenReader() {
-    buffer_reader_ = make_unique<io::BufferReader>(file_buffer_);
+    buffer_reader_ = std::make_shared<io::BufferReader>(file_buffer_);
     tracked_ = std::make_shared<TrackedRandomAccessFile>(buffer_reader_.get());
     auto read_options = IpcReadOptions::Defaults();
     if (ReadsArePlugged()) {
@@ -2843,7 +2841,7 @@ class PreBufferingTest : public ::testing::TestWithParam<bool> {
   }
 
   std::vector<std::shared_ptr<RecordBatch>> LoadExpected() {
-    auto buffer_reader = make_unique<io::BufferReader>(file_buffer_);
+    auto buffer_reader = std::make_shared<io::BufferReader>(file_buffer_);
     auto read_options = IpcReadOptions::Defaults();
     EXPECT_OK_AND_ASSIGN(auto reader,
                          RecordBatchFileReader::Open(buffer_reader.get(), read_options));
@@ -2878,7 +2876,7 @@ class PreBufferingTest : public ::testing::TestWithParam<bool> {
 
   std::vector<std::shared_ptr<RecordBatch>> batches_;
   std::shared_ptr<Buffer> file_buffer_;
-  std::unique_ptr<io::BufferReader> buffer_reader_;
+  std::shared_ptr<io::BufferReader> buffer_reader_;
   std::shared_ptr<TrackedRandomAccessFile> tracked_;
   std::shared_ptr<RecordBatchFileReader> reader_;
 };

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <ostream>
 #include <string>
 #include <unordered_set>

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -51,6 +51,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
+#include "arrow/util/make_unique.h"
 
 #include "generated/Message_generated.h"  // IWYU pragma: keep
 
@@ -59,6 +60,7 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::GetByteWidth;
+using internal::make_unique;
 using internal::TemporaryDir;
 
 namespace ipc {
@@ -2645,33 +2647,43 @@ TEST(IoRecordedRandomAccessFile, ReadWithCurrentPosition) {
   ASSERT_EQ(file.GetReadRanges()[0], (io::ReadRange{0, 20}));
 }
 
-Status MakeBooleanInt32Int64Batch(const int length, std::shared_ptr<RecordBatch>* out) {
-  // Make the schema
+std::shared_ptr<Schema> MakeBooleanInt32Int64Schema() {
   auto f0 = field("f0", boolean());
   auto f1 = field("f1", int32());
   auto f2 = field("f2", int64());
-  auto schema = ::arrow::schema({f0, f1, f2});
+  return ::arrow::schema({f0, f1, f2});
+}
 
+Status MakeBooleanInt32Int64Batch(const int length, std::shared_ptr<RecordBatch>* out) {
+  auto schema_ = MakeBooleanInt32Int64Schema();
   std::shared_ptr<Array> a0, a1, a2;
   RETURN_NOT_OK(MakeRandomBooleanArray(length, false, &a0));
   RETURN_NOT_OK(MakeRandomInt32Array(length, false, arrow::default_memory_pool(), &a1));
   RETURN_NOT_OK(MakeRandomInt64Array(length, false, arrow::default_memory_pool(), &a2));
-  *out = RecordBatch::Make(schema, length, {a0, a1, a2});
+  *out = RecordBatch::Make(std::move(schema_), length, {a0, a1, a2});
   return Status::OK();
+}
+
+std::shared_ptr<Buffer> MakeBooleanInt32Int64File(int num_rows, int num_batches) {
+  auto schema_ = MakeBooleanInt32Int64Schema();
+  EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create(0));
+  EXPECT_OK_AND_ASSIGN(auto writer, MakeFileWriter(sink.get(), schema_));
+
+  std::shared_ptr<RecordBatch> batch;
+  for (int i = 0; i < num_batches; i++) {
+    ARROW_EXPECT_OK(MakeBooleanInt32Int64Batch(num_rows, &batch));
+    ARROW_EXPECT_OK(writer->WriteRecordBatch(*batch));
+  }
+
+  ARROW_EXPECT_OK(writer->Close());
+  EXPECT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  return buffer;
 }
 
 void GetReadRecordBatchReadRanges(
     uint32_t num_rows, const std::vector<int>& included_fields,
     const std::vector<int64_t>& expected_body_read_lengths) {
-  std::shared_ptr<RecordBatch> batch;
-  // [bool, int32, int64] batch
-  ASSERT_OK(MakeBooleanInt32Int64Batch(num_rows, &batch));
-
-  ASSERT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create(0));
-  ASSERT_OK_AND_ASSIGN(auto writer, MakeFileWriter(sink.get(), batch->schema()));
-  ASSERT_OK(writer->WriteRecordBatch(*batch));
-  ASSERT_OK(writer->Close());
-  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto buffer = MakeBooleanInt32Int64File(num_rows, /*num_batches=*/1);
 
   io::BufferReader buffer_reader(buffer);
   TrackedRandomAccessFile tracked(&buffer_reader);
@@ -2769,6 +2781,133 @@ TEST(TestRecordBatchFileReaderIo, ReadTwoContinousFieldsWithIoMerged) {
   // + 64 int32: 64 * 4 bytes (256 bytes)
   GetReadRecordBatchReadRanges(64, {0, 1}, {8 + 64 * 4});
 }
+
+constexpr static int kNumBatches = 10;
+// It can be difficult to know the exact size of the schema.  Instead we just make the
+// row data big enough that we can easily identify if a read is for a schema or for
+// row data.
+//
+// This needs to be large enough to space record batches kDefaultHoleSizeLimit bytes apart
+// and also large enough that record batch data is more than kMaxMetadataSizeBytes bytes
+constexpr static int kRowsPerBatch = 1000;
+constexpr static int64_t kMaxMetadataSizeBytes = 1 << 13;
+// There are always 2 reads when the file is opened
+constexpr static int kNumReadsOnOpen = 2;
+
+class PreBufferingTest : public ::testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    file_buffer_ = MakeBooleanInt32Int64File(kRowsPerBatch, kNumBatches);
+  }
+
+  void OpenReader() {
+    buffer_reader_ = make_unique<io::BufferReader>(file_buffer_);
+    tracked_ = std::make_shared<TrackedRandomAccessFile>(buffer_reader_.get());
+    auto read_options = IpcReadOptions::Defaults();
+    if (ReadsArePlugged()) {
+      // This will ensure that all reads get globbed together into one large read
+      read_options.pre_buffer_cache_options.hole_size_limit =
+          std::numeric_limits<int64_t>::max() - 1;
+      read_options.pre_buffer_cache_options.range_size_limit =
+          std::numeric_limits<int64_t>::max();
+    }
+    ASSERT_OK_AND_ASSIGN(reader_, RecordBatchFileReader::Open(tracked_, read_options));
+  }
+
+  bool ReadsArePlugged() { return GetParam(); }
+
+  std::vector<int> AllBatchIndices() {
+    std::vector<int> all_batch_indices(kNumBatches);
+    std::iota(all_batch_indices.begin(), all_batch_indices.end(), 0);
+    return all_batch_indices;
+  }
+
+  void AssertMetadataLoaded(std::vector<int> batch_indices) {
+    if (batch_indices.size() == 0) {
+      batch_indices = AllBatchIndices();
+    }
+    const auto& read_ranges = tracked_->get_read_ranges();
+    if (ReadsArePlugged()) {
+      // The read should have arrived as one large read
+      ASSERT_EQ(kNumReadsOnOpen + 1, read_ranges.size());
+      if (batch_indices.size() > 1) {
+        ASSERT_GT(read_ranges[kNumReadsOnOpen].length, kMaxMetadataSizeBytes);
+      }
+    } else {
+      // We should get many small reads of metadata only
+      ASSERT_EQ(batch_indices.size() + kNumReadsOnOpen, read_ranges.size());
+      for (const auto& read_range : read_ranges) {
+        ASSERT_LT(read_range.length, kMaxMetadataSizeBytes);
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<RecordBatch>> LoadExpected() {
+    auto buffer_reader = make_unique<io::BufferReader>(file_buffer_);
+    auto read_options = IpcReadOptions::Defaults();
+    EXPECT_OK_AND_ASSIGN(auto reader,
+                         RecordBatchFileReader::Open(buffer_reader.get(), read_options));
+    std::vector<std::shared_ptr<RecordBatch>> expected_batches;
+    for (int i = 0; i < reader->num_record_batches(); i++) {
+      EXPECT_OK_AND_ASSIGN(auto expected_batch, reader->ReadRecordBatch(i));
+      expected_batches.push_back(expected_batch);
+    }
+    return expected_batches;
+  }
+
+  void CheckFileRead(int num_indices_pre_buffered) {
+    auto expected_batches = LoadExpected();
+    const std::vector<io::ReadRange>& read_ranges = tracked_->get_read_ranges();
+    std::size_t starting_reads = read_ranges.size();
+    for (int i = 0; i < reader_->num_record_batches(); i++) {
+      ASSERT_OK_AND_ASSIGN(auto next_batch, reader_->ReadRecordBatch(i));
+      AssertBatchesEqual(*expected_batches[i], *next_batch);
+    }
+    int metadata_reads = 0;
+    int data_reads = 0;
+    for (std::size_t i = starting_reads; i < read_ranges.size(); i++) {
+      if (read_ranges[i].length > kMaxMetadataSizeBytes) {
+        data_reads++;
+      } else {
+        metadata_reads++;
+      }
+    }
+    ASSERT_EQ(metadata_reads, reader_->num_record_batches() - num_indices_pre_buffered);
+    ASSERT_EQ(data_reads, reader_->num_record_batches());
+  }
+
+  std::vector<std::shared_ptr<RecordBatch>> batches_;
+  std::shared_ptr<Buffer> file_buffer_;
+  std::unique_ptr<io::BufferReader> buffer_reader_;
+  std::shared_ptr<TrackedRandomAccessFile> tracked_;
+  std::shared_ptr<RecordBatchFileReader> reader_;
+};
+
+TEST_P(PreBufferingTest, MetadataOnlyAllBatches) {
+  OpenReader();
+  // Should pre_buffer all metadata
+  ASSERT_OK(reader_->PreBufferMetadata({}));
+  AssertMetadataLoaded({});
+  CheckFileRead(kNumBatches);
+}
+
+TEST_P(PreBufferingTest, MetadataOnlySomeBatches) {
+  OpenReader();
+  // Should pre_buffer all metadata
+  ASSERT_OK(reader_->PreBufferMetadata({1, 2, 3}));
+  AssertMetadataLoaded({1, 2, 3});
+  CheckFileRead(3);
+}
+
+INSTANTIATE_TEST_SUITE_P(PreBufferingTests, PreBufferingTest,
+                         ::testing::Values(false, true),
+                         [](const ::testing::TestParamInfo<bool>& info) {
+                           if (info.param) {
+                             return "plugged";
+                           } else {
+                             return "not_plugged";
+                           }
+                         });
 
 }  // namespace test
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1754,8 +1754,8 @@ Future<std::shared_ptr<RecordBatchFileReader>> RecordBatchFileReader::OpenAsync(
       .Then([=]() -> Result<std::shared_ptr<RecordBatchFileReader>> { return result; });
 }
 
-Future<SelectiveIpcFileRecordBatchGenerator::Item> SelectiveIpcFileRecordBatchGenerator::
-operator()() {
+Future<SelectiveIpcFileRecordBatchGenerator::Item>
+SelectiveIpcFileRecordBatchGenerator::operator()() {
   int index = index_++;
   if (index >= state_->num_record_batches()) {
     return IterationEnd<SelectiveIpcFileRecordBatchGenerator::Item>();
@@ -1763,8 +1763,8 @@ operator()() {
   return state_->ReadRecordBatchAsync(index);
 }
 
-Future<WholeIpcFileRecordBatchGenerator::Item> WholeIpcFileRecordBatchGenerator::
-operator()() {
+Future<WholeIpcFileRecordBatchGenerator::Item>
+WholeIpcFileRecordBatchGenerator::operator()() {
   auto state = state_;
   if (!read_dictionaries_.is_valid()) {
     std::vector<Future<std::shared_ptr<Message>>> messages(state->num_dictionaries());

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -72,7 +72,6 @@ namespace flatbuf = org::apache::arrow::flatbuf;
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::GetByteWidth;
-using internal::make_unique;
 
 namespace ipc {
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -196,6 +196,18 @@ class ARROW_EXPORT RecordBatchFileReader
   /// \brief Computes the total number of rows in the file.
   virtual Result<int64_t> CountRows() = 0;
 
+  /// \brief Begin loading metadata for the desired batches into memory.
+  ///
+  /// This method will also begin loading all dictionaries messages into memory.
+  ///
+  /// For a regular file this will immediately begin disk I/O in the background on a
+  /// thread on the IOContext's thread pool.  If the file is memory mapped this will
+  /// ensure the memory needed for the metadata is paged from disk into memory
+  ///
+  /// \param indices Indices of the batches to prefetch
+  ///                If empty then all batches will be prefetched.
+  virtual Status PreBufferMetadata(const std::vector<int>& indices) = 0;
+
   /// \brief Get a reentrant generator of record batches.
   ///
   /// \param[in] coalesce If true, enable I/O coalescing.

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -75,11 +75,12 @@ void CompareBatchColumnsDetailed(const RecordBatch& result, const RecordBatch& e
 }
 
 Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool,
-                            std::shared_ptr<Array>* out, uint32_t seed) {
+                            std::shared_ptr<Array>* out, uint32_t seed, int32_t min,
+                            int32_t max) {
   random::RandomArrayGenerator rand(seed);
   const double null_probability = include_nulls ? 0.5 : 0.0;
 
-  *out = rand.Int32(length, 0, 1000, null_probability);
+  *out = rand.Int32(length, min, max, null_probability);
 
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -42,7 +42,8 @@ void CompareBatchColumnsDetailed(const RecordBatch& result, const RecordBatch& e
 
 ARROW_TESTING_EXPORT
 Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool,
-                            std::shared_ptr<Array>* out, uint32_t seed = 0);
+                            std::shared_ptr<Array>* out, uint32_t seed = 0,
+                            int32_t min = 0, int32_t max = 1000);
 
 ARROW_TESTING_EXPORT
 Status MakeRandomInt64Array(int64_t length, bool include_nulls, MemoryPool* pool,


### PR DESCRIPTION
In the end this PR only addresses projection pushdown on the asynchronous path.  The approach laid out here could be used on the synchronous path to offer pre-buffering.  Tests should be done to see if that is faster.

The memory mapped / will need issue should be solved by making auto-will-need a property of the memory mapped file and will not be addressed here.