### PR TITLE
ARROW-14796: [Python] Documentation: Correct default value

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1253,7 +1253,7 @@ cdef class Table(_PandasConvertible):
 
         Parameters
         ----------
-        show_metadata : bool, default True
+        show_metadata : bool, default False
             Display Field-level and Schema-level KeyValueMetadata.
         preview_cols : int, default 0
             Display values of the columns for the first N columns.


### PR DESCRIPTION
This PR corrects the default value in the documentation text for the Python function `to_string`.

Jira ARROW-14796