### PR TITLE
ARROW-14665: [JAVA] fix JdbcToArrow ResultSet iteration bug

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -263,7 +263,7 @@ public class JdbcToArrowUtils {
           readRowCount++;
         }
       } else {
-        while (rs.next() && readRowCount < config.getTargetBatchSize()) {
+        while (readRowCount < config.getTargetBatchSize() && rs.next()) {
           compositeConsumer.consume(rs);
           readRowCount++;
         }


### PR DESCRIPTION
JdbcToArrowUtils.jdbcToArrowVectors can skip rows in the ResultSet in between batches.