### PR TITLE
ARROW-13950: [C++] min_element_wise/max_element_wise missing support for some types

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1170,7 +1170,7 @@ ArrayKernelExec GeneratePhysicalNumeric(detail::GetTypeId get_id) {
 }
 
 template <template <typename... Args> class Generator, typename... Args>
-ArrayKernelExec GeneratePhysicalDecimal(detail::GetTypeId get_id) {
+ArrayKernelExec GeneratePhysicalDecimalToPhysicalDecimal(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::DECIMAL128:
       return Generator<Decimal128Type, Args...>::Exec;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1169,6 +1169,19 @@ ArrayKernelExec GeneratePhysicalNumeric(detail::GetTypeId get_id) {
   }
 }
 
+template <template <typename... Args> class Generator, typename... Args>
+ArrayKernelExec GeneratePhysicalDecimal(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::DECIMAL128:
+      return Generator<Decimal128Type, Args...>::Exec;
+    case Type::DECIMAL256:
+      return Generator<Decimal256Type, Args...>::Exec;
+    default:
+      DCHECK(false);
+      return ExecFail;
+  }
+}
+
 // Generate a kernel given a templated functor for integer types
 //
 // See "Numeric" above for description of the generator functor

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1169,8 +1169,9 @@ ArrayKernelExec GeneratePhysicalNumeric(detail::GetTypeId get_id) {
   }
 }
 
+// Generate a kernel given a templated functor for decimal types
 template <template <typename... Args> class Generator, typename... Args>
-ArrayKernelExec GeneratePhysicalDecimalToPhysicalDecimal(detail::GetTypeId get_id) {
+ArrayKernelExec GenerateDecimalToDecimal(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::DECIMAL128:
       return Generator<Decimal128Type, Args...>::Exec;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -84,7 +84,7 @@ struct Minimum {
     return std::min(left, right);
   }
 
-  static util::string_view CallBinary(util::string_view left, util::string_view right) {
+  static string_view CallBinary(string_view left, string_view right) {
     return std::min(left, right);
   }
 
@@ -128,7 +128,7 @@ struct Maximum {
     return std::max(left, right);
   }
 
-  static util::string_view CallBinary(util::string_view left, util::string_view right) {
+  static string_view CallBinary(string_view left, string_view right) {
     return std::max(left, right);
   }
 
@@ -508,7 +508,7 @@ struct BinaryScalarMinMax {
       return Status::OK();
     }
     const Scalar& first_scalar = *batch.values.front().scalar();
-    util::string_view result = UnboxScalar<Type>::Unbox(first_scalar);
+    string_view result = UnboxScalar<Type>::Unbox(first_scalar);
     bool valid = first_scalar.is_valid;
     for (size_t i = 1; i < num_args; i++) {
       const Scalar& scalar = *batch[i].scalar();
@@ -516,7 +516,7 @@ struct BinaryScalarMinMax {
         DCHECK(options.skip_nulls);
         continue;
       } else {
-        util::string_view value = UnboxScalar<Type>::Unbox(scalar);
+        string_view value = UnboxScalar<Type>::Unbox(scalar);
         result = result.empty() ? value : Op::CallBinary(result, value);
         valid = true;
       }
@@ -546,7 +546,7 @@ struct BinaryScalarMinMax {
     RETURN_NOT_OK(builder.Reserve(batch.length));
     RETURN_NOT_OK(builder.ReserveData(final_size));
 
-    std::vector<util::string_view> valid_cols(batch.values.size());
+    std::vector<string_view> valid_cols(batch.values.size());
     for (size_t row = 0; row < static_cast<size_t>(batch.length); row++) {
       size_t num_valid = 0;
       for (size_t col = 0; col < batch.values.size(); col++) {
@@ -556,7 +556,7 @@ struct BinaryScalarMinMax {
             valid_cols[col] = UnboxScalar<Type>::Unbox(scalar);
             num_valid++;
           } else {
-            valid_cols[col] = util::string_view();
+            valid_cols[col] = string_view();
           }
         } else {
           const ArrayData& array = *batch[col].array();
@@ -565,11 +565,11 @@ struct BinaryScalarMinMax {
             const offset_type* offsets = array.GetValues<offset_type>(1);
             const uint8_t* data = array.GetValues<uint8_t>(2, /*absolute_offset=*/0);
             const int64_t length = offsets[row + 1] - offsets[row];
-            valid_cols[col] = util::string_view(
-                reinterpret_cast<const char*>(data + offsets[row]), length);
+            valid_cols[col] =
+                string_view(reinterpret_cast<const char*>(data + offsets[row]), length);
             num_valid++;
           } else {
-            valid_cols[col] = util::string_view();
+            valid_cols[col] = string_view();
           }
         }
       }
@@ -579,9 +579,9 @@ struct BinaryScalarMinMax {
         builder.UnsafeAppendNull();
         continue;
       }
-      util::string_view result = valid_cols.front();
+      string_view result = valid_cols.front();
       for (size_t col = 1; col < batch.values.size(); ++col) {
-        util::string_view value = valid_cols[col];
+        string_view value = valid_cols[col];
         if (value.empty()) {
           DCHECK(options.skip_nulls);
           continue;
@@ -664,7 +664,7 @@ struct FixedSizeBinaryScalarMinMax {
       output->is_valid = false;
       return Status::OK();
     }
-    util::string_view result =
+    string_view result =
         UnboxScalar<FixedSizeBinaryType>::Unbox(*batch.values.front().scalar());
     for (size_t i = 1; i < num_args; i++) {
       const Scalar& scalar = *batch[i].scalar();
@@ -672,7 +672,7 @@ struct FixedSizeBinaryScalarMinMax {
         continue;
       }
       if (scalar.is_valid) {
-        util::string_view value = UnboxScalar<FixedSizeBinaryType>::Unbox(scalar);
+        string_view value = UnboxScalar<FixedSizeBinaryType>::Unbox(scalar);
         result = result.empty() ? value : Op::CallBinary(result, value);
       }
     }
@@ -702,7 +702,7 @@ struct FixedSizeBinaryScalarMinMax {
     RETURN_NOT_OK(builder.Reserve(batch.length));
     RETURN_NOT_OK(builder.ReserveData(final_size));
 
-    std::vector<util::string_view> valid_cols(batch.values.size());
+    std::vector<string_view> valid_cols(batch.values.size());
     for (size_t row = 0; row < static_cast<size_t>(batch.length); row++) {
       size_t num_valid = 0;
       for (size_t col = 0; col < batch.values.size(); col++) {
@@ -712,18 +712,18 @@ struct FixedSizeBinaryScalarMinMax {
             valid_cols[col] = UnboxScalar<FixedSizeBinaryType>::Unbox(scalar);
             num_valid++;
           } else {
-            valid_cols[col] = util::string_view();
+            valid_cols[col] = string_view();
           }
         } else {
           const ArrayData& array = *batch[col].array();
           if (!array.MayHaveNulls() ||
               BitUtil::GetBit(array.buffers[0]->data(), array.offset + row)) {
             const uint8_t* data = array.GetValues<uint8_t>(1, /*absolute_offset=*/0);
-            valid_cols[col] = util::string_view(
+            valid_cols[col] = string_view(
                 reinterpret_cast<const char*>(data) + row * byte_width, byte_width);
             num_valid++;
           } else {
-            valid_cols[col] = util::string_view();
+            valid_cols[col] = string_view();
           }
         }
       }
@@ -733,9 +733,9 @@ struct FixedSizeBinaryScalarMinMax {
         builder.UnsafeAppendNull();
         continue;
       }
-      util::string_view result = valid_cols.front();
+      string_view result = valid_cols.front();
       for (size_t col = 1; col < batch.values.size(); ++col) {
-        util::string_view value = valid_cols[col];
+        string_view value = valid_cols[col];
         if (value.empty()) {
           DCHECK(options.skip_nulls);
           continue;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -553,11 +553,11 @@ struct BinaryScalarMinMax {
             valid_cols[col] = util::nullopt;
           }
         } else {
-          const ArrayData& array = *batch[col].array();
+          const auto& array = *batch[col].array();
           if (!array.MayHaveNulls() ||
               bit_util::GetBit(array.buffers[0]->data(), array.offset + row)) {
-            const offset_type* offsets = array.GetValues<offset_type>(1);
-            const uint8_t* data = array.GetValues<uint8_t>(2, /*absolute_offset=*/0);
+            const auto offsets = array.GetValues<offset_type>(1);
+            const auto data = array.GetValues<uint8_t>(2, /*absolute_offset=*/0);
             const int64_t length = offsets[row + 1] - offsets[row];
             valid_cols[col] =
                 string_view(reinterpret_cast<const char*>(data + offsets[row]), length);
@@ -573,9 +573,9 @@ struct BinaryScalarMinMax {
         builder.UnsafeAppendNull();
         continue;
       }
-      util::optional<string_view> result = valid_cols.front();
+      auto result = valid_cols.front();
       for (size_t col = 1; col < batch.values.size(); ++col) {
-        util::optional<string_view> value = valid_cols[col];
+        const auto value = valid_cols[col];
         if (!value) {
           DCHECK(options.skip_nulls);
           continue;
@@ -612,10 +612,10 @@ struct BinaryScalarMinMax {
         valid = scalar.is_valid;
         element_size = static_cast<int64_t>(UnboxScalar<Type>::Unbox(scalar).size());
       } else {
-        const ArrayData& array = *batch[i].array();
+        const auto& array = *batch[i].array();
         valid = !array.MayHaveNulls() ||
                 bit_util::GetBit(array.buffers[0]->data(), array.offset + index);
-        const offset_type* offsets = array.GetValues<offset_type>(1);
+        const auto offsets = array.GetValues<offset_type>(1);
         element_size = offsets[index + 1] - offsets[index];
       }
       if (!valid) {
@@ -648,7 +648,7 @@ struct FixedSizeBinaryScalarMinMax {
     if (batch.values.empty()) {
       return Status::OK();
     }
-    BaseBinaryScalar* output = checked_cast<BaseBinaryScalar*>(out->scalar().get());
+    auto output = checked_cast<BaseBinaryScalar*>(out->scalar().get());
     const size_t num_args = batch.values.size();
 
     const auto batch_type = batch[0].type();
@@ -709,10 +709,10 @@ struct FixedSizeBinaryScalarMinMax {
             valid_cols[col] = string_view();
           }
         } else {
-          const ArrayData& array = *batch[col].array();
+          const auto& array = *batch[col].array();
           if (!array.MayHaveNulls() ||
               bit_util::GetBit(array.buffers[0]->data(), array.offset + row)) {
-            const uint8_t* data = array.GetValues<uint8_t>(1, /*absolute_offset=*/0);
+            const auto data = array.GetValues<uint8_t>(1, /*absolute_offset=*/0);
             valid_cols[col] = string_view(
                 reinterpret_cast<const char*>(data) + row * byte_width, byte_width);
             num_valid++;
@@ -727,9 +727,9 @@ struct FixedSizeBinaryScalarMinMax {
         builder.UnsafeAppendNull();
         continue;
       }
-      string_view result = valid_cols.front();
+      auto result = valid_cols.front();
       for (size_t col = 1; col < batch.values.size(); ++col) {
-        string_view value = valid_cols[col];
+        const auto value = valid_cols[col];
         if (value.empty()) {
           DCHECK(options.skip_nulls);
           continue;
@@ -763,7 +763,7 @@ struct FixedSizeBinaryScalarMinMax {
         const auto& scalar = *batch[i].scalar();
         valid = scalar.is_valid;
       } else {
-        const ArrayData& array = *batch[i].array();
+        const auto& array = *batch[i].array();
         valid = !array.MayHaveNulls() ||
                 bit_util::GetBit(array.buffers[0]->data(), array.offset + index);
       }

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -754,7 +754,7 @@ std::shared_ptr<ScalarFunction> MakeScalarMinMax(std::string name,
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
   for (const auto id : {Type::DECIMAL128, Type::DECIMAL256}) {
-    auto exec = GeneratePhysicalDecimalToPhysicalDecimal<ScalarMinMax, Op>(id);
+    auto exec = GenerateDecimalToDecimal<ScalarMinMax, Op>(id);
     OutputType out_type(ResolveMinOrMaxOutputType);
     ScalarKernel kernel{KernelSignature::Make({InputType{id}}, out_type,
                                               /*is_varargs=*/true),

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -715,7 +715,7 @@ Result<ValueDescr> ResolveMinOrMaxOutputType(KernelContext*,
     auto type = args[i].type;
     if (*type != *first_type) {
       return Status::NotImplemented(
-          "Different decimal types not implemented for {min, max}_element_wise");
+          "Different input types not supported for {min, max}_element_wise");
     }
   }
   return ValueDescr(first_type, GetBroadcastShape(args));

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -518,12 +518,12 @@ struct BinaryScalarMinMax {
         continue;
       } else {
         string_view value = UnboxScalar<Type>::Unbox(scalar);
-        result = result.empty() ? value : Op::CallBinary(result, value);
+        result = !valid ? value : Op::CallBinary(result, value);
         valid = true;
       }
     }
     if (valid) {
-      ARROW_ASSIGN_OR_RAISE(output->value, ctx->Allocate(final_size));
+      ARROW_ASSIGN_OR_RAISE(output->value, ctx->Allocate(result.size()));
       uint8_t* buf = output->value->mutable_data();
       buf = std::copy(result.begin(), result.end(), buf);
       output->is_valid = true;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -531,7 +531,7 @@ struct BinaryScalarMinMax {
   static Status ExecContainingArrays(KernelContext* ctx,
                                      const ElementWiseAggregateOptions& options,
                                      const ExecBatch& batch, Datum* out) {
-    // Presize data to avoid reallocations, using an upper bound estimation of final size.
+    // Presize data to avoid reallocations, using an estimation of final size.
     int64_t estimated_final_size = EstimateOutputSize(batch);
     BuilderType builder(ctx->memory_pool());
     RETURN_NOT_OK(builder.Reserve(batch.length));
@@ -569,9 +569,9 @@ struct BinaryScalarMinMax {
       }
 
       if (result) {
-        builder.Append(*result);
+        RETURN_NOT_OK(builder.Append(*result));
       } else {
-        builder.AppendNull();
+        builder.UnsafeAppendNull();
       }
     }
 
@@ -583,7 +583,7 @@ struct BinaryScalarMinMax {
     return Status::OK();
   }
 
-  // Compute an upper bound for the length of the output batch.
+  // Compute an estimation for the length of the output batch.
   static int64_t EstimateOutputSize(const ExecBatch& batch) {
     int64_t estimated_final_size = 0;
     for (size_t col = 0; col < batch.values.size(); col++) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -503,11 +503,11 @@ struct BinaryScalarMinMax {
         }
       }
     }
-    const Scalar& first_scalar = *batch.values.front().scalar();
+    const auto& first_scalar = *batch.values.front().scalar();
     string_view result = UnboxScalar<Type>::Unbox(first_scalar);
     bool valid = first_scalar.is_valid;
     for (size_t i = 1; i < batch.values.size(); i++) {
-      const Scalar& scalar = *batch[i].scalar();
+      const auto& scalar = *batch[i].scalar();
       if (!scalar.is_valid) {
         DCHECK(options.skip_nulls);
         continue;
@@ -519,8 +519,7 @@ struct BinaryScalarMinMax {
     }
     if (valid) {
       ARROW_ASSIGN_OR_RAISE(output->value, ctx->Allocate(result.size()));
-      uint8_t* buf = output->value->mutable_data();
-      buf = std::copy(result.begin(), result.end(), buf);
+      std::copy(result.begin(), result.end(), output->value->mutable_data());
       output->is_valid = true;
     } else {
       output->is_valid = false;
@@ -609,9 +608,9 @@ struct BinaryScalarMinMax {
       int64_t element_size = 0;
       bool valid = true;
       if (batch[i].is_scalar()) {
-        const Scalar& scalar = *batch[i].scalar();
+        const auto& scalar = *batch[i].scalar();
         valid = scalar.is_valid;
-        element_size = UnboxScalar<Type>::Unbox(scalar).size();
+        element_size = static_cast<int64_t>(UnboxScalar<Type>::Unbox(scalar).size());
       } else {
         const ArrayData& array = *batch[i].array();
         valid = !array.MayHaveNulls() ||
@@ -662,7 +661,7 @@ struct FixedSizeBinaryScalarMinMax {
     string_view result =
         UnboxScalar<FixedSizeBinaryType>::Unbox(*batch.values.front().scalar());
     for (size_t i = 1; i < num_args; i++) {
-      const Scalar& scalar = *batch[i].scalar();
+      const auto& scalar = *batch[i].scalar();
       if (!scalar.is_valid && options.skip_nulls) {
         continue;
       }
@@ -761,7 +760,7 @@ struct FixedSizeBinaryScalarMinMax {
     for (size_t i = 0; i < num_args; i++) {
       bool valid = true;
       if (batch[i].is_scalar()) {
-        const Scalar& scalar = *batch[i].scalar();
+        const auto& scalar = *batch[i].scalar();
         valid = scalar.is_valid;
       } else {
         const ArrayData& array = *batch[i].array();

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -85,7 +86,7 @@ struct Minimum {
     return std::min(left, right);
   }
 
-  static string_view CallBinary(string_view left, string_view right) {
+  static string_view Call(string_view left, string_view right) {
     return std::min(left, right);
   }
 
@@ -129,7 +130,7 @@ struct Maximum {
     return std::max(left, right);
   }
 
-  static string_view CallBinary(string_view left, string_view right) {
+  static string_view Call(string_view left, string_view right) {
     return std::max(left, right);
   }
 
@@ -518,7 +519,7 @@ struct BinaryScalarMinMax {
         continue;
       } else {
         string_view value = UnboxScalar<Type>::Unbox(scalar);
-        result = !valid ? value : Op::CallBinary(result, value);
+        result = !valid ? value : Op::Call(result, value);
         valid = true;
       }
     }
@@ -587,7 +588,7 @@ struct BinaryScalarMinMax {
           DCHECK(options.skip_nulls);
           continue;
         }
-        result = !result ? *value : Op::CallBinary(*result, *value);
+        result = !result ? *value : Op::Call(*result, *value);
       }
       if (result) {
         builder.UnsafeAppend(*result);
@@ -674,7 +675,7 @@ struct FixedSizeBinaryScalarMinMax {
       }
       if (scalar.is_valid) {
         string_view value = UnboxScalar<FixedSizeBinaryType>::Unbox(scalar);
-        result = result.empty() ? value : Op::CallBinary(result, value);
+        result = result.empty() ? value : Op::Call(result, value);
       }
     }
     if (!result.empty()) {
@@ -741,7 +742,7 @@ struct FixedSizeBinaryScalarMinMax {
           DCHECK(options.skip_nulls);
           continue;
         }
-        result = result.empty() ? value : Op::CallBinary(result, value);
+        result = result.empty() ? value : Op::Call(result, value);
       }
       if (result.empty()) {
         builder.UnsafeAppendNull();

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -21,8 +21,8 @@
 
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
-#include "arrow/util/endian.h"
 #include "arrow/util/optional.h"
 
 namespace arrow {
@@ -555,7 +555,7 @@ struct BinaryScalarMinMax {
         } else {
           const ArrayData& array = *batch[col].array();
           if (!array.MayHaveNulls() ||
-              BitUtil::GetBit(array.buffers[0]->data(), array.offset + row)) {
+              bit_util::GetBit(array.buffers[0]->data(), array.offset + row)) {
             const offset_type* offsets = array.GetValues<offset_type>(1);
             const uint8_t* data = array.GetValues<uint8_t>(2, /*absolute_offset=*/0);
             const int64_t length = offsets[row + 1] - offsets[row];
@@ -614,7 +614,7 @@ struct BinaryScalarMinMax {
       } else {
         const ArrayData& array = *batch[i].array();
         valid = !array.MayHaveNulls() ||
-                BitUtil::GetBit(array.buffers[0]->data(), array.offset + index);
+                bit_util::GetBit(array.buffers[0]->data(), array.offset + index);
         const offset_type* offsets = array.GetValues<offset_type>(1);
         element_size = offsets[index + 1] - offsets[index];
       }
@@ -711,7 +711,7 @@ struct FixedSizeBinaryScalarMinMax {
         } else {
           const ArrayData& array = *batch[col].array();
           if (!array.MayHaveNulls() ||
-              BitUtil::GetBit(array.buffers[0]->data(), array.offset + row)) {
+              bit_util::GetBit(array.buffers[0]->data(), array.offset + row)) {
             const uint8_t* data = array.GetValues<uint8_t>(1, /*absolute_offset=*/0);
             valid_cols[col] = string_view(
                 reinterpret_cast<const char*>(data) + row * byte_width, byte_width);
@@ -765,7 +765,7 @@ struct FixedSizeBinaryScalarMinMax {
       } else {
         const ArrayData& array = *batch[i].array();
         valid = !array.MayHaveNulls() ||
-                BitUtil::GetBit(array.buffers[0]->data(), array.offset + index);
+                bit_util::GetBit(array.buffers[0]->data(), array.offset + index);
       }
       if (!valid) {
         if (options.skip_nulls) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -491,7 +491,7 @@ struct BinaryScalarMinMax {
     if (batch.values.empty()) {
       return Status::OK();
     }
-    BaseBinaryScalar* output = checked_cast<BaseBinaryScalar*>(out->scalar().get());
+    auto output = checked_cast<BaseBinaryScalar*>(out->scalar().get());
     if (!options.skip_nulls) {
       // any nulls in the input will produce a null output
       for (const auto& value : batch.values) {
@@ -835,7 +835,7 @@ std::shared_ptr<ScalarFunction> MakeScalarMinMax(std::string name,
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
   for (const auto id : {Type::DECIMAL128, Type::DECIMAL256}) {
-    auto exec = GeneratePhysicalDecimal<ScalarMinMax, Op>(id);
+    auto exec = GeneratePhysicalDecimalToPhysicalDecimal<ScalarMinMax, Op>(id);
     OutputType out_type(ResolveMinOrMaxOutputType);
     ScalarKernel kernel{KernelSignature::Make({InputType{id}}, out_type,
                                               /*is_varargs=*/true),

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1368,6 +1368,8 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
   this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MinElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});
+  this->Assert(MinElementWise, this->array(R"(["", ""])"),
+               {this->array(R"(["1", ""])"), this->array(R"(["", "2"])")});
 
   this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
                {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});
@@ -1698,6 +1700,8 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
   this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});
+  this->Assert(MaxElementWise, this->array(R"(["1", "2"])"),
+               {this->array(R"(["1", ""])"), this->array(R"(["", "2"])")});
 
   this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
                {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1361,7 +1361,10 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
   this->Assert(MinElementWise, this->scalar(R"("1")"),
                {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
                 this->scalar("null")});
-
+  this->Assert(MinElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("")"), this->scalar(R"("")")});
+  this->Assert(MinElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("")"), this->scalar("null")});
   this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MinElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});
@@ -1688,7 +1691,10 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
   this->Assert(MaxElementWise, this->scalar(R"("1")"),
                {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
                 this->scalar("null")});
-
+  this->Assert(MaxElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("")"), this->scalar(R"("")")});
+  this->Assert(MaxElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("")"), this->scalar("null")});
   this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1502,11 +1502,23 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MinElementWise) {
                {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar("null"),
                 this->scalar(R"("abc")")});
 
+  this->Assert(MinElementWise, this->scalar(R"("")", /*byte_width=*/0),
+               {this->scalar(R"("")", /*byte_width=*/0)});
+  this->Assert(MinElementWise, this->scalar("null", /*byte_width=*/0),
+               {this->scalar("null", /*byte_width=*/0)});
+  this->Assert(
+      MinElementWise, this->scalar(R"("")", /*byte_width=*/0),
+      {this->scalar("null", /*byte_width=*/0), this->scalar(R"("")", /*byte_width=*/0)});
+
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
   this->Assert(MinElementWise, this->array(R"(["abc", "abc", "abc", null, null])"),
                {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
                 this->array(R"(["abc", "abd", "abc", "abc", null])")});
+
+  this->Assert(
+      MinElementWise, this->scalar("null", /*byte_width=*/0),
+      {this->scalar("null", /*byte_width=*/0), this->scalar(R"("")", /*byte_width=*/0)});
 
   // Test error handling
   auto result = MinElementWise({this->scalar(R"("abc")", /*byte_width=*/3),
@@ -1795,11 +1807,23 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MaxElementWise) {
                {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar("null"),
                 this->scalar(R"("abc")")});
 
+  this->Assert(MaxElementWise, this->scalar(R"("")", /*byte_width=*/0),
+               {this->scalar(R"("")", /*byte_width=*/0)});
+  this->Assert(MaxElementWise, this->scalar("null", /*byte_width=*/0),
+               {this->scalar("null", /*byte_width=*/0)});
+  this->Assert(
+      MaxElementWise, this->scalar(R"("")", /*byte_width=*/0),
+      {this->scalar("null", /*byte_width=*/0), this->scalar(R"("")", /*byte_width=*/0)});
+
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
   this->Assert(MaxElementWise, this->array(R"(["abc", "abd", "abd", null, null])"),
                {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
                 this->array(R"(["abc", "abd", "abc", "abc", null])")});
+
+  this->Assert(
+      MaxElementWise, this->scalar("null", /*byte_width=*/0),
+      {this->scalar("null", /*byte_width=*/0), this->scalar(R"("")", /*byte_width=*/0)});
 
   // Test error handling
   auto result = MaxElementWise({this->scalar(R"("abc")", /*byte_width=*/3),

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1365,6 +1365,10 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
                {this->scalar(R"("")"), this->scalar(R"("")")});
   this->Assert(MinElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar("null")});
+  this->Assert(MinElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("2")"), this->scalar(R"("")")});
+  this->Assert(MinElementWise, this->scalar(R"("")"),
+               {this->scalar(R"("")"), this->scalar(R"("2")")});
   this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MinElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});
@@ -1697,6 +1701,10 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
                {this->scalar(R"("")"), this->scalar(R"("")")});
   this->Assert(MaxElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar("null")});
+  this->Assert(MaxElementWise, this->scalar(R"("2")"),
+               {this->scalar(R"("2")"), this->scalar(R"("")")});
+  this->Assert(MaxElementWise, this->scalar(R"("2")"),
+               {this->scalar(R"("")"), this->scalar(R"("2")")});
   this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
   this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", null])"),
                {this->array(R"(["1", "2", "3", null])")});

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1181,12 +1181,12 @@ class TestVarArgsCompareBinary : public TestVarArgsCompare<T> {};
 template <typename T>
 class TestVarArgsCompareFixedSizeBinary : public TestVarArgsCompare<T> {
  protected:
-  Datum scalar(const std::string& value, int32_t byte_width = 1) {
+  Datum scalar(const std::string& value, int32_t byte_width = 3) {
     return ScalarFromJSON(fixed_size_binary(byte_width), value);
   }
 
-  Datum array(const std::string& value, int32_t byte_width = 1) {
-    return ArrayFromJSON(fixed_size_binary(byte_width), value);
+  Datum array(const std::string& value) {
+    return ArrayFromJSON(fixed_size_binary(3), value);
   }
 };
 
@@ -1402,71 +1402,15 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
   this->AssertNullScalar(MinElementWise, {});
   this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(MinElementWise, this->scalar(R"("0")"), {this->scalar(R"("0")")});
-  this->Assert(MinElementWise, this->scalar(R"("0")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")")});
-  this->Assert(MinElementWise, this->scalar(R"("0")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")"),
-                this->scalar("null")});
-  this->Assert(MinElementWise, this->scalar(R"("1")"),
-               {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
-                this->scalar("null")});
   this->Assert(MinElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar(R"("")")});
   this->Assert(MinElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar("null")});
   this->Assert(MinElementWise, this->scalar(R"("")"),
-               {this->scalar(R"("2")"), this->scalar(R"("")")});
+               {this->scalar(R"("a")"), this->scalar(R"("")")});
   this->Assert(MinElementWise, this->scalar(R"("")"),
-               {this->scalar(R"("")"), this->scalar(R"("2")")});
+               {this->scalar(R"("")"), this->scalar(R"("a")")});
   this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "3", null])"),
-               {this->array(R"(["1", "2", "3", null])")});
-  this->Assert(MinElementWise, this->array(R"(["", ""])"),
-               {this->array(R"(["1", ""])"), this->array(R"(["", "2"])")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", null, "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", "2", null, "6"])"),
-               {this->array(R"(["1", "2", null, null])"),
-                this->array(R"(["4", null, null, "6"])")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", null, "6"])"),
-               {this->array(R"(["4", null, null, "6"])"),
-                this->array(R"(["1", "2", null, null])")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array("[null, null, null, null]")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array("[null, null, null, null]"), this->array(R"(["1", "2", "3", "4"])")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array(R"(["1", "2", "3", "4"])")});
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array("[null, null, null, null]")});
 
   this->Assert(MinElementWise, this->scalar(R"("ab")"), {this->scalar(R"("ab")")});
   this->Assert(
@@ -1499,24 +1443,6 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(MinElementWise, {this->scalar(R"("0")"), this->scalar("null")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", null, "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", null, "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-
   this->Assert(MinElementWise, this->scalar("null"),
                {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
                 this->scalar("null")});
@@ -1543,115 +1469,40 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MinElementWise) {
   this->AssertNullScalar(MinElementWise, {});
   this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(MinElementWise, this->scalar(R"("0")"), {this->scalar(R"("0")")});
-  this->Assert(MinElementWise, this->scalar(R"("0")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")")});
-  this->Assert(MinElementWise, this->scalar(R"("0")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")"),
-                this->scalar("null")});
-  this->Assert(MinElementWise, this->scalar(R"("1")"),
-               {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
-                this->scalar("null")});
-
+  this->Assert(MinElementWise, this->scalar(R"("aaa")"), {this->scalar(R"("aaa")")});
+  this->Assert(
+      MinElementWise, this->scalar(R"("aaa")"),
+      {this->scalar(R"("ccc")"), this->scalar(R"("aaa")"), this->scalar(R"("bbb")")});
+  this->Assert(MinElementWise, this->scalar(R"("aaa")"),
+               {this->scalar(R"("ccc")"), this->scalar(R"("aaa")"),
+                this->scalar(R"("bbb")"), this->scalar("null")});
   this->Assert(MinElementWise, (this->array("[]")), {this->array("[]")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "3", null])"),
-               {this->array(R"(["1", "2", "3", null])")});
 
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
+  this->Assert(MinElementWise, this->array(R"(["abc", "abc", "abc", "abc", "abc"])"),
+               {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
+                this->array(R"(["abc", "abd", "abc", "abc", null])")});
+  this->Assert(
+      MinElementWise, this->scalar(R"("abc")"),
+      {this->scalar(R"("abe")"), this->scalar(R"("abc")"), this->scalar(R"("abd")")});
 
   this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
+      MinElementWise, this->array(R"(["abc", "abc", "abc", "abc", "abc"])"),
+      {this->array(R"(["abc", "abc", "abd", null, "abc"])"), this->scalar(R"("abc")")});
   this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "2", "2"])"),
-      {this->array(R"(["1", null, "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", "2", null, "6"])"),
-               {this->array(R"(["1", "2", null, null])"),
-                this->array(R"(["4", null, null, "6"])")});
-  this->Assert(MinElementWise, this->array(R"(["1", "2", null, "6"])"),
-               {this->array(R"(["4", null, null, "6"])"),
-                this->array(R"(["1", "2", null, null])")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array("[null, null, null, null]")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array("[null, null, null, null]"), this->array(R"(["1", "2", "3", "4"])")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array(R"(["1", "2", "3", "4"])")});
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MinElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array("[null, null, null, null]")});
-
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->array(R"(["abc", "abd", "abc", "abc", null])", /*byte_width=*/3)});
-  this->Assert(MinElementWise, this->scalar(R"("abc")", /*byte_width=*/3),
-               {this->scalar(R"("abe")", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3),
-                this->scalar(R"("abd")", /*byte_width=*/3)});
-
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3),
-                this->scalar(R"("abd")", /*byte_width=*/3)});
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar("null", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
+      MinElementWise, this->array(R"(["abc", "abc", "abc", "abc", "abc"])"),
+      {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar(R"("abc")")});
+  this->Assert(MinElementWise, this->array(R"(["abc", "abc", "abc", "abc", "abc"])"),
+               {this->array(R"(["abc", null, "abd", null, "abc"])"),
+                this->scalar(R"("abc")"), this->scalar(R"("abd")")});
+  this->Assert(MinElementWise, this->array(R"(["abc", "abc", "abc", "abc", "abc"])"),
+               {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar("null"),
+                this->scalar(R"("abc")")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(MinElementWise, {this->scalar(R"("0")"), this->scalar("null")});
-
-  this->Assert(MinElementWise, this->array(R"(["1", null, "2", "2"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1", null, "2", "2"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MinElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-
-  this->Assert(MinElementWise,
-               this->array(R"(["abc", "abc", "abc", null, null])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->array(R"(["abc", "abd", "abc", "abc", null])", /*byte_width=*/3)});
+  this->Assert(MinElementWise, this->array(R"(["abc", "abc", "abc", null, null])"),
+               {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
+                this->array(R"(["abc", "abd", "abc", "abc", null])")});
 
   // Test error handling
   auto result = MinElementWise({this->scalar(R"("abc")", /*byte_width=*/3),
@@ -1840,71 +1691,15 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
   this->AssertNullScalar(MaxElementWise, {});
   this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(MaxElementWise, this->scalar(R"("0")"), {this->scalar(R"("0")")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")"),
-                this->scalar("null")});
-  this->Assert(MaxElementWise, this->scalar(R"("1")"),
-               {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
-                this->scalar("null")});
   this->Assert(MaxElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar(R"("")")});
   this->Assert(MaxElementWise, this->scalar(R"("")"),
                {this->scalar(R"("")"), this->scalar("null")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("2")"), this->scalar(R"("")")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("")"), this->scalar(R"("2")")});
+  this->Assert(MaxElementWise, this->scalar(R"("a")"),
+               {this->scalar(R"("a")"), this->scalar(R"("")")});
+  this->Assert(MaxElementWise, this->scalar(R"("a")"),
+               {this->scalar(R"("")"), this->scalar(R"("a")")});
   this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", null])"),
-               {this->array(R"(["1", "2", "3", null])")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "2"])"),
-               {this->array(R"(["1", ""])"), this->array(R"(["", "2"])")});
-
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MaxElementWise, this->array(R"(["4", "4", "4", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", null, "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-
-  this->Assert(MaxElementWise, this->array(R"(["4", "2", null, "6"])"),
-               {this->array(R"(["1", "2", null, null])"),
-                this->array(R"(["4", null, null, "6"])")});
-  this->Assert(MaxElementWise, this->array(R"(["4", "2", null, "6"])"),
-               {this->array(R"(["4", null, null, "6"])"),
-                this->array(R"(["1", "2", null, null])")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array("[null, null, null, null]")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array("[null, null, null, null]"), this->array(R"(["1", "2", "3", "4"])")});
-
-  this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-               {this->scalar(R"("1")"), this->array(R"(["1", "2", "3", "4"])")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array("[null, null, null, null]")});
 
   this->Assert(MaxElementWise, this->scalar(R"("ab")"), {this->scalar(R"("ab")")});
   this->Assert(
@@ -1937,24 +1732,6 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(MaxElementWise, {this->scalar(R"("0")"), this->scalar("null")});
-
-  this->Assert(MaxElementWise, this->array(R"(["4", null, "4", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", null, "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-
   this->Assert(MaxElementWise, this->scalar("null"),
                {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
                 this->scalar("null")});
@@ -1981,115 +1758,40 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MaxElementWise) {
   this->AssertNullScalar(MaxElementWise, {});
   this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
 
-  this->Assert(MaxElementWise, this->scalar(R"("0")"), {this->scalar(R"("0")")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")")});
-  this->Assert(MaxElementWise, this->scalar(R"("2")"),
-               {this->scalar(R"("2")"), this->scalar(R"("0")"), this->scalar(R"("1")"),
-                this->scalar("null")});
-  this->Assert(MaxElementWise, this->scalar(R"("1")"),
-               {this->scalar("null"), this->scalar("null"), this->scalar(R"("1")"),
-                this->scalar("null")});
-
+  this->Assert(MaxElementWise, this->scalar(R"("aaa")"), {this->scalar(R"("aaa")")});
+  this->Assert(
+      MaxElementWise, this->scalar(R"("ccc")"),
+      {this->scalar(R"("ccc")"), this->scalar(R"("aaa")"), this->scalar(R"("bbb")")});
+  this->Assert(MaxElementWise, this->scalar(R"("ccc")"),
+               {this->scalar(R"("ccc")"), this->scalar(R"("aaa")"),
+                this->scalar(R"("bbb")"), this->scalar("null")});
   this->Assert(MaxElementWise, (this->array("[]")), {this->array("[]")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", null])"),
-               {this->array(R"(["1", "2", "3", null])")});
 
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", "2", "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")")});
-  this->Assert(MaxElementWise, this->array(R"(["4", "4", "4", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
+  this->Assert(MaxElementWise, this->array(R"(["abc", "abd", "abd", "abc", "abc"])"),
+               {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
+                this->array(R"(["abc", "abd", "abc", "abc", null])")});
+  this->Assert(
+      MaxElementWise, this->scalar(R"("abe")"),
+      {this->scalar(R"("abe")"), this->scalar(R"("abc")"), this->scalar(R"("abd")")});
 
   this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
+      MaxElementWise, this->array(R"(["abc", "abc", "abd", "abc", "abc"])"),
+      {this->array(R"(["abc", "abc", "abd", null, "abc"])"), this->scalar(R"("abc")")});
   this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", "2", "3", "4"])"),
-      {this->array(R"(["1", null, "3", "4"])"), this->array(R"(["2", "2", "2", "2"])")});
-
-  this->Assert(MaxElementWise, this->array(R"(["4", "2", null, "6"])"),
-               {this->array(R"(["1", "2", null, null])"),
-                this->array(R"(["4", null, null, "6"])")});
-  this->Assert(MaxElementWise, this->array(R"(["4", "2", null, "6"])"),
-               {this->array(R"(["4", null, null, "6"])"),
-                this->array(R"(["1", "2", null, null])")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array("[null, null, null, null]")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-      {this->array("[null, null, null, null]"), this->array(R"(["1", "2", "3", "4"])")});
-
-  this->Assert(MaxElementWise, this->array(R"(["1", "2", "3", "4"])"),
-               {this->scalar(R"("1")"), this->array(R"(["1", "2", "3", "4"])")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MaxElementWise, this->array(R"(["1", "1", "1", "1"])"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array("[null, null, null, null]")});
-
-  this->Assert(MaxElementWise,
-               this->array(R"(["abc", "abd", "abd", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->array(R"(["abc", "abd", "abc", "abc", null])", /*byte_width=*/3)});
-  this->Assert(MaxElementWise, this->scalar(R"("abe")", /*byte_width=*/3),
-               {this->scalar(R"("abe")", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3),
-                this->scalar(R"("abd")", /*byte_width=*/3)});
-
-  this->Assert(MaxElementWise,
-               this->array(R"(["abc", "abc", "abd", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
-  this->Assert(MaxElementWise,
-               this->array(R"(["abc", "abc", "abd", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
-  this->Assert(MaxElementWise,
-               this->array(R"(["abd", "abd", "abd", "abd", "abd"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3),
-                this->scalar(R"("abd")", /*byte_width=*/3)});
-  this->Assert(MaxElementWise,
-               this->array(R"(["abc", "abc", "abd", "abc", "abc"])", /*byte_width=*/3),
-               {this->array(R"(["abc", null, "abd", null, "abc"])", /*byte_width=*/3),
-                this->scalar("null", /*byte_width=*/3),
-                this->scalar(R"("abc")", /*byte_width=*/3)});
+      MaxElementWise, this->array(R"(["abc", "abc", "abd", "abc", "abc"])"),
+      {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar(R"("abc")")});
+  this->Assert(MaxElementWise, this->array(R"(["abd", "abd", "abd", "abd", "abd"])"),
+               {this->array(R"(["abc", null, "abd", null, "abc"])"),
+                this->scalar(R"("abc")"), this->scalar(R"("abd")")});
+  this->Assert(MaxElementWise, this->array(R"(["abc", "abc", "abd", "abc", "abc"])"),
+               {this->array(R"(["abc", null, "abd", null, "abc"])"), this->scalar("null"),
+                this->scalar(R"("abc")")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
-  this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
-  this->AssertNullScalar(MaxElementWise, {this->scalar(R"("0")"), this->scalar("null")});
-
-  this->Assert(MaxElementWise, this->array(R"(["4", null, "4", "4"])"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar(R"("2")"),
-                this->scalar(R"("4")")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->array(R"(["1", null, "3", "4"])"), this->scalar("null"),
-                this->scalar(R"("2")")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["2", null, "3", "4"])"),
-      {this->array(R"(["1", "2", "3", "4"])"), this->array(R"(["2", null, "2", "2"])")});
-
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
-  this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
-               {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
-
-  this->Assert(MaxElementWise,
-               this->array(R"(["abc", "abd", "abd", null, null])", /*byte_width=*/3),
-               {this->array(R"(["abc", "abc", "abd", null, "abc"])", /*byte_width=*/3),
-                this->array(R"(["abc", "abd", "abc", "abc", null])", /*byte_width=*/3)});
+  this->Assert(MaxElementWise, this->array(R"(["abc", "abd", "abd", null, null])"),
+               {this->array(R"(["abc", "abc", "abd", null, "abc"])"),
+                this->array(R"(["abc", "abd", "abc", "abc", null])")});
 
   // Test error handling
   auto result = MaxElementWise({this->scalar(R"("abc")", /*byte_width=*/3),

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1296,6 +1296,50 @@ TYPED_TEST(TestVarArgsCompareNumeric, MinElementWise) {
 TYPED_TEST(TestVarArgsCompareDecimal, MinElementWise) {
   this->Assert(MinElementWise, this->scalar(R"("2.14")"),
                {this->scalar(R"("3.14")"), this->scalar(R"("2.14")")});
+
+  this->Assert(MinElementWise, this->scalar(R"("2.14")"),
+               {this->scalar("null"), this->scalar(R"("2.14")")});
+  this->Assert(MinElementWise, this->scalar(R"("3.14")"),
+               {this->scalar(R"("3.14")"), this->scalar("null")});
+
+  this->Assert(MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+  this->Assert(MinElementWise, this->array(R"(["1.00", "12.01", "2.00", "2.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", null, "2.00", "2.00"])")});
+  this->Assert(MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
+               {this->array(R"(["1.00", null, "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+
+  this->Assert(
+      MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
+      {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
+  this->Assert(
+      MinElementWise, this->array(R"(["1.00", "2.00", "3.00", "4.00"])"),
+      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
+
+  // Test null handling
+  this->element_wise_aggregate_options_.skip_nulls = false;
+
+  this->Assert(MinElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar(R"("2.14")")});
+  this->Assert(MinElementWise, this->scalar("null"),
+               {this->scalar(R"("3.14")"), this->scalar("null")});
+
+  this->Assert(MinElementWise, this->array(R"(["1.00", null, "2.00", "2.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", null, "2.00", "2.00"])")});
+  this->Assert(MinElementWise, this->array(R"(["1.00", null, "2.00", "2.00"])"),
+               {this->array(R"(["1.00", null, "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+
+  this->Assert(
+      MinElementWise, this->array(R"(["1.00", null, "2.00", "2.00"])"),
+      {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
+  this->Assert(
+      MinElementWise, this->array(R"([null, null, null, null])"),
+      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
 }
 
 TYPED_TEST(TestVarArgsCompareFloating, MinElementWise) {
@@ -1418,6 +1462,35 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
   this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[null, null, null, null]")});
 
+  this->Assert(MinElementWise, this->scalar(R"("ab")"), {this->scalar(R"("ab")")});
+  this->Assert(
+      MinElementWise, this->scalar(R"("aaa")"),
+      {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")")});
+  this->Assert(MinElementWise, this->scalar(R"("aaa")"),
+               {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
+                this->scalar("null")});
+  this->Assert(MinElementWise, this->scalar(R"("aa")"),
+               {this->scalar("null"), this->scalar("null"), this->scalar(R"("aa")"),
+                this->scalar("null")});
+
+  this->Assert(MinElementWise, this->array(R"(["aaa", "b", "cc", null])"),
+               {this->array(R"(["aaa", "b", "cc", null])")});
+  this->Assert(MinElementWise, this->array(R"(["aaa", "bb", "bb", "bb"])"),
+               {this->array(R"(["aaa", "bb", "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MinElementWise, this->array(R"(["aaa", "bb", "bb", "bb"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MinElementWise, this->array(R"(["aaa", "bb", "bb", "bb"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")"),
+                this->scalar(R"("dddd")")});
+  this->Assert(MinElementWise, this->array(R"(["aaa", "bb", "bb", "bb"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar("null"),
+                this->scalar(R"("bb")")});
+
+  this->Assert(MinElementWise, this->array(R"(["foo", "a", "bb", "bb"])"),
+               {this->array(R"([null, "a", "bb", "cccc"])"),
+                this->array(R"(["gg", null, "h", "iii"])"),
+                this->array(R"(["foo", "bar", null, "bb"])")});
+
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
   this->AssertNullScalar(MinElementWise, {this->scalar("null"), this->scalar("null")});
@@ -1437,6 +1510,22 @@ TYPED_TEST(TestVarArgsCompareBinary, MinElementWise) {
                {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
   this->Assert(MinElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
+
+  this->Assert(MinElementWise, this->scalar("null"),
+               {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
+                this->scalar("null")});
+  this->Assert(MinElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar("null"), this->scalar(R"("aa")"),
+                this->scalar("null")});
+
+  this->Assert(MinElementWise, this->array(R"(["aaa", null, "bb", "bb"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MinElementWise, this->array(R"(["aaa", null, "bb", "bb"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")"),
+                this->scalar(R"("dddd")")});
+  this->Assert(MinElementWise, this->array(R"([null, null, null, null])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar("null"),
+                this->scalar(R"("bb")")});
 
   this->Assert(MinElementWise, this->array(R"([null, null, null, "bb"])"),
                {this->array(R"([null, "a", "bb", "cccc"])"),
@@ -1632,6 +1721,50 @@ TYPED_TEST(TestVarArgsCompareNumeric, MaxElementWise) {
 TYPED_TEST(TestVarArgsCompareDecimal, MaxElementWise) {
   this->Assert(MaxElementWise, this->scalar(R"("3.14")"),
                {this->scalar(R"("3.14")"), this->scalar(R"("2.14")")});
+
+  this->Assert(MaxElementWise, this->scalar(R"("2.14")"),
+               {this->scalar("null"), this->scalar(R"("2.14")")});
+  this->Assert(MaxElementWise, this->scalar(R"("3.14")"),
+               {this->scalar(R"("3.14")"), this->scalar("null")});
+
+  this->Assert(MaxElementWise, this->array(R"(["2.00", "12.01", "3.00", "4.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+  this->Assert(MaxElementWise, this->array(R"(["2.00", "12.01", "3.00", "4.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", null, "2.00", "2.00"])")});
+  this->Assert(MaxElementWise, this->array(R"(["2.00", "2.00", "3.00", "4.00"])"),
+               {this->array(R"(["1.00", null, "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+
+  this->Assert(
+      MaxElementWise, this->array(R"(["2.00", "2.00", "3.00", "4.00"])"),
+      {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
+  this->Assert(
+      MaxElementWise, this->array(R"(["1.00", "2.00", "3.00", "4.00"])"),
+      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
+
+  // Test null handling
+  this->element_wise_aggregate_options_.skip_nulls = false;
+
+  this->Assert(MaxElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar(R"("2.14")")});
+  this->Assert(MaxElementWise, this->scalar("null"),
+               {this->scalar(R"("3.14")"), this->scalar("null")});
+
+  this->Assert(MaxElementWise, this->array(R"(["2.00", null, "3.00", "4.00"])"),
+               {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
+                this->array(R"(["2.00", null, "2.00", "2.00"])")});
+  this->Assert(MaxElementWise, this->array(R"(["2.00", null, "3.00", "4.00"])"),
+               {this->array(R"(["1.00", null, "3.00", "4.00"])"),
+                this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+
+  this->Assert(
+      MaxElementWise, this->array(R"(["2.00", null, "3.00", "4.00"])"),
+      {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
+  this->Assert(
+      MaxElementWise, this->array(R"([null, null, null, null])"),
+      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
 }
 
 TYPED_TEST(TestVarArgsCompareFloating, MaxElementWise) {
@@ -1754,6 +1887,35 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
   this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array("[null, null, null, null]")});
 
+  this->Assert(MaxElementWise, this->scalar(R"("ab")"), {this->scalar(R"("ab")")});
+  this->Assert(
+      MaxElementWise, this->scalar(R"("c")"),
+      {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")")});
+  this->Assert(MaxElementWise, this->scalar(R"("c")"),
+               {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
+                this->scalar("null")});
+  this->Assert(MaxElementWise, this->scalar(R"("aa")"),
+               {this->scalar("null"), this->scalar("null"), this->scalar(R"("aa")"),
+                this->scalar("null")});
+
+  this->Assert(MaxElementWise, this->array(R"(["aaa", "b", "cc", null])"),
+               {this->array(R"(["aaa", "b", "cc", null])")});
+  this->Assert(MaxElementWise, this->array(R"(["bb", "bb", "cc", "dddd"])"),
+               {this->array(R"(["aaa", "bb", "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MaxElementWise, this->array(R"(["bb", "bb", "cc", "dddd"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MaxElementWise, this->array(R"(["dddd", "dddd", "dddd", "dddd"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")"),
+                this->scalar(R"("dddd")")});
+  this->Assert(MaxElementWise, this->array(R"(["bb", "bb", "cc", "dddd"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar("null"),
+                this->scalar(R"("bb")")});
+
+  this->Assert(MaxElementWise, this->array(R"(["gg", "bar", "h", "iii"])"),
+               {this->array(R"([null, "a", "bb", "cccc"])"),
+                this->array(R"(["gg", null, "h", "iii"])"),
+                this->array(R"(["foo", "bar", null, "bb"])")});
+
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
   this->AssertNullScalar(MaxElementWise, {this->scalar("null"), this->scalar("null")});
@@ -1773,6 +1935,22 @@ TYPED_TEST(TestVarArgsCompareBinary, MaxElementWise) {
                {this->scalar(R"("1")"), this->array("[null, null, null, null]")});
   this->Assert(MaxElementWise, this->array("[null, null, null, null]"),
                {this->scalar("null"), this->array(R"(["1", "1", "1", "1"])")});
+
+  this->Assert(MaxElementWise, this->scalar("null"),
+               {this->scalar(R"("bb")"), this->scalar(R"("aaa")"), this->scalar(R"("c")"),
+                this->scalar("null")});
+  this->Assert(MaxElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar("null"), this->scalar(R"("aa")"),
+                this->scalar("null")});
+
+  this->Assert(MaxElementWise, this->array(R"(["bb", null, "cc", "dddd"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")")});
+  this->Assert(MaxElementWise, this->array(R"(["dddd", null, "dddd", "dddd"])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar(R"("bb")"),
+                this->scalar(R"("dddd")")});
+  this->Assert(MaxElementWise, this->array(R"([null, null, null, null])"),
+               {this->array(R"(["aaa", null, "cc", "dddd"])"), this->scalar("null"),
+                this->scalar(R"("bb")")});
 
   this->Assert(MaxElementWise, this->array(R"([null, null, null, "iii"])"),
                {this->array(R"([null, "a", "bb", "cccc"])"),

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1300,6 +1300,8 @@ TYPED_TEST(TestVarArgsCompareDecimal, MinElementWise) {
                {this->scalar("null"), this->scalar(R"("2.14")")});
   this->Assert(MinElementWise, this->scalar(R"("3.14")"),
                {this->scalar(R"("3.14")"), this->scalar("null")});
+  this->Assert(MinElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar("null")});
 
   this->Assert(MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
                {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
@@ -1310,13 +1312,15 @@ TYPED_TEST(TestVarArgsCompareDecimal, MinElementWise) {
   this->Assert(MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
                {this->array(R"(["1.00", null, "3.00", "4.00"])"),
                 this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+  this->Assert(MinElementWise, this->array(R"([null, null, null, null])"),
+               {this->array(R"([null, null, null, null])"),
+                this->array(R"([null, null, null, null])")});
 
   this->Assert(
       MinElementWise, this->array(R"(["1.00", "2.00", "2.00", "2.00"])"),
       {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
-  this->Assert(
-      MinElementWise, this->array(R"(["1.00", "2.00", "3.00", "4.00"])"),
-      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
+  this->Assert(MinElementWise, this->array(R"([null, "2.00", "3.00", "4.00"])"),
+               {this->array(R"([null, "2.00", "3.00", "4.00"])"), this->scalar("null")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
@@ -1345,7 +1349,7 @@ TYPED_TEST(TestVarArgsCompareDecimal, MinElementWise) {
       MinElementWise({this->scalar(R"("3.1415")", /*precision=*/38, /*scale=*/4),
                       this->scalar(R"("2.14")", /*precision=*/38, /*scale=*/2)},
                      this->element_wise_aggregate_options_, nullptr);
-  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsNotImplemented());
 }
 
 TYPED_TEST(TestVarArgsCompareFloating, MinElementWise) {
@@ -1508,7 +1512,7 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MinElementWise) {
   auto result = MinElementWise({this->scalar(R"("abc")", /*byte_width=*/3),
                                 this->scalar(R"("abcd")", /*byte_width=*/4)},
                                this->element_wise_aggregate_options_, nullptr);
-  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsNotImplemented());
 }
 
 TYPED_TEST(TestVarArgsCompareNumeric, MaxElementWise) {
@@ -1589,6 +1593,8 @@ TYPED_TEST(TestVarArgsCompareDecimal, MaxElementWise) {
                {this->scalar("null"), this->scalar(R"("2.14")")});
   this->Assert(MaxElementWise, this->scalar(R"("3.14")"),
                {this->scalar(R"("3.14")"), this->scalar("null")});
+  this->Assert(MaxElementWise, this->scalar("null"),
+               {this->scalar("null"), this->scalar("null")});
 
   this->Assert(MaxElementWise, this->array(R"(["2.00", "12.01", "3.00", "4.00"])"),
                {this->array(R"(["1.00", "12.01", "3.00", "4.00"])"),
@@ -1599,13 +1605,15 @@ TYPED_TEST(TestVarArgsCompareDecimal, MaxElementWise) {
   this->Assert(MaxElementWise, this->array(R"(["2.00", "2.00", "3.00", "4.00"])"),
                {this->array(R"(["1.00", null, "3.00", "4.00"])"),
                 this->array(R"(["2.00", "2.00", "2.00", "2.00"])")});
+  this->Assert(MaxElementWise, this->array(R"([null, null, null, null])"),
+               {this->array(R"([null, null, null, null])"),
+                this->array(R"([null, null, null, null])")});
 
   this->Assert(
       MaxElementWise, this->array(R"(["2.00", "2.00", "3.00", "4.00"])"),
       {this->array(R"(["1.00", null, "3.00", "4.00"])"), this->scalar(R"("2.00")")});
-  this->Assert(
-      MaxElementWise, this->array(R"(["1.00", "2.00", "3.00", "4.00"])"),
-      {this->array(R"(["1.00", "2.00", "3.00", "4.00"])"), this->scalar("null")});
+  this->Assert(MaxElementWise, this->array(R"([null, "2.00", "3.00", "4.00"])"),
+               {this->array(R"([null, "2.00", "3.00", "4.00"])"), this->scalar("null")});
 
   // Test null handling
   this->element_wise_aggregate_options_.skip_nulls = false;
@@ -1634,7 +1642,7 @@ TYPED_TEST(TestVarArgsCompareDecimal, MaxElementWise) {
       MaxElementWise({this->scalar(R"("3.1415")", /*precision=*/38, /*scale=*/4),
                       this->scalar(R"("2.14")", /*precision=*/38, /*scale=*/2)},
                      this->element_wise_aggregate_options_, nullptr);
-  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsNotImplemented());
 }
 
 TYPED_TEST(TestVarArgsCompareFloating, MaxElementWise) {
@@ -1797,7 +1805,7 @@ TYPED_TEST(TestVarArgsCompareFixedSizeBinary, MaxElementWise) {
   auto result = MaxElementWise({this->scalar(R"("abc")", /*byte_width=*/3),
                                 this->scalar(R"("abcd")", /*byte_width=*/4)},
                                this->element_wise_aggregate_options_, nullptr);
-  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsNotImplemented());
 }
 
 TEST(TestMaxElementWiseMinElementWise, CommonTemporal) {

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -794,7 +794,7 @@ TEST(TimestampParser, StrptimeZoneOffset) {
   // N.B. GNU %z supports ISO8601 format while BSD %z supports only
   // +HHMM or -HHMM and POSIX doesn't appear to define %z at all
   for (auto unit : TimeUnit::values()) {
-    for (const std::string& value :
+    for (const std::string value :
          {"2018-01-01 00:00:00+0000", "2018-01-01 00:00:00+0100",
           "2018-01-01 00:00:00+0130", "2018-01-01 00:00:00-0117"}) {
       SCOPED_TRACE(value);
@@ -804,7 +804,7 @@ TEST(TimestampParser, StrptimeZoneOffset) {
       ASSERT_TRUE(ParseTimestampISO8601(value.c_str(), value.size(), unit, &expected));
       ASSERT_EQ(expected, converted);
     }
-    for (const std::string& value : {"2018-01-01 00:00:00", "2018-01-01 00:00:00EST"}) {
+    for (const std::string value : {"2018-01-01 00:00:00", "2018-01-01 00:00:00EST"}) {
       SCOPED_TRACE(value);
       int64_t converted = 0;
       ASSERT_FALSE((*parser)(value.c_str(), value.size(), unit, &converted));

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -696,13 +696,14 @@ expanded for the purposes of comparison.
 +------------------+------------+---------------------------------------------+---------------------+---------------------------------------+-------+
 | Function names   | Arity      | Input types                                 | Output type         | Options class                         | Notes |
 +==================+============+=============================================+=====================+=======================================+=======+
-| max_element_wise | Varargs    | Numeric and Temporal                        | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
+| max_element_wise | Varargs    | Numeric, Temporal, Binary- and String-like  | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
 +------------------+------------+---------------------------------------------+---------------------+---------------------------------------+-------+
-| min_element_wise | Varargs    | Numeric and Temporal                        | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
+| min_element_wise | Varargs    | Numeric, Temporal, Binary- and String-like  | Numeric or Temporal | :struct:`ElementWiseAggregateOptions` | \(1)  |
 +------------------+------------+---------------------------------------------+---------------------+---------------------------------------+-------+
 
 * \(1) By default, nulls are skipped (but the kernel can be configured to propagate nulls).
   For floating point values, NaN will be taken over null but not over any other value.
+  For binary- and string-like values, only identical type parameters are supported.
 
 Logical functions
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This adds support for all sortable types. For decimal and fixed size binary, we only support types with the same parameters - scale and precision for decimal, byte width for fixed size binary.