### PR TITLE
ARROW-14717: [Go] Use the ipc.Reader allocator in messageReader

### DIFF
--- a/go/arrow/internal/arrdata/ioutil.go
+++ b/go/arrow/internal/arrdata/ioutil.go
@@ -85,6 +85,7 @@ func CheckArrowConcurrentFile(t *testing.T, f *os.File, mem memory.Allocator, sc
 			errs <- fmt.Errorf("could not read record %d: %v", i, err)
 			return
 		}
+		defer rec.Release()
 		if !array.RecordEqual(rec, recs[i]) {
 			errs <- fmt.Errorf("records[%d] differ", i)
 		}

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -340,12 +340,8 @@ func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker, mem
 	cols := make([]array.Interface, len(schema.Fields()))
 	for i, field := range schema.Fields() {
 		cols[i] = ctx.loadArray(field.Type)
+		defer cols[i].Release()
 	}
-	defer func() {
-		for _, c := range cols {
-			c.Release()
-		}
-	}()
 
 	return array.NewRecord(schema, cols, rows)
 }

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -47,6 +47,8 @@ type FileReader struct {
 
 	irec int   // current record index. used for the arrio.Reader interface
 	err  error // last error
+
+	mem memory.Allocator
 }
 
 // NewFileReader opens an Arrow file using the provided reader r.
@@ -59,6 +61,7 @@ func NewFileReader(r ReadAtSeeker, opts ...Option) (*FileReader, error) {
 			r:      r,
 			fields: make(dictTypeMap),
 			memo:   newMemo(),
+			mem:    cfg.alloc,
 		}
 	)
 
@@ -288,7 +291,7 @@ func (f *FileReader) RecordAt(i int) (array.Record, error) {
 		return nil, xerrors.Errorf("arrow/ipc: message %d is not a Record", i)
 	}
 
-	return newRecord(f.schema, msg.meta, bytes.NewReader(msg.body.Bytes())), nil
+	return newRecord(f.schema, msg.meta, bytes.NewReader(msg.body.Bytes()), f.mem), nil
 }
 
 // Read reads the current record from the underlying stream and an error, if any.
@@ -310,7 +313,7 @@ func (f *FileReader) ReadAt(i int64) (array.Record, error) {
 	return f.Record(int(i))
 }
 
-func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker) array.Record {
+func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker, mem memory.Allocator) array.Record {
 	var (
 		msg   = flatbuf.GetRootAsMessage(meta.Bytes(), 0)
 		md    flatbuf.RecordBatch
@@ -329,6 +332,7 @@ func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker) arr
 			meta:  &md,
 			r:     body,
 			codec: codec,
+			mem:   mem,
 		},
 		max: kMaxNestingDepth,
 	}
@@ -337,6 +341,11 @@ func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker) arr
 	for i, field := range schema.Fields() {
 		cols[i] = ctx.loadArray(field.Type)
 	}
+	defer func() {
+		for _, c := range cols {
+			c.Release()
+		}
+	}()
 
 	return array.NewRecord(schema, cols, rows)
 }
@@ -345,6 +354,7 @@ type ipcSource struct {
 	meta  *flatbuf.RecordBatch
 	r     ReadAtSeeker
 	codec decompressor
+	mem   memory.Allocator
 }
 
 func (src *ipcSource) buffer(i int) *memory.Buffer {
@@ -356,10 +366,10 @@ func (src *ipcSource) buffer(i int) *memory.Buffer {
 		return memory.NewBufferBytes(nil)
 	}
 
-	var raw []byte
+	raw := memory.NewResizableBuffer(src.mem)
 	if src.codec == nil {
-		raw = make([]byte, buf.Length())
-		_, err := src.r.ReadAt(raw, buf.Offset())
+		raw.Resize(int(buf.Length()))
+		_, err := src.r.ReadAt(raw.Bytes(), buf.Offset())
 		if err != nil {
 			panic(err)
 		}
@@ -375,19 +385,19 @@ func (src *ipcSource) buffer(i int) *memory.Buffer {
 		var r io.Reader = sr
 		// check for an uncompressed buffer
 		if int64(uncompressedSize) != -1 {
-			raw = make([]byte, uncompressedSize)
+			raw.Resize(int(uncompressedSize))
 			src.codec.Reset(sr)
 			r = src.codec
 		} else {
-			raw = make([]byte, buf.Length())
+			raw.Resize(int(buf.Length()))
 		}
 
-		if _, err = io.ReadFull(r, raw); err != nil {
+		if _, err = io.ReadFull(r, raw.Bytes()); err != nil {
 			panic(err)
 		}
 	}
 
-	return memory.NewBufferBytes(raw)
+	return raw
 }
 
 func (src *ipcSource) fieldMetadata(i int) *flatbuf.FieldNode {
@@ -507,6 +517,8 @@ func (ctx *arrayLoaderContext) loadPrimitive(dt arrow.DataType) array.Interface 
 		buffers = append(buffers, ctx.buffer())
 	}
 
+	defer releaseBuffers(buffers)
+
 	data := array.NewData(dt, int(field.Length()), buffers, nil, int(field.NullCount()), 0)
 	defer data.Release()
 
@@ -516,6 +528,7 @@ func (ctx *arrayLoaderContext) loadPrimitive(dt arrow.DataType) array.Interface 
 func (ctx *arrayLoaderContext) loadBinary(dt arrow.DataType) array.Interface {
 	field, buffers := ctx.loadCommon(3)
 	buffers = append(buffers, ctx.buffer(), ctx.buffer())
+	defer releaseBuffers(buffers)
 
 	data := array.NewData(dt, int(field.Length()), buffers, nil, int(field.NullCount()), 0)
 	defer data.Release()
@@ -526,6 +539,7 @@ func (ctx *arrayLoaderContext) loadBinary(dt arrow.DataType) array.Interface {
 func (ctx *arrayLoaderContext) loadFixedSizeBinary(dt *arrow.FixedSizeBinaryType) array.Interface {
 	field, buffers := ctx.loadCommon(2)
 	buffers = append(buffers, ctx.buffer())
+	defer releaseBuffers(buffers)
 
 	data := array.NewData(dt, int(field.Length()), buffers, nil, int(field.NullCount()), 0)
 	defer data.Release()
@@ -536,6 +550,7 @@ func (ctx *arrayLoaderContext) loadFixedSizeBinary(dt *arrow.FixedSizeBinaryType
 func (ctx *arrayLoaderContext) loadMap(dt *arrow.MapType) array.Interface {
 	field, buffers := ctx.loadCommon(2)
 	buffers = append(buffers, ctx.buffer())
+	defer releaseBuffers(buffers)
 
 	sub := ctx.loadChild(dt.ValueType())
 	defer sub.Release()
@@ -549,6 +564,7 @@ func (ctx *arrayLoaderContext) loadMap(dt *arrow.MapType) array.Interface {
 func (ctx *arrayLoaderContext) loadList(dt *arrow.ListType) array.Interface {
 	field, buffers := ctx.loadCommon(2)
 	buffers = append(buffers, ctx.buffer())
+	defer releaseBuffers(buffers)
 
 	sub := ctx.loadChild(dt.Elem())
 	defer sub.Release()
@@ -561,6 +577,7 @@ func (ctx *arrayLoaderContext) loadList(dt *arrow.ListType) array.Interface {
 
 func (ctx *arrayLoaderContext) loadFixedSizeList(dt *arrow.FixedSizeListType) array.Interface {
 	field, buffers := ctx.loadCommon(1)
+	defer releaseBuffers(buffers)
 
 	sub := ctx.loadChild(dt.Elem())
 	defer sub.Release()
@@ -573,6 +590,7 @@ func (ctx *arrayLoaderContext) loadFixedSizeList(dt *arrow.FixedSizeListType) ar
 
 func (ctx *arrayLoaderContext) loadStruct(dt *arrow.StructType) array.Interface {
 	field, buffers := ctx.loadCommon(1)
+	defer releaseBuffers(buffers)
 
 	arrs := make([]array.Interface, len(dt.Fields()))
 	subs := make([]*array.Data, len(dt.Fields()))
@@ -633,4 +651,12 @@ func readDictionary(meta *memory.Buffer, types dictTypeMap, r ReadAtSeeker) (int
 	//	batch := array.NewRecord(schema, cols, rows)
 
 	panic("not implemented")
+}
+
+func releaseBuffers(buffers []*memory.Buffer) {
+	for _, b := range buffers {
+		if b != nil {
+			b.Release()
+		}
+	}
 }

--- a/go/arrow/ipc/message.go
+++ b/go/arrow/ipc/message.go
@@ -154,11 +154,18 @@ type messageReader struct {
 
 	refCount int64
 	msg      *Message
+
+	mem memory.Allocator
 }
 
 // NewMessageReader returns a reader that reads messages from an input stream.
-func NewMessageReader(r io.Reader) MessageReader {
-	return &messageReader{r: r, refCount: 1}
+func NewMessageReader(r io.Reader, opts ...Option) MessageReader {
+	cfg := newConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &messageReader{r: r, refCount: 1, mem: cfg.alloc}
 }
 
 // Retain increases the reference count by 1.
@@ -224,12 +231,14 @@ func (r *messageReader) Message() (*Message, error) {
 	meta := flatbuf.GetRootAsMessage(buf, 0)
 	bodyLen := meta.BodyLength()
 
-	buf = make([]byte, bodyLen)
-	_, err = io.ReadFull(r.r, buf)
+	body := memory.NewResizableBuffer(r.mem)
+	defer body.Release()
+	body.Resize(int(bodyLen))
+
+	_, err = io.ReadFull(r.r, body.Bytes())
 	if err != nil {
 		return nil, xerrors.Errorf("arrow/ipc: could not read message body: %w", err)
 	}
-	body := memory.NewBufferBytes(buf)
 
 	if r.msg != nil {
 		r.msg.Release()

--- a/go/arrow/ipc/message_test.go
+++ b/go/arrow/ipc/message_test.go
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/apache/arrow/go/v7/arrow"
+	"github.com/apache/arrow/go/v7/arrow/array"
+	"github.com/apache/arrow/go/v7/arrow/memory"
+)
+
+func TestMessageReaderBodyInAllocator(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	const numRecords = 3
+	buf := writeRecordsIntoBuffer(t, numRecords)
+	r := NewMessageReader(buf, WithAllocator(mem))
+	defer r.Release()
+
+	msgs := make([]*Message, 0)
+	for {
+		m, err := r.Message()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.Retain()
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != numRecords+1 {
+		t.Fatalf("expected %d messages but got %d", numRecords+1, len(msgs))
+	}
+
+	if mem.CurrentAlloc() <= 0 {
+		t.Fatal("message bodies should have been allocated")
+	}
+
+	for _, m := range msgs {
+		m.Release()
+	}
+}
+
+func writeRecordsIntoBuffer(t *testing.T, numRecords int) *bytes.Buffer {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	s, recs := getTestRecords(mem, numRecords)
+	buf := new(bytes.Buffer)
+	w := NewWriter(buf, WithAllocator(mem), WithSchema(s))
+	for _, rec := range recs {
+		err := w.Write(rec)
+		rec.Release()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf
+}
+
+func getTestRecords(mem memory.Allocator, numRecords int) (*arrow.Schema, []array.Record) {
+	meta := arrow.NewMetadata([]string{}, []string{})
+	s := arrow.NewSchema([]arrow.Field{
+		{Name: "test-col", Type: arrow.PrimitiveTypes.Int64},
+	}, &meta)
+
+	builder := array.NewRecordBuilder(mem, s)
+	defer builder.Release()
+
+	recs := make([]array.Record, numRecords)
+	for i := 0; i < len(recs); i++ {
+		col := builder.Field(0).(*array.Int64Builder)
+		for i := 0; i < 10; i++ {
+			col.Append(int64(i))
+		}
+		recs[i] = builder.NewRecord()
+	}
+
+	return s, recs
+}

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -176,7 +176,7 @@ func (r *Reader) next() bool {
 		return false
 	}
 
-	r.rec = newRecord(r.schema, msg.meta, bytes.NewReader(msg.body.Bytes()))
+	r.rec = newRecord(r.schema, msg.meta, bytes.NewReader(msg.body.Bytes()), r.mem)
 	return true
 }
 

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -75,7 +75,7 @@ func NewReaderFromMessageReader(r MessageReader, opts ...Option) (*Reader, error
 
 // NewReader returns a reader that reads records from an input stream.
 func NewReader(r io.Reader, opts ...Option) (*Reader, error) {
-	return NewReaderFromMessageReader(NewMessageReader(r), opts...)
+	return NewReaderFromMessageReader(NewMessageReader(r, opts...), opts...)
 }
 
 // Err returns the last error encountered during the iteration over the


### PR DESCRIPTION
Allocate the body of messages from the memory.Allocator instead
of using make.