### PR TITLE
ARROW-14627: [C++] Fix tests compilation error using GCC 11.1

### DIFF
--- a/cpp/src/arrow/util/align_util_test.cc
+++ b/cpp/src/arrow/util/align_util_test.cc
@@ -60,7 +60,7 @@ void CheckBitmapWordAlign(const uint8_t* data, int64_t bit_offset, int64_t lengt
 }
 
 TEST(BitmapWordAlign, AlignedDataStart) {
-  alignas(8) char buf[136];
+  alignas(8) char buf[136] = {0};
 
   // A 8-byte aligned pointer
   const uint8_t* P = reinterpret_cast<const uint8_t*>(buf);
@@ -104,7 +104,7 @@ TEST(BitmapWordAlign, AlignedDataStart) {
 }
 
 TEST(BitmapWordAlign, UnalignedDataStart) {
-  alignas(8) char buf[136];
+  alignas(8) char buf[136] = {0};
 
   const uint8_t* P = reinterpret_cast<const uint8_t*>(buf) + 1;
   const uint8_t* A = P + 7;

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -2187,7 +2187,7 @@ TEST(Bitmap, VisitWords) {
 
 // This test reads uninitialized memory
 TEST(Bitmap, VisitPartialWords) {
-  uint64_t words[2];
+  uint64_t words[2] = {0};
   constexpr auto nbytes = sizeof(words);
   constexpr auto nbits = nbytes * 8;
 


### PR DESCRIPTION
The following files have some uninitialised static arrays which are giving compilation errors with new GCC version 11.1

1) align_util_test.cc
2) bit_util_test.cc