### PR TITLE
ARROW-14936: [C++][Gandiva] Fix split_part function in gandiva

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2040,16 +2040,7 @@ const char* split_part(gdv_int64 context, const char* text, gdv_int32 text_len,
         }
 
         *out_len = end_pos - i;
-        char* out_str =
-            reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
-        if (out_str == nullptr) {
-          gdv_fn_context_set_error_msg(context,
-                                       "Could not allocate memory for output string");
-          *out_len = 0;
-          return "";
-        }
-        memcpy(out_str, text + i, *out_len);
-        return out_str;
+        return text + i;
       } else {
         i = match_pos;
         match_no++;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1764,6 +1764,9 @@ TEST(TestStringOps, TestSplitPart) {
   gdv_int32 out_len = 0;
   const char* out_str;
 
+  out_str = split_part(ctx_ptr, "abc::def", 8, ":", 1, 2, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+
   out_str = split_part(ctx_ptr, "A,B,C", 5, ",", 1, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_THAT(


### PR DESCRIPTION
Split_part function sporadically returns error. This happens when the output string is empty. The call to gdv_fn_context_arena_malloc with size 0 returns nullptr when there has been no earlier call which leads to the error.
The allocation here is also redundant since we can return slice of the input string