### PR TITLE
ARROW-4975: [C++] Support concatenation of UnionArrays

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -708,10 +708,6 @@ DenseUnionArray::DenseUnionArray(std::shared_ptr<DataType> type, int64_t length,
 Result<std::shared_ptr<Array>> DenseUnionArray::Make(
     const Array& type_ids, const Array& value_offsets, ArrayVector children,
     std::vector<std::string> field_names, std::vector<type_code_t> type_codes) {
-  if (value_offsets.length() == 0) {
-    return Status::Invalid("UnionArray offsets must have non-zero length");
-  }
-
   if (value_offsets.type_id() != Type::INT32) {
     return Status::TypeError("UnionArray offsets must be signed int32");
   }

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -408,8 +408,8 @@ class ConcatenateImpl {
         // offset to the concatenated offsets buffer.
         for (auto j = 0; j < in_[i]->length; j++) {
           int32_t offset;
-          if (internal::AddWithOverflow(offset_map[type_ids[j]], offset_values[j],
-                                        &offset)) {
+          if (internal::AddWithOverflow(offset_map[u.child_ids()[type_ids[j]]],
+                                        offset_values[j], &offset)) {
             return Status::Invalid("Offset value overflow when concatenating arrays");
           }
           RETURN_NOT_OK(builder.Append(offset));

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "arrow/array/array_base.h"
+#include "arrow/array/builder_primitive.h"
 #include "arrow/array/data.h"
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
@@ -349,7 +350,86 @@ class ConcatenateImpl {
   }
 
   Status Visit(const UnionType& u) {
-    return Status::NotImplemented("concatenation of ", u);
+    // This implementation assumes that all input arrays are valid union arrays
+    // with same number of variants.
+
+    // Concatenate the type buffers.
+    ARROW_ASSIGN_OR_RAISE(auto type_buffers, Buffers(1, sizeof(int8_t)));
+    RETURN_NOT_OK(ConcatenateBuffers(type_buffers, pool_).Value(&out_->buffers[1]));
+
+    // Concatenate the child data. For sparse unions the child data is sliced
+    // based on the offset and length of the array data. For dense unions the
+    // child data is not sliced because this makes constructing the concatenated
+    // offsets buffer more simple. We could however choose to modify this and
+    // slice the child arrays and reflect this in the concatenated offsets
+    // buffer.
+    switch (u.mode()) {
+      case UnionMode::SPARSE: {
+        for (int i = 0; i < u.num_fields(); i++) {
+          ARROW_ASSIGN_OR_RAISE(auto child_data, ChildData(i));
+          RETURN_NOT_OK(
+              ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[i]));
+        }
+        break;
+      }
+      case UnionMode::DENSE: {
+        for (int i = 0; i < u.num_fields(); i++) {
+          ArrayDataVector child_data(in_.size());
+          for (size_t j = 0; j < in_.size(); j++) {
+            child_data[j] = in_[j]->child_data[i];
+          }
+          RETURN_NOT_OK(
+              ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[i]));
+        }
+        break;
+      }
+    }
+
+    // Concatenate offsets buffers for dense union arrays.
+    if (u.mode() == UnionMode::DENSE) {
+      // The number of offset values is equal to the number of type_ids in the
+      // concatenated type buffers.
+      TypedBufferBuilder<int32_t> builder;
+      RETURN_NOT_OK(builder.Reserve(out_->length));
+
+      // Initialize a vector for child array lengths. These are updated during
+      // iteration over the input arrays to track the concatenated child array
+      // lengths. These lengths are used as offsets for the concatenated offsets
+      // buffer.
+      std::vector<int32_t> offset_map(u.num_fields());
+
+      // Iterate over all input arrays.
+      for (size_t i = 0; i < in_.size(); i++) {
+        // Get sliced type ids and offsets.
+        auto type_ids = in_[i]->GetValues<int8_t>(1);
+        auto offset_values = in_[i]->GetValues<int32_t>(2);
+
+        // Iterate over all elements in the type buffer and append the updated
+        // offset to the concatenated offsets buffer.
+        for (auto j = 0; j < in_[i]->length; j++) {
+          int32_t offset;
+          if (internal::AddWithOverflow(offset_map[type_ids[j]], offset_values[j],
+                                        &offset)) {
+            return Status::Invalid("Offset value overflow when concatenating arrays");
+          }
+          RETURN_NOT_OK(builder.Append(offset));
+        }
+
+        // Increment the offsets in the offset map for the next iteration.
+        for (int j = 0; j < u.num_fields(); j++) {
+          int32_t length;
+          if (internal::AddWithOverflow(offset_map[j], in_[i]->child_data[j]->length,
+                                        &length)) {
+            return Status::Invalid("Offset value overflow when concatenating arrays");
+          }
+          offset_map[j] = length;
+        }
+      }
+
+      ARROW_ASSIGN_OR_RAISE(out_->buffers[2], builder.Finish());
+    }
+
+    return Status::OK();
   }
 
   Status Visit(const ExtensionType& e) {

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -367,20 +367,20 @@ TEST_F(ConcatenateTest, DictionaryTypeNullSlots) {
 TEST_F(ConcatenateTest, UnionType) {
   // sparse mode
   Check([this](int32_t size, double null_probability, std::shared_ptr<Array>* out) {
-    auto foo = this->GeneratePrimitive<Int8Type>(size, 0);
-    auto bar = this->GeneratePrimitive<DoubleType>(size, null_probability);
-    auto baz = this->GeneratePrimitive<BooleanType>(size, null_probability);
-    auto type_ids = rng_.Numeric<Int8Type>(size, 0, 2, 0);
-    ASSERT_OK_AND_ASSIGN(*out, SparseUnionArray::Make(*type_ids, {foo, bar, baz}));
+    *out = rng_.ArrayOf(sparse_union({
+                            field("a", float64()),
+                            field("b", boolean()),
+                        }),
+                        size, null_probability);
   });
   // dense mode
-  Check([this](int32_t size, double null_probabilities, std::shared_ptr<Array>* out) {
+  Check([this](int32_t size, double null_probability, std::shared_ptr<Array>* out) {
     *out = rng_.ArrayOf(dense_union({
                             field("a", uint32()),
                             field("b", boolean()),
                             field("c", int8()),
                         }),
-                        size, null_probabilities);
+                        size, null_probability);
   });
 }
 

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -435,16 +435,18 @@ TEST_F(ConcatenateTest, DenseUnionType) {
                        Concatenate(sliced_arrays, default_memory_pool()));
   ASSERT_OK(concat_sliced_arrays->ValidateFull());
 
-  auto type_ids_sliced = ArrayFromJSON(int8(), "[0, 1, 1, 0, 0, 0, 1, 1, 0, 1]");
-  auto offsets_sliced = ArrayFromJSON(int32(), "[1, 0, 1, 2, 3, 4, 3, 4, 5, 5]");
-  auto child_one_sliced =
-      ArrayFromJSON(boolean(), "[true, true, false, true, true, false]");
-  auto child_two_sliced = ArrayFromJSON(int8(), "[1, 2, 3, 1, 2, 3]");
-  ASSERT_OK_AND_ASSIGN(auto expected_sliced,
-                       DenseUnionArray::Make(*type_ids_sliced, *offsets_sliced,
-                                             {child_one_sliced, child_two_sliced}));
-  ASSERT_OK(expected_sliced->ValidateFull());
-  AssertArraysEqual(*expected_sliced, *concat_sliced_arrays);
+  AssertArraysEqual(*ArrayFromJSON(dense_union({field("", boolean()), field("", int8())}), R"([
+    [0, true],
+    [1, 1],
+    [1, 2],
+    [0, true],
+    [0, false],
+    [0, true],
+    [1, 3],
+    [1, 1],
+    [0, true],
+    [1, 3]
+  ])"), *concat_sliced_arrays);
 }
 
 TEST_F(ConcatenateTest, OffsetOverflow) {

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -66,9 +66,6 @@ TEST_P(RandomArrayTest, GenerateBatch) {
 
 TEST_P(RandomArrayTest, GenerateZeroLengthArray) {
   auto field = GetField();
-  if (field->type()->id() == Type::type::DENSE_UNION) {
-    GTEST_SKIP() << "Cannot generate zero-length dense union arrays";
-  }
   auto array = GenerateArray(*field, 0, 0xDEADBEEF);
   AssertTypeEqual(field->type(), array->type());
   ASSERT_EQ(0, array->length());


### PR DESCRIPTION
This PR adds support for concatenation of union arrays. 

For sparse union arrays this is trivial: the type buffers and child arrays are concatenated like the other concatenate implementations.
For dense union arrays the following approach is used:
- The type buffers are concatenated.
- The child arrays are concatenated, but slicing is ignored. This makes building the offsets buffer more simple.
- For every input array the length of the different child arrays (concatenated up to that point) is tracked. By iterating over the types buffers these offsets can be applied to the values in the concatenated offsets buffer.

Does this make sense or should we slice child arrays (when required) and reflect this in the concatenated offsets buffer?

This PR also removes a check in `DenseUnionArray::Make` that rejected empty offsets buffers. This made it impossible to construct empty dense union arrays. I discussed removing this check with @bkietz. 