### PR TITLE
ARROW-14664: [C++] Fix accepted types for Parquet encoding DELTA_BYTE_ARRAY

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2709,11 +2709,10 @@ std::unique_ptr<Decoder> MakeDecoder(Type::type type_num, Encoding::type encodin
         break;
     }
   } else if (encoding == Encoding::DELTA_BYTE_ARRAY) {
-    if (type_num == Type::BYTE_ARRAY || type_num == Type::FIXED_LEN_BYTE_ARRAY) {
+    if (type_num == Type::BYTE_ARRAY) {
       return std::unique_ptr<Decoder>(new DeltaByteArrayDecoder(descr));
     }
-    throw ParquetException(
-        "DELTA_BYTE_ARRAY only supports BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY");
+    throw ParquetException("DELTA_BYTE_ARRAY only supports BYTE_ARRAY");
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }


### PR DESCRIPTION
DELTA_BYTE_ARRAY is only applicable to BYTE_ARRAY but we would also accept FIXED_LEN_BYTE_ARRAY.
Casting the decoder to the expected subtype would then produce a null pointer.

Found by OSS-Fuzz.  Should fix the following issue:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40865