### PR TITLE
ARROW-14662: [Docs] Add note about linking Flight/gRPC/Protobuf

### DIFF
--- a/cpp/examples/arrow/flight_grpc_example.cc
+++ b/cpp/examples/arrow/flight_grpc_example.cc
@@ -37,6 +37,23 @@
 // For example, with grpcurl (https://github.com/fullstorydev/grpcurl):
 //
 // grpcurl -d '{"name": "Rakka"}' -plaintext localhost:31337 HelloWorldService/SayHello
+//
+// Note that for applications that wish to follow the example here,
+// care must be taken to ensure that Protobuf and gRPC are not
+// multiply linked, else the resulting program may crash or silently
+// corrupt data. In particular:
+//
+// * If dynamically linking Arrow Flight, then your application and
+//   Arrow Flight must also dynamically link Protobuf and gRPC. (The
+//   same goes for static linking.)
+// * The Flight packages on some platforms may make this difficult,
+//   because the Flight dynamic library will itself have statically
+//   linked Protobuf and gRPC since the platform does not ship a
+//   recent enough version of those dependencies.
+// * The versions of Protobuf and gRPC must be the same between Flight
+//   and your application.
+//
+// See "Using Arrow C++ in your own project" in the documentation.
 
 DEFINE_int32(port, -1, "Server port to listen on");
 

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -155,7 +155,8 @@ class ARROW_FLIGHT_EXPORT FlightServerOptions {
   /// Not guaranteed to be called. The type of the parameter is
   /// specific to the Flight implementation. Users should take care to
   /// link to the same transport implementation as Flight to avoid
-  /// runtime problems.
+  /// runtime problems. See "Using Arrow C++ in your own project" in
+  /// the documentation for more details.
   std::function<void(void*)> builder_hook;
 };
 

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -153,7 +153,7 @@ the following guidelines:
   linked, and the same goes for dynamic linking.
 * Some platforms (e.g. Ubuntu 20.04 at the time of this writing) may ship a
   version of Protobuf and/or gRPC that is not recent enough for Arrow
-  Flight. In that case, Arrow Flight bundles these dependencies, so case must
+  Flight. In that case, Arrow Flight bundles these dependencies, so care must
   be taken not to mix the Arrow Flight library with the platform Protobuf/gRPC
   libraries (as then you will have two versions of Protobuf and/or gRPC linked
   into your application).

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -134,3 +134,32 @@ all available packages:
   * ``gandiva``
   * ``parquet``
   * ``plasma``
+
+A Note on Linking
+=================
+
+Some Arrow components have dependencies that you may want to use in your own
+project. Care must be taken to ensure that your project links the same version
+of these dependencies in the same way (statically or dynamically) as Arrow,
+else `ODR <https://en.wikipedia.org/wiki/One_Definition_Rule>`_ violations may
+result and your program may crash or silently corrupt data.
+
+In particular, Arrow Flight and its dependencies `Protocol Buffers (Protobuf)
+<https://developers.google.com/protocol-buffers/>`_ and `gRPC
+<https://grpc.io/>`_ are likely to cause issues. When using Arrow Flight, note
+the following guidelines:
+
+* If statically linking Arrow Flight, Protobuf and gRPC must also be statically
+  linked, and the same goes for dynamic linking.
+* Some platforms (e.g. Ubuntu 20.04 at the time of this writing) may ship a
+  version of Protobuf and/or gRPC that is not recent enough for Arrow
+  Flight. In that case, Arrow Flight bundles these dependencies, so case must
+  be taken not to mix the Arrow Flight library with the platform Protobuf/gRPC
+  libraries (as then you will have two versions of Protobuf and/or gRPC linked
+  into your application).
+
+It may be easiest to depend on a version of Arrow built from source, where you
+can control the source of each dependency and whether it is statically or
+dynamically linked. See :doc:`/developers/cpp/building` for instructions. Or
+alternatively, use Arrow from a package manager such as Conda or vcpkg which
+will manage consistent versions of Arrow and its dependencies.

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -50,12 +50,12 @@ as they are pushed to it along an edge of the graph by upstream nodes
 (its inputs), and pushes batches along an edge of the graph to downstream
 nodes (its outputs) as they are finalized.
 
-..seealso::
+.. seealso::
 
-  `SHAIKHHA, A., DASHTI, M., & KOCH, C.
-  (2018). Push versus pull-based loop fusion in query engines.
-  Journal of Functional Programming, 28.
-  <https://doi.org/10.1017/s0956796818000102>`_
+   `SHAIKHHA, A., DASHTI, M., & KOCH, C.
+   (2018). Push versus pull-based loop fusion in query engines.
+   Journal of Functional Programming, 28.
+   <https://doi.org/10.1017/s0956796818000102>`_
 
 Overview
 --------

--- a/docs/source/developers/archery.rst
+++ b/docs/source/developers/archery.rst
@@ -90,5 +90,5 @@ help output, for example:
      push    Push the generated docker-compose image.
      run     Execute docker-compose builds.
 
-A more detailed introduction to using docker with
-Archery is available in a separate :ref:`page <docker>`.
+A more detailed introduction to using Docker with
+Archery is available at :doc:`docker`.

--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -47,10 +47,12 @@ Classes
    :toctree: ../generated/
 
    FileFormat
-   ParquetFileFormat
-   ORCFileFormat
-   IpcFileFormat
    CsvFileFormat
+   CsvFragmentScanOptions
+   IpcFileFormat
+   ParquetFileFormat
+   ParquetFragmentScanOptions
+   ORCFileFormat
    Partitioning
    PartitioningFactory
    DirectoryPartitioning

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1840,11 +1840,11 @@ cdef class CsvFileFormat(FileFormat):
 
     Parameters
     ----------
-    parse_options : ParseOptions
+    parse_options : csv.ParseOptions
         Options regarding CSV parsing.
-    convert_options : ConvertOptions
+    convert_options : csv.ConvertOptions
         Options regarding value conversion.
-    read_options : ReadOptions
+    read_options : csv.ReadOptions
         General read options.
     default_fragment_scan_options : CsvFragmentScanOptions
         Default options for fragments scan.
@@ -1923,9 +1923,9 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
 
     Parameters
     ----------
-    convert_options : ConvertOptions
+    convert_options : csv.ConvertOptions
         Options regarding value conversion.
-    read_options : ReadOptions
+    read_options : csv.ReadOptions
         General read options.
     """
 


### PR DESCRIPTION
Adds a note about linking Flight/gRPC/Protobuf as a reference for issues like those seen in apache/arrow#11657.

Also fixes a number of build warnings.