### PR TITLE
ARROW-14903: [C++] Enable CSV Writer to control string to be used for missing data

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -180,7 +180,7 @@ struct ARROW_EXPORT WriteOptions {
   /// This number can impact performance.
   int32_t batch_size = 1024;
 
-  /// \brief The string to write for null values. Any quotes are escaped.
+  /// \brief The string to write for null values. Quotes are not allowed in this string.
   std::string null_string;
 
   /// \brief IO context for writing.

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -180,6 +180,9 @@ struct ARROW_EXPORT WriteOptions {
   /// This number can impact performance.
   int32_t batch_size = 1024;
 
+  /// \brief The string to write for null values. Any quotes are escaped.
+  std::string null_string;
+
   /// \brief IO context for writing.
   io::IOContext io_context;
 

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -148,7 +148,7 @@ class UnquotedColumnPopulator : public ColumnPopulator {
 
   Status UpdateRowLengths(int32_t* row_lengths) override {
     for (int x = 0; x < casted_array_->length(); x++) {
-      row_lengths[x] += casted_array_->value_length(x) == 0
+      row_lengths[x] += casted_array_->IsNull(x)
                             ? static_cast<int32_t>(null_string_->size())
                             : casted_array_->value_length(x);
     }

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -87,7 +87,8 @@ constexpr int64_t kQuoteDelimiterCount = kQuoteCount + /*end_char*/ 1;
 // populators (it populates data backwards).
 class ColumnPopulator {
  public:
-  ColumnPopulator(MemoryPool* pool, char end_char) : end_char_(end_char), pool_(pool) {}
+  ColumnPopulator(MemoryPool* pool, char end_char, std::shared_ptr<Buffer> null_string)
+      : end_char_(end_char), null_string_(std::move(null_string)), pool_(pool) {}
 
   virtual ~ColumnPopulator() = default;
 
@@ -117,6 +118,7 @@ class ColumnPopulator {
   virtual Status UpdateRowLengths(int32_t* row_lengths) = 0;
   std::shared_ptr<StringArray> casted_array_;
   const char end_char_;
+  std::shared_ptr<Buffer> null_string_;
 
  private:
   MemoryPool* const pool_;
@@ -135,17 +137,27 @@ char* EscapeReverse(arrow::util::string_view s, char* out_end) {
   return out_end;
 }
 
+Result<std::shared_ptr<arrow::Buffer>> EscapeStringToBuffer(arrow::util::string_view s) {
+  auto new_length = static_cast<int64_t>(s.length() + CountEscapes(s));
+  ASSIGN_OR_RAISE(std::shared_ptr<arrow::Buffer> out, AllocateBuffer(new_length));
+  EscapeReverse(s, reinterpret_cast<char*>(out->mutable_data()) + new_length - 1);
+  return out;
+}
+
 // Populator for non-string types.  This populator relies on compute Cast functionality to
 // String if it doesn't exist it will be an error.  it also assumes the resulting string
 // from a cast does not require quoting or escaping.
 class UnquotedColumnPopulator : public ColumnPopulator {
  public:
-  explicit UnquotedColumnPopulator(MemoryPool* memory_pool, char end_char)
-      : ColumnPopulator(memory_pool, end_char) {}
+  explicit UnquotedColumnPopulator(MemoryPool* memory_pool, char end_char,
+                                   std::shared_ptr<Buffer> null_string_)
+      : ColumnPopulator(memory_pool, end_char, std::move(null_string_)) {}
 
   Status UpdateRowLengths(int32_t* row_lengths) override {
     for (int x = 0; x < casted_array_->length(); x++) {
-      row_lengths[x] += casted_array_->value_length(x);
+      row_lengths[x] += casted_array_->value_length(x) == 0
+                            ? static_cast<int32_t>(null_string_->size())
+                            : casted_array_->value_length(x);
     }
     return Status::OK();
   }
@@ -154,16 +166,20 @@ class UnquotedColumnPopulator : public ColumnPopulator {
     VisitArrayDataInline<StringType>(
         *casted_array_->data(),
         [&](arrow::util::string_view s) {
-          int64_t next_column_offset = s.length() + /*end_char*/ 1;
+          int32_t next_column_offset = static_cast<int32_t>(s.length()) + /*end_char*/ 1;
           memcpy((output + *offsets - next_column_offset), s.data(), s.length());
           *(output + *offsets - 1) = end_char_;
-          *offsets -= static_cast<int32_t>(next_column_offset);
+          *offsets -= next_column_offset;
           offsets++;
         },
         [&]() {
-          // Nulls are empty (unquoted) to distinguish with empty string.
+          // For nulls, the configured null value string is copied into the output.
+          int32_t next_column_offset =
+              static_cast<int32_t>(null_string_->size()) + /*end_char*/ 1;
+          memcpy((output + *offsets - next_column_offset), null_string_->data(),
+                 null_string_->size());
           *(output + *offsets - 1) = end_char_;
-          *offsets -= 1;
+          *offsets -= next_column_offset;
           offsets++;
         });
   }
@@ -175,8 +191,9 @@ class UnquotedColumnPopulator : public ColumnPopulator {
 // a quote character (") and escaping is done my adding another quote.
 class QuotedColumnPopulator : public ColumnPopulator {
  public:
-  QuotedColumnPopulator(MemoryPool* pool, char end_char)
-      : ColumnPopulator(pool, end_char) {}
+  QuotedColumnPopulator(MemoryPool* pool, char end_char,
+                        std::shared_ptr<Buffer> null_string)
+      : ColumnPopulator(pool, end_char, std::move(null_string)) {}
 
   Status UpdateRowLengths(int32_t* row_lengths) override {
     const StringArray& input = *casted_array_;
@@ -194,6 +211,7 @@ class QuotedColumnPopulator : public ColumnPopulator {
         },
         [&]() {
           row_needs_escaping_[row_number] = false;
+          row_lengths[row_number] += static_cast<int32_t>(null_string_->size());
           row_number++;
         });
     return Status::OK();
@@ -225,9 +243,13 @@ class QuotedColumnPopulator : public ColumnPopulator {
           needs_escaping++;
         },
         [&]() {
-          // Nulls are empty (unquoted) to distinguish with empty string.
+          // For nulls, the configured null value string is copied into the output.
+          int32_t next_column_offset =
+              static_cast<int32_t>(null_string_->size()) + /*end_char*/ 1;
+          memcpy((output + *offsets - next_column_offset), null_string_->data(),
+                 null_string_->size());
           *(output + *offsets - 1) = end_char_;
-          *offsets -= 1;
+          *offsets -= next_column_offset;
           offsets++;
           needs_escaping++;
         });
@@ -246,7 +268,7 @@ struct PopulatorFactory {
                   std::is_same<FixedSizeBinaryType, TypeClass>::value,
               Status>
   Visit(const TypeClass& type) {
-    populator = new QuotedColumnPopulator(pool, end_char);
+    populator = new QuotedColumnPopulator(pool, end_char, null_string);
     return Status::OK();
   }
 
@@ -267,18 +289,20 @@ struct PopulatorFactory {
                   is_null_type<TypeClass>::value || is_temporal_type<TypeClass>::value,
               Status>
   Visit(const TypeClass& type) {
-    populator = new UnquotedColumnPopulator(pool, end_char);
+    populator = new UnquotedColumnPopulator(pool, end_char, null_string);
     return Status::OK();
   }
 
   char end_char;
+  std::shared_ptr<Buffer> null_string;
   MemoryPool* pool;
   ColumnPopulator* populator;
 };
 
-Result<std::unique_ptr<ColumnPopulator>> MakePopulator(const Field& field, char end_char,
-                                                       MemoryPool* pool) {
-  PopulatorFactory factory{end_char, pool, nullptr};
+Result<std::unique_ptr<ColumnPopulator>> MakePopulator(
+    const Field& field, char end_char, std::shared_ptr<Buffer> null_string,
+    MemoryPool* pool) {
+  PopulatorFactory factory{end_char, std::move(null_string), pool, nullptr};
   RETURN_NOT_OK(VisitTypeInline(*field.type(), &factory));
   return std::unique_ptr<ColumnPopulator>(factory.populator);
 }
@@ -290,10 +314,12 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
       std::shared_ptr<Schema> schema, const WriteOptions& options) {
     RETURN_NOT_OK(options.Validate());
     std::vector<std::unique_ptr<ColumnPopulator>> populators(schema->num_fields());
+    ASSIGN_OR_RAISE(auto null_string, EscapeStringToBuffer(options.null_string));
     for (int col = 0; col < schema->num_fields(); col++) {
       char end_char = col < schema->num_fields() - 1 ? ',' : '\n';
-      ASSIGN_OR_RAISE(populators[col], MakePopulator(*schema->field(col), end_char,
-                                                     options.io_context.pool()));
+      ASSIGN_OR_RAISE(populators[col],
+                      MakePopulator(*schema->field(col), end_char, null_string,
+                                    options.io_context.pool()));
     }
     auto writer = std::make_shared<CSVWriterImpl>(
         sink, std::move(owned_sink), std::move(schema), std::move(populators), options);

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -308,8 +308,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     RETURN_NOT_OK(options.Validate());
     // Reject null string values that contain quotes.
     if (CountEscapes(options.null_string) != 0) {
-      return Status::Invalid("CSV null value string cannot contain quotes.",
-                             options.null_string);
+      return Status::Invalid("Null string cannot contain quotes.");
     }
 
     ASSIGN_OR_RAISE(std::shared_ptr<Buffer> null_string,

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -88,13 +88,12 @@ std::vector<WriterTestParams> GenerateTestCases() {
   auto schema_custom_na = schema({field("g", uint64()), field("h", utf8())});
 
   auto populated_batch_custom_na = R"([{"g": 42, "h": "NA"},
-                                        {}])";
+                                                  { },
+                                                  {"g": 1337, "h": "\"NA\""}])";
 
   std::string expected_custom_na = std::string(R"(42,"NA")") + "\n" +  // line 1
-                                   R"(NA,NA)" + "\n";                  // line 2
-
-  std::string expected_custom_quoted_na = std::string(R"(42,"NA")") + "\n" +  // line 1
-                                          R"(""NA"",""NA"")" + "\n";          // line 2
+                                   R"(NA,NA)" + "\n" +                 // line 2
+                                   R"(1337,"""NA""")" + "\n";            // line 3
 
   return std::vector<WriterTestParams>{
       {abc_schema, "[]", DefaultTestOptions(/*include_header=*/false, /*null_string=*/""),
@@ -109,10 +108,7 @@ std::vector<WriterTestParams> GenerateTestCases() {
        expected_header + expected_without_header},
       {schema_custom_na, populated_batch_custom_na,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"NA"),
-       expected_custom_na},
-      {schema_custom_na, populated_batch_custom_na,
-       DefaultTestOptions(/*include_header=*/false, /*null_string=*/R"("NA")"),
-       expected_custom_quoted_na}};
+       expected_custom_na}};
 }
 
 class TestWriteCSV : public ::testing::TestWithParam<WriterTestParams> {


### PR DESCRIPTION
This adds the option to configure the string that is rendered in the CSV output for null values.
If this null string has any quotes, they are escaped. I decided not to deal with the fact that the user can provide a string that cause rendered values to become ambiguous. E.g. when the user supplies `42` and an integer column has a null, it will render as `42` making it indistinguishable from the actual value of 42.
The reason is that if we were to quote a valid value or the null value, this may annoy downstream applications that perform e.g. type inference for said column. But the most major drawback is that we'd need to check every valid value for equality to the configured null value, which I think may be a price too costly to pay for users making awkward choices for their null value.