### PR TITLE
ARROW-14784: [GLib][Ruby] Rename GArrowSortKey::name to ::target

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -2299,7 +2299,7 @@ typedef struct GArrowSortKeyPrivate_ {
 } GArrowSortKeyPrivate;
 
 enum {
-  PROP_SORT_KEY_NAME = 1,
+  PROP_SORT_KEY_TARGET = 1,
   PROP_SORT_KEY_ORDER,
 };
 
@@ -2329,9 +2329,6 @@ garrow_sort_key_set_property(GObject *object,
   auto priv = GARROW_SORT_KEY_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_SORT_KEY_NAME:
-    priv->sort_key.target = g_value_get_string(value);
-    break;
   case PROP_SORT_KEY_ORDER:
     priv->sort_key.order =
       static_cast<arrow::compute::SortOrder>(g_value_get_enum(value));
@@ -2351,11 +2348,14 @@ garrow_sort_key_get_property(GObject *object,
   auto priv = GARROW_SORT_KEY_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_SORT_KEY_NAME:
-    if (auto name = priv->sort_key.target.name()) {
-      g_value_set_string(value, name->c_str());
-    } else {
-      g_value_set_string(value, "");
+  case PROP_SORT_KEY_TARGET:
+    {
+      auto name = priv->sort_key.target.name();
+      if (name) {
+        g_value_set_string(value, name->c_str());
+      } else {
+        g_value_set_string(value, priv->sort_key.target.ToDotPath().c_str());
+      }
     }
     break;
   case PROP_SORT_KEY_ORDER:
@@ -2385,18 +2385,22 @@ garrow_sort_key_class_init(GArrowSortKeyClass *klass)
 
   GParamSpec *spec;
   /**
-   * GArrowSortKey:name:
+   * GArrowSortKey:target:
    *
-   * The column name to be used.
+   * A name or dot path for the sort target.
    *
-   * Since: 3.0.0
+   *     dot_path = '.' name
+   *              | '[' digit+ ']'
+   *              | dot_path+
+   *
+   * Since: 7.0.0
    */
-  spec = g_param_spec_string("name",
-                             "Name",
-                             "The column name to be used",
+  spec = g_param_spec_string("target",
+                             "Target",
+                             "The sort target",
                              NULL,
-                             static_cast<GParamFlags>(G_PARAM_READWRITE));
-  g_object_class_install_property(gobject_class, PROP_SORT_KEY_NAME, spec);
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_SORT_KEY_TARGET, spec);
 
   /**
    * GArrowSortKey:order:
@@ -2410,13 +2414,14 @@ garrow_sort_key_class_init(GArrowSortKeyClass *klass)
                            "How to order values",
                            GARROW_TYPE_SORT_ORDER,
                            0,
-                           static_cast<GParamFlags>(G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                    G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_SORT_KEY_ORDER, spec);
 }
 
 /**
  * garrow_sort_key_new:
- * @name: A column name to be used.
+ * @target: A name or dot path for sort target.
  * @order: How to order by this sort key.
  *
  * Returns: A newly created #GArrowSortKey.
@@ -2424,12 +2429,21 @@ garrow_sort_key_class_init(GArrowSortKeyClass *klass)
  * Since: 3.0.0
  */
 GArrowSortKey *
-garrow_sort_key_new(const gchar *name, GArrowSortOrder order)
+garrow_sort_key_new(const gchar *target,
+                    GArrowSortOrder order,
+                    GError **error)
 {
+  auto arrow_reference_result = garrow_field_reference_resolve_raw(target);
+  if (!garrow::check(error,
+                     arrow_reference_result,
+                     "[sort-key][new]")) {
+    return NULL;
+  }
   auto sort_key = g_object_new(GARROW_TYPE_SORT_KEY,
-                               "name", name,
                                "order", order,
                                NULL);
+  auto priv = GARROW_SORT_KEY_GET_PRIVATE(sort_key);
+  priv->sort_key.target = *arrow_reference_result;
   return GARROW_SORT_KEY(sort_key);
 }
 
@@ -2535,8 +2549,7 @@ garrow_sort_options_get_sort_keys(GArrowSortOptions *options)
   auto arrow_options = garrow_sort_options_get_raw(options);
   GList *sort_keys = NULL;
   for (const auto &arrow_sort_key : arrow_options->sort_keys) {
-    auto sort_key = g_object_new(GARROW_TYPE_SORT_KEY, NULL);
-    GARROW_SORT_KEY_GET_PRIVATE(sort_key)->sort_key = arrow_sort_key;
+    auto sort_key = garrow_sort_key_new_raw(arrow_sort_key);
     sort_keys = g_list_prepend(sort_keys, sort_key);
   }
   return g_list_reverse(sort_keys);
@@ -4068,6 +4081,19 @@ garrow_record_batch_filter(GArrowRecordBatch *record_batch,
 
 G_END_DECLS
 
+
+arrow::Result<arrow::FieldRef>
+garrow_field_reference_resolve_raw(const gchar *reference)
+{
+  if (reference && reference[0] == '.') {
+    return arrow::FieldRef::FromDotPath(reference);
+  } else {
+    arrow::FieldRef arrow_reference(reference);
+    return arrow_reference;
+  }
+}
+
+
 arrow::compute::ExecContext *
 garrow_execute_context_get_raw(GArrowExecuteContext *context)
 {
@@ -4231,12 +4257,23 @@ garrow_array_sort_options_get_raw(GArrowArraySortOptions *options)
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }
 
+
+GArrowSortKey *
+garrow_sort_key_new_raw(const arrow::compute::SortKey &arrow_sort_key)
+{
+  auto sort_key = g_object_new(GARROW_TYPE_SORT_KEY, NULL);
+  auto priv = GARROW_SORT_KEY_GET_PRIVATE(sort_key);
+  priv->sort_key = arrow_sort_key;
+  return GARROW_SORT_KEY(sort_key);
+}
+
 arrow::compute::SortKey *
 garrow_sort_key_get_raw(GArrowSortKey *sort_key)
 {
   auto priv = GARROW_SORT_KEY_GET_PRIVATE(sort_key);
   return &(priv->sort_key);
 }
+
 
 arrow::compute::SortOptions *
 garrow_sort_options_get_raw(GArrowSortOptions *options)

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -426,7 +426,9 @@ struct _GArrowSortKeyClass
 
 GARROW_AVAILABLE_IN_3_0
 GArrowSortKey *
-garrow_sort_key_new(const gchar *name, GArrowSortOrder order);
+garrow_sort_key_new(const gchar *target,
+                    GArrowSortOrder order,
+                    GError **error);
 
 GARROW_AVAILABLE_IN_3_0
 gboolean

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -24,6 +24,10 @@
 #include <arrow-glib/compute.h>
 
 
+arrow::Result<arrow::FieldRef>
+garrow_field_reference_resolve_raw(const gchar *reference);
+
+
 arrow::compute::ExecContext *
 garrow_execute_context_get_raw(GArrowExecuteContext *context);
 
@@ -88,6 +92,8 @@ arrow::compute::ArraySortOptions *
 garrow_array_sort_options_get_raw(GArrowArraySortOptions *options);
 
 
+GArrowSortKey *
+garrow_sort_key_new_raw(const arrow::compute::SortKey &arrow_sort_key);
 arrow::compute::SortKey *
 garrow_sort_key_get_raw(GArrowSortKey *sort_key);
 

--- a/c_glib/arrow-glib/expression.cpp
+++ b/c_glib/arrow-glib/expression.cpp
@@ -175,20 +175,14 @@ GArrowFieldExpression *
 garrow_field_expression_new(const gchar *reference,
                             GError **error)
 {
-  if (reference && reference[0] == '.') {
-    auto arrow_reference_result = arrow::FieldRef::FromDotPath(reference);
-    if (!garrow::check(error,
-                       arrow_reference_result,
-                       "[field-expression][new]")) {
-      return NULL;
-    }
-    auto arrow_expression = arrow::compute::field_ref(*arrow_reference_result);
-    return GARROW_FIELD_EXPRESSION(garrow_expression_new_raw(arrow_expression));
-  } else {
-    arrow::FieldRef arrow_reference(reference);
-    auto arrow_expression = arrow::compute::field_ref(arrow_reference);
-    return GARROW_FIELD_EXPRESSION(garrow_expression_new_raw(arrow_expression));
+  auto arrow_reference_result = garrow_field_reference_resolve_raw(reference);
+  if (!garrow::check(error,
+                     arrow_reference_result,
+                     "[field-expression][new]")) {
+    return NULL;
   }
+  auto arrow_expression = arrow::compute::field_ref(*arrow_reference_result);
+  return GARROW_FIELD_EXPRESSION(garrow_expression_new_raw(arrow_expression));
 }
 
 

--- a/ruby/red-arrow/lib/arrow/sort-key.rb
+++ b/ruby/red-arrow/lib/arrow/sort-key.rb
@@ -29,25 +29,26 @@ module Arrow
       #
       #   @return [Arrow::SortKey] The given sort key itself.
       #
-      # @overload resolve(name)
+      # @overload resolve(target)
       #
-      #   Creates a new suitable sort key from column name with
-      #   leading order mark. See {#initialize} for details about
+      #   Creates a new suitable sort key from column name or dot path
+      #   with leading order mark. See {#initialize} for details about
       #   order mark.
       #
       #   @return [Arrow::SortKey] A new suitable sort key.
       #
-      # @overload resolve(name, order)
+      # @overload resolve(target, order)
       #
-      #   Creates a new suitable sort key from column name without
-      #   leading order mark and order. See {#initialize} for details.
+      #   Creates a new suitable sort key from column name or dot path
+      #   without leading order mark and order. See {#initialize} for
+      #   details.
       #
       #   @return [Arrow::SortKey] A new suitable sort key.
       #
       # @since 4.0.0
-      def resolve(name, order=nil)
-        return name if name.is_a?(self)
-        new(name, order)
+      def resolve(target, order=nil)
+        return target if target.is_a?(self)
+        new(target, order)
       end
 
       # @api private
@@ -65,47 +66,49 @@ module Arrow
     private :initialize_raw
     # Creates a new {Arrow::SortKey}.
     #
-    # @overload initialize(name)
+    # @overload initialize(target)
     #
-    #   @param name [Symbol, String] The name of the sort column.
+    #   @param target [Symbol, String] The name or dot path of the
+    #     sort column.
     #
-    #     If `name` is a String, the first character may be processed
-    #     as the "leading order mark". If the first character is `"+"`
-    #     or `"-"`, they are processed as a leading order mark. If the
-    #     first character is processed as a leading order mark, the
-    #     first character is removed from sort column name and
-    #     corresponding order is used. `"+"` uses ascending order and
-    #     `"-"` uses ascending order.
+    #     If `target` is a String, the first character may be
+    #     processed as the "leading order mark". If the first
+    #     character is `"+"` or `"-"`, they are processed as a leading
+    #     order mark. If the first character is processed as a leading
+    #     order mark, the first character is removed from sort column
+    #     target and corresponding order is used. `"+"` uses ascending
+    #     order and `"-"` uses ascending order.
     #
-    #     If `name` is not a String nor `name` doesn't start with the
-    #     leading order mark, sort column name is `name` as-is and
+    #     If `target` is not a String nor `target` doesn't start with the
+    #     leading order mark, sort column target is `target` as-is and
     #     ascending order is used.
     #
     #   @example String without the leading order mark
     #     key = Arrow::SortKey.new("count")
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::ASCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::ASCENDING
     #
     #   @example String with the "+" leading order mark
     #     key = Arrow::SortKey.new("+count")
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::ASCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::ASCENDING
     #
     #   @example String with the "-" leading order mark
     #     key = Arrow::SortKey.new("-count")
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::DESCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::DESCENDING
     #
     #   @example Symbol that starts with "-"
     #     key = Arrow::SortKey.new(:"-count")
-    #     key.name  # => "-count"
-    #     key.order # => Arrow::SortOrder::ASCENDING
+    #     key.target # => "-count"
+    #     key.order  # => Arrow::SortOrder::ASCENDING
     #
-    # @overload initialize(name, order)
+    # @overload initialize(target, order)
     #
-    #   @param name [Symbol, String] The name of the sort column.
+    #   @param target [Symbol, String] The name or dot path of the
+    #     sort column.
     #
-    #     No leading order mark processing. The given `name` is used
+    #     No leading order mark processing. The given `target` is used
     #     as-is.
     #
     #   @param order [Symbol, String, Arrow::SortOrder] How to order
@@ -117,29 +120,29 @@ module Arrow
     #
     #   @example No leading order mark processing
     #     key = Arrow::SortKey.new("-count", :ascending)
-    #     key.name  # => "-count"
-    #     key.order # => Arrow::SortOrder::ASCENDING
+    #     key.target # => "-count"
+    #     key.order  # => Arrow::SortOrder::ASCENDING
     #
-    #   @example Order by abbreviated name with Symbol
+    #   @example Order by abbreviated target with Symbol
     #     key = Arrow::SortKey.new("count", :desc)
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::DESCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::DESCENDING
     #
     #   @example Order by String
     #     key = Arrow::SortKey.new("count", "descending")
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::DESCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::DESCENDING
     #
     #   @example Order by Arrow::SortOrder
     #     key = Arrow::SortKey.new("count", Arrow::SortOrder::DESCENDING)
-    #     key.name  # => "count"
-    #     key.order # => Arrow::SortOrder::DESCENDING
+    #     key.target # => "count"
+    #     key.order  # => Arrow::SortOrder::DESCENDING
     #
     # @since 4.0.0
-    def initialize(name, order=nil)
-      name, order = normalize_name(name, order)
+    def initialize(target, order=nil)
+      target, order = normalize_target(target, order)
       order = normalize_order(order) || :ascending
-      initialize_raw(name, order)
+      initialize_raw(target, order)
     end
 
     # @return [String] The string representation of this sort key. You
@@ -154,28 +157,31 @@ module Arrow
     # @since 4.0.0
     def to_s
       if order == SortOrder::ASCENDING
-        "+#{name}"
+        "+#{target}"
       else
-        "-#{name}"
+        "-#{target}"
       end
     end
 
+    # For backward compatibility
+    alias_method :name, :target
+
     private
-    def normalize_name(name, order)
-      case name
+    def normalize_target(target, order)
+      case target
       when Symbol
-        return name.to_s, order
+        return target.to_s, order
       when String
-        return name, order if order
-        if name.start_with?("-")
-          return name[1..-1], order || :descending
-        elsif name.start_with?("+")
-          return name[1..-1], order || :ascending
+        return target, order if order
+        if target.start_with?("-")
+          return target[1..-1], order || :descending
+        elsif target.start_with?("+")
+          return target[1..-1], order || :ascending
         else
-          return name, order
+          return target, order
         end
       else
-        return name, order
+        return target, order
       end
     end
 

--- a/ruby/red-arrow/lib/arrow/sort-options.rb
+++ b/ruby/red-arrow/lib/arrow/sort-options.rb
@@ -78,20 +78,20 @@ module Arrow
     #     options.add_sort_key(Arrow::SortKey.new(:price, :descending))
     #     options.sort_keys.collect(&:to_s) # => ["-price"]
     #
-    # @overload add_sort_key(name)
+    # @overload add_sort_key(target)
     #
-    #   @param name [Symbol, String] The sort key name to be
-    #     added. See also {Arrow::SortKey#initialize} for the leading
-    #     order mark for String name.
+    #   @param target [Symbol, String] The sort key name or dot path
+    #     to be added. See also {Arrow::SortKey#initialize} for the
+    #     leading order mark for `String` target.
     #
     #   @example Add a key to sort by "price" column in descending order
     #     options = Arrow::SortOptions.new
     #     options.add_sort_key("-price")
     #     options.sort_keys.collect(&:to_s) # => ["-price"]
     #
-    # @overload add_sort_key(name, order)
+    # @overload add_sort_key(target, order)
     #
-    #   @param name [Symbol, String] The sort key name.
+    #   @param target [Symbol, String] The sort key name or dot path.
     #
     #   @param order [Symbol, String, Arrow::SortOrder] The sort
     #     order. See {Arrow::SortKey#initialize} for details.
@@ -102,8 +102,8 @@ module Arrow
     #     options.sort_keys.collect(&:to_s) # => ["-price"]
     #
     # @since 4.0.0
-    def add_sort_key(name, order=nil)
-      add_sort_key_raw(SortKey.resolve(name, order))
+    def add_sort_key(target, order=nil)
+      add_sort_key_raw(SortKey.resolve(target, order))
     end
   end
 end


### PR DESCRIPTION
Because arrow::compute::SortKey::name was renamed to ::target by
528625e6ed4bf1f6540f8a410a496a14712252e7 ARROW-14074.

This is a backward incompatible change in GLib.

This doesn't break backward compatibility in Ruby.