### PR TITLE
ARROW-14992: [R] Installation can't use prebuilt Arrow binaries on Pop! OS

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -47,7 +47,7 @@ quietly <- !env_is("ARROW_R_DEV", "true")
 
 # Default is build from source, not download a binary
 build_ok <- !env_is("LIBARROW_BUILD", "false")
-binary_ok <- env_is("LIBARROW_BINARY", "true")
+binary_ok <- env_is("LIBARROW_BINARY", "true") || env_is("NOT_CRAN", "true")
 
 # Check if we're doing an offline build.
 # (Note that cmake will still be downloaded if necessary
@@ -77,7 +77,7 @@ download_binary <- function(os = identify_os()) {
         cat("**** If installation fails, retry after installing those system requirements\n")
       }
     } else {
-      cat(sprintf("*** No C++ binaries found for %s\n", os))
+      cat(sprintf("*** No Arrow binary found for version %s on %s\n", VERSION, os))
       libfile <- NULL
     }
   } else {

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -48,7 +48,7 @@ quietly <- !env_is("ARROW_R_DEV", "true")
 # Default is build from source, not download a binary
 build_ok <- !env_is("LIBARROW_BUILD", "false")
 # For LIBARROW_BINARY we support "true" or the name of the OS to use to
-# locate the appropriate binary (e.g., ubuntu-18.04). When NOT_CRAN=true, the
+# locate the appropriate binary (e.g., 'ubuntu-18.04'). When NOT_CRAN=true, the
 # configure script sets LIBARROW_BINARY=true.
 binary_ok <- !env_is("LIBARROW_BINARY", "false") || env_is("LIBARROW_BINARY", "")
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -48,8 +48,8 @@ quietly <- !env_is("ARROW_R_DEV", "true")
 # Default is build from source, not download a binary
 build_ok <- !env_is("LIBARROW_BUILD", "false")
 # For LIBARROW_BINARY we support "true" or the name of the OS to use to
-# locate the appropriate binary (e.g., 'ubuntu-18.04'). When NOT_CRAN=true, the
-# configure script sets LIBARROW_BINARY=true.
+# locate the appropriate binary (e.g., 'ubuntu-18.04'). When NOT_CRAN=true, and
+# LIBARROW_BINARY is unset, configure script sets LIBARROW_BINARY=true.
 binary_ok <- !env_is("LIBARROW_BINARY", "false") || env_is("LIBARROW_BINARY", "")
 
 # Check if we're doing an offline build.

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -77,7 +77,7 @@ download_binary <- function(os = identify_os()) {
         cat("**** If installation fails, retry after installing those system requirements\n")
       }
     } else {
-      cat(sprintf("*** No Arrow binary found for version %s on %s\n", VERSION, os))
+      cat(sprintf("*** No Arrow C++ binary found for version %s on %s\n", VERSION, os))
       libfile <- NULL
     }
   } else {

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -80,7 +80,7 @@ download_binary <- function(os = identify_os()) {
         cat("**** If installation fails, retry after installing those system requirements\n")
       }
     } else {
-      cat(sprintf("*** No Arrow C++ binary found for version %s on %s\n", VERSION, os))
+      cat(sprintf("*** No libarrow binary found for version %s on %s\n", VERSION, os))
       libfile <- NULL
     }
   } else {

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -47,7 +47,10 @@ quietly <- !env_is("ARROW_R_DEV", "true")
 
 # Default is build from source, not download a binary
 build_ok <- !env_is("LIBARROW_BUILD", "false")
-binary_ok <- env_is("LIBARROW_BINARY", "true") || env_is("NOT_CRAN", "true")
+# For LIBARROW_BINARY we support "true" or the name of the OS to use to
+# locate the appropriate binary (e.g., ubuntu-18.04). When NOT_CRAN=true, the
+# configure script sets LIBARROW_BINARY=true.
+binary_ok <- !env_is("LIBARROW_BINARY", "false") || env_is("LIBARROW_BINARY", "")
 
 # Check if we're doing an offline build.
 # (Note that cmake will still be downloaded if necessary


### PR DESCRIPTION
This PR makes a few small changes to help users (and maintainers responding to install issues) troubleshoot installing when there isn't a prebuilt binary for a given platform/Arrow version. It's difficult to test this since there isn't a prebuilt Arrow binary for master but perhaps there is a way to do this that I'm not aware of. I verified that it downloads a prebuilt binary on a Pop! OS Docker image. The install still fails because there's no prebuilt binary for the dev version (but at least it's in the error message).

``` bash
# docker pull hugojosefson/popos
# docker run --rm -it hugojosefson/popos
apt-get update && apt-get install -y r-base
R -e "install.packages(c('remotes', 'bit', 'magrittr', 'ellipsis', 'glue', 'assertthat', 'bit64', 'purrr', 'R6', 'rlang', 'tidyselect', 'vctrs'))"
LIBARROW_BINARY=ubuntu-18.04 NOT_CRAN=true R -e "remotes::install_github('apache/arrow/r')"
# *** Proceeding without C++ dependencies

LIBARROW_BINARY=ubuntu-18.04 NOT_CRAN=true R -e "remotes::install_github('paleolimbot/arrow/r@r-nixlibs')"
# *** No Arrow binary found for version 6.0.1.9000 on ubuntu-18.04
# *** Proceeding without C++ dependencies
```
