### PR TITLE
ARROW-8823: [C++] Add total size of batch buffers to IPC write statistics

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1731,9 +1731,6 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
   // ARROW-8823: Calculating the compression ratio
   FileWriterHelper helper;
   IpcWriteOptions options_uncompressed = IpcWriteOptions::Defaults();
-  IpcWriteOptions options_compressed = IpcWriteOptions::Defaults();
-  ASSERT_OK_AND_ASSIGN(options_compressed.codec,
-                       util::Codec::Create(Compression::LZ4_FRAME));
 
   std::vector<std::shared_ptr<RecordBatch>> batches(3);
   // empty record batch
@@ -1771,6 +1768,10 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
     if (!util::Codec::IsAvailable(Compression::LZ4_FRAME)) {
       continue;
     }
+
+    IpcWriteOptions options_compressed = IpcWriteOptions::Defaults();
+    ASSERT_OK_AND_ASSIGN(options_compressed.codec,
+                         util::Codec::Create(Compression::LZ4_FRAME));
 
     // with compression
     ASSERT_OK(helper.Init(batches[i]->schema(), options_compressed));

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -25,7 +25,6 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
-#include <arrow/device.h>
 
 #include "arrow/array.h"
 #include "arrow/array/builder_primitive.h"

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1768,6 +1768,10 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
     ASSERT_LE(helper.writer_->stats().total_raw_body_size,
               helper.writer_->stats().total_serialized_body_size);
 
+    if (!util::Codec::IsAvailable(Compression::LZ4_FRAME)) {
+      continue;
+    }
+
     // with compression
     ASSERT_OK(helper.Init(batches[i]->schema(), options_compressed));
     ASSERT_OK(helper.WriteBatch(batches[i]));

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1749,9 +1749,9 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
   int64_t length = 500;
   int dict_size = 50;
   std::shared_ptr<Array> dict =
-    rg.String(dict_size, /*min_length=*/5, /*max_length=*/5, /*null_probability=*/0);
+      rg.String(dict_size, /*min_length=*/5, /*max_length=*/5, /*null_probability=*/0);
   std::shared_ptr<Array> indices =
-    rg.Int32(length, /*min=*/0, /*max=*/dict_size - 1, /*null_probability=*/0.1);
+      rg.Int32(length, /*min=*/0, /*max=*/dict_size - 1, /*null_probability=*/0.1);
   auto dict_type = dictionary(int32(), utf8());
   auto dict_field = field("f1", dict_type);
   ASSERT_OK_AND_ASSIGN(auto dict_array,
@@ -1759,7 +1759,7 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
 
   auto schema = ::arrow::schema({field("f0", utf8()), dict_field});
   batches[2] =
-    RecordBatch::Make(schema, length, {rg.String(500, 0, 10, 0.1), dict_array});
+      RecordBatch::Make(schema, length, {rg.String(500, 0, 10, 0.1), dict_array});
 
   for (size_t i = 0; i < batches.size(); ++i) {
     // without compression

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1735,9 +1735,6 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
   ASSERT_OK_AND_ASSIGN(options_compressed.codec,
                        util::Codec::Create(Compression::LZ4_FRAME));
 
-  // pre-computed total raw sizes for the record batches
-  std::vector<int64_t> raw_sizes{0, 61000, 6346};
-
   std::vector<std::shared_ptr<RecordBatch>> batches(3);
   // empty record batch
   ASSERT_OK(MakeIntBatchSized(0, &batches[0]));
@@ -1775,8 +1772,8 @@ TEST_F(TestWriteRecordBatch, CompressionRatio) {
     ASSERT_OK(helper.Init(batches[i]->schema(), options_compressed));
     ASSERT_OK(helper.WriteBatch(batches[i]));
     ASSERT_OK(helper.Finish());
-    ASSERT_EQ(helper.writer_->stats().total_raw_body_size, raw_sizes[i]);
-    ASSERT_LE(helper.writer_->stats().total_serialized_body_size, raw_sizes[i]);
+    ASSERT_GE(helper.writer_->stats().total_raw_body_size,
+              helper.writer_->stats().total_serialized_body_size);
   }
 }
 

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1727,8 +1727,8 @@ TEST(TestIpcFileFormat, FooterMetaData) {
   ASSERT_TRUE(out_metadata->Equals(*metadata));
 }
 
-TEST_F(TestWriteRecordBatch, CompressionRatio) {
-  // ARROW-8823: Calculating the compression ratio
+TEST_F(TestWriteRecordBatch, RawAndSerializedSizes) {
+  // ARROW-8823: Recording total raw and serialized record batch sizes in WriteStats
   FileWriterHelper helper;
   IpcWriteOptions options_uncompressed = IpcWriteOptions::Defaults();
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -830,6 +830,7 @@ class SparseTensorSerializer {
 
     int64_t offset = buffer_start_offset_;
     buffer_meta_.reserve(out_->body_buffers.size());
+    int64_t raw_size = 0;
 
     for (size_t i = 0; i < out_->body_buffers.size(); ++i) {
       const Buffer* buffer = out_->body_buffers[i].get();
@@ -837,10 +838,12 @@ class SparseTensorSerializer {
       int64_t padding = bit_util::RoundUpToMultipleOf8(size) - size;
       buffer_meta_.push_back({offset, size + padding});
       offset += size + padding;
+      raw_size += size;
     }
 
     out_->body_length = offset - buffer_start_offset_;
     DCHECK(bit_util::IsMultipleOf8(out_->body_length));
+    out_->raw_body_length = raw_size;
 
     return SerializeMetadata(sparse_tensor);
   }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -830,6 +830,7 @@ class SparseTensorSerializer {
 
     int64_t offset = buffer_start_offset_;
     buffer_meta_.reserve(out_->body_buffers.size());
+    int64_t raw_size = 0;
 
     for (size_t i = 0; i < out_->body_buffers.size(); ++i) {
       const Buffer* buffer = out_->body_buffers[i].get();
@@ -837,9 +838,11 @@ class SparseTensorSerializer {
       int64_t padding = BitUtil::RoundUpToMultipleOf8(size) - size;
       buffer_meta_.push_back({offset, size + padding});
       offset += size + padding;
+      raw_size += size;
     }
 
     out_->body_length = offset - buffer_start_offset_;
+    out_->raw_body_length = raw_size;
     DCHECK(BitUtil::IsMultipleOf8(out_->body_length));
 
     return SerializeMetadata(sparse_tensor);

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -227,7 +227,7 @@ class RecordBatchSerializer {
 
     // calculate initial body length using all buffer sizes
     int64_t raw_size = 0;
-    for (const auto& buf: out_->body_buffers) {
+    for (const auto& buf : out_->body_buffers) {
       if (buf) {
         raw_size += buf->size();
       }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1012,11 +1012,8 @@ class ARROW_EXPORT IpcFormatWriter : public RecordBatchWriter {
     RETURN_NOT_OK(WritePayload(payload));
     ++stats_.num_record_batches;
 
-    stats_.raw_body_length += payload.raw_body_length;
-    stats_.serialized_body_length += payload.body_length;
-    if (options_.codec != nullptr && stats_.raw_body_length != 0) {
-      stats_.comp_ratio = static_cast<double>(stats_.serialized_body_length) / static_cast<double>(stats_.raw_body_length);
-    }
+    stats_.total_raw_body_size += payload.raw_body_length;
+    stats_.total_serialized_body_size += payload.body_length;
 
     return Status::OK();
   }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -226,13 +226,13 @@ class RecordBatchSerializer {
     }
 
     // calculate initial body length using all buffer sizes
-    int64_t init_size = 0;
+    int64_t raw_size = 0;
     for (const auto& buf: out_->body_buffers) {
       if (buf) {
-        init_size += buf->size();
+        raw_size += buf->size();
       }
     }
-    out_->initial_body_length = init_size;
+    out_->raw_body_length = raw_size;
 
     if (options_.codec != nullptr) {
       RETURN_NOT_OK(CompressBodyBuffers());
@@ -1009,10 +1009,10 @@ class ARROW_EXPORT IpcFormatWriter : public RecordBatchWriter {
     RETURN_NOT_OK(WritePayload(payload));
     ++stats_.num_record_batches;
 
-    stats_.initial_body_length += payload.initial_body_length;
+    stats_.raw_body_length += payload.raw_body_length;
     stats_.serialized_body_length += payload.body_length;
-    if (options_.codec != nullptr && stats_.serialized_body_length != 0) {
-      stats_.comp_ratio = static_cast<float>(stats_.initial_body_length) / static_cast<float>(stats_.serialized_body_length);
+    if (options_.codec != nullptr && stats_.raw_body_length != 0) {
+      stats_.comp_ratio = static_cast<double>(stats_.serialized_body_length) / static_cast<double>(stats_.raw_body_length);
     }
 
     return Status::OK();

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -57,8 +57,8 @@ struct IpcPayload {
   MessageType type = MessageType::NONE;
   std::shared_ptr<Buffer> metadata;
   std::vector<std::shared_ptr<Buffer>> body_buffers;
-  int64_t body_length = 0;      // serialized body length (maybe compressed)
-  int64_t raw_body_length = 0;  // initial uncompressed body_length
+  int64_t body_length = 0;      // serialized body length (padded, maybe compressed)
+  int64_t raw_body_length = 0;  // initial uncompressed body length
 };
 
 struct WriteStats {
@@ -77,8 +77,9 @@ struct WriteStats {
   /// an existing dictionary with an unrelated new dictionary).
   int64_t num_replaced_dictionaries = 0;
 
-  /// initial and serialized (may be compressed) body sizes in bytes for record batches
-  /// these values show the total sizes of all record batch body lengths
+  /// Total size in bytes of record batches emitted.
+  /// The "raw" size counts the original buffer sizes, while the "serialized" size
+  /// includes padding and (optionally) compression.
   int64_t total_raw_body_size = 0;
   int64_t total_serialized_body_size = 0;
 };

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -57,8 +57,8 @@ struct IpcPayload {
   MessageType type = MessageType::NONE;
   std::shared_ptr<Buffer> metadata;
   std::vector<std::shared_ptr<Buffer>> body_buffers;
-  int64_t body_length = 0; // serialized body length (maybe compressed)
-  int64_t raw_body_length = 0; // initial uncompressed body_length
+  int64_t body_length = 0;      // serialized body length (maybe compressed)
+  int64_t raw_body_length = 0;  // initial uncompressed body_length
 };
 
 struct WriteStats {

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -57,7 +57,8 @@ struct IpcPayload {
   MessageType type = MessageType::NONE;
   std::shared_ptr<Buffer> metadata;
   std::vector<std::shared_ptr<Buffer>> body_buffers;
-  int64_t body_length = 0;
+  int64_t body_length = 0; // serialized body length (maybe compressed)
+  int64_t initial_body_length = 0; // initial uncompressed body_length
 };
 
 struct WriteStats {
@@ -75,6 +76,19 @@ struct WriteStats {
   /// Number of replaced dictionaries (i.e. where a dictionary batch replaces
   /// an existing dictionary with an unrelated new dictionary).
   int64_t num_replaced_dictionaries = 0;
+
+  /// initial and serialized (may be compressed) body lengths for record batches
+  /// these values show the total sizes of all record batch body lengths
+  int64_t initial_body_length = 0;
+  int64_t serialized_body_length = 0;
+
+  /// compression ratio for the body of all record batches serialized
+  /// this is equivalent to:
+  ///    initial_body_length / serialized_body_length
+  /// if it is 1, it means there is no compression
+  /// if it is > 1, compression reduced the body length with some space savings
+  /// if it is < 1, compression increased the body length
+  float comp_ratio = 1;
 };
 
 /// \class RecordBatchWriter

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -58,7 +58,7 @@ struct IpcPayload {
   std::shared_ptr<Buffer> metadata;
   std::vector<std::shared_ptr<Buffer>> body_buffers;
   int64_t body_length = 0; // serialized body length (maybe compressed)
-  int64_t initial_body_length = 0; // initial uncompressed body_length
+  int64_t raw_body_length = 0; // initial uncompressed body_length
 };
 
 struct WriteStats {
@@ -79,15 +79,15 @@ struct WriteStats {
 
   /// initial and serialized (may be compressed) body lengths for record batches
   /// these values show the total sizes of all record batch body lengths
-  int64_t initial_body_length = 0;
+  int64_t raw_body_length = 0;
   int64_t serialized_body_length = 0;
 
   /// compression ratio for the body of all record batches serialized
   /// this is equivalent to:
-  ///    initial_body_length / serialized_body_length
+  ///    serialized_body_length / raw_body_length
   /// if it is 1, it means there is no compression
-  /// if it is > 1, compression reduced the body length with some space savings
-  /// if it is < 1, compression increased the body length
+  /// if it is < 1, compression reduced the body length with some space savings
+  /// if it is > 1, compression increased the body length
   float comp_ratio = 1;
 };
 

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -77,18 +77,10 @@ struct WriteStats {
   /// an existing dictionary with an unrelated new dictionary).
   int64_t num_replaced_dictionaries = 0;
 
-  /// initial and serialized (may be compressed) body lengths for record batches
+  /// initial and serialized (may be compressed) body sizes in bytes for record batches
   /// these values show the total sizes of all record batch body lengths
-  int64_t raw_body_length = 0;
-  int64_t serialized_body_length = 0;
-
-  /// compression ratio for the body of all record batches serialized
-  /// this is equivalent to:
-  ///    serialized_body_length / raw_body_length
-  /// if it is 1, it means there is no compression
-  /// if it is < 1, compression reduced the body length with some space savings
-  /// if it is > 1, compression increased the body length
-  float comp_ratio = 1;
+  int64_t total_raw_body_size = 0;
+  int64_t total_serialized_body_size = 0;
 };
 
 /// \class RecordBatchWriter


### PR DESCRIPTION
Add statistics about both the original buffer sizes and the padded/compressed sizes.