### PR TITLE
ARROW-11549: [C++][Gandiva] Fix issues with FilterCacheKey caused by ToString() not distinguishing null and 'null'

### DIFF
--- a/cpp/src/gandiva/like_holder_test.cc
+++ b/cpp/src/gandiva/like_holder_test.cc
@@ -109,17 +109,17 @@ TEST_F(TestLikeHolder, TestOptimise) {
   // optimise for 'starts_with'
   auto fnode = LikeHolder::TryOptimize(BuildLike("xy 123z%"));
   EXPECT_EQ(fnode.descriptor()->name(), "starts_with");
-  EXPECT_EQ(fnode.ToString(), "bool starts_with((string) in, (const string) xy 123z)");
+  EXPECT_EQ(fnode.ToString(), "bool starts_with((string) in, (const string) 'xy 123z')");
 
   // optimise for 'ends_with'
   fnode = LikeHolder::TryOptimize(BuildLike("%xyz"));
   EXPECT_EQ(fnode.descriptor()->name(), "ends_with");
-  EXPECT_EQ(fnode.ToString(), "bool ends_with((string) in, (const string) xyz)");
+  EXPECT_EQ(fnode.ToString(), "bool ends_with((string) in, (const string) 'xyz')");
 
   // optimise for 'is_substr'
   fnode = LikeHolder::TryOptimize(BuildLike("%abc%"));
   EXPECT_EQ(fnode.descriptor()->name(), "is_substr");
-  EXPECT_EQ(fnode.ToString(), "bool is_substr((string) in, (const string) abc)");
+  EXPECT_EQ(fnode.ToString(), "bool is_substr((string) in, (const string) 'abc')");
 
   // no optimisation for others.
   fnode = LikeHolder::TryOptimize(BuildLike("xyz_"));
@@ -141,7 +141,7 @@ TEST_F(TestLikeHolder, TestOptimise) {
   fnode = LikeHolder::TryOptimize(BuildLike("\\%xyz", '\\'));
   EXPECT_EQ(fnode.descriptor()->name(), "like");
   EXPECT_EQ(fnode.ToString(),
-            "bool like((string) in, (const string) \\%xyz, (const int8) \\)");
+            "bool like((string) in, (const string) '\\%xyz', (const int8) \\)");
 }
 
 TEST_F(TestLikeHolder, TestMatchOneEscape) {

--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -72,7 +72,12 @@ class GANDIVA_EXPORT LiteralNode : public Node {
       return ss.str();
     }
 
-    ss << gandiva::ToString(holder_);
+    if (return_type()->id() == arrow::Type::STRING ||
+        return_type()->id() == arrow::Type::LARGE_STRING) {
+      ss << "'" << gandiva::ToString(holder_) << "'";
+    } else {
+      ss << gandiva::ToString(holder_);
+    }
     // The default formatter prints in decimal can cause a loss in precision. so,
     // print in hex. Can't use hexfloat since gcc 4.9 doesn't support it.
     if (return_type()->id() == arrow::Type::DOUBLE) {


### PR DESCRIPTION
This is the same fix as https://github.com/apache/arrow/pull/9453

The previous PR (https://github.com/apache/arrow/pull/9453) got stale and cannot be merged, and I simply copied the modification in that PR to get ARROW-11549 addressed.

P.S.: the author of PR #9453 is my friend and former co-worker, and he got some personal matter and may not merge the PR now.