### PR TITLE
ARROW-14586  [R] summarise() with nested aggregate expressions has a confusing error

### DIFF
--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -238,9 +238,11 @@ summarize_eval <- function(name, quosure, ctx, hash, recurse = FALSE) {
 
   # Backstop for any other odd cases, like fun(x, y) (i.e. no aggregation),
   # or aggregation functions that aren't supported in Arrow (not in agg_funcs)
-  stop(
-    handle_arrow_not_supported(quo_get_expr(quosure), format_expr(quosure)),
-    call. = FALSE
+  abort(
+    paste(
+      "Expression", format_expr(quosure),
+      "is not an aggregate expression or is not supported in Arrow"
+    )
   )
 }
 
@@ -263,10 +265,10 @@ extract_aggregations <- function(expr, ctx) {
       # aggregations (e.g. sum(x - mean(x)))
       # TODO: support in ARROW-13926
       abort(
-        paste0(
-          "Aggregate within aggregate `",
+        paste(
+          "Aggregate within aggregate expression",
           format_expr(original_expr),
-          "` not supported in Arrow"
+          "not supported in Arrow"
         )
       )
     }

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -258,16 +258,16 @@ extract_aggregations <- function(expr, ctx) {
   }
   if (funs[1] %in% names(agg_funcs)) {
     inner_agg_exprs <- all_vars(expr) %in% names(ctx$aggregations)
-    if (any(inner_agg_exprs) & !all(inner_agg_exprs)) {
+    if (any(inner_agg_exprs)) {
       # We can't aggregate over a combination of dataset columns and other
       # aggregations (e.g. sum(x - mean(x)))
       # TODO: support in ARROW-13926
-      # TODO: Add "because" arg to explain _why_ it's not supported?
-      # TODO: this message could also say "not supported in summarize()"
-      #       since some of these expressions may be legal elsewhere
-      stop(
-        handle_arrow_not_supported(original_expr, format_expr(original_expr)),
-        call. = FALSE
+      abort(
+        paste0(
+          "Aggregate within aggregate `",
+          format_expr(original_expr),
+          "` not supported in Arrow"
+        )
       )
     }
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -913,7 +913,7 @@ test_that("summarise() passes through type information for temporary columns", {
 })
 
 test_that("summarise() can handle scalars and literal values", {
-  some_scalar_value = 2L
+  some_scalar_value <- 2L
 
   compare_dplyr_binding(
     .input %>% summarise(y = 1L) %>% collect(),

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -708,17 +708,27 @@ test_that("Expressions on aggregations", {
   # Aggregates on aggregates are not supported
   expect_warning(
     record_batch(tbl) %>% summarise(any(any(lgl))),
-    "Aggregate within aggregate expression any\\(any\\(lgl\\)\\) not supported in Arrow"
+    paste(
+      "Aggregate within aggregate expression",
+      "any\\(any\\(lgl\\)\\) not supported in Arrow"
+    )
   )
 
   # Check aggregates on aggeregates with more complex calls
   expect_warning(
     record_batch(tbl) %>% summarise(any(any(!lgl))),
-    "Aggregate within aggregate expression any\\(any\\(!lgl\\)\\) not supported in Arrow"
+    paste(
+      "Aggregate within aggregate expression",
+      "any\\(any\\(!lgl\\)\\) not supported in Arrow"
+    )
+
   )
   expect_warning(
     record_batch(tbl) %>% summarise(!any(any(lgl))),
-    "Aggregate within aggregate expression any\\(any\\(lgl\\)\\) not supported in Arrow"
+    paste(
+      "Aggregate within aggregate expression",
+      "any\\(any\\(lgl\\)\\) not supported in Arrow"
+    )
   )
 })
 
@@ -742,7 +752,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\)",
+      "not supported in Arrow; pulling data into R"
+    )
   )
   compare_dplyr_binding(
     .input %>%
@@ -752,7 +765,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Aggregate within aggregate expression sum\\(dbl - mean\\(dbl\\)\\) not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Aggregate within aggregate expression sum\\(dbl - mean\\(dbl\\)\\)",
+      "not supported in Arrow; pulling data into R"
+    )
   )
   compare_dplyr_binding(
     .input %>%
@@ -762,7 +778,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\)",
+      "not supported in Arrow; pulling data into R"
+    )
   )
 
   compare_dplyr_binding(
@@ -773,7 +792,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression dbl - mean\\(dbl\\) is not an aggregate expression or is not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Expression dbl - mean\\(dbl\\) is not an aggregate expression",
+      "or is not supported in Arrow; pulling data into R"
+    )
   )
 
   compare_dplyr_binding(
@@ -784,7 +806,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression dbl is not an aggregate expression or is not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Expression dbl is not an aggregate expression",
+      "or is not supported in Arrow; pulling data into R"
+    )
   )
 
   # This one could possibly be supported--in mutate()
@@ -796,7 +821,10 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression dbl - int is not an aggregate expression or is not supported in Arrow; pulling data into R"
+    warning = paste(
+      "Expression dbl - int is not an aggregate expression",
+      "or is not supported in Arrow; pulling data into R"
+    )
   )
 })
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -705,16 +705,20 @@ test_that("Expressions on aggregations", {
     tbl
   )
 
-  # Aggregate on an aggregate (trivial but dplyr allows)
-  skip("Aggregate on an aggregate not supported")
-  compare_dplyr_binding(
-    .input %>%
-      group_by(some_grouping) %>%
-      summarize(
-        any_lgl = any(any(lgl))
-      ) %>%
-      collect(),
-    tbl
+  # Aggregates on aggregates are not supported
+  expect_warning(
+    record_batch(tbl) %>% summarise(any(any(lgl))),
+    "Aggregate within aggregate `any\\(any\\(lgl\\)\\)` not supported in Arrow"
+  )
+
+  # Check aggregates on aggeregates with more complex calls
+  expect_warning(
+    record_batch(tbl) %>% summarise(any(any(!lgl))),
+    "Aggregate within aggregate `any\\(any\\(!lgl\\)\\)` not supported in Arrow"
+  )
+  expect_warning(
+    record_batch(tbl) %>% summarise(!any(any(lgl))),
+    "Aggregate within aggregate `any\\(any\\(lgl\\)\\)` not supported in Arrow"
   )
 })
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -742,7 +742,7 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
+    warning = "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
   )
   compare_dplyr_binding(
     .input %>%
@@ -752,7 +752,7 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression sum\\(dbl - mean\\(dbl\\)\\) not supported in Arrow; pulling data into R"
+    warning = "Aggregate within aggregate expression sum\\(dbl - mean\\(dbl\\)\\) not supported in Arrow; pulling data into R"
   )
   compare_dplyr_binding(
     .input %>%
@@ -762,7 +762,7 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
+    warning = "Aggregate within aggregate expression sum\\(\\(dbl - mean\\(dbl\\)\\)\\^2\\) not supported in Arrow; pulling data into R"
   )
 
   compare_dplyr_binding(
@@ -773,7 +773,7 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression dbl - mean\\(dbl\\) not supported in Arrow; pulling data into R"
+    warning = "Expression dbl - mean\\(dbl\\) is not an aggregate expression or is not supported in Arrow; pulling data into R"
   )
 
   # This one could possibly be supported--in mutate()
@@ -785,7 +785,7 @@ test_that("Not (yet) supported: implicit join", {
       ) %>%
       collect(),
     tbl,
-    warning = "Expression dbl - int not supported in Arrow; pulling data into R"
+    warning = "Expression dbl - int is not an aggregate expression or is not supported in Arrow; pulling data into R"
   )
 })
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -708,17 +708,17 @@ test_that("Expressions on aggregations", {
   # Aggregates on aggregates are not supported
   expect_warning(
     record_batch(tbl) %>% summarise(any(any(lgl))),
-    "Aggregate within aggregate `any\\(any\\(lgl\\)\\)` not supported in Arrow"
+    "Aggregate within aggregate expression any\\(any\\(lgl\\)\\) not supported in Arrow"
   )
 
   # Check aggregates on aggeregates with more complex calls
   expect_warning(
     record_batch(tbl) %>% summarise(any(any(!lgl))),
-    "Aggregate within aggregate `any\\(any\\(!lgl\\)\\)` not supported in Arrow"
+    "Aggregate within aggregate expression any\\(any\\(!lgl\\)\\) not supported in Arrow"
   )
   expect_warning(
     record_batch(tbl) %>% summarise(!any(any(lgl))),
-    "Aggregate within aggregate `any\\(any\\(lgl\\)\\)` not supported in Arrow"
+    "Aggregate within aggregate expression any\\(any\\(lgl\\)\\) not supported in Arrow"
   )
 })
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -900,3 +900,25 @@ test_that("summarise() passes through type information for temporary columns", {
     )
   )
 })
+
+test_that("summarise() can handle scalars and literal values", {
+  compare_dplyr_binding(
+    .input %>% summarise(y = 1L) %>% collect(),
+    tbl
+  )
+
+  expect_identical(
+    record_batch(tbl) %>% summarise(y = 1L) %>% collect(),
+    tibble(y = 1L)
+  )
+
+  expect_identical(
+    record_batch(tbl) %>% summarise(y = Expression$scalar(1L)) %>% collect(),
+    tibble(y = 1L)
+  )
+
+  expect_identical(
+    record_batch(tbl) %>% summarise(y = Scalar$create(1L)) %>% collect(),
+    tibble(y = 1L)
+  )
+})


### PR DESCRIPTION
This PR:

- Improves error messages for aggregate expressions that are not supported
- Allows a scalar to be passed into an aggregate expression. This is related because it is valid in dplyr and currently gives very weird errors.

Reprex before this PR:

``` r
# remotes::install_github("apache/arrow/r@master")
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

record_batch(x = 4) %>% summarise(y = mean(mean(x)))
#> Warning: Error in mean(..temp0) : object '..temp0' not found; pulling data into
#> R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     4
record_batch(x = 4) %>% summarize(y = x + 1)
#> Warning: Error : Expression x + 1 not supported in Arrow; pulling data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     5
record_batch(x = 4) %>% summarize(y = x)
#> Warning: Error in .f(.x[[i]], ...) : attempt to apply non-function; pulling data
#> into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     4

record_batch(x = 4) %>% summarise(y = 1)
#> Warning: Error in .$data : $ operator is invalid for atomic vectors; pulling
#> data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     1
record_batch(x = 4) %>% summarise(y = Expression$scalar(1))
#> InMemoryDataset (query)
#> y: double (1)
#> 
#> See $.data for the source Arrow object
record_batch(x = 4) %>% summarise(y = Scalar$create(1))
#> Error in if (nzchar(name)) {: argument is of length zero

some_scalar_value <- 3
record_batch(x = 4) %>% summarise(y = some_scalar_value)
#> Warning: Error in .$data : $ operator is invalid for atomic vectors; pulling
#> data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     3
record_batch(x = 4) %>% summarise(y = !! some_scalar_value)
#> Warning: Error in .$data : $ operator is invalid for atomic vectors; pulling
#> data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     3
```

Reprex after this PR:

``` r
# remotes::install_github("paleolimbot/arrow/r@r-summarise-eval")
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

record_batch(x = 4) %>% summarise(y = mean(mean(x)))
#> Warning: Error : Aggregate within aggregate expression mean(mean(x)) not
#> supported in Arrow; pulling data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     4
record_batch(x = 4) %>% summarize(y = x + 1)
#> Warning: Error : Expression x + 1 is not an aggregate expression or is not
#> supported in Arrow; pulling data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     5
record_batch(x = 4) %>% summarize(y = x)
#> Warning: Error : Expression x is not an aggregate expression or is not supported
#> in Arrow; pulling data into R
#> # A tibble: 1 × 1
#>       y
#>   <dbl>
#> 1     4

record_batch(x = 4) %>% summarise(y = 1)
#> InMemoryDataset (query)
#> y: double (1)
#> 
#> See $.data for the source Arrow object
record_batch(x = 4) %>% summarise(y = Expression$scalar(1))
#> InMemoryDataset (query)
#> y: double (1)
#> 
#> See $.data for the source Arrow object
record_batch(x = 4) %>% summarise(y = Scalar$create(1))
#> InMemoryDataset (query)
#> y: double (1)
#> 
#> See $.data for the source Arrow object

some_scalar_value <- 3
record_batch(x = 4) %>% summarise(y = some_scalar_value)
#> InMemoryDataset (query)
#> y: double (3)
#> 
#> See $.data for the source Arrow object
record_batch(x = 4) %>% summarise(y = !! some_scalar_value)
#> InMemoryDataset (query)
#> y: double (3)
#> 
#> See $.data for the source Arrow object
```

<sup>Created on 2021-11-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

