### PR TITLE
MINOR: [R] Namespace missing from dplyr::tbl call

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -59,7 +59,7 @@ to_duckdb <- function(.data,
   .data <- as_adq(.data)
   duckdb::duckdb_register_arrow(con, table_name, .data)
 
-  tbl <- tbl(con, table_name)
+  tbl <- dplyr::tbl(con, table_name)
   groups <- dplyr::groups(.data)
   if (length(groups)) {
     tbl <- dplyr::group_by(tbl, groups)


### PR DESCRIPTION
Trivial fix here, apologies if you would prefer this as bug report instead of PR.

The call to `tbl` here is not namespaced from `dplyr`, which can cause problems when other packages attempt to use this function.