### PR TITLE
ARROW-5599: [Go] Migrate array.{Interface,Record,Column,Chunked,Table} to arrow.{Array,Record,Column,Chunked,Table}

### DIFF
--- a/go/arrow/array.go
+++ b/go/arrow/array.go
@@ -34,7 +34,7 @@ type ArrayData interface {
 	Reset(DataType, int, []*memory.Buffer, []ArrayData, int, int)
 }
 
-// A type which satisfies array.Interface represents an immutable sequence of values.
+// A type which satisfies arrow.Array represents an immutable sequence of values.
 type Array interface {
 	json.Marshaler
 

--- a/go/arrow/array.go
+++ b/go/arrow/array.go
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import (
+	"encoding/json"
+
+	"github.com/apache/arrow/go/v7/arrow/memory"
+)
+
+type ArrayData interface {
+	Retain()
+	Release()
+	DataType() DataType
+	NullN() int
+	Len() int
+	Offset() int
+	Buffers() []*memory.Buffer
+	Children() []ArrayData
+	Reset(DataType, int, []*memory.Buffer, []ArrayData, int, int)
+}
+
+// A type which satisfies array.Interface represents an immutable sequence of values.
+type Array interface {
+	json.Marshaler
+
+	// DataType returns the type metadata for this instance.
+	DataType() DataType
+
+	// NullN returns the number of null values in the array.
+	NullN() int
+
+	// NullBitmapBytes returns a byte slice of the validity bitmap.
+	NullBitmapBytes() []byte
+
+	// IsNull returns true if value at index is null.
+	// NOTE: IsNull will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
+	IsNull(i int) bool
+
+	// IsValid returns true if value at index is not null.
+	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
+	IsValid(i int) bool
+
+	Data() ArrayData
+
+	// Len returns the number of elements in the array.
+	Len() int
+
+	// Retain increases the reference count by 1.
+	// Retain may be called simultaneously from multiple goroutines.
+	Retain()
+
+	// Release decreases the reference count by 1.
+	// Release may be called simultaneously from multiple goroutines.
+	// When the reference count goes to zero, the memory is freed.
+	Release()
+}

--- a/go/arrow/array/array.go
+++ b/go/arrow/array/array.go
@@ -36,43 +36,6 @@ type arraymarshal interface {
 	getOneForMarshal(i int) interface{}
 }
 
-// // A type which satisfies array.Interface represents an immutable sequence of values.
-// type Interface interface {
-// 	json.Marshaler
-
-// 	// DataType returns the type metadata for this instance.
-// 	DataType() arrow.DataType
-
-// 	// NullN returns the number of null values in the array.
-// 	NullN() int
-
-// 	// NullBitmapBytes returns a byte slice of the validity bitmap.
-// 	NullBitmapBytes() []byte
-
-// 	// IsNull returns true if value at index is null.
-// 	// NOTE: IsNull will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
-// 	IsNull(i int) bool
-
-// 	// IsValid returns true if value at index is not null.
-// 	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
-// 	IsValid(i int) bool
-
-// 	Data() *Data
-
-// 	// Len returns the number of elements in the array.
-// 	Len() int
-
-// 	// Retain increases the reference count by 1.
-// 	// Retain may be called simultaneously from multiple goroutines.
-// 	Retain()
-
-// 	// Release decreases the reference count by 1.
-// 	// Release may be called simultaneously from multiple goroutines.
-// 	// When the reference count goes to zero, the memory is freed.
-// 	Release()
-
-// }
-
 const (
 	// UnknownNullCount specifies the NullN should be calculated from the null bitmap buffer.
 	UnknownNullCount = -1

--- a/go/arrow/array/array.go
+++ b/go/arrow/array/array.go
@@ -17,7 +17,6 @@
 package array
 
 import (
-	"encoding/json"
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/v7/arrow"
@@ -25,43 +24,50 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
-// A type which satisfies array.Interface represents an immutable sequence of values.
-type Interface interface {
-	json.Marshaler
+type Interface = arrow.Array
 
-	// DataType returns the type metadata for this instance.
-	DataType() arrow.DataType
-
-	// NullN returns the number of null values in the array.
-	NullN() int
-
-	// NullBitmapBytes returns a byte slice of the validity bitmap.
-	NullBitmapBytes() []byte
-
-	// IsNull returns true if value at index is null.
-	// NOTE: IsNull will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
-	IsNull(i int) bool
-
-	// IsValid returns true if value at index is not null.
-	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
-	IsValid(i int) bool
-
-	Data() *Data
-
-	// Len returns the number of elements in the array.
-	Len() int
-
-	// Retain increases the reference count by 1.
-	// Retain may be called simultaneously from multiple goroutines.
-	Retain()
-
-	// Release decreases the reference count by 1.
-	// Release may be called simultaneously from multiple goroutines.
-	// When the reference count goes to zero, the memory is freed.
-	Release()
+type arraymarshal interface {
+	arrow.Array
 
 	getOneForMarshal(i int) interface{}
 }
+
+// // A type which satisfies array.Interface represents an immutable sequence of values.
+// type Interface interface {
+// 	json.Marshaler
+
+// 	// DataType returns the type metadata for this instance.
+// 	DataType() arrow.DataType
+
+// 	// NullN returns the number of null values in the array.
+// 	NullN() int
+
+// 	// NullBitmapBytes returns a byte slice of the validity bitmap.
+// 	NullBitmapBytes() []byte
+
+// 	// IsNull returns true if value at index is null.
+// 	// NOTE: IsNull will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
+// 	IsNull(i int) bool
+
+// 	// IsValid returns true if value at index is not null.
+// 	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
+// 	IsValid(i int) bool
+
+// 	Data() *Data
+
+// 	// Len returns the number of elements in the array.
+// 	Len() int
+
+// 	// Retain increases the reference count by 1.
+// 	// Retain may be called simultaneously from multiple goroutines.
+// 	Retain()
+
+// 	// Release decreases the reference count by 1.
+// 	// Release may be called simultaneously from multiple goroutines.
+// 	// When the reference count goes to zero, the memory is freed.
+// 	Release()
+
+// }
 
 const (
 	// UnknownNullCount specifies the NullN should be calculated from the null bitmap buffer.
@@ -106,7 +112,7 @@ func (a *array) NullN() int {
 // NullBitmapBytes returns a byte slice of the validity bitmap.
 func (a *array) NullBitmapBytes() []byte { return a.nullBitmapBytes }
 
-func (a *array) Data() *Data { return a.data }
+func (a *array) Data() arrow.ArrayData { return a.data }
 
 // Len returns the number of elements in the array.
 func (a *array) Len() int { return a.data.length }
@@ -141,23 +147,23 @@ func (a *array) Offset() int {
 	return a.data.Offset()
 }
 
-type arrayConstructorFn func(*Data) Interface
+type arrayConstructorFn func(arrow.ArrayData) arrow.Array
 
 var (
 	makeArrayFn [64]arrayConstructorFn
 )
 
-func unsupportedArrayType(data *Data) Interface {
-	panic("unsupported data type: " + data.dtype.ID().String())
+func unsupportedArrayType(data arrow.ArrayData) arrow.Array {
+	panic("unsupported data type: " + data.DataType().ID().String())
 }
 
-func invalidDataType(data *Data) Interface {
-	panic("invalid data type: " + data.dtype.ID().String())
+func invalidDataType(data arrow.ArrayData) arrow.Array {
+	panic("invalid data type: " + data.DataType().ID().String())
 }
 
 // MakeFromData constructs a strongly-typed array instance from generic Data.
-func MakeFromData(data *Data) Interface {
-	return makeArrayFn[byte(data.dtype.ID()&0x3f)](data)
+func MakeFromData(data arrow.ArrayData) arrow.Array {
+	return makeArrayFn[byte(data.DataType().ID()&0x3f)](data)
 }
 
 // NewSlice constructs a zero-copy slice of the array with the indicated
@@ -166,7 +172,7 @@ func MakeFromData(data *Data) Interface {
 //
 // NewSlice panics if the slice is outside the valid range of the input array.
 // NewSlice panics if j < i.
-func NewSlice(arr Interface, i, j int64) Interface {
+func NewSlice(arr arrow.Array, i, j int64) arrow.Array {
 	data := NewSliceData(arr.Data(), i, j)
 	slice := MakeFromData(data)
 	data.Release()
@@ -175,45 +181,45 @@ func NewSlice(arr Interface, i, j int64) Interface {
 
 func init() {
 	makeArrayFn = [...]arrayConstructorFn{
-		arrow.NULL:                    func(data *Data) Interface { return NewNullData(data) },
-		arrow.BOOL:                    func(data *Data) Interface { return NewBooleanData(data) },
-		arrow.UINT8:                   func(data *Data) Interface { return NewUint8Data(data) },
-		arrow.INT8:                    func(data *Data) Interface { return NewInt8Data(data) },
-		arrow.UINT16:                  func(data *Data) Interface { return NewUint16Data(data) },
-		arrow.INT16:                   func(data *Data) Interface { return NewInt16Data(data) },
-		arrow.UINT32:                  func(data *Data) Interface { return NewUint32Data(data) },
-		arrow.INT32:                   func(data *Data) Interface { return NewInt32Data(data) },
-		arrow.UINT64:                  func(data *Data) Interface { return NewUint64Data(data) },
-		arrow.INT64:                   func(data *Data) Interface { return NewInt64Data(data) },
-		arrow.FLOAT16:                 func(data *Data) Interface { return NewFloat16Data(data) },
-		arrow.FLOAT32:                 func(data *Data) Interface { return NewFloat32Data(data) },
-		arrow.FLOAT64:                 func(data *Data) Interface { return NewFloat64Data(data) },
-		arrow.STRING:                  func(data *Data) Interface { return NewStringData(data) },
-		arrow.BINARY:                  func(data *Data) Interface { return NewBinaryData(data) },
-		arrow.FIXED_SIZE_BINARY:       func(data *Data) Interface { return NewFixedSizeBinaryData(data) },
-		arrow.DATE32:                  func(data *Data) Interface { return NewDate32Data(data) },
-		arrow.DATE64:                  func(data *Data) Interface { return NewDate64Data(data) },
-		arrow.TIMESTAMP:               func(data *Data) Interface { return NewTimestampData(data) },
-		arrow.TIME32:                  func(data *Data) Interface { return NewTime32Data(data) },
-		arrow.TIME64:                  func(data *Data) Interface { return NewTime64Data(data) },
-		arrow.INTERVAL_MONTHS:         func(data *Data) Interface { return NewMonthIntervalData(data) },
-		arrow.INTERVAL_DAY_TIME:       func(data *Data) Interface { return NewDayTimeIntervalData(data) },
-		arrow.DECIMAL128:              func(data *Data) Interface { return NewDecimal128Data(data) },
+		arrow.NULL:                    func(data arrow.ArrayData) arrow.Array { return NewNullData(data) },
+		arrow.BOOL:                    func(data arrow.ArrayData) arrow.Array { return NewBooleanData(data) },
+		arrow.UINT8:                   func(data arrow.ArrayData) arrow.Array { return NewUint8Data(data) },
+		arrow.INT8:                    func(data arrow.ArrayData) arrow.Array { return NewInt8Data(data) },
+		arrow.UINT16:                  func(data arrow.ArrayData) arrow.Array { return NewUint16Data(data) },
+		arrow.INT16:                   func(data arrow.ArrayData) arrow.Array { return NewInt16Data(data) },
+		arrow.UINT32:                  func(data arrow.ArrayData) arrow.Array { return NewUint32Data(data) },
+		arrow.INT32:                   func(data arrow.ArrayData) arrow.Array { return NewInt32Data(data) },
+		arrow.UINT64:                  func(data arrow.ArrayData) arrow.Array { return NewUint64Data(data) },
+		arrow.INT64:                   func(data arrow.ArrayData) arrow.Array { return NewInt64Data(data) },
+		arrow.FLOAT16:                 func(data arrow.ArrayData) arrow.Array { return NewFloat16Data(data) },
+		arrow.FLOAT32:                 func(data arrow.ArrayData) arrow.Array { return NewFloat32Data(data) },
+		arrow.FLOAT64:                 func(data arrow.ArrayData) arrow.Array { return NewFloat64Data(data) },
+		arrow.STRING:                  func(data arrow.ArrayData) arrow.Array { return NewStringData(data) },
+		arrow.BINARY:                  func(data arrow.ArrayData) arrow.Array { return NewBinaryData(data) },
+		arrow.FIXED_SIZE_BINARY:       func(data arrow.ArrayData) arrow.Array { return NewFixedSizeBinaryData(data) },
+		arrow.DATE32:                  func(data arrow.ArrayData) arrow.Array { return NewDate32Data(data) },
+		arrow.DATE64:                  func(data arrow.ArrayData) arrow.Array { return NewDate64Data(data) },
+		arrow.TIMESTAMP:               func(data arrow.ArrayData) arrow.Array { return NewTimestampData(data) },
+		arrow.TIME32:                  func(data arrow.ArrayData) arrow.Array { return NewTime32Data(data) },
+		arrow.TIME64:                  func(data arrow.ArrayData) arrow.Array { return NewTime64Data(data) },
+		arrow.INTERVAL_MONTHS:         func(data arrow.ArrayData) arrow.Array { return NewMonthIntervalData(data) },
+		arrow.INTERVAL_DAY_TIME:       func(data arrow.ArrayData) arrow.Array { return NewDayTimeIntervalData(data) },
+		arrow.DECIMAL128:              func(data arrow.ArrayData) arrow.Array { return NewDecimal128Data(data) },
 		arrow.DECIMAL256:              unsupportedArrayType,
-		arrow.LIST:                    func(data *Data) Interface { return NewListData(data) },
-		arrow.STRUCT:                  func(data *Data) Interface { return NewStructData(data) },
+		arrow.LIST:                    func(data arrow.ArrayData) arrow.Array { return NewListData(data) },
+		arrow.STRUCT:                  func(data arrow.ArrayData) arrow.Array { return NewStructData(data) },
 		arrow.SPARSE_UNION:            unsupportedArrayType,
 		arrow.DENSE_UNION:             unsupportedArrayType,
 		arrow.DICTIONARY:              unsupportedArrayType,
-		arrow.MAP:                     func(data *Data) Interface { return NewMapData(data) },
-		arrow.EXTENSION:               func(data *Data) Interface { return NewExtensionData(data) },
-		arrow.FIXED_SIZE_LIST:         func(data *Data) Interface { return NewFixedSizeListData(data) },
-		arrow.DURATION:                func(data *Data) Interface { return NewDurationData(data) },
+		arrow.MAP:                     func(data arrow.ArrayData) arrow.Array { return NewMapData(data) },
+		arrow.EXTENSION:               func(data arrow.ArrayData) arrow.Array { return NewExtensionData(data) },
+		arrow.FIXED_SIZE_LIST:         func(data arrow.ArrayData) arrow.Array { return NewFixedSizeListData(data) },
+		arrow.DURATION:                func(data arrow.ArrayData) arrow.Array { return NewDurationData(data) },
 		arrow.LARGE_STRING:            unsupportedArrayType,
 		arrow.LARGE_BINARY:            unsupportedArrayType,
 		arrow.LARGE_LIST:              unsupportedArrayType,
-		arrow.INTERVAL:                func(data *Data) Interface { return NewIntervalData(data) },
-		arrow.INTERVAL_MONTH_DAY_NANO: func(data *Data) Interface { return NewMonthDayNanoIntervalData(data) },
+		arrow.INTERVAL:                func(data arrow.ArrayData) arrow.Array { return NewIntervalData(data) },
+		arrow.INTERVAL_MONTH_DAY_NANO: func(data arrow.ArrayData) arrow.Array { return NewMonthDayNanoIntervalData(data) },
 
 		// invalid data types to fill out array to size 2^6 - 1
 		63: invalidDataType,

--- a/go/arrow/array/array.go
+++ b/go/arrow/array/array.go
@@ -24,6 +24,10 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
+// Interface aliases arrow.Array so that existing users don't get broken by
+// the migration to arrow.Array.
+//
+// Deprecated: This alias will be removed in v8
 type Interface = arrow.Array
 
 type arraymarshal interface {

--- a/go/arrow/array/array_test.go
+++ b/go/arrow/array/array_test.go
@@ -41,7 +41,7 @@ func TestMakeFromData(t *testing.T) {
 		name     string
 		d        arrow.DataType
 		size     int
-		child    []*array.Data
+		child    []arrow.ArrayData
 		expPanic bool
 		expError string
 	}{
@@ -71,25 +71,25 @@ func TestMakeFromData(t *testing.T) {
 		{name: "decimal128", d: &testDataType{arrow.DECIMAL128}},
 		{name: "month_day_nano_interval", d: arrow.FixedWidthTypes.MonthDayNanoInterval},
 
-		{name: "list", d: &testDataType{arrow.LIST}, child: []*array.Data{
+		{name: "list", d: &testDataType{arrow.LIST}, child: []arrow.ArrayData{
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 		}},
 
 		{name: "struct", d: &testDataType{arrow.STRUCT}},
-		{name: "struct", d: &testDataType{arrow.STRUCT}, child: []*array.Data{
+		{name: "struct", d: &testDataType{arrow.STRUCT}, child: []arrow.ArrayData{
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 		}},
 
-		{name: "fixed_size_list", d: arrow.FixedSizeListOf(4, arrow.PrimitiveTypes.Int64), child: []*array.Data{
+		{name: "fixed_size_list", d: arrow.FixedSizeListOf(4, arrow.PrimitiveTypes.Int64), child: []arrow.ArrayData{
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 			array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 		}},
 		{name: "duration", d: &testDataType{arrow.DURATION}},
 
-		{name: "map", d: &testDataType{arrow.MAP}, child: []*array.Data{
-			array.NewData(&testDataType{arrow.STRUCT}, 0 /* length */, make([]*memory.Buffer, 3 /*null bitmap, values, offsets*/), []*array.Data{
+		{name: "map", d: &testDataType{arrow.MAP}, child: []arrow.ArrayData{
+			array.NewData(&testDataType{arrow.STRUCT}, 0 /* length */, make([]*memory.Buffer, 3 /*null bitmap, values, offsets*/), []arrow.ArrayData{
 				array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 				array.NewData(&testDataType{arrow.INT64}, 0 /* length */, make([]*memory.Buffer, 2 /*null bitmap, values*/), nil /* childData */, 0 /* nulls */, 0 /* offset */),
 			}, 0 /* nulls */, 0 /* offset */)},

--- a/go/arrow/array/binary.go
+++ b/go/arrow/array/binary.go
@@ -34,10 +34,10 @@ type Binary struct {
 }
 
 // NewBinaryData constructs a new Binary array from data.
-func NewBinaryData(data *Data) *Binary {
+func NewBinaryData(data arrow.ArrayData) *Binary {
 	a := &Binary{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/binarybuilder.go
+++ b/go/arrow/array/binarybuilder.go
@@ -181,7 +181,7 @@ func (b *BinaryBuilder) Resize(n int) {
 
 // NewArray creates a Binary array from the memory buffers used by the builder and resets the BinaryBuilder
 // so it can be used to build a new array.
-func (b *BinaryBuilder) NewArray() Interface {
+func (b *BinaryBuilder) NewArray() arrow.Array {
 	return b.NewBinaryArray()
 }
 

--- a/go/arrow/array/binarybuilder.go
+++ b/go/arrow/array/binarybuilder.go
@@ -213,7 +213,7 @@ func (b *BinaryBuilder) newData() (data *Data) {
 
 func (b *BinaryBuilder) appendNextOffset() {
 	numBytes := b.values.Len()
-	// TODO(sgc): check binaryArrayMaximumCapacity?
+	debug.Assert(numBytes <= binaryArrayMaximumCapacity, "exceeded maximum capacity of binary array")
 	b.offsets.AppendValue(int32(numBytes))
 }
 

--- a/go/arrow/array/boolean.go
+++ b/go/arrow/array/boolean.go
@@ -41,10 +41,10 @@ func NewBoolean(length int, data *memory.Buffer, nullBitmap *memory.Buffer, null
 	return NewBooleanData(arrdata)
 }
 
-func NewBooleanData(data *Data) *Boolean {
+func NewBooleanData(data arrow.ArrayData) *Boolean {
 	a := &Boolean{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/booleanbuilder.go
+++ b/go/arrow/array/booleanbuilder.go
@@ -134,7 +134,7 @@ func (b *BooleanBuilder) Resize(n int) {
 
 // NewArray creates a Boolean array from the memory buffers used by the builder and resets the BooleanBuilder
 // so it can be used to build a new array.
-func (b *BooleanBuilder) NewArray() Interface {
+func (b *BooleanBuilder) NewArray() arrow.Array {
 	return b.NewBooleanArray()
 }
 

--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -66,7 +66,7 @@ type Builder interface {
 	// NewArray creates a new array from the memory buffers used
 	// by the builder and resets the Builder so it can be used to build
 	// a new array.
-	NewArray() Interface
+	NewArray() arrow.Array
 
 	init(capacity int)
 	resize(newBits int, init func(int))

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -565,7 +565,7 @@ func TestChunkedApproxEqual(t *testing.T) {
 
 	c1 := array.NewChunked(
 		arrow.PrimitiveTypes.Float64,
-		[]array.Interface{f1, f2, f3},
+		[]arrow.Array{f1, f2, f3},
 	)
 	defer c1.Release()
 
@@ -587,7 +587,7 @@ func TestChunkedApproxEqual(t *testing.T) {
 
 	c2 := array.NewChunked(
 		arrow.PrimitiveTypes.Float64,
-		[]array.Interface{f4, f5, f6, f7},
+		[]arrow.Array{f4, f5, f6, f7},
 	)
 	defer c2.Release()
 

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -302,7 +302,7 @@ func TestArrayApproxEqualFloats(t *testing.T) {
 	}
 }
 
-func arrayOf(mem memory.Allocator, a interface{}, valids []bool) array.Interface {
+func arrayOf(mem memory.Allocator, a interface{}, valids []bool) arrow.Array {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}

--- a/go/arrow/array/concat.go
+++ b/go/arrow/array/concat.go
@@ -32,13 +32,13 @@ import (
 //
 // The passed in arrays still need to be released manually, and will not be
 // released by this function.
-func Concatenate(arrs []Interface, mem memory.Allocator) (Interface, error) {
+func Concatenate(arrs []arrow.Array, mem memory.Allocator) (arrow.Array, error) {
 	if len(arrs) == 0 {
 		return nil, xerrors.New("array/concat: must pass at least one array")
 	}
 
 	// gather Data of inputs
-	data := make([]*Data, len(arrs))
+	data := make([]arrow.ArrayData, len(arrs))
 	for i, ar := range arrs {
 		if !arrow.TypeEqual(ar.DataType(), arrs[0].DataType()) {
 			return nil, xerrors.Errorf("arrays to be concatenated must be identically typed, but %s and %s were encountered",
@@ -69,14 +69,14 @@ type bitmap struct {
 }
 
 // gather up the bitmaps from the passed in data objects
-func gatherBitmaps(data []*Data, idx int) []bitmap {
+func gatherBitmaps(data []arrow.ArrayData, idx int) []bitmap {
 	out := make([]bitmap, len(data))
 	for i, d := range data {
-		if d.buffers[idx] != nil {
-			out[i].data = d.buffers[idx].Bytes()
+		if d.Buffers()[idx] != nil {
+			out[i].data = d.Buffers()[idx].Bytes()
 		}
-		out[i].rng.offset = d.offset
-		out[i].rng.len = d.length
+		out[i].rng.offset = d.Offset()
+		out[i].rng.len = d.Len()
 	}
 	return out
 }
@@ -85,32 +85,32 @@ func gatherBitmaps(data []*Data, idx int) []bitmap {
 // returning only the slices of the buffers which are relevant to the passed in arrays
 // in case they are themselves slices of other arrays. nil buffers are ignored and not
 // in the output slice.
-func gatherFixedBuffers(data []*Data, idx, byteWidth int) []*memory.Buffer {
+func gatherFixedBuffers(data []arrow.ArrayData, idx, byteWidth int) []*memory.Buffer {
 	out := make([]*memory.Buffer, 0, len(data))
 	for _, d := range data {
-		buf := d.buffers[idx]
+		buf := d.Buffers()[idx]
 		if buf == nil {
 			continue
 		}
 
-		out = append(out, memory.NewBufferBytes(buf.Bytes()[d.offset*byteWidth:(d.offset+d.length)*byteWidth]))
+		out = append(out, memory.NewBufferBytes(buf.Bytes()[d.Offset()*byteWidth:(d.Offset()+d.Len())*byteWidth]))
 	}
 	return out
 }
 
 // gatherBuffersFixedWidthType is like gatherFixedBuffers, but uses a datatype to determine the size
 // to use for determining the byte slice rather than a passed in bytewidth.
-func gatherBuffersFixedWidthType(data []*Data, idx int, fixed arrow.FixedWidthDataType) []*memory.Buffer {
+func gatherBuffersFixedWidthType(data []arrow.ArrayData, idx int, fixed arrow.FixedWidthDataType) []*memory.Buffer {
 	return gatherFixedBuffers(data, idx, fixed.BitWidth()/8)
 }
 
 // gatherBufferRanges requires that len(ranges) == len(data) and returns a list of buffers
 // which represent the corresponding range of each buffer in the specified index of each
 // data object.
-func gatherBufferRanges(data []*Data, idx int, ranges []rng) []*memory.Buffer {
+func gatherBufferRanges(data []arrow.ArrayData, idx int, ranges []rng) []*memory.Buffer {
 	out := make([]*memory.Buffer, 0, len(data))
 	for i, d := range data {
-		buf := d.buffers[idx]
+		buf := d.Buffers()[idx]
 		if buf == nil {
 			debug.Assert(ranges[i].len == 0, "misaligned buffer value ranges")
 			continue
@@ -122,28 +122,28 @@ func gatherBufferRanges(data []*Data, idx int, ranges []rng) []*memory.Buffer {
 }
 
 // gatherChildren gathers the children data objects for child of index idx for all of the data objects.
-func gatherChildren(data []*Data, idx int) []*Data {
+func gatherChildren(data []arrow.ArrayData, idx int) []arrow.ArrayData {
 	return gatherChildrenMultiplier(data, idx, 1)
 }
 
 // gatherChildrenMultiplier gathers the full data slice of the underlying values from the children data objects
 // such as the values data for a list array so that it can return a slice of the buffer for a given
 // index into the children.
-func gatherChildrenMultiplier(data []*Data, idx, multiplier int) []*Data {
-	out := make([]*Data, len(data))
+func gatherChildrenMultiplier(data []arrow.ArrayData, idx, multiplier int) []arrow.ArrayData {
+	out := make([]arrow.ArrayData, len(data))
 	for i, d := range data {
-		out[i] = NewSliceData(d.childData[idx], int64(d.offset*multiplier), int64(d.offset+d.length)*int64(multiplier))
+		out[i] = NewSliceData(d.Children()[idx], int64(d.Offset()*multiplier), int64(d.Offset()+d.Len())*int64(multiplier))
 	}
 	return out
 }
 
 // gatherChildrenRanges returns a slice of Data objects which each represent slices of the given ranges from the
 // child in the specified index from each data object.
-func gatherChildrenRanges(data []*Data, idx int, ranges []rng) []*Data {
+func gatherChildrenRanges(data []arrow.ArrayData, idx int, ranges []rng) []arrow.ArrayData {
 	debug.Assert(len(data) == len(ranges), "mismatched children ranges for concat")
-	out := make([]*Data, len(data))
+	out := make([]arrow.ArrayData, len(data))
 	for i, d := range data {
-		out[i] = NewSliceData(d.childData[idx], int64(ranges[i].offset), int64(ranges[i].offset+ranges[i].len))
+		out[i] = NewSliceData(d.Children()[idx], int64(ranges[i].offset), int64(ranges[i].offset+ranges[i].len))
 	}
 	return out
 }
@@ -223,18 +223,18 @@ func concatOffsets(buffers []*memory.Buffer, mem memory.Allocator) (*memory.Buff
 
 // concat is the implementation for actually performing the concatenation of the *array.Data
 // objects that we can call internally for nested types.
-func concat(data []*Data, mem memory.Allocator) (*Data, error) {
-	out := &Data{refCount: 1, dtype: data[0].dtype, nulls: 0}
+func concat(data []arrow.ArrayData, mem memory.Allocator) (arrow.ArrayData, error) {
+	out := &Data{refCount: 1, dtype: data[0].DataType(), nulls: 0}
 	for _, d := range data {
-		out.length += d.length
-		if out.nulls == UnknownNullCount || d.nulls == UnknownNullCount {
+		out.length += d.Len()
+		if out.nulls == UnknownNullCount || d.NullN() == UnknownNullCount {
 			out.nulls = UnknownNullCount
 			continue
 		}
-		out.nulls += d.nulls
+		out.nulls += d.NullN()
 	}
 
-	out.buffers = make([]*memory.Buffer, len(data[0].buffers))
+	out.buffers = make([]*memory.Buffer, len(data[0].Buffers()))
 	if out.nulls != 0 && out.dtype.ID() != arrow.NULL {
 		bm, err := concatBitmaps(gatherBitmaps(data, 0), mem)
 		if err != nil {
@@ -271,7 +271,7 @@ func concat(data []*Data, mem memory.Allocator) (*Data, error) {
 		}
 
 		out.buffers[1] = offsetBuffer
-		out.childData = make([]*Data, 1)
+		out.childData = make([]arrow.ArrayData, 1)
 		out.childData[0], err = concat(childData, mem)
 		if err != nil {
 			return nil, err
@@ -286,9 +286,9 @@ func concat(data []*Data, mem memory.Allocator) (*Data, error) {
 		if err != nil {
 			return nil, err
 		}
-		out.childData = []*Data{children}
+		out.childData = []arrow.ArrayData{children}
 	case *arrow.StructType:
-		out.childData = make([]*Data, len(dt.Fields()))
+		out.childData = make([]arrow.ArrayData, len(dt.Fields()))
 		for i := range dt.Fields() {
 			children := gatherChildren(data, i)
 			for _, c := range children {
@@ -312,7 +312,7 @@ func concat(data []*Data, mem memory.Allocator) (*Data, error) {
 		}
 
 		out.buffers[1] = offsetBuffer
-		out.childData = make([]*Data, 1)
+		out.childData = make([]arrow.ArrayData, 1)
 		out.childData[0], err = concat(childData, mem)
 		if err != nil {
 			return nil, err

--- a/go/arrow/array/concat.go
+++ b/go/arrow/array/concat.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Concatenate creates a new array.Interface which is the concatenation of the
+// Concatenate creates a new arrow.Array which is the concatenation of the
 // passed in arrays. Returns nil if an error is encountered.
 //
 // The passed in arrays still need to be released manually, and will not be
@@ -221,7 +221,7 @@ func concatOffsets(buffers []*memory.Buffer, mem memory.Allocator) (*memory.Buff
 	return out, valuesRanges, nil
 }
 
-// concat is the implementation for actually performing the concatenation of the *array.Data
+// concat is the implementation for actually performing the concatenation of the arrow.ArrayData
 // objects that we can call internally for nested types.
 func concat(data []arrow.ArrayData, mem memory.Allocator) (arrow.ArrayData, error) {
 	out := &Data{refCount: 1, dtype: data[0].DataType(), nulls: 0}

--- a/go/arrow/array/data.go
+++ b/go/arrow/array/data.go
@@ -34,12 +34,12 @@ type Data struct {
 	nulls     int
 	offset    int
 	length    int
-	buffers   []*memory.Buffer // TODO(sgc): should this be an interface?
-	childData []*Data          // TODO(sgc): managed by ListArray, StructArray and UnionArray types
+	buffers   []*memory.Buffer  // TODO(sgc): should this be an interface?
+	childData []arrow.ArrayData // TODO(sgc): managed by ListArray, StructArray and UnionArray types
 }
 
 // NewData creates a new Data.
-func NewData(dtype arrow.DataType, length int, buffers []*memory.Buffer, childData []*Data, nulls, offset int) *Data {
+func NewData(dtype arrow.DataType, length int, buffers []*memory.Buffer, childData []arrow.ArrayData, nulls, offset int) *Data {
 	for _, b := range buffers {
 		if b != nil {
 			b.Retain()
@@ -64,7 +64,7 @@ func NewData(dtype arrow.DataType, length int, buffers []*memory.Buffer, childDa
 }
 
 // Reset sets the Data for re-use.
-func (d *Data) Reset(dtype arrow.DataType, length int, buffers []*memory.Buffer, childData []*Data, nulls, offset int) {
+func (d *Data) Reset(dtype arrow.DataType, length int, buffers []*memory.Buffer, childData []arrow.ArrayData, nulls, offset int) {
 	// Retain new buffers before releasing existing buffers in-case they're the same ones to prevent accidental premature
 	// release.
 	for _, b := range buffers {
@@ -140,6 +140,8 @@ func (d *Data) Offset() int { return d.offset }
 // Buffers returns the buffers.
 func (d *Data) Buffers() []*memory.Buffer { return d.buffers }
 
+func (d *Data) Children() []arrow.ArrayData { return d.childData }
+
 // NewSliceData returns a new slice that shares backing data with the input.
 // The returned Data slice starts at i and extends j-i elements, such as:
 //    slice := data[i:j]
@@ -147,18 +149,18 @@ func (d *Data) Buffers() []*memory.Buffer { return d.buffers }
 //
 // NewSliceData panics if the slice is outside the valid range of the input Data.
 // NewSliceData panics if j < i.
-func NewSliceData(data *Data, i, j int64) *Data {
-	if j > int64(data.length) || i > j || data.offset+int(i) > data.offset+data.length {
+func NewSliceData(data arrow.ArrayData, i, j int64) arrow.ArrayData {
+	if j > int64(data.Len()) || i > j || data.Offset()+int(i) > data.Offset()+data.Len() {
 		panic("arrow/array: index out of range")
 	}
 
-	for _, b := range data.buffers {
+	for _, b := range data.Buffers() {
 		if b != nil {
 			b.Retain()
 		}
 	}
 
-	for _, child := range data.childData {
+	for _, child := range data.Children() {
 		if child != nil {
 			child.Retain()
 		}
@@ -166,22 +168,24 @@ func NewSliceData(data *Data, i, j int64) *Data {
 
 	o := &Data{
 		refCount:  1,
-		dtype:     data.dtype,
+		dtype:     data.DataType(),
 		nulls:     UnknownNullCount,
 		length:    int(j - i),
-		offset:    data.offset + int(i),
-		buffers:   data.buffers,
-		childData: data.childData,
+		offset:    data.Offset() + int(i),
+		buffers:   data.Buffers(),
+		childData: data.Children(),
 	}
 
-	if data.nulls == 0 {
+	if data.NullN() == 0 {
 		o.nulls = 0
 	}
 
 	return o
 }
 
-func Hash(h *maphash.Hash, a *Data) {
+func Hash(h *maphash.Hash, data arrow.ArrayData) {
+	a := data.(*Data)
+
 	h.Write((*[bits.UintSize / 8]byte)(unsafe.Pointer(&a.length))[:])
 	h.Write((*[bits.UintSize / 8]byte)(unsafe.Pointer(&a.length))[:])
 	if len(a.buffers) > 0 && a.buffers[0] != nil {

--- a/go/arrow/array/decimal128.go
+++ b/go/arrow/array/decimal128.go
@@ -40,10 +40,10 @@ type Decimal128 struct {
 	values []decimal128.Num
 }
 
-func NewDecimal128Data(data *Data) *Decimal128 {
+func NewDecimal128Data(data arrow.ArrayData) *Decimal128 {
 	a := &Decimal128{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -222,7 +222,7 @@ func (b *Decimal128Builder) Resize(n int) {
 
 // NewArray creates a Decimal128 array from the memory buffers used by the builder and resets the Decimal128Builder
 // so it can be used to build a new array.
-func (b *Decimal128Builder) NewArray() Interface {
+func (b *Decimal128Builder) NewArray() arrow.Array {
 	return b.NewDecimal128Array()
 }
 

--- a/go/arrow/array/extension_test.go
+++ b/go/arrow/array/extension_test.go
@@ -49,7 +49,7 @@ func (e *ExtensionTypeTestSuite) TestParametricEquals() {
 	e.False(arrow.TypeEqual(p1Type, p3Type))
 }
 
-func exampleParametric(mem memory.Allocator, dt arrow.DataType, vals []int32, valid []bool) array.Interface {
+func exampleParametric(mem memory.Allocator, dt arrow.DataType, vals []int32, valid []bool) arrow.Array {
 	bldr := array.NewBuilder(mem, dt)
 	defer bldr.Release()
 
@@ -85,7 +85,7 @@ func (e *ExtensionTypeTestSuite) TestParametricArrays() {
 		{Name: "f1", Type: p2Type, Nullable: true},
 		{Name: "f2", Type: p3Type, Nullable: true},
 		{Name: "f3", Type: p4Type, Nullable: true},
-	}, nil), []array.Interface{p1, p2, p3, p4}, -1)
+	}, nil), []arrow.Array{p1, p2, p3, p4}, -1)
 	defer rb.Release()
 
 	e.True(array.RecordEqual(rb, rb))

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -33,18 +33,18 @@ import (
 type FixedSizeList struct {
 	array
 	n      int32
-	values Interface
+	values arrow.Array
 }
 
 // NewFixedSizeListData returns a new List array value, from data.
-func NewFixedSizeListData(data *Data) *FixedSizeList {
+func NewFixedSizeListData(data arrow.ArrayData) *FixedSizeList {
 	a := &FixedSizeList{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
-func (a *FixedSizeList) ListValues() Interface { return a.values }
+func (a *FixedSizeList) ListValues() arrow.Array { return a.values }
 
 func (a *FixedSizeList) String() string {
 	o := new(strings.Builder)
@@ -65,7 +65,7 @@ func (a *FixedSizeList) String() string {
 	return o.String()
 }
 
-func (a *FixedSizeList) newListValue(i int) Interface {
+func (a *FixedSizeList) newListValue(i int) arrow.Array {
 	n := int64(a.n)
 	off := int64(a.array.data.offset)
 	beg := (off + int64(i)) * n
@@ -240,7 +240,7 @@ func (b *FixedSizeListBuilder) ValueBuilder() Builder {
 
 // NewArray creates a List array from the memory buffers used by the builder and resets the FixedSizeListBuilder
 // so it can be used to build a new array.
-func (b *FixedSizeListBuilder) NewArray() Interface {
+func (b *FixedSizeListBuilder) NewArray() arrow.Array {
 	return b.NewListArray()
 }
 
@@ -260,7 +260,7 @@ func (b *FixedSizeListBuilder) newData() (data *Data) {
 	data = NewData(
 		arrow.FixedSizeListOf(b.n, b.etype), b.length,
 		[]*memory.Buffer{b.nullBitmap},
-		[]*Data{values.Data()},
+		[]arrow.ArrayData{values.Data()},
 		b.nulls,
 		0,
 	)

--- a/go/arrow/array/fixedsize_binary.go
+++ b/go/arrow/array/fixedsize_binary.go
@@ -34,10 +34,10 @@ type FixedSizeBinary struct {
 }
 
 // NewFixedSizeBinaryData constructs a new fixed-size binary array from data.
-func NewFixedSizeBinaryData(data *Data) *FixedSizeBinary {
+func NewFixedSizeBinaryData(data arrow.ArrayData) *FixedSizeBinary {
 	a := &FixedSizeBinary{bytewidth: int32(data.DataType().(arrow.FixedWidthDataType).BitWidth() / 8)}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/fixedsize_binarybuilder.go
+++ b/go/arrow/array/fixedsize_binarybuilder.go
@@ -127,7 +127,7 @@ func (b *FixedSizeBinaryBuilder) Resize(n int) {
 
 // NewArray creates a FixedSizeBinary array from the memory buffers used by the
 // builder and resets the FixedSizeBinaryBuilder so it can be used to build a new array.
-func (b *FixedSizeBinaryBuilder) NewArray() Interface {
+func (b *FixedSizeBinaryBuilder) NewArray() arrow.Array {
 	return b.NewFixedSizeBinaryArray()
 }
 

--- a/go/arrow/array/float16.go
+++ b/go/arrow/array/float16.go
@@ -31,10 +31,10 @@ type Float16 struct {
 	values []float16.Num
 }
 
-func NewFloat16Data(data *Data) *Float16 {
+func NewFloat16Data(data arrow.ArrayData) *Float16 {
 	a := &Float16{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/float16_builder.go
+++ b/go/arrow/array/float16_builder.go
@@ -138,7 +138,7 @@ func (b *Float16Builder) Resize(n int) {
 
 // NewArray creates a Float16 array from the memory buffers used by the builder and resets the Float16Builder
 // so it can be used to build a new array.
-func (b *Float16Builder) NewArray() Interface {
+func (b *Float16Builder) NewArray() arrow.Array {
 	return b.NewFloat16Array()
 }
 

--- a/go/arrow/array/interval.go
+++ b/go/arrow/array/interval.go
@@ -30,16 +30,16 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func NewIntervalData(data *Data) Interface {
-	switch data.dtype.(type) {
+func NewIntervalData(data arrow.ArrayData) Interface {
+	switch data.DataType().(type) {
 	case *arrow.MonthIntervalType:
-		return NewMonthIntervalData(data)
+		return NewMonthIntervalData(data.(*Data))
 	case *arrow.DayTimeIntervalType:
-		return NewDayTimeIntervalData(data)
+		return NewDayTimeIntervalData(data.(*Data))
 	case *arrow.MonthDayNanoIntervalType:
-		return NewMonthDayNanoIntervalData(data)
+		return NewMonthDayNanoIntervalData(data.(*Data))
 	default:
-		panic(xerrors.Errorf("arrow/array: unknown interval data type %T", data.dtype))
+		panic(xerrors.Errorf("arrow/array: unknown interval data type %T", data.DataType()))
 	}
 }
 
@@ -49,10 +49,10 @@ type MonthInterval struct {
 	values []arrow.MonthInterval
 }
 
-func NewMonthIntervalData(data *Data) *MonthInterval {
+func NewMonthIntervalData(data arrow.ArrayData) *MonthInterval {
 	a := &MonthInterval{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -231,7 +231,7 @@ func (b *MonthIntervalBuilder) Resize(n int) {
 
 // NewArray creates a MonthInterval array from the memory buffers used by the builder and resets the MonthIntervalBuilder
 // so it can be used to build a new array.
-func (b *MonthIntervalBuilder) NewArray() Interface {
+func (b *MonthIntervalBuilder) NewArray() arrow.Array {
 	return b.NewMonthIntervalArray()
 }
 
@@ -308,10 +308,10 @@ type DayTimeInterval struct {
 	values []arrow.DayTimeInterval
 }
 
-func NewDayTimeIntervalData(data *Data) *DayTimeInterval {
+func NewDayTimeIntervalData(data arrow.ArrayData) *DayTimeInterval {
 	a := &DayTimeInterval{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -488,7 +488,7 @@ func (b *DayTimeIntervalBuilder) Resize(n int) {
 
 // NewArray creates a DayTimeInterval array from the memory buffers used by the builder and resets the DayTimeIntervalBuilder
 // so it can be used to build a new array.
-func (b *DayTimeIntervalBuilder) NewArray() Interface {
+func (b *DayTimeIntervalBuilder) NewArray() arrow.Array {
 	return b.NewDayTimeIntervalArray()
 }
 
@@ -564,10 +564,10 @@ type MonthDayNanoInterval struct {
 	values []arrow.MonthDayNanoInterval
 }
 
-func NewMonthDayNanoIntervalData(data *Data) *MonthDayNanoInterval {
+func NewMonthDayNanoIntervalData(data arrow.ArrayData) *MonthDayNanoInterval {
 	a := &MonthDayNanoInterval{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -746,7 +746,7 @@ func (b *MonthDayNanoIntervalBuilder) Resize(n int) {
 
 // NewArray creates a MonthDayNanoInterval array from the memory buffers used by the builder and resets the MonthDayNanoIntervalBuilder
 // so it can be used to build a new array.
-func (b *MonthDayNanoIntervalBuilder) NewArray() Interface {
+func (b *MonthDayNanoIntervalBuilder) NewArray() arrow.Array {
 	return b.NewMonthDayNanoIntervalArray()
 }
 

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -32,19 +32,19 @@ import (
 // List represents an immutable sequence of array values.
 type List struct {
 	array
-	values  Interface
+	values  arrow.Array
 	offsets []int32
 }
 
 // NewListData returns a new List array value, from data.
-func NewListData(data *Data) *List {
+func NewListData(data arrow.ArrayData) *List {
 	a := &List{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
-func (a *List) ListValues() Interface { return a.values }
+func (a *List) ListValues() arrow.Array { return a.values }
 
 func (a *List) String() string {
 	o := new(strings.Builder)
@@ -65,7 +65,7 @@ func (a *List) String() string {
 	return o.String()
 }
 
-func (a *List) newListValue(i int) Interface {
+func (a *List) newListValue(i int) arrow.Array {
 	j := i + a.array.data.offset
 	beg := int64(a.offsets[j])
 	end := int64(a.offsets[j+1])
@@ -249,7 +249,7 @@ func (b *ListBuilder) ValueBuilder() Builder {
 
 // NewArray creates a List array from the memory buffers used by the builder and resets the ListBuilder
 // so it can be used to build a new array.
-func (b *ListBuilder) NewArray() Interface {
+func (b *ListBuilder) NewArray() arrow.Array {
 	return b.NewListArray()
 }
 
@@ -273,7 +273,7 @@ func (b *ListBuilder) newData() (data *Data) {
 	if b.offsets != nil {
 		arr := b.offsets.NewInt32Array()
 		defer arr.Release()
-		offsets = arr.Data().buffers[1]
+		offsets = arr.Data().Buffers()[1]
 	}
 
 	data = NewData(
@@ -282,7 +282,7 @@ func (b *ListBuilder) newData() (data *Data) {
 			b.nullBitmap,
 			offsets,
 		},
-		[]*Data{values.Data()},
+		[]arrow.ArrayData{values.Data()},
 		b.nulls,
 		0,
 	)

--- a/go/arrow/array/null.go
+++ b/go/arrow/array/null.go
@@ -51,10 +51,10 @@ func NewNull(n int) *Null {
 }
 
 // NewNullData returns a new Null array value, from data.
-func NewNullData(data *Data) *Null {
+func NewNullData(data arrow.ArrayData) *Null {
 	a := &Null{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -120,7 +120,7 @@ func (*NullBuilder) resize(newBits int, init func(int)) {}
 
 // NewArray creates a Null array from the memory buffers used by the builder and resets the NullBuilder
 // so it can be used to build a new array.
-func (b *NullBuilder) NewArray() Interface {
+func (b *NullBuilder) NewArray() arrow.Array {
 	return b.NewNullArray()
 }
 

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -33,10 +33,10 @@ type Int64 struct {
 }
 
 // NewInt64Data creates a new Int64.
-func NewInt64Data(data *Data) *Int64 {
+func NewInt64Data(data arrow.ArrayData) *Int64 {
 	a := &Int64{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -121,10 +121,10 @@ type Uint64 struct {
 }
 
 // NewUint64Data creates a new Uint64.
-func NewUint64Data(data *Data) *Uint64 {
+func NewUint64Data(data arrow.ArrayData) *Uint64 {
 	a := &Uint64{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -209,10 +209,10 @@ type Float64 struct {
 }
 
 // NewFloat64Data creates a new Float64.
-func NewFloat64Data(data *Data) *Float64 {
+func NewFloat64Data(data arrow.ArrayData) *Float64 {
 	a := &Float64{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -297,10 +297,10 @@ type Int32 struct {
 }
 
 // NewInt32Data creates a new Int32.
-func NewInt32Data(data *Data) *Int32 {
+func NewInt32Data(data arrow.ArrayData) *Int32 {
 	a := &Int32{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -385,10 +385,10 @@ type Uint32 struct {
 }
 
 // NewUint32Data creates a new Uint32.
-func NewUint32Data(data *Data) *Uint32 {
+func NewUint32Data(data arrow.ArrayData) *Uint32 {
 	a := &Uint32{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -473,10 +473,10 @@ type Float32 struct {
 }
 
 // NewFloat32Data creates a new Float32.
-func NewFloat32Data(data *Data) *Float32 {
+func NewFloat32Data(data arrow.ArrayData) *Float32 {
 	a := &Float32{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -561,10 +561,10 @@ type Int16 struct {
 }
 
 // NewInt16Data creates a new Int16.
-func NewInt16Data(data *Data) *Int16 {
+func NewInt16Data(data arrow.ArrayData) *Int16 {
 	a := &Int16{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -649,10 +649,10 @@ type Uint16 struct {
 }
 
 // NewUint16Data creates a new Uint16.
-func NewUint16Data(data *Data) *Uint16 {
+func NewUint16Data(data arrow.ArrayData) *Uint16 {
 	a := &Uint16{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -737,10 +737,10 @@ type Int8 struct {
 }
 
 // NewInt8Data creates a new Int8.
-func NewInt8Data(data *Data) *Int8 {
+func NewInt8Data(data arrow.ArrayData) *Int8 {
 	a := &Int8{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -825,10 +825,10 @@ type Uint8 struct {
 }
 
 // NewUint8Data creates a new Uint8.
-func NewUint8Data(data *Data) *Uint8 {
+func NewUint8Data(data arrow.ArrayData) *Uint8 {
 	a := &Uint8{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -913,10 +913,10 @@ type Timestamp struct {
 }
 
 // NewTimestampData creates a new Timestamp.
-func NewTimestampData(data *Data) *Timestamp {
+func NewTimestampData(data arrow.ArrayData) *Timestamp {
 	a := &Timestamp{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -996,10 +996,10 @@ type Time32 struct {
 }
 
 // NewTime32Data creates a new Time32.
-func NewTime32Data(data *Data) *Time32 {
+func NewTime32Data(data arrow.ArrayData) *Time32 {
 	a := &Time32{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -1079,10 +1079,10 @@ type Time64 struct {
 }
 
 // NewTime64Data creates a new Time64.
-func NewTime64Data(data *Data) *Time64 {
+func NewTime64Data(data arrow.ArrayData) *Time64 {
 	a := &Time64{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -1162,10 +1162,10 @@ type Date32 struct {
 }
 
 // NewDate32Data creates a new Date32.
-func NewDate32Data(data *Data) *Date32 {
+func NewDate32Data(data arrow.ArrayData) *Date32 {
 	a := &Date32{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -1245,10 +1245,10 @@ type Date64 struct {
 }
 
 // NewDate64Data creates a new Date64.
-func NewDate64Data(data *Data) *Date64 {
+func NewDate64Data(data arrow.ArrayData) *Date64 {
 	a := &Date64{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
@@ -1328,10 +1328,10 @@ type Duration struct {
 }
 
 // NewDurationData creates a new Duration.
-func NewDurationData(data *Data) *Duration {
+func NewDurationData(data arrow.ArrayData) *Duration {
 	a := &Duration{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -34,10 +34,10 @@ type {{.Name}} struct {
 }
 
 // New{{.Name}}Data creates a new {{.Name}}.
-func New{{.Name}}Data(data *Data) *{{.Name}} {
+func New{{.Name}}Data(data arrow.ArrayData) *{{.Name}} {
 	a := &{{.Name}}{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 

--- a/go/arrow/array/numericbuilder.gen.go
+++ b/go/arrow/array/numericbuilder.gen.go
@@ -139,7 +139,7 @@ func (b *Int64Builder) Resize(n int) {
 
 // NewArray creates a Int64 array from the memory buffers used by the builder and resets the Int64Builder
 // so it can be used to build a new array.
-func (b *Int64Builder) NewArray() Interface {
+func (b *Int64Builder) NewArray() arrow.Array {
 	return b.NewInt64Array()
 }
 
@@ -342,7 +342,7 @@ func (b *Uint64Builder) Resize(n int) {
 
 // NewArray creates a Uint64 array from the memory buffers used by the builder and resets the Uint64Builder
 // so it can be used to build a new array.
-func (b *Uint64Builder) NewArray() Interface {
+func (b *Uint64Builder) NewArray() arrow.Array {
 	return b.NewUint64Array()
 }
 
@@ -545,7 +545,7 @@ func (b *Float64Builder) Resize(n int) {
 
 // NewArray creates a Float64 array from the memory buffers used by the builder and resets the Float64Builder
 // so it can be used to build a new array.
-func (b *Float64Builder) NewArray() Interface {
+func (b *Float64Builder) NewArray() arrow.Array {
 	return b.NewFloat64Array()
 }
 
@@ -748,7 +748,7 @@ func (b *Int32Builder) Resize(n int) {
 
 // NewArray creates a Int32 array from the memory buffers used by the builder and resets the Int32Builder
 // so it can be used to build a new array.
-func (b *Int32Builder) NewArray() Interface {
+func (b *Int32Builder) NewArray() arrow.Array {
 	return b.NewInt32Array()
 }
 
@@ -951,7 +951,7 @@ func (b *Uint32Builder) Resize(n int) {
 
 // NewArray creates a Uint32 array from the memory buffers used by the builder and resets the Uint32Builder
 // so it can be used to build a new array.
-func (b *Uint32Builder) NewArray() Interface {
+func (b *Uint32Builder) NewArray() arrow.Array {
 	return b.NewUint32Array()
 }
 
@@ -1154,7 +1154,7 @@ func (b *Float32Builder) Resize(n int) {
 
 // NewArray creates a Float32 array from the memory buffers used by the builder and resets the Float32Builder
 // so it can be used to build a new array.
-func (b *Float32Builder) NewArray() Interface {
+func (b *Float32Builder) NewArray() arrow.Array {
 	return b.NewFloat32Array()
 }
 
@@ -1357,7 +1357,7 @@ func (b *Int16Builder) Resize(n int) {
 
 // NewArray creates a Int16 array from the memory buffers used by the builder and resets the Int16Builder
 // so it can be used to build a new array.
-func (b *Int16Builder) NewArray() Interface {
+func (b *Int16Builder) NewArray() arrow.Array {
 	return b.NewInt16Array()
 }
 
@@ -1560,7 +1560,7 @@ func (b *Uint16Builder) Resize(n int) {
 
 // NewArray creates a Uint16 array from the memory buffers used by the builder and resets the Uint16Builder
 // so it can be used to build a new array.
-func (b *Uint16Builder) NewArray() Interface {
+func (b *Uint16Builder) NewArray() arrow.Array {
 	return b.NewUint16Array()
 }
 
@@ -1763,7 +1763,7 @@ func (b *Int8Builder) Resize(n int) {
 
 // NewArray creates a Int8 array from the memory buffers used by the builder and resets the Int8Builder
 // so it can be used to build a new array.
-func (b *Int8Builder) NewArray() Interface {
+func (b *Int8Builder) NewArray() arrow.Array {
 	return b.NewInt8Array()
 }
 
@@ -1966,7 +1966,7 @@ func (b *Uint8Builder) Resize(n int) {
 
 // NewArray creates a Uint8 array from the memory buffers used by the builder and resets the Uint8Builder
 // so it can be used to build a new array.
-func (b *Uint8Builder) NewArray() Interface {
+func (b *Uint8Builder) NewArray() arrow.Array {
 	return b.NewUint8Array()
 }
 
@@ -2170,7 +2170,7 @@ func (b *TimestampBuilder) Resize(n int) {
 
 // NewArray creates a Timestamp array from the memory buffers used by the builder and resets the TimestampBuilder
 // so it can be used to build a new array.
-func (b *TimestampBuilder) NewArray() Interface {
+func (b *TimestampBuilder) NewArray() arrow.Array {
 	return b.NewTimestampArray()
 }
 
@@ -2362,7 +2362,7 @@ func (b *Time32Builder) Resize(n int) {
 
 // NewArray creates a Time32 array from the memory buffers used by the builder and resets the Time32Builder
 // so it can be used to build a new array.
-func (b *Time32Builder) NewArray() Interface {
+func (b *Time32Builder) NewArray() arrow.Array {
 	return b.NewTime32Array()
 }
 
@@ -2554,7 +2554,7 @@ func (b *Time64Builder) Resize(n int) {
 
 // NewArray creates a Time64 array from the memory buffers used by the builder and resets the Time64Builder
 // so it can be used to build a new array.
-func (b *Time64Builder) NewArray() Interface {
+func (b *Time64Builder) NewArray() arrow.Array {
 	return b.NewTime64Array()
 }
 
@@ -2745,7 +2745,7 @@ func (b *Date32Builder) Resize(n int) {
 
 // NewArray creates a Date32 array from the memory buffers used by the builder and resets the Date32Builder
 // so it can be used to build a new array.
-func (b *Date32Builder) NewArray() Interface {
+func (b *Date32Builder) NewArray() arrow.Array {
 	return b.NewDate32Array()
 }
 
@@ -2936,7 +2936,7 @@ func (b *Date64Builder) Resize(n int) {
 
 // NewArray creates a Date64 array from the memory buffers used by the builder and resets the Date64Builder
 // so it can be used to build a new array.
-func (b *Date64Builder) NewArray() Interface {
+func (b *Date64Builder) NewArray() arrow.Array {
 	return b.NewDate64Array()
 }
 
@@ -3128,7 +3128,7 @@ func (b *DurationBuilder) Resize(n int) {
 
 // NewArray creates a Duration array from the memory buffers used by the builder and resets the DurationBuilder
 // so it can be used to build a new array.
-func (b *DurationBuilder) NewArray() Interface {
+func (b *DurationBuilder) NewArray() arrow.Array {
 	return b.NewDurationArray()
 }
 

--- a/go/arrow/array/numericbuilder.gen.go.tmpl
+++ b/go/arrow/array/numericbuilder.gen.go.tmpl
@@ -140,7 +140,7 @@ func (b *{{.Name}}Builder) Resize(n int) {
 
 // NewArray creates a {{.Name}} array from the memory buffers used by the builder and resets the {{.Name}}Builder
 // so it can be used to build a new array.
-func (b *{{.Name}}Builder) NewArray() Interface {
+func (b *{{.Name}}Builder) NewArray() arrow.Array {
 	return b.New{{.Name}}Array()
 }
 

--- a/go/arrow/array/record.go
+++ b/go/arrow/array/record.go
@@ -108,31 +108,7 @@ func (rs *simpleRecords) Next() bool {
 	return true
 }
 
-// Record is a collection of equal-length arrays
-// matching a particular Schema.
-type Record interface {
-	json.Marshaler
-
-	Release()
-	Retain()
-
-	Schema() *arrow.Schema
-
-	NumRows() int64
-	NumCols() int64
-
-	Columns() []Interface
-	Column(i int) Interface
-	ColumnName(i int) string
-
-	// NewSlice constructs a zero-copy slice of the record with the indicated
-	// indices i and j, corresponding to array[i:j].
-	// The returned record must be Release()'d after use.
-	//
-	// NewSlice panics if the slice is outside the valid range of the record array.
-	// NewSlice panics if j < i.
-	NewSlice(i, j int64) Record
-}
+type Record = arrow.Record
 
 // simpleRecord is a basic, non-lazy in-memory record batch.
 type simpleRecord struct {
@@ -141,19 +117,19 @@ type simpleRecord struct {
 	schema *arrow.Schema
 
 	rows int64
-	arrs []Interface
+	arrs []arrow.Array
 }
 
 // NewRecord returns a basic, non-lazy in-memory record batch.
 //
 // NewRecord panics if the columns and schema are inconsistent.
 // NewRecord panics if rows is larger than the height of the columns.
-func NewRecord(schema *arrow.Schema, cols []Interface, nrows int64) *simpleRecord {
+func NewRecord(schema *arrow.Schema, cols []arrow.Array, nrows int64) *simpleRecord {
 	rec := &simpleRecord{
 		refCount: 1,
 		schema:   schema,
 		rows:     nrows,
-		arrs:     make([]Interface, len(cols)),
+		arrs:     make([]arrow.Array, len(cols)),
 	}
 	copy(rec.arrs, cols)
 	for _, arr := range rec.arrs {
@@ -221,12 +197,12 @@ func (rec *simpleRecord) Release() {
 	}
 }
 
-func (rec *simpleRecord) Schema() *arrow.Schema   { return rec.schema }
-func (rec *simpleRecord) NumRows() int64          { return rec.rows }
-func (rec *simpleRecord) NumCols() int64          { return int64(len(rec.arrs)) }
-func (rec *simpleRecord) Columns() []Interface    { return rec.arrs }
-func (rec *simpleRecord) Column(i int) Interface  { return rec.arrs[i] }
-func (rec *simpleRecord) ColumnName(i int) string { return rec.schema.Field(i).Name }
+func (rec *simpleRecord) Schema() *arrow.Schema    { return rec.schema }
+func (rec *simpleRecord) NumRows() int64           { return rec.rows }
+func (rec *simpleRecord) NumCols() int64           { return int64(len(rec.arrs)) }
+func (rec *simpleRecord) Columns() []arrow.Array   { return rec.arrs }
+func (rec *simpleRecord) Column(i int) arrow.Array { return rec.arrs[i] }
+func (rec *simpleRecord) ColumnName(i int) string  { return rec.schema.Field(i).Name }
 
 // NewSlice constructs a zero-copy slice of the record with the indicated
 // indices i and j, corresponding to array[i:j].
@@ -235,7 +211,7 @@ func (rec *simpleRecord) ColumnName(i int) string { return rec.schema.Field(i).N
 // NewSlice panics if the slice is outside the valid range of the record array.
 // NewSlice panics if j < i.
 func (rec *simpleRecord) NewSlice(i, j int64) Record {
-	arrs := make([]Interface, len(rec.arrs))
+	arrs := make([]arrow.Array, len(rec.arrs))
 	for ii, arr := range rec.arrs {
 		arrs[ii] = NewSlice(arr, i, j)
 	}
@@ -324,10 +300,10 @@ func (b *RecordBuilder) Reserve(size int) {
 //
 // NewRecord panics if the fields' builder do not have the same length.
 func (b *RecordBuilder) NewRecord() Record {
-	cols := make([]Interface, len(b.fields))
+	cols := make([]arrow.Array, len(b.fields))
 	rows := int64(0)
 
-	defer func(cols []Interface) {
+	defer func(cols []arrow.Array) {
 		for _, col := range cols {
 			if col == nil {
 				continue

--- a/go/arrow/array/record.go
+++ b/go/arrow/array/record.go
@@ -108,6 +108,10 @@ func (rs *simpleRecords) Next() bool {
 	return true
 }
 
+// Record aliases arrow.Record so that existing consumers do not get broken
+// by the migration to arrow.Record.
+//
+// Deprecated: this alias will be removed in v8
 type Record = arrow.Record
 
 // simpleRecord is a basic, non-lazy in-memory record batch.

--- a/go/arrow/array/record_test.go
+++ b/go/arrow/array/record_test.go
@@ -38,7 +38,7 @@ func TestRecord(t *testing.T) {
 		},
 		nil,
 	)
-	col1 := func() array.Interface {
+	col1 := func() arrow.Array {
 		ib := array.NewInt32Builder(mem)
 		defer ib.Release()
 
@@ -47,7 +47,7 @@ func TestRecord(t *testing.T) {
 	}()
 	defer col1.Release()
 
-	col2 := func() array.Interface {
+	col2 := func() arrow.Array {
 		b := array.NewFloat64Builder(mem)
 		defer b.Release()
 
@@ -56,7 +56,7 @@ func TestRecord(t *testing.T) {
 	}()
 	defer col2.Release()
 
-	cols := []array.Interface{col1, col2}
+	cols := []arrow.Array{col1, col2}
 	rec := array.NewRecord(schema, cols, -1)
 	defer rec.Release()
 
@@ -128,7 +128,7 @@ func TestRecord(t *testing.T) {
 
 	for _, tc := range []struct {
 		schema *arrow.Schema
-		cols   []array.Interface
+		cols   []arrow.Array
 		rows   int64
 		err    error
 	}{
@@ -233,8 +233,8 @@ func TestRecordReader(t *testing.T) {
 		},
 		nil,
 	)
-	rec1 := func() array.Record {
-		col1 := func() array.Interface {
+	rec1 := func() arrow.Record {
+		col1 := func() arrow.Array {
 			ib := array.NewInt32Builder(mem)
 			defer ib.Release()
 
@@ -243,7 +243,7 @@ func TestRecordReader(t *testing.T) {
 		}()
 		defer col1.Release()
 
-		col2 := func() array.Interface {
+		col2 := func() arrow.Array {
 			b := array.NewFloat64Builder(mem)
 			defer b.Release()
 
@@ -252,13 +252,13 @@ func TestRecordReader(t *testing.T) {
 		}()
 		defer col2.Release()
 
-		cols := []array.Interface{col1, col2}
+		cols := []arrow.Array{col1, col2}
 		return array.NewRecord(schema, cols, -1)
 	}()
 	defer rec1.Release()
 
-	rec2 := func() array.Record {
-		col1 := func() array.Interface {
+	rec2 := func() arrow.Record {
+		col1 := func() arrow.Array {
 			ib := array.NewInt32Builder(mem)
 			defer ib.Release()
 
@@ -267,7 +267,7 @@ func TestRecordReader(t *testing.T) {
 		}()
 		defer col1.Release()
 
-		col2 := func() array.Interface {
+		col2 := func() arrow.Array {
 			b := array.NewFloat64Builder(mem)
 			defer b.Release()
 
@@ -276,12 +276,12 @@ func TestRecordReader(t *testing.T) {
 		}()
 		defer col2.Release()
 
-		cols := []array.Interface{col1, col2}
+		cols := []arrow.Array{col1, col2}
 		return array.NewRecord(schema, cols, -1)
 	}()
 	defer rec2.Release()
 
-	recs := []array.Record{rec1, rec2}
+	recs := []arrow.Record{rec1, rec2}
 	itr, err := array.NewRecordReader(schema, recs)
 	if err != nil {
 		t.Fatal(err)
@@ -473,7 +473,7 @@ var testMessageSchema = arrow.NewSchema(
 	nil,
 )
 
-func (m *testMessage) Fill(rec array.Record, row int) error {
+func (m *testMessage) Fill(rec arrow.Record, row int) error {
 	m.Reset()
 
 	// foo
@@ -572,7 +572,7 @@ type testMessageArrowRecordBuilder struct {
 	rb *array.RecordBuilder
 }
 
-func (b *testMessageArrowRecordBuilder) Build() array.Record {
+func (b *testMessageArrowRecordBuilder) Build() arrow.Record {
 	return b.rb.NewRecord()
 }
 

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -41,16 +41,16 @@ type String struct {
 }
 
 // NewStringData constructs a new String array from data.
-func NewStringData(data *Data) *String {
+func NewStringData(data arrow.ArrayData) *String {
 	a := &String{}
 	a.refCount = 1
-	a.setData(data)
+	a.setData(data.(*Data))
 	return a
 }
 
 // Reset resets the String with a different set of Data.
-func (a *String) Reset(data *Data) {
-	a.setData(data)
+func (a *String) Reset(data arrow.ArrayData) {
+	a.setData(data.(*Data))
 }
 
 // Value returns the slice at index i. This value should not be mutated.
@@ -231,7 +231,7 @@ func (b *StringBuilder) Resize(n int) {
 
 // NewArray creates a String array from the memory buffers used by the builder and resets the StringBuilder
 // so it can be used to build a new array.
-func (b *StringBuilder) NewArray() Interface {
+func (b *StringBuilder) NewArray() arrow.Array {
 	return b.NewStringArray()
 }
 

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -19,7 +19,6 @@ package array
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
 	"unsafe"
@@ -27,10 +26,6 @@ import (
 	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"github.com/goccy/go-json"
-)
-
-const (
-	stringArrayMaximumCapacity = math.MaxInt32
 )
 
 // String represents an immutable sequence of variable-length UTF-8 strings.

--- a/go/arrow/array/table.go
+++ b/go/arrow/array/table.go
@@ -26,18 +26,35 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
+// type aliases to preserve functionality and avoid breaking consumers
+// by the shift to arrow.Table, arrow.Column and arrow.Chunked over array each.
 type (
-	Table   = arrow.Table
-	Column  = arrow.Column
+	// Table aliases arrow.Table
+	//
+	// Deprecated: this alias will be removed in v8
+	Table = arrow.Table
+	// Column aliases arrow.Column
+	//
+	// Deprecated: this alias will be removed in v8
+	Column = arrow.Column
+	// Chunked aliases arrow.Chunked
+	//
+	// Deprecated: this alias will be removed in v8
 	Chunked = arrow.Chunked
 )
 
 var (
-	NewColumn  = arrow.NewColumn
+	// NewColumn aliases the arrow.NewColumn function to avoid breaking consumers.
+	//
+	// Deprecated: this alias will be removed in v8
+	NewColumn = arrow.NewColumn
+	// NewChunked aliases the arrow.NewChunked function to avoid breaking consumers.
+	//
+	// Deprecated: this alias will be removed in v8
 	NewChunked = arrow.NewChunked
 )
 
-// NewColSlice returns a new zero-copy slice of the column with the indicated
+// NewColumnSlice returns a new zero-copy slice of the column with the indicated
 // indices i and j, corresponding to the column's array[i:j].
 // The returned column must be Release()'d after use.
 //
@@ -49,7 +66,7 @@ func NewColumnSlice(col *arrow.Column, i, j int64) *arrow.Column {
 	return arrow.NewColumn(col.Field(), slice)
 }
 
-// NewSlice constructs a zero-copy slice of the chunked array with the indicated
+// NewChunkedSlice constructs a zero-copy slice of the chunked array with the indicated
 // indices i and j, corresponding to array[i:j].
 // The returned chunked array must be Release()'d after use.
 //

--- a/go/arrow/array/table.go
+++ b/go/arrow/array/table.go
@@ -26,135 +26,28 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
-// Table represents a logical sequence of chunked arrays.
-type Table interface {
-	Schema() *arrow.Schema
-	NumRows() int64
-	NumCols() int64
-	Column(i int) *Column
+type (
+	Table   = arrow.Table
+	Column  = arrow.Column
+	Chunked = arrow.Chunked
+)
 
-	Retain()
-	Release()
-}
+var (
+	NewColumn  = arrow.NewColumn
+	NewChunked = arrow.NewChunked
+)
 
-// Column is an immutable column data structure consisting of
-// a field (type metadata) and a chunked data array.
-type Column struct {
-	field arrow.Field
-	data  *Chunked
-}
-
-// NewColumn returns a column from a field and a chunked data array.
-//
-// NewColumn panics if the field's data type is inconsistent with the data type
-// of the chunked data array.
-func NewColumn(field arrow.Field, chunks *Chunked) *Column {
-	col := Column{
-		field: field,
-		data:  chunks,
-	}
-	col.data.Retain()
-
-	if !arrow.TypeEqual(col.data.DataType(), col.field.Type) {
-		col.data.Release()
-		panic("arrow/array: inconsistent data type")
-	}
-
-	return &col
-}
-
-// Retain increases the reference count by 1.
-// Retain may be called simultaneously from multiple goroutines.
-func (col *Column) Retain() {
-	col.data.Retain()
-}
-
-// Release decreases the reference count by 1.
-// When the reference count goes to zero, the memory is freed.
-// Release may be called simultaneously from multiple goroutines.
-func (col *Column) Release() {
-	col.data.Release()
-}
-
-func (col *Column) Len() int                 { return col.data.Len() }
-func (col *Column) NullN() int               { return col.data.NullN() }
-func (col *Column) Data() *Chunked           { return col.data }
-func (col *Column) Field() arrow.Field       { return col.field }
-func (col *Column) Name() string             { return col.field.Name }
-func (col *Column) DataType() arrow.DataType { return col.field.Type }
-
-// NewSlice returns a new zero-copy slice of the column with the indicated
+// NewColSlice returns a new zero-copy slice of the column with the indicated
 // indices i and j, corresponding to the column's array[i:j].
 // The returned column must be Release()'d after use.
 //
-// NewSlice panics if the slice is outside the valid range of the column's array.
-// NewSlice panics if j < i.
-func (col *Column) NewSlice(i, j int64) *Column {
-	return &Column{
-		field: col.field,
-		data:  col.data.NewSlice(i, j),
-	}
+// NewColSlice panics if the slice is outside the valid range of the column's array.
+// NewColSlice panics if j < i.
+func NewColumnSlice(col *arrow.Column, i, j int64) *arrow.Column {
+	slice := NewChunkedSlice(col.Data(), i, j)
+	defer slice.Release()
+	return arrow.NewColumn(col.Field(), slice)
 }
-
-// Chunked manages a collection of primitives arrays as one logical large array.
-type Chunked struct {
-	refCount int64 // refCount must be first in the struct for 64 bit alignment and sync/atomic (https://github.com/golang/go/issues/37262)
-	
-	chunks []Interface
-
-	length int
-	nulls  int
-	dtype  arrow.DataType
-}
-
-// NewChunked returns a new chunked array from the slice of arrays.
-//
-// NewChunked panics if the chunks do not have the same data type.
-func NewChunked(dtype arrow.DataType, chunks []Interface) *Chunked {
-	arr := &Chunked{
-		chunks:   make([]Interface, len(chunks)),
-		refCount: 1,
-		dtype:    dtype,
-	}
-	for i, chunk := range chunks {
-		if !arrow.TypeEqual(chunk.DataType(), dtype) {
-			panic("arrow/array: mismatch data type")
-		}
-		chunk.Retain()
-		arr.chunks[i] = chunk
-		arr.length += chunk.Len()
-		arr.nulls += chunk.NullN()
-	}
-	return arr
-}
-
-// Retain increases the reference count by 1.
-// Retain may be called simultaneously from multiple goroutines.
-func (a *Chunked) Retain() {
-	atomic.AddInt64(&a.refCount, 1)
-}
-
-// Release decreases the reference count by 1.
-// When the reference count goes to zero, the memory is freed.
-// Release may be called simultaneously from multiple goroutines.
-func (a *Chunked) Release() {
-	debug.Assert(atomic.LoadInt64(&a.refCount) > 0, "too many releases")
-
-	if atomic.AddInt64(&a.refCount, -1) == 0 {
-		for _, arr := range a.chunks {
-			arr.Release()
-		}
-		a.chunks = nil
-		a.length = 0
-		a.nulls = 0
-	}
-}
-
-func (a *Chunked) Len() int                 { return a.length }
-func (a *Chunked) NullN() int               { return a.nulls }
-func (a *Chunked) DataType() arrow.DataType { return a.dtype }
-func (a *Chunked) Chunks() []Interface      { return a.chunks }
-func (a *Chunked) Chunk(i int) Interface    { return a.chunks[i] }
 
 // NewSlice constructs a zero-copy slice of the chunked array with the indicated
 // indices i and j, corresponding to array[i:j].
@@ -162,8 +55,8 @@ func (a *Chunked) Chunk(i int) Interface    { return a.chunks[i] }
 //
 // NewSlice panics if the slice is outside the valid range of the input array.
 // NewSlice panics if j < i.
-func (a *Chunked) NewSlice(i, j int64) *Chunked {
-	if j > int64(a.length) || i > j || i > int64(a.length) {
+func NewChunkedSlice(a *arrow.Chunked, i, j int64) *Chunked {
+	if j > int64(a.Len()) || i > j || i > int64(a.Len()) {
 		panic("arrow/array: index out of range")
 	}
 
@@ -171,16 +64,16 @@ func (a *Chunked) NewSlice(i, j int64) *Chunked {
 		cur    = 0
 		beg    = i
 		sz     = j - i
-		chunks = make([]Interface, 0, len(a.chunks))
+		chunks = make([]arrow.Array, 0, len(a.Chunks()))
 	)
 
-	for cur < len(a.chunks) && beg >= int64(a.chunks[cur].Len()) {
-		beg -= int64(a.chunks[cur].Len())
+	for cur < len(a.Chunks()) && beg >= int64(a.Chunks()[cur].Len()) {
+		beg -= int64(a.Chunks()[cur].Len())
 		cur++
 	}
 
-	for cur < len(a.chunks) && sz > 0 {
-		arr := a.chunks[cur]
+	for cur < len(a.Chunks()) && sz > 0 {
+		arr := a.Chunks()[cur]
 		end := beg + sz
 		if end > int64(arr.Len()) {
 			end = int64(arr.Len())
@@ -197,7 +90,7 @@ func (a *Chunked) NewSlice(i, j int64) *Chunked {
 		}
 	}()
 
-	return NewChunked(a.dtype, chunks)
+	return NewChunked(a.DataType(), chunks)
 }
 
 // simpleTable is a basic, non-lazy in-memory table.
@@ -250,7 +143,7 @@ func NewTable(schema *arrow.Schema, cols []Column, rows int64) *simpleTable {
 //
 // NewTableFromRecords panics if the records and schema are inconsistent.
 func NewTableFromRecords(schema *arrow.Schema, recs []Record) *simpleTable {
-	arrs := make([]Interface, len(recs))
+	arrs := make([]arrow.Array, len(recs))
 	cols := make([]Column, len(schema.Fields()))
 
 	defer func(cols []Column) {
@@ -264,8 +157,8 @@ func NewTableFromRecords(schema *arrow.Schema, recs []Record) *simpleTable {
 		for j, rec := range recs {
 			arrs[j] = rec.Column(i)
 		}
-		chunk := NewChunked(field.Type, arrs)
-		cols[i] = *NewColumn(field, chunk)
+		chunk := arrow.NewChunked(field.Type, arrs)
+		cols[i] = *arrow.NewColumn(field, chunk)
 		chunk.Release()
 	}
 
@@ -282,7 +175,7 @@ func (tbl *simpleTable) validate() {
 		panic(errors.New("arrow/array: table schema mismatch"))
 	}
 	for i, col := range tbl.cols {
-		if !col.field.Equal(tbl.schema.Field(i)) {
+		if !col.Field().Equal(tbl.schema.Field(i)) {
 			panic(fmt.Errorf("arrow/array: column field %q is inconsistent with schema", col.Name()))
 		}
 
@@ -369,7 +262,7 @@ func (tr *TableReader) Next() bool {
 
 	// determine the minimum contiguous slice across all columns
 	chunksz := imin64(tr.max, tr.chksz)
-	chunks := make([]Interface, len(tr.chunks))
+	chunks := make([]arrow.Array, len(tr.chunks))
 	for i := range chunks {
 		j := tr.slots[i]
 		chunk := tr.chunks[i].Chunk(j)
@@ -382,9 +275,9 @@ func (tr *TableReader) Next() bool {
 	}
 
 	// slice the chunks, advance each chunk slot as appropriate.
-	batch := make([]Interface, len(tr.chunks))
+	batch := make([]arrow.Array, len(tr.chunks))
 	for i, chunk := range chunks {
-		var slice Interface
+		var slice arrow.Array
 		offset := tr.offsets[i]
 		switch int64(chunk.Len()) - offset {
 		case chunksz:

--- a/go/arrow/array/table_test.go
+++ b/go/arrow/array/table_test.go
@@ -61,7 +61,7 @@ func TestChunked(t *testing.T) {
 
 	c2 := array.NewChunked(
 		arrow.PrimitiveTypes.Float64,
-		[]array.Interface{f1, f2, f3},
+		[]arrow.Array{f1, f2, f3},
 	)
 	defer c2.Release()
 
@@ -93,7 +93,7 @@ func TestChunked(t *testing.T) {
 		{i: 10, j: 10, len: 0, nulls: 0, chunks: 0},
 	} {
 		t.Run("", func(t *testing.T) {
-			sub := c2.NewSlice(tc.i, tc.j)
+			sub := array.NewChunkedSlice(c2, tc.i, tc.j)
 			defer sub.Release()
 
 			if got, want := sub.Len(), tc.len; got != want {
@@ -128,7 +128,7 @@ func TestChunkedEqualDataType(t *testing.T) {
 	v2 := lb2.NewArray()
 	defer v2.Release()
 
-	c1 := array.NewChunked(arrow.ListOf(arrow.PrimitiveTypes.Int32), []array.Interface{
+	c1 := array.NewChunked(arrow.ListOf(arrow.PrimitiveTypes.Int32), []arrow.Array{
 		v1, v2,
 	})
 	defer c1.Release()
@@ -162,7 +162,7 @@ func TestChunkedInvalid(t *testing.T) {
 		}
 	}()
 
-	c1 := array.NewChunked(arrow.PrimitiveTypes.Int32, []array.Interface{
+	c1 := array.NewChunked(arrow.PrimitiveTypes.Int32, []arrow.Array{
 		f1, f2,
 	})
 	defer c1.Release()
@@ -189,7 +189,7 @@ func TestChunkedSliceInvalid(t *testing.T) {
 
 	c := array.NewChunked(
 		arrow.PrimitiveTypes.Float64,
-		[]array.Interface{f1, f2, f3},
+		[]arrow.Array{f1, f2, f3},
 	)
 	defer c.Release()
 
@@ -210,7 +210,7 @@ func TestChunkedSliceInvalid(t *testing.T) {
 					t.Fatalf("invalid error. got=%q, want=%q", got, want)
 				}
 			}()
-			sub := c.NewSlice(tc.i, tc.j)
+			sub := array.NewChunkedSlice(c, tc.i, tc.j)
 			defer sub.Release()
 		})
 	}
@@ -248,7 +248,7 @@ func TestColumn(t *testing.T) {
 
 				c := array.NewChunked(
 					arrow.PrimitiveTypes.Int32,
-					[]array.Interface{i1, i2},
+					[]arrow.Array{i1, i2},
 				)
 				return c
 			}(),
@@ -282,7 +282,7 @@ func TestColumn(t *testing.T) {
 
 				c := array.NewChunked(
 					arrow.PrimitiveTypes.Float64,
-					[]array.Interface{f1, f2, f3},
+					[]arrow.Array{f1, f2, f3},
 				)
 				return c
 			}(),
@@ -308,7 +308,7 @@ func TestColumn(t *testing.T) {
 
 				c := array.NewChunked(
 					arrow.PrimitiveTypes.Float64,
-					[]array.Interface{f1},
+					[]arrow.Array{f1},
 				)
 				return c
 			}(),
@@ -367,7 +367,7 @@ func TestColumn(t *testing.T) {
 
 			for _, slice := range tc.slices {
 				t.Run("", func(t *testing.T) {
-					sub := col.NewSlice(slice.i, slice.j)
+					sub := array.NewColumnSlice(col, slice.i, slice.j)
 					defer sub.Release()
 
 					if got, want := sub.Len(), slice.len; got != want {
@@ -415,7 +415,7 @@ func TestTable(t *testing.T) {
 
 			c := array.NewChunked(
 				arrow.PrimitiveTypes.Int32,
-				[]array.Interface{i1, i2},
+				[]arrow.Array{i1, i2},
 			)
 			return c
 		}()
@@ -444,7 +444,7 @@ func TestTable(t *testing.T) {
 
 			c := array.NewChunked(
 				arrow.PrimitiveTypes.Float64,
-				[]array.Interface{f1, f2, f3},
+				[]arrow.Array{f1, f2, f3},
 			)
 			return c
 		}()
@@ -600,7 +600,7 @@ func TestTableFromRecords(t *testing.T) {
 	rec2 := b.NewRecord()
 	defer rec2.Release()
 
-	tbl := array.NewTableFromRecords(schema, []array.Record{rec1, rec2})
+	tbl := array.NewTableFromRecords(schema, []arrow.Record{rec1, rec2})
 	defer tbl.Release()
 
 	if got, want := tbl.Schema(), schema; !got.Equal(want) {
@@ -644,7 +644,7 @@ func TestTableReader(t *testing.T) {
 
 			c := array.NewChunked(
 				arrow.PrimitiveTypes.Int32,
-				[]array.Interface{i1, i2},
+				[]arrow.Array{i1, i2},
 			)
 			return c
 		}()
@@ -673,7 +673,7 @@ func TestTableReader(t *testing.T) {
 
 			c := array.NewChunked(
 				arrow.PrimitiveTypes.Float64,
-				[]array.Interface{f1, f2, f3},
+				[]arrow.Array{f1, f2, f3},
 			)
 			return c
 		}()

--- a/go/arrow/array/util.go
+++ b/go/arrow/array/util.go
@@ -107,7 +107,7 @@ func WithStartOffset(off int64) FromJSONOption {
 // The fractions of a second cannot exceed the precision allowed by the timeunit of the datatype.
 //
 // When processing structs as objects order of keys does not matter, but keys cannot be repeated.
-func FromJSON(mem memory.Allocator, dt arrow.DataType, r io.Reader, opts ...FromJSONOption) (arr Interface, offset int64, err error) {
+func FromJSON(mem memory.Allocator, dt arrow.DataType, r io.Reader, opts ...FromJSONOption) (arr arrow.Array, offset int64, err error) {
 	var cfg fromJSONCfg
 	for _, o := range opts {
 		o(&cfg)
@@ -160,7 +160,7 @@ func FromJSON(mem memory.Allocator, dt arrow.DataType, r io.Reader, opts ...From
 // RecordToStructArray constructs a struct array from the columns of the record batch
 // by referencing them, zero-copy.
 func RecordToStructArray(rec Record) *Struct {
-	cols := make([]*Data, rec.NumCols())
+	cols := make([]arrow.ArrayData, rec.NumCols())
 	for i, c := range rec.Columns() {
 		cols[i] = c.Data()
 	}
@@ -210,7 +210,7 @@ func RecordToJSON(rec Record, w io.Writer) error {
 	cols := make(map[string]interface{})
 	for i := 0; int64(i) < rec.NumRows(); i++ {
 		for j, c := range rec.Columns() {
-			cols[fields[j].Name] = c.getOneForMarshal(i)
+			cols[fields[j].Name] = c.(arraymarshal).getOneForMarshal(i)
 		}
 		if err := enc.Encode(cols); err != nil {
 			return err

--- a/go/arrow/array/util.go
+++ b/go/arrow/array/util.go
@@ -57,7 +57,7 @@ func WithStartOffset(off int64) FromJSONOption {
 	}
 }
 
-// FromJSON creates an array.Interface from a corresponding JSON stream and defined data type. If the types in the
+// FromJSON creates an arrow.Array from a corresponding JSON stream and defined data type. If the types in the
 // json do not match the type provided, it will return errors. This is *not* the integration test format
 // and should not be used as such. This intended to be used by consumers more similarly to the current exposing of
 // the csv reader/writer. It also returns the input offset in the reader where it finished decoding since buffering

--- a/go/arrow/arrio/arrio.go
+++ b/go/arrow/arrio/arrio.go
@@ -21,25 +21,25 @@ package arrio
 import (
 	"io"
 
-	"github.com/apache/arrow/go/v7/arrow/array"
+	"github.com/apache/arrow/go/v7/arrow"
 )
 
 // Reader is the interface that wraps the Read method.
 type Reader interface {
 	// Read reads the current record from the underlying stream and an error, if any.
 	// When the Reader reaches the end of the underlying stream, it returns (nil, io.EOF).
-	Read() (array.Record, error)
+	Read() (arrow.Record, error)
 }
 
 // ReaderAt is the interface that wraps the ReadAt method.
 type ReaderAt interface {
 	// ReadAt reads the i-th record from the underlying stream and an error, if any.
-	ReadAt(i int64) (array.Record, error)
+	ReadAt(i int64) (arrow.Record, error)
 }
 
 // Writer is the interface that wraps the Write method.
 type Writer interface {
-	Write(rec array.Record) error
+	Write(rec arrow.Record) error
 }
 
 // Copy copies all the records available from src to dst.

--- a/go/arrow/arrio/arrio_test.go
+++ b/go/arrow/arrio/arrio_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/arrio"
 	"github.com/apache/arrow/go/v7/arrow/internal/arrdata"
 	"github.com/apache/arrow/go/v7/arrow/ipc"
@@ -38,7 +37,7 @@ const (
 	streamKind
 )
 
-func (k copyKind) write(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func (k copyKind) write(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	switch k {
@@ -51,7 +50,7 @@ func (k copyKind) write(t *testing.T, f *os.File, mem memory.Allocator, schema *
 	}
 }
 
-func (k copyKind) check(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func (k copyKind) check(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	switch k {

--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
 // +build cgo
 
 package cdata
@@ -374,7 +375,7 @@ func (imp *cimporter) doImport(src *CArrowArray) error {
 			return err
 		}
 
-		imp.data = array.NewData(dt, int(imp.arr.length), []*memory.Buffer{nulls}, []*array.Data{imp.children[0].data}, int(imp.arr.null_count), int(imp.arr.offset))
+		imp.data = array.NewData(dt, int(imp.arr.length), []*memory.Buffer{nulls}, []arrow.ArrayData{imp.children[0].data}, int(imp.arr.null_count), int(imp.arr.offset))
 	case *arrow.StructType:
 		if err := imp.checkNumBuffers(1); err != nil {
 			return err
@@ -385,7 +386,7 @@ func (imp *cimporter) doImport(src *CArrowArray) error {
 			return err
 		}
 
-		children := make([]*array.Data, len(imp.children))
+		children := make([]arrow.ArrayData, len(imp.children))
 		for i := range imp.children {
 			children[i] = imp.children[i].data
 		}
@@ -433,7 +434,7 @@ func (imp *cimporter) importListLike() error {
 	}
 
 	offsets := imp.importOffsetsBuffer(1)
-	imp.data = array.NewData(imp.dt, int(imp.arr.length), []*memory.Buffer{nulls, offsets}, []*array.Data{imp.children[0].data}, int(imp.arr.null_count), int(imp.arr.offset))
+	imp.data = array.NewData(imp.dt, int(imp.arr.length), []*memory.Buffer{nulls, offsets}, []arrow.ArrayData{imp.children[0].data}, int(imp.arr.null_count), int(imp.arr.offset))
 	return nil
 }
 
@@ -548,7 +549,7 @@ func (n *nativeCRecordBatchReader) getError(errno int) error {
 	return xerrors.Errorf("%w: %s", syscall.Errno(errno), C.GoString(C.stream_get_last_error(n.stream)))
 }
 
-func (n *nativeCRecordBatchReader) Read() (array.Record, error) {
+func (n *nativeCRecordBatchReader) Read() (arrow.Record, error) {
 	if n.schema == nil {
 		var sc CArrowSchema
 		errno := C.stream_get_schema(n.stream, &sc)

--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -255,7 +255,7 @@ func importSchema(schema *CArrowSchema) (ret arrow.Field, err error) {
 type cimporter struct {
 	dt       arrow.DataType
 	arr      *CArrowArray
-	data     *array.Data
+	data     arrow.ArrayData
 	parent   *cimporter
 	children []cimporter
 	cbuffers []*C.void
@@ -317,11 +317,11 @@ func (imp *cimporter) doImport(src *CArrowArray) error {
 	imp.initarr()
 	// move the array from the src object passed in to the one referenced by
 	// this importer. That way we can set up a finalizer on the created
-	// *array.Data object so we clean up our Array's memory when garbage collected.
+	// arrow.ArrayData object so we clean up our Array's memory when garbage collected.
 	C.ArrowArrayMove(src, imp.arr)
 	defer func(arr *CArrowArray) {
 		if imp.data != nil {
-			runtime.SetFinalizer(imp.data, func(*array.Data) {
+			runtime.SetFinalizer(imp.data, func(arrow.ArrayData) {
 				defer C.free(unsafe.Pointer(arr))
 				C.ArrowArrayRelease(arr)
 				if C.ArrowArrayIsReleased(arr) != 1 {

--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -328,7 +328,7 @@ func exportField(field arrow.Field, out *CArrowSchema) {
 	exp.finish(out)
 }
 
-func exportArray(arr array.Interface, out *CArrowArray, outSchema *CArrowSchema) {
+func exportArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 	if outSchema != nil {
 		exportField(arrow.Field{Type: arr.DataType()}, outSchema)
 	}

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build cgo
-// +build test
+//go:build cgo && test
+// +build cgo,test
 
 // use test tag so that we only run these tests when the "test" tag is present
 // so that the .c and other framework infrastructure is only compiled in during
@@ -82,7 +82,7 @@ func TestSimpleArrayAndSchema(t *testing.T) {
 	assert.EqualValues(t, 10, arr.Len())
 
 	// verify that the address is the same of the first integer for the
-	// slice that is being used by the array.Interface and the original buffer
+	// slice that is being used by the arrow.Array and the original buffer
 	vals := arr.(*array.Int32).Int32Values()
 	assert.Same(t, &vals[0], &origvals[0])
 
@@ -280,7 +280,7 @@ func TestSchema(t *testing.T) {
 	assert.True(t, schemaIsReleased(top))
 }
 
-func createTestInt8Arr() array.Interface {
+func createTestInt8Arr() arrow.Array {
 	bld := array.NewInt8Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -288,7 +288,7 @@ func createTestInt8Arr() array.Interface {
 	return bld.NewInt8Array()
 }
 
-func createTestInt16Arr() array.Interface {
+func createTestInt16Arr() arrow.Array {
 	bld := array.NewInt16Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -296,7 +296,7 @@ func createTestInt16Arr() array.Interface {
 	return bld.NewInt16Array()
 }
 
-func createTestInt32Arr() array.Interface {
+func createTestInt32Arr() arrow.Array {
 	bld := array.NewInt32Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -304,7 +304,7 @@ func createTestInt32Arr() array.Interface {
 	return bld.NewInt32Array()
 }
 
-func createTestInt64Arr() array.Interface {
+func createTestInt64Arr() arrow.Array {
 	bld := array.NewInt64Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -312,7 +312,7 @@ func createTestInt64Arr() array.Interface {
 	return bld.NewInt64Array()
 }
 
-func createTestUint8Arr() array.Interface {
+func createTestUint8Arr() arrow.Array {
 	bld := array.NewUint8Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -320,7 +320,7 @@ func createTestUint8Arr() array.Interface {
 	return bld.NewUint8Array()
 }
 
-func createTestUint16Arr() array.Interface {
+func createTestUint16Arr() arrow.Array {
 	bld := array.NewUint16Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -328,7 +328,7 @@ func createTestUint16Arr() array.Interface {
 	return bld.NewUint16Array()
 }
 
-func createTestUint32Arr() array.Interface {
+func createTestUint32Arr() arrow.Array {
 	bld := array.NewUint32Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -336,7 +336,7 @@ func createTestUint32Arr() array.Interface {
 	return bld.NewUint32Array()
 }
 
-func createTestUint64Arr() array.Interface {
+func createTestUint64Arr() arrow.Array {
 	bld := array.NewUint64Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -344,7 +344,7 @@ func createTestUint64Arr() array.Interface {
 	return bld.NewUint64Array()
 }
 
-func createTestBoolArr() array.Interface {
+func createTestBoolArr() arrow.Array {
 	bld := array.NewBooleanBuilder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -352,11 +352,11 @@ func createTestBoolArr() array.Interface {
 	return bld.NewBooleanArray()
 }
 
-func createTestNullArr() array.Interface {
+func createTestNullArr() arrow.Array {
 	return array.NewNull(2)
 }
 
-func createTestFloat32Arr() array.Interface {
+func createTestFloat32Arr() arrow.Array {
 	bld := array.NewFloat32Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -364,7 +364,7 @@ func createTestFloat32Arr() array.Interface {
 	return bld.NewFloat32Array()
 }
 
-func createTestFloat64Arr() array.Interface {
+func createTestFloat64Arr() arrow.Array {
 	bld := array.NewFloat64Builder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -372,7 +372,7 @@ func createTestFloat64Arr() array.Interface {
 	return bld.NewFloat64Array()
 }
 
-func createTestFSBArr() array.Interface {
+func createTestFSBArr() arrow.Array {
 	bld := array.NewFixedSizeBinaryBuilder(memory.DefaultAllocator, &arrow.FixedSizeBinaryType{ByteWidth: 3})
 	defer bld.Release()
 
@@ -380,7 +380,7 @@ func createTestFSBArr() array.Interface {
 	return bld.NewFixedSizeBinaryArray()
 }
 
-func createTestBinaryArr() array.Interface {
+func createTestBinaryArr() arrow.Array {
 	bld := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 	defer bld.Release()
 
@@ -388,7 +388,7 @@ func createTestBinaryArr() array.Interface {
 	return bld.NewBinaryArray()
 }
 
-func createTestStrArr() array.Interface {
+func createTestStrArr() arrow.Array {
 	bld := array.NewStringBuilder(memory.DefaultAllocator)
 	defer bld.Release()
 
@@ -396,7 +396,7 @@ func createTestStrArr() array.Interface {
 	return bld.NewStringArray()
 }
 
-func createTestDecimalArr() array.Interface {
+func createTestDecimalArr() arrow.Array {
 	bld := array.NewDecimal128Builder(memory.DefaultAllocator, &arrow.Decimal128Type{Precision: 16, Scale: 4})
 	defer bld.Release()
 
@@ -407,7 +407,7 @@ func createTestDecimalArr() array.Interface {
 func TestPrimitiveArrs(t *testing.T) {
 	tests := []struct {
 		name string
-		fn   func() array.Interface
+		fn   func() arrow.Array
 	}{
 		{"int8", createTestInt8Arr},
 		{"uint8", createTestUint8Arr},
@@ -464,7 +464,7 @@ func TestPrimitiveSliced(t *testing.T) {
 	imported.Release()
 }
 
-func createTestListArr() array.Interface {
+func createTestListArr() arrow.Array {
 	bld := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int8)
 	defer bld.Release()
 
@@ -481,7 +481,7 @@ func createTestListArr() array.Interface {
 	return bld.NewArray()
 }
 
-func createTestFixedSizeList() array.Interface {
+func createTestFixedSizeList() arrow.Array {
 	bld := array.NewFixedSizeListBuilder(memory.DefaultAllocator, 2, arrow.PrimitiveTypes.Int64)
 	defer bld.Release()
 
@@ -497,7 +497,7 @@ func createTestFixedSizeList() array.Interface {
 	return bld.NewArray()
 }
 
-func createTestStructArr() array.Interface {
+func createTestStructArr() arrow.Array {
 	bld := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
 		arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int8, Nullable: true},
 		arrow.Field{Name: "b", Type: arrow.BinaryTypes.String, Nullable: true},
@@ -518,7 +518,7 @@ func createTestStructArr() array.Interface {
 	return bld.NewArray()
 }
 
-func createTestMapArr() array.Interface {
+func createTestMapArr() arrow.Array {
 	bld := array.NewMapBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int8, arrow.BinaryTypes.String, false)
 	defer bld.Release()
 
@@ -541,7 +541,7 @@ func createTestMapArr() array.Interface {
 func TestNestedArrays(t *testing.T) {
 	tests := []struct {
 		name string
-		fn   func() array.Interface
+		fn   func() arrow.Array
 	}{
 		{"list", createTestListArr},
 		{"fixed size list", createTestFixedSizeList},
@@ -587,7 +587,7 @@ func TestRecordBatch(t *testing.T) {
 	assert.Equal(t, "a", rbschema.Field(0).Name)
 	assert.Equal(t, "b", rbschema.Field(1).Name)
 
-	rec := array.NewRecord(rbschema, []array.Interface{arr.(*array.Struct).Field(0), arr.(*array.Struct).Field(1)}, -1)
+	rec := array.NewRecord(rbschema, []arrow.Array{arr.(*array.Struct).Field(0), arr.(*array.Struct).Field(1)}, -1)
 	defer rec.Release()
 
 	assert.True(t, array.RecordEqual(rb, rec))

--- a/go/arrow/cdata/cdata_test_framework.go
+++ b/go/arrow/cdata/cdata_test_framework.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build test
 // +build test
 
 package cdata
@@ -195,7 +196,7 @@ func freeTestArr(carr *CArrowArray) {
 	C.free(unsafe.Pointer(carr))
 }
 
-func createCArr(arr array.Interface) *CArrowArray {
+func createCArr(arr arrow.Array) *CArrowArray {
 	var (
 		carr      = C.get_test_arr()
 		children  = (**CArrowArray)(nil)

--- a/go/arrow/cdata/exports.go
+++ b/go/arrow/cdata/exports.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/array"
 )
 
@@ -36,7 +37,7 @@ var (
 
 type dataHandle uintptr
 
-func storeData(d *array.Data) dataHandle {
+func storeData(d arrow.ArrayData) dataHandle {
 	h := atomic.AddUintptr(&handleIdx, 1)
 	if h == 0 {
 		panic("cgo: ran out of space")

--- a/go/arrow/cdata/exports.go
+++ b/go/arrow/cdata/exports.go
@@ -23,7 +23,6 @@ import (
 	"unsafe"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 )
 
 // #include <stdlib.h>
@@ -52,7 +51,7 @@ func (d dataHandle) releaseData() {
 	if !ok {
 		panic("cgo: invalid datahandle")
 	}
-	arrd.(*array.Data).Release()
+	arrd.(arrow.ArrayData).Release()
 }
 
 //export releaseExportedSchema

--- a/go/arrow/cdata/interface.go
+++ b/go/arrow/cdata/interface.go
@@ -66,13 +66,13 @@ func ImportCArrowSchema(out *CArrowSchema) (*arrow.Schema, error) {
 //
 // The underlying buffers will not be copied, but will instead be referenced directly
 // by the resulting array interface object. The passed in ArrowArray will have it's ownership
-// transferred to the resulting array.Interface via ArrowArrayMove. The underlying array.Data
+// transferred to the resulting arrow.Array via ArrowArrayMove. The underlying array.Data
 // object that is owned by the Array will now be the owner of the memory pointer and
 // will call ArrowArrayRelease when it is released and garbage collected via runtime.SetFinalizer.
 //
 // NOTE: The array takes ownership of the underlying memory buffers via ArrowArrayMove,
 // it does not take ownership of the actual arr object itself.
-func ImportCArrayWithType(arr *CArrowArray, dt arrow.DataType) (array.Interface, error) {
+func ImportCArrayWithType(arr *CArrowArray, dt arrow.DataType) (arrow.Array, error) {
 	imp, err := importCArrayAsType(arr, dt)
 	if err != nil {
 		return nil, err
@@ -88,12 +88,12 @@ func ImportCArrayWithType(arr *CArrowArray, dt arrow.DataType) (array.Interface,
 //
 // The Schema will be copied with the information used to populate the returned Field, complete
 // with metadata. The array will reference the same memory that is referred to by the ArrowArray
-// object and take ownership of it as per ImportCArrayWithType. The returned array.Interface will
+// object and take ownership of it as per ImportCArrayWithType. The returned arrow.Array will
 // own the C memory and call ArrowArrayRelease when the array.Data object is cleaned up.
 //
 // NOTE: The array takes ownership of the underlying memory buffers via ArrowArrayMove,
 // it does not take ownership of the actual arr object itself.
-func ImportCArray(arr *CArrowArray, schema *CArrowSchema) (arrow.Field, array.Interface, error) {
+func ImportCArray(arr *CArrowArray, schema *CArrowSchema) (arrow.Field, arrow.Array, error) {
 	field, err := importSchema(schema)
 	if err != nil {
 		return field, nil, err
@@ -122,7 +122,7 @@ func ImportCRecordBatchWithSchema(arr *CArrowArray, sc *arrow.Schema) (arrow.Rec
 
 	// now that we have our fields, we can split them out into the slice of arrays
 	// and construct a record batch from them to return.
-	cols := make([]array.Interface, st.NumField())
+	cols := make([]arrow.Array, st.NumField())
 	for i := 0; i < st.NumField(); i++ {
 		cols[i] = st.Field(i)
 	}
@@ -218,10 +218,10 @@ func ExportArrowRecordBatch(rb arrow.Record, out *CArrowArray, outSchema *CArrow
 }
 
 // ExportArrowArray populates the CArrowArray that is passed in with the pointers to the memory
-// being used by the array.Interface passed in, in order to share with zero-copy across the C
+// being used by the arrow.Array passed in, in order to share with zero-copy across the C
 // Data Interface. See the documentation for ExportArrowRecordBatch for details on how to ensure
 // you do not leak memory and prevent unwanted, undefined or strange behaviors.
-func ExportArrowArray(arr array.Interface, out *CArrowArray, outSchema *CArrowSchema) {
+func ExportArrowArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 	exportArray(arr, out, outSchema)
 }
 

--- a/go/arrow/cdata/interface.go
+++ b/go/arrow/cdata/interface.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
 // +build cgo
 
 package cdata
@@ -110,7 +111,7 @@ func ImportCArray(arr *CArrowArray, schema *CArrowSchema) (arrow.Field, array.In
 //
 // NOTE: The array takes ownership of the underlying memory buffers via ArrowArrayMove,
 // it does not take ownership of the actual arr object itself.
-func ImportCRecordBatchWithSchema(arr *CArrowArray, sc *arrow.Schema) (array.Record, error) {
+func ImportCRecordBatchWithSchema(arr *CArrowArray, sc *arrow.Schema) (arrow.Record, error) {
 	imp, err := importCArrayAsType(arr, arrow.StructOf(sc.Fields()...))
 	if err != nil {
 		return nil, err
@@ -141,7 +142,7 @@ func ImportCRecordBatchWithSchema(arr *CArrowArray, sc *arrow.Schema) (array.Rec
 //
 // NOTE: The array takes ownership of the underlying memory buffers via ArrowArrayMove,
 // it does not take ownership of the actual arr object itself.
-func ImportCRecordBatch(arr *CArrowArray, sc *CArrowSchema) (array.Record, error) {
+func ImportCRecordBatch(arr *CArrowArray, sc *CArrowSchema) (arrow.Record, error) {
 	field, err := importSchema(sc)
 	if err != nil {
 		return nil, err
@@ -197,8 +198,8 @@ func ExportArrowSchema(schema *arrow.Schema, out *CArrowSchema) {
 // The release function on the populated CArrowArray will properly decrease the reference counts,
 // and release the memory if the record has already been released. But since this must be explicitly
 // done, make sure it is released so that you do not create a memory leak.
-func ExportArrowRecordBatch(rb array.Record, out *CArrowArray, outSchema *CArrowSchema) {
-	children := make([]*array.Data, rb.NumCols())
+func ExportArrowRecordBatch(rb arrow.Record, out *CArrowArray, outSchema *CArrowSchema) {
+	children := make([]arrow.ArrayData, rb.NumCols())
 	for i := range rb.Columns() {
 		children[i] = rb.Column(i).Data()
 	}

--- a/go/arrow/cdata/test/test_cimport.go
+++ b/go/arrow/cdata/test/test_cimport.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cdata_test
 // +build cdata_test
 
 package main
@@ -109,7 +110,7 @@ func makeSchema() *arrow.Schema {
 	}, &meta)
 }
 
-func makeBatch() array.Record {
+func makeBatch() arrow.Record {
 	bldr := array.NewRecordBuilder(alloc, makeSchema())
 	defer bldr.Release()
 

--- a/go/arrow/compute/datum.go
+++ b/go/arrow/compute/datum.go
@@ -317,7 +317,7 @@ func NewDatum(value interface{}) Datum {
 		return v
 	case array.Interface:
 		v.Data().Retain()
-		return &ArrayDatum{v.Data()}
+		return &ArrayDatum{v.Data().(*array.Data)}
 	case *array.Chunked:
 		v.Retain()
 		return &ChunkedDatum{v}

--- a/go/arrow/compute/datum.go
+++ b/go/arrow/compute/datum.go
@@ -86,7 +86,7 @@ type ArrayLikeDatum interface {
 	Descr() ValueDescr
 	NullN() int64
 	Type() arrow.DataType
-	Chunks() []array.Interface
+	Chunks() []arrow.Array
 }
 
 // TableLikeDatum is an interface type for specifying either a RecordBatch or a
@@ -113,13 +113,13 @@ type ScalarDatum struct {
 	Value scalar.Scalar
 }
 
-func (ScalarDatum) Kind() DatumKind           { return KindScalar }
-func (ScalarDatum) Shape() ValueShape         { return ShapeScalar }
-func (ScalarDatum) Len() int64                { return 1 }
-func (ScalarDatum) Chunks() []array.Interface { return nil }
-func (d *ScalarDatum) Type() arrow.DataType   { return d.Value.DataType() }
-func (d *ScalarDatum) String() string         { return d.Value.String() }
-func (d *ScalarDatum) Descr() ValueDescr      { return ValueDescr{ShapeScalar, d.Value.DataType()} }
+func (ScalarDatum) Kind() DatumKind         { return KindScalar }
+func (ScalarDatum) Shape() ValueShape       { return ShapeScalar }
+func (ScalarDatum) Len() int64              { return 1 }
+func (ScalarDatum) Chunks() []arrow.Array   { return nil }
+func (d *ScalarDatum) Type() arrow.DataType { return d.Value.DataType() }
+func (d *ScalarDatum) String() string       { return d.Value.String() }
+func (d *ScalarDatum) Descr() ValueDescr    { return ValueDescr{ShapeScalar, d.Value.DataType()} }
 func (d *ScalarDatum) ToScalar() (scalar.Scalar, error) {
 	return d.Value, nil
 }
@@ -151,18 +151,18 @@ func (d *ScalarDatum) Equals(other Datum) bool {
 // ArrayDatum references an array.Data object which can be used to create
 // array instances from if needed.
 type ArrayDatum struct {
-	Value *array.Data
+	Value arrow.ArrayData
 }
 
-func (ArrayDatum) Kind() DatumKind               { return KindArray }
-func (ArrayDatum) Shape() ValueShape             { return ShapeArray }
-func (d *ArrayDatum) Type() arrow.DataType       { return d.Value.DataType() }
-func (d *ArrayDatum) Len() int64                 { return int64(d.Value.Len()) }
-func (d *ArrayDatum) NullN() int64               { return int64(d.Value.NullN()) }
-func (d *ArrayDatum) Descr() ValueDescr          { return ValueDescr{ShapeArray, d.Value.DataType()} }
-func (d *ArrayDatum) String() string             { return fmt.Sprintf("Array:{%s}", d.Value.DataType()) }
-func (d *ArrayDatum) MakeArray() array.Interface { return array.MakeFromData(d.Value) }
-func (d *ArrayDatum) Chunks() []array.Interface  { return []array.Interface{d.MakeArray()} }
+func (ArrayDatum) Kind() DatumKind           { return KindArray }
+func (ArrayDatum) Shape() ValueShape         { return ShapeArray }
+func (d *ArrayDatum) Type() arrow.DataType   { return d.Value.DataType() }
+func (d *ArrayDatum) Len() int64             { return int64(d.Value.Len()) }
+func (d *ArrayDatum) NullN() int64           { return int64(d.Value.NullN()) }
+func (d *ArrayDatum) Descr() ValueDescr      { return ValueDescr{ShapeArray, d.Value.DataType()} }
+func (d *ArrayDatum) String() string         { return fmt.Sprintf("Array:{%s}", d.Value.DataType()) }
+func (d *ArrayDatum) MakeArray() arrow.Array { return array.MakeFromData(d.Value) }
+func (d *ArrayDatum) Chunks() []arrow.Array  { return []arrow.Array{d.MakeArray()} }
 func (d *ArrayDatum) ToScalar() (scalar.Scalar, error) {
 	return scalar.NewListScalarData(d.Value), nil
 }
@@ -187,17 +187,17 @@ func (d *ArrayDatum) Equals(other Datum) bool {
 
 // ChunkedDatum contains a chunked array for use with expressions and compute.
 type ChunkedDatum struct {
-	Value *array.Chunked
+	Value *arrow.Chunked
 }
 
-func (ChunkedDatum) Kind() DatumKind              { return KindChunked }
-func (ChunkedDatum) Shape() ValueShape            { return ShapeArray }
-func (d *ChunkedDatum) Type() arrow.DataType      { return d.Value.DataType() }
-func (d *ChunkedDatum) Len() int64                { return int64(d.Value.Len()) }
-func (d *ChunkedDatum) NullN() int64              { return int64(d.Value.NullN()) }
-func (d *ChunkedDatum) Descr() ValueDescr         { return ValueDescr{ShapeArray, d.Value.DataType()} }
-func (d *ChunkedDatum) String() string            { return fmt.Sprintf("Array:{%s}", d.Value.DataType()) }
-func (d *ChunkedDatum) Chunks() []array.Interface { return d.Value.Chunks() }
+func (ChunkedDatum) Kind() DatumKind          { return KindChunked }
+func (ChunkedDatum) Shape() ValueShape        { return ShapeArray }
+func (d *ChunkedDatum) Type() arrow.DataType  { return d.Value.DataType() }
+func (d *ChunkedDatum) Len() int64            { return int64(d.Value.Len()) }
+func (d *ChunkedDatum) NullN() int64          { return int64(d.Value.NullN()) }
+func (d *ChunkedDatum) Descr() ValueDescr     { return ValueDescr{ShapeArray, d.Value.DataType()} }
+func (d *ChunkedDatum) String() string        { return fmt.Sprintf("Array:{%s}", d.Value.DataType()) }
+func (d *ChunkedDatum) Chunks() []arrow.Array { return d.Value.Chunks() }
 
 func (d *ChunkedDatum) Release() {
 	d.Value.Release()
@@ -214,7 +214,7 @@ func (d *ChunkedDatum) Equals(other Datum) bool {
 // RecordDatum contains an array.Record for passing a full record to an expression
 // or to compute.
 type RecordDatum struct {
-	Value array.Record
+	Value arrow.Record
 }
 
 func (RecordDatum) Kind() DatumKind          { return KindRecord }
@@ -237,7 +237,7 @@ func (r *RecordDatum) Equals(other Datum) bool {
 // TableDatum contains a table so that multiple record batches can be worked with
 // together as a single table for being passed to compute and expression handling.
 type TableDatum struct {
-	Value array.Table
+	Value arrow.Table
 }
 
 func (TableDatum) Kind() DatumKind          { return KindTable }
@@ -302,7 +302,7 @@ func (c CollectionDatum) Equals(other Datum) bool {
 // NewDatum will construct the appropriate Datum type based on what is passed in
 // as the argument.
 //
-// An array.Interface gets an ArrayDatum
+// An arrow.Array gets an ArrayDatum
 // An array.Chunked gets a ChunkedDatum
 // An array.Record gets a RecordDatum
 // an array.Table gets a TableDatum
@@ -315,16 +315,16 @@ func NewDatum(value interface{}) Datum {
 	switch v := value.(type) {
 	case Datum:
 		return v
-	case array.Interface:
+	case arrow.Array:
 		v.Data().Retain()
 		return &ArrayDatum{v.Data().(*array.Data)}
-	case *array.Chunked:
+	case *arrow.Chunked:
 		v.Retain()
 		return &ChunkedDatum{v}
-	case array.Record:
+	case arrow.Record:
 		v.Retain()
 		return &RecordDatum{v}
-	case array.Table:
+	case arrow.Table:
 		v.Retain()
 		return &TableDatum{v}
 	case []Datum:

--- a/go/arrow/compute/expression.go
+++ b/go/arrow/compute/expression.go
@@ -250,6 +250,7 @@ const (
 	compGE comparisonType = compGT | compEQ
 )
 
+//lint:ignore U1000 ignore that this is unused for now
 func (c comparisonType) name() string {
 	switch c {
 	case compEQ:

--- a/go/arrow/compute/expression.go
+++ b/go/arrow/compute/expression.go
@@ -745,7 +745,7 @@ func SerializeOptions(opts FunctionOptions, mem memory.Allocator) (*memory.Buffe
 	}
 	defer arr.Release()
 
-	batch := array.NewRecord(arrow.NewSchema([]arrow.Field{{Type: arr.DataType(), Nullable: true}}, nil), []array.Interface{arr}, 1)
+	batch := array.NewRecord(arrow.NewSchema([]arrow.Field{{Type: arr.DataType(), Nullable: true}}, nil), []arrow.Array{arr}, 1)
 	defer batch.Release()
 
 	buf := &bufferWriteSeeker{mem: mem}
@@ -764,7 +764,7 @@ func SerializeOptions(opts FunctionOptions, mem memory.Allocator) (*memory.Buffe
 // stored in its columns. Finally the record is written as an IPC file
 func SerializeExpr(expr Expression, mem memory.Allocator) (*memory.Buffer, error) {
 	var (
-		cols      []array.Interface
+		cols      []arrow.Array
 		metaKey   []string
 		metaValue []string
 		visit     func(Expression) error

--- a/go/arrow/compute/fieldref.go
+++ b/go/arrow/compute/fieldref.go
@@ -48,18 +48,18 @@ func getFields(typ arrow.DataType) []arrow.Field {
 }
 
 type listvals interface {
-	ListValues() array.Interface
+	ListValues() arrow.Array
 }
 
-func getChildren(arr array.Interface) (ret []array.Interface) {
+func getChildren(arr arrow.Array) (ret []arrow.Array) {
 	switch arr := arr.(type) {
 	case *array.Struct:
-		ret = make([]array.Interface, arr.NumField())
+		ret = make([]arrow.Array, arr.NumField())
 		for i := 0; i < arr.NumField(); i++ {
 			ret[i] = arr.Field(i)
 		}
 	case listvals:
-		ret = []array.Interface{arr.ListValues()}
+		ret = []arrow.Array{arr.ListValues()}
 	}
 	return
 }
@@ -74,7 +74,7 @@ func getChildren(arr array.Interface) (ret []array.Interface) {
 // FieldPaths provide for drilling down to potentially nested children for convenience
 // of accepting a slice of fields, a schema or a datatype (which should contain child fields).
 //
-// A fieldpath can also be used to retrieve a child array.Interface or column from a record batch.
+// A fieldpath can also be used to retrieve a child arrow.Array or column from a record batch.
 type FieldPath []int
 
 func (f FieldPath) String() string {
@@ -126,14 +126,14 @@ func (f FieldPath) GetFieldFromSlice(fields []arrow.Field) (*arrow.Field, error)
 	return out, nil
 }
 
-func (f FieldPath) getArray(arrs []array.Interface) (array.Interface, error) {
+func (f FieldPath) getArray(arrs []arrow.Array) (arrow.Array, error) {
 	if len(f) == 0 {
 		return nil, ErrEmpty
 	}
 
 	var (
 		depth = 0
-		out   array.Interface
+		out   arrow.Array
 	)
 	for _, idx := range f {
 		if len(arrs) == 0 {
@@ -164,7 +164,7 @@ func (f FieldPath) GetField(field arrow.Field) (*arrow.Field, error) {
 
 // GetColumn will return the correct child array by traversing the fieldpath
 // going to the nested arrays of the columns in the record batch.
-func (f FieldPath) GetColumn(batch array.Record) (array.Interface, error) {
+func (f FieldPath) GetColumn(batch array.Record) (arrow.Array, error) {
 	return f.getArray(batch.Columns())
 }
 
@@ -549,8 +549,8 @@ func (f FieldRef) FindOne(schema *arrow.Schema) (FieldPath, error) {
 
 // GetAllColumns gets all the matching column arrays from the given record that
 // this FieldRef references.
-func (f FieldRef) GetAllColumns(root array.Record) ([]array.Interface, error) {
-	out := make([]array.Interface, 0)
+func (f FieldRef) GetAllColumns(root array.Record) ([]arrow.Array, error) {
+	out := make([]arrow.Array, 0)
 	for _, m := range f.FindAll(root.Schema().Fields()) {
 		n, err := m.GetColumn(root)
 		if err != nil {
@@ -587,7 +587,7 @@ func (f FieldRef) GetOneOrNone(schema *arrow.Schema) (*arrow.Field, error) {
 
 // GetOneColumnOrNone returns either a nil or the referenced array if it can be
 // found, erroring only if there is an ambiguous multiple matches.
-func (f FieldRef) GetOneColumnOrNone(root array.Record) (array.Interface, error) {
+func (f FieldRef) GetOneColumnOrNone(root array.Record) (arrow.Array, error) {
 	match, err := f.FindOneOrNoneRecord(root)
 	if err != nil {
 		return nil, err

--- a/go/arrow/compute/fieldref.go
+++ b/go/arrow/compute/fieldref.go
@@ -164,7 +164,7 @@ func (f FieldPath) GetField(field arrow.Field) (*arrow.Field, error) {
 
 // GetColumn will return the correct child array by traversing the fieldpath
 // going to the nested arrays of the columns in the record batch.
-func (f FieldPath) GetColumn(batch array.Record) (arrow.Array, error) {
+func (f FieldPath) GetColumn(batch arrow.Record) (arrow.Array, error) {
 	return f.getArray(batch.Columns())
 }
 
@@ -530,7 +530,7 @@ func (f FieldRef) FindOneOrNone(schema *arrow.Schema) (FieldPath, error) {
 
 // FindOneOrNoneRecord is like FindOneOrNone but for the schema of a record,
 // returning an error only if there are multiple matches.
-func (f FieldRef) FindOneOrNoneRecord(root array.Record) (FieldPath, error) {
+func (f FieldRef) FindOneOrNoneRecord(root arrow.Record) (FieldPath, error) {
 	return f.FindOneOrNone(root.Schema())
 }
 
@@ -549,7 +549,7 @@ func (f FieldRef) FindOne(schema *arrow.Schema) (FieldPath, error) {
 
 // GetAllColumns gets all the matching column arrays from the given record that
 // this FieldRef references.
-func (f FieldRef) GetAllColumns(root array.Record) ([]arrow.Array, error) {
+func (f FieldRef) GetAllColumns(root arrow.Record) ([]arrow.Array, error) {
 	out := make([]arrow.Array, 0)
 	for _, m := range f.FindAll(root.Schema().Fields()) {
 		n, err := m.GetColumn(root)
@@ -587,7 +587,7 @@ func (f FieldRef) GetOneOrNone(schema *arrow.Schema) (*arrow.Field, error) {
 
 // GetOneColumnOrNone returns either a nil or the referenced array if it can be
 // found, erroring only if there is an ambiguous multiple matches.
-func (f FieldRef) GetOneColumnOrNone(root array.Record) (arrow.Array, error) {
+func (f FieldRef) GetOneColumnOrNone(root arrow.Record) (arrow.Array, error) {
 	match, err := f.FindOneOrNoneRecord(root)
 	if err != nil {
 		return nil, err

--- a/go/arrow/compute/fieldref_test.go
+++ b/go/arrow/compute/fieldref_test.go
@@ -271,7 +271,7 @@ func TestFieldRefRecord(t *testing.T) {
 		{Name: "alpha", Type: alpha.DataType(), Nullable: true},
 		{Name: "alpha", Type: beta.DataType(), Nullable: true},
 		{Name: "alpha", Type: gamma.DataType(), Nullable: true},
-	}, nil), []array.Interface{alpha, beta, gamma}, 10)
+	}, nil), []arrow.Array{alpha, beta, gamma}, 10)
 	defer rec.Release()
 
 	arr, err := compute.FieldPath{2, 0}.GetColumn(rec)
@@ -296,7 +296,7 @@ func TestFieldRefRecord(t *testing.T) {
 
 	arrs, err := compute.FieldRefName("alpha").GetAllColumns(rec)
 	assert.NoError(t, err)
-	assert.Equal(t, []array.Interface{alpha, beta, gamma}, arrs)
+	assert.Equal(t, []arrow.Array{alpha, beta, gamma}, arrs)
 
 	arrs, err = compute.FieldRefName("delta").GetAllColumns(rec)
 	assert.NoError(t, err)

--- a/go/arrow/csv/reader.go
+++ b/go/arrow/csv/reader.go
@@ -38,7 +38,7 @@ type Reader struct {
 
 	refs int64
 	bld  *array.RecordBuilder
-	cur  array.Record
+	cur  arrow.Record
 	err  error
 
 	chunk int
@@ -57,7 +57,7 @@ type Reader struct {
 }
 
 // NewReader returns a reader that reads from the CSV file and creates
-// array.Records from the given schema.
+// arrow.Records from the given schema.
 //
 // NewReader panics if the given schema contains fields that have types that are not
 // primitive types.
@@ -133,7 +133,7 @@ func (r *Reader) Schema() *arrow.Schema { return r.schema }
 // Record returns the current record that has been extracted from the
 // underlying CSV file.
 // It is valid until the next call to Next.
-func (r *Reader) Record() array.Record { return r.cur }
+func (r *Reader) Record() arrow.Record { return r.cur }
 
 // Next returns whether a Record could be extracted from the underlying CSV file.
 //

--- a/go/arrow/csv/writer.go
+++ b/go/arrow/csv/writer.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/array"
 )
 
-// Writer wraps encoding/csv.Writer and writes array.Record based on a schema.
+// Writer wraps encoding/csv.Writer and writes arrow.Record based on a schema.
 type Writer struct {
 	w         *csv.Writer
 	schema    *arrow.Schema
@@ -35,7 +35,7 @@ type Writer struct {
 	nullValue string
 }
 
-// NewWriter returns a writer that writes array.Records to the CSV file
+// NewWriter returns a writer that writes arrow.Records to the CSV file
 // with the given schema.
 //
 // NewWriter panics if the given schema contains fields that have types that are not
@@ -58,7 +58,7 @@ func NewWriter(w io.Writer, schema *arrow.Schema, opts ...Option) *Writer {
 func (w *Writer) Schema() *arrow.Schema { return w.schema }
 
 // Write writes a single Record as one row to the CSV file
-func (w *Writer) Write(record array.Record) error {
+func (w *Writer) Write(record arrow.Record) error {
 	if !record.Schema().Equal(w.schema) {
 		return ErrMismatchFields
 	}

--- a/go/arrow/datatype_extension.go
+++ b/go/arrow/datatype_extension.go
@@ -165,6 +165,7 @@ func (e *ExtensionBase) Fields() []Field {
 }
 
 // this no-op exists to ensure that this type must be embedded in any user-defined extension type.
+//lint:ignore U1000 this function is intentionally unused as it only exists to ensure embedding happens
 func (ExtensionBase) mustEmbedExtensionBase() {}
 
 var (

--- a/go/arrow/example_test.go
+++ b/go/arrow/example_test.go
@@ -509,7 +509,7 @@ func Example_recordReader() {
 	rec2 := b.NewRecord()
 	defer rec2.Release()
 
-	itr, err := array.NewRecordReader(schema, []array.Record{rec1, rec2})
+	itr, err := array.NewRecordReader(schema, []arrow.Record{rec1, rec2})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func Example_table() {
 	rec2 := b.NewRecord()
 	defer rec2.Release()
 
-	tbl := array.NewTableFromRecords(schema, []array.Record{rec1, rec2})
+	tbl := array.NewTableFromRecords(schema, []arrow.Record{rec1, rec2})
 	defer tbl.Release()
 
 	tr := array.NewTableReader(tbl, 5)

--- a/go/arrow/flight/record_batch_writer.go
+++ b/go/arrow/flight/record_batch_writer.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/ipc"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 )
@@ -69,7 +68,7 @@ func (w *Writer) SetFlightDescriptor(descr *FlightDescriptor) {
 }
 
 // Write writes a recordbatch payload and returns any error, implementing the arrio.Writer interface
-func (w *Writer) Write(rec array.Record) error {
+func (w *Writer) Write(rec arrow.Record) error {
 	if w.pw.fd.FlightDescriptor != nil {
 		defer func() {
 			w.pw.fd.FlightDescriptor = nil
@@ -80,7 +79,7 @@ func (w *Writer) Write(rec array.Record) error {
 
 // WriteWithAppMetadata will write this record with the supplied application
 // metadata attached in the flightData message.
-func (w *Writer) WriteWithAppMetadata(rec array.Record, appMeta []byte) error {
+func (w *Writer) WriteWithAppMetadata(rec arrow.Record, appMeta []byte) error {
 	w.pw.fd.AppMetadata = appMeta
 	defer func() {
 		w.pw.fd.AppMetadata = nil

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -71,14 +71,14 @@ func makeNullRecords() []arrow.Record {
 	)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []nullT{null, null, null, null, null}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []nullT{null, null, null, null, null}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []nullT{null, null, null, null, null}, mask),
 		},
 	}
@@ -124,8 +124,8 @@ func makePrimitiveRecords() []arrow.Record {
 	)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []bool{true, false, true, false, true}, mask),
 			arrayOf(mem, []int8{-1, -2, -3, -4, -5}, mask),
 			arrayOf(mem, []int16{-1, -2, -3, -4, -5}, mask),
@@ -138,7 +138,7 @@ func makePrimitiveRecords() []arrow.Record {
 			arrayOf(mem, []float32{+1, +2, +3, +4, +5}, mask),
 			arrayOf(mem, []float64{+1, +2, +3, +4, +5}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []bool{true, false, true, false, true}, mask),
 			arrayOf(mem, []int8{-11, -12, -13, -14, -15}, mask),
 			arrayOf(mem, []int16{-11, -12, -13, -14, -15}, mask),
@@ -151,7 +151,7 @@ func makePrimitiveRecords() []arrow.Record {
 			arrayOf(mem, []float32{+11, +12, +13, +14, +15}, mask),
 			arrayOf(mem, []float64{+11, +12, +13, +14, +15}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []bool{true, false, true, false, true}, mask),
 			arrayOf(mem, []int8{-21, -22, -23, -24, -25}, mask),
 			arrayOf(mem, []int16{-21, -22, -23, -24, -25}, mask),
@@ -193,50 +193,50 @@ func makeStructsRecords() []arrow.Record {
 	schema := arrow.NewSchema([]arrow.Field{{Name: "struct_nullable", Type: dtype, Nullable: true}}, nil)
 
 	mask := []bool{true, false, false, true, true, true, false, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
-			structOf(mem, dtype, [][]array.Interface{
-				[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
+			structOf(mem, dtype, [][]arrow.Array{
+				[]arrow.Array{
 					arrayOf(mem, []int32{-1, -2, -3, -4, -5}, mask[:5]),
 					arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{-11, -12, -13, -14, -15}, mask[:5]),
 					arrayOf(mem, []string{"1111", "1222", "1333", "1444", "1555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{-21, -22, -23, -24, -25}, mask[:5]),
 					arrayOf(mem, []string{"2111", "2222", "2333", "2444", "2555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{-31, -32, -33, -34, -35}, mask[:5]),
 					arrayOf(mem, []string{"3111", "3222", "3333", "3444", "3555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{-41, -42, -43, -44, -45}, mask[:5]),
 					arrayOf(mem, []string{"4111", "4222", "4333", "4444", "4555"}, mask[:5]),
 				},
 			}, []bool{true, false, true, true, true}),
 		},
-		[]array.Interface{
-			structOf(mem, dtype, [][]array.Interface{
-				[]array.Interface{
+		[]arrow.Array{
+			structOf(mem, dtype, [][]arrow.Array{
+				[]arrow.Array{
 					arrayOf(mem, []int32{1, 2, 3, 4, 5}, mask[:5]),
 					arrayOf(mem, []string{"-111", "-222", "-333", "-444", "-555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{11, 12, 13, 14, 15}, mask[:5]),
 					arrayOf(mem, []string{"-1111", "-1222", "-1333", "-1444", "-1555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{21, 22, 23, 24, 25}, mask[:5]),
 					arrayOf(mem, []string{"-2111", "-2222", "-2333", "-2444", "-2555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{31, 32, 33, 34, 35}, mask[:5]),
 					arrayOf(mem, []string{"-3111", "-3222", "-3333", "-3444", "-3555"}, mask[:5]),
 				},
-				[]array.Interface{
+				[]arrow.Array{
 					arrayOf(mem, []int32{41, 42, 43, 44, 45}, mask[:5]),
 					arrayOf(mem, []string{"-4111", "-4222", "-4333", "-4444", "-4555"}, mask[:5]),
 				},
@@ -269,30 +269,30 @@ func makeListsRecords() []arrow.Record {
 
 	mask := []bool{true, false, false, true, true}
 
-	chunks := [][]array.Interface{
-		[]array.Interface{
-			listOf(mem, []array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
+			listOf(mem, []arrow.Array{
 				arrayOf(mem, []int32{1, 2, 3, 4, 5}, mask),
 				arrayOf(mem, []int32{11, 12, 13, 14, 15}, mask),
 				arrayOf(mem, []int32{21, 22, 23, 24, 25}, mask),
 			}, nil),
 		},
-		[]array.Interface{
-			listOf(mem, []array.Interface{
+		[]arrow.Array{
+			listOf(mem, []arrow.Array{
 				arrayOf(mem, []int32{-1, -2, -3, -4, -5}, mask),
 				arrayOf(mem, []int32{-11, -12, -13, -14, -15}, mask),
 				arrayOf(mem, []int32{-21, -22, -23, -24, -25}, mask),
 			}, nil),
 		},
-		[]array.Interface{
-			listOf(mem, []array.Interface{
+		[]arrow.Array{
+			listOf(mem, []arrow.Array{
 				arrayOf(mem, []int32{-1, -2, -3, -4, -5}, mask),
 				arrayOf(mem, []int32{-11, -12, -13, -14, -15}, mask),
 				arrayOf(mem, []int32{-21, -22, -23, -24, -25}, mask),
 			}, []bool{true, false, true}),
 		},
-		[]array.Interface{
-			func() array.Interface {
+		[]arrow.Array{
+			func() arrow.Array {
 				bldr := array.NewListBuilder(mem, arrow.PrimitiveTypes.Int32)
 				defer bldr.Release()
 
@@ -327,23 +327,23 @@ func makeFixedSizeListsRecords() []arrow.Record {
 
 	mask := []bool{true, false, true}
 
-	chunks := [][]array.Interface{
-		[]array.Interface{
-			fixedSizeListOf(mem, N, []array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
+			fixedSizeListOf(mem, N, []arrow.Array{
 				arrayOf(mem, []int32{1, 2, 3}, mask),
 				arrayOf(mem, []int32{11, 12, 13}, mask),
 				arrayOf(mem, []int32{21, 22, 23}, mask),
 			}, nil),
 		},
-		[]array.Interface{
-			fixedSizeListOf(mem, N, []array.Interface{
+		[]arrow.Array{
+			fixedSizeListOf(mem, N, []arrow.Array{
 				arrayOf(mem, []int32{-1, -2, -3}, mask),
 				arrayOf(mem, []int32{-11, -12, -13}, mask),
 				arrayOf(mem, []int32{-21, -22, -23}, mask),
 			}, nil),
 		},
-		[]array.Interface{
-			fixedSizeListOf(mem, N, []array.Interface{
+		[]arrow.Array{
+			fixedSizeListOf(mem, N, []arrow.Array{
 				arrayOf(mem, []int32{-1, -2, -3}, mask),
 				arrayOf(mem, []int32{-11, -12, -13}, mask),
 				arrayOf(mem, []int32{-21, -22, -23}, mask),
@@ -375,16 +375,16 @@ func makeStringsRecords() []arrow.Record {
 	}, nil)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []string{"1é", "2", "3", "4", "5"}, mask),
 			arrayOf(mem, [][]byte{[]byte("1é"), []byte("2"), []byte("3"), []byte("4"), []byte("5")}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []string{"11", "22", "33", "44", "55"}, mask),
 			arrayOf(mem, [][]byte{[]byte("11"), []byte("22"), []byte("33"), []byte("44"), []byte("55")}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask),
 			arrayOf(mem, [][]byte{[]byte("111"), []byte("222"), []byte("333"), []byte("444"), []byte("555")}, mask),
 		},
@@ -449,8 +449,8 @@ func makeFixedWidthTypesRecords() []arrow.Record {
 	}
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, float16s([]float32{+1, +2, +3, +4, +5}), mask),
 			arrayOf(mem, []time32ms{-2, -1, 0, +1, +2}, mask),
 			arrayOf(mem, []time32s{-2, -1, 0, +1, +2}, mask),
@@ -463,7 +463,7 @@ func makeFixedWidthTypesRecords() []arrow.Record {
 			arrayOf(mem, []arrow.Date32{-2, -1, 0, +1, +2}, mask),
 			arrayOf(mem, []arrow.Date64{-2, -1, 0, +1, +2}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, float16s([]float32{+11, +12, +13, +14, +15}), mask),
 			arrayOf(mem, []time32ms{-12, -11, 10, +11, +12}, mask),
 			arrayOf(mem, []time32s{-12, -11, 10, +11, +12}, mask),
@@ -476,7 +476,7 @@ func makeFixedWidthTypesRecords() []arrow.Record {
 			arrayOf(mem, []arrow.Date32{-12, -11, 10, +11, +12}, mask),
 			arrayOf(mem, []arrow.Date64{-12, -11, 10, +11, +12}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, float16s([]float32{+21, +22, +23, +24, +25}), mask),
 			arrayOf(mem, []time32ms{-22, -21, 20, +21, +22}, mask),
 			arrayOf(mem, []time32s{-22, -21, 20, +21, +22}, mask),
@@ -518,14 +518,14 @@ func makeFixedSizeBinariesRecords() []arrow.Record {
 	)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []fsb3{"001", "002", "003", "004", "005"}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []fsb3{"011", "012", "013", "014", "015"}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []fsb3{"021", "022", "023", "024", "025"}, mask),
 		},
 	}
@@ -558,18 +558,18 @@ func makeIntervalsRecords() []arrow.Record {
 	)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []arrow.MonthInterval{1, 2, 3, 4, 5}, mask),
 			arrayOf(mem, []arrow.DayTimeInterval{{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}, mask),
 			arrayOf(mem, []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}, {5, 5, 5000}}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []arrow.MonthInterval{-11, -12, -13, -14, -15}, mask),
 			arrayOf(mem, []arrow.DayTimeInterval{{-11, -11}, {-12, -12}, {-13, -13}, {-14, -14}, {-15, -15}}, mask),
 			arrayOf(mem, []arrow.MonthDayNanoInterval{{-11, -11, -11000}, {-12, -12, -12000}, {-13, -13, -13000}, {-14, -14, -14000}, {-15, -15, -15000}}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []arrow.MonthInterval{21, 22, 23, 24, 25, 0}, append(mask, true)),
 			arrayOf(mem, []arrow.DayTimeInterval{{21, 21}, {22, 22}, {23, 23}, {24, 24}, {25, 25}, {0, 0}}, append(mask, true)),
 			arrayOf(mem, []arrow.MonthDayNanoInterval{{21, 21, 21000}, {22, 22, 22000}, {23, 23, 23000}, {24, 24, 24000}, {25, 25, 25000}, {0, 0, 0}}, append(mask, true)),
@@ -612,20 +612,20 @@ func makeDurationsRecords() []arrow.Record {
 	)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, []duration_s{1, 2, 3, 4, 5}, mask),
 			arrayOf(mem, []duration_ms{1, 2, 3, 4, 5}, mask),
 			arrayOf(mem, []duration_us{1, 2, 3, 4, 5}, mask),
 			arrayOf(mem, []duration_ns{1, 2, 3, 4, 5}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []duration_s{11, 12, 13, 14, 15}, mask),
 			arrayOf(mem, []duration_ms{11, 12, 13, 14, 15}, mask),
 			arrayOf(mem, []duration_us{11, 12, 13, 14, 15}, mask),
 			arrayOf(mem, []duration_ns{11, 12, 13, 14, 15}, mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, []duration_s{21, 22, 23, 24, 25}, mask),
 			arrayOf(mem, []duration_ms{21, 22, 23, 24, 25}, mask),
 			arrayOf(mem, []duration_us{21, 22, 23, 24, 25}, mask),
@@ -670,14 +670,14 @@ func makeDecimal128sRecords() []arrow.Record {
 	}
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
-		[]array.Interface{
+	chunks := [][]arrow.Array{
+		[]arrow.Array{
 			arrayOf(mem, dec128s([]int64{31, 32, 33, 34, 35}), mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, dec128s([]int64{41, 42, 43, 44, 45}), mask),
 		},
-		[]array.Interface{
+		[]arrow.Array{
 			arrayOf(mem, dec128s([]int64{51, 52, 53, 54, 55}), mask),
 		},
 	}
@@ -705,10 +705,10 @@ func makeMapsRecords() []arrow.Record {
 	schema := arrow.NewSchema([]arrow.Field{{Name: "map_int_utf8", Type: dtype, Nullable: true}}, nil)
 
 	mask := []bool{true, false, false, true, true}
-	chunks := [][]array.Interface{
+	chunks := [][]arrow.Array{
 		{
-			mapOf(mem, dtype.KeysSorted, []array.Interface{
-				structOf(mem, dtype.ValueType(), [][]array.Interface{
+			mapOf(mem, dtype.KeysSorted, []arrow.Array{
+				structOf(mem, dtype.ValueType(), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{-1, -2, -3, -4, -5}, nil),
 						arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask[:5]),
@@ -730,7 +730,7 @@ func makeMapsRecords() []arrow.Record {
 						arrayOf(mem, []string{"4111", "4222", "4333", "4444", "4555"}, mask[:5]),
 					},
 				}, nil),
-				structOf(mem, dtype.ValueType(), [][]array.Interface{
+				structOf(mem, dtype.ValueType(), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{1, 2, 3, 4, 5}, nil),
 						arrayOf(mem, []string{"-111", "-222", "-333", "-444", "-555"}, mask[:5]),
@@ -755,8 +755,8 @@ func makeMapsRecords() []arrow.Record {
 			}, []bool{true, false, true, true, true}),
 		},
 		{
-			mapOf(mem, dtype.KeysSorted, []array.Interface{
-				structOf(mem, dtype.ValueType(), [][]array.Interface{
+			mapOf(mem, dtype.KeysSorted, []arrow.Array{
+				structOf(mem, dtype.ValueType(), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{1, 2, 3, 4, 5}, nil),
 						arrayOf(mem, []string{"-111", "-222", "-333", "-444", "-555"}, mask[:5]),
@@ -778,7 +778,7 @@ func makeMapsRecords() []arrow.Record {
 						arrayOf(mem, []string{"-4111", "-4222", "-4333", "-4444", "-4555"}, mask[:5]),
 					},
 				}, nil),
-				structOf(mem, dtype.ValueType(), [][]array.Interface{
+				structOf(mem, dtype.ValueType(), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{-1, -2, -3, -4, -5}, nil),
 						arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask[:5]),
@@ -854,13 +854,13 @@ func makeExtensionRecords() []arrow.Record {
 		}, nil)
 
 	mask := []bool{true, false, true, true, false}
-	chunks := [][]array.Interface{
+	chunks := [][]arrow.Array{
 		{
 			extArray(mem, p1Type, []int32{1, -1, 2, 3, -1}, mask),
 			extArray(mem, p2Type, []int32{2, -1, 3, 4, -1}, mask),
 			extArray(mem, p3Type, []int32{5, -1, 6, 7, 8}, mask),
 			extArray(mem, p4Type, []int32{5, -1, 7, 9, -1}, mask),
-			extArray(mem, p5Type, [][]array.Interface{
+			extArray(mem, p5Type, [][]arrow.Array{
 				{
 					arrayOf(mem, []int64{1, -1, 2, 3, -1}, mask),
 					arrayOf(mem, []float64{0.1, -1, 0.2, 0.3, -1}, mask),
@@ -873,7 +873,7 @@ func makeExtensionRecords() []arrow.Record {
 			extArray(mem, p2Type, []int32{20, -1, 30, 40, -1}, mask),
 			extArray(mem, p3Type, []int32{50, -1, 60, 70, 8}, mask),
 			extArray(mem, p4Type, []int32{50, -1, 70, 90, -1}, mask),
-			extArray(mem, p5Type, [][]array.Interface{
+			extArray(mem, p5Type, [][]arrow.Array{
 				{
 					arrayOf(mem, []int64{10, -1, 20, 30, -1}, mask),
 					arrayOf(mem, []float64{0.01, -1, 0.02, 0.03, -1}, mask),
@@ -899,15 +899,15 @@ func makeExtensionRecords() []arrow.Record {
 	return recs
 }
 
-func extArray(mem memory.Allocator, dt arrow.ExtensionType, a interface{}, valids []bool) array.Interface {
-	var storage array.Interface
+func extArray(mem memory.Allocator, dt arrow.ExtensionType, a interface{}, valids []bool) arrow.Array {
+	var storage arrow.Array
 	switch st := dt.StorageType().(type) {
 	case *arrow.StructType:
-		storage = structOf(mem, st, a.([][]array.Interface), valids)
+		storage = structOf(mem, st, a.([][]arrow.Array), valids)
 	case *arrow.MapType:
-		storage = mapOf(mem, false, a.([]array.Interface), valids)
+		storage = mapOf(mem, false, a.([]arrow.Array), valids)
 	case *arrow.ListType:
-		storage = listOf(mem, a.([]array.Interface), valids)
+		storage = listOf(mem, a.([]arrow.Array), valids)
 	default:
 		storage = arrayOf(mem, a, valids)
 	}
@@ -916,7 +916,7 @@ func extArray(mem memory.Allocator, dt arrow.ExtensionType, a interface{}, valid
 	return array.NewExtensionArrayWithStorage(dt, storage)
 }
 
-func arrayOf(mem memory.Allocator, a interface{}, valids []bool) array.Interface {
+func arrayOf(mem memory.Allocator, a interface{}, valids []bool) arrow.Array {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -1209,7 +1209,7 @@ func arrayOf(mem memory.Allocator, a interface{}, valids []bool) array.Interface
 	}
 }
 
-func listOf(mem memory.Allocator, values []array.Interface, valids []bool) *array.List {
+func listOf(mem memory.Allocator, values []arrow.Array, valids []bool) *array.List {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -1233,7 +1233,7 @@ func listOf(mem memory.Allocator, values []array.Interface, valids []bool) *arra
 	return bldr.NewListArray()
 }
 
-func fixedSizeListOf(mem memory.Allocator, n int32, values []array.Interface, valids []bool) *array.FixedSizeList {
+func fixedSizeListOf(mem memory.Allocator, n int32, values []arrow.Array, valids []bool) *array.FixedSizeList {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -1257,7 +1257,7 @@ func fixedSizeListOf(mem memory.Allocator, n int32, values []array.Interface, va
 	return bldr.NewListArray()
 }
 
-func structOf(mem memory.Allocator, dtype *arrow.StructType, fields [][]array.Interface, valids []bool) *array.Struct {
+func structOf(mem memory.Allocator, dtype *arrow.StructType, fields [][]arrow.Array, valids []bool) *array.Struct {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -1283,7 +1283,7 @@ func structOf(mem memory.Allocator, dtype *arrow.StructType, fields [][]array.In
 	return bldr.NewStructArray()
 }
 
-func mapOf(mem memory.Allocator, sortedKeys bool, values []array.Interface, valids []bool) *array.Map {
+func mapOf(mem memory.Allocator, sortedKeys bool, values []arrow.Array, valids []bool) *array.Map {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -1310,7 +1310,7 @@ func mapOf(mem memory.Allocator, sortedKeys bool, values []array.Interface, vali
 	return bldr.NewMapArray()
 }
 
-func buildArray(bldr array.Builder, data array.Interface) {
+func buildArray(bldr array.Builder, data arrow.Array) {
 	defer data.Release()
 
 	switch bldr := bldr.(type) {

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	Records     = make(map[string][]array.Record)
+	Records     = make(map[string][]arrow.Record)
 	RecordNames []string
 )
 
@@ -56,7 +56,7 @@ func init() {
 	sort.Strings(RecordNames)
 }
 
-func makeNullRecords() []array.Record {
+func makeNullRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	meta := arrow.NewMetadata(
@@ -91,7 +91,7 @@ func makeNullRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -99,7 +99,7 @@ func makeNullRecords() []array.Record {
 	return recs
 }
 
-func makePrimitiveRecords() []array.Record {
+func makePrimitiveRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	meta := arrow.NewMetadata(
@@ -174,7 +174,7 @@ func makePrimitiveRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -182,7 +182,7 @@ func makePrimitiveRecords() []array.Record {
 	return recs
 }
 
-func makeStructsRecords() []array.Record {
+func makeStructsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	fields := []arrow.Field{
@@ -252,7 +252,7 @@ func makeStructsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -260,7 +260,7 @@ func makeStructsRecords() []array.Record {
 	return recs
 }
 
-func makeListsRecords() []array.Record {
+func makeListsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	dtype := arrow.ListOf(arrow.PrimitiveTypes.Int32)
 	schema := arrow.NewSchema([]arrow.Field{
@@ -309,7 +309,7 @@ func makeListsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -317,7 +317,7 @@ func makeListsRecords() []array.Record {
 	return recs
 }
 
-func makeFixedSizeListsRecords() []array.Record {
+func makeFixedSizeListsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	const N = 3
 	dtype := arrow.FixedSizeListOf(N, arrow.PrimitiveTypes.Int32)
@@ -359,7 +359,7 @@ func makeFixedSizeListsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -367,7 +367,7 @@ func makeFixedSizeListsRecords() []array.Record {
 	return recs
 }
 
-func makeStringsRecords() []array.Record {
+func makeStringsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "strings", Type: arrow.BinaryTypes.String},
@@ -398,7 +398,7 @@ func makeStringsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -422,7 +422,7 @@ var (
 	null nullT
 )
 
-func makeFixedWidthTypesRecords() []array.Record {
+func makeFixedWidthTypesRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	schema := arrow.NewSchema(
 		[]arrow.Field{
@@ -499,7 +499,7 @@ func makeFixedWidthTypesRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -509,7 +509,7 @@ func makeFixedWidthTypesRecords() []array.Record {
 
 type fsb3 string
 
-func makeFixedSizeBinariesRecords() []array.Record {
+func makeFixedSizeBinariesRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	schema := arrow.NewSchema(
 		[]arrow.Field{
@@ -538,7 +538,7 @@ func makeFixedSizeBinariesRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -546,7 +546,7 @@ func makeFixedSizeBinariesRecords() []array.Record {
 	return recs
 }
 
-func makeIntervalsRecords() []array.Record {
+func makeIntervalsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	schema := arrow.NewSchema(
@@ -584,7 +584,7 @@ func makeIntervalsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -599,7 +599,7 @@ type (
 	duration_ns arrow.Duration
 )
 
-func makeDurationsRecords() []array.Record {
+func makeDurationsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	schema := arrow.NewSchema(
@@ -641,7 +641,7 @@ func makeDurationsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -653,7 +653,7 @@ var (
 	decimal128Type = &arrow.Decimal128Type{Precision: 10, Scale: 1}
 )
 
-func makeDecimal128sRecords() []array.Record {
+func makeDecimal128sRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	schema := arrow.NewSchema(
 		[]arrow.Field{
@@ -690,7 +690,7 @@ func makeDecimal128sRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -698,7 +698,7 @@ func makeDecimal128sRecords() []array.Record {
 	return recs
 }
 
-func makeMapsRecords() []array.Record {
+func makeMapsRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 	dtype := arrow.MapOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String)
 	dtype.KeysSorted = true
@@ -812,7 +812,7 @@ func makeMapsRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}
@@ -820,7 +820,7 @@ func makeMapsRecords() []array.Record {
 	return recs
 }
 
-func makeExtensionRecords() []array.Record {
+func makeExtensionRecords() []arrow.Record {
 	mem := memory.NewGoAllocator()
 
 	p1Type := types.NewParametric1Type(6)
@@ -891,7 +891,7 @@ func makeExtensionRecords() []array.Record {
 		}
 	}()
 
-	recs := make([]array.Record, len(chunks))
+	recs := make([]arrow.Record, len(chunks))
 	for i, chunk := range chunks {
 		recs[i] = array.NewRecord(schema, chunk, -1)
 	}

--- a/go/arrow/internal/arrdata/ioutil.go
+++ b/go/arrow/internal/arrdata/ioutil.go
@@ -31,7 +31,7 @@ import (
 )
 
 // CheckArrowFile checks whether a given ARROW file contains the expected list of records.
-func CheckArrowFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func CheckArrowFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	_, err := f.Seek(0, io.SeekStart)
@@ -62,7 +62,7 @@ func CheckArrowFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arro
 
 }
 
-func CheckArrowConcurrentFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func CheckArrowConcurrentFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	_, err := f.Seek(0, io.SeekStart)
@@ -112,7 +112,7 @@ func CheckArrowConcurrentFile(t *testing.T, f *os.File, mem memory.Allocator, sc
 }
 
 // CheckArrowStream checks whether a given ARROW stream contains the expected list of records.
-func CheckArrowStream(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func CheckArrowStream(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	_, err := f.Seek(0, io.SeekStart)
@@ -142,7 +142,7 @@ func CheckArrowStream(t *testing.T, f *os.File, mem memory.Allocator, schema *ar
 }
 
 // WriteFile writes a list of records to the given file descriptor, as an ARROW file.
-func WriteFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func WriteFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	w, err := ipc.NewFileWriter(f, ipc.WithSchema(schema), ipc.WithAllocator(mem))
@@ -178,7 +178,7 @@ func WriteFile(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Sch
 }
 
 // WriteFile writes a list of records to the given file descriptor, as an ARROW file.
-func WriteFileCompressed(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record, codec flatbuf.CompressionType) {
+func WriteFileCompressed(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record, codec flatbuf.CompressionType) {
 	t.Helper()
 
 	opts := []ipc.Option{ipc.WithSchema(schema), ipc.WithAllocator(mem)}
@@ -224,7 +224,7 @@ func WriteFileCompressed(t *testing.T, f *os.File, mem memory.Allocator, schema 
 }
 
 // WriteStream writes a list of records to the given file descriptor, as an ARROW stream.
-func WriteStream(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record) {
+func WriteStream(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record) {
 	t.Helper()
 
 	w := ipc.NewWriter(f, ipc.WithSchema(schema), ipc.WithAllocator(mem))
@@ -245,7 +245,7 @@ func WriteStream(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.S
 
 // WriteStreamCompressed writes a list of records to the given file descriptor as an ARROW stream
 // using the provided compression type.
-func WriteStreamCompressed(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []array.Record, codec flatbuf.CompressionType, np int) {
+func WriteStreamCompressed(t *testing.T, f *os.File, mem memory.Allocator, schema *arrow.Schema, recs []arrow.Record, codec flatbuf.CompressionType, np int) {
 	t.Helper()
 
 	opts := []ipc.Option{ipc.WithSchema(schema), ipc.WithAllocator(mem), ipc.WithCompressConcurrency(np)}

--- a/go/arrow/internal/arrjson/arrjson.go
+++ b/go/arrow/internal/arrjson/arrjson.go
@@ -629,15 +629,15 @@ type Array struct {
 	Children []Array       `json:"children,omitempty"`
 }
 
-func arraysFromJSON(mem memory.Allocator, schema *arrow.Schema, arrs []Array) []array.Interface {
-	o := make([]array.Interface, len(arrs))
+func arraysFromJSON(mem memory.Allocator, schema *arrow.Schema, arrs []Array) []arrow.Array {
+	o := make([]arrow.Array, len(arrs))
 	for i, v := range arrs {
 		o[i] = arrayFromJSON(mem, schema.Field(i).Type, v)
 	}
 	return o
 }
 
-func arraysToJSON(schema *arrow.Schema, arrs []array.Interface) []Array {
+func arraysToJSON(schema *arrow.Schema, arrs []arrow.Array) []Array {
 	o := make([]Array, len(arrs))
 	for i, v := range arrs {
 		o[i] = arrayToJSON(schema.Field(i), v)
@@ -655,7 +655,7 @@ func validsToBitmap(valids []bool, mem memory.Allocator) *memory.Buffer {
 	return buf
 }
 
-func arrayFromJSON(mem memory.Allocator, dt arrow.DataType, arr Array) array.Interface {
+func arrayFromJSON(mem memory.Allocator, dt arrow.DataType, arr Array) arrow.Array {
 	switch dt := dt.(type) {
 	case *arrow.NullType:
 		return array.NewNull(arr.Count)
@@ -944,7 +944,7 @@ func arrayFromJSON(mem memory.Allocator, dt arrow.DataType, arr Array) array.Int
 	panic("impossible")
 }
 
-func arrayToJSON(field arrow.Field, arr array.Interface) Array {
+func arrayToJSON(field arrow.Field, arr arrow.Array) Array {
 	switch arr := arr.(type) {
 	case *array.Null:
 		return Array{
@@ -1225,7 +1225,7 @@ func validsFromJSON(vs []int) []bool {
 	return o
 }
 
-func validsToJSON(arr array.Interface) []int {
+func validsToJSON(arr arrow.Array) []int {
 	o := make([]int, arr.Len())
 	for i := range o {
 		if arr.IsValid(i) {

--- a/go/arrow/internal/arrjson/reader.go
+++ b/go/arrow/internal/arrjson/reader.go
@@ -22,7 +22,6 @@ import (
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/arrio"
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
@@ -31,7 +30,7 @@ type Reader struct {
 	refs int64
 
 	schema *arrow.Schema
-	recs   []array.Record
+	recs   []arrow.Record
 
 	irec int // current record index. used for the arrio.Reader interface.
 }
@@ -83,7 +82,7 @@ func (r *Reader) Release() {
 func (r *Reader) Schema() *arrow.Schema { return r.schema }
 func (r *Reader) NumRecords() int       { return len(r.recs) }
 
-func (r *Reader) Read() (array.Record, error) {
+func (r *Reader) Read() (arrow.Record, error) {
 	if r.irec == r.NumRecords() {
 		return nil, io.EOF
 	}

--- a/go/arrow/internal/arrjson/writer.go
+++ b/go/arrow/internal/arrjson/writer.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/arrio"
 )
 
@@ -52,7 +51,7 @@ func NewWriter(w io.Writer, schema *arrow.Schema) (*Writer, error) {
 	return ww, nil
 }
 
-func (w *Writer) Write(rec array.Record) error {
+func (w *Writer) Write(rec arrow.Record) error {
 	w.raw.Records = append(w.raw.Records, recordToJSON(rec))
 	w.nrecs++
 	return nil

--- a/go/arrow/internal/flight_integration/scenario.go
+++ b/go/arrow/internal/flight_integration/scenario.go
@@ -68,10 +68,10 @@ func initServer(port int, srv flight.Server) int {
 
 type integrationDataSet struct {
 	schema *arrow.Schema
-	chunks []array.Record
+	chunks []arrow.Record
 }
 
-func consumeFlightLocation(ctx context.Context, loc *flight.Location, tkt *flight.Ticket, orig []array.Record, opts ...grpc.DialOption) error {
+func consumeFlightLocation(ctx context.Context, loc *flight.Location, tkt *flight.Ticket, orig []arrow.Record, opts ...grpc.DialOption) error {
 	client, err := flight.NewClientWithMiddleware(loc.GetUri(), nil, nil, opts...)
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func (s *defaultIntegrationTester) RunClient(addr string, opts ...grpc.DialOptio
 	}
 
 	dataSet := integrationDataSet{
-		chunks: make([]array.Record, 0),
+		chunks: make([]arrow.Record, 0),
 		schema: rdr.Schema(),
 	}
 
@@ -294,7 +294,7 @@ func (s *defaultIntegrationTester) DoPut(stream flight.FlightService_DoPutServer
 
 	key = desc.Path[0]
 	dataset.schema = rdr.Schema()
-	dataset.chunks = make([]array.Record, 0)
+	dataset.chunks = make([]arrow.Record, 0)
 	for rdr.Next() {
 		rec := rdr.Record()
 		rec.Retain()

--- a/go/arrow/internal/testing/gen/random_array_gen.go
+++ b/go/arrow/internal/testing/gen/random_array_gen.go
@@ -63,7 +63,7 @@ func (r *RandomArrayGenerator) GenerateBitmap(buffer []byte, n int64, prob float
 	return count
 }
 
-func (r *RandomArrayGenerator) Boolean(size int64, prob, nullProb float64) array.Interface {
+func (r *RandomArrayGenerator) Boolean(size int64, prob, nullProb float64) arrow.Array {
 	buffers := make([]*memory.Buffer, 2)
 	nullcount := int64(0)
 
@@ -96,7 +96,7 @@ func (r *RandomArrayGenerator) baseGenPrimitive(size int64, prob float64, byteWi
 	return buffers, nullCount
 }
 
-func (r *RandomArrayGenerator) Int8(size int64, min, max int8, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Int8(size int64, min, max int8, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Int8SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -114,7 +114,7 @@ func (r *RandomArrayGenerator) Int8(size int64, min, max int8, prob float64) arr
 	return array.NewInt8Data(data)
 }
 
-func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Uint8SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -132,7 +132,7 @@ func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) a
 	return array.NewUint8Data(data)
 }
 
-func (r *RandomArrayGenerator) Int16(size int64, min, max int16, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Int16(size int64, min, max int16, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Int16SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -150,7 +150,7 @@ func (r *RandomArrayGenerator) Int16(size int64, min, max int16, prob float64) a
 	return array.NewInt16Data(data)
 }
 
-func (r *RandomArrayGenerator) Uint16(size int64, min, max uint16, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Uint16(size int64, min, max uint16, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Uint16SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -168,7 +168,7 @@ func (r *RandomArrayGenerator) Uint16(size int64, min, max uint16, prob float64)
 	return array.NewUint16Data(data)
 }
 
-func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Int32SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -186,7 +186,7 @@ func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) a
 	return array.NewInt32Data(data)
 }
 
-func (r *RandomArrayGenerator) Uint32(size int64, min, max uint32, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Uint32(size int64, min, max uint32, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Uint32SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -204,7 +204,7 @@ func (r *RandomArrayGenerator) Uint32(size int64, min, max uint32, prob float64)
 	return array.NewUint32Data(data)
 }
 
-func (r *RandomArrayGenerator) Int64(size int64, min, max int64, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Int64(size int64, min, max int64, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Int64SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -222,7 +222,7 @@ func (r *RandomArrayGenerator) Int64(size int64, min, max int64, prob float64) a
 	return array.NewInt64Data(data)
 }
 
-func (r *RandomArrayGenerator) Uint64(size int64, min, max uint64, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Uint64(size int64, min, max uint64, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Uint64SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -240,7 +240,7 @@ func (r *RandomArrayGenerator) Uint64(size int64, min, max uint64, prob float64)
 	return array.NewUint64Data(data)
 }
 
-func (r *RandomArrayGenerator) Float32(size int64, min, max float32, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Float32(size int64, min, max float32, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Float32SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -258,7 +258,7 @@ func (r *RandomArrayGenerator) Float32(size int64, min, max float32, prob float6
 	return array.NewFloat32Data(data)
 }
 
-func (r *RandomArrayGenerator) Float64(size int64, min, max float64, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Float64(size int64, min, max float64, prob float64) arrow.Array {
 	buffers, nullcount := r.baseGenPrimitive(size, prob, arrow.Float64SizeBytes)
 	for _, b := range buffers {
 		defer b.Release()
@@ -276,7 +276,7 @@ func (r *RandomArrayGenerator) Float64(size int64, min, max float64, prob float6
 	return array.NewFloat64Data(data)
 }
 
-func (r *RandomArrayGenerator) String(size int64, minLength, maxLength int, nullprob float64) array.Interface {
+func (r *RandomArrayGenerator) String(size int64, minLength, maxLength int, nullprob float64) arrow.Array {
 	lengths := r.Int32(size, int32(minLength), int32(maxLength), nullprob).(*array.Int32)
 	defer lengths.Release()
 

--- a/go/arrow/ipc/cmd/arrow-cat/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-cat/main_test.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/apache/arrow/go/v7/arrow/array"
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/internal/arrdata"
 	"github.com/apache/arrow/go/v7/arrow/ipc"
 	"github.com/apache/arrow/go/v7/arrow/memory"
@@ -534,7 +534,7 @@ record 3/3...
 
 				var w interface {
 					io.Closer
-					Write(array.Record) error
+					Write(arrow.Record) error
 				}
 
 				switch {

--- a/go/arrow/ipc/cmd/arrow-ls/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-ls/main_test.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/apache/arrow/go/v7/arrow/array"
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/internal/arrdata"
 	"github.com/apache/arrow/go/v7/arrow/ipc"
 	"github.com/apache/arrow/go/v7/arrow/memory"
@@ -293,7 +293,7 @@ records: 3
 
 				var w interface {
 					io.Closer
-					Write(array.Record) error
+					Write(arrow.Record) error
 				}
 
 				switch {

--- a/go/arrow/ipc/dict.go
+++ b/go/arrow/ipc/dict.go
@@ -18,21 +18,20 @@ package ipc
 
 import (
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"golang.org/x/xerrors"
 )
 
-type dictMap map[int64]array.Interface
+type dictMap map[int64]arrow.Array
 type dictTypeMap map[int64]arrow.Field
 
 type dictMemo struct {
-	dict2id map[array.Interface]int64
+	dict2id map[arrow.Array]int64
 	id2dict dictMap // map of dictionary ID to dictionary array
 }
 
 func newMemo() dictMemo {
 	return dictMemo{
-		dict2id: make(map[array.Interface]int64),
+		dict2id: make(map[arrow.Array]int64),
 		id2dict: make(dictMap),
 	}
 }
@@ -47,12 +46,12 @@ func (memo *dictMemo) delete() {
 	}
 }
 
-func (memo dictMemo) Dict(id int64) (array.Interface, bool) {
+func (memo dictMemo) Dict(id int64) (arrow.Array, bool) {
 	v, ok := memo.id2dict[id]
 	return v, ok
 }
 
-func (memo *dictMemo) ID(v array.Interface) int64 {
+func (memo *dictMemo) ID(v arrow.Array) int64 {
 	id, ok := memo.dict2id[v]
 	if ok {
 		return id
@@ -65,7 +64,7 @@ func (memo *dictMemo) ID(v array.Interface) int64 {
 	return id
 }
 
-func (memo dictMemo) HasDict(v array.Interface) bool {
+func (memo dictMemo) HasDict(v arrow.Array) bool {
 	_, ok := memo.dict2id[v]
 	return ok
 }
@@ -75,7 +74,7 @@ func (memo dictMemo) HasID(id int64) bool {
 	return ok
 }
 
-func (memo *dictMemo) Add(id int64, v array.Interface) {
+func (memo *dictMemo) Add(id int64, v arrow.Array) {
 	if _, dup := memo.id2dict[id]; dup {
 		panic(xerrors.Errorf("arrow/ipc: duplicate id=%d", id))
 	}

--- a/go/arrow/ipc/dict_test.go
+++ b/go/arrow/ipc/dict_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 )
@@ -65,7 +66,7 @@ func TestDictMemo(t *testing.T) {
 		t.Fatalf("invalid length: got=%d, want=%d", got, want)
 	}
 
-	var ff array.Interface
+	var ff arrow.Array
 
 	ff = f0
 	if !memo.HasDict(ff) {
@@ -82,7 +83,7 @@ func TestDictMemo(t *testing.T) {
 		t.Fatalf("should not have found f2")
 	}
 
-	fct := func(v array.Interface) array.Interface {
+	fct := func(v arrow.Array) arrow.Array {
 		return v
 	}
 
@@ -95,7 +96,7 @@ func TestDictMemo(t *testing.T) {
 	}
 
 	ff = f0
-	for i, f := range []array.Interface{f0, f1, ff, fct(f0), fct(f1)} {
+	for i, f := range []arrow.Array{f0, f1, ff, fct(f0), fct(f1)} {
 		if !memo.HasDict(f) {
 			t.Fatalf("failed to find dict %d", i)
 		}
@@ -159,15 +160,15 @@ func TestDictMemoPanics(t *testing.T) {
 	defer f1.Release()
 
 	for _, tc := range []struct {
-		vs  []array.Interface
+		vs  []arrow.Array
 		ids []int64
 	}{
 		{
-			vs:  []array.Interface{f0, f1},
+			vs:  []arrow.Array{f0, f1},
 			ids: []int64{0, 0},
 		},
 		{
-			vs:  []array.Interface{f0, f0},
+			vs:  []arrow.Array{f0, f0},
 			ids: []int64{0, 0},
 		},
 	} {

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -137,6 +137,7 @@ func (f *FileReader) readSchema() error {
 		return xerrors.Errorf("arrow/ipc: could not load dictionary types from file: %w", err)
 	}
 
+	//lint:ignore SA4008 readDictionary always panics currently. ignore lint until DictionaryArray is implemented.
 	for i := 0; i < f.NumDictionaries(); i++ {
 		blk, err := f.dict(i)
 		if err != nil {

--- a/go/arrow/ipc/file_writer.go
+++ b/go/arrow/ipc/file_writer.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/bitutil"
 	"github.com/apache/arrow/go/v7/arrow/internal/flatbuf"
 	"github.com/apache/arrow/go/v7/arrow/memory"
@@ -323,7 +322,7 @@ func (f *FileWriter) Close() error {
 	return nil
 }
 
-func (f *FileWriter) Write(rec array.Record) error {
+func (f *FileWriter) Write(rec arrow.Record) error {
 	schema := rec.Schema()
 	if schema == nil || !schema.Equal(f.schema) {
 		return errInconsistentSchema

--- a/go/arrow/ipc/ipc_test.go
+++ b/go/arrow/ipc/ipc_test.go
@@ -62,13 +62,13 @@ func TestArrow12072(t *testing.T) {
 	rec := b.NewRecord()
 	defer rec.Release()
 
-	tbl := array.NewTableFromRecords(schema, []array.Record{rec})
+	tbl := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer tbl.Release()
 
 	tr := array.NewTableReader(tbl, 1)
 	defer tr.Release()
 
-	data := []array.Record{}
+	data := []arrow.Record{}
 	for tr.Next() {
 		rec := tr.Record()
 		rec.Retain()
@@ -124,7 +124,7 @@ func (r *testMessageReader) Message() (*ipc.Message, error) {
 	return nil, errors.New("Error!")
 }
 func (r *testMessageReader) Release() {}
-func (r *testMessageReader) Retain() {}
+func (r *testMessageReader) Retain()  {}
 
 // Ensure that if the MessageReader errors, we get the error from Read
 func TestArrow14769(t *testing.T) {

--- a/go/arrow/ipc/message.go
+++ b/go/arrow/ipc/message.go
@@ -65,13 +65,6 @@ func (m MessageType) String() string {
 	return fmt.Sprintf("MessageType(%d)", int(m))
 }
 
-const (
-	// maxNestingDepth is an arbitrary value to catch user mistakes.
-	// For deeply nested schemas, it is expected the user will indicate
-	// explicitly the maximum allowed recursion depth.
-	maxNestingDepth = 64
-)
-
 // Message is an IPC message, including metadata and body.
 type Message struct {
 	refCount int64

--- a/go/arrow/ipc/message_test.go
+++ b/go/arrow/ipc/message_test.go
@@ -80,7 +80,7 @@ func writeRecordsIntoBuffer(t *testing.T, numRecords int) *bytes.Buffer {
 	return buf
 }
 
-func getTestRecords(mem memory.Allocator, numRecords int) (*arrow.Schema, []array.Record) {
+func getTestRecords(mem memory.Allocator, numRecords int) (*arrow.Schema, []arrow.Record) {
 	meta := arrow.NewMetadata([]string{}, []string{})
 	s := arrow.NewSchema([]arrow.Field{
 		{Name: "test-col", Type: arrow.PrimitiveTypes.Int64},
@@ -89,7 +89,7 @@ func getTestRecords(mem memory.Allocator, numRecords int) (*arrow.Schema, []arra
 	builder := array.NewRecordBuilder(mem, s)
 	defer builder.Release()
 
-	recs := make([]array.Record, numRecords)
+	recs := make([]arrow.Record, numRecords)
 	for i := 0; i < len(recs); i++ {
 		col := builder.Field(0).(*array.Int64Builder)
 		for i := 0; i < 10; i++ {

--- a/go/arrow/ipc/metadata_test.go
+++ b/go/arrow/ipc/metadata_test.go
@@ -162,7 +162,7 @@ func TestRWFooter(t *testing.T) {
 	}
 }
 
-func exampleUUID(mem memory.Allocator) array.Interface {
+func exampleUUID(mem memory.Allocator) arrow.Array {
 	extType := types.NewUUIDType()
 	bldr := array.NewExtensionBuilder(mem, extType)
 	defer bldr.Release()
@@ -187,7 +187,7 @@ func TestUnrecognizedExtensionType(t *testing.T) {
 	batch := array.NewRecord(
 		arrow.NewSchema([]arrow.Field{
 			{Name: "f0", Type: extArr.DataType(), Nullable: true}}, nil),
-		[]array.Interface{extArr}, 4)
+		[]arrow.Array{extArr}, 4)
 	defer batch.Release()
 
 	storageArr := extArr.(array.ExtensionArray).Storage()
@@ -215,7 +215,7 @@ func TestUnrecognizedExtensionType(t *testing.T) {
 	batchNoExt := array.NewRecord(
 		arrow.NewSchema([]arrow.Field{
 			{Name: "f0", Type: storageArr.DataType(), Nullable: true, Metadata: extMetadata},
-		}, nil), []array.Interface{storageArr}, 4)
+		}, nil), []arrow.Array{storageArr}, 4)
 	defer batchNoExt.Release()
 
 	assert.Truef(t, array.RecordEqual(rec, batchNoExt), "expected: %s\ngot: %s\n", batchNoExt, rec)

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -37,7 +37,7 @@ type Reader struct {
 	schema *arrow.Schema
 
 	refCount int64
-	rec      array.Record
+	rec      arrow.Record
 	err      error
 
 	types dictTypeMap
@@ -183,13 +183,13 @@ func (r *Reader) next() bool {
 // Record returns the current record that has been extracted from the
 // underlying stream.
 // It is valid until the next call to Next.
-func (r *Reader) Record() array.Record {
+func (r *Reader) Record() arrow.Record {
 	return r.rec
 }
 
 // Read reads the current record from the underlying stream and an error, if any.
 // When the Reader reaches the end of the underlying stream, it returns (nil, io.EOF).
-func (r *Reader) Read() (array.Record, error) {
+func (r *Reader) Read() (arrow.Record, error) {
 	if r.rec != nil {
 		r.rec.Release()
 		r.rec = nil

--- a/go/arrow/ipc/writer.go
+++ b/go/arrow/ipc/writer.go
@@ -307,7 +307,7 @@ func (w *recordEncoder) Encode(p *Payload, rec arrow.Record) error {
 	return w.encodeMetadata(p, rec.NumRows())
 }
 
-func (w *recordEncoder) visit(p *Payload, arr array.Interface) error {
+func (w *recordEncoder) visit(p *Payload, arr arrow.Array) error {
 	if w.depth <= 0 {
 		return errMaxRecursion
 	}
@@ -553,7 +553,7 @@ func (w *recordEncoder) visit(p *Payload, arr array.Interface) error {
 	return nil
 }
 
-func (w *recordEncoder) getZeroBasedValueOffsets(arr array.Interface) (*memory.Buffer, error) {
+func (w *recordEncoder) getZeroBasedValueOffsets(arr arrow.Array) (*memory.Buffer, error) {
 	data := arr.Data()
 	voffsets := data.Buffers()[1]
 	if data.Offset() != 0 {

--- a/go/arrow/ipc/writer.go
+++ b/go/arrow/ipc/writer.go
@@ -117,7 +117,7 @@ func (w *Writer) Close() error {
 	return nil
 }
 
-func (w *Writer) Write(rec array.Record) error {
+func (w *Writer) Write(rec arrow.Record) error {
 	if !w.started {
 		err := w.start()
 		if err != nil {
@@ -260,7 +260,7 @@ func (w *recordEncoder) compressBodyBuffers(p *Payload) error {
 	return <-errch
 }
 
-func (w *recordEncoder) Encode(p *Payload, rec array.Record) error {
+func (w *recordEncoder) Encode(p *Payload, rec arrow.Record) error {
 
 	// perform depth-first traversal of the row-batch
 	for i, col := range rec.Columns() {

--- a/go/arrow/ipc/writer_test.go
+++ b/go/arrow/ipc/writer_test.go
@@ -42,7 +42,7 @@ func TestSliceAndWrite(t *testing.T) {
 	rec := b.NewRecord()
 	defer rec.Release()
 
-	sliceAndWrite := func(rec array.Record, schema *arrow.Schema) {
+	sliceAndWrite := func(rec arrow.Record, schema *arrow.Schema) {
 		slice := rec.NewSlice(1, 2)
 		defer slice.Release()
 

--- a/go/arrow/record.go
+++ b/go/arrow/record.go
@@ -18,8 +18,11 @@ package arrow
 
 import "encoding/json"
 
-// Record is a collection of equal-length arrays
-// matching a particular Schema.
+// Record is a collection of equal-length arrays matching a particular Schema.
+// Also known as a RecordBatch in the spec and in some implementations.
+//
+// It is also possible to construct a Table from a collection of Records that
+// all have the same schema.
 type Record interface {
 	json.Marshaler
 

--- a/go/arrow/record.go
+++ b/go/arrow/record.go
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import "encoding/json"
+
+// Record is a collection of equal-length arrays
+// matching a particular Schema.
+type Record interface {
+	json.Marshaler
+
+	Release()
+	Retain()
+
+	Schema() *Schema
+
+	NumRows() int64
+	NumCols() int64
+
+	Columns() []Array
+	Column(i int) Array
+	ColumnName(i int) string
+
+	// NewSlice constructs a zero-copy slice of the record with the indicated
+	// indices i and j, corresponding to array[i:j].
+	// The returned record must be Release()'d after use.
+	//
+	// NewSlice panics if the slice is outside the valid range of the record array.
+	// NewSlice panics if j < i.
+	NewSlice(i, j int64) Record
+}

--- a/go/arrow/scalar/nested.go
+++ b/go/arrow/scalar/nested.go
@@ -29,20 +29,20 @@ import (
 
 type ListScalar interface {
 	Scalar
-	GetList() array.Interface
+	GetList() arrow.Array
 	Release()
 	Retain()
 }
 
 type List struct {
 	scalar
-	Value array.Interface
+	Value arrow.Array
 }
 
-func (l *List) Release()                 { l.Value.Release() }
-func (l *List) Retain()                  { l.Value.Retain() }
-func (l *List) value() interface{}       { return l.Value }
-func (l *List) GetList() array.Interface { return l.Value }
+func (l *List) Release()             { l.Value.Release() }
+func (l *List) Retain()              { l.Value.Retain() }
+func (l *List) value() interface{}   { return l.Value }
+func (l *List) GetList() arrow.Array { return l.Value }
 func (l *List) equals(rhs Scalar) bool {
 	return array.ArrayEqual(l.Value, rhs.(ListScalar).GetList())
 }
@@ -111,7 +111,7 @@ func (l *List) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func NewListScalar(val array.Interface) *List {
+func NewListScalar(val arrow.Array) *List {
 	return &List{scalar{arrow.ListOf(val.DataType()), true}, array.MakeFromData(val.Data())}
 }
 
@@ -128,7 +128,7 @@ type Map struct {
 	*List
 }
 
-func NewMapScalar(val array.Interface) *Map {
+func NewMapScalar(val arrow.Array) *Map {
 	return &Map{&List{scalar{makeMapType(val.DataType().(*arrow.StructType)), true}, array.MakeFromData(val.Data())}}
 }
 
@@ -153,11 +153,11 @@ func (f *FixedSizeList) Validate() (err error) {
 
 func (f *FixedSizeList) ValidateFull() error { return f.Validate() }
 
-func NewFixedSizeListScalar(val array.Interface) *FixedSizeList {
+func NewFixedSizeListScalar(val arrow.Array) *FixedSizeList {
 	return NewFixedSizeListScalarWithType(val, arrow.FixedSizeListOf(int32(val.Len()), val.DataType()))
 }
 
-func NewFixedSizeListScalarWithType(val array.Interface, typ arrow.DataType) *FixedSizeList {
+func NewFixedSizeListScalarWithType(val arrow.Array, typ arrow.DataType) *FixedSizeList {
 	debug.Assert(val.Len() == int(typ.(*arrow.FixedSizeListType).Len()), "length of value for fixed size list scalar must match type")
 	return &FixedSizeList{&List{scalar{typ, true}, array.MakeFromData(val.Data())}}
 }

--- a/go/arrow/scalar/nested.go
+++ b/go/arrow/scalar/nested.go
@@ -115,7 +115,7 @@ func NewListScalar(val arrow.Array) *List {
 	return &List{scalar{arrow.ListOf(val.DataType()), true}, array.MakeFromData(val.Data())}
 }
 
-func NewListScalarData(val *array.Data) *List {
+func NewListScalarData(val arrow.ArrayData) *List {
 	return &List{scalar{arrow.ListOf(val.DataType()), true}, array.MakeFromData(val)}
 }
 

--- a/go/arrow/scalar/parse.go
+++ b/go/arrow/scalar/parse.go
@@ -167,7 +167,7 @@ func createListScalar(sliceval reflect.Value, mem memory.Allocator) (Scalar, err
 		return nil, xerrors.Errorf("createListScalar only works for slices, not %s", sliceval.Kind())
 	}
 
-	var arr array.Interface
+	var arr arrow.Array
 
 	switch sliceval.Type().Elem().Kind() {
 	case reflect.String:

--- a/go/arrow/scalar/parse.go
+++ b/go/arrow/scalar/parse.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v7/arrow"
+	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/float16"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"golang.org/x/xerrors"

--- a/go/arrow/scalar/parse.go
+++ b/go/arrow/scalar/parse.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/float16"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"golang.org/x/xerrors"
@@ -402,7 +401,7 @@ func MakeScalarParam(val interface{}, dt arrow.DataType) (Scalar, error) {
 		return NewTime64Scalar(v, dt), nil
 	case arrow.Timestamp:
 		return NewTimestampScalar(v, dt), nil
-	case array.Interface:
+	case arrow.Array:
 		switch dt.ID() {
 		case arrow.LIST:
 			if !arrow.TypeEqual(v.DataType(), dt.(*arrow.ListType).Elem()) {

--- a/go/arrow/scalar/scalar.go
+++ b/go/arrow/scalar/scalar.go
@@ -683,7 +683,7 @@ func MakeArrayFromScalar(sc Scalar, length int, mem memory.Allocator) (array.Int
 
 		offsetsBuf := createOffsets(int32(s.Value.Len()))
 		defer offsetsBuf.Release()
-		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil, offsetsBuf}, []*array.Data{valueArray.Data()}, 0, 0)
+		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil, offsetsBuf}, []arrow.ArrayData{valueArray.Data()}, 0, 0)
 		defer data.Release()
 		return array.MakeFromData(data), nil
 	case *FixedSizeList:
@@ -698,11 +698,11 @@ func MakeArrayFromScalar(sc Scalar, length int, mem memory.Allocator) (array.Int
 		}
 		defer valueArray.Release()
 
-		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil}, []*array.Data{valueArray.Data()}, 0, 0)
+		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil}, []arrow.ArrayData{valueArray.Data()}, 0, 0)
 		defer data.Release()
 		return array.MakeFromData(data), nil
 	case *Struct:
-		fields := make([]*array.Data, 0)
+		fields := make([]arrow.ArrayData, 0)
 		for _, v := range s.Value {
 			arr, err := MakeArrayFromScalar(v, length, mem)
 			if err != nil {
@@ -737,8 +737,8 @@ func MakeArrayFromScalar(sc Scalar, length int, mem memory.Allocator) (array.Int
 		defer valueArr.Release()
 
 		offsetsBuf := createOffsets(int32(structArr.Len()))
-		outStructArr := array.NewData(structArr.DataType(), keyArr.Len(), []*memory.Buffer{nil}, []*array.Data{keyArr.Data(), valueArr.Data()}, 0, 0)
-		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil, offsetsBuf}, []*array.Data{outStructArr}, 0, 0)
+		outStructArr := array.NewData(structArr.DataType(), keyArr.Len(), []*memory.Buffer{nil}, []arrow.ArrayData{keyArr.Data(), valueArr.Data()}, 0, 0)
+		data := array.NewData(s.DataType(), length, []*memory.Buffer{nil, offsetsBuf}, []arrow.ArrayData{outStructArr}, 0, 0)
 		defer func() {
 			offsetsBuf.Release()
 			outStructArr.Release()

--- a/go/arrow/scalar/scalar.go
+++ b/go/arrow/scalar/scalar.go
@@ -564,7 +564,7 @@ func GetScalar(arr arrow.Array, idx int) (Scalar, error) {
 }
 
 // MakeArrayOfNull creates an array of size length which is all null of the given data type.
-func MakeArrayOfNull(dt arrow.DataType, length int, mem memory.Allocator) array.Interface {
+func MakeArrayOfNull(dt arrow.DataType, length int, mem memory.Allocator) arrow.Array {
 	var (
 		buffers  = []*memory.Buffer{nil}
 		children []arrow.ArrayData

--- a/go/arrow/scalar/scalar_test.go
+++ b/go/arrow/scalar/scalar_test.go
@@ -627,7 +627,7 @@ type ListScalarSuite struct {
 	suite.Suite
 
 	typ arrow.DataType
-	val array.Interface
+	val arrow.Array
 }
 
 func (l *ListScalarSuite) SetupTest() {

--- a/go/arrow/table.go
+++ b/go/arrow/table.go
@@ -22,7 +22,10 @@ import (
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
-// Table represents a logical sequence of chunked arrays.
+// Table represents a logical sequence of chunked arrays of equal length. It is
+// similar to a Record except that the columns are ChunkedArrays instead,
+// allowing for a Table to be built up by chunks progressively whereas the columns
+// in a single Record are always each a single contiguous array.
 type Table interface {
 	Schema() *Schema
 	NumRows() int64
@@ -35,6 +38,24 @@ type Table interface {
 
 // Column is an immutable column data structure consisting of
 // a field (type metadata) and a chunked data array.
+//
+// To get strongly typed data from a Column, you need to iterate the
+// chunks and type assert each individual Array. For example:
+//
+// 		switch column.DataType().ID {
+//		case arrow.INT32:
+//			for _, c := range column.Data().Chunks() {
+//				arr := c.(*array.Int32)
+//				// do something with arr
+//			}
+//		case arrow.INT64:
+//			for _, c := range column.Data().Chunks() {
+//				arr := c.(*array.Int64)
+//				// do something with arr
+//			}
+//		case ...
+//		}
+//
 type Column struct {
 	field Field
 	data  *Chunked

--- a/go/arrow/table.go
+++ b/go/arrow/table.go
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/v7/arrow/internal/debug"
+)
+
+// Table represents a logical sequence of chunked arrays.
+type Table interface {
+	Schema() *Schema
+	NumRows() int64
+	NumCols() int64
+	Column(i int) *Column
+
+	Retain()
+	Release()
+}
+
+// Column is an immutable column data structure consisting of
+// a field (type metadata) and a chunked data array.
+type Column struct {
+	field Field
+	data  *Chunked
+}
+
+// NewColumn returns a column from a field and a chunked data array.
+//
+// NewColumn panics if the field's data type is inconsistent with the data type
+// of the chunked data array.
+func NewColumn(field Field, chunks *Chunked) *Column {
+	col := Column{
+		field: field,
+		data:  chunks,
+	}
+	col.data.Retain()
+
+	if !TypeEqual(col.data.DataType(), col.field.Type) {
+		col.data.Release()
+		panic("arrow/array: inconsistent data type")
+	}
+
+	return &col
+}
+
+// Retain increases the reference count by 1.
+// Retain may be called simultaneously from multiple goroutines.
+func (col *Column) Retain() {
+	col.data.Retain()
+}
+
+// Release decreases the reference count by 1.
+// When the reference count goes to zero, the memory is freed.
+// Release may be called simultaneously from multiple goroutines.
+func (col *Column) Release() {
+	col.data.Release()
+}
+
+func (col *Column) Len() int           { return col.data.Len() }
+func (col *Column) NullN() int         { return col.data.NullN() }
+func (col *Column) Data() *Chunked     { return col.data }
+func (col *Column) Field() Field       { return col.field }
+func (col *Column) Name() string       { return col.field.Name }
+func (col *Column) DataType() DataType { return col.field.Type }
+
+// Chunked manages a collection of primitives arrays as one logical large array.
+type Chunked struct {
+	refCount int64 // refCount must be first in the struct for 64 bit alignment and sync/atomic (https://github.com/golang/go/issues/37262)
+
+	chunks []Array
+
+	length int
+	nulls  int
+	dtype  DataType
+}
+
+// NewChunked returns a new chunked array from the slice of arrays.
+//
+// NewChunked panics if the chunks do not have the same data type.
+func NewChunked(dtype DataType, chunks []Array) *Chunked {
+	arr := &Chunked{
+		chunks:   make([]Array, len(chunks)),
+		refCount: 1,
+		dtype:    dtype,
+	}
+	for i, chunk := range chunks {
+		if !TypeEqual(chunk.DataType(), dtype) {
+			panic("arrow/array: mismatch data type")
+		}
+		chunk.Retain()
+		arr.chunks[i] = chunk
+		arr.length += chunk.Len()
+		arr.nulls += chunk.NullN()
+	}
+	return arr
+}
+
+// Retain increases the reference count by 1.
+// Retain may be called simultaneously from multiple goroutines.
+func (a *Chunked) Retain() {
+	atomic.AddInt64(&a.refCount, 1)
+}
+
+// Release decreases the reference count by 1.
+// When the reference count goes to zero, the memory is freed.
+// Release may be called simultaneously from multiple goroutines.
+func (a *Chunked) Release() {
+	debug.Assert(atomic.LoadInt64(&a.refCount) > 0, "too many releases")
+
+	if atomic.AddInt64(&a.refCount, -1) == 0 {
+		for _, arr := range a.chunks {
+			arr.Release()
+		}
+		a.chunks = nil
+		a.length = 0
+		a.nulls = 0
+	}
+}
+
+func (a *Chunked) Len() int           { return a.length }
+func (a *Chunked) NullN() int         { return a.nulls }
+func (a *Chunked) DataType() DataType { return a.dtype }
+func (a *Chunked) Chunks() []Array    { return a.chunks }
+func (a *Chunked) Chunk(i int) Array  { return a.chunks[i] }

--- a/go/arrow/tensor/numeric.gen.go
+++ b/go/arrow/tensor/numeric.gen.go
@@ -20,7 +20,6 @@ package tensor
 
 import (
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 )
 
 // Int8 is an n-dim array of int8s.
@@ -32,7 +31,7 @@ type Int8 struct {
 // NewInt8 returns a new n-dimensional array of int8s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewInt8(data *array.Data, shape, strides []int64, names []string) *Int8 {
+func NewInt8(data arrow.ArrayData, shape, strides []int64, names []string) *Int8 {
 	tsr := &Int8{tensorBase: *newTensor(arrow.PrimitiveTypes.Int8, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -56,7 +55,7 @@ type Int16 struct {
 // NewInt16 returns a new n-dimensional array of int16s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewInt16(data *array.Data, shape, strides []int64, names []string) *Int16 {
+func NewInt16(data arrow.ArrayData, shape, strides []int64, names []string) *Int16 {
 	tsr := &Int16{tensorBase: *newTensor(arrow.PrimitiveTypes.Int16, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -80,7 +79,7 @@ type Int32 struct {
 // NewInt32 returns a new n-dimensional array of int32s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewInt32(data *array.Data, shape, strides []int64, names []string) *Int32 {
+func NewInt32(data arrow.ArrayData, shape, strides []int64, names []string) *Int32 {
 	tsr := &Int32{tensorBase: *newTensor(arrow.PrimitiveTypes.Int32, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -104,7 +103,7 @@ type Int64 struct {
 // NewInt64 returns a new n-dimensional array of int64s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewInt64(data *array.Data, shape, strides []int64, names []string) *Int64 {
+func NewInt64(data arrow.ArrayData, shape, strides []int64, names []string) *Int64 {
 	tsr := &Int64{tensorBase: *newTensor(arrow.PrimitiveTypes.Int64, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -128,7 +127,7 @@ type Uint8 struct {
 // NewUint8 returns a new n-dimensional array of uint8s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewUint8(data *array.Data, shape, strides []int64, names []string) *Uint8 {
+func NewUint8(data arrow.ArrayData, shape, strides []int64, names []string) *Uint8 {
 	tsr := &Uint8{tensorBase: *newTensor(arrow.PrimitiveTypes.Uint8, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -152,7 +151,7 @@ type Uint16 struct {
 // NewUint16 returns a new n-dimensional array of uint16s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewUint16(data *array.Data, shape, strides []int64, names []string) *Uint16 {
+func NewUint16(data arrow.ArrayData, shape, strides []int64, names []string) *Uint16 {
 	tsr := &Uint16{tensorBase: *newTensor(arrow.PrimitiveTypes.Uint16, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -176,7 +175,7 @@ type Uint32 struct {
 // NewUint32 returns a new n-dimensional array of uint32s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewUint32(data *array.Data, shape, strides []int64, names []string) *Uint32 {
+func NewUint32(data arrow.ArrayData, shape, strides []int64, names []string) *Uint32 {
 	tsr := &Uint32{tensorBase: *newTensor(arrow.PrimitiveTypes.Uint32, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -200,7 +199,7 @@ type Uint64 struct {
 // NewUint64 returns a new n-dimensional array of uint64s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewUint64(data *array.Data, shape, strides []int64, names []string) *Uint64 {
+func NewUint64(data arrow.ArrayData, shape, strides []int64, names []string) *Uint64 {
 	tsr := &Uint64{tensorBase: *newTensor(arrow.PrimitiveTypes.Uint64, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -224,7 +223,7 @@ type Float32 struct {
 // NewFloat32 returns a new n-dimensional array of float32s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewFloat32(data *array.Data, shape, strides []int64, names []string) *Float32 {
+func NewFloat32(data arrow.ArrayData, shape, strides []int64, names []string) *Float32 {
 	tsr := &Float32{tensorBase: *newTensor(arrow.PrimitiveTypes.Float32, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -248,7 +247,7 @@ type Float64 struct {
 // NewFloat64 returns a new n-dimensional array of float64s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewFloat64(data *array.Data, shape, strides []int64, names []string) *Float64 {
+func NewFloat64(data arrow.ArrayData, shape, strides []int64, names []string) *Float64 {
 	tsr := &Float64{tensorBase: *newTensor(arrow.PrimitiveTypes.Float64, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -272,7 +271,7 @@ type Date32 struct {
 // NewDate32 returns a new n-dimensional array of date32s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewDate32(data *array.Data, shape, strides []int64, names []string) *Date32 {
+func NewDate32(data arrow.ArrayData, shape, strides []int64, names []string) *Date32 {
 	tsr := &Date32{tensorBase: *newTensor(arrow.PrimitiveTypes.Date32, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {
@@ -296,7 +295,7 @@ type Date64 struct {
 // NewDate64 returns a new n-dimensional array of date64s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func NewDate64(data *array.Data, shape, strides []int64, names []string) *Date64 {
+func NewDate64(data arrow.ArrayData, shape, strides []int64, names []string) *Date64 {
 	tsr := &Date64{tensorBase: *newTensor(arrow.PrimitiveTypes.Date64, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {

--- a/go/arrow/tensor/numeric.gen.go.tmpl
+++ b/go/arrow/tensor/numeric.gen.go.tmpl
@@ -32,7 +32,7 @@ type {{.Name}} struct {
 // New{{.Name}} returns a new n-dimensional array of {{.Type}}s.
 // If strides is nil, row-major strides will be inferred.
 // If names is nil, a slice of empty strings will be created.
-func New{{.Name}}(data *array.Data, shape, strides []int64, names []string) *{{.Name}} {
+func New{{.Name}}(data arrow.ArrayData, shape, strides []int64, names []string) *{{.Name}} {
 	tsr := &{{.Name}}{tensorBase:*newTensor(arrow.PrimitiveTypes.{{.Name}}, data, shape, strides, names)}
 	vals := tsr.data.Buffers()[1]
 	if vals != nil {

--- a/go/arrow/tensor/tensor.go
+++ b/go/arrow/tensor/tensor.go
@@ -22,7 +22,6 @@ import (
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/v7/arrow"
-	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/internal/debug"
 )
 
@@ -56,7 +55,7 @@ type Interface interface {
 	DimNames() []string
 
 	DataType() arrow.DataType
-	Data() *array.Data
+	Data() arrow.ArrayData
 
 	// IsMutable returns whether the underlying data buffer is mutable.
 	IsMutable() bool
@@ -69,7 +68,7 @@ type tensorBase struct {
 	refCount int64
 	dtype    arrow.DataType
 	bw       int64 // bytes width
-	data     *array.Data
+	data     arrow.ArrayData
 	shape    []int64
 	strides  []int64
 	names    []string
@@ -106,7 +105,7 @@ func (tb *tensorBase) Strides() []int64         { return tb.strides }
 func (tb *tensorBase) NumDims() int             { return len(tb.shape) }
 func (tb *tensorBase) DimName(i int) string     { return tb.names[i] }
 func (tb *tensorBase) DataType() arrow.DataType { return tb.dtype }
-func (tb *tensorBase) Data() *array.Data        { return tb.data }
+func (tb *tensorBase) Data() arrow.ArrayData    { return tb.data }
 func (tb *tensorBase) DimNames() []string       { return tb.names }
 
 // IsMutable returns whether the underlying data buffer is mutable.
@@ -139,7 +138,7 @@ func (tb *tensorBase) offset(index []int64) int64 {
 // If names is nil, a slice of empty strings will be created.
 //
 // New panics if the backing data is not a numerical type.
-func New(data *array.Data, shape, strides []int64, names []string) Interface {
+func New(data arrow.ArrayData, shape, strides []int64, names []string) Interface {
 	dt := data.DataType()
 	switch dt.ID() {
 	case arrow.INT8:
@@ -171,7 +170,7 @@ func New(data *array.Data, shape, strides []int64, names []string) Interface {
 	}
 }
 
-func newTensor(dtype arrow.DataType, data *array.Data, shape, strides []int64, names []string) *tensorBase {
+func newTensor(dtype arrow.DataType, data arrow.ArrayData, shape, strides []int64, names []string) *tensorBase {
 	tb := tensorBase{
 		refCount: 1,
 		dtype:    dtype,

--- a/go/parquet/internal/testutils/random.go
+++ b/go/parquet/internal/testutils/random.go
@@ -75,7 +75,7 @@ func (r *RandomArrayGenerator) GenerateBitmap(buffer []byte, n int64, prob float
 // with nullProb being the probability of a given index being null.
 //
 // For this generation we only generate ascii values with a min of 'A' and max of 'z'.
-func (r *RandomArrayGenerator) ByteArray(size int64, minLen, maxLen int32, nullProb float64) array.Interface {
+func (r *RandomArrayGenerator) ByteArray(size int64, minLen, maxLen int32, nullProb float64) arrow.Array {
 	if nullProb < 0 || nullProb > 1 {
 		panic("null prob must be between 0 and 1")
 	}
@@ -108,7 +108,7 @@ func (r *RandomArrayGenerator) ByteArray(size int64, minLen, maxLen int32, nullP
 
 // Uint8 generates a random array.Uint8 of the requested size whose values are between min and max
 // with prob as the probability that a given index will be null.
-func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) arrow.Array {
 	buffers := make([]*memory.Buffer, 2)
 	nullCount := int64(0)
 

--- a/go/parquet/internal/testutils/random_arrow.go
+++ b/go/parquet/internal/testutils/random_arrow.go
@@ -33,7 +33,7 @@ import (
 // binary will have each value between length 2 and 12 but random bytes that are not limited to ascii
 // fixed size binary will all be of length 10, random bytes are not limited to ascii
 // bool will be approximately half false and half true randomly.
-func RandomNonNull(dt arrow.DataType, size int) array.Interface {
+func RandomNonNull(dt arrow.DataType, size int) arrow.Array {
 	switch dt.ID() {
 	case arrow.FLOAT32:
 		bldr := array.NewFloat32Builder(memory.DefaultAllocator)
@@ -182,7 +182,7 @@ func RandomNonNull(dt arrow.DataType, size int) array.Interface {
 // RandomNullable generates a random arrow array of length size with approximately numNulls,
 // at most there can be size/2 nulls. Other than there being nulls, the values follow the same rules
 // as described in the docs for RandomNonNull.
-func RandomNullable(dt arrow.DataType, size int, numNulls int) array.Interface {
+func RandomNullable(dt arrow.DataType, size int, numNulls int) arrow.Array {
 	switch dt.ID() {
 	case arrow.FLOAT32:
 		bldr := array.NewFloat32Builder(memory.DefaultAllocator)

--- a/go/parquet/internal/utils/bit_reader_test.go
+++ b/go/parquet/internal/utils/bit_reader_test.go
@@ -492,7 +492,7 @@ func (r *RLERandomSuite) checkRoundTrip(vals []uint64, width int) bool {
 	return res
 }
 
-func (r *RLERandomSuite) checkRoundTripSpaced(vals array.Interface, width int) {
+func (r *RLERandomSuite) checkRoundTripSpaced(vals arrow.Array, width int) {
 	nvalues := vals.Len()
 	bufsize := utils.MaxBufferSize(width, nvalues)
 
@@ -587,7 +587,7 @@ func (r *RandomArrayGenerator) generateBitmap(buffer []byte, n int64, prob float
 	return count
 }
 
-func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) array.Interface {
+func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) arrow.Array {
 	buffers := make([]*memory.Buffer, 2)
 	nullCount := int64(0)
 


### PR DESCRIPTION
Aliases are introduced in the array package so that existing consumers do not get broken by the migration. Deprecation messages are added to the comments so that they are warned that the aliases will be removed in v8. 

Also adds an interface `arrow.ArrayData`. I personally like this updated naming scheme and it makes things easier to understand.