### PR TITLE
ARROW-14686: [Python][C++] make byte order detection for numpy builtin type correct

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -40,6 +40,7 @@
 #include "arrow/util/bitmap_generate.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/endian.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string.h"
@@ -662,7 +663,11 @@ Status NumPyConverter::Visit(const StringType& type) {
   char numpy_byteorder = dtype_->byteorder;
 
   // For Python C API, -1 is little-endian, 1 is big-endian
+#if ARROW_LITTLE_ENDIAN
   int byteorder = numpy_byteorder == '>' ? 1 : -1;
+#else
+  int byteorder = numpy_byteorder == '<' ? -1 : 1;
+#endif
 
   PyAcquireGIL gil_lock;
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -664,8 +664,10 @@ Status NumPyConverter::Visit(const StringType& type) {
 
   // For Python C API, -1 is little-endian, 1 is big-endian
 #if ARROW_LITTLE_ENDIAN
+  // Yield little-endian from both '|' (native) and '<'
   int byteorder = numpy_byteorder == '>' ? 1 : -1;
 #else
+  // Yield big-endian from both '|' (native) and '>'
   int byteorder = numpy_byteorder == '<' ? -1 : 1;
 #endif
 


### PR DESCRIPTION
This PR fixes the following test failures

```
FAILED pyarrow/tests/test_array.py::test_array_from_numpy_unicode - UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
FAILED pyarrow/tests/test_array.py::test_array_from_strided - UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
FAILED pyarrow/tests/test_array.py::test_array_from_numpy_str_utf8 - UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
```