### PR TITLE
ARROW-13781: [Python] Allow per column encoding in parquet writer

### DIFF
--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -528,6 +528,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             use_byte_stream_split=(
                 self._properties["use_byte_stream_split"]
             ),
+            column_encoding=self._properties["column_encoding"],
             data_page_version=self._properties["data_page_version"],
         )
 
@@ -559,6 +560,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             data_page_size=None,
             compression_level=None,
             use_byte_stream_split=False,
+            column_encoding=None,
             data_page_version="1.0",
             use_deprecated_int96_timestamps=False,
             coerce_timestamps=None,

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -505,6 +505,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     data_page_size=*,
     compression_level=*,
     use_byte_stream_split=*,
+    col_encoding=*,
     data_page_version=*) except *
 
 

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -505,7 +505,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     data_page_size=*,
     compression_level=*,
     use_byte_stream_split=*,
-    col_encoding=*,
+    column_encoding=*,
     data_page_version=*) except *
 
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -888,9 +888,13 @@ cdef encoding_enum_from_name(str encoding_name):
         'BYTE_STREAM_SPLIT': ParquetEncoding_BYTE_STREAM_SPLIT,
         'DELTA_BINARY_PACKED': ParquetEncoding_DELTA_BINARY_PACKED,
         'DELTA_BYTE_ARRAY': ParquetEncoding_DELTA_BYTE_ARRAY,
+        'RLE_DICTIONARY': 'dict',
+        'PLAIN_DICTIONARY': 'dict',
     }.get(encoding_name, None)
     if enc is None:
         raise ValueError(f"Unsupported column encoding: {encoding_name!r}")
+    elif enc == 'dict':
+        raise ValueError(f"{encoding_name!r} is already used by default.")
     else:
         return enc
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1317,9 +1317,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     # encoding map - encode individual columns
 
     if column_encoding is not None:
-        if not isinstance(column_encoding, dict):
-            raise AttributeError("'column_encoding' should be a dictionary")
-        else:
+        if isinstance(column_encoding, dict):
             for column, _encoding in column_encoding.items():
                 if encoding_enum_from_name(_encoding) is None:
                     raise ValueError("Unsupported column encoding: {0}"
@@ -1327,6 +1325,15 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
                 else:
                     props.encoding(tobytes(column),
                                    encoding_enum_from_name(_encoding))
+        elif isinstance(column_encoding, str):
+            if encoding_enum_from_name(column_encoding) is None:
+                raise ValueError("Unsupported column encoding: {0}"
+                                 .format(column_encoding))
+            else:
+                props.encoding(encoding_enum_from_name(column_encoding))
+        else:
+            raise AttributeError(
+                "'column_encoding' should be a dictionary or a string")
 
     if data_page_size is not None:
         props.data_pagesize(data_page_size)

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -885,6 +885,8 @@ cdef encoding_enum_from_name(str encoding_name):
         'BIT_PACKED': ParquetEncoding_BIT_PACKED,
         'RLE': ParquetEncoding_RLE,
         'BYTE_STREAM_SPLIT': ParquetEncoding_BYTE_STREAM_SPLIT,
+        'DELTA_BINARY_PACKED': ParquetEncoding_DELTA_BINARY_PACKED,
+        'DELTA_BYTE_ARRAY': ParquetEncoding_DELTA_BYTE_ARRAY,
     }.get(encoding_name, None)
 
 cdef compression_name_from_enum(ParquetCompression compression_):

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1299,8 +1299,14 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
 
     if col_encoding is not None:
         for column, _encoding in col_encoding.items():
-            props.encoding(tobytes(column),
-                           encoding_enum_from_name(_encoding))
+            if not use_dictionary or \
+                (_encoding!='PLAIN_DICTIONARY' and
+                 _encoding!='RLE_DICTIONARY'):
+                props.encoding(tobytes(column),
+                               encoding_enum_from_name(_encoding))
+            else:
+                raise ValueError("Turn use_dictionary to False to use \
+                                 dictionary col_encoding.")
 
     if data_page_size is not None:
         props.data_pagesize(data_page_size)

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -882,10 +882,8 @@ cdef encoding_name_from_enum(ParquetEncoding encoding_):
 cdef encoding_enum_from_name(str encoding_name):
     return {
         'PLAIN': ParquetEncoding_PLAIN,
-        'PLAIN_DICTIONARY': ParquetEncoding_PLAIN_DICTIONARY,
         'BIT_PACKED': ParquetEncoding_BIT_PACKED,
         'RLE': ParquetEncoding_RLE,
-        'RLE_DICTIONARY': ParquetEncoding_RLE_DICTIONARY,
         'BYTE_STREAM_SPLIT': ParquetEncoding_BYTE_STREAM_SPLIT,
     }.get(encoding_name, None)
 
@@ -1299,14 +1297,8 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
 
     if col_encoding is not None:
         for column, _encoding in col_encoding.items():
-            if not use_dictionary or \
-                (_encoding!='PLAIN_DICTIONARY' and
-                 _encoding!='RLE_DICTIONARY'):
-                props.encoding(tobytes(column),
-                               encoding_enum_from_name(_encoding))
-            else:
-                raise ValueError("Turn use_dictionary to False to use \
-                                 dictionary col_encoding.")
+            props.encoding(tobytes(column),
+                           encoding_enum_from_name(_encoding))
 
     if data_page_size is not None:
         props.data_pagesize(data_page_size)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -560,7 +560,7 @@ use_byte_stream_split : bool or list, default False
     enabled, then dictionary is preferred.
     The byte_stream_split encoding is valid only for floating-point data types
     and should be combined with a compression codec.
-column_encoding : dict, default None
+column_encoding : string or dict, default None
     Specify the encoding scheme on a per column basis.
     Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT',
     'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -560,15 +560,15 @@ use_byte_stream_split : bool or list, default False
     enabled, then dictionary is preferred.
     The byte_stream_split encoding is valid only for floating-point data types
     and should be combined with a compression codec.
-col_encoding : dict, default None
+column_encoding : dict, default None
     Specify the encoding scheme on a per column basis.
     Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT',
     'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}
     Unsupported encodings: DELTA_LENGTH_BYTE_ARRAY, PLAIN_DICTIONARY and
     RLE_DICTIONARY. Last two options are already used by default.
     Certain encodings are only compatible with certain data types.
-    Please refer to the encodings section of Reading and writing Parquet
-    files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>_.
+    Please refer to the encodings section of `Reading and writing Parquet
+    files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>`_.
 data_page_version : {"1.0", "2.0"}, default "1.0"
     The serialized Parquet data page format version to write, defaults to
     1.0. This does not impact the file schema logical types and Arrow to
@@ -627,7 +627,7 @@ writer_engine_version : unused
                  use_deprecated_int96_timestamps=None,
                  compression_level=None,
                  use_byte_stream_split=False,
-                 col_encoding=None,
+                 column_encoding=None,
                  writer_engine_version=None,
                  data_page_version='1.0',
                  use_compliant_nested_type=False,
@@ -679,7 +679,7 @@ writer_engine_version : unused
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,
             compression_level=compression_level,
             use_byte_stream_split=use_byte_stream_split,
-            col_encoding=col_encoding,
+            column_encoding=column_encoding,
             writer_engine_version=engine_version,
             data_page_version=data_page_version,
             use_compliant_nested_type=use_compliant_nested_type,
@@ -2064,7 +2064,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 filesystem=None,
                 compression_level=None,
                 use_byte_stream_split=False,
-                col_encoding=None,
+                column_encoding=None,
                 data_page_version='1.0',
                 use_compliant_nested_type=False,
                 **kwargs):
@@ -2085,7 +2085,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 use_deprecated_int96_timestamps=use_int96,
                 compression_level=compression_level,
                 use_byte_stream_split=use_byte_stream_split,
-                col_encoding=col_encoding,
+                column_encoding=column_encoding,
                 data_page_version=data_page_version,
                 use_compliant_nested_type=use_compliant_nested_type,
                 **kwargs) as writer:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -560,6 +560,14 @@ use_byte_stream_split : bool or list, default False
     enabled, then dictionary is preferred.
     The byte_stream_split encoding is valid only for floating-point data types
     and should be combined with a compression codec.
+col_encoding : dict, default None
+    Specify the encoding scheme on a per column basis.
+    Valid values: {'PLAIN', 'PLAIN_DICTIONARY', 'BIT_PACKED', 'RLE',
+                   'RLE_DICTIONARY', 'BYTE_STREAM_SPLIT'}
+    Unsupported encodings: DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY,
+    DELTA_BYTE_ARRAY. Certain encodings are only compatible with certain data
+    types. Please refer to the encodings section of Reading and writing Parquet
+    files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>_.
 data_page_version : {"1.0", "2.0"}, default "1.0"
     The serialized Parquet data page format version to write, defaults to
     1.0. This does not impact the file schema logical types and Arrow to
@@ -618,6 +626,7 @@ writer_engine_version : unused
                  use_deprecated_int96_timestamps=None,
                  compression_level=None,
                  use_byte_stream_split=False,
+                 col_encoding=None,
                  writer_engine_version=None,
                  data_page_version='1.0',
                  use_compliant_nested_type=False,
@@ -669,6 +678,7 @@ writer_engine_version : unused
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,
             compression_level=compression_level,
             use_byte_stream_split=use_byte_stream_split,
+            col_encoding=col_encoding,
             writer_engine_version=engine_version,
             data_page_version=data_page_version,
             use_compliant_nested_type=use_compliant_nested_type,
@@ -2053,6 +2063,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 filesystem=None,
                 compression_level=None,
                 use_byte_stream_split=False,
+                col_encoding=None,
                 data_page_version='1.0',
                 use_compliant_nested_type=False,
                 **kwargs):
@@ -2073,6 +2084,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 use_deprecated_int96_timestamps=use_int96,
                 compression_level=compression_level,
                 use_byte_stream_split=use_byte_stream_split,
+                col_encoding=col_encoding,
                 data_page_version=data_page_version,
                 use_compliant_nested_type=use_compliant_nested_type,
                 **kwargs) as writer:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -562,8 +562,7 @@ use_byte_stream_split : bool or list, default False
     and should be combined with a compression codec.
 column_encoding : string or dict, default None
     Specify the encoding scheme on a per column basis.
-    Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT',
-    'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}.
+    Currently supported values: {'PLAIN', 'BYTE_STREAM_SPLIT'}.
     Certain encodings are only compatible with certain data types.
     Please refer to the encodings section of `Reading and writing Parquet
     files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>`_.

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -563,9 +563,7 @@ use_byte_stream_split : bool or list, default False
 column_encoding : string or dict, default None
     Specify the encoding scheme on a per column basis.
     Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT',
-    'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}
-    Unsupported encodings: DELTA_LENGTH_BYTE_ARRAY, PLAIN_DICTIONARY and
-    RLE_DICTIONARY. Last two options are already used by default.
+    'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}.
     Certain encodings are only compatible with certain data types.
     Please refer to the encodings section of `Reading and writing Parquet
     files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>`_.

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -562,10 +562,10 @@ use_byte_stream_split : bool or list, default False
     and should be combined with a compression codec.
 col_encoding : dict, default None
     Specify the encoding scheme on a per column basis.
-    Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT'}
-    Unsupported encodings: DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY,
-    DELTA_BYTE_ARRAY, PLAIN_DICTIONARY and RLE_DICTIONARY. Last two options
-    are already used by default.
+    Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT',
+    'DELTA_BINARY_PACKED', 'DELTA_BYTE_ARRAY'}
+    Unsupported encodings: DELTA_LENGTH_BYTE_ARRAY, PLAIN_DICTIONARY and
+    RLE_DICTIONARY. Last two options are already used by default.
     Certain encodings are only compatible with certain data types.
     Please refer to the encodings section of Reading and writing Parquet
     files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>_.

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -562,11 +562,12 @@ use_byte_stream_split : bool or list, default False
     and should be combined with a compression codec.
 col_encoding : dict, default None
     Specify the encoding scheme on a per column basis.
-    Valid values: {'PLAIN', 'PLAIN_DICTIONARY', 'BIT_PACKED', 'RLE',
-                   'RLE_DICTIONARY', 'BYTE_STREAM_SPLIT'}
+    Valid values: {'PLAIN', 'BIT_PACKED', 'RLE', 'BYTE_STREAM_SPLIT'}
     Unsupported encodings: DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY,
-    DELTA_BYTE_ARRAY. Certain encodings are only compatible with certain data
-    types. Please refer to the encodings section of Reading and writing Parquet
+    DELTA_BYTE_ARRAY, PLAIN_DICTIONARY and RLE_DICTIONARY. Last two options
+    are already used by default.
+    Certain encodings are only compatible with certain data types.
+    Please refer to the encodings section of Reading and writing Parquet
     files <https://arrow.apache.org/docs/cpp/parquet.html#encodings>_.
 data_page_version : {"1.0", "2.0"}, default "1.0"
     The serialized Parquet data page format version to write, defaults to

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -369,10 +369,10 @@ def test_column_encoding(use_legacy_dataset):
                      column_encoding={'a': "BYTE_STREAM_SPLIT", 'b': "PLAIN"},
                      use_legacy_dataset=use_legacy_dataset)
 
-    # Check "DELTA_BINARY_PACKED" column encoding for column 'b'.
-    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
-                     column_encoding={'b': "DELTA_BINARY_PACKED"},
-                     use_legacy_dataset=use_legacy_dataset)
+    # Check "DELTA_BINARY_PACKED" column encoding for int column 'b'.
+    #_check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
+    #                 column_encoding={'b': "DELTA_BINARY_PACKED"},
+    #                 use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass unsupported encoding
     with pytest.raises(ValueError):

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -372,18 +372,9 @@ def test_col_encoding(use_legacy_dataset):
     # Check "RLE" for column 'a' and "BYTE_STREAM_SPLIT" col_encoding for
     # column 'b'.
     _check_roundtrip(mixed_table, expected=mixed_table,
+                     use_byte_stream_split=['a'],
                      col_encoding={'a': "RLE", 'b': "BYTE_STREAM_SPLIT"},
                      use_legacy_dataset=use_legacy_dataset)
-
-    # Fatal Python error: Aborted
-
-    # _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
-    #                 col_encoding={'a': "RLE_DICTIONARY"},
-    #                 use_legacy_dataset=use_legacy_dataset)
-
-    # _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
-    #                 use_byte_stream_split=['b'],
-    #                 col_encoding={'a': "PLAIN_DICTIONARY"})
 
 
 @parametrize_legacy_dataset

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -373,7 +373,8 @@ def test_column_encoding(use_legacy_dataset):
 
     # Try to pass "BYTE_STREAM_SPLIT" column encoding for integer column 'b'.
     # This should throw an error as it is only supports FLOAT and DOUBLE.
-    with pytest.raises(IOError):
+    with pytest.raises(IOError,
+                       match="BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE"):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
                          column_encoding={'b': "BYTE_STREAM_SPLIT"},
@@ -381,10 +382,18 @@ def test_column_encoding(use_legacy_dataset):
 
     # Try to pass "DELTA_BINARY_PACKED".
     # This should throw an error as it is only supported for reading.
-    with pytest.raises(IOError):
+    with pytest.raises(IOError,
+                       match="Not yet implemented: Selected encoding is not supported."):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
                          column_encoding={'b': "DELTA_BINARY_PACKED"},
+                         use_legacy_dataset=use_legacy_dataset)
+
+    # Try to pass "RLE_DICTIONARY".
+    with pytest.raises(ValueError):
+        _check_roundtrip(mixed_table, expected=mixed_table,
+                         use_dictionary=False,
+                         column_encoding="RLE_DICTIONARY",
                          use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass unsupported encoding.
@@ -399,14 +408,14 @@ def test_column_encoding(use_legacy_dataset):
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=['b'],
-                         column_encoding={'b': "DELTA_BINARY_PACKED"},
+                         column_encoding={'b': "PLAIN"},
                          use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass column_encoding and use_dictionary=True (default value).
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
-                         column_encoding={'b': "DELTA_BINARY_PACKED"},
+                         column_encoding={'b': "PLAIN"},
                          use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass column_encoding and use_byte_stream_split on same column.

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -356,34 +356,32 @@ def test_byte_stream_split(use_legacy_dataset):
 def test_col_encoding(use_legacy_dataset):
     arr_float = pa.array(list(map(float, range(100))))
     arr_int = pa.array(list(map(int, range(100))))
-    table = pa.Table.from_arrays([arr_float, arr_float], names=['a', 'b'])
     mixed_table = pa.Table.from_arrays([arr_float, arr_int],
                                        names=['a', 'b'])
 
     # Check NONE col_encoding.
-    _check_roundtrip(table, expected=table, use_dictionary=False,
+    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
                      col_encoding=None, use_legacy_dataset=use_legacy_dataset)
 
-    # Check "PLAIN" col_encoding for column 'b' and "BYTE_STREAM_SPLIT"
-    # for column 'a'.
-    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=['a'],
+    # Check "BYTE_STREAM_SPLIT" for column 'a' and "PLAIN" col_encoding for
+    # column 'b'.
+    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
                      col_encoding={'a': "BYTE_STREAM_SPLIT", 'b': "PLAIN"},
                      use_legacy_dataset=use_legacy_dataset)
 
-    # Should raise error (and it did,  but now it doesn't anymore :S)
+    # Check "RLE" for column 'a' and "BYTE_STREAM_SPLIT" col_encoding for
+    # column 'b'.
     _check_roundtrip(mixed_table, expected=mixed_table,
-                     use_byte_stream_split=['a'],
                      col_encoding={'a': "RLE", 'b': "BYTE_STREAM_SPLIT"},
                      use_legacy_dataset=use_legacy_dataset)
 
     # Fatal Python error: Aborted
-    # _check_roundtrip(mixed_table, expected=mixed_table,
-    #                 use_byte_stream_split=['b'],
+
+    # _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
     #                 col_encoding={'a': "RLE_DICTIONARY"},
     #                 use_legacy_dataset=use_legacy_dataset)
 
-    # Fatal Python error: Aborted
-    # _check_roundtrip(mixed_table, expected=mixed_table,
+    # _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
     #                 use_byte_stream_split=['b'],
     #                 col_encoding={'a': "PLAIN_DICTIONARY"})
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -374,7 +374,8 @@ def test_column_encoding(use_legacy_dataset):
     # Try to pass "BYTE_STREAM_SPLIT" column encoding for integer column 'b'.
     # This should throw an error as it is only supports FLOAT and DOUBLE.
     with pytest.raises(IOError,
-                       match="BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE"):
+                       match="BYTE_STREAM_SPLIT only supports FLOAT and"
+                             " DOUBLE"):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
                          column_encoding={'b': "BYTE_STREAM_SPLIT"},
@@ -383,13 +384,16 @@ def test_column_encoding(use_legacy_dataset):
     # Try to pass "DELTA_BINARY_PACKED".
     # This should throw an error as it is only supported for reading.
     with pytest.raises(IOError,
-                       match="Not yet implemented: Selected encoding is not supported."):
+                       match="Not yet implemented: Selected encoding is"
+                             " not supported."):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
                          column_encoding={'b': "DELTA_BINARY_PACKED"},
                          use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass "RLE_DICTIONARY".
+    # This should throw an error as dictionary encoding is already used by
+    # default and not supported to be specified as "fallback" encoding
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -353,6 +353,42 @@ def test_byte_stream_split(use_legacy_dataset):
 
 
 @parametrize_legacy_dataset
+def test_col_encoding(use_legacy_dataset):
+    arr_float = pa.array(list(map(float, range(100))))
+    arr_int = pa.array(list(map(int, range(100))))
+    table = pa.Table.from_arrays([arr_float, arr_float], names=['a', 'b'])
+    mixed_table = pa.Table.from_arrays([arr_float, arr_int],
+                                       names=['a', 'b'])
+
+    # Check NONE col_encoding.
+    _check_roundtrip(table, expected=table, use_dictionary=False,
+                     col_encoding=None, use_legacy_dataset=use_legacy_dataset)
+
+    # Check "PLAIN" col_encoding for column 'b' and "BYTE_STREAM_SPLIT"
+    # for column 'a'.
+    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=['a'],
+                     col_encoding={'a': "BYTE_STREAM_SPLIT", 'b': "PLAIN"},
+                     use_legacy_dataset=use_legacy_dataset)
+
+    # Should raise error (and it did,  but now it doesn't anymore :S)
+    _check_roundtrip(mixed_table, expected=mixed_table,
+                     use_byte_stream_split=['a'],
+                     col_encoding={'a': "RLE", 'b': "BYTE_STREAM_SPLIT"},
+                     use_legacy_dataset=use_legacy_dataset)
+
+    # Fatal Python error: Aborted
+    # _check_roundtrip(mixed_table, expected=mixed_table,
+    #                 use_byte_stream_split=['b'],
+    #                 col_encoding={'a': "RLE_DICTIONARY"},
+    #                 use_legacy_dataset=use_legacy_dataset)
+
+    # Fatal Python error: Aborted
+    # _check_roundtrip(mixed_table, expected=mixed_table,
+    #                 use_byte_stream_split=['b'],
+    #                 col_encoding={'a': "PLAIN_DICTIONARY"})
+
+
+@parametrize_legacy_dataset
 def test_compression_level(use_legacy_dataset):
     arr = pa.array(list(map(int, range(1000))))
     data = [arr, arr]

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -369,10 +369,13 @@ def test_column_encoding(use_legacy_dataset):
                      column_encoding={'a': "BYTE_STREAM_SPLIT", 'b': "PLAIN"},
                      use_legacy_dataset=use_legacy_dataset)
 
-    # Check "DELTA_BINARY_PACKED" column encoding for int column 'b'.
-    #_check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
-    #                 column_encoding={'b': "DELTA_BINARY_PACKED"},
-    #                 use_legacy_dataset=use_legacy_dataset)
+    # Try to pass "DELTA_BINARY_PACKED" column encoding for int column 'a'.
+    # This should throw and error as it is only supported for reading.
+    with pytest.raises(IOError):
+        _check_roundtrip(mixed_table, expected=mixed_table,
+                         use_dictionary=False,
+                         column_encoding={'b': "DELTA_BINARY_PACKED"},
+                         use_legacy_dataset=use_legacy_dataset)
 
     # Try to pass unsupported encoding
     with pytest.raises(ValueError):

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -365,7 +365,7 @@ def test_column_encoding(use_legacy_dataset):
                      column_encoding={'a': "BYTE_STREAM_SPLIT", 'b': "PLAIN"},
                      use_legacy_dataset=use_legacy_dataset)
 
-    # Check "PLAIN" for all columns
+    # Check "PLAIN" for all columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
                      use_dictionary=False,
                      column_encoding="PLAIN",
@@ -387,14 +387,14 @@ def test_column_encoding(use_legacy_dataset):
                          column_encoding={'b': "DELTA_BINARY_PACKED"},
                          use_legacy_dataset=use_legacy_dataset)
 
-    # Try to pass unsupported encoding
+    # Try to pass unsupported encoding.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
                          column_encoding={'a': "MADE_UP_ENCODING"},
                          use_legacy_dataset=use_legacy_dataset)
 
-    # Try to pass column_encoding and use_dictionary
+    # Try to pass column_encoding and use_dictionary.
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
@@ -402,14 +402,14 @@ def test_column_encoding(use_legacy_dataset):
                          column_encoding={'b': "DELTA_BINARY_PACKED"},
                          use_legacy_dataset=use_legacy_dataset)
 
-    # Try to pass column_encoding and use_dictionary=True (default value)
+    # Try to pass column_encoding and use_dictionary=True (default value).
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          column_encoding={'b': "DELTA_BINARY_PACKED"},
                          use_legacy_dataset=use_legacy_dataset)
 
-    # Try to pass column_encoding and use_byte_stream_split on same column
+    # Try to pass column_encoding and use_byte_stream_split on same column.
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
@@ -419,7 +419,7 @@ def test_column_encoding(use_legacy_dataset):
                                           'b': "BYTE_STREAM_SPLIT"},
                          use_legacy_dataset=use_legacy_dataset)
 
-    # Try to pass column_encoding and use_byte_stream_split=True
+    # Try to pass column_encoding and use_byte_stream_split=True.
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
@@ -427,6 +427,14 @@ def test_column_encoding(use_legacy_dataset):
                          use_byte_stream_split=True,
                          column_encoding={'a': "RLE",
                                           'b': "BYTE_STREAM_SPLIT"},
+                         use_legacy_dataset=use_legacy_dataset)
+
+    # Try to pass column_encoding=True.
+    # This should throw an error.
+    with pytest.raises(TypeError):
+        _check_roundtrip(mixed_table, expected=mixed_table,
+                         use_dictionary=False,
+                         column_encoding=True,
                          use_legacy_dataset=use_legacy_dataset)
 
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -376,6 +376,12 @@ def test_col_encoding(use_legacy_dataset):
                      col_encoding={'a': "RLE", 'b': "BYTE_STREAM_SPLIT"},
                      use_legacy_dataset=use_legacy_dataset)
 
+    # Check "DELTA_BINARY_PACKED" col_encoding for column 'b'.
+    _check_roundtrip(mixed_table, expected=mixed_table,
+                     use_dictionary=['b'],
+                     col_encoding={'b': "DELTA_BINARY_PACKED"},
+                     use_legacy_dataset=use_legacy_dataset)
+
 
 @parametrize_legacy_dataset
 def test_compression_level(use_legacy_dataset):


### PR DESCRIPTION
This PR adds a new parameter to `write_table` to allow parquet encodings to be defined on a per column basis. The encodings currently supported are: PLAIN, BIT_PACKED, RLE, BYTE_STREAM_SPLIT, DELTA_BINARY_PACKED, DELTA_BYTE_ARRAY    .

It is not possible to set PLAIN_DICTIONARY and RLE_DICTIONARY for fallback encoding (those options will already be used by default in the C++ Parquet library).