### PR TITLE
ARROW-14242: Exposing the correct `indent` paramenter in `to_string`

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1005,7 +1005,7 @@ cdef class Array(_PandasConvertible):
         type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
-    def to_string(self, *, int indent=0, int top_level_indent=0, int window=10,
+    def to_string(self, *, int indent=2, int top_level_indent=0, int window=10,
                   c_bool skip_new_lines=False):
         """
         Render a "pretty-printed" string representation of the Array.
@@ -1014,7 +1014,7 @@ cdef class Array(_PandasConvertible):
         ----------
         indent : int
             How much to indent the internal items in the string to 
-            the right, by default ``0``.
+            the right, by default ``2``.
         top_level_indent : int
             How much to indent right the entire content of the array,
             by default ``0``. 
@@ -1033,8 +1033,7 @@ cdef class Array(_PandasConvertible):
         with nogil:
             options = PrettyPrintOptions(top_level_indent, window)
             options.skip_new_lines = skip_new_lines
-            if indent is not 0:
-                options.indent_size = indent
+            options.indent_size = indent
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1012,7 +1012,7 @@ cdef class Array(_PandasConvertible):
 
         Parameters
         ----------
-        indent : int
+        indent : int, default 2
             How much to indent the internal items in the string to 
             the right, by default ``2``.
         top_level_indent : int

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1033,7 +1033,8 @@ cdef class Array(_PandasConvertible):
         with nogil:
             options = PrettyPrintOptions(top_level_indent, window)
             options.skip_new_lines = skip_new_lines
-            options.indent_size = indent
+            if indent is not 0:
+                options.indent_size = indent
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1005,7 +1005,7 @@ cdef class Array(_PandasConvertible):
         type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
-    def to_string(self, *, int indent=0, int window=10,
+    def to_string(self, *, int indent=0, int indent_size=0, int window=10,
                   c_bool skip_new_lines=False):
         """
         Render a "pretty-printed" string representation of the Array.
@@ -1014,7 +1014,10 @@ cdef class Array(_PandasConvertible):
         ----------
         indent : int
             How much to indent right the content of the array,
-            by default ``0``.
+            by default ``0``. Note this idents the entire string
+        indent_size : int
+            How much to indent the internal items in the string to 
+            the right, by default ``0``.
         window : int
             How many items to preview at the begin and end
             of the array when the arrays is bigger than the window.
@@ -1030,6 +1033,7 @@ cdef class Array(_PandasConvertible):
         with nogil:
             options = PrettyPrintOptions(indent, window)
             options.skip_new_lines = skip_new_lines
+            options.indent_size = indent_size
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1015,7 +1015,7 @@ cdef class Array(_PandasConvertible):
         indent : int, default 2
             How much to indent the internal items in the string to 
             the right, by default ``2``.
-        top_level_indent : int
+        top_level_indent : int, default 0
             How much to indent right the entire content of the array,
             by default ``0``. 
         window : int

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1005,7 +1005,7 @@ cdef class Array(_PandasConvertible):
         type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
-    def to_string(self, *, int indent=0, int indent_size=0, int window=10,
+    def to_string(self, *, int indent=0, int top_level_indent=0, int window=10,
                   c_bool skip_new_lines=False):
         """
         Render a "pretty-printed" string representation of the Array.
@@ -1013,11 +1013,11 @@ cdef class Array(_PandasConvertible):
         Parameters
         ----------
         indent : int
-            How much to indent right the content of the array,
-            by default ``0``. Note this idents the entire string
-        indent_size : int
             How much to indent the internal items in the string to 
             the right, by default ``0``.
+        top_level_indent : int
+            How much to indent right the entire content of the array,
+            by default ``0``. 
         window : int
             How many items to preview at the begin and end
             of the array when the arrays is bigger than the window.
@@ -1031,9 +1031,9 @@ cdef class Array(_PandasConvertible):
             PrettyPrintOptions options
 
         with nogil:
-            options = PrettyPrintOptions(indent, window)
+            options = PrettyPrintOptions(top_level_indent, window)
             options.skip_new_lines = skip_new_lines
-            options.indent_size = indent_size
+            options.indent_size = indent
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -112,7 +112,7 @@ def test_indented_string_format():
     arr = pa.array(['', None, 'foo'])
     result = arr.to_string(indent=1)
     expected = '[\n "",\n null,\n "foo"\n]'
-         
+
     assert result == expected
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -108,6 +108,22 @@ def test_long_array_format():
     assert result == expected
 
 
+def test_indented_string_format():
+    arr = pa.array(['', None, 'foo'])
+    result = arr.to_string(indent=1)
+    expected = '[\n "",\n null,\n "foo"\n]'
+         
+    assert result == expected
+
+
+def test_top_level_indented_string_format():
+    arr = pa.array(['', None, 'foo'])
+    result = arr.to_string(top_level_indent=1)
+    expected = ' [\n   "",\n   null,\n   "foo"\n ]'
+
+    assert result == expected
+
+
 def test_binary_format():
     arr = pa.array([b'\x00', b'', None, b'\x01foo', b'\x80\xff'])
     result = arr.to_string()


### PR DESCRIPTION
This PR closes ARROW-14242.
This allows the expected behavior of `ident` in the `to_string` function to be able to indent the items and then for the top_level_indent parameter to indent the entire string. 