### PR TITLE
ARROW-8340: [Documentation] Remove the old Sphinx pin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@
 !ci/**
 !c_glib/Gemfile
 !dev/archery/setup.py
+!docs/requirements*.txt
 !python/requirements*.txt
 !python/manylinux1/**
 !python/manylinux2010/**

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -74,7 +74,7 @@ RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-RUN pip install -r /arrow/docs/requirements.txt meson
+RUN pip install -r docs/requirements.txt meson
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN gem install --no-document bundler && \

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -74,7 +74,7 @@ RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-RUN pip install -r /arrow/docs/requirements.txt
+RUN pip install -r /arrow/docs/requirements.txt meson
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN gem install --no-document bundler && \

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -74,7 +74,8 @@ RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-RUN pip install -r docs/requirements.txt meson
+COPY docs/requirements.txt /arrow/docs/
+RUN pip install -r arrow/docs/requirements.txt meson
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN gem install --no-document bundler && \

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -74,13 +74,7 @@ RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-RUN pip install \
-        breathe \
-        ipython \
-        meson \
-        pydata-sphinx-theme \
-        sphinx-tabs \
-        sphinx>=4.2
+RUN pip install -r /arrow/docs/requirements.txt
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN gem install --no-document bundler && \

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 breathe
 ipython
 numpydoc
-sphinx==2.4.4
+sphinx
 pydata-sphinx-theme
 sphinx-tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 breathe
 ipython
 numpydoc
-meson
 pydata-sphinx-theme
 sphinx-tabs
 sphinx>=4.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 breathe
 ipython
 numpydoc
-sphinx
+meson
 pydata-sphinx-theme
 sphinx-tabs
+sphinx>=4.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
+#
+# Note: keep this file in sync with conda_env_sphinx.txt !
+#
+
 breathe
 ipython
 numpydoc


### PR DESCRIPTION
Remove the pin for `Sphinx` in `requirements.txt`. The documentation builds successfully with `Sphinx` version 4.3.1.