### PR TITLE
ARROW-14969: [C++][Python] Un-deprecate FileSystem::OpenAppendStream

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -239,9 +239,7 @@ Result<std::shared_ptr<io::OutputStream>> FileSystem::OpenOutputStream(
 
 Result<std::shared_ptr<io::OutputStream>> FileSystem::OpenAppendStream(
     const std::string& path) {
-  ARROW_SUPPRESS_DEPRECATION_WARNING
   return OpenAppendStream(path, std::shared_ptr<const KeyValueMetadata>{});
-  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -469,9 +467,7 @@ Result<std::shared_ptr<io::OutputStream>> SubTreeFileSystem::OpenAppendStream(
     const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
   auto s = path;
   RETURN_NOT_OK(PrependBaseNonEmpty(&s));
-  ARROW_SUPPRESS_DEPRECATION_WARNING
   return base_fs_->OpenAppendStream(s, metadata);
-  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -578,9 +574,7 @@ Result<std::shared_ptr<io::OutputStream>> SlowFileSystem::OpenOutputStream(
 Result<std::shared_ptr<io::OutputStream>> SlowFileSystem::OpenAppendStream(
     const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
   latencies_->Sleep();
-  ARROW_SUPPRESS_DEPRECATION_WARNING
   return base_fs_->OpenAppendStream(path, metadata);
-  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 Status CopyFiles(const std::vector<FileLocator>& sources,

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -290,8 +290,10 @@ class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> 
   /// Open an output stream for appending.
   ///
   /// If the target doesn't exist, a new empty file is created.
-  /// Note: This cannot be supported by all filesystem kinds, it will remain
-  ///       unimplemented for filesystems which don't support it
+  ///
+  /// Note: some filesystem implementations do not support efficient appending
+  /// to an existing file, in which case this method will return NotImplemented.
+  /// Consider writing to multiple files (using e.g. the dataset layer) instead.
   virtual Result<std::shared_ptr<io::OutputStream>> OpenAppendStream(
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) = 0;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -290,9 +290,8 @@ class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> 
   /// Open an output stream for appending.
   ///
   /// If the target doesn't exist, a new empty file is created.
-  ARROW_DEPRECATED(
-      "Deprecated in 6.0.0. "
-      "OpenAppendStream is unsupported on several filesystems and will be later removed.")
+  /// Note: This cannot be supported by all filesystem kinds, it will remain
+  ///       unimplemented for filesystems which don't support it
   virtual Result<std::shared_ptr<io::OutputStream>> OpenAppendStream(
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) = 0;

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -30,7 +30,6 @@ from datetime import datetime, timezone
 import os
 import pathlib
 import sys
-import warnings
 
 
 cdef _init_ca_paths():
@@ -681,13 +680,10 @@ cdef class FileSystem(_Weakrefable):
     def open_append_stream(self, path, compression='detect',
                            buffer_size=None, metadata=None):
         """
-        DEPRECATED: Open an output stream for appending.
 
         If the target doesn't exist, a new empty file is created.
-
-        .. deprecated:: 6.0
-            Several filesystems don't support this functionality
-            and it will be later removed.
+        Note: This cannot be supported by all filesystem kinds, it will remain
+              unimplemented for filesystems which don't support it
 
         Parameters
         ----------
@@ -717,11 +713,6 @@ cdef class FileSystem(_Weakrefable):
             NativeFile stream = NativeFile()
             shared_ptr[COutputStream] out_handle
             shared_ptr[const CKeyValueMetadata] c_metadata
-
-        warnings.warn(
-            "`open_append_stream` is deprecated as of 6.0.0; several "
-            "filesystems don't support it and it will be later removed",
-            FutureWarning)
 
         if metadata is not None:
             c_metadata = pyarrow_unwrap_metadata(KeyValueMetadata(metadata))

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -680,10 +680,16 @@ cdef class FileSystem(_Weakrefable):
     def open_append_stream(self, path, compression='detect',
                            buffer_size=None, metadata=None):
         """
+        Open an output stream for appending.
 
         If the target doesn't exist, a new empty file is created.
-        Note: This cannot be supported by all filesystem kinds, it will remain
-              unimplemented for filesystems which don't support it
+
+        .. note::
+            Some filesystem implementations do not support efficient
+            appending to an existing file, in which case this method will
+            raise NotImplementedError.
+            Consider writing to multiple files (using e.g. the dataset layer)
+            instead.
 
         Parameters
         ----------

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1011,7 +1011,6 @@ def test_open_output_stream(fs, pathfn, compression, buffer_size,
         ('gzip', 256, gzip.compress, gzip.decompress),
     ]
 )
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_open_append_stream(fs, pathfn, compression, buffer_size, compressor,
                             decompressor, allow_append_to_file):
     p = pathfn('open-append-stream')
@@ -1579,7 +1578,6 @@ def test_py_open_output_stream():
         f.write(b"data")
 
 
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_py_open_append_stream():
     fs = PyFileSystem(DummyHandler())
 


### PR DESCRIPTION
Un-deprecating FileSystem::OpenAppendStream in C++ and Python. It will remain unimplemented for filesystems which don't support it.