### PR TITLE
ARROW-14879: [Python][Packaging] Remove manylinux2010 wheels

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -606,7 +606,7 @@ test_linux_wheels() {
   fi
 
   local py_arches="3.6m 3.7m 3.8 3.9 3.10"
-  local platform_tags="manylinux_2_12_${arch}.manylinux2010_${arch} manylinux_2_17_${arch}.manylinux2014_${arch}"
+  local platform_tags="manylinux_2_17_${arch}.manylinux2014_${arch}"
 
   for py_arch in ${py_arches}; do
     local env=_verify_wheel-${py_arch}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -360,8 +360,7 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for ci, arch, arch_alias, x_y, manylinux in [("github", "amd64", "x86_64", "2_12", "2010"),
-                                                ("github", "amd64", "x86_64", "2_17", "2014"),
+{% for ci, arch, arch_alias, x_y, manylinux in [("github", "amd64", "x86_64", "2_17", "2014"),
                                                 ("travis", "arm64", "aarch64", "2_17", "2014")] %}
   wheel-manylinux{{ manylinux }}-{{ python_tag }}-{{ arch }}:
     ci: "{{ ci }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,6 @@ x-hierarchy:
   # helper services
   - impala
   - postgres
-  - python-wheel-manylinux-2010
   - python-wheel-manylinux-2014:
     - java-jni-manylinux-2014
   - python-wheel-manylinux-test-imports
@@ -167,8 +166,6 @@ volumes:
     name: ${ARCH}-debian-${DEBIAN}-rust
   maven-cache:
     name: maven-cache
-  python-wheel-manylinux2010-ccache:
-    name: python-wheel-manylinux2010-ccache
   python-wheel-manylinux2014-ccache:
     name: python-wheel-manylinux2014-ccache
   python-wheel-windows-clcache:
@@ -778,30 +775,6 @@ services:
         /arrow/ci/scripts/python_sdist_test.sh /arrow"
 
   ############################ Python wheels ##################################
-
-  # See available versions at:
-  #    https://quay.io/repository/pypa/manylinux2010_x86_64?tab=tags
-  #    only amd64 arch is supported
-  python-wheel-manylinux-2010:
-    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010-vcpkg-${VCPKG}
-    build:
-      args:
-        arch_alias: ${ARCH_ALIAS}
-        arch_short_alias: ${ARCH_SHORT_ALIAS}
-        base: quay.io/pypa/manylinux2010_${ARCH_ALIAS}:2021-10-11-14ac00e
-        vcpkg: ${VCPKG}
-        python: ${PYTHON}
-      context: .
-      dockerfile: ci/docker/python-wheel-manylinux-201x.dockerfile
-      cache_from:
-        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2010-vcpkg-${VCPKG}
-    environment:
-      <<: *ccache
-      MANYLINUX_VERSION: 2010
-    volumes:
-      - .:/arrow:delegated
-      - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux2010-ccache:/ccache:delegated
-    command: /arrow/ci/scripts/python_wheel_manylinux_build.sh
 
   # See available versions at:
   #    https://quay.io/repository/pypa/manylinux2014_x86_64?tab=tags

--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -472,11 +472,10 @@ Toolchain Compatibility (Linux)
 
 The Python wheels for Linux are built using the
 `PyPA manylinux images <https://quay.io/organization/pypa>`_ which use
-the CentOS `devtoolset-8` or `devtoolset-9` depending on which manylinux
-wheel version (2010 or 2014) is being used. In addition to the other notes
-above, if you are compiling C++ using these shared libraries, you will need
-to make sure you use a compatible toolchain as well or you might see a
-segfault during runtime.
+the CentOS `devtoolset-9` for the manylinux2014 platform tag.
+In addition to the other notes above, if you are compiling C++ using these
+shared libraries, you will need to make sure you use a compatible toolchain as
+well or you might see a segfault during runtime.
 
 Also, if you encounter errors when linking or loading the library, consider
 setting the ``_GLIBCXX_USE_CXX11_ABI`` preprocessor macro to ``0``


### PR DESCRIPTION
More recent vcpkg [is not compatible with older glibc shipped by manylinux2010](https://github.com/apache/arrow/pull/11569#issuecomment-978031842) so we won't be able to regularly update the dependencies. Besides that manylinux2010 [has reached EOL](https://github.com/pypa/manylinux#manylinux2010-centos-6-based---eol).
