### PR TITLE
ARROW-13672: [C++] Make BinaryBuilder preserve the type parameter

### DIFF
--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -50,14 +50,6 @@ class BaseBinaryBuilder : public ArrayBuilder {
   using TypeClass = TYPE;
   using offset_type = typename TypeClass::offset_type;
 
-  explicit BaseBinaryBuilder(MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), offsets_builder_(pool),
-        value_data_builder_(pool), type_(binary()) {}
-
-  BaseBinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-      : ArrayBuilder(pool), offsets_builder_(pool),
-        value_data_builder_(pool), type_(type) {}
-
   Status Append(const uint8_t* value, offset_type length) {
     ARROW_RETURN_NOT_OK(Reserve(1));
     ARROW_RETURN_NOT_OK(AppendNextOffset());
@@ -385,6 +377,10 @@ class BaseBinaryBuilder : public ArrayBuilder {
   TypedBufferBuilder<offset_type> offsets_builder_;
   TypedBufferBuilder<uint8_t> value_data_builder_;
   std::shared_ptr<DataType> type_;
+
+  BaseBinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+      : ArrayBuilder(pool), offsets_builder_(pool),
+        value_data_builder_(pool), type_(type) {}
 
   Status AppendNextOffset() {
     const int64_t num_bytes = value_data_builder_.length();

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -379,8 +379,10 @@ class BaseBinaryBuilder : public ArrayBuilder {
   std::shared_ptr<DataType> type_;
 
   BaseBinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-      : ArrayBuilder(pool), offsets_builder_(pool),
-        value_data_builder_(pool), type_(type) {}
+      : ArrayBuilder(pool),
+        offsets_builder_(pool),
+        value_data_builder_(pool),
+        type_(type) {}
 
   Status AppendNextOffset() {
     const int64_t num_bytes = value_data_builder_.length();
@@ -400,7 +402,7 @@ class ARROW_EXPORT BinaryBuilder : public BaseBinaryBuilder<BinaryType> {
   explicit BinaryBuilder(MemoryPool* pool = default_memory_pool())
       : BaseBinaryBuilder(binary(), pool) {}
 
-  BinaryBuilder(const std::shared_ptr<DataType> &type, MemoryPool *pool)
+  BinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
       : BaseBinaryBuilder(type, pool) {}
 
   /// \cond FALSE
@@ -417,7 +419,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   explicit StringBuilder(MemoryPool* pool = default_memory_pool())
       : BinaryBuilder(utf8(), pool) {}
 
-  StringBuilder(const std::shared_ptr<DataType> &type, MemoryPool *pool)
+  StringBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
       : BinaryBuilder(type, pool) {}
 
   /// \cond FALSE
@@ -434,7 +436,7 @@ class ARROW_EXPORT LargeBinaryBuilder : public BaseBinaryBuilder<LargeBinaryType
   explicit LargeBinaryBuilder(MemoryPool* pool = default_memory_pool())
       : BaseBinaryBuilder(large_binary(), pool) {}
 
-  LargeBinaryBuilder(const std::shared_ptr<DataType> &type, MemoryPool *pool)
+  LargeBinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
       : BaseBinaryBuilder(type, pool) {}
 
   /// \cond FALSE
@@ -449,10 +451,10 @@ class ARROW_EXPORT LargeBinaryBuilder : public BaseBinaryBuilder<LargeBinaryType
 class ARROW_EXPORT LargeStringBuilder : public LargeBinaryBuilder {
  public:
   explicit LargeStringBuilder(MemoryPool* pool = default_memory_pool())
-     : LargeBinaryBuilder(large_utf8(), pool) {}
+      : LargeBinaryBuilder(large_utf8(), pool) {}
 
-  LargeStringBuilder(const std::shared_ptr<DataType> &type, MemoryPool *pool)
-     : LargeBinaryBuilder(type, pool) {}
+  LargeStringBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+      : LargeBinaryBuilder(type, pool) {}
 
   /// \cond FALSE
   using ArrayBuilder::Finish;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -58,7 +58,7 @@ struct NumericToStringCastFunctor {
 
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     FormatterType formatter(input.type);
-    BuilderType builder(utf8(), ctx->memory_pool());
+    BuilderType builder(ctx->memory_pool());
     RETURN_NOT_OK(VisitArrayDataInline<I>(
         input,
         [&](value_type v) {
@@ -91,7 +91,7 @@ struct TemporalToStringCastFunctor {
 
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     FormatterType formatter(input.type);
-    BuilderType builder(utf8(), ctx->memory_pool());
+    BuilderType builder(ctx->memory_pool());
     RETURN_NOT_OK(VisitArrayDataInline<I>(
         input,
         [&](value_type v) {
@@ -122,7 +122,7 @@ struct TemporalToStringCastFunctor<O, TimestampType> {
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     const auto& timezone = GetInputTimezone(*input.type);
     const auto& ty = checked_cast<const TimestampType&>(*input.type);
-    BuilderType builder(utf8(), ctx->memory_pool());
+    BuilderType builder(ctx->memory_pool());
 
     // Preallocate
     int64_t string_length = 19;  // YYYY-MM-DD HH:MM:SS

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -58,7 +58,7 @@ struct NumericToStringCastFunctor {
 
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     FormatterType formatter(input.type);
-    BuilderType builder(input.type, ctx->memory_pool());
+    BuilderType builder(utf8(), ctx->memory_pool());
     RETURN_NOT_OK(VisitArrayDataInline<I>(
         input,
         [&](value_type v) {
@@ -91,7 +91,7 @@ struct TemporalToStringCastFunctor {
 
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     FormatterType formatter(input.type);
-    BuilderType builder(input.type, ctx->memory_pool());
+    BuilderType builder(utf8(), ctx->memory_pool());
     RETURN_NOT_OK(VisitArrayDataInline<I>(
         input,
         [&](value_type v) {
@@ -122,7 +122,7 @@ struct TemporalToStringCastFunctor<O, TimestampType> {
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     const auto& timezone = GetInputTimezone(*input.type);
     const auto& ty = checked_cast<const TimestampType&>(*input.type);
-    BuilderType builder(input.type, ctx->memory_pool());
+    BuilderType builder(utf8(), ctx->memory_pool());
 
     // Preallocate
     int64_t string_length = 19;  // YYYY-MM-DD HH:MM:SS


### PR DESCRIPTION
This pull request preserves the passed-in type parameter to the BinaryBuilders.