### PR TITLE
ARROW-14765: [Python] StructFieldOptions not exposed

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -967,6 +967,18 @@ class MakeStructOptions(_MakeStructOptions):
         self._set_options(field_names, field_nullability, field_metadata)
 
 
+cdef class _StructFieldOptions(FunctionOptions):
+    def _set_options(self, indices):
+        self.wrapped.reset(new CStructFieldOptions(indices))
+
+
+class StructFieldOptions(_StructFieldOptions):
+    def __init__(self, indices=None):
+        if indices is None:
+            indices = []
+        self._set_options(indices)
+
+
 cdef class _ScalarAggregateOptions(FunctionOptions):
     def _set_options(self, skip_nulls, min_count):
         self.wrapped.reset(new CScalarAggregateOptions(skip_nulls, min_count))

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -973,9 +973,7 @@ cdef class _StructFieldOptions(FunctionOptions):
 
 
 class StructFieldOptions(_StructFieldOptions):
-    def __init__(self, indices=None):
-        if indices is None:
-            indices = []
+    def __init__(self, indices):
         self._set_options(indices)
 
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -60,6 +60,7 @@ from pyarrow._compute import (  # noqa
     SplitPatternOptions,
     StrftimeOptions,
     StrptimeOptions,
+    StructFieldOptions,
     TakeOptions,
     TDigestOptions,
     TrimOptions,
@@ -187,7 +188,7 @@ def _make_generic_wrapper(func_name, func, option_class, arity):
             if arity is not Ellipsis and len(args) != arity:
                 raise TypeError(
                     f"{func_name} takes {arity} positional argument(s), "
-                    "but {len(args)} were given"
+                    f"but {len(args)} were given"
                 )
             return func.call(args, None, memory_pool)
     else:
@@ -195,7 +196,7 @@ def _make_generic_wrapper(func_name, func, option_class, arity):
             if arity is not Ellipsis and len(args) != arity:
                 raise TypeError(
                     f"{func_name} takes {arity} positional argument(s), "
-                    "but {len(args)} were given"
+                    f"but {len(args)} were given"
                 )
             options = _handle_options(func_name, option_class, options,
                                       kwargs)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2097,6 +2097,11 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         vector[c_bool] field_nullability
         vector[shared_ptr[const CKeyValueMetadata]] field_metadata
 
+    cdef cppclass CStructFieldOptions \
+            "arrow::compute::StructFieldOptions"(CFunctionOptions):
+        CStructFieldOptions(vector[int] indices)
+        vector[int] indices
+
     ctypedef enum CSortOrder" arrow::compute::SortOrder":
         CSortOrder_Ascending \
             "arrow::compute::SortOrder::Ascending"

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2208,6 +2208,21 @@ def test_make_struct():
         pc.make_struct(field_names=['one', 'two'])
 
 
+def test_struct_fields_options():
+    a = pa.array([4, 5, 6], type=pa.int64())
+    b = pa.array(["bar", None, ""])
+    c = pa.StructArray.from_arrays([a, b], ["a", "b"])
+    arr = pa.StructArray.from_arrays([a, c], ["a", "c"])
+
+    assert pc.struct_field(arr,
+                           indices=[1, 1]) == pa.array(["bar", None, ""])
+    assert pc.struct_field(arr,
+                           indices=[0]) == pa.array([4, 5, 6], type=pa.int64())
+    assert pc.struct_field(arr, indices=[]) == arr
+
+    # errors pc.struct_field(arr)
+
+
 def test_case_when():
     assert pc.case_when(pc.make_struct([True, False, None],
                                        [False, True, None]),

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2220,7 +2220,8 @@ def test_struct_fields_options():
                            indices=[0]) == pa.array([4, 5, 6], type=pa.int64())
     assert pc.struct_field(arr, indices=[]) == arr
 
-    # errors pc.struct_field(arr)
+    # TODO: https://issues.apache.org/jira/browse/ARROW-14853
+    # assert pc.struct_field(arr) == arr
 
 
 def test_case_when():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -152,6 +152,7 @@ def test_option_class_equality():
         pc.SplitPatternOptions("pattern"),
         pc.StrftimeOptions(),
         pc.StrptimeOptions("%Y", "s"),
+        pc.StructFieldOptions(indices=[]),
         pc.TakeOptions(),
         pc.TDigestOptions(),
         pc.TrimOptions(" "),
@@ -2219,6 +2220,9 @@ def test_struct_fields_options():
     assert pc.struct_field(arr,
                            indices=[0]) == pa.array([4, 5, 6], type=pa.int64())
     assert pc.struct_field(arr, indices=[]) == arr
+
+    with pytest.raises(TypeError, match="an integer is required"):
+        pc.struct_field(arr, indices=['a'])
 
     # TODO: https://issues.apache.org/jira/browse/ARROW-14853
     # assert pc.struct_field(arr) == arr


### PR DESCRIPTION
In this PR I added `StructFieldOptions` binding and two small typo corrections for `TypeError` message in `compute.py`.

What I haven't managed to solve and would ask for suggestions is the case when options are not specified. Example:

```python
import pyarrow as pa
import pyarrow.compute as pc

a = pa.array([4, 5, 6], type=pa.int64())
b = pa.array(["bar", None, ""])
c = pa.StructArray.from_arrays([a, b], ["a", "b"])
arr = pa.StructArray.from_arrays([a, c], ["a", "c"])

pc.struct_field(arr)
```
This error I get:

```python-traceback
>>> pc.struct_field(arr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alenkafrim/repos/arrow/python/pyarrow/compute.py", line 202, in wrapper
    return func.call(args, options, memory_pool)
  File "pyarrow/_compute.pyx", line 327, in pyarrow._compute.Function.call
    result = GetResultValue(
  File "pyarrow/error.pxi", line 143, in pyarrow.lib.pyarrow_internal_check_status
    return check_status(status)
  File "pyarrow/error.pxi", line 99, in pyarrow.lib.check_status
    raise ArrowInvalid(message)
pyarrow.lib.ArrowInvalid: Attempted to initialize KernelState from null FunctionOptions
```

For which I tried to add
https://github.com/AlenkaF/arrow/blob/bec0a6beac3415e03400088a3269f3be3fc7150c/python/pyarrow/_compute.pyx#L977-L978
but it doesn't seem to help.
