### PR TITLE
ARROW-14984: [CI][Debian] rsync is missing

### DIFF
--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update -y -q && \
         protobuf-compiler \
         python3-pip \
         rapidjson-dev \
+        rsync \
         tzdata \
         zlib1g-dev && \
     apt-get clean && \

--- a/ci/docker/debian-11-cpp.dockerfile
+++ b/ci/docker/debian-11-cpp.dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update -y -q && \
         protobuf-compiler-grpc \
         python3-pip \
         rapidjson-dev \
+        rsync \
         tzdata \
         zlib1g-dev && \
     apt-get clean && \


### PR DESCRIPTION
A follow-up of #11567.

https://github.com/ursacomputing/crossbow/runs/4415960154?check_suite_focus=true

    + mkdir -p /build/docs/c_glib
    + rsync -a /usr/local/share/gtk-doc/html/ /build/docs/c_glib
    /arrow/ci/scripts/c_glib_build.sh: line 52: rsync: command not found
    127