### PR TITLE
ARROW-12629: [C++] Add option for disabling readahead in CSV and JSON readers

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -166,6 +166,9 @@ struct ARROW_EXPORT ReadOptions {
   /// Create read options with default values
   static ReadOptions Defaults();
 
+  /// weather to use an IO thread to read ahead
+  bool use_read_ahead = false;
+
   /// \brief Test that all set options are valid
   Status Validate() const;
 };

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -166,8 +166,8 @@ struct ARROW_EXPORT ReadOptions {
   /// Create read options with default values
   static ReadOptions Defaults();
 
-  /// weather to use an IO thread to read ahead
-  bool use_read_ahead = false;
+  /// Weather to use an IO thread to read ahead while other blocks are decoding
+  bool use_readahead = true;
 
   /// \brief Test that all set options are valid
   Status Validate() const;

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -981,9 +981,9 @@ class SerialTableReader : public BaseTableReader {
 
     // Since we're converting serially, no need to readahead more than one block
     int32_t block_queue_size = 1;
-    if (read_options_.use_read_ahead) {
-      ARROW_ASSIGN_OR_RAISE(auto rh_it,
-                            MakeReadaheadIterator(std::move(istream_it), block_queue_size));
+    if (read_options_.use_readahead) {
+      ARROW_ASSIGN_OR_RAISE(
+          auto rh_it, MakeReadaheadIterator(std::move(istream_it), block_queue_size));
       buffer_iterator_ = CSVBufferIterator::Make(std::move(rh_it));
     } else {
       buffer_iterator_ = CSVBufferIterator::Make(std::move(istream_it));

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -981,9 +981,13 @@ class SerialTableReader : public BaseTableReader {
 
     // Since we're converting serially, no need to readahead more than one block
     int32_t block_queue_size = 1;
-    ARROW_ASSIGN_OR_RAISE(auto rh_it,
-                          MakeReadaheadIterator(std::move(istream_it), block_queue_size));
-    buffer_iterator_ = CSVBufferIterator::Make(std::move(rh_it));
+    if (read_options_.use_read_ahead) {
+      ARROW_ASSIGN_OR_RAISE(auto rh_it,
+                            MakeReadaheadIterator(std::move(istream_it), block_queue_size));
+      buffer_iterator_ = CSVBufferIterator::Make(std::move(rh_it));
+    } else {
+      buffer_iterator_ = CSVBufferIterator::Make(std::move(istream_it));
+    }
     return Status::OK();
   }
 

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -231,9 +231,11 @@ TEST(SerialReaderTests, InvalidRowsSkipped) {
   TestInvalidRowsSkipped(MakeSerialFactory(), /*async=*/false);
 }
 TEST(SerialReaderTests, StressNoReadAhead) {
-  StressTableReader(MakeSerialFactory(false)); }
+  StressTableReader(MakeSerialFactory(false));
+}
 TEST(SerialReaderTests, StressInvalidNoReadAhead) {
-  StressInvalidTableReader(MakeSerialFactory(false)); }
+  StressInvalidTableReader(MakeSerialFactory(false));
+}
 
 Result<TableReaderFactory> MakeAsyncFactory(
     std::shared_ptr<internal::ThreadPool> thread_pool = nullptr) {

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -208,11 +208,12 @@ void TestInvalidRowsSkipped(TableReaderFactory reader_factory, bool async) {
 }
 
 TableReaderFactory MakeSerialFactory(bool use_read_ahead = true) {
-  return [use_read_ahead](std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options) {
+  return [use_read_ahead](std::shared_ptr<io::InputStream> input_stream,
+                          ParseOptions parse_options) {
     auto read_options = ReadOptions::Defaults();
     read_options.block_size = 1 << 10;
     read_options.use_threads = false;
-    read_options.use_read_ahead = use_read_ahead;
+    read_options.use_readahead = use_read_ahead;
     return TableReader::Make(io::default_io_context(), input_stream, read_options,
                              std::move(parse_options), ConvertOptions::Defaults());
   };
@@ -229,8 +230,10 @@ TEST(SerialReaderTests, NestedParallelism) {
 TEST(SerialReaderTests, InvalidRowsSkipped) {
   TestInvalidRowsSkipped(MakeSerialFactory(), /*async=*/false);
 }
-TEST(SerialReaderTests, StressNoReadAhead) { StressTableReader(MakeSerialFactory(false)); }
-TEST(SerialReaderTests, StressInvalidNoReadAhead) { StressInvalidTableReader(MakeSerialFactory(false)); }
+TEST(SerialReaderTests, StressNoReadAhead) {
+  StressTableReader(MakeSerialFactory(false)); }
+TEST(SerialReaderTests, StressInvalidNoReadAhead) {
+  StressInvalidTableReader(MakeSerialFactory(false)); }
 
 Result<TableReaderFactory> MakeAsyncFactory(
     std::shared_ptr<internal::ThreadPool> thread_pool = nullptr) {

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -207,11 +207,12 @@ void TestInvalidRowsSkipped(TableReaderFactory reader_factory, bool async) {
   ASSERT_EQ(NINVALID, num_invalid_rows);
 }
 
-TableReaderFactory MakeSerialFactory() {
-  return [](std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options) {
+TableReaderFactory MakeSerialFactory(bool use_read_ahead = true) {
+  return [use_read_ahead](std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options) {
     auto read_options = ReadOptions::Defaults();
     read_options.block_size = 1 << 10;
     read_options.use_threads = false;
+    read_options.use_read_ahead = use_read_ahead;
     return TableReader::Make(io::default_io_context(), input_stream, read_options,
                              std::move(parse_options), ConvertOptions::Defaults());
   };
@@ -228,6 +229,8 @@ TEST(SerialReaderTests, NestedParallelism) {
 TEST(SerialReaderTests, InvalidRowsSkipped) {
   TestInvalidRowsSkipped(MakeSerialFactory(), /*async=*/false);
 }
+TEST(SerialReaderTests, StressNoReadAhead) { StressTableReader(MakeSerialFactory(false)); }
+TEST(SerialReaderTests, StressInvalidNoReadAhead) { StressInvalidTableReader(MakeSerialFactory(false)); }
 
 Result<TableReaderFactory> MakeAsyncFactory(
     std::shared_ptr<internal::ThreadPool> thread_pool = nullptr) {

--- a/cpp/src/arrow/json/options.h
+++ b/cpp/src/arrow/json/options.h
@@ -65,8 +65,8 @@ struct ARROW_EXPORT ReadOptions {
   /// Block size we request from the IO layer; also determines the size of
   /// chunks when use_threads is true
   int32_t block_size = 1 << 20;  // 1 MB
-  /// weather we will use a separate thread for read ahead
-  bool use_read_ahead = true;
+  /// Weather to use an IO thread to read ahead while other blocks are decoding
+  bool use_readahead = true;
 
   /// Create read options with default values
   static ReadOptions Defaults();

--- a/cpp/src/arrow/json/options.h
+++ b/cpp/src/arrow/json/options.h
@@ -65,6 +65,8 @@ struct ARROW_EXPORT ReadOptions {
   /// Block size we request from the IO layer; also determines the size of
   /// chunks when use_threads is true
   int32_t block_size = 1 << 20;  // 1 MB
+  /// weather we will use a separate thread for read ahead
+  bool use_read_ahead = true;
 
   /// Create read options with default values
   static ReadOptions Defaults();

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -63,7 +63,7 @@ class TableReaderImpl : public TableReader,
   Status Init(std::shared_ptr<io::InputStream> input) {
     ARROW_ASSIGN_OR_RAISE(auto it,
                           io::MakeInputStreamIterator(input, read_options_.block_size));
-    if (read_options_.use_read_ahead) {
+    if (read_options_.use_readahead) {
       return MakeReadaheadIterator(std::move(it), task_group_->parallelism())
           .Value(&block_iterator_);
     } else {

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -35,11 +35,18 @@ using util::string_view;
 
 using internal::checked_cast;
 
-class ReaderTest : public ::testing::TestWithParam<std::pair<bool, bool>> {
+struct ReaderTestParam {
+  bool use_threads;
+  bool use_readahead;
+  ReaderTestParam(bool threads, bool readahead)
+      : use_threads(threads), use_readahead(readahead) {}
+};
+
+class ReaderTest : public ::testing::TestWithParam<ReaderTestParam> {
  public:
   void SetUpReader() {
-    read_options_.use_threads = GetParam().first;
-    read_options_.use_readahead = GetParam().second;
+    read_options_.use_threads = GetParam().use_threads;
+    read_options_.use_readahead = GetParam().use_readahead;
     ASSERT_OK_AND_ASSIGN(reader_, TableReader::Make(default_memory_pool(), input_,
                                                     read_options_, parse_options_));
   }
@@ -66,10 +73,10 @@ class ReaderTest : public ::testing::TestWithParam<std::pair<bool, bool>> {
 };
 
 INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest,
-                         ::testing::Values(std::make_pair(true, false),
-                                           std::make_pair(true, true),
-                                           std::make_pair(false, false),
-                                           std::make_pair(false, true)));
+                         ::testing::Values(ReaderTestParam(true, false),
+                                           ReaderTestParam(true, true),
+                                           ReaderTestParam(false, false),
+                                           ReaderTestParam(false, true)));
 
 TEST_P(ReaderTest, Empty) {
   SetUpReader("{}\n{}\n");

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -35,10 +35,11 @@ using util::string_view;
 
 using internal::checked_cast;
 
-class ReaderTest : public ::testing::TestWithParam<bool> {
+class ReaderTest : public ::testing::TestWithParam<std::pair<bool, bool>> {
  public:
   void SetUpReader() {
-    read_options_.use_threads = GetParam();
+    read_options_.use_threads = GetParam().first;
+    read_options_.use_read_ahead = GetParam().second;
     ASSERT_OK_AND_ASSIGN(reader_, TableReader::Make(default_memory_pool(), input_,
                                                     read_options_, parse_options_));
   }
@@ -64,7 +65,9 @@ class ReaderTest : public ::testing::TestWithParam<bool> {
   std::shared_ptr<Table> table_;
 };
 
-INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest, ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest, ::testing::Values(
+    std::make_pair(true, false), std::make_pair(true, true),
+    std::make_pair(false, false), std::make_pair(false, true)));
 
 TEST_P(ReaderTest, Empty) {
   SetUpReader("{}\n{}\n");

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -39,7 +39,7 @@ class ReaderTest : public ::testing::TestWithParam<std::pair<bool, bool>> {
  public:
   void SetUpReader() {
     read_options_.use_threads = GetParam().first;
-    read_options_.use_read_ahead = GetParam().second;
+    read_options_.use_readahead = GetParam().second;
     ASSERT_OK_AND_ASSIGN(reader_, TableReader::Make(default_memory_pool(), input_,
                                                     read_options_, parse_options_));
   }
@@ -65,9 +65,11 @@ class ReaderTest : public ::testing::TestWithParam<std::pair<bool, bool>> {
   std::shared_ptr<Table> table_;
 };
 
-INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest, ::testing::Values(
-    std::make_pair(true, false), std::make_pair(true, true),
-    std::make_pair(false, false), std::make_pair(false, true)));
+INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest,
+                         ::testing::Values(std::make_pair(true, false),
+                                           std::make_pair(true, true),
+                                           std::make_pair(false, false),
+                                           std::make_pair(false, true)));
 
 TEST_P(ReaderTest, Empty) {
   SetUpReader("{}\n{}\n");

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -35,14 +35,20 @@ using util::string_view;
 
 using internal::checked_cast;
 
-struct ReaderTestParam {
+struct ReaderTestParams {
   bool use_threads;
   bool use_readahead;
-  ReaderTestParam(bool threads, bool readahead)
+  ReaderTestParams(bool threads, bool readahead)
       : use_threads(threads), use_readahead(readahead) {}
+
+  static std::vector<ReaderTestParams> Values() {
+    std::vector<ReaderTestParams> params{
+        {true, false}, {true, true}, {false, true}, {false, false}};
+    return params;
+  }
 };
 
-class ReaderTest : public ::testing::TestWithParam<ReaderTestParam> {
+class ReaderTest : public ::testing::TestWithParam<ReaderTestParams> {
  public:
   void SetUpReader() {
     read_options_.use_threads = GetParam().use_threads;
@@ -73,10 +79,7 @@ class ReaderTest : public ::testing::TestWithParam<ReaderTestParam> {
 };
 
 INSTANTIATE_TEST_SUITE_P(ReaderTest, ReaderTest,
-                         ::testing::Values(ReaderTestParam(true, false),
-                                           ReaderTestParam(true, true),
-                                           ReaderTestParam(false, false),
-                                           ReaderTestParam(false, true)));
+                         ::testing::ValuesIn(ReaderTestParams::Values()));
 
 TEST_P(ReaderTest, Empty) {
   SetUpReader("{}\n{}\n");


### PR DESCRIPTION
ARROW-12090 - Adding use_read_ahead parameter to json/options.h and csv/options.h. This option is used by the csv SerialReader and json Table reader to control the read ahead thread creation.