### PR TITLE
ARROW-14711: [Javascript] Fixed TextDecoder for old NodeJS versions

### DIFF
--- a/js/src/util/utf8.ts
+++ b/js/src/util/utf8.ts
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-const decoder = new TextDecoder('utf-8');
+// TextDecoder backward compatibility with older NodeJS versions
+if (typeof TextDecoder === "undefined" && typeof require !== "undefined") {
+  (global as any).TextDecoder = require("util").TextDecoder;
+}
+
+const decoder = new TextDecoder("utf-8");
 /** @ignore */
 export const decodeUtf8 = (buffer?: BufferSource) => decoder.decode(buffer);
 


### PR DESCRIPTION
A fix was proposed for the issue stated at https://github.com/apache/arrow/issues/11662.

This fix would allow the developer to use older _NodeJS_ versions for running _Arrow_. An expert review is required for testing the fixed usability.