### PR TITLE
ARROW-14644: [C++][R] open_dataset doesn't ignore BOM in csv file

### DIFF
--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -88,9 +88,9 @@ Result<std::unordered_set<std::string>> GetColumnNames(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
         // Skip BOM when reading column names (ARROW-14644)
         ARROW_ASSIGN_OR_RAISE(auto data_no_bom, util::SkipUTF8BOM(data, size));
-        int32_t offset = data_no_bom - data;
+        ptrdiff_t offset = data_no_bom - data;
         DCHECK_GE(offset, 0);
-        size = size - offset;
+        size = size - static_cast<uint32_t>(offset);
 
         util::string_view view{reinterpret_cast<const char*>(data_no_bom), size};
         if (column_names.emplace(std::string(view)).second) {

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -87,12 +87,12 @@ Result<std::unordered_set<std::string>> GetColumnNames(
   RETURN_NOT_OK(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
         // Skip BOM when reading column names (ARROW-14644)
-        ARROW_ASSIGN_OR_RAISE(auto data2, util::SkipUTF8BOM(data, size));
-        int64_t offset = data2 - data;
+        ARROW_ASSIGN_OR_RAISE(auto data_no_bom, util::SkipUTF8BOM(data, size));
+        int32_t offset = data_no_bom - data;
         DCHECK_GE(offset, 0);
         size = size - offset;
 
-        util::string_view view{reinterpret_cast<const char*>(data2), size};
+        util::string_view view{reinterpret_cast<const char*>(data_no_bom), size};
         if (column_names.emplace(std::string(view)).second) {
           return Status::OK();
         }

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -39,6 +39,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/utf8.h"
 
 namespace arrow {
 
@@ -85,7 +86,12 @@ Result<std::unordered_set<std::string>> GetColumnNames(
 
   RETURN_NOT_OK(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
-        util::string_view view{reinterpret_cast<const char*>(data), size};
+        // Handle BOM (ARROW-14644)
+        ARROW_ASSIGN_OR_RAISE(auto data2, util::SkipUTF8BOM(data, size));
+        int64_t offset = data2 - data;
+        DCHECK_GE(offset, 0);
+        uint32_t new_size = size - offset;
+        util::string_view view{reinterpret_cast<const char*>(data2), new_size};
         if (column_names.emplace(std::string(view)).second) {
           return Status::OK();
         }

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -86,12 +86,13 @@ Result<std::unordered_set<std::string>> GetColumnNames(
 
   RETURN_NOT_OK(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
-        // Handle BOM (ARROW-14644)
+        // Skip BOM when reading column names (ARROW-14644)
         ARROW_ASSIGN_OR_RAISE(auto data2, util::SkipUTF8BOM(data, size));
         int64_t offset = data2 - data;
         DCHECK_GE(offset, 0);
-        uint32_t new_size = size - offset;
-        util::string_view view{reinterpret_cast<const char*>(data2), new_size};
+        size = size - offset;
+
+        util::string_view view{reinterpret_cast<const char*>(data2), size};
         if (column_names.emplace(std::string(view)).second) {
           return Status::OK();
         }

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -88,9 +88,7 @@ Result<std::unordered_set<std::string>> GetColumnNames(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
         // Skip BOM when reading column names (ARROW-14644)
         ARROW_ASSIGN_OR_RAISE(auto data_no_bom, util::SkipUTF8BOM(data, size));
-        ptrdiff_t offset = data_no_bom - data;
-        DCHECK_GE(offset, 0);
-        size = size - static_cast<uint32_t>(offset);
+        size = size - static_cast<uint32_t>(data_no_bom - data);
 
         util::string_view view{reinterpret_cast<const char*>(data_no_bom), size};
         if (column_names.emplace(std::string(view)).second) {

--- a/r/cleanup
+++ b/r/cleanup
@@ -18,4 +18,3 @@
 # under the License.
 
 rm -f src/Makevars
-

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -447,8 +447,9 @@ test_that("write_csv_arrow deals with duplication in include_headers/col_names",
   )
   expect_true(file.exists(csv_file))
   expect_identical(tbl_no_dates, written_tbl)
+})
 
-test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+test_that("read_csv_arrow() deals with BOMs (bite-order-marks) correctly", {
   writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
 
   expect_equal(

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -448,4 +448,11 @@ test_that("write_csv_arrow deals with duplication in include_headers/col_names",
   expect_true(file.exists(csv_file))
   expect_identical(tbl_no_dates, written_tbl)
 
+test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+
+  expect_equal(
+    read_csv_arrow(csv_file),
+    tibble(a = 1, b = 2)
+  )
 })

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -449,8 +449,8 @@ test_that("write_csv_arrow deals with duplication in include_headers/col_names",
   expect_identical(tbl_no_dates, written_tbl)
 })
 
-test_that("read_csv_arrow() deals with BOMs (bite-order-marks) correctly", {
-  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+test_that("read_csv_arrow() deals with BOMs (byte-order-marks) correctly", {
+  writeLines("\xef\xbb\xbfa,b\n1,2\n", con = csv_file)
 
   expect_equal(
     read_csv_arrow(csv_file),

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -289,7 +289,7 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
   expect_equal(ds %>% collect(), tbl)
 })
 
-test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+test_that("open_dataset() deals with BOMs (bite-order-marks) correctly", {
   writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
 
   expect_equal(

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -290,8 +290,8 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
   expect_equal(ds %>% collect(), tbl)
 })
 
-test_that("open_dataset() deals with BOMs (bite-order-marks) correctly", {
-  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+test_that("open_dataset() deals with BOMs (byte-order-marks) correctly", {
+  writeLines("\xef\xbb\xbfa,b\n1,2\n", con = csv_file)
 
   expect_equal(
     open_dataset(csv_file, format = "csv") %>% collect(),

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -21,7 +21,6 @@ library(dplyr, warn.conflicts = FALSE)
 
 csv_dir <- make_temp_dir()
 tsv_dir <- make_temp_dir()
-csv_file <- tempfile()
 
 test_that("Setup (putting data in the dirs)", {
   dir.create(file.path(csv_dir, 5))
@@ -291,10 +290,12 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
 })
 
 test_that("open_dataset() deals with BOMs (byte-order-marks) correctly", {
-  writeLines("\xef\xbb\xbfa,b\n1,2\n", con = csv_file)
+  temp_dir <- make_temp_dir()
+  writeLines("\xef\xbb\xbfa,b\n1,2\n", con = file.path(temp_dir, "file1.csv"))
+  writeLines("\xef\xbb\xbfa,b\n3,4\n", con = file.path(temp_dir, "file2.csv"))
 
   expect_equal(
-    open_dataset(csv_file, format = "csv") %>% collect(),
-    tibble(a = 1, b = 2)
+    open_dataset(temp_dir, format = "csv") %>% collect(),
+    tibble(a = c(1, 3), b = c(2, 4))
   )
 })

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -288,3 +288,12 @@ test_that("Column names inferred from schema for headerless CSVs (ARROW-14063)",
   ds <- open_dataset(headerless_csv_dir, format = "csv", schema = schema(int = int32(), dbl = float64()))
   expect_equal(ds %>% collect(), tbl)
 })
+
+test_that("read_csv_arrow() deals with BOM (bite-order-marks) correctly", {
+  writeLines('\xef\xbb\xbfa,b\n1,2\n', con = csv_file)
+
+  expect_equal(
+    open_dataset(csv_file, format = "csv") %>% collect(),
+    tibble(a = 1, b = 2)
+  )
+})

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -21,6 +21,7 @@ library(dplyr, warn.conflicts = FALSE)
 
 csv_dir <- make_temp_dir()
 tsv_dir <- make_temp_dir()
+csv_file <- tempfile()
 
 test_that("Setup (putting data in the dirs)", {
   dir.create(file.path(csv_dir, 5))


### PR DESCRIPTION
`arrow::csv::StreamingReader` already has handling for byte order marks (BOM). However, #7896 introduced `arrow::dataset::GetColumnNames` which is called prior to instantiating the reader and was missing BOM handling. This PR adds BOM handling to that method.

Without BOM handling, the first column as parsed by `arrow::dataset::GetColumnNames` contained the BOM (e.g. was `"<BOM>a"` instead of `"a"`). Because of this, it failed the test on line 120 below and was not added to `convert_options.include_columns`. 

https://github.com/apache/arrow/blob/9cf4275a19c994879172e5d3b03ade9a96a10721/cpp/src/arrow/dataset/file_csv.cc#L117-L122

