### PR TITLE
ARROW-14791: [C++] Fix crash when validating corrupt list array

### DIFF
--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -564,7 +564,7 @@ struct ValidateArrayImpl {
                              " and offset: ", data.offset);
     }
 
-    if (full_validation && offsets_byte_size != 0) {
+    if (full_validation && required_offsets > 0) {
       // Validate all offset values
       const offset_type* offsets = data.GetValues<offset_type>(1);
 


### PR DESCRIPTION
Should fix the following failure (found by OSS-Fuzz):
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41143