### PR TITLE
ARROW-13756: [Python] Error in pandas conversion for datetimetz column index

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1021,6 +1021,7 @@ def _is_generated_index_name(name):
 _pandas_logical_type_map = {
     'date': 'datetime64[D]',
     'datetime': 'datetime64[ns]',
+    'datetimetz': 'datetime64[ns, tz]',
     'unicode': np.unicode_,
     'bytes': np.bytes_,
     'string': np.str_,
@@ -1109,10 +1110,15 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
         # convert them back to bytes to preserve metadata.
         if dtype == np.bytes_:
             level = level.map(encoder)
+        # ARROW-13756: if index is timezone aware DataTimeIndex
+        if dtype == 'datetime64[ns, tz]':
+            tz = pa.lib.string_to_tzinfo(column_indexes[0]['metadata']['timezone'])
+            dt = level.astype(numpy_dtype)
+            level = dt.tz_localize('utc').tz_convert(tz)
         elif level.dtype != dtype:
             level = level.astype(dtype)
         # ARROW-9096: if original DataFrame was upcast we keep that
-        if level.dtype != numpy_dtype:
+        if level.dtype != numpy_dtype and dtype != 'datetime64[ns, tz]':
             level = level.astype(numpy_dtype)
 
         new_levels.append(level)

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1021,7 +1021,7 @@ def _is_generated_index_name(name):
 _pandas_logical_type_map = {
     'date': 'datetime64[D]',
     'datetime': 'datetime64[ns]',
-    'datetimetz': 'datetime64[ns, tz]',
+    'datetimetz': 'datetime64[ns]',
     'unicode': np.unicode_,
     'bytes': np.bytes_,
     'string': np.str_,
@@ -1111,7 +1111,7 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
         if dtype == np.bytes_:
             level = level.map(encoder)
         # ARROW-13756: if index is timezone aware DataTimeIndex
-        if dtype == 'datetime64[ns, tz]':
+        if pandas_dtype == "datetimetz":
             tz = pa.lib.string_to_tzinfo(
                 column_indexes[0]['metadata']['timezone'])
             dt = level.astype(numpy_dtype)
@@ -1119,7 +1119,7 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
         elif level.dtype != dtype:
             level = level.astype(dtype)
         # ARROW-9096: if original DataFrame was upcast we keep that
-        if level.dtype != numpy_dtype and dtype != 'datetime64[ns, tz]':
+        if level.dtype != numpy_dtype and pandas_dtype != "datetimetz":
             level = level.astype(numpy_dtype)
 
         new_levels.append(level)

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1112,7 +1112,8 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
             level = level.map(encoder)
         # ARROW-13756: if index is timezone aware DataTimeIndex
         if dtype == 'datetime64[ns, tz]':
-            tz = pa.lib.string_to_tzinfo(column_indexes[0]['metadata']['timezone'])
+            tz = pa.lib.string_to_tzinfo(
+                column_indexes[0]['metadata']['timezone'])
             dt = level.astype(numpy_dtype)
             level = dt.tz_localize('utc').tz_convert(tz)
         elif level.dtype != dtype:

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -168,6 +168,17 @@ class TestConvertMetadata:
         df.columns.names = ['a']
         _check_pandas_roundtrip(df, preserve_index=True)
 
+    def test_column_index_names_with_tz(self):
+        # ARROW-13756
+        # Bug if index is timezone aware DataTimeIndex
+
+        df = pd.DataFrame(
+            np.random.randn(5, 3),
+            columns=pd.date_range(
+                "2021-01-01", "2021-01-3", freq="D", tz="CET")
+        )
+        _check_pandas_roundtrip(df, preserve_index=True)
+
     def test_range_index_shortcut(self):
         # ARROW-1639
         index_name = 'foo'
@@ -235,17 +246,6 @@ class TestConvertMetadata:
             names=['level_1', 'level_2'],
         )
         df = pd.DataFrame([(1, 'a'), (2, 'b'), (3, 'c')], columns=columns)
-        _check_pandas_roundtrip(df, preserve_index=True)
-
-    def test_multiindex_columns_with_tz(self):
-        # ARROW-13756
-        # Bug if index is timezone aware DataTimeIndex
-
-        df = pd.DataFrame(
-            np.random.randn(5, 3),
-            columns=pd.date_range(
-                "2021-01-01", "2021-01-3", freq="D", tz="CET")
-        )
         _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_multiindex_with_column_dtype_object(self):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -237,6 +237,16 @@ class TestConvertMetadata:
         df = pd.DataFrame([(1, 'a'), (2, 'b'), (3, 'c')], columns=columns)
         _check_pandas_roundtrip(df, preserve_index=True)
 
+    def test_multiindex_columns_with_tz(self):
+        # ARROW-13756
+        # Bug if index is timezone aware DataTimeIndex
+
+        df = pd.DataFrame(
+            np.random.randn(5, 3),
+            columns=pd.date_range("2021-01-01", "2021-01-3", freq="D", tz="CET")
+        )
+        _check_pandas_roundtrip(df, preserve_index=True)
+
     def test_multiindex_with_column_dtype_object(self):
         # ARROW-3651 & ARROW-9096
         # Bug when dtype of the columns is object.

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -243,7 +243,8 @@ class TestConvertMetadata:
 
         df = pd.DataFrame(
             np.random.randn(5, 3),
-            columns=pd.date_range("2021-01-01", "2021-01-3", freq="D", tz="CET")
+            columns=pd.date_range(
+                "2021-01-01", "2021-01-3", freq="D", tz="CET")
         )
         _check_pandas_roundtrip(df, preserve_index=True)
 


### PR DESCRIPTION
Specifically deal with timezone-aware data in the code to reconstruct the column Index `(_reconstruct_columns_from_metadata)`.