### PR TITLE
ARROW-14667: [C++] Added a dcheck to ensure aws is initialized before s3 options are used

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -210,6 +210,10 @@ bool S3ProxyOptions::Equals(const S3ProxyOptions& other) const {
 // -----------------------------------------------------------------------
 // S3Options implementation
 
+S3Options::S3Options() {
+  DCHECK(aws_initialized.load()) << "Must initialize S3 before using S3Options";
+}
+
 void S3Options::ConfigureDefaultCredentials() {
   credentials_provider =
       std::make_shared<Aws::Auth::DefaultAWSCredentialsProviderChain>();

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -139,6 +139,8 @@ struct ARROW_EXPORT S3Options {
   /// delay between retries.
   std::shared_ptr<S3RetryStrategy> retry_strategy;
 
+  S3Options();
+
   /// Configure with the default AWS credentials provider chain.
   void ConfigureDefaultCredentials();
 


### PR DESCRIPTION
ARROW-14667 was fixed in R but we could probably do better to prevent this kind of thing.  Short of requiring `S3Options` to have a `Make` method we could just add a simple `DCHECK`.