### PR TITLE
MINOR: [R] Small addition to disable extraneous duckdb building

### DIFF
--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -46,7 +46,7 @@ ${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran
 # (though only if we haven't filtered it out of the deps above,
 # and if we can't get a binary from RSPM)
 # Remove when there is a DuckDB release > 0.3.1-1
-if grep -q "duckdb" DESCRIPTION; then
+if grep -q "duckdb," DESCRIPTION; then
   ${R_BIN} -e "if (all(!grepl('packagemanager.rstudio', options('repos')))) { remotes::install_github('duckdb/duckdb', subdir = '/tools/rpkg', build = FALSE) }"
 fi
 


### PR DESCRIPTION
_It turns out_ that simply grepping DESCRIPTION for `duckdb` will always return true (even if it has been pruned from Suggests), since we collate our filenames and one of our filenames includes duckdb