### PR TITLE
WIP: [C++] Demonstrate C++ OTel instrumentation

### DIFF
--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -31,6 +31,7 @@
 #include "arrow/datum.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/tracing_internal.h"
 
 namespace arrow {
 
@@ -203,6 +204,11 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
     ExecContext default_ctx;
     return Execute(args, options, &default_ctx);
   }
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+  auto span = arrow::internal::tracing::GetTracer()->StartSpan("Function::Execute", {{"function", name()}});
+  auto scope = opentelemetry::trace::Scope(span);
+#endif
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -104,9 +104,10 @@ class FlushLog {
   explicit FlushLog(nostd::shared_ptr<sdktrace::TracerProvider> provider)
       : provider_(std::move(provider)) {}
   ~FlushLog() {
-    if (provider_) {
-      provider_->ForceFlush(std::chrono::microseconds(1000000));
-    }
+    // TODO: ForceFlush apparently sends data that OTLP connector can't handle
+    // if (provider_) {
+    //   provider_->ForceFlush(std::chrono::microseconds(1000000));
+    // }
   }
   nostd::shared_ptr<sdktrace::TracerProvider> provider_;
 };

--- a/cpp/src/arrow/util/tracing_internal.h
+++ b/cpp/src/arrow/util/tracing_internal.h
@@ -28,6 +28,7 @@
 #pragma warning(disable : 4522)
 #endif
 #include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/scope.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
Instructions:

```
$ mkdir otlp
$ nvim otlp/config.dev.yml
exporters:
  file:
    path: /dev/stdout
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: "0.0.0.0:4318"
        cors_allowed_origins:
        - '*'
service:
  pipelines:
    traces:
      receivers:
      - otlp
      exporters:
      - file
$ docker run --rm -it -p 4317:4317 -p 4318:4318 -v (pwd)/otlp:/cfg otel/opentelemetry-collector:0.40.0 --config=/cfg/config.dev.yml
# In another terminal
$ pwd
/path/to/arrow/repo/root
$ mkdir build; cd build
$ cmake ../cpp -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja -DCMAKE_INSTALL_PREFIX=$(pwd)/../install -DCMAKE_INSTALL_LIBDIR=lib -DARROW_DATASET=ON -DARROW_PARQUET=ON -DARROW_JSON=ON -DARROW_CSV=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_S3=ON -DARROW_ENGINE=ON -DARROW_WITH_OPENTELEMETRY=ON
$ ninja install
$ cd ../r
$ export ARROW_HOME=$(pwd)/../install
$ export LD_LIBRARY_PATH=$(pwd)/../install/lib
$ env LIBARROW_DOWNLOAD=false LIBARROW_BUILD=false ARROW_R_DEV=true R CMD INSTALL .
$ R -e 'remotes::install_github("ursacomputing/arrowbench")'
$ env ARROW_TRACING_BACKEND=otlp_http R -e 'library(arrowbench);run_benchmark(tpc_h, engine=c("arrow"), query_id=c(1), format=c("parquet"), scale_factor=c(1))'
# Go look at the terminal running the OTLP collector
```