### PR TITLE
ARROW-14718: [Java] loadValidityBuffer should avoid allocating memory when input is not null and there are only null or non-null values

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -328,10 +328,13 @@ public class BitVectorHelper {
                                             final BufferAllocator allocator) {
     final int valueCount = fieldNode.getLength();
     ArrowBuf newBuffer = null;
+
+    // Create a new validity buffer iff both of the following are true:
+    //   - validity buffer is not present, that is, it is either null or empty (in the case of
+    //     IPC for instance).
+    //   - values are either all NULLs or all non-NULLs
     boolean isValidityBufferNull = sourceValidityBuffer == null ||
-        sourceValidityBuffer.memoryAddress() == 0;
-    // create a new validity buffer iff all values are not null AND values
-    // are either all NULLs or all non-NULLs
+        sourceValidityBuffer.capacity() == 0;
     if (isValidityBufferNull &&
         (fieldNode.getNullCount() == 0 || fieldNode.getNullCount() == valueCount)) {
       newBuffer = allocator.buffer(getValidityBufferSize(valueCount));

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -329,7 +329,8 @@ public class BitVectorHelper {
     final int valueCount = fieldNode.getLength();
     ArrowBuf newBuffer = null;
     /* either all NULLs or all non-NULLs */
-    if (fieldNode.getNullCount() == 0 || fieldNode.getNullCount() == valueCount) {
+    if (sourceValidityBuffer == null && (fieldNode.getNullCount() == 0 ||
+        fieldNode.getNullCount() == valueCount)) {
       newBuffer = allocator.buffer(getValidityBufferSize(valueCount));
       newBuffer.setZero(0, newBuffer.capacity());
       if (fieldNode.getNullCount() != 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -328,16 +328,12 @@ public class BitVectorHelper {
                                             final BufferAllocator allocator) {
     final int valueCount = fieldNode.getLength();
     ArrowBuf newBuffer = null;
-    /* either all NULLs or all non-NULLs */
-    if (sourceValidityBuffer == null && (fieldNode.getNullCount() == 0 ||
-        fieldNode.getNullCount() == valueCount)) {
+    boolean isValidityBufferNull = sourceValidityBuffer == null || sourceValidityBuffer.memoryAddress() == 0;
+    // create a new validity buffer iff all values are not null AND the original validity buffer
+    // is null
+    if (isValidityBufferNull && fieldNode.getNullCount() == 0) {
       newBuffer = allocator.buffer(getValidityBufferSize(valueCount));
       newBuffer.setZero(0, newBuffer.capacity());
-      if (fieldNode.getNullCount() != 0) {
-        /* all NULLs */
-        return newBuffer;
-      }
-      /* all non-NULLs */
       int fullBytesCount = valueCount / 8;
       newBuffer.setOne(0, fullBytesCount);
       int remainder = valueCount % 8;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -263,10 +263,12 @@ public class TestBitVectorHelper {
       int numNulls = 100;
       fieldNode = new ArrowFieldNode(1024, numNulls);
       try (ArrowBuf src = allocator.buffer(128)) {
+        src.setZero(0, src.capacity());
         for (int i = 0; i < numNulls; i++) {
           BitVectorHelper.setBit(src, i);
         }
         try (ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {
+          assertEquals(src.memoryAddress(), dst.memoryAddress());
           assertEquals(128, allocator.getAllocatedMemory());
           for (int i = 0; i < 1024; i++) {
             assertEquals(BitVectorHelper.get(src, i), BitVectorHelper.get(dst, i));

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.junit.Test;
 
 import io.netty.util.internal.PlatformDependent;
@@ -218,6 +219,59 @@ public class TestBitVectorHelper {
 
         // the remaining bits in the second set is spread in two bytes
         concatAndVerify(buf1, 31, buf2, 55, buf1);
+      }
+    }
+  }
+
+  @Test
+  public void testLoadValidityBuffer() {
+    try (RootAllocator allocator = new RootAllocator(1024)) {
+      // if the input validity buffer is all null, we should allocate new memory
+      ArrowFieldNode fieldNode = new ArrowFieldNode(1024, 1024);
+      try (ArrowBuf buf = BitVectorHelper.loadValidityBuffer(fieldNode, null, allocator)) {
+        assertEquals(128, allocator.getAllocatedMemory());
+        for (int i = 0; i < 128; i++) {
+          assertEquals(0, buf.getByte(i));
+        }
+      }
+
+      // should also allocate memory if input validity buffer is all not-null
+      fieldNode = new ArrowFieldNode(1024, 0);
+      try (ArrowBuf buf = BitVectorHelper.loadValidityBuffer(fieldNode, null, allocator)) {
+        assertEquals(128, allocator.getAllocatedMemory());
+        for (int i = 0; i < 128; i++) {
+          assertEquals((byte) 0xff, buf.getByte(i));
+        }
+      }
+
+      // should not allocate memory if input validity buffer is not null, even if all values are
+      // null
+      fieldNode = new ArrowFieldNode(1024, 1024);
+      try (ArrowBuf src = allocator.buffer(128);
+           ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {
+        assertEquals(128, allocator.getAllocatedMemory());
+      }
+
+      // ... similarly if all values are not null
+      fieldNode = new ArrowFieldNode(1024, 0);
+      try (ArrowBuf src = allocator.buffer(128);
+           ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {
+        assertEquals(128, allocator.getAllocatedMemory());
+      }
+
+      // mixed case, input should match output
+      int numNulls = 100;
+      fieldNode = new ArrowFieldNode(1024, numNulls);
+      try (ArrowBuf src = allocator.buffer(128)) {
+        for (int i = 0; i < numNulls; i++) {
+          BitVectorHelper.setBit(src, i);
+        }
+        try (ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {
+          assertEquals(128, allocator.getAllocatedMemory());
+          for (int i = 0; i < 1024; i++) {
+            assertEquals(BitVectorHelper.get(src, i), BitVectorHelper.get(dst, i));
+          }
+        }
       }
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -226,17 +226,8 @@ public class TestBitVectorHelper {
   @Test
   public void testLoadValidityBuffer() {
     try (RootAllocator allocator = new RootAllocator(1024)) {
-      // if the input validity buffer is all null, we should allocate new memory
-      ArrowFieldNode fieldNode = new ArrowFieldNode(1024, 1024);
-      try (ArrowBuf buf = BitVectorHelper.loadValidityBuffer(fieldNode, null, allocator)) {
-        assertEquals(128, allocator.getAllocatedMemory());
-        for (int i = 0; i < 128; i++) {
-          assertEquals(0, buf.getByte(i));
-        }
-      }
-
-      // should also allocate memory if input validity buffer is all not-null
-      fieldNode = new ArrowFieldNode(1024, 0);
+      // should allocate memory if input are all not-null and input validity buffer is null
+      ArrowFieldNode fieldNode = new ArrowFieldNode(1024, 0);
       try (ArrowBuf buf = BitVectorHelper.loadValidityBuffer(fieldNode, null, allocator)) {
         assertEquals(128, allocator.getAllocatedMemory());
         for (int i = 0; i < 128; i++) {
@@ -245,14 +236,7 @@ public class TestBitVectorHelper {
       }
 
       // should not allocate memory if input validity buffer is not null, even if all values are
-      // null
-      fieldNode = new ArrowFieldNode(1024, 1024);
-      try (ArrowBuf src = allocator.buffer(128);
-           ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {
-        assertEquals(128, allocator.getAllocatedMemory());
-      }
-
-      // ... similarly if all values are not null
+      // not null
       fieldNode = new ArrowFieldNode(1024, 0);
       try (ArrowBuf src = allocator.buffer(128);
            ArrowBuf dst = BitVectorHelper.loadValidityBuffer(fieldNode, src, allocator)) {


### PR DESCRIPTION
Currently in `BitVectorHelper.loadValidityBuffer`, we always allocate memory when the source vector contains only null or non-null values. However, as the [format also allows](https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps) allocating validity buffer even if all values are null or not-null, the method should also consider whether the input validity buffer is null or not, and avoiding allocating new buffer when it is latter.
