### PR TITLE
ARROW-13832: [Doc] Improve compute documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -482,14 +482,20 @@ class ComputeFunctionsTableDirective(Directive):
         function_kind = self.options.get('kind', None)
 
         result.append(".. csv-table::", "<computefuncs>")
-        result.append("   :widths: 30, 70", "<computefuncs>")
+        result.append("   :widths: 20, 60, 20", "<computefuncs>")
         result.append("   ", "<computefuncs>")
         funcs_reg = pyarrow._compute.function_registry()
         for fname in funcs_reg.list_functions():
             f = funcs_reg.get_function(fname)
+            option_class = ""
+            if f._doc.options_class:
+                option_class = ":class:`{}`".format(
+                    f._doc.options_class
+                )
             if not function_kind or f.kind == function_kind:
-                result.append('   "{}", "{}"'.format(fname, f._doc.summary),
-                              "<computefuncs>")
+                result.append('   "{}", "{}", "{}"'.format(
+                    fname, f._doc.summary, option_class
+                ), "<computefuncs>")
 
         node = nodes.section()
         node.document = self.state.document

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -479,7 +479,6 @@ class ComputeFunctionsTableDirective(Directive):
         import pyarrow._compute
 
         result = ViewList()
-        print("OPTIONS", self.options)
         function_kind = self.options.get('kind', None)
 
         result.append(".. csv-table::", "<computefuncs>")

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -45,28 +45,6 @@ Aggregations
    tdigest
    variance
 
-Grouped Aggregations
---------------------
-
-.. autosummary::
-   :toctree: ../generated/
-
-   hash_all
-   hash_any
-   hash_approximate_median
-   hash_count
-   hash_count_distinct
-   hash_distinct
-   hash_max
-   hash_mean
-   hash_min
-   hash_min_max
-   hash_product
-   hash_stddev
-   hash_sum
-   hash_tdigest
-   hash_variance
-
 Arithmetic Functions
 --------------------
 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -498,3 +498,50 @@ Structural Transforms
    make_struct
    replace_with_mask
    struct_field
+
+Compute Options
+---------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   ScalarAggregateOptions
+   CountOptions
+   TDigestOptions
+   ArraySortOptions
+   AssumeTimezoneOptions
+   CastOptions
+   CountOptions
+   DayOfWeekOptions
+   DictionaryEncodeOptions
+   ElementWiseAggregateOptions
+   ExtractRegexOptions
+   FilterOptions
+   IndexOptions
+   JoinOptions
+   MakeStructOptions
+   MatchSubstringOptions
+   ModeOptions
+   NullOptions
+   PadOptions
+   PartitionNthOptions
+   QuantileOptions
+   ReplaceSliceOptions
+   ReplaceSubstringOptions
+   RoundOptions
+   RoundToMultipleOptions
+   ScalarAggregateOptions
+   SelectKOptions
+   SetLookupOptions
+   SliceOptions
+   SortOptions
+   SplitOptions
+   SplitPatternOptions
+   StrftimeOptions
+   StrptimeOptions
+   StructFieldOptions
+   TakeOptions
+   TDigestOptions
+   TrimOptions
+   VarianceOptions
+   WeekOptions

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -505,12 +505,10 @@ Compute Options
 .. autosummary::
    :toctree: ../generated/
 
-   ScalarAggregateOptions
-   CountOptions
-   TDigestOptions
    ArraySortOptions
    AssumeTimezoneOptions
    CastOptions
+   CountOptions
    CountOptions
    DayOfWeekOptions
    DictionaryEncodeOptions
@@ -531,6 +529,7 @@ Compute Options
    RoundOptions
    RoundToMultipleOptions
    ScalarAggregateOptions
+   ScalarAggregateOptions
    SelectKOptions
    SetLookupOptions
    SliceOptions
@@ -541,6 +540,7 @@ Compute Options
    StrptimeOptions
    StructFieldOptions
    TakeOptions
+   TDigestOptions
    TDigestOptions
    TrimOptions
    VarianceOptions

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -106,7 +106,7 @@ to which the hash aggregation functions can be applied::
    keys: [["a","b","c"]]
 
 The ``"sum"`` aggregation passed to the ``aggregate`` method in the previous
-example is the :func:`hash_sum` compute function. 
+example is the ``hash_sum`` compute function.
 
 Multiple aggregations can be performed at the same time by providing them
 to the ``aggregate`` method::
@@ -161,5 +161,5 @@ null values::
 Following is a list of all supported grouped aggregation functions.
 You can use them with or without the ``"hash_"`` prefix.
 
-.. computefuncs::
+.. arrow-computefuncs::
   :kind: hash_aggregate

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -23,17 +23,32 @@ Compute Functions
 =================
 
 Arrow supports logical compute operations over inputs of possibly
-varying types.  Many compute functions support both array (chunked or not)
-and scalar inputs, but some will mandate either.  For example,
-``sort_indices`` requires its first and only input to be an array.
+varying types.  
 
-Below are a few simple examples:
+The standard compute operations are provided by the :mod:`pyarrow.compute`
+module and can be used directly::
 
    >>> import pyarrow as pa
    >>> import pyarrow.compute as pc
    >>> a = pa.array([1, 1, 2, 3])
    >>> pc.sum(a)
    <pyarrow.Int64Scalar: 7>
+
+The grouped aggregation functions are instead an exception 
+and need to be used through the :meth:`pyarrow.Table.group_by` capabilities.
+
+Standard Compute Functions
+==========================
+
+Many compute functions support both array (chunked or not)
+and scalar inputs, but some will mandate either.  For example,
+``sort_indices`` requires its first and only input to be an array.
+
+Below are a few simple examples::
+
+   >>> import pyarrow as pa
+   >>> import pyarrow.compute as pc
+   >>> a = pa.array([1, 1, 2, 3])
    >>> b = pa.array([4, 1, 2, 8])
    >>> pc.equal(a, b)
    <pyarrow.lib.BooleanArray object at 0x7f686e4eef30>
@@ -48,7 +63,7 @@ Below are a few simple examples:
    <pyarrow.DoubleScalar: 72.54>
 
 These functions can do more than just element-by-element operations.
-Here is an example of sorting a table:
+Here is an example of sorting a table::
 
     >>> import pyarrow as pa
     >>> import pyarrow.compute as pc
@@ -62,8 +77,39 @@ Here is an example of sorting a table:
       0
     ]
 
-
+For a complete list of the compute functions that PyArrow provides
+you can refer to :ref:`api.compute` reference.
 
 .. seealso::
 
    :ref:`Available compute functions (C++ documentation) <compute-function-list>`.
+
+Grouped Aggregations
+====================
+
+PyArrow supports grouped aggregations over :class:`pyarrow.Table` through the
+:meth:`pyarrow.Table.group_by` method. 
+The method will return a grouping declaration
+to which the hash aggregation functions can be applied::
+
+   >>> import pyarrow as pa
+   >>> t = pa.table([
+   ...       pa.array(["a", "a", "b", "b", "c"]),
+   ...       pa.array([1, 2, 3, 4, 5]),
+   ... ], names=["keys", "values"])
+   >>> t.group_by("keys").aggregate([("values", "sum")])
+   pyarrow.Table
+   values_sum: int64
+   keys: string
+   ----
+   values_sum: [[3,7,5]]
+   keys: [["a","b","c"]]
+
+The ``"sum"`` aggregation passed to the ``aggregate`` method in the previous
+example is the :func:`hash_sum` compute function. 
+
+Following is a list of all supported grouped aggregation functions.
+You can use them with our without the ``"hash_"`` prefix.
+
+.. computefuncs::
+  :kind: hash_aggregate

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -109,7 +109,7 @@ The ``"sum"`` aggregation passed to the ``aggregate`` method in the previous
 example is the :func:`hash_sum` compute function. 
 
 Following is a list of all supported grouped aggregation functions.
-You can use them with our without the ``"hash_"`` prefix.
+You can use them with or without the ``"hash_"`` prefix.
 
 .. computefuncs::
   :kind: hash_aggregate

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -34,7 +34,7 @@ module and can be used directly::
    >>> pc.sum(a)
    <pyarrow.Int64Scalar: 7>
 
-The grouped aggregation functions are instead an exception 
+The grouped aggregation functions raise an exception instead
 and need to be used through the :meth:`pyarrow.Table.group_by` capabilities.
 
 Standard Compute Functions

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -36,6 +36,7 @@ module and can be used directly::
 
 The grouped aggregation functions raise an exception instead
 and need to be used through the :meth:`pyarrow.Table.group_by` capabilities.
+See :ref:`py-grouped-aggrs` for more details.
 
 Standard Compute Functions
 ==========================
@@ -83,6 +84,8 @@ you can refer to :ref:`api.compute` reference.
 .. seealso::
 
    :ref:`Available compute functions (C++ documentation) <compute-function-list>`.
+
+.. _py-grouped-aggrs:
 
 Grouped Aggregations
 ====================


### PR DESCRIPTION
Document a bit better the compute functions and add a section about grouped aggregations. Also list the available aggregation functions automatically.

![sshot2](https://user-images.githubusercontent.com/601423/144261429-90ca370c-8431-424b-9f6d-44a17846c055.png)

