### PR TITLE
ARROW-13035: [C++] indices_nonzero compute function

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -312,7 +312,6 @@ const FunctionDoc is_nan_doc("Return true if NaN",
                              ("For each input value, emit true iff the value is NaN."),
                              {"values"});
 
-
 }  // namespace
 
 void RegisterScalarValidity(FunctionRegistry* registry) {

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -208,19 +208,18 @@ struct NonZeroVisitor {
     using T = typename GetViewType<Type>::T;
     uint32_t index = 0;
 
-    return VisitArrayDataInline<Type>(
+    VisitArrayDataInline<Type>(
         this->array,
         [&](T v) {
           if (v) {
             this->builder->UnsafeAppend(index);
           }
           ++index;
-          return Status::OK();
         },
         [&]() {
           ++index;
-          return Status::OK();
         });
+    return Status::OK();
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -214,7 +214,7 @@ struct NonZeroVisitor {
      return VisitArrayDataInline<Type>(
         this->array,
         [&](T v) {
-          if(v != 0) {
+          if(v) {
             this->builder->UnsafeAppend(index);
           }
           ++index;

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -17,8 +17,8 @@
 
 #include <cmath>
 #include <cstdint>
-#include <type_traits>
 #include <memory>
+#include <type_traits>
 
 #include "arrow/array/builder_primitive.h"
 
@@ -195,26 +195,23 @@ Status ConstBoolExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 }
 
 struct NonZeroVisitor {
-   UInt64Builder *builder;
-   const ArrayData& array;
+  UInt64Builder* builder;
+  const ArrayData& array;
 
-   NonZeroVisitor(UInt64Builder *builder, const ArrayData& array)
-   : builder(builder), array(array) {}
+  NonZeroVisitor(UInt64Builder* builder, const ArrayData& array)
+      : builder(builder), array(array) {}
 
-  Status Visit(const DataType& type) {
-    return Status::NotImplemented(type.ToString());
-  }
+  Status Visit(const DataType& type) { return Status::NotImplemented(type.ToString()); }
 
-   template <typename Type> 
-   enable_if_t<is_primitive_ctype<Type>::value, Status>
-   Visit(const Type&) {
-     using T = typename GetViewType<Type>::T;
-     uint32_t index = 0;
+  template <typename Type>
+  enable_if_t<is_primitive_ctype<Type>::value, Status> Visit(const Type&) {
+    using T = typename GetViewType<Type>::T;
+    uint32_t index = 0;
 
-     return VisitArrayDataInline<Type>(
+    return VisitArrayDataInline<Type>(
         this->array,
         [&](T v) {
-          if(v) {
+          if (v) {
             this->builder->UnsafeAppend(index);
           }
           ++index;
@@ -224,7 +221,7 @@ struct NonZeroVisitor {
           ++index;
           return Status::OK();
         });
-   }
+  }
 };
 
 Status IndicesNonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
@@ -244,7 +241,7 @@ Status IndicesNonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out
 std::shared_ptr<ScalarFunction> MakeIndicesNonZeroFunction(std::string name,
                                                            const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
-      
+
   for (const auto& ty : NumericTypes()) {
     ScalarKernel kernel;
     kernel.exec = IndicesNonZeroExec;
@@ -382,9 +379,10 @@ const FunctionDoc is_nan_doc("Return true if NaN",
                              ("For each input value, emit true iff the value is NaN."),
                              {"values"});
 
-const FunctionDoc indices_nonzero_doc{"Compare to zero or false",
-                                      ("Return the indices of the array containing non false or zero values."),
-                                      {"values"}};
+const FunctionDoc indices_nonzero_doc{
+    "Compare to zero or false",
+    ("Return the indices of the array containing non false or zero values."),
+    {"values"}};
 
 }  // namespace
 
@@ -401,7 +399,8 @@ void RegisterScalarValidity(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(MakeIsInfFunction("is_inf", &is_inf_doc)));
   DCHECK_OK(registry->AddFunction(MakeIsNanFunction("is_nan", &is_nan_doc)));
 
-  DCHECK_OK(registry->AddFunction(MakeIndicesNonZeroFunction("indices_nonzero", &indices_nonzero_doc)));
+  DCHECK_OK(registry->AddFunction(
+      MakeIndicesNonZeroFunction("indices_nonzero", &indices_nonzero_doc)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -227,7 +227,7 @@ struct NonZeroVisitor {
    }
 };
 
-Status NonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status IndicesNonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   std::shared_ptr<ArrayData> array = batch[0].array();
   UInt64Builder builder;
 
@@ -241,13 +241,13 @@ Status NonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   return Status::OK();
 }
 
-std::shared_ptr<ScalarFunction> MakeNonZeroFunction(std::string name,
-                                                    const FunctionDoc* doc) {
+std::shared_ptr<ScalarFunction> MakeIndicesNonZeroFunction(std::string name,
+                                                           const FunctionDoc* doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
       
   for (const auto& ty : NumericTypes()) {
     ScalarKernel kernel;
-    kernel.exec = NonZeroExec;
+    kernel.exec = IndicesNonZeroExec;
     kernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
     kernel.signature = KernelSignature::Make({InputType(ty->id())}, uint64());
@@ -255,7 +255,7 @@ std::shared_ptr<ScalarFunction> MakeNonZeroFunction(std::string name,
   }
 
   ScalarKernel boolkernel;
-  boolkernel.exec = NonZeroExec;
+  boolkernel.exec = IndicesNonZeroExec;
   boolkernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
   boolkernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
   boolkernel.signature = KernelSignature::Make({boolean()}, uint64());
@@ -382,9 +382,9 @@ const FunctionDoc is_nan_doc("Return true if NaN",
                              ("For each input value, emit true iff the value is NaN."),
                              {"values"});
 
-const FunctionDoc nonzero_doc{"Compare to zero or false",
-                                ("TBD?"),
-                                {"values"}};
+const FunctionDoc indices_nonzero_doc{"Compare to zero or false",
+                                      ("Return the indices of the array containing non false or zero values."),
+                                      {"values"}};
 
 }  // namespace
 
@@ -401,7 +401,7 @@ void RegisterScalarValidity(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(MakeIsInfFunction("is_inf", &is_inf_doc)));
   DCHECK_OK(registry->AddFunction(MakeIsNanFunction("is_nan", &is_nan_doc)));
 
-  DCHECK_OK(registry->AddFunction(MakeNonZeroFunction("nonzero", &nonzero_doc)));
+  DCHECK_OK(registry->AddFunction(MakeIndicesNonZeroFunction("indices_nonzero", &indices_nonzero_doc)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -216,9 +216,7 @@ struct NonZeroVisitor {
           }
           ++index;
         },
-        [&]() {
-          ++index;
-        });
+        [&]() { ++index; });
     return Status::OK();
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -78,13 +78,6 @@ struct IsInfOperator {
   }
 };
 
-struct NonZeroOperator {
-  template <typename OutType, typename InType>
-  static constexpr OutType Call(KernelContext*, const InType& value, Status*) {
-    return value != 0;
-  }
-};
-
 using NanOptionsState = OptionsWrapper<NullOptions>;
 
 struct IsNullOperator {

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -216,12 +216,9 @@ struct NonZeroVisitor {
         [&](T v) {
           if(v != 0)
             this->builder->UnsafeAppend(index);
-          else
-            this->builder->UnsafeAppendNull();
           ++index;
         },
         [&]() {
-          this->builder->UnsafeAppendNull();
           ++index;
         });
      return Status::OK();
@@ -231,7 +228,7 @@ struct NonZeroVisitor {
 Status NonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   std::shared_ptr<ArrayData> array = batch[0].array();
   UInt32Builder builder;
-  RETURN_NOT_OK(builder.Reserve(array->length));
+  //RETURN_NOT_OK(builder.Reserve(array->length));
 
   NonZeroVisitor visitor(&builder, *array.get());
   RETURN_NOT_OK(VisitTypeInline(*(array->type), &visitor));
@@ -249,7 +246,7 @@ std::shared_ptr<ScalarFunction> MakeNonZeroFunction(std::string name,
   for (const auto& ty : IntTypes()) {
     ScalarKernel kernel;
     kernel.exec = NonZeroExec;
-    kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
+    kernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
     kernel.signature = KernelSignature::Make({InputType(ty->id())}, uint32());
     DCHECK_OK(func->AddKernel(kernel));

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -16,11 +16,6 @@
 // under the License.
 
 #include <cmath>
-#include <cstdint>
-#include <memory>
-#include <type_traits>
-
-#include "arrow/array/builder_primitive.h"
 
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common.h"

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -238,12 +238,12 @@ Status IndicesNonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out
   return Status::OK();
 }
 
-std::shared_ptr<ScalarFunction> MakeIndicesNonZeroFunction(std::string name,
+std::shared_ptr<VectorFunction> MakeIndicesNonZeroFunction(std::string name,
                                                            const FunctionDoc* doc) {
-  auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
+  auto func = std::make_shared<VectorFunction>(name, Arity::Unary(), doc);
 
   for (const auto& ty : NumericTypes()) {
-    ScalarKernel kernel;
+    VectorKernel kernel;
     kernel.exec = IndicesNonZeroExec;
     kernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
@@ -251,7 +251,7 @@ std::shared_ptr<ScalarFunction> MakeIndicesNonZeroFunction(std::string name,
     DCHECK_OK(func->AddKernel(kernel));
   }
 
-  ScalarKernel boolkernel;
+  VectorKernel boolkernel;
   boolkernel.exec = IndicesNonZeroExec;
   boolkernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
   boolkernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
@@ -380,8 +380,9 @@ const FunctionDoc is_nan_doc("Return true if NaN",
                              {"values"});
 
 const FunctionDoc indices_nonzero_doc{
-    "Compare to zero or false",
-    ("Return the indices of the array containing non false or zero values."),
+    "Return indices of the array containing non zero or false values",
+    ("For each input value, check if it's zero, false or null. Emit the index\n"
+     "of the value in the array if it's none of the those."),
     {"values"}};
 
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -211,24 +211,26 @@ struct NonZeroVisitor {
      using T = typename GetViewType<Type>::T;
      uint32_t index = 0;
 
-     VisitArrayDataInline<Type>(
+     return VisitArrayDataInline<Type>(
         this->array,
         [&](T v) {
-          if(v != 0)
+          if(v != 0) {
+            RETURN_NOT_OK(this->builder->Reserve(1));
             this->builder->UnsafeAppend(index);
+          }
           ++index;
+          return Status::OK();
         },
         [&]() {
           ++index;
+          return Status::OK();
         });
-     return Status::OK();
    }
 };
 
 Status NonZeroExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   std::shared_ptr<ArrayData> array = batch[0].array();
   UInt32Builder builder;
-  //RETURN_NOT_OK(builder.Reserve(array->length));
 
   NonZeroVisitor visitor(&builder, *array.get());
   RETURN_NOT_OK(VisitTypeInline(*(array->type), &visitor));

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -241,8 +241,8 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsInf) { this->TestIsInf(); }
 TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
 TEST(TestValidityKernels, NonZero) {
-  CheckScalarUnary("nonzero", int32(), "[null, 50, 0, 10]", 
-                   uint32(), "[1, 3]");
+  ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
+  AssertArraysEqual(*actual.make_array(), *ArrayFromJSON(uint32(), "[1, 3]"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -242,7 +242,8 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
 TEST(TestValidityKernels, NonZero) {
   ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
-  AssertArraysEqual(*actual.make_array(), *ArrayFromJSON(uint32(), "[1, 3]"));
+  std::shared_ptr<Array> result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -240,5 +240,10 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsInf) { this->TestIsInf(); }
 
 TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
+TEST(TestValidityKernels, NonZero) {
+  CheckScalarUnary("nonzero", int32(), "[null, 50, 0, null]", uint32(),
+                   "[null, 1, null, null]");
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -244,15 +244,15 @@ TEST(TestValidityKernels, NonZero) {
   Datum actual;
   std::shared_ptr<Array> result;
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -241,8 +241,8 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsInf) { this->TestIsInf(); }
 TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
 TEST(TestValidityKernels, NonZero) {
-  CheckScalarUnary("nonzero", int32(), "[null, 50, 0, null]", uint32(),
-                   "[null, 1, null, null]");
+  CheckScalarUnary("nonzero", int32(), "[null, 50, 0, 10]", 
+                   uint32(), "[1, 3]");
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -261,6 +261,11 @@ TEST(TestValidityKernels, NonZero) {
                                     {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -241,8 +241,19 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsInf) { this->TestIsInf(); }
 TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
 TEST(TestValidityKernels, NonZero) {
-  ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
-  std::shared_ptr<Array> result = actual.make_array();
+  Datum actual;
+  std::shared_ptr<Array> result;
+
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("nonzero", {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
+  result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -244,15 +244,21 @@ TEST(TestValidityKernels, NonZero) {
   Datum actual;
   std::shared_ptr<Array> result;
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
+  ASSERT_OK_AND_ASSIGN(
+      actual,
+      CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction("indices_nonzero",
+                           {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 
-  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero",
+                                    {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -240,33 +240,5 @@ TYPED_TEST(TestFloatingPointValidityKernels, IsInf) { this->TestIsInf(); }
 
 TYPED_TEST(TestFloatingPointValidityKernels, IsNan) { this->TestIsNan(); }
 
-TEST(TestValidityKernels, NonZero) {
-  Datum actual;
-  std::shared_ptr<Array> result;
-
-  ASSERT_OK_AND_ASSIGN(
-      actual,
-      CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
-  ASSERT_OK_AND_ASSIGN(
-      actual, CallFunction("indices_nonzero",
-                           {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
-  ASSERT_OK_AND_ASSIGN(actual,
-                       CallFunction("indices_nonzero",
-                                    {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
-  ASSERT_OK_AND_ASSIGN(actual,
-                       CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
-}
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2492,7 +2492,7 @@ void RegisterVectorSelection(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::make_shared<DropNullMetaFunction>()));
 
   DCHECK_OK(registry->AddFunction(
-    MakeIndicesNonZeroFunction("indices_nonzero", &indices_nonzero_doc)));
+      MakeIndicesNonZeroFunction("indices_nonzero", &indices_nonzero_doc)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2378,7 +2378,7 @@ struct NonZeroVisitor {
     using T = typename GetViewType<Type>::T;
     uint64_t index = 0;
 
-    for (const auto &current_array : arrays) {
+    for (const auto& current_array : arrays) {
       VisitArrayDataInline<Type>(
           *current_array,
           [&](T v) {

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2359,7 +2359,7 @@ const FunctionDoc array_take_doc(
     {"array", "indices"}, "TakeOptions");
 
 const FunctionDoc indices_nonzero_doc(
-    "Return indices of the array containing non zero or false values",
+    "Return the indices of the values in the array that are non-zero",
     ("For each input value, check if it's zero, false or null. Emit the index\n"
      "of the value in the array if it's none of the those."),
     {"values"});

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -18,6 +18,9 @@
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
 
 #include "arrow/array/array_binary.h"
 #include "arrow/array/array_dict.h"

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -16,9 +16,9 @@
 // under the License.
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <limits>
-#include <cstdint>
 #include <memory>
 #include <type_traits>
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2391,6 +2391,13 @@ TEST(TestIndicesNonZero, IndicesNonZero) {
                        CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
+
+  ChunkedArray chunkedarr({ArrayFromJSON(uint32(), "[1, 0, 3]"),
+                           ArrayFromJSON(uint32(), "[4, 0, 6]")});
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero", {static_cast<Datum>(chunkedarr)}));
+  Datum expected = ChunkedArrayFromJSON(uint64(), {R"([0, 2])", R"([0, 2])"});
+  AssertDatumsEqual(actual, expected);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2396,8 +2396,7 @@ TEST(TestIndicesNonZero, IndicesNonZero) {
       {ArrayFromJSON(uint32(), "[1, 0, 3]"), ArrayFromJSON(uint32(), "[4, 0, 6]")});
   ASSERT_OK_AND_ASSIGN(actual,
                        CallFunction("indices_nonzero", {static_cast<Datum>(chunkedarr)}));
-  Datum expected = ChunkedArrayFromJSON(uint64(), {R"([0, 2])", R"([0, 2])"});
-  AssertDatumsEqual(actual, expected);
+  AssertArraysEqual(*actual.make_array(), *ArrayFromJSON(uint64(), "[0, 2, 3, 5]"));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2392,8 +2392,8 @@ TEST(TestIndicesNonZero, IndicesNonZero) {
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
 
-  ChunkedArray chunkedarr({ArrayFromJSON(uint32(), "[1, 0, 3]"),
-                           ArrayFromJSON(uint32(), "[4, 0, 6]")});
+  ChunkedArray chunkedarr(
+      {ArrayFromJSON(uint32(), "[1, 0, 3]"), ArrayFromJSON(uint32(), "[4, 0, 6]")});
   ASSERT_OK_AND_ASSIGN(actual,
                        CallFunction("indices_nonzero", {static_cast<Datum>(chunkedarr)}));
   Datum expected = ChunkedArrayFromJSON(uint64(), {R"([0, 2])", R"([0, 2])"});

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2365,5 +2365,33 @@ TEST_F(TestDropNullKernelWithTable, DropNullTableWithSlices) {
   });
 }
 
+TEST(TestIndicesNonZero, IndicesNonZero) {
+  Datum actual;
+  std::shared_ptr<Array> result;
+
+  ASSERT_OK_AND_ASSIGN(
+      actual,
+      CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction("indices_nonzero",
+                           {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero",
+                                    {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
+
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1103,7 +1103,7 @@ Containment tests
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | starts_with           | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| indices_nonzero       | Unary | Boolean, Null, Numeric            | Int64          |                                 |       |
+| indices_nonzero       | Unary | Boolean, Null, Numeric            | UInt64         |                                 |       |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 * \(1) Output is the number of occurrences of

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1567,7 +1567,7 @@ These functions select and return a subset of their input.
 Containment tests
 ~~~~~~~~~~~~~~~~~
 
-This functions return the indices at which elements match a predicate
+This function returns the indices at which array elements are non-null and non-zero.
 
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | Function name         | Arity | Input types                       | Output type    | Options class                   | Notes |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1103,8 +1103,6 @@ Containment tests
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | starts_with           | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
-| indices_nonzero       | Unary | Boolean, Null, Numeric            | UInt64         |                                 |       |
-+-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 * \(1) Output is the number of occurrences of
   :member:`MatchSubstringOptions::pattern` in the corresponding input
@@ -1565,6 +1563,17 @@ These functions select and return a subset of their input.
 
 * \(4) For each element *i* in input 2 (the indices), the *i*'th element
   in input 1 (the values) is appended to the output.
+
+Containment tests
+~~~~~~~~~~~~~~~~~
+
+This functions return the indices at which elements match a predicate
+
++-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
+| Function name         | Arity | Input types                       | Output type    | Options class                   | Notes |
++=======================+=======+===================================+================+=================================+=======+
+| indices_nonzero       | Unary | Boolean, Null, Numeric            | UInt64         |                                 |       |
++-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 Sorts and partitions
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1103,6 +1103,8 @@ Containment tests
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | starts_with           | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(2)  |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
+| indices_nonzero       | Unary | Boolean, Null, Numeric            | Int64          |                                 |       |
++-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 * \(1) Output is the number of occurrences of
   :member:`MatchSubstringOptions::pattern` in the corresponding input

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -344,6 +344,7 @@ Containment Tests
    match_substring
    match_substring_regex
    starts_with
+   indices_nonzero
 
 Categorizations
 ---------------


### PR DESCRIPTION
Add a `indices_nonzero` compute function that returns the indices of an array that contain values `!= 0` or `!= false`.
This can be used in conjunction with our existing functions that return a mask to get back the indices where the mask matches.