### PR TITLE
ARROW-14714: [C++][Doc] Rework CMake presets and add documentation

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -108,27 +108,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Run
-        run: |
-          cd cpp/examples/minimal_build
-          docker-compose run --rm minimal
-
-  cmake-checks:
-    name: CMake checks
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 5
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Run
+      - name: Check CMake presets
         run: |
           cd cpp
           cmake --list-presets
+      - name: Run minimal example
+        run: |
+          cd cpp/examples/minimal_build
+          docker-compose run --rm minimal
 
   macos:
     name: AMD64 MacOS 10.15 C++

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -113,6 +113,23 @@ jobs:
           cd cpp/examples/minimal_build
           docker-compose run --rm minimal
 
+  cmake-checks:
+    name: CMake checks
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run
+        run: |
+          cd cpp
+          cmake --list-presets
+
   macos:
     name: AMD64 MacOS 10.15 C++
     runs-on: macos-latest

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -1,164 +1,230 @@
 {
-  "version": 2,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 20,
+    "minor": 21,
     "patch": 0
   },
   "configurePresets": [
     {
-      "name": "ninja-benchmarks",
-      "description": "Build for benchmarks",
-      "inherits": "ninja-release",
+      "name": "ninja-debug-minimal",
+      "displayName": "Debug build without anything enabled",
+      "generator": "Ninja",
       "cacheVariables": {
-        "ARROW_BUILD_BENCHMARKS": "ON",
-        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
-        "ARROW_BUILD_TESTS": "OFF"
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_STATIC": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "ON",
+        "ARROW_WITH_RE2": "OFF",
+        "ARROW_WITH_UTF8PROC": "OFF",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "ninja-debug-basic",
+      "inherits": "ninja-debug-minimal",
+      "displayName": "Debug build with tests and reduced dependencies",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "ON",
+        "ARROW_BUILD_TESTS": "ON",
+        "ARROW_COMPUTE": "ON",
+        "ARROW_CSV": "ON",
+        "ARROW_DATASET": "ON",
+        "ARROW_EXTRA_ERROR_CONTEXT": "ON",
+        "ARROW_FILESYSTEM": "ON",
+        "ARROW_JSON": "ON"
       }
     },
     {
       "name": "ninja-debug",
-      "description": "Debug configuration with basic build",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and more optional components",
       "cacheVariables": {
-        "ARROW_BUILD_BENCHMARKS": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_BUILD_TESTS": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_COMPUTE": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_CSV": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_CUDA": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_DATASET": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_GANDIVA": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_GANDIVA_JAVA": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_GANDIVA_JNI": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_FILESYSTEM": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_IPC": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_PARQUET": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_PLASMA_JAVA_CLIENT": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_PYTHON": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "ARROW_SKYHOOK": {
-          "type": "BOOL",
-          "value": "OFF"
-        },
-        "ARROW_WITH_RE2": {
-          "type": "BOOL",
-          "value": "ON"
-        },
-        "CMAKE_BUILD_TYPE": {
-          "type": "String",
-          "value": "Debug"
-        },
-        "CMAKE_INSTALL_PREFIX": {
-          "type": "PATH",
-          "value": "${sourceDir}/build/${presetName}/pkg"
-        }
+        "ARROW_ENGINE": "ON",
+        "ARROW_MIMALLOC": "ON",
+        "ARROW_PARQUET": "ON",
+        "ARROW_WITH_BROTLI": "ON",
+        "ARROW_WITH_BZ2": "ON",
+        "ARROW_WITH_LZ4": "ON",
+        "ARROW_WITH_RE2": "ON",
+        "ARROW_WITH_SNAPPY": "ON",
+        "ARROW_WITH_UTF8PROC": "ON",
+        "ARROW_WITH_ZLIB": "ON",
+        "ARROW_WITH_ZSTD": "ON"
       }
     },
     {
       "name": "ninja-debug-cuda",
-      "description": "Debug Arrow build with CUDA extensions (requires CUDA toolkit)",
-      "inherits": "ninja-debug",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and CUDA integration",
       "cacheVariables": {
         "ARROW_CUDA": "ON"
       }
     },
     {
-      "name": "ninja-debug-dataset",
-      "description": "Builds Arrow Dataset modules",
-      "inherits": "ninja-debug",
+      "name": "ninja-debug-filesystems",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and filesystems",
       "cacheVariables": {
-        "ARROW_DATASET": "ON"
+        "ARROW_GCS": "ON",
+        "ARROW_HDFS": "ON",
+        "ARROW_S3": "ON"
+      }
+    },
+    {
+      "name": "ninja-debug-flight",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and Flight",
+      "cacheVariables": {
+        "ARROW_FLIGHT": "ON"
       }
     },
     {
       "name": "ninja-debug-gandiva",
-      "description": "Builds Gandiva libraries",
-      "inherits": "ninja-debug",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and Gandiva",
       "cacheVariables": {
         "ARROW_GANDIVA": "ON"
       }
     },
     {
-      "name": "ninja-debug-parquet",
-      "description": "Builds Parquet libraries",
-      "inherits": "ninja-debug",
+      "name": "ninja-debug-python",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Debug build with tests and Python support",
       "cacheVariables": {
-        "ARROW_PARQUET": "ON"
+        "ARROW_PYTHON": "ON"
       }
     },
     {
-      "name": "ninja-debug-skyhook",
-      "description": "Builds Skyhook libraries",
-
+      "name": "ninja-debug-maximal",
       "inherits": "ninja-debug",
+      "displayName": "Debug build with everything enabled (except benchmarks and CUDA)",
       "cacheVariables": {
-        "ARROW_SKYHOOK": "ON"
+        "ARROW_BUILD_EXAMPLES": "ON",
+        "ARROW_BUILD_UTILITIES": "ON",
+        "ARROW_FLIGHT": "ON",
+        "ARROW_GANDIVA": "ON",
+        "ARROW_GCS": "ON",
+        "ARROW_HDFS": "ON",
+        "ARROW_HIVESERVER2": "ON",
+        "ARROW_ORC": "ON",
+        "ARROW_PLASMA": "ON",
+        "ARROW_PYTHON": "ON",
+        "ARROW_S3": "ON",
+        "ARROW_SKYHOOK": "ON",
+        "ARROW_TENSORFLOW": "ON",
+        "PARQUET_BUILD_EXAMPLES": "ON",
+        "PARQUET_BUILD_EXECUTABLES": "ON",
+        "PARQUET_REQUIRE_ENCRYPTION": "ON"
+      }
+    },
+
+    {
+      "name": "ninja-release-minimal",
+      "inherits": "ninja-debug-minimal",
+      "displayName": "Release build without anything enabled",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-release-basic",
+      "inherits": "ninja-debug-basic",
+      "displayName": "Release build with reduced dependencies",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "ninja-release",
-      "description": "Release configuration",
       "inherits": "ninja-debug",
+      "displayName": "Release build with more optional components",
       "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-release-cuda",
+      "inherits": "ninja-debug-cuda",
+      "displayName": "Release build with CUDA integration",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-release-flight",
+      "inherits": "ninja-debug-flight",
+      "displayName": "Release build with Flight",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
         "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "ninja-release-gandiva",
-      "description": "Release configuration with Gandiva",
-      "inherits": "ninja-release",
+      "inherits": "ninja-debug-gandiva",
+      "displayName": "Release build with Gandiva",
       "cacheVariables": {
-        "ARROW_GANDIVA": "ON"
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
-      "name": "ninja-release-parquet",
-      "description": "Release configuration with Parquet",
-      "inherits": "ninja-release",
+      "name": "ninja-release-python",
+      "inherits": "ninja-debug-python",
+      "displayName": "Release build with Python support",
       "cacheVariables": {
-        "ARROW_PARQUET": "ON"
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "ninja-release-maximal",
+      "inherits": "ninja-debug-maximal",
+      "displayName": "Release build with everything enabled (except benchmarks and CUDA)",
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "OFF",
+        "ARROW_BUILD_TESTS": "OFF",
+        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+
+    {
+      "name": "ninja-benchmarks-basic",
+      "inherits": "ninja-release-basic",
+      "displayName": "Benchmarking build with reduced dependencies",
+      "cacheVariables": {
+        "ARROW_BUILD_BENCHMARKS": "ON",
+        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "ninja-benchmarks",
+      "inherits": "ninja-release",
+      "displayName": "Benchmarking build with more optional components",
+      "cacheVariables": {
+        "ARROW_BUILD_BENCHMARKS": "ON",
+        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     }
   ]

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -7,37 +7,66 @@
   },
   "configurePresets": [
     {
-      "name": "ninja-debug-minimal",
-      "displayName": "Debug build without anything enabled",
+      "name": "base",
+      "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_STATIC": "OFF",
+        "ARROW_BUILD_STATIC": "OFF"
+      }
+    },
+    {
+      "name": "base-debug",
+      "inherits": "base",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_BUILD_INTEGRATION": "ON",
+        "ARROW_BUILD_TESTS": "ON",
         "ARROW_EXTRA_ERROR_CONTEXT": "ON",
-        "ARROW_WITH_RE2": "OFF",
-        "ARROW_WITH_UTF8PROC": "OFF",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "ninja-debug-basic",
-      "inherits": "ninja-debug-minimal",
-      "displayName": "Debug build with tests and reduced dependencies",
+      "name": "base-release",
+      "inherits": "base",
+      "hidden": true,
       "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "ON",
-        "ARROW_BUILD_TESTS": "ON",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "base-benchmarks",
+      "inherits": "base",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_BUILD_BENCHMARKS": "ON",
+        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "features-minimal",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_WITH_RE2": "OFF",
+        "ARROW_WITH_UTF8PROC": "OFF"
+      }
+    },
+    {
+      "name": "features-basic",
+      "inherits": "features-minimal",
+      "hidden": true,
+      "cacheVariables": {
         "ARROW_COMPUTE": "ON",
         "ARROW_CSV": "ON",
         "ARROW_DATASET": "ON",
-        "ARROW_EXTRA_ERROR_CONTEXT": "ON",
         "ARROW_FILESYSTEM": "ON",
         "ARROW_JSON": "ON"
       }
     },
     {
-      "name": "ninja-debug",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and more optional components",
+      "name": "features-main",
+      "inherits": "features-basic",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_ENGINE": "ON",
         "ARROW_MIMALLOC": "ON",
@@ -53,17 +82,17 @@
       }
     },
     {
-      "name": "ninja-debug-cuda",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and CUDA integration",
+      "name": "features-cuda",
+      "inherits": "features-basic",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_CUDA": "ON"
       }
     },
     {
-      "name": "ninja-debug-filesystems",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and filesystems",
+      "name": "features-filesystems",
+      "inherits": "features-basic",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_GCS": "ON",
         "ARROW_HDFS": "ON",
@@ -71,45 +100,41 @@
       }
     },
     {
-      "name": "ninja-debug-flight",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and Flight",
+      "name": "features-flight",
+      "inherits": "features-basic",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_FLIGHT": "ON"
       }
     },
     {
-      "name": "ninja-debug-gandiva",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and Gandiva",
+      "name": "features-gandiva",
+      "inherits": "features-basic",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_GANDIVA": "ON"
       }
     },
     {
-      "name": "ninja-debug-python",
-      "inherits": "ninja-debug-basic",
-      "displayName": "Debug build with tests and Python support",
+      "name": "features-python",
+      "inherits": "features-main",
+      "hidden": true,
       "cacheVariables": {
         "ARROW_PYTHON": "ON"
       }
     },
     {
-      "name": "ninja-debug-maximal",
-      "inherits": "ninja-debug",
+      "name": "features-maximal",
+      "inherits": ["features-main", "features-cuda",
+                   "features-filesystems", "features-flight",
+                   "features-gandiva", "features-python"],
+      "hidden": true,
       "displayName": "Debug build with everything enabled (except benchmarks and CUDA)",
       "cacheVariables": {
         "ARROW_BUILD_EXAMPLES": "ON",
         "ARROW_BUILD_UTILITIES": "ON",
-        "ARROW_FLIGHT": "ON",
-        "ARROW_GANDIVA": "ON",
-        "ARROW_GCS": "ON",
-        "ARROW_HDFS": "ON",
         "ARROW_HIVESERVER2": "ON",
         "ARROW_ORC": "ON",
-        "ARROW_PLASMA": "ON",
-        "ARROW_PYTHON": "ON",
-        "ARROW_S3": "ON",
         "ARROW_SKYHOOK": "ON",
         "ARROW_TENSORFLOW": "ON",
         "PARQUET_BUILD_EXAMPLES": "ON",
@@ -119,113 +144,123 @@
     },
 
     {
-      "name": "ninja-release-minimal",
-      "inherits": "ninja-debug-minimal",
-      "displayName": "Release build without anything enabled",
+      "name": "ninja-debug-minimal",
+      "inherits": ["base-debug", "features-minimal"],
+      "displayName": "Debug build without anything enabled",
       "cacheVariables": {
         "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
+        "ARROW_BUILD_TESTS": "OFF"
       }
+    },
+    {
+      "name": "ninja-debug-basic",
+      "inherits": ["base-debug", "features-basic"],
+      "displayName": "Debug build with tests and reduced dependencies",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug",
+      "inherits": ["base-debug", "features-main"],
+      "displayName": "Debug build with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-cuda",
+      "inherits": ["base-debug", "features-cuda"],
+      "displayName": "Debug build with tests and CUDA integration",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-filesystems",
+      "inherits": ["base-debug", "features-filesystems"],
+      "displayName": "Debug build with tests and filesystems",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-flight",
+      "inherits": ["base-debug", "features-flight"],
+      "displayName": "Debug build with tests and Flight",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-gandiva",
+      "inherits": ["base-debug", "features-gandiva"],
+      "displayName": "Debug build with tests and Gandiva",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-python",
+      "inherits": ["base-debug", "features-python"],
+      "displayName": "Debug build with tests and Python support",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-maximal",
+      "inherits": ["base-debug", "features-maximal"],
+      "displayName": "Debug build with everything enabled (except benchmarks and CUDA)",
+      "cacheVariables": {}
+    },
+
+    {
+      "name": "ninja-release-minimal",
+      "inherits": ["base-release", "features-minimal"],
+      "displayName": "Release build without anything enabled",
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-basic",
-      "inherits": "ninja-debug-basic",
+      "inherits": ["base-release", "features-basic"],
       "displayName": "Release build with reduced dependencies",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release",
-      "inherits": "ninja-debug",
+      "inherits": ["base-release", "features-main"],
       "displayName": "Release build with more optional components",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-cuda",
-      "inherits": "ninja-debug-cuda",
+      "inherits": ["base-release", "features-cuda"],
       "displayName": "Release build with CUDA integration",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-flight",
-      "inherits": "ninja-debug-flight",
+      "inherits": ["base-release", "features-flight"],
       "displayName": "Release build with Flight",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-gandiva",
-      "inherits": "ninja-debug-gandiva",
+      "inherits": ["base-release", "features-gandiva"],
       "displayName": "Release build with Gandiva",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-python",
-      "inherits": "ninja-debug-python",
+      "inherits": ["base-release", "features-python"],
       "displayName": "Release build with Python support",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-release-maximal",
-      "inherits": "ninja-debug-maximal",
+      "inherits": ["base-release", "features-maximal"],
       "displayName": "Release build with everything enabled (except benchmarks and CUDA)",
-      "cacheVariables": {
-        "ARROW_BUILD_INTEGRATION": "OFF",
-        "ARROW_BUILD_TESTS": "OFF",
-        "ARROW_EXTRA_ERROR_CONTEXT": "OFF",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "cacheVariables": {}
     },
 
     {
       "name": "ninja-benchmarks-basic",
-      "inherits": "ninja-release-basic",
+      "inherits": ["base-benchmarks", "features-basic"],
       "displayName": "Benchmarking build with reduced dependencies",
-      "cacheVariables": {
-        "ARROW_BUILD_BENCHMARKS": "ON",
-        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
+      "cacheVariables": {}
     },
     {
       "name": "ninja-benchmarks",
-      "inherits": "ninja-release",
+      "inherits": ["base-benchmarks", "features-main"],
       "displayName": "Benchmarking build with more optional components",
-      "cacheVariables": {
-        "ARROW_BUILD_BENCHMARKS": "ON",
-        "ARROW_BUILD_BENCHMARKS_REFERENCE": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
+      "cacheVariables": {}
     }
   ]
 }

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -219,6 +219,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 
   define_option(ARROW_DATASET "Build the Arrow Dataset Modules" OFF)
 
+  define_option(ARROW_ENGINE "Build the Arrow Execution Engine" OFF)
+
   define_option(ARROW_FILESYSTEM "Build the Arrow Filesystem Layer" OFF)
 
   define_option(ARROW_FLIGHT

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1539,6 +1539,7 @@ TYPED_TEST(TestStringKernels, SplitWhitespaceAsciiReverse) {
                    &options_max);
 }
 
+#ifdef ARROW_WITH_UTF8PROC
 TYPED_TEST(TestStringKernels, SplitWhitespaceUTF8) {
   SplitOptions options;
   SplitOptions options_max{1};
@@ -1563,6 +1564,7 @@ TYPED_TEST(TestStringKernels, SplitWhitespaceUTF8Reverse) {
                    "[[\"foo\", \"bar\"], [\"foo\xe2\x80\x88  bar\", \"ba\"]]",
                    &options_max);
 }
+#endif
 
 #ifdef ARROW_WITH_RE2
 TYPED_TEST(TestBaseBinaryKernels, SplitRegex) {

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -207,6 +207,9 @@ and then ask to compile the build targets:
    automated builds, continuous integration, release scripts, etc. use
    manual configuration instead, as outlined below.
 
+.. seealso::
+   `Official documentation for CMake presets <https://cmake.org/cmake/help/v3.21/manual/cmake-presets.7.html>`_.
+
 
 Manual configuration
 --------------------

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -138,7 +138,7 @@ using ``cmake --list-presets``:
 
 .. code-block:: shell
 
-   $ cmake --list-presets
+   $ cmake --list-presets   # from inside the `cpp` subdirectory
    Available configure presets:
 
      "ninja-debug-minimal"     - Debug build without anything enabled
@@ -166,7 +166,7 @@ You can also create a build from a given preset:
 
 .. code-block:: shell
 
-   $ mkdir build
+   $ mkdir build   # from inside the `cpp` subdirectory
    $ cd build
    $ cmake .. --preset ninja-debug-minimal
       Preset CMake variables:

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -197,6 +197,13 @@ and then ask to compile the build targets:
 
    0 directories, 3 files
 
+When creating a build, it is possible to pass custom options besides
+the preset-defined ones, for example:
+
+.. code-block:: shell
+
+   $ cmake .. --preset ninja-debug-minimal -DCMAKE_INSTALL_PREFIX=/usr/local
+
 .. note::
    The CMake presets are provided as a help to get started with Arrow
    development and understand common build configurations.  They are not
@@ -205,7 +212,7 @@ and then ask to compile the build targets:
 
    Instead of relying on CMake presets, it is **highly recommended** that
    automated builds, continuous integration, release scripts, etc. use
-   manual configuration instead, as outlined below.
+   manual configuration, as outlined below.
 
 .. seealso::
    `Official documentation for CMake presets <https://cmake.org/cmake/help/v3.21/manual/cmake-presets.7.html>`_.

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -43,7 +43,7 @@ Building requires:
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities
 * At least 1GB of RAM for a minimal build, 4GB for a minimal  
   debug build with tests and 8GB for a full build using
-  :ref:`docker <docker>`.
+  :ref:`docker <docker-builds>`.
 
 On Ubuntu/Debian you can install the requirements with:
 
@@ -121,6 +121,96 @@ On MSYS2:
 Building
 ========
 
+All the instructions below assume that you have cloned the Arrow git
+repository and navigated to the ``cpp`` subdirectory:
+
+.. code-block:: shell
+
+   $ git clone https://github.com/apache/arrow.git
+   $ cd arrow/cpp
+
+CMake presets
+-------------
+
+Using CMake version 3.21.0 or higher, some presets for various build
+configurations are provided.  You can get a list of the available presets
+using ``cmake --list-presets``:
+
+.. code-block:: shell
+
+   $ cmake --list-presets
+   Available configure presets:
+
+     "ninja-debug-minimal"     - Debug build without anything enabled
+     "ninja-debug-basic"       - Debug build with tests and reduced dependencies
+     "ninja-debug"             - Debug build with tests and more optional components
+      [ etc. ]
+
+You can inspect the specific options enabled by a given preset using
+``cmake -N --preset <preset name>``:
+
+.. code-block:: shell
+
+   $ cmake --preset -N ninja-debug-minimal
+   Preset CMake variables:
+
+     ARROW_BUILD_INTEGRATION="OFF"
+     ARROW_BUILD_STATIC="OFF"
+     ARROW_BUILD_TESTS="OFF"
+     ARROW_EXTRA_ERROR_CONTEXT="ON"
+     ARROW_WITH_RE2="OFF"
+     ARROW_WITH_UTF8PROC="OFF"
+     CMAKE_BUILD_TYPE="Debug"
+
+You can also create a build from a given preset:
+
+.. code-block:: shell
+
+   $ mkdir build
+   $ cd build
+   $ cmake .. --preset ninja-debug-minimal
+      Preset CMake variables:
+
+        ARROW_BUILD_INTEGRATION="OFF"
+        ARROW_BUILD_STATIC="OFF"
+        ARROW_BUILD_TESTS="OFF"
+        ARROW_EXTRA_ERROR_CONTEXT="ON"
+        ARROW_WITH_RE2="OFF"
+        ARROW_WITH_UTF8PROC="OFF"
+        CMAKE_BUILD_TYPE="Debug"
+
+      -- Building using CMake version: 3.21.3
+      [ etc. ]
+
+and then ask to compile the build targets:
+
+.. code-block:: shell
+
+   $ cmake --build .
+   [142/142] Creating library symlink debug/libarrow.so.700 debug/libarrow.so
+
+   $ tree debug/
+   debug/
+   ├── libarrow.so -> libarrow.so.700
+   ├── libarrow.so.700 -> libarrow.so.700.0.0
+   └── libarrow.so.700.0.0
+
+   0 directories, 3 files
+
+.. note::
+   The CMake presets are provided as a help to get started with Arrow
+   development and understand common build configurations.  They are not
+   guaranteed to be immutable but may change in the future based on
+   feedback.
+
+   Instead of relying on CMake presets, it is **highly recommended** that
+   automated builds, continuous integration, release scripts, etc. use
+   manual configuration instead, as outlined below.
+
+
+Manual configuration
+--------------------
+
 The build system uses ``CMAKE_BUILD_TYPE=release`` by default, so if this
 argument is omitted then a release build will be produced.
 
@@ -145,37 +235,26 @@ Minimal release build (1GB of RAM for building or more recommended):
 
 .. code-block:: shell
 
-   git clone https://github.com/apache/arrow.git
-   cd arrow/cpp
-   mkdir release
-   cd release
-   cmake ..
-   make
+   $ mkdir build-release
+   $ cd build-release
+   $ cmake ..
+   $ make -j8       # if you have 8 CPU cores, otherwise adjust
 
 Minimal debug build with unit tests (4GB of RAM for building or more recommended):
 
 .. code-block:: shell
 
-   git clone https://github.com/apache/arrow.git
-   cd arrow
-   git submodule update --init --recursive
-   export ARROW_TEST_DATA=$PWD/testing/data
-   cd cpp
-   mkdir debug
-   cd debug
-   cmake -DCMAKE_BUILD_TYPE=Debug -DARROW_BUILD_TESTS=ON ..
-   make unittest
+   $ git submodule update --init --recursive
+   $ export ARROW_TEST_DATA=$PWD/../testing/data
+   $ mkdir build-debug
+   $ cd build-debug
+   $ cmake -DCMAKE_BUILD_TYPE=Debug -DARROW_BUILD_TESTS=ON ..
+   $ make -j8       # if you have 8 CPU cores, otherwise adjust
+   $ make unittest  # to run the tests
 
 The unit tests are not built by default. After building, one can also invoke
 the unit tests using the ``ctest`` tool provided by CMake (note that ``test``
 depends on ``python`` being available).
-
-CMake 
-`UNITY_BUILD <https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html/>`_
-can increase memory requirements to complete a build, so in memory constrained
-environments it should be turned off.
-
-* ``-DCMAKE_UNITY_BUILD=OFF``: Combine source files during building
 
 On some Linux distributions, running the test suite might require setting an
 explicit locale. If you see any locale-related errors, try setting the
@@ -183,7 +262,7 @@ environment variable (which requires the `locales` package or equivalent):
 
 .. code-block:: shell
 
-   export LC_ALL="en_US.UTF-8"
+   $ export LC_ALL="en_US.UTF-8"
 
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,6 +271,15 @@ Many contributors use the `Ninja build system <https://ninja-build.org/>`_ to
 get faster builds. It especially speeds up incremental builds. To use
 ``ninja``, pass ``-GNinja`` when calling ``cmake`` and then use the ``ninja``
 command instead of ``make``.
+
+Unity builds
+~~~~~~~~~~~~
+
+The CMake
+`unity builds <https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html/>`_
+option can make full builds significantly faster, but it also increases the
+memory requirements.  Consider turning it on (using ``-DCMAKE_UNITY_BUILD=ON``)
+if memory consumption is not an issue.
 
 Optional Components
 ~~~~~~~~~~~~~~~~~~~
@@ -355,7 +443,7 @@ environment (detected by presence of the ``$CONDA_PREFIX`` environment
 variable), in which case it is ``CONDA``.
 
 Individual Dependency Resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 While ``-DARROW_DEPENDENCY_SOURCE=$SOURCE`` sets a global default for all
 packages, the resolution strategy can be overridden for individual packages by
@@ -371,7 +459,7 @@ is listed above, but the most up-to-date listing can be found in
 `cpp/cmake_modules/ThirdpartyToolchain.cmake <https://github.com/apache/arrow/blob/master/cpp/cmake_modules/ThirdpartyToolchain.cmake>`_.
 
 Bundled Dependency Versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 When using the ``BUNDLED`` method to build a dependency from source, the
 version number from ``cpp/thirdparty/versions.txt`` is used. There is also a
@@ -384,7 +472,7 @@ Arrow libraries in a third party project is more complex. See below for
 instructions about how to configure your build system in this case.
 
 Boost-related Options
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 We depend on some Boost C++ libraries for cross-platform support. In most cases,
 the Boost version available in your package manager may be new enough, and the
@@ -394,7 +482,7 @@ non-standard location, you can specify it by passing
 variable.
 
 Offline Builds
-~~~~~~~~~~~~~~
+--------------
 
 If you do not use the above variables to direct the Arrow build system to
 preinstalled dependencies, they will be built automatically by the Arrow build
@@ -422,7 +510,7 @@ declared environment variable pointing to downloaded archives instead of
 downloading them (one for each build dir!).
 
 Statically Linking
-~~~~~~~~~~~~~~~~~~
+------------------
 
 When ``-DARROW_BUILD_STATIC=ON``, all build dependencies built as static
 libraries by the Arrow build system will be merged together to create a static
@@ -451,7 +539,7 @@ this can be accomplished with the ``Threads`` built-in package:
 .. _cpp-extra-debugging:
 
 Extra debugging help
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 If you use the CMake option ``-DARROW_EXTRA_ERROR_CONTEXT=ON`` it will compile
 the libraries with extra debugging information on error checks inside the
@@ -473,14 +561,14 @@ outputs like:
    NotImplemented: Unable to convert type: decimal(19, 4)
 
 Deprecations and API Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 We use the compiler definition ``ARROW_NO_DEPRECATED_API`` to disable APIs that
 have been deprecated. It is a good practice to compile third party applications
 with this flag to proactively catch and account for API changes.
 
 Modular Build Targets
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 Since there are several major parts of the C++ project, we have provided
 modular CMake targets for building each library component, group of unit tests
@@ -516,7 +604,7 @@ If you omit an explicit target when invoking ``make``, all targets will be
 built.
 
 Debugging with Xcode on macOS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 Xcode is the IDE provided with macOS and can be use to develop and debug Arrow
 by generating an Xcode project:


### PR DESCRIPTION
Try to define CMake presets that correspond to common use cases.
Switch to version 3 of the format so that `binaryDir` isn't mandatory anymore.
Also add display names so that the command line can be more informative.
Document the use of CMake presets.

Summary of available presets:
```
$ cmake --list-presets
Available configure presets:

  "ninja-debug-minimal"     - Debug build without anything enabled
  "ninja-debug-basic"       - Debug build with tests and reduced dependencies
  "ninja-debug"             - Debug build with tests and more optional components
  "ninja-debug-cuda"        - Debug build with tests and CUDA integration
  "ninja-debug-filesystems" - Debug build with tests and filesystems
  "ninja-debug-flight"      - Debug build with tests and Flight
  "ninja-debug-gandiva"     - Debug build with tests and Gandiva
  "ninja-debug-python"      - Debug build with tests and Python support
  "ninja-debug-maximal"     - Debug build with everything enabled (except benchmarks and CUDA)
  "ninja-release-minimal"   - Release build without anything enabled
  "ninja-release-basic"     - Release build with reduced dependencies
  "ninja-release"           - Release build with more optional components
  "ninja-release-cuda"      - Release build with CUDA integration
  "ninja-release-flight"    - Release build with Flight
  "ninja-release-gandiva"   - Release build with Gandiva
  "ninja-release-python"    - Release build with Python support
  "ninja-release-maximal"   - Release build with everything enabled (except benchmarks and CUDA)
  "ninja-benchmarks-basic"  - Benchmarking build with reduced dependencies
  "ninja-benchmarks"        - Benchmarking build with more optional components
```