### PR TITLE
ARROW-14914: [C++] gcsfs will not implement DeleteRootDirContents

### DIFF
--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -385,7 +385,9 @@ Status GcsFileSystem::DeleteDirContents(const std::string& path) {
 }
 
 Status GcsFileSystem::DeleteRootDirContents() {
-  return Status::NotImplemented("The GCS FileSystem is not fully implemented");
+  return Status::NotImplemented(
+      std::string(__func__) +
+      " is not implemented as it is too dangerous to delete all the buckets");
 }
 
 Status GcsFileSystem::DeleteFile(const std::string& path) {

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -342,6 +342,12 @@ TEST_F(GcsIntegrationTest, GetFileInfoObject) {
   arrow::fs::AssertFileInfo(fs.get(), PreexistingObjectPath(), FileType::File);
 }
 
+TEST_F(GcsIntegrationTest, DeleteRootDirContents) {
+  auto fs = internal::MakeGcsFileSystemForTest(TestGcsOptions());
+  EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented, HasSubstr("too dangerous"),
+                                  fs->DeleteRootDirContents());
+}
+
 TEST_F(GcsIntegrationTest, DeleteFileSuccess) {
   auto fs = internal::MakeGcsFileSystemForTest(TestGcsOptions());
   ASSERT_OK(fs->DeleteFile(PreexistingObjectPath()));


### PR DESCRIPTION
The function is too dangerous for GCS. Leave it unimplemented, with a
message that explains why, and add a test.