### PR TITLE
ARROW-14769: [Go] Ensure MessageReader errors get reported

### DIFF
--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -196,9 +196,7 @@ func (r *Reader) Read() (array.Record, error) {
 	}
 
 	if !r.next() {
-		if r.err != nil {
-			return nil, r.err
-		} else if r.done {
+		if r.done && r.err == nil {
 			return nil, io.EOF
 		}
 		return nil, r.err

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -196,7 +196,9 @@ func (r *Reader) Read() (array.Record, error) {
 	}
 
 	if !r.next() {
-		if r.done {
+		if r.err != nil {
+			return nil, r.err
+		} else if r.done {
 			return nil, io.EOF
 		}
 		return nil, r.err


### PR DESCRIPTION
If there's an error in the reader state, prefer returning that over EOF.