### PR TITLE
ARROW-14842: [C++] Improve precision range error messages for Decimal

### DIFF
--- a/c_glib/test/test-decimal128-data-type.rb
+++ b/c_glib/test/test-decimal128-data-type.rb
@@ -48,7 +48,7 @@ class TestDecimal128DataType < Test::Unit::TestCase
 
   def test_invalid_precision
     message =
-      "[decimal128-data-type][new]: Invalid: Decimal precision out of range: 39"
+      "[decimal128-data-type][new]: Invalid: Decimal precision out of range [1, 38]: 39"
     assert_raise(Arrow::Error::Invalid.new(message)) do
       Arrow::Decimal128DataType.new(39, 1)
     end

--- a/c_glib/test/test-decimal256-data-type.rb
+++ b/c_glib/test/test-decimal256-data-type.rb
@@ -48,7 +48,7 @@ class TestDecimal256DataType < Test::Unit::TestCase
 
   def test_invalid_precision
     message =
-      "[decimal256-data-type][new]: Invalid: Decimal precision out of range: 77"
+      "[decimal256-data-type][new]: Invalid: Decimal precision out of range [1, 76]: 77"
     assert_raise(Arrow::Error::Invalid.new(message)) do
       Arrow::Decimal256DataType.new(77, 1)
     end

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -831,9 +831,8 @@ Decimal128Type::Decimal128Type(int32_t precision, int32_t scale)
 
 Result<std::shared_ptr<DataType>> Decimal128Type::Make(int32_t precision, int32_t scale) {
   if (precision < kMinPrecision || precision > kMaxPrecision) {
-    const auto min = kMinPrecision, max = kMaxPrecision;
-    return Status::Invalid("Decimal precision out of range [", min, ", ", max,
-                           "]: ", precision);
+    return Status::Invalid("Decimal precision out of range [", int32_t(kMinPrecision),
+                           ", ", int32_t(kMaxPrecision), "]: ", precision);
   }
   return std::make_shared<Decimal128Type>(precision, scale);
 }
@@ -849,9 +848,8 @@ Decimal256Type::Decimal256Type(int32_t precision, int32_t scale)
 
 Result<std::shared_ptr<DataType>> Decimal256Type::Make(int32_t precision, int32_t scale) {
   if (precision < kMinPrecision || precision > kMaxPrecision) {
-    const auto min = kMinPrecision, max = kMaxPrecision;
-    return Status::Invalid("Decimal precision out of range [", min, ", ", max,
-                           "]: ", precision);
+    return Status::Invalid("Decimal precision out of range [", int32_t(kMinPrecision),
+                           ", ", int32_t(kMaxPrecision), "]: ", precision);
   }
   return std::make_shared<Decimal256Type>(precision, scale);
 }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -831,7 +831,9 @@ Decimal128Type::Decimal128Type(int32_t precision, int32_t scale)
 
 Result<std::shared_ptr<DataType>> Decimal128Type::Make(int32_t precision, int32_t scale) {
   if (precision < kMinPrecision || precision > kMaxPrecision) {
-    return Status::Invalid("Decimal precision out of range: ", precision);
+    const auto min = kMinPrecision, max = kMaxPrecision;
+    return Status::Invalid("Decimal precision out of range [", min, ", ", max,
+                           "]: ", precision);
   }
   return std::make_shared<Decimal128Type>(precision, scale);
 }
@@ -847,7 +849,9 @@ Decimal256Type::Decimal256Type(int32_t precision, int32_t scale)
 
 Result<std::shared_ptr<DataType>> Decimal256Type::Make(int32_t precision, int32_t scale) {
   if (precision < kMinPrecision || precision > kMaxPrecision) {
-    return Status::Invalid("Decimal precision out of range: ", precision);
+    const auto min = kMinPrecision, max = kMaxPrecision;
+    return Status::Invalid("Decimal precision out of range [", min, ", ", max,
+                           "]: ", precision);
   }
   return std::make_shared<Decimal256Type>(precision, scale);
 }

--- a/r/tests/testthat/test-data-type.R
+++ b/r/tests/testthat/test-data-type.R
@@ -390,8 +390,8 @@ test_that("decimal type and validation", {
   expect_error(decimal(4))
   expect_error(decimal(4, "two"), '"scale" must be an integer')
   expect_error(decimal(NA, 2), '"precision" must be an integer')
-  expect_error(decimal(0, 2), "Invalid: Decimal precision out of range [1, 38]: 0")
-  expect_error(decimal(100, 2), "Invalid: Decimal precision out of range [1, 38]: 100")
+  expect_error(decimal(0, 2), "Invalid: Decimal precision out of range [1, 38]: 0", fixed = TRUE)
+  expect_error(decimal(100, 2), "Invalid: Decimal precision out of range [1, 38]: 100", fixed = TRUE)
   expect_error(decimal(4, NA), '"scale" must be an integer')
 
   expect_r6_class(decimal(4, 2), "Decimal128Type")

--- a/r/tests/testthat/test-data-type.R
+++ b/r/tests/testthat/test-data-type.R
@@ -390,8 +390,8 @@ test_that("decimal type and validation", {
   expect_error(decimal(4))
   expect_error(decimal(4, "two"), '"scale" must be an integer')
   expect_error(decimal(NA, 2), '"precision" must be an integer')
-  expect_error(decimal(0, 2), "Invalid: Decimal precision out of range: 0")
-  expect_error(decimal(100, 2), "Invalid: Decimal precision out of range: 100")
+  expect_error(decimal(0, 2), "Invalid: Decimal precision out of range [1, 38]: 0")
+  expect_error(decimal(100, 2), "Invalid: Decimal precision out of range [1, 38]: 100")
   expect_error(decimal(4, NA), '"scale" must be an integer')
 
   expect_r6_class(decimal(4, 2), "Decimal128Type")


### PR DESCRIPTION
Decimal128: `Invalid: Decimal precision out of range [1, 38]: 0`
Decimal256: `Invalid: Decimal precision out of range [1, 76]: 100`