### PR TITLE
ARROW-14637: [GLib][Ruby] Add support for initializing S3 APIs explicitly

### DIFF
--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -1637,9 +1637,11 @@ garrow_slow_file_system_new_raw(
                  NULL));
 }
 
+#ifdef ARROW_S3
 arrow::fs::S3GlobalOptions *
 garrow_s3_global_options_get_raw(GArrowS3GlobalOptions *options)
 {
   auto priv = GARROW_S3_GLOBAL_OPTIONS_GET_PRIVATE(options);
   return &(priv->options);
 }
+#endif

--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -1504,6 +1504,24 @@ garrow_s3_global_options_new(void)
 
 
 /**
+ * garrow_s3_enabled:
+ *
+ * Returns: %TRUE if Apache Arrow C++ is built with S3 support, %FALSE
+ *   otherwise.
+ *
+ * Since: 7.0.0
+ */
+gboolean
+garrow_s3_enabled(void)
+{
+#ifdef ARROW_S3
+  return TRUE;
+#else
+  return FALSE;
+#endif
+}
+
+/**
  * garrow_s3_initialize:
  * @options: (nullable): Options to initialize the S3 APIs.
  * @error: (nullable): Return location for a #GError or %NULL.

--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -1504,7 +1504,7 @@ garrow_s3_global_options_new(void)
 
 
 /**
- * garrow_s3_enabled:
+ * garrow_s3_is_enabled:
  *
  * Returns: %TRUE if Apache Arrow C++ is built with S3 support, %FALSE
  *   otherwise.
@@ -1512,7 +1512,7 @@ garrow_s3_global_options_new(void)
  * Since: 7.0.0
  */
 gboolean
-garrow_s3_enabled(void)
+garrow_s3_is_enabled(void)
 {
 #ifdef ARROW_S3
   return TRUE;

--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -1409,6 +1409,7 @@ garrow_s3_global_options_set_property(GObject *object,
                                       const GValue *value,
                                       GParamSpec *pspec)
 {
+#ifdef ARROW_S3
   auto arrow_options =
     garrow_s3_global_options_get_raw(GARROW_S3_GLOBAL_OPTIONS(object));
 
@@ -1421,6 +1422,9 @@ garrow_s3_global_options_set_property(GObject *object,
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
   }
+#else
+  G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+#endif
 }
 
 static void
@@ -1429,6 +1433,7 @@ garrow_s3_global_options_get_property(GObject *object,
                                       GValue *value,
                                       GParamSpec *pspec)
 {
+#ifdef ARROW_S3
   auto arrow_options =
     garrow_s3_global_options_get_raw(GARROW_S3_GLOBAL_OPTIONS(object));
 
@@ -1441,6 +1446,9 @@ garrow_s3_global_options_get_property(GObject *object,
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
   }
+#else
+  G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+#endif
 }
 
 static void

--- a/c_glib/arrow-glib/file-system.h
+++ b/c_glib/arrow-glib/file-system.h
@@ -311,7 +311,7 @@ garrow_s3_global_options_new(void);
 
 GARROW_AVAILABLE_IN_7_0
 gboolean
-garrow_s3_enabled(void);
+garrow_s3_is_enabled(void);
 GARROW_AVAILABLE_IN_7_0
 gboolean
 garrow_s3_initialize(GArrowS3GlobalOptions *options,

--- a/c_glib/arrow-glib/file-system.h
+++ b/c_glib/arrow-glib/file-system.h
@@ -311,6 +311,9 @@ garrow_s3_global_options_new(void);
 
 GARROW_AVAILABLE_IN_7_0
 gboolean
+garrow_s3_enabled(void);
+GARROW_AVAILABLE_IN_7_0
+gboolean
 garrow_s3_initialize(GArrowS3GlobalOptions *options,
                      GError **error);
 GARROW_AVAILABLE_IN_7_0

--- a/c_glib/arrow-glib/file-system.h
+++ b/c_glib/arrow-glib/file-system.h
@@ -268,6 +268,56 @@ struct _GArrowHDFSFileSystemClass
 };
 
 
+/**
+ * GArrowS3LogLevel:
+ * @GARROW_S3_LOG_LEVEL_OFF: Off.
+ * @GARROW_S3_LOG_LEVEL_FATAL: Fatal. This is the default.
+ * @GARROW_S3_LOG_LEVEL_ERROR: Error.
+ * @GARROW_S3_LOG_LEVEL_WARN: Warn.
+ * @GARROW_S3_LOG_LEVEL_INFO: Info.
+ * @GARROW_S3_LOG_LEVEL_DEBUG: Debug.
+ * @GARROW_S3_LOG_LEVEL_TRACE: Trace.
+ *
+ * They are corresponding to `arrow::fs::S3LogLevel` values.
+ *
+ * Since: 7.0.0
+ */
+typedef enum {
+  GARROW_S3_LOG_LEVEL_OFF,
+  GARROW_S3_LOG_LEVEL_FATAL,
+  GARROW_S3_LOG_LEVEL_ERROR,
+  GARROW_S3_LOG_LEVEL_WARN,
+  GARROW_S3_LOG_LEVEL_INFO,
+  GARROW_S3_LOG_LEVEL_DEBUG,
+  GARROW_S3_LOG_LEVEL_TRACE,
+} GArrowS3LogLevel;
+
+
+#define GARROW_TYPE_S3_GLOBAL_OPTIONS (garrow_s3_global_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowS3GlobalOptions,
+                         garrow_s3_global_options,
+                         GARROW,
+                         S3_GLOBAL_OPTIONS,
+                         GObject)
+struct _GArrowS3GlobalOptionsClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_7_0
+GArrowS3GlobalOptions *
+garrow_s3_global_options_new(void);
+
+
+GARROW_AVAILABLE_IN_7_0
+gboolean
+garrow_s3_initialize(GArrowS3GlobalOptions *options,
+                     GError **error);
+GARROW_AVAILABLE_IN_7_0
+gboolean
+garrow_s3_finalize(GError **error);
+
+
 #define GARROW_TYPE_S3_FILE_SYSTEM (garrow_s3_file_system_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowS3FileSystem,
                          garrow_s3_file_system,

--- a/c_glib/arrow-glib/file-system.hpp
+++ b/c_glib/arrow-glib/file-system.hpp
@@ -47,5 +47,7 @@ garrow_slow_file_system_new_raw(
   GArrowFileSystem *base_file_system);
 
 
+#ifdef ARROW_S3
 arrow::fs::S3GlobalOptions *
 garrow_s3_global_options_get_raw(GArrowS3GlobalOptions *options);
+#endif

--- a/c_glib/arrow-glib/file-system.hpp
+++ b/c_glib/arrow-glib/file-system.hpp
@@ -46,3 +46,6 @@ garrow_slow_file_system_new_raw(
   std::shared_ptr<arrow::fs::FileSystem> *arrow_file_system,
   GArrowFileSystem *base_file_system);
 
+
+arrow::fs::S3GlobalOptions *
+garrow_s3_global_options_get_raw(GArrowS3GlobalOptions *options);

--- a/c_glib/arrow-glib/version.h.in
+++ b/c_glib/arrow-glib/version.h.in
@@ -111,6 +111,15 @@
 #endif
 
 /**
+ * GARROW_VERSION_7_0:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 7.0.0
+ */
+#define GARROW_VERSION_7_0 G_ENCODE_VERSION(7, 0)
+
+/**
  * GARROW_VERSION_6_0:
  *
  * You can use this macro value for compile time API version check.
@@ -273,6 +282,20 @@
 
 
 #define GARROW_AVAILABLE_IN_ALL
+
+#if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_7_0
+#  define GARROW_DEPRECATED_IN_7_0                GARROW_DEPRECATED
+#  define GARROW_DEPRECATED_IN_7_0_FOR(function)  GARROW_DEPRECATED_FOR(function)
+#else
+#  define GARROW_DEPRECATED_IN_7_0
+#  define GARROW_DEPRECATED_IN_7_0_FOR(function)
+#endif
+
+#if GARROW_VERSION_MAX_ALLOWED < GARROW_VERSION_7_0
+#  define GARROW_AVAILABLE_IN_7_0 GARROW_UNAVAILABLE(7, 0)
+#else
+#  define GARROW_AVAILABLE_IN_7_0
+#endif
 
 #if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_6_0
 #  define GARROW_DEPRECATED_IN_6_0                GARROW_DEPRECATED

--- a/c_glib/doc/arrow-glib/arrow-glib-docs.xml
+++ b/c_glib/doc/arrow-glib/arrow-glib-docs.xml
@@ -184,6 +184,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-7-0-0" role="7.0.0">
+    <title>Index of new symbols in 7.0.0</title>
+    <xi:include href="xml/api-index-7.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-6-0-0" role="6.0.0">
     <title>Index of new symbols in 6.0.0</title>
     <xi:include href="xml/api-index-6.0.0.xml"><xi:fallback /></xi:include>

--- a/c_glib/test/test-s3-global-options.rb
+++ b/c_glib/test/test-s3-global-options.rb
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestS3GlobalOptions < Test::Unit::TestCase
+  def setup
+    @options = Arrow::S3GlobalOptions.new
+  end
+
+  sub_test_case("#log_level") do
+    test("default") do
+      assert_equal(Arrow::S3LogLevel::FATAL,
+                   @options.log_level)
+    end
+  end
+
+  test("#log_level=") do
+    @options.log_level = :trace
+    assert_equal(Arrow::S3LogLevel::TRACE,
+                 @options.log_level)
+  end
+end

--- a/c_glib/test/test-s3-global-options.rb
+++ b/c_glib/test/test-s3-global-options.rb
@@ -17,6 +17,7 @@
 
 class TestS3GlobalOptions < Test::Unit::TestCase
   def setup
+    omit("S3 enabled Apache Arrow C++ is needed") unless Arrow.s3_enabled?
     @options = Arrow::S3GlobalOptions.new
   end
 

--- a/c_glib/test/test-s3-global-options.rb
+++ b/c_glib/test/test-s3-global-options.rb
@@ -17,7 +17,7 @@
 
 class TestS3GlobalOptions < Test::Unit::TestCase
   def setup
-    omit("S3 enabled Apache Arrow C++ is needed") unless Arrow.s3_enabled?
+    omit("S3 enabled Apache Arrow C++ is needed") unless Arrow.s3_is_enabled?
     @options = Arrow::S3GlobalOptions.new
   end
 

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -93,6 +93,7 @@ module Arrow
       require "arrow/record-batch-reader"
       require "arrow/record-batch-stream-reader"
       require "arrow/rolling-window"
+      require "arrow/s3-global-options"
       require "arrow/scalar"
       require "arrow/schema"
       require "arrow/slicer"

--- a/ruby/red-arrow/lib/arrow/s3-global-options.rb
+++ b/ruby/red-arrow/lib/arrow/s3-global-options.rb
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class S3GlobalOptions
+    class << self
+      # @api private
+      def try_convert(value)
+        case value
+        when Hash
+          options = new
+          value.each do |k, v|
+            setter = :"#{k}="
+            return unless options.respond_to?(setter)
+            options.__send__(setter, v)
+          end
+          options
+        else
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby API: Arrow.s3_initialize(log_level: :trace)