### PR TITLE
ARROW-14641: [C++][Compute] Reduce print statements from unit tests

### DIFF
--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -1061,16 +1061,18 @@ TEST(HashJoin, Random) {
 
     // Print test case parameters
     // print num_rows, batch_size, join_type, join_cmp
-    std::cout << join_type_name << " " << key_cmp_str << " ";
-    key_types.Print();
-    std::cout << " payload_l: ";
-    payload_types[0].Print();
-    std::cout << " payload_r: ";
-    payload_types[1].Print();
-    std::cout << " num_rows_l = " << num_rows_l << " num_rows_r = " << num_rows_r
-              << " batch size = " << batch_size
-              << " parallel = " << (parallel ? "true" : "false");
-    std::cout << std::endl;
+    // std::cout << join_type_name << " " << key_cmp_str << " ";
+    // key_types.Print();
+    // std::cout << " payload_l: ";
+    // payload_types[0].Print();
+    // std::cout << " payload_r: ";
+    // payload_types[1].Print();
+    // std::cout << " num_rows_l = " << num_rows_l << " num_rows_r = " << num_rows_r
+    //           << " batch size = " << batch_size
+    //           << " parallel = " << (parallel ? "true" : "false");
+    // std::cout << std::endl;
+    ARROW_SCOPED_TRACE(join_type_name, " ", key_cmp_str,
+                       " parallel = ", (parallel ? "true" : "false"));
 
     // Run reference join implementation
     std::vector<bool> null_in_key_vectors[2];

--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -1059,18 +1059,6 @@ TEST(HashJoin, Random) {
                        &(key_fields[i]), &(output_fields[i]), &(output_field_ids[i]));
     }
 
-    // Print test case parameters
-    // print num_rows, batch_size, join_type, join_cmp
-    // std::cout << join_type_name << " " << key_cmp_str << " ";
-    // key_types.Print();
-    // std::cout << " payload_l: ";
-    // payload_types[0].Print();
-    // std::cout << " payload_r: ";
-    // payload_types[1].Print();
-    // std::cout << " num_rows_l = " << num_rows_l << " num_rows_r = " << num_rows_r
-    //           << " batch size = " << batch_size
-    //           << " parallel = " << (parallel ? "true" : "false");
-    // std::cout << std::endl;
     ARROW_SCOPED_TRACE(join_type_name, " ", key_cmp_str,
                        " parallel = ", (parallel ? "true" : "false"));
 

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -1313,32 +1313,22 @@ TEST(FutureLoopTest, AllowsBreakFutToBeDiscarded) {
 
 class MoveTrackingCallable {
  public:
-  MoveTrackingCallable() {
-    // std::cout << "CONSTRUCT" << std::endl;
-  }
-  ~MoveTrackingCallable() {
-    valid_ = false;
-    // std::cout << "DESTRUCT" << std::endl;
-  }
-  MoveTrackingCallable(const MoveTrackingCallable& other) {
-    // std::cout << "COPY CONSTRUCT" << std::endl;
-  }
-  MoveTrackingCallable(MoveTrackingCallable&& other) {
-    other.valid_ = false;
-    // std::cout << "MOVE CONSTRUCT" << std::endl;
-  }
-  MoveTrackingCallable& operator=(const MoveTrackingCallable& other) {
-    // std::cout << "COPY ASSIGN" << std::endl;
-    return *this;
-  }
+  MoveTrackingCallable() {}
+
+  ~MoveTrackingCallable() { valid_ = false; }
+
+  MoveTrackingCallable(const MoveTrackingCallable& other) {}
+
+  MoveTrackingCallable(MoveTrackingCallable&& other) { other.valid_ = false; }
+
+  MoveTrackingCallable& operator=(const MoveTrackingCallable& other) { return *this; }
+
   MoveTrackingCallable& operator=(MoveTrackingCallable&& other) {
     other.valid_ = false;
-    // std::cout << "MOVE ASSIGN" << std::endl;
     return *this;
   }
 
   Status operator()() {
-    // std::cout << "TRIGGER" << std::endl;
     if (valid_) {
       return Status::OK();
     } else {

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -452,8 +452,7 @@ TEST_F(TestProjector, TestTimestampDiffMonth) {
   std::shared_ptr<Projector> projector;
   auto status =
       Projector::Make(schema, {diff_months_expr}, TestConfiguration(), &projector);
-  // std::cout << status.message();
-  SCOPED_TRACE(status.message());
+
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();
@@ -511,8 +510,7 @@ TEST_F(TestProjector, TestMonthsBetween) {
   std::shared_ptr<Projector> projector;
   auto status =
       Projector::Make(schema, {months_between_expr}, TestConfiguration(), &projector);
-  // std::cout << status.message();
-  SCOPED_TRACE(status.message());
+
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();
@@ -562,8 +560,7 @@ TEST_F(TestProjector, TestLastDay) {
 
   std::shared_ptr<Projector> projector;
   auto status = Projector::Make(schema, {last_day_expr}, TestConfiguration(), &projector);
-  // std::cout << status.message();
-  SCOPED_TRACE(status.message());
+
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -452,7 +452,8 @@ TEST_F(TestProjector, TestTimestampDiffMonth) {
   std::shared_ptr<Projector> projector;
   auto status =
       Projector::Make(schema, {diff_months_expr}, TestConfiguration(), &projector);
-  std::cout << status.message();
+  // std::cout << status.message();
+  SCOPED_TRACE(status.message());
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();
@@ -510,7 +511,8 @@ TEST_F(TestProjector, TestMonthsBetween) {
   std::shared_ptr<Projector> projector;
   auto status =
       Projector::Make(schema, {months_between_expr}, TestConfiguration(), &projector);
-  std::cout << status.message();
+  // std::cout << status.message();
+  SCOPED_TRACE(status.message());
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();
@@ -560,7 +562,8 @@ TEST_F(TestProjector, TestLastDay) {
 
   std::shared_ptr<Projector> projector;
   auto status = Projector::Make(schema, {last_day_expr}, TestConfiguration(), &projector);
-  std::cout << status.message();
+  // std::cout << status.message();
+  SCOPED_TRACE(status.message());
   ASSERT_TRUE(status.ok());
 
   time_t epoch = Epoch();

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -254,7 +254,8 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
     for (size_t i = 0; i < this->values_.size(); i++) {
       if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
           comparator->Compare(this->values_out_[i], this->values_[i])) {
-        std::cout << "Failed at " << i << std::endl;
+        // std::cout << "Failed at " << i << std::endl;
+        ARROW_SCOPED_TRACE("Failed at ", i);
       }
       ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
       ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));
@@ -355,7 +356,8 @@ void TestPrimitiveWriter<Int96Type>::ReadAndCompare(Compression::type compressio
   for (size_t i = 0; i < this->values_.size(); i++) {
     if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
         comparator->Compare(this->values_out_[i], this->values_[i])) {
-      std::cout << "Failed at " << i << std::endl;
+      // std::cout << "Failed at " << i << std::endl;
+      ARROW_SCOPED_TRACE("Failed at ", i);
     }
     ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
     ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -254,8 +254,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
     for (size_t i = 0; i < this->values_.size(); i++) {
       if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
           comparator->Compare(this->values_out_[i], this->values_[i])) {
-        // std::cout << "Failed at " << i << std::endl;
-        ARROW_SCOPED_TRACE("Failed at ", i);
+        ARROW_SCOPED_TRACE("i = ", i);
       }
       ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
       ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));
@@ -356,8 +355,7 @@ void TestPrimitiveWriter<Int96Type>::ReadAndCompare(Compression::type compressio
   for (size_t i = 0; i < this->values_.size(); i++) {
     if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
         comparator->Compare(this->values_out_[i], this->values_[i])) {
-      // std::cout << "Failed at " << i << std::endl;
-      ARROW_SCOPED_TRACE("Failed at ", i);
+      ARROW_SCOPED_TRACE("i = ", i);
     }
     ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
     ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));


### PR DESCRIPTION
Update unconditional exposed `std::cout`s in unittests to use ARROW_SCOPED_TRACE or SCOPED_TRACE macros as appropriate.