### PR TITLE
ARROW-14644 [R] open_dataset doesn't ignore BOM in csv file

### DIFF
--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -378,3 +378,12 @@ test_that("time mapping work as expected (ARROW-13624)", {
 
   expect_equal(df, tbl, ignore_attr = "tzone")
 })
+
+test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+
+  expect_equal(
+    read_csv_arrow(csv_file),
+    tibble(a = 1, b = 2)
+  )
+})

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -379,7 +379,7 @@ test_that("time mapping work as expected (ARROW-13624)", {
   expect_equal(df, tbl, ignore_attr = "tzone")
 })
 
-test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+test_that("read_csv_arrow() deals with BOMs (bite-order-marks) correctly", {
   writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
 
   expect_equal(

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -289,7 +289,7 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
   expect_equal(ds %>% collect(), tbl)
 })
 
-test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+test_that("open_dataset() deals with BOMs (bite-order-marks) correctly", {
   writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
 
   expect_equal(

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -288,3 +288,12 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
   ds <- open_dataset(headerless_csv_dir, format = "csv", schema = schema(int = int32(), dbl = float64()))
   expect_equal(ds %>% collect(), tbl)
 })
+
+test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+
+  expect_equal(
+    open_dataset(csv_file, format = "csv") %>% collect(),
+    tibble(a = 1, b = 2)
+  )
+})


### PR DESCRIPTION
This draft PR only adds a failing unit test for the failure to skip BOMs when reading a CSV file with `open_dataset()`. 