### PR TITLE
ARROW-6276: [C++] Add operator[] for some arrow classes

### DIFF
--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -75,6 +75,10 @@ class BaseBinaryArray : public FlatArray {
                              raw_value_offsets_[i + 1] - pos);
   }
 
+  util::optional<util::string_view> operator[](int64_t i) const {
+    return *IteratorType(*this, i);
+  }
+
   /// \brief Get binary value as a string_view
   /// Provided for consistency with other arrays.
   ///
@@ -234,6 +238,10 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
 
   util::string_view GetView(int64_t i) const {
     return util::string_view(reinterpret_cast<const char*>(GetValue(i)), byte_width());
+  }
+
+  util::optional<util::string_view> operator[](int64_t i) const {
+    return *IteratorType(*this, i);
   }
 
   std::string GetString(int64_t i) const { return std::string(GetView(i)); }

--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -106,6 +106,18 @@ class TestStringArray : public ::testing::Test {
     AssertZeroPadded(*strings_);
   }
 
+  void TestArrayIndexOperator() {
+    const auto& arr = *strings_;
+    for (int64_t i = 0; i < arr.length(); ++i) {
+      if (valid_bytes_[i]) {
+        ASSERT_TRUE(arr[i].has_value());
+        ASSERT_EQ(expected_[i], arr[i].value());
+      } else {
+        ASSERT_FALSE(arr[i].has_value());
+      }
+    }
+  }
+
   void TestArrayCtors() {
     // ARROW-8863: ArrayData::null_count set to 0 when no validity bitmap
     // provided
@@ -327,6 +339,8 @@ class TestStringArray : public ::testing::Test {
 TYPED_TEST_SUITE(TestStringArray, BaseBinaryArrowTypes);
 
 TYPED_TEST(TestStringArray, TestArrayBasics) { this->TestArrayBasics(); }
+
+TYPED_TEST(TestStringArray, TestArrayIndexOperator) { this->TestArrayIndexOperator(); }
 
 TYPED_TEST(TestStringArray, TestArrayCtors) { this->TestArrayCtors(); }
 

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -54,6 +54,8 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
 
   bool GetView(int64_t i) const { return Value(i); }
 
+  util::optional<bool> operator[](int64_t i) const { return *IteratorType(*this, i); }
+
   /// \brief Return the number of false (0) values among the valid
   /// values. Result is not cached.
   int64_t false_count() const;
@@ -109,6 +111,10 @@ class NumericArray : public PrimitiveArray {
   // For API compatibility with BinaryArray etc.
   value_type GetView(int64_t i) const { return Value(i); }
 
+  util::optional<value_type> operator[](int64_t i) const {
+    return *IteratorType(*this, i);
+  }
+
   IteratorType begin() const { return IteratorType(*this); }
 
   IteratorType end() const { return IteratorType(*this, length()); }
@@ -123,6 +129,7 @@ class NumericArray : public PrimitiveArray {
 class ARROW_EXPORT DayTimeIntervalArray : public PrimitiveArray {
  public:
   using TypeClass = DayTimeIntervalType;
+  using IteratorType = stl::ArrayIterator<DayTimeIntervalArray>;
 
   explicit DayTimeIntervalArray(const std::shared_ptr<ArrayData>& data);
 
@@ -141,6 +148,14 @@ class ARROW_EXPORT DayTimeIntervalArray : public PrimitiveArray {
   // For compatibility with Take kernel.
   TypeClass::DayMilliseconds GetView(int64_t i) const { return GetValue(i); }
 
+  IteratorType begin() const { return IteratorType(*this); }
+
+  IteratorType end() const { return IteratorType(*this, length()); }
+
+  util::optional<TypeClass::DayMilliseconds> operator[](int64_t i) const {
+    return *IteratorType(*this, i);
+  }
+
   int32_t byte_width() const { return sizeof(TypeClass::DayMilliseconds); }
 
   const uint8_t* raw_values() const { return raw_values_ + data_->offset * byte_width(); }
@@ -150,6 +165,7 @@ class ARROW_EXPORT DayTimeIntervalArray : public PrimitiveArray {
 class ARROW_EXPORT MonthDayNanoIntervalArray : public PrimitiveArray {
  public:
   using TypeClass = MonthDayNanoIntervalType;
+  using IteratorType = stl::ArrayIterator<MonthDayNanoIntervalArray>;
 
   explicit MonthDayNanoIntervalArray(const std::shared_ptr<ArrayData>& data);
 
@@ -167,6 +183,14 @@ class ARROW_EXPORT MonthDayNanoIntervalArray : public PrimitiveArray {
 
   // For compatibility with Take kernel.
   TypeClass::MonthDayNanos GetView(int64_t i) const { return GetValue(i); }
+
+  IteratorType begin() const { return IteratorType(*this); }
+
+  IteratorType end() const { return IteratorType(*this, length()); }
+
+  util::optional<TypeClass::MonthDayNanos> operator[](int64_t i) const {
+    return *IteratorType(*this, i);
+  }
 
   int32_t byte_width() const { return sizeof(TypeClass::MonthDayNanos); }
 

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3396,8 +3396,8 @@ TYPED_TEST_SUITE(TestPrimitiveArray, Primitives);
 
 TYPED_TEST(TestPrimitiveArray, IndexOperator) {
   typename TypeParam::BuilderType builder;
-  builder.Reserve(this->values_.size());
-  builder.AppendValues(this->values_, this->null_tags_);
+  ASSERT_OK(builder.Reserve(this->values_.size()));
+  ASSERT_OK(builder.AppendValues(this->values_, this->null_tags_));
   ASSERT_OK_AND_ASSIGN(auto array, builder.Finish());
 
   const auto& carray = checked_cast<typename TypeParam::ArrayType&>(*array);


### PR DESCRIPTION
The following classes have now an additional operator[](int64_t)
overload that fetches ith element.

- BooleanArray
- NumericArray
- DayTimeIntervalArray
- MonthDayNanoIntervalArray
- BaseBinaryArray
- FixedSizeBinaryArray