### PR TITLE
ARROW-14623: [Packaging][Java] Upload not only .jar but also .pom

### DIFF
--- a/ci/scripts/java_full_build.sh
+++ b/ci/scripts/java_full_build.sh
@@ -27,10 +27,16 @@ export ARROW_TEST_DATA=${arrow_dir}/testing/data
 pushd ${arrow_dir}/java
 
 # build the entire project
-mvn clean install -Parrow-c-data -Parrow-jni -Darrow.cpp.build.dir=$dist_dir -Darrow.c.jni.dist.dir=$dist_dir
+mvn clean install \
+  -Parrow-c-data \
+  -Parrow-jni \
+  -Darrow.cpp.build.dir=$dist_dir \
+  -Darrow.c.jni.dist.dir=$dist_dir
 
 # copy all jars and pom files to the distribution folder
-find . -name "*.jar" -exec echo {} \; -exec cp {} $dist_dir \;
-find . -name "*.pom" -exec echo {} \; -exec cp {} $dist_dir \;
+find ~/.m2/repository/org/apache/arrow \
+     "(" -name "*.jar" -o -name "*.pom" ")" \
+     -exec echo {} ";" \
+     -exec cp {} $dist_dir ";"
 
 popd

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -e
           pushd arrow/java
-          mvn versions:set -DnewVersion={{ arrow.version }}
+          mvn versions:set -DnewVersion={{ arrow.no_rc_version }}
           popd
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Build Bundled Jar
         run: |
           set -e
+          pushd arrow/java
+          mvn versions:set -DnewVersion=${{ arrow.version }}
+          popd
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \
             $GITHUB_WORKSPACE/arrow/java-dist

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build C++ Libs
         run: archery docker run java-jni-manylinux-2014
       - name: Compress into single artifact
-        run: tar -cvzf arrow-shared-libs-linux.tar.gz arrow/java/dist/
+        run: tar -cvzf arrow-shared-libs-linux.tar.gz arrow/java-dist/
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -59,16 +59,16 @@ jobs:
           arrow/ci/scripts/java_cdata_build.sh \
             $GITHUB_WORKSPACE/arrow \
             $GITHUB_WORKSPACE/arrow/java-native-build \
-            $GITHUB_WORKSPACE/arrow/java/dist
+            $GITHUB_WORKSPACE/arrow/java-dist
       - name: Build C++ Libs
         run: |
           set -e
           arrow/ci/scripts/java_jni_macos_build.sh \
             $GITHUB_WORKSPACE/arrow \
             $GITHUB_WORKSPACE/arrow/cpp-build \
-            $GITHUB_WORKSPACE/arrow/java/dist
+            $GITHUB_WORKSPACE/arrow/java-dist
       - name: Compress into single artifact
-        run: tar -cvzf arrow-shared-libs-macos.tar.gz arrow/java/dist/
+        run: tar -cvzf arrow-shared-libs-macos.tar.gz arrow/java-dist/
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -95,18 +95,18 @@ jobs:
           tar -xvzf arrow-shared-libs-linux.tar.gz
       - name: Test that Shared Libraries Exist
         run: |
-          test -f arrow/java/dist/libarrow_cdata_jni.dylib
-          test -f arrow/java/dist/libarrow_dataset_jni.dylib
-          test -f arrow/java/dist/libgandiva_jni.dylib
-          test -f arrow/java/dist/libarrow_orc_jni.dylib
-          test -f arrow/java/dist/libarrow_cdata_jni.so
-          test -f arrow/java/dist/libarrow_dataset_jni.so
-          test -f arrow/java/dist/libarrow_orc_jni.so
-          test -f arrow/java/dist/libgandiva_jni.so
+          test -f arrow/java-dist/libarrow_cdata_jni.dylib
+          test -f arrow/java-dist/libarrow_dataset_jni.dylib
+          test -f arrow/java-dist/libgandiva_jni.dylib
+          test -f arrow/java-dist/libarrow_orc_jni.dylib
+          test -f arrow/java-dist/libarrow_cdata_jni.so
+          test -f arrow/java-dist/libarrow_dataset_jni.so
+          test -f arrow/java-dist/libarrow_orc_jni.so
+          test -f arrow/java-dist/libgandiva_jni.so
       - name: Build Bundled Jar
         run: |
           set -e
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \
-            $GITHUB_WORKSPACE/arrow/java/dist
-      {{ macros.github_upload_releases(["arrow/java/dist/*.jar", "arrow/java/dist/*.pom"])|indent }}
+            $GITHUB_WORKSPACE/arrow/java-dist
+      {{ macros.github_upload_releases(["arrow/java-dist/*.jar", "arrow/java-dist/*.pom"])|indent }}

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set -e
           pushd arrow/java
-          mvn versions:set -DnewVersion=${{ arrow.version }}
+          mvn versions:set -DnewVersion={{ arrow.version }}
           popd
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -695,43 +695,60 @@ tasks:
     artifacts:
       - arrow-algorithm-{no_rc_version}-tests.jar
       - arrow-algorithm-{no_rc_version}.jar
+      - arrow-algorithm-{no_rc_version}.pom
       - arrow-avro-{no_rc_version}-tests.jar
       - arrow-avro-{no_rc_version}.jar
+      - arrow-avro-{no_rc_version}.pom
       - arrow-compression-{no_rc_version}-tests.jar
       - arrow-compression-{no_rc_version}.jar
+      - arrow-compression-{no_rc_version}.pom
       - arrow-dataset-{no_rc_version}-tests.jar
       - arrow-dataset-{no_rc_version}.jar
+      - arrow-dataset-{no_rc_version}.pom
       - arrow-format-{no_rc_version}-tests.jar
       - arrow-format-{no_rc_version}.jar
+      - arrow-format-{no_rc_version}.pom
       - arrow-gandiva-{no_rc_version}-tests.jar
       - arrow-gandiva-{no_rc_version}.jar
+      - arrow-gandiva-{no_rc_version}.pom
       - arrow-jdbc-{no_rc_version}-tests.jar
       - arrow-jdbc-{no_rc_version}.jar
+      - arrow-jdbc-{no_rc_version}.pom
       - arrow-memory-core-{no_rc_version}-tests.jar
       - arrow-memory-core-{no_rc_version}.jar
+      - arrow-memory-core-{no_rc_version}.pom
       - arrow-memory-netty-{no_rc_version}-tests.jar
       - arrow-memory-netty-{no_rc_version}.jar
+      - arrow-memory-netty-{no_rc_version}.pom
       - arrow-memory-unsafe-{no_rc_version}-tests.jar
       - arrow-memory-unsafe-{no_rc_version}.jar
+      - arrow-memory-unsafe-{no_rc_version}.pom
       - arrow-orc-{no_rc_version}-tests.jar
       - arrow-orc-{no_rc_version}.jar
+      - arrow-orc-{no_rc_version}.pom
       - arrow-performance-{no_rc_version}-tests.jar
       - arrow-performance-{no_rc_version}.jar
+      - arrow-performance-{no_rc_version}.pom
       - arrow-plasma-{no_rc_version}-tests.jar
       - arrow-plasma-{no_rc_version}.jar
+      - arrow-plasma-{no_rc_version}.pom
       - arrow-tools-{no_rc_version}-jar-with-dependencies.jar
       - arrow-tools-{no_rc_version}-tests.jar
       - arrow-tools-{no_rc_version}.jar
+      - arrow-tools-{no_rc_version}.pom
       - arrow-vector-{no_rc_version}-shade-format-flatbuffers.jar
       - arrow-vector-{no_rc_version}-tests.jar
       - arrow-vector-{no_rc_version}.jar
-      - benchmarks.jar
+      - arrow-vector-{no_rc_version}.pom
       - flight-core-{no_rc_version}-jar-with-dependencies.jar
       - flight-core-{no_rc_version}-shaded-ext.jar
       - flight-core-{no_rc_version}-shaded.jar
       - flight-core-{no_rc_version}-tests.jar
       - flight-core-{no_rc_version}.jar
+      - flight-core-{no_rc_version}.pom
       - flight-grpc-{no_rc_version}-tests.jar
+      - flight-grpc-{no_rc_version}.jar
+      - flight-grpc-{no_rc_version}.pom
 
   ############################## NuGet packages ###############################
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -699,6 +699,9 @@ tasks:
       - arrow-avro-{no_rc_version}-tests.jar
       - arrow-avro-{no_rc_version}.jar
       - arrow-avro-{no_rc_version}.pom
+      - arrow-c-data-{no_rc_version}-tests.jar
+      - arrow-c-data-{no_rc_version}.jar
+      - arrow-c-data-{no_rc_version}.pom
       - arrow-compression-{no_rc_version}-tests.jar
       - arrow-compression-{no_rc_version}.jar
       - arrow-compression-{no_rc_version}.pom
@@ -711,9 +714,11 @@ tasks:
       - arrow-gandiva-{no_rc_version}-tests.jar
       - arrow-gandiva-{no_rc_version}.jar
       - arrow-gandiva-{no_rc_version}.pom
+      - arrow-java-root-{no_rc_version}.pom
       - arrow-jdbc-{no_rc_version}-tests.jar
       - arrow-jdbc-{no_rc_version}.jar
       - arrow-jdbc-{no_rc_version}.pom
+      - arrow-memory-{no_rc_version}.pom
       - arrow-memory-core-{no_rc_version}-tests.jar
       - arrow-memory-core-{no_rc_version}.jar
       - arrow-memory-core-{no_rc_version}.pom

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -901,8 +901,8 @@ services:
       - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux2014-ccache:/ccache:delegated
     command:
       ["pip install -e /arrow/dev/archery &&
-        /arrow/ci/scripts/java_cdata_build.sh /arrow /java-native-build /arrow/java/dist &&
-        /arrow/ci/scripts/java_jni_manylinux_build.sh /arrow /build /arrow/java/dist"]
+        /arrow/ci/scripts/java_cdata_build.sh /arrow /java-native-build /arrow/java-dist &&
+        /arrow/ci/scripts/java_jni_manylinux_build.sh /arrow /build /arrow/java-dist"]
 
   ##############################  Integration #################################
 


### PR DESCRIPTION
.pom files will be needed to publish packages at https://repository.apache.org/#staging-upload .

.jar files are generated at target/ and installed to ~/.m2/repository/org/apache/arrow/.
.pom files are only installed to ~/.m2/repository/org/apache/arrow/.

So this change collects artifacts from ~/.m2/repository/org/apache/arrow/ instead of build directory.

Dist path change (arrow/java/dist -> arrow/java-dist) isn't required but it's better that
we use out of source directory for dist path. It's easy to debug.
