### PR TITLE
MINOR: [C++] Ignore clangd index files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ perf.data.old
 cpp/.idea/
 .clangd/
 cpp/.clangd/
+.cache/clangd/
+cpp/.cache/clangd/
 cpp/apidoc/xml/
 docs/example.gz
 docs/example1.dat


### PR DESCRIPTION
clangd 12 has moved index files from .clangd/ to .cache/clangd/.
clangd is a language server for code completion, go-to-definition, etc.