### PR TITLE
ARROW-14600: [Docs] Fix broken link in Python Development page

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -330,7 +330,7 @@ virtualenv) enables cmake to choose the python executable which you are using.
 .. note::
 
    With older versions of ``cmake`` (<3.15) you might need to pass ``-DPYTHON_EXECUTABLE``
-   instead of ``-DPython3_EXECUTABLE``. See `cmake documentation <https://cmake.org/cmake/help/latest/module/FindPython3.html#artifacts-specification>`
+   instead of ``-DPython3_EXECUTABLE``. See `cmake documentation <https://cmake.org/cmake/help/latest/module/FindPython3.html#artifacts-specification>`_
    for more details.
 
 For any other C++ build challenges, see :ref:`cpp-development`.


### PR DESCRIPTION
Fix a simple sphinx grammatical error of external web pages link here:
https://arrow.apache.org/docs/developers/python.html#build-and-test
