### PR TITLE
ARROW-14678: [C++] Add reasonable CMake presets for quick dev setup

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -18,6 +18,7 @@
 thirdparty/*.tar*
 CMakeFiles/
 CMakeCache.txt
+CMakeUserPresets.json
 CTestTestfile.cmake
 Makefile
 cmake_install.cmake

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -1,0 +1,150 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ninja-debug",
+      "description": "Debug configuration with basic arrow build",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "String",
+          "value": "Debug"
+        },
+        "ARROW_WITH_RE2": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_COMPUTE": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_CSV": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_FILESYSTEM": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_PYTHON": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_IPC": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_DATASET": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_SKYHOOK": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_CUDA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_GANDIVA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_PARQUET": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_PLASMA_JAVA_CLIENT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_GANDIVA_JAVA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_GANDIVA_JNI": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_BUILD_TESTS": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_BUILD_BENCHMARKS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/${presetName}/pkg"
+        }
+      }
+    },
+    {
+      "name": "ninja-debug-gandiva",
+      "description": "Builds gandiva libraries along with arrow",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_GANDIVA": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-skyhook",
+      "description": "Builds Skyhook libraries along with arrow",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_SKYHOOK": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-dataset",
+      "description": "Builds Arrow Dataset Modules along with arrow",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_DATASET": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-parquet",
+      "description": "Builds Parquet libraries along with arrow",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_PARQUET": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-cuda",
+      "description": "Debug Arrow build with CUDA extensions (requires CUDA toolkit)",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_CUDA": "ON"
+      }
+    },
+    {
+      "name": "ninja-release",
+      "description": "Release Configuration",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "ARROW_GANDIVA": "ON",
+        "ARROW_PARQUET": "ON"
+      }
+    },
+    {
+      "name": "ninja-benchmarks",
+      "description": "Build for benchmarks with Ninja Generator",
+      "inherits": "ninja-release",
+      "cacheVariables": {
+        "ARROW_BUILD_BENCHMARKS": "ON",
+        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
+        "ARROW_BUILD_TESTS": "OFF"
+      }
+    }
+  ]
+}

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -7,16 +7,26 @@
   },
   "configurePresets": [
     {
+      "name": "ninja-benchmarks",
+      "description": "Build for benchmarks",
+      "inherits": "ninja-release",
+      "cacheVariables": {
+        "ARROW_BUILD_BENCHMARKS": "ON",
+        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
+        "ARROW_BUILD_TESTS": "OFF"
+      }
+    },
+    {
       "name": "ninja-debug",
-      "description": "Debug configuration with basic arrow build",
+      "description": "Debug configuration with basic build",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "generator": "Ninja",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": {
-          "type": "String",
-          "value": "Debug"
+        "ARROW_BUILD_BENCHMARKS": {
+          "type": "BOOL",
+          "value": "OFF"
         },
-        "ARROW_WITH_RE2": {
+        "ARROW_BUILD_TESTS": {
           "type": "BOOL",
           "value": "ON"
         },
@@ -28,39 +38,15 @@
           "type": "BOOL",
           "value": "ON"
         },
-        "ARROW_FILESYSTEM": {
+        "ARROW_CUDA": {
           "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_PYTHON": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_IPC": {
-          "type": "BOOL",
-          "value": "ON"
+          "value": "OFF"
         },
         "ARROW_DATASET": {
           "type": "BOOL",
           "value": "OFF"
         },
-        "ARROW_SKYHOOK": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_CUDA": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
         "ARROW_GANDIVA": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_PARQUET": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_PLASMA_JAVA_CLIENT": {
           "type": "BOOL",
           "value": "OFF"
         },
@@ -72,50 +58,42 @@
           "type": "BOOL",
           "value": "OFF"
         },
-        "ARROW_BUILD_TESTS": {
+        "ARROW_FILESYSTEM": {
           "type": "BOOL",
           "value": "ON"
         },
-        "ARROW_BUILD_BENCHMARKS": {
+        "ARROW_IPC": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_PARQUET": {
           "type": "BOOL",
           "value": "OFF"
+        },
+        "ARROW_PLASMA_JAVA_CLIENT": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_PYTHON": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "ARROW_SKYHOOK": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "ARROW_WITH_RE2": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "String",
+          "value": "Debug"
         },
         "CMAKE_INSTALL_PREFIX": {
           "type": "PATH",
           "value": "${sourceDir}/build/${presetName}/pkg"
         }
-      }
-    },
-    {
-      "name": "ninja-debug-gandiva",
-      "description": "Builds gandiva libraries along with arrow",
-      "inherits": "ninja-debug",
-      "cacheVariables": {
-        "ARROW_GANDIVA": "ON"
-      }
-    },
-    {
-      "name": "ninja-debug-skyhook",
-      "description": "Builds Skyhook libraries along with arrow",
-      "inherits": "ninja-debug",
-      "cacheVariables": {
-        "ARROW_SKYHOOK": "ON"
-      }
-    },
-    {
-      "name": "ninja-debug-dataset",
-      "description": "Builds Arrow Dataset Modules along with arrow",
-      "inherits": "ninja-debug",
-      "cacheVariables": {
-        "ARROW_DATASET": "ON"
-      }
-    },
-    {
-      "name": "ninja-debug-parquet",
-      "description": "Builds Parquet libraries along with arrow",
-      "inherits": "ninja-debug",
-      "cacheVariables": {
-        "ARROW_PARQUET": "ON"
       }
     },
     {
@@ -127,23 +105,59 @@
       }
     },
     {
-      "name": "ninja-release",
-      "description": "Release Configuration",
+      "name": "ninja-debug-dataset",
+      "description": "Builds Arrow Dataset modules",
       "inherits": "ninja-debug",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "ARROW_GANDIVA": "ON",
+        "ARROW_DATASET": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-gandiva",
+      "description": "Builds Gandiva libraries",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_GANDIVA": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-parquet",
+      "description": "Builds Parquet libraries",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
         "ARROW_PARQUET": "ON"
       }
     },
     {
-      "name": "ninja-benchmarks",
-      "description": "Build for benchmarks with Ninja Generator",
+      "name": "ninja-debug-skyhook",
+      "description": "Builds Skyhook libraries along with arrow",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "ARROW_SKYHOOK": "ON"
+      }
+    },
+    {
+      "name": "ninja-release",
+      "description": "Release configuration",
+      "inherits": "ninja-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-release-gandiva",
+      "description": "Release configuration with Gandiva",
       "inherits": "ninja-release",
       "cacheVariables": {
-        "ARROW_BUILD_BENCHMARKS": "ON",
-        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
-        "ARROW_BUILD_TESTS": "OFF"
+        "ARROW_GANDIVA": "ON"
+      }
+    },
+    {
+      "name": "ninja-release-parquet",
+      "description": "Release configuration with Parquet",
+      "inherits": "ninja-release",
+      "cacheVariables": {
+        "ARROW_PARQUET": "ON"
       }
     }
   ]

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -130,7 +130,8 @@
     },
     {
       "name": "ninja-debug-skyhook",
-      "description": "Builds Skyhook libraries along with arrow",
+      "description": "Builds Skyhook libraries",
+
       "inherits": "ninja-debug",
       "cacheVariables": {
         "ARROW_SKYHOOK": "ON"


### PR DESCRIPTION
Run the following command for cpp builds to see list of presets available.

```bash
cmake --list-presets ..
```

Run the following command to setup build folder.
```bash
cmake --preset <chosen-preset-name> ..
```

Note that, we can still pass the regular `-D<OPTION>=<VALUE` style arguments when using presets. Presets require a minimum CMake version of 3.19. One doesn't need to use presets, they just provide a convenience if the user feasible CMake version.

This is not a comprehensive list by any means, but only a starter based on what I have been building in arrow repository. If there are given list of most used combinations, please suggest and I can add accordingly. The reason I added `ninja` prefix to current presets is different any potential `make` or `msvc` generators we might add later.

Shown below is the first few lines of sample output of CMake command with presets, it shows the CMake options set by the chosen preset.
```bash
Preset CMake variables:

  ARROW_BUILD_BENCHMARKS:BOOL="OFF"
  ARROW_BUILD_TESTS:BOOL="ON"
  ARROW_COMPUTE:BOOL="ON"
  ARROW_CSV:BOOL="ON"
  ARROW_CUDA="ON"
  ARROW_DATASET:BOOL="OFF"
  ARROW_FILESYSTEM:BOOL="ON"
  ARROW_GANDIVA:BOOL="OFF"
  ARROW_GANDIVA_JAVA:BOOL="OFF"
  ARROW_GANDIVA_JNI:BOOL="OFF"
  ARROW_IPC:BOOL="ON"
  ARROW_PARQUET:BOOL="OFF"
  ARROW_PLASMA_JAVA_CLIENT:BOOL="OFF"
  ARROW_PYTHON:BOOL="ON"
  ARROW_SKYHOOK:BOOL="OFF"
  ARROW_WITH_RE2:BOOL="ON"
  CMAKE_BUILD_TYPE:STRING="Debug"
  CMAKE_INSTALL_PREFIX:PATH="/home/pradeep/arrow/cpp/build/ninja-debug-cuda/pkg"

-- Building using CMake version: 3.21.4

```