### PR TITLE
ARROW-14647: [JS] fix bignumToNumber for negative numbers

### DIFF
--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -72,17 +72,19 @@ Object.assign(DecimalBigNum.prototype, BigNum.prototype, { 'constructor': Decima
 /** @ignore */
 function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
     const { buffer, byteOffset, length, 'signed': signed } = bn;
-    const words = new Uint32Array(buffer, byteOffset, length);
-    const n = words.length;
-    const negative = signed && words[n - 1] & 0x80000000;
-    let number = negative ? 1 : 0;
-    let v = 0;
-    for (let i = 0; i < n; i++) {
-        v = words[i];
-        number += (negative ? ~v : v) * Math.pow(2, 32 * i);
-    }
-    if (negative) {
-        number *= -1;
+    const words = new BigUint64Array(buffer, byteOffset, length);
+    const negative = signed && words[words.length - 1] & 0x8000000000000000n;
+    let number = negative ? 1n : 0n;
+    let i = 0n;
+    if (!negative) {
+        for (let word of words) {
+            number += word * (2n ** (32n * i++));
+        }
+    } else {
+        for (let word of words) {
+            number += ~word * (2n ** (32n * i++));
+        }
+        number *= -1n;
     }
     return number;
 }

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -77,11 +77,11 @@ function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
     let number = negative ? 1n : 0n;
     let i = 0n;
     if (!negative) {
-        for (let word of words) {
+        for (const word of words) {
             number += word * (2n ** (32n * i++));
         }
     } else {
-        for (let word of words) {
+        for (const word of words) {
             number += ~word * (2n ** (32n * i++));
         }
         number *= -1n;

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -73,18 +73,18 @@ Object.assign(DecimalBigNum.prototype, BigNum.prototype, { 'constructor': Decima
 function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
     const { buffer, byteOffset, length, 'signed': signed } = bn;
     const words = new BigUint64Array(buffer, byteOffset, length);
-    const negative = signed && words[words.length - 1] & 0x8000000000000000n;
-    let number = negative ? 1n : 0n;
-    let i = 0n;
+    const negative = signed && words[words.length - 1] & (BigInt(1) << BigInt(63));
+    let number = negative ? BigInt(1) : BigInt(0);
+    let i = BigInt(0);
     if (!negative) {
         for (const word of words) {
-            number += word * (2n ** (32n * i++));
+            number += word * (BigInt(1) << (BigInt(32) * i++));
         }
     } else {
         for (const word of words) {
-            number += ~word * (2n ** (32n * i++));
+            number += ~word * (BigInt(1) << (BigInt(32) * i++));
         }
-        number *= -1n;
+        number *= BigInt(-1);
     }
     return number;
 }

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -72,15 +72,17 @@ Object.assign(DecimalBigNum.prototype, BigNum.prototype, { 'constructor': Decima
 /** @ignore */
 function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
     const { buffer, byteOffset, length, 'signed': signed } = bn;
-    const words = new Int32Array(buffer, byteOffset, length);
-    let number = 0, i = 0;
+    const words = new Uint32Array(buffer, byteOffset, length);
     const n = words.length;
-    let hi, lo;
-    while (i < n) {
-        lo = words[i++];
-        hi = words[i++];
-        signed || (hi = hi >>> 0);
-        number += (lo >>> 0) + (hi * (i ** 32));
+    const negative = signed && words[n - 1] & 0x80000000;
+    let number = negative ? 1 : 0;
+    let v = 0;
+    for (let i = 0; i < n; i++) {
+        v = words[i];
+        number += (negative ? ~v : v) * Math.pow(2, 32 * i);
+    }
+    if (negative) {
+        number *= -1;
     }
     return number;
 }


### PR DESCRIPTION
`bignumToNumber` is giving incorrect results for negative numbers. For example, the following data exists in my dataset:

```javascript
// this represents the value -180846 but bignumToNumber() returns -18446744069414765000
const v = new Uint32Array([4294786450, 4294967295, 4294967295, 4294967295])
```

In this PR, I rewrote the function to handle negative numbers correctly. I've tested it locally. Not sure if there's a more efficient way to write the function. It basically checks the most significant bit to see if it's negative, and, if it is, applies the 2's compliment and multiplies by -1 at the end. I couldn't think of any safe way to avoid multiplying at the end since JS's Number type is not guaranteed to be able to handle the values BigNum can represent, so, there's going to (potentially) be some bits lost in the conversion. So, any bitwise method may result in losing more information than we'd like.

Thinking about it some more, I actually think the existing bignumToNumber will fail on anything with more than 64-bits - doesn't really have anything to do with the number being negative. The original function actually works on my example above if I only let it run on the first two 32-bits.