### PR TITLE
ARROW-13769: [C++] Modify BitmapOp API to fetch output validity count if requested

### DIFF
--- a/cpp/src/arrow/util/bit_util_benchmark.cc
+++ b/cpp/src/arrow/util/bit_util_benchmark.cc
@@ -165,6 +165,17 @@ static void BenchmarkBitmapAnd(benchmark::State& state) {
   });
 }
 
+static void BenchmarkBitmapAndWithPopCount(benchmark::State& state) {
+  BenchmarkAndImpl(state, [](const internal::Bitmap(&bitmaps)[2], internal::Bitmap* out) {
+    int64_t validity_count = 0;
+    internal::BitmapAnd(bitmaps[0].buffer()->data(), bitmaps[0].offset(),
+                        bitmaps[1].buffer()->data(), bitmaps[1].offset(),
+                        bitmaps[0].length(), 0, out->buffer()->mutable_data(),
+                        &validity_count);
+    benchmark::DoNotOptimize(validity_count);
+  });
+}
+
 static void BenchmarkBitmapVisitBitsetAnd(benchmark::State& state) {
   BenchmarkAndImpl(state, [](const internal::Bitmap(&bitmaps)[2], internal::Bitmap* out) {
     int64_t i = 0;
@@ -552,6 +563,7 @@ BENCHMARK(BitmapEqualsWithOffset)->Arg(kBufferSize);
     {kBufferSize * 4, kBufferSize * 16}, { 0, 2 } \
   }
 BENCHMARK(BenchmarkBitmapAnd)->Ranges(AND_BENCHMARK_RANGES);
+BENCHMARK(BenchmarkBitmapAndWithPopCount)->Ranges(AND_BENCHMARK_RANGES);
 BENCHMARK(BenchmarkBitmapVisitBitsetAnd)->Ranges(AND_BENCHMARK_RANGES);
 BENCHMARK(BenchmarkBitmapVisitUInt8And)->Ranges(AND_BENCHMARK_RANGES);
 BENCHMARK(BenchmarkBitmapVisitUInt64And)->Ranges(AND_BENCHMARK_RANGES);

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -117,14 +117,16 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> BitmapAnd(MemoryPool* pool, const uint8_t* left,
                                           int64_t left_offset, const uint8_t* right,
                                           int64_t right_offset, int64_t length,
-                                          int64_t out_offset);
+                                          int64_t out_offset,
+                                          int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out starting at the given bit-offset.
 ARROW_EXPORT
 void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out,
+               int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap or" for the given bit length on right and left buffers
 /// starting at their respective bit-offsets and put the results in out_buffer
@@ -136,14 +138,16 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> BitmapOr(MemoryPool* pool, const uint8_t* left,
                                          int64_t left_offset, const uint8_t* right,
                                          int64_t right_offset, int64_t length,
-                                         int64_t out_offset);
+                                         int64_t out_offset,
+                                         int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap or" for the given bit length on right and left buffers
 /// starting at their respective bit-offsets and put the results in out
 /// starting at the given bit-offset.
 ARROW_EXPORT
 void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
+              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out,
+              int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in
@@ -155,14 +159,16 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> BitmapXor(MemoryPool* pool, const uint8_t* left,
                                           int64_t left_offset, const uint8_t* right,
                                           int64_t right_offset, int64_t length,
-                                          int64_t out_offset);
+                                          int64_t out_offset,
+                                          int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in
 /// out starting at the given bit offset.
 ARROW_EXPORT
 void BitmapXor(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out,
+               int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap and not" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
@@ -174,14 +180,16 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> BitmapAndNot(MemoryPool* pool, const uint8_t* left,
                                              int64_t left_offset, const uint8_t* right,
                                              int64_t right_offset, int64_t length,
-                                             int64_t out_offset);
+                                             int64_t out_offset,
+                                             int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap and not" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out starting at the given bit-offset.
 ARROW_EXPORT
 void BitmapAndNot(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-                  int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
+                  int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out,
+                  int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap or not" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
@@ -193,14 +201,16 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> BitmapOrNot(MemoryPool* pool, const uint8_t* left,
                                             int64_t left_offset, const uint8_t* right,
                                             int64_t right_offset, int64_t length,
-                                            int64_t out_offset);
+                                            int64_t out_offset,
+                                            int64_t* out_validity_count = NULLPTR);
 
 /// \brief Do a "bitmap or not" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out starting at the given bit-offset.
 ARROW_EXPORT
 void BitmapOrNot(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-                 int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
+                 int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out,
+                 int64_t* out_validity_count = NULLPTR);
 
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
Currently there are two versions of Bitmap operations in the API.

1. Returns a Buffer object
2. Updates the output pointer passed in as function argument

With this change, they can now return bitmap operation result's validity count. All bitmap ops are updated to reflect the same.

This new output argument passed to the function should be pointer to single value (only first value is used if pointer to an array is passed). If this pointer is set to `nullptr`, the output validity count isn't calculated.