### PR TITLE
ARROW-14773: [JS] Fix sourcemap paths

### DIFF
--- a/js/gulp/typescript-task.js
+++ b/js/gulp/typescript-task.js
@@ -66,12 +66,12 @@ function compileTypescript(out, tsconfigPath, tsconfigOverrides) {
     const writeSources = observableFromStreams(tsProject.src(), gulp.dest(path.join(out, 'src')));
     const writeDTypes = observableFromStreams(dts, sourcemaps.write('./', { includeContent: false, sourceRoot: 'src' }), gulp.dest(out));
     const mapFile = tsProject.options.module === 5 ? esmMapFile : cjsMapFile;
-    const writeJS = observableFromStreams(js, sourcemaps.write('./', { mapFile, includeContent: false }), gulp.dest(out));
+    const writeJS = observableFromStreams(js, sourcemaps.write('./', { mapFile, includeContent: false, sourceRoot: 'src' }), gulp.dest(out));
     return ObservableForkJoin([writeSources, writeDTypes, writeJS]);
 }
 
-function cjsMapFile(mapFilePath) { return mapFilePath; }
-function esmMapFile(mapFilePath) { return mapFilePath.replace('.js.map', '.mjs.map'); }
+const cjsMapFile = (mapFilePath) => mapFilePath;
+const esmMapFile = (mapFilePath) => mapFilePath.replace('.js.map', '.mjs.map');
 
 module.exports = typescriptTask;
 module.exports.typescriptTask = typescriptTask;


### PR DESCRIPTION
This fixes an issue where the source maps point to files in the root directory, not `src`, which is where the sources actually are. 