### PR TITLE
ARROW-14659: [R] Remove warning about factor conversion to string in if_else()

### DIFF
--- a/r/R/dplyr-functions.R
+++ b/r/R/dplyr-functions.R
@@ -908,17 +908,6 @@ nse_funcs$if_else <- function(condition, true, false, missing = NULL) {
     ))
   }
 
-  # if_else doesn't yet support factors/dictionaries
-  # TODO: remove this after ARROW-13358 is merged
-  warn_types <- nse_funcs$is.factor(true) | nse_funcs$is.factor(false)
-  if (warn_types) {
-    warning(
-      "Dictionaries (in R: factors) are currently converted to strings (characters) ",
-      "in if_else and ifelse",
-      call. = FALSE
-    )
-  }
-
   build_expr("if_else", condition, true, false)
 }
 

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -122,7 +122,7 @@ test_that("if_else and ifelse", {
         y = if_else(int > 5, fct, factor("a"))
       ) %>%
       collect() %>%
-      # Arrow coalesce() kernel does not preserve unused factor levels,
+      # Arrow if_else() kernel does not preserve unused factor levels,
       # so reset the levels of all the factor columns to make the test pass
       # (ARROW-14649)
       transmute(across(where(is.factor), ~ factor(.x, levels = c("a", "b", "c")))),

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -116,8 +116,6 @@ test_that("if_else and ifelse", {
     tbl
   )
 
-  # TODO: remove the mutate + warning after ARROW-13358 is merged and Arrow
-  # supports factors in if(_)else
   compare_dplyr_binding(
     .input %>%
       mutate(
@@ -126,8 +124,7 @@ test_that("if_else and ifelse", {
       collect() %>%
       # This is a no-op on the Arrow side, but necessary to make the results equal
       mutate(y = as.character(y)),
-    tbl,
-    warning = "Dictionaries .* are currently converted to strings .* in if_else and ifelse"
+    tbl
   )
 
   # detecting NA and NaN works just fine

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -125,7 +125,10 @@ test_that("if_else and ifelse", {
       # Arrow if_else() kernel does not preserve unused factor levels,
       # so reset the levels of all the factor columns to make the test pass
       # (ARROW-14649)
-      transmute(across(where(is.factor), ~ factor(.x, levels = c("a", "b", "c")))),
+      transmute(across(
+        where(is.factor),
+        ~ factor(.x, levels = c("a", "b", "c", "d", "g", "h", "i", "j"))
+      )),
     tbl
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -122,8 +122,10 @@ test_that("if_else and ifelse", {
         y = if_else(int > 5, fct, factor("a"))
       ) %>%
       collect() %>%
-      # This is a no-op on the Arrow side, but necessary to make the results equal
-      mutate(y = as.character(y)),
+      # Arrow coalesce() kernel does not preserve unused factor levels,
+      # so reset the levels of all the factor columns to make the test pass
+      # (ARROW-14649)
+      transmute(across(where(is.factor), ~ factor(.x, levels = c("a", "b", "c")))),
     tbl
   )
 


### PR DESCRIPTION
This is my first PR contributing (or an attempt to contribute) to {arrow}.

This PR:

• removes `warn_types` warning that factors are converted to strings, which is no longer true https://github.com/apache/arrow/blob/master/r/R/dplyr-functions.R#L911-L920
• updates the test by removing the warning https://github.com/apache/arrow/blob/master/r/tests/testthat/test-dplyr-funcs-conditional.R#L130 ~however it does not remove the `mutate()` in the test as suggested in the TODO, if removed the test fails?~
• [UPDATE] test includes a reset of the levels of all factor columns to pass, since Arrow if_else() kernel does not preserve unused factor levels (ARROW-14649)