### PR TITLE
MINOR: [R] [CI] Use Ubuntu 20.04 for system deps test

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1139,9 +1139,6 @@ tasks:
     ci: github
     template: docker-tests/github.linux.yml
     params:
-      env:
-        UBUNTU: 21.04
-        CLANG_TOOLS: 9 # can remove this when >=9 is the default
       flags: '-e ARROW_SOURCE_HOME="/arrow" -e FORCE_BUNDLED_BUILD=TRUE -e LIBARROW_BUILD=TRUE -e ARROW_DEPENDENCY_SOURCE=SYSTEM'
       image: ubuntu-r-only-r
 


### PR DESCRIPTION
We were using 21.04, but that is not supported by RSPM, so requires source installs of R dependencies which sometimes time out. This uses 20.04 which should be quicker + more reliable. 