### PR TITLE
ARROW-14788: [C++] Fix warning in dataset/file_orc_test.cc

### DIFF
--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -44,7 +44,7 @@ class OrcFormatHelper {
     ARROW_ASSIGN_OR_RAISE(auto writer, adapters::orc::ORCFileWriter::Open(sink.get()));
     std::shared_ptr<Table> table;
     RETURN_NOT_OK(reader->ReadAll(&table));
-    writer->Write(*table);
+    RETURN_NOT_OK(writer->Write(*table));
     RETURN_NOT_OK(writer->Close());
     return sink->Finish();
   }


### PR DESCRIPTION
This is a very minor issue that is likely to have blocked our tests in master for a while. I do wonder why it was only discovered last night though. Is it because we are not testing ORC-related code by default?