### PR TITLE
ARROW-8605: [R] Add brotli to Windows R build

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -360,12 +360,6 @@ jobs:
         shell: bash
         run: find r/check -name 'testthat.Rout*' -exec cat '{}' \; || true
         if: always()
-      - name: Save the test output
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-output-${{ matrix.config.rtools }}-${{ matrix.config.arch }}
-          path: r/check/arrow.Rcheck/tests/testthat.Rout*
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -358,7 +358,7 @@ jobs:
         if: always()
       - name: Dump test logs
         shell: bash
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        run: find r/check -name 'testthat.Rout*' -exec cat '{}' \; || true
         if: always()
       - name: Save the test output
         if: always()

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -357,6 +357,7 @@ jobs:
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
+        shell: bash
         run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
         if: always()
       - name: Save the test output

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -356,6 +356,15 @@ jobs:
         shell: cmd
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
+      - name: Dump test logs
+        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output-${{ matrix.config.rtools }}-${{ matrix.config.arch }}
+          path: r/check/arrow.Rcheck/tests/testthat.Rout*
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -357,7 +357,7 @@ jobs:
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
-        run: cat r/check/arrow.Rcheck/tests/testthat.Rout*
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
         if: always()
       - name: Save the test output
         if: always()

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -31,7 +31,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp"
          "${MINGW_PACKAGE_PREFIX}-snappy"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-lz4"
-         "${MINGW_PACKAGE_PREFIX}-zstd")
+         "${MINGW_PACKAGE_PREFIX}-zstd"
+         "${MINGW_PACKAGE_PREFIX}-brotli")
 makedepends=("${MINGW_PACKAGE_PREFIX}-ccache"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
@@ -115,6 +116,7 @@ build() {
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
+    -DARROW_WITH_BROTLI=ON \
     -DARROW_ZSTD_USE_SHARED=OFF \
     -DARROW_CXXFLAGS="${CPPFLAGS}" \
     -DCMAKE_BUILD_TYPE="release" \

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -97,7 +97,7 @@ if [ -d mingw32/lib/ ]; then
   mkdir -p $DST_DIR/lib/i386
   mv mingw32/lib/*.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
   cp $MSYS_LIB_DIR/mingw32/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
-  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
+  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,brotli*,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
 fi
 
 # Do the same also for ucrt64
@@ -105,7 +105,7 @@ if [ -d ucrt64/lib/ ]; then
   ls $MSYS_LIB_DIR/ucrt64/lib/
   mkdir -p $DST_DIR/lib/x64-ucrt
   mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
-  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
+  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,brotli*,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
 fi
 
 # Create build artifact

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -87,7 +87,7 @@ if [ -d mingw64/lib/ ]; then
   # These may be from https://dl.bintray.com/rtools/backports/
   cp $MSYS_LIB_DIR/mingw64/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/x64
   # These are from https://dl.bintray.com/rtools/mingw{32,64}/
-  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
+  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
 fi
 
 # Same for the 32-bit versions
@@ -97,7 +97,7 @@ if [ -d mingw32/lib/ ]; then
   mkdir -p $DST_DIR/lib/i386
   mv mingw32/lib/*.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
   cp $MSYS_LIB_DIR/mingw32/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
-  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
+  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
 fi
 
 # Do the same also for ucrt64
@@ -105,7 +105,7 @@ if [ -d ucrt64/lib/ ]; then
   ls $MSYS_LIB_DIR/ucrt64/lib/
   mkdir -p $DST_DIR/lib/x64-ucrt
   mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
-  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
+  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
 fi
 
 # Create build artifact

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -87,7 +87,7 @@ if [ -d mingw64/lib/ ]; then
   # These may be from https://dl.bintray.com/rtools/backports/
   cp $MSYS_LIB_DIR/mingw64/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/x64
   # These are from https://dl.bintray.com/rtools/mingw{32,64}/
-  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
+  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
 fi
 
 # Same for the 32-bit versions
@@ -97,7 +97,7 @@ if [ -d mingw32/lib/ ]; then
   mkdir -p $DST_DIR/lib/i386
   mv mingw32/lib/*.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
   cp $MSYS_LIB_DIR/mingw32/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
-  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
+  cp $MSYS_LIB_DIR/mingw32/lib/lib{zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/i386
 fi
 
 # Do the same also for ucrt64
@@ -105,7 +105,7 @@ if [ -d ucrt64/lib/ ]; then
   ls $MSYS_LIB_DIR/ucrt64/lib/
   mkdir -p $DST_DIR/lib/x64-ucrt
   mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
-  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
+  cp $MSYS_LIB_DIR/ucrt64/lib/lib{thrift,snappy,zstd,lz4,brotli,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64-ucrt
 fi
 
 # Create build artifact

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -87,7 +87,7 @@ if [ -d mingw64/lib/ ]; then
   # These may be from https://dl.bintray.com/rtools/backports/
   cp $MSYS_LIB_DIR/mingw64/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/x64
   # These are from https://dl.bintray.com/rtools/mingw{32,64}/
-  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,brotlicommon,brotlidec,brotlienc,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
+  cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,brotli*,crypto,utf8proc,re2,aws*}.a $DST_DIR/lib/x64
 fi
 
 # Same for the 32-bit versions

--- a/r/configure.win
+++ b/r/configure.win
@@ -52,7 +52,7 @@ function configure_release() {
   # NOTE: If you make changes to the libraries below, you should also change
   # ci/scripts/r_windows_build.sh and ci/scripts/PKGBUILD
   PKG_CFLAGS="-I${RWINLIB}/include -DARROW_STATIC -DPARQUET_STATIC -DARROW_DS_STATIC -DARROW_R_WITH_ARROW -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON"
-  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 -lbrotli -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
+  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
 
   # S3 and re2 support only for Rtools40 (i.e. R >= 4.0)
   "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'R.version$major >= 4' | grep TRUE >/dev/null 2>&1

--- a/r/configure.win
+++ b/r/configure.win
@@ -26,6 +26,7 @@ fi
 
 OPENSSL_LIBS="-lcrypto -lcrypt32"
 MIMALLOC_LIBS="-lbcrypt -lpsapi"
+BROTLI_LIBS="-lbrotlicommon -lbrotlienc -lbrotlidec"
 AWS_LIBS="-laws-cpp-sdk-config -laws-cpp-sdk-transfer -laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common -lUserenv -lversion -lws2_32 -lBcrypt -lWininet -lwinhttp"
 
 function configure_release() {
@@ -52,7 +53,7 @@ function configure_release() {
   # NOTE: If you make changes to the libraries below, you should also change
   # ci/scripts/r_windows_build.sh and ci/scripts/PKGBUILD
   PKG_CFLAGS="-I${RWINLIB}/include -DARROW_STATIC -DPARQUET_STATIC -DARROW_DS_STATIC -DARROW_R_WITH_ARROW -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON"
-  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
+  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 ${BROTLI_LIBS} -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
 
   # S3 and re2 support only for Rtools40 (i.e. R >= 4.0)
   "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'R.version$major >= 4' | grep TRUE >/dev/null 2>&1

--- a/r/configure.win
+++ b/r/configure.win
@@ -27,7 +27,10 @@ fi
 OPENSSL_LIBS="-lcrypto -lcrypt32"
 MIMALLOC_LIBS="-lbcrypt -lpsapi"
 BROTLI_LIBS="-lbrotlienc -lbrotlidec -lbrotlicommon" # Common goes last since dec and enc depend on it
-AWS_LIBS="-laws-cpp-sdk-config -laws-cpp-sdk-transfer -laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common -lUserenv -lversion -lws2_32 -lBcrypt -lWininet -lwinhttp"
+AWS_LIBS="-laws-cpp-sdk-config -laws-cpp-sdk-transfer -laws-cpp-sdk-identity-management \
+          -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 \
+          -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
+          -lUserenv -lversion -lws2_32 -lBcrypt -lWininet -lwinhttp"
 
 function configure_release() {
   VERSION=$(grep ^Version DESCRIPTION | sed s/Version:\ //)
@@ -52,8 +55,14 @@ function configure_release() {
 
   # NOTE: If you make changes to the libraries below, you should also change
   # ci/scripts/r_windows_build.sh and ci/scripts/PKGBUILD
-  PKG_CFLAGS="-I${RWINLIB}/include -DARROW_STATIC -DPARQUET_STATIC -DARROW_DS_STATIC -DARROW_R_WITH_ARROW -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON"
-  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 ${BROTLI_LIBS} -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
+  PKG_CFLAGS="-I${RWINLIB}/include -DARROW_STATIC -DPARQUET_STATIC -DARROW_DS_STATIC \
+              -DARROW_R_WITH_ARROW -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET \
+              -DARROW_R_WITH_JSON"
+  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '
+  PKG_LIBS="$PKG_LIBS -L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '
+  PKG_LIBS="$PKG_LIBS -lparquet -larrow_dataset -larrow -larrow_bundled_dependencies \
+            -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 ${BROTLI_LIBS} -lole32 \
+            ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
 
   # S3 and re2 support only for Rtools40 (i.e. R >= 4.0)
   "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'R.version$major >= 4' | grep TRUE >/dev/null 2>&1

--- a/r/configure.win
+++ b/r/configure.win
@@ -26,7 +26,7 @@ fi
 
 OPENSSL_LIBS="-lcrypto -lcrypt32"
 MIMALLOC_LIBS="-lbcrypt -lpsapi"
-BROTLI_LIBS="-lbrotlicommon -lbrotlienc -lbrotlidec"
+BROTLI_LIBS="-lbrotlienc -lbrotlidec -lbrotlicommon" # Common goes last since dec and enc depend on it
 AWS_LIBS="-laws-cpp-sdk-config -laws-cpp-sdk-transfer -laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common -lUserenv -lversion -lws2_32 -lBcrypt -lWininet -lwinhttp"
 
 function configure_release() {

--- a/r/configure.win
+++ b/r/configure.win
@@ -52,7 +52,7 @@ function configure_release() {
   # NOTE: If you make changes to the libraries below, you should also change
   # ci/scripts/r_windows_build.sh and ci/scripts/PKGBUILD
   PKG_CFLAGS="-I${RWINLIB}/include -DARROW_STATIC -DPARQUET_STATIC -DARROW_DS_STATIC -DARROW_R_WITH_ARROW -DARROW_R_WITH_PARQUET -DARROW_R_WITH_DATASET -DARROW_R_WITH_JSON"
-  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
+  PKG_LIBS="-L${RWINLIB}/lib"'$(subst gcc,,$(COMPILED_BY))$(R_ARCH) '"-L${RWINLIB}/lib"'$(R_ARCH)$(CRT) '"-lparquet -larrow_dataset -larrow -larrow_bundled_dependencies -lutf8proc -lthrift -lsnappy -lz -lzstd -llz4 -lbrotli -lole32 ${MIMALLOC_LIBS} ${OPENSSL_LIBS}"
 
   # S3 and re2 support only for Rtools40 (i.e. R >= 4.0)
   "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e 'R.version$major >= 4' | grep TRUE >/dev/null 2>&1

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -27,6 +27,7 @@ if (identical(Sys.getenv("APPVEYOR"), "True")) {
   test_that("Compression codecs are included in the Windows build", {
     expect_true(codec_is_available("lz4"))
     expect_true(codec_is_available("zstd"))
+    expect_true(codec_is_available("brotli"))
   })
 }
 

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -23,13 +23,12 @@ test_that("codec_is_available", {
   expect_true(codec_is_available("GZIP"))
 })
 
-if (tolower(Sys.info()[["sysname"]]) == "windows") {
-  test_that("Compression codecs are included in the Windows build", {
-    expect_true(codec_is_available("lz4"))
-    expect_true(codec_is_available("zstd"))
-    expect_true(codec_is_available("brotli"))
-  })
-}
+test_that("Compression codecs are included in the Windows build", {
+  skip_if(tolower(Sys.info()[["sysname"]]) == "windows")
+  expect_true(codec_is_available("lz4"))
+  expect_true(codec_is_available("zstd"))
+  expect_true(codec_is_available("brotli"))
+})
 
 test_that("Codec attributes", {
   skip_if_not_available("gzip")

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -23,7 +23,7 @@ test_that("codec_is_available", {
   expect_true(codec_is_available("GZIP"))
 })
 
-if (identical(Sys.getenv("APPVEYOR"), "True")) {
+if (tolower(Sys.info()[["sysname"]]) == "windows") {
   test_that("Compression codecs are included in the Windows build", {
     expect_true(codec_is_available("lz4"))
     expect_true(codec_is_available("zstd"))

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -24,7 +24,7 @@ test_that("codec_is_available", {
 })
 
 test_that("Compression codecs are included in the Windows build", {
-  skip_if(tolower(Sys.info()[["sysname"]]) == "windows")
+  skip_if(tolower(Sys.info()[["sysname"]]) != "windows")
   expect_true(codec_is_available("lz4"))
   expect_true(codec_is_available("zstd"))
   expect_true(codec_is_available("brotli"))


### PR DESCRIPTION
Adds brotli compression to Windows R build.

In addition, Windows CI R Check jobs will now dump the test output.

Added brotli to rtools-packages here: https://github.com/r-windows/rtools-packages/pull/232