### PR TITLE
ARROW-14803: [R] Function not declared in scope

### DIFF
--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -706,7 +706,7 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
 
 bool is_arrow_altrep(SEXP) { return false; }
 
-std::shared_ptr<Array> vec_to_arrow_altrep_bypass(SEXP x) { return nullptr; }
+std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP x) { return nullptr; }
 
 }  // namespace altrep
 }  // namespace r

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -25,6 +25,8 @@
 #include <cpp11.hpp>
 #include <cpp11/altrep.hpp>
 
+#include "./arrow_types.h"
+
 #include "./nameof.h"
 
 // borrowed from enc package

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -25,8 +25,6 @@
 #include <cpp11.hpp>
 #include <cpp11/altrep.hpp>
 
-#include "./arrow_types.h"
-
 #include "./nameof.h"
 
 // borrowed from enc package
@@ -41,6 +39,17 @@
 // https://github.com/r-devel/r-svn/blob/6418faeb6f5d87d3d9b92b8978773bc3856b4b6f/src/main/altrep.c#L37
 #define ALTREP_CLASS_SERIALIZED_CLASS(x) ATTRIB(x)
 #define ALTREP_SERIALIZED_CLASS_PKGSYM(x) CADR(x)
+
+#if (R_VERSION < R_Version(3, 5, 0))
+#define LOGICAL_RO(x) ((const int*)LOGICAL(x))
+#define INTEGER_RO(x) ((const int*)INTEGER(x))
+#define REAL_RO(x) ((const double*)REAL(x))
+#define COMPLEX_RO(x) ((const Rcomplex*)COMPLEX(x))
+#define STRING_PTR_RO(x) ((const SEXP*)STRING_PTR(x))
+#define RAW_RO(x) ((const Rbyte*)RAW(x))
+#define DATAPTR_RO(x) ((const void*)STRING_PTR(x))
+#define DATAPTR(x) (void*)STRING_PTR(x)
+#endif
 
 namespace arrow {
 namespace r {

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -75,17 +75,6 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP, SEXP);
 arrow::MemoryPool* gc_memory_pool();
 arrow::compute::ExecContext* gc_context();
 
-#if (R_VERSION < R_Version(3, 5, 0))
-#define LOGICAL_RO(x) ((const int*)LOGICAL(x))
-#define INTEGER_RO(x) ((const int*)INTEGER(x))
-#define REAL_RO(x) ((const double*)REAL(x))
-#define COMPLEX_RO(x) ((const Rcomplex*)COMPLEX(x))
-#define STRING_PTR_RO(x) ((const SEXP*)STRING_PTR(x))
-#define RAW_RO(x) ((const Rbyte*)RAW(x))
-#define DATAPTR_RO(x) ((const void*)STRING_PTR(x))
-#define DATAPTR(x) (void*)STRING_PTR(x)
-#endif
-
 #define VECTOR_PTR_RO(x) ((const SEXP*)DATAPTR_RO(x))
 
 namespace arrow {


### PR DESCRIPTION
It looks like there was an order-of-imports issue and then one place where a return type wasn't quite right (when altrep wasn't defined). These changes make the old versions pass again (though there might be a better way to accomplish this!) 