### PR TITLE
ARROW-14712: [R] fix compare_dplyr_error() for dplyr 1.0.8 

### DIFF
--- a/r/tests/testthat/helper-expectation.R
+++ b/r/tests/testthat/helper-expectation.R
@@ -157,6 +157,10 @@ compare_dplyr_error <- function(expr,
     error = function(e) {
       msg <- conditionMessage(e)
 
+      if (grepl("Problem while computing", msg[1])) {
+        msg <- conditionMessage(e$parent)
+      }
+
       # The error here is of the form:
       #
       # Problem with `filter()` .input `..1`.


### PR DESCRIPTION
As of `dplyr` 1.0.8, we're starting to use chained errors so the messages this was after is now in the parent error. 

This pull request should be fine with both cran dplyr and future dplyr. We then can adapt again when dplyr 1.0.8 is on cran. 