### PR TITLE
ARROW-13371 [R] binding for make_struct -> StructArray$create()

### DIFF
--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -251,7 +251,10 @@ nse_funcs$is_logical <- function(x, n = NULL) {
 }
 
 # Create a data frame/tibble/struct column
-nse_funcs$tibble <- function(...) {
+nse_funcs$tibble <- function(..., .rows = NULL, .name_repair = NULL) {
+  if (!is.null(.rows)) arrow_not_supported(".rows")
+  if (!is.null(.name_repair)) arrow_not_supported(".name_repair")
+
   # use dots_list() because this is what tibble() uses to allow the
   # useful shorthand of tibble(col1, col2) -> tibble(col1 = col1, col2 = col2_)
   args <- rlang::dots_list(..., .named = TRUE)
@@ -263,10 +266,19 @@ nse_funcs$tibble <- function(...) {
   )
 }
 
-nse_funcs$data.frame <- function(..., stringsAsFactors = FALSE) {
+nse_funcs$data.frame <- function(..., row.names = NULL,
+                                 check.rows = NULL, check.names = NULL, fix.empty.names = NULL,
+                                 stringsAsFactors = FALSE) {
+  # we need a specific value of stringsAsFactors because the default was
+  # TRUE in R <= 3.6
   if (!identical(stringsAsFactors, FALSE)) {
     arrow_not_supported("stringsAsFactors = TRUE")
   }
+
+  if (!is.null(row.names)) arrow_not_supported("row.names")
+  if (!is.null(check.rows)) arrow_not_supported("check.rows")
+  if (!is.null(check.names)) arrow_not_supported("check.names")
+  if (!is.null(fix.empty.names)) arrow_not_supported("fix.empty.names")
 
   nse_funcs$tibble(...)
 }

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -271,7 +271,7 @@ nse_funcs$tibble <- function(..., .rows = NULL, .name_repair = NULL) {
 }
 
 nse_funcs$data.frame <- function(..., row.names = NULL,
-                                 check.rows = NULL, check.names = NULL, fix.empty.names = TRUE,
+                                 check.rows = NULL, check.names = TRUE, fix.empty.names = TRUE,
                                  stringsAsFactors = FALSE) {
   # we need a specific value of stringsAsFactors because the default was
   # TRUE in R <= 3.6
@@ -284,9 +284,17 @@ nse_funcs$data.frame <- function(..., row.names = NULL,
   if (!is.null(check.rows)) warning("Argument `check.rows` will be ignored", call. = FALSE)
 
   args <- rlang::dots_list(..., .named = fix.empty.names)
+  if (is.null(names(args))) {
+    names(args) <- rep("", length(args))
+  }
 
   if (identical(check.names, TRUE)) {
-    names(args) <- make.names(names(args), unique = TRUE)
+    if (identical(fix.empty.names, TRUE)) {
+      names(args) <- make.names(names(args), unique = TRUE)
+    } else {
+      name_emtpy <- names(args) == ""
+      names(args)[!name_emtpy] <- make.names(names(args)[!name_emtpy], unique = TRUE)
+    }
   }
 
   build_expr(

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -251,7 +251,7 @@ nse_funcs$is_logical <- function(x, n = NULL) {
 }
 
 # Create a data frame/tibble/struct column
-nse_funcs$data.frame <- nse_funcs$tibble <- function(...) {
+nse_funcs$tibble <- function(...) {
   # use dots_list() because this is what tibble() uses to allow the
   # useful shorthand of tibble(col1, col2) -> tibble(col1 = col1, col2 = col2_)
   args <- rlang::dots_list(..., .named = TRUE)
@@ -261,6 +261,14 @@ nse_funcs$data.frame <- nse_funcs$tibble <- function(...) {
     args = unname(args),
     options = list(field_names = names(args))
   )
+}
+
+nse_funcs$data.frame <- function(..., stringsAsFactors = FALSE) {
+  if (!identical(stringsAsFactors, FALSE)) {
+    arrow_not_supported("stringsAsFactors = TRUE")
+  }
+
+  nse_funcs$tibble(...)
 }
 
 # String functions

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -256,7 +256,7 @@ nse_funcs$tibble <- function(..., .rows = NULL, .name_repair = NULL) {
   if (!is.null(.name_repair)) arrow_not_supported(".name_repair")
 
   # use dots_list() because this is what tibble() uses to allow the
-  # useful shorthand of tibble(col1, col2) -> tibble(col1 = col1, col2 = col2_)
+  # useful shorthand of tibble(col1, col2) -> tibble(col1 = col1, col2 = col2)
   args <- rlang::dots_list(..., .named = TRUE)
 
   build_expr(

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -250,6 +250,16 @@ nse_funcs$is_logical <- function(x, n = NULL) {
   nse_funcs$is.logical(x)
 }
 
+# Create a data frame/tibble/struct column
+nse_funcs$data.frame <- nse_funcs$tibble <- function(...) {
+  args <- rlang::list2(...)
+  build_expr(
+    "make_struct",
+    args = unname(args),
+    options = list(field_names = names(args))
+  )
+}
+
 # String functions
 nse_funcs$nchar <- function(x, type = "chars", allowNA = FALSE, keepNA = NA) {
   if (allowNA) {

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -252,7 +252,10 @@ nse_funcs$is_logical <- function(x, n = NULL) {
 
 # Create a data frame/tibble/struct column
 nse_funcs$data.frame <- nse_funcs$tibble <- function(...) {
-  args <- rlang::list2(...)
+  # use dots_list() because this is what tibble() uses to allow the
+  # useful shorthand of tibble(col1, col2) -> tibble(col1 = col1, col2 = col2_)
+  args <- rlang::dots_list(..., .named = TRUE)
+
   build_expr(
     "make_struct",
     args = unname(args),

--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -280,8 +280,8 @@ nse_funcs$data.frame <- function(..., row.names = NULL,
   }
 
   # ignore row.names and check.rows with a warning
-  if (!is.null(row.names)) warning("Argument `row.names` will be ignored", call. = FALSE)
-  if (!is.null(check.rows)) warning("Argument `check.rows` will be ignored", call. = FALSE)
+  if (!is.null(row.names)) arrow_not_supported("row.names")
+  if (!is.null(check.rows)) arrow_not_supported("check.rows")
 
   args <- rlang::dots_list(..., .named = fix.empty.names)
   if (is.null(names(args))) {

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -651,6 +651,19 @@ test_that("structs/nested data frames/tibbles can be created", {
     df
   )
 
+  # ...and that other arguments are not supported
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = tibble(char_col, .rows = 1L)),
+    ".rows not supported in Arrow"
+  )
+
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = tibble(char_col, .name_repair = "universal")),
+    ".name_repair not supported in Arrow"
+  )
+
   # check that data.frame is mapped too
   # stringsAsFactors default is TRUE in R 3.6, which is still tested on CI
   compare_dplyr_binding(
@@ -663,10 +676,34 @@ test_that("structs/nested data frames/tibbles can be created", {
     df
   )
 
-  # ...and that stringsAsFactors = TRUE is not supported
+  # ...and that other arguments are not supported
   expect_warning(
     RecordBatch$create(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, stringsAsFactors = TRUE)),
     "stringsAsFactors = TRUE not supported in Arrow"
+  )
+
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = data.frame(char_col, row.names = 1L)),
+    "row.names not supported in Arrow"
+  )
+
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = data.frame(char_col, check.rows = TRUE)),
+    "check.rows not supported in Arrow"
+  )
+
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = data.frame(char_col, check.names = 1L)),
+    "check.names not supported in Arrow"
+  )
+
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = data.frame(char_col, fix.empty.names = 1L)),
+    "fix.empty.names not supported in Arrow"
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -625,3 +625,40 @@ test_that("bad explicit type conversions with as.*()", {
     )
   )
 })
+
+test_that("structs/nested data frames/tibbles can be created", {
+  df <- tibble(regular_col1 = 1L, regular_col2 = "a")
+
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = tibble(
+          regular_col1 = regular_col1,
+          regular_col2 = regular_col2
+        )
+      ) %>%
+      collect(),
+    df
+  )
+
+  # check auto column naming
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = tibble(regular_col1, regular_col2)
+      ) %>%
+      collect(),
+    df
+  )
+
+  # check that data.frame is mapped too
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = data.frame(regular_col1, regular_col2)
+      ) %>%
+      collect() %>%
+      mutate(df_col = as.data.frame(df_col)),
+    df
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -727,3 +727,26 @@ test_that("structs/nested data frames/tibbles can be created", {
     "check.rows not supported in Arrow"
   )
 })
+
+test_that("nested structs can be created from scalars and existing data frames", {
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = tibble(b = 3)
+      ) %>%
+      collect(),
+    tibble(a = 1:2)
+  )
+
+  # technically this is handled by Scalar$create() since there is no
+  # call to data.frame or tibble() within a dplyr verb
+  existing_data_frame <- tibble(b = 3)
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = existing_data_frame
+      ) %>%
+      collect(),
+    tibble(a = 1:2)
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -652,13 +652,21 @@ test_that("structs/nested data frames/tibbles can be created", {
   )
 
   # check that data.frame is mapped too
+  # stringsAsFactors default is TRUE in R 3.6, which is still tested on CI
   compare_dplyr_binding(
     .input %>%
       transmute(
-        df_col = data.frame(regular_col1, regular_col2)
+        df_col = data.frame(regular_col1, regular_col2, stringsAsFactors = FALSE)
       ) %>%
       collect() %>%
       mutate(df_col = as.data.frame(df_col)),
     df
+  )
+
+  # ...and that stringsAsFactors = TRUE is not supported
+  expect_warning(
+    RecordBatch$create(char_col = "a") %>%
+      mutate(df_col = data.frame(char_col, stringsAsFactors = TRUE)),
+    "stringsAsFactors = TRUE not supported in Arrow"
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -718,12 +718,12 @@ test_that("structs/nested data frames/tibbles can be created", {
   expect_warning(
     record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, row.names = 1L)),
-    "`row.names` will be ignored"
+    "row.names not supported in Arrow"
   )
 
   expect_warning(
     record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, check.rows = TRUE)),
-    "`check.rows` will be ignored"
+    "check.rows not supported in Arrow"
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -653,13 +653,13 @@ test_that("structs/nested data frames/tibbles can be created", {
 
   # ...and that other arguments are not supported
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = tibble(char_col, .rows = 1L)),
     ".rows not supported in Arrow"
   )
 
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = tibble(char_col, .name_repair = "universal")),
     ".name_repair not supported in Arrow"
   )
@@ -678,31 +678,31 @@ test_that("structs/nested data frames/tibbles can be created", {
 
   # ...and that other arguments are not supported
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, stringsAsFactors = TRUE)),
     "stringsAsFactors = TRUE not supported in Arrow"
   )
 
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, row.names = 1L)),
     "row.names not supported in Arrow"
   )
 
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, check.rows = TRUE)),
     "check.rows not supported in Arrow"
   )
 
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, check.names = 1L)),
     "check.names not supported in Arrow"
   )
 
   expect_warning(
-    RecordBatch$create(char_col = "a") %>%
+    record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, fix.empty.names = 1L)),
     "fix.empty.names not supported in Arrow"
   )

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -676,6 +676,38 @@ test_that("structs/nested data frames/tibbles can be created", {
     df
   )
 
+  # check with fix.empty.names = FALSE
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = data.frame(regular_col1, fix.empty.names = FALSE)
+      ) %>%
+      collect() %>%
+      mutate(df_col = as.data.frame(df_col)),
+    df
+  )
+
+  # check with check.names = TRUE and FALSE
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = data.frame(regular_col1, regular_col1, check.names = TRUE)
+      ) %>%
+      collect() %>%
+      mutate(df_col = as.data.frame(df_col)),
+    df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      transmute(
+        df_col = data.frame(regular_col1, regular_col1, check.names = FALSE)
+      ) %>%
+      collect() %>%
+      mutate(df_col = as.data.frame(df_col)),
+    df
+  )
+
   # ...and that other arguments are not supported
   expect_warning(
     record_batch(char_col = "a") %>%
@@ -686,24 +718,12 @@ test_that("structs/nested data frames/tibbles can be created", {
   expect_warning(
     record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, row.names = 1L)),
-    "row.names not supported in Arrow"
+    "`row.names` will be ignored"
   )
 
   expect_warning(
     record_batch(char_col = "a") %>%
       mutate(df_col = data.frame(char_col, check.rows = TRUE)),
-    "check.rows not supported in Arrow"
-  )
-
-  expect_warning(
-    record_batch(char_col = "a") %>%
-      mutate(df_col = data.frame(char_col, check.names = 1L)),
-    "check.names not supported in Arrow"
-  )
-
-  expect_warning(
-    record_batch(char_col = "a") %>%
-      mutate(df_col = data.frame(char_col, fix.empty.names = 1L)),
-    "fix.empty.names not supported in Arrow"
+    "`check.rows` will be ignored"
   )
 })


### PR DESCRIPTION
This PR implements a binding for the `make_struct` compute function. This function was already being called in the translation for `case_when()` but didn't have a binding of its own. Because you can do this in dplyr too (create a nested data frame), I mapped `tibble()` and `data.frame()` since it can be tested using `compare_dplyr_binding()`. `StructArray$create()` is a nested call and is probably not that useful of a translation for dplyr users (I'd never think to use it).

Basically, you can now do this:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

df <- RecordBatch$create(a = 1, b = "two")
df %>% 
  mutate(df_col = tibble(a, b)) %>% 
  collect()
#> # A tibble: 1 × 3
#>       a b     df_col$a $b   
#>   <dbl> <chr>    <dbl> <chr>
#> 1     1 two          1 two
```

Something I didn't do but could is add all the arguments of `tibble()` and `data.frame()` that aren't supported (e.g., `stringsAsFactors`). It seems like this is done for other translations but I just wanted to check!
