### PR TITLE
ARROW-14786: [R][CI] Try without caching

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -213,10 +213,11 @@ jobs:
         # So that they're unique when multiple are downloaded in the next step
         shell: bash
         run: mv libarrow.zip libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
           path: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
+          retention-days: 1
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -212,11 +212,11 @@ jobs:
       - name: Rename libarrow.zip
         # So that they're unique when multiple are downloaded in the next step
         shell: bash
-        run: mv libarrow.zip libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
+        run: mv libarrow.zip libarrow-test-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
       - uses: actions/upload-artifact@v2
         with:
-          name: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
-          path: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
+          name: libarrow-test-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
+          path: libarrow-test-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
           retention-days: 1
       # We can remove this when we drop support for Rtools 3.5.
       - name: Ensure using system tar in actions/cache
@@ -248,31 +248,31 @@ jobs:
         if: ${{ matrix.rtools == 35 }}
         uses: actions/download-artifact@v2
         with:
-          name: libarrow-rtools35-mingw32.zip
+          name: libarrow-test-rtools35-mingw32.zip
           path: r/windows
       - name: Download artifacts
         if: ${{ matrix.rtools == 35 }}
         uses: actions/download-artifact@v2
         with:
-          name: libarrow-rtools35-mingw64.zip
+          name: libarrow-test-rtools35-mingw64.zip
           path: r/windows
       - name: Download artifacts
         if: ${{ matrix.rtools == 40 }}
         uses: actions/download-artifact@v2
         with:
-          name: libarrow-rtools40-mingw32.zip
+          name: libarrow-test-rtools40-mingw32.zip
           path: r/windows
       - name: Download artifacts
         if: ${{ matrix.rtools == 40 }}
         uses: actions/download-artifact@v2
         with:
-          name: libarrow-rtools40-mingw64.zip
+          name: libarrow-test-rtools40-mingw64.zip
           path: r/windows
       - name: Download artifacts
         if: ${{ matrix.rtools == 40 }}
         uses: actions/download-artifact@v2
         with:
-          name: libarrow-rtools40-ucrt64.zip
+          name: libarrow-test-rtools40-ucrt64.zip
           path: r/windows
       - name: Unzip and rezip libarrows
         shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -190,22 +190,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup ccache
-        shell: bash
-        run: |
-          ci/scripts/ccache_setup.sh
-          echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
-      # We must enable actions/cache before r-lib/actions/setup-r to ensure
-      # using system tar instead of tar provided by Rtools.
-      # We can use tar provided by Rtools when we drop support for Rtools 3.5.
-      # Because Rtools 4.0 or later has zstd. actions/cache requires zstd
-      # when tar is GNU tar.
-      - name: Cache ccache
-        uses: actions/cache@v2
-        with:
-          path: ccache
-          key: r-${{ matrix.config.rtools }}-ccache-mingw-${{ hashFiles('cpp/**') }}
-          restore-keys: r-${{ matrix.config.rtools }}-ccache-mingw-
       # We use the makepkg-mingw setup that is included in rtools40 even when
       # we use the rtools35 compilers, so we always install R 4.0/Rtools40
       - uses: r-lib/actions/setup-r@master
@@ -295,22 +279,6 @@ jobs:
           cd r/windows
           ls *.zip | xargs -n 1 unzip -uo
           rm -rf *.zip
-      - name: Setup ccache
-        shell: bash
-        run: |
-          ci/scripts/ccache_setup.sh
-          echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
-      # We must enable actions/cache before r-lib/actions/setup-r to ensure
-      # using system tar instead of tar provided by Rtools.
-      # We can use tar provided by Rtools when we drop support for Rtools 3.5.
-      # Because Rtools 4.0 or later has zstd. actions/cache requires zstd
-      # when tar is GNU tar.
-      - name: Cache ccache
-        uses: actions/cache@v2
-        with:
-          path: ccache
-          key: r-${{ matrix.rtools }}-ccache-mingw-${{ hashFiles('cpp/**') }}
-          restore-keys: r-${{ matrix.rtools }}-ccache-mingw-
       - uses: r-lib/actions/setup-r@master
         if: ${{ matrix.rtools == 40 }}
         with:


### PR DESCRIPTION
Caching can take upto 7 days to get a new upgrade and at present no nice way to invalidate the cache likely leading to test failures after a release