### PR TITLE
ARROW-14977: [Python] Add a "made-up" feature for the guide tutorial

### DIFF
--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -780,14 +780,13 @@ def tutorial_min_max(values, skip_nulls=True):
     """
     Compute the minimum-1 and maximum+1 values of a numeric array.
 
-    Null values are ignored by default. This can be changed through
-    ScalarAggregateOptions.
-
     This is a made-up feature for the tutorial purposes.
 
     Parameters
     ----------
     values : Array
+    skip_nulls : bool, default True
+        If True, ignore nulls in the input.
 
     Returns
     -------

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -774,3 +774,45 @@ def bottom_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
         sort_keys = map(lambda key_name: (key_name, "ascending"), sort_keys)
     options = SelectKOptions(k, sort_keys)
     return call_function("select_k_unstable", [values], options, memory_pool)
+
+
+def tutorial_min_max(values, skip_nulls=True):
+    """
+    Compute the minimum-1 and maximum+1 values of a numeric array.
+
+    Null values are ignored by default. This can be changed through
+    ScalarAggregateOptions.
+
+    This is a made-up feature for the tutorial purposes.
+
+    Parameters
+    ----------
+    values : Array
+
+    Returns
+    -------
+    result : StructScalar of min-1 and max+1
+
+    Examples
+    --------
+    >>> import pyarrow.compute as pc
+    >>> data = [4, 5, 6, None, 1]
+    >>> pc.tutorial_min_max(data)
+    <pyarrow.StructScalar: [('min-', 0), ('max+', 7)]>
+    """
+
+    options = ScalarAggregateOptions(skip_nulls=skip_nulls)
+    min_max = call_function("min_max", [values], options)
+
+    if min_max[0].as_py() is not None:
+        min_t = min_max[0].as_py()-1
+        max_t = min_max[1].as_py()+1
+    else:
+        min_t = min_max[0].as_py()
+        max_t = min_max[1].as_py()
+
+    ty = pa.struct([
+        pa.field('min-', pa.int64()),
+        pa.field('max+', pa.int64()),
+    ])
+    return pa.scalar([('min-', min_t), ('max+', max_t)], type=ty)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2279,3 +2279,12 @@ def test_utf8_normalize():
             ValueError,
             match='"NFZ" is not a valid Unicode normalization form'):
         pc.utf8_normalize(arr, form="NFZ")
+
+
+def test_tutorial_min_max():
+    arr = [4, 5, 6, None, 1]
+    l1 = {'min-': 0, 'max+': 7}
+    l2 = {'min-': None, 'max+': None}
+    assert pc.tutorial_min_max(arr).as_py() == l1
+    assert pc.tutorial_min_max(arr,
+                               skip_nulls=False).as_py() == l2


### PR DESCRIPTION
We would like to add a **Tutorial** on how to **add a simple feature to PyArrow** that would be a part of the (New) Contributor's Guide.

For this reason I made up a feature called `tutorial_min_max` that I added to `compute.py` plus a unit test to `test_compute.py.` The steps of making this PR will be added to the guide content separately [ARROW-14602](https://issues.apache.org/jira/browse/ARROW-14602.)

cc @jorisvandenbossche @amol- @dragosmg 