### PR TITLE
ARROW-14958: [C++][Python][FlightRPC] Implement Flight middleware for OpenTelemetry propagation

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -184,10 +184,13 @@ set(ARROW_FLIGHT_SRCS
     "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.cc"
     client.cc
     client_cookie_middleware.cc
+    client_tracing_middleware.cc
     cookie_internal.cc
+    middleware.cc
     serialization_internal.cc
     server.cc
     server_auth.cc
+    server_tracing_middleware.cc
     transport.cc
     transport_server.cc
     # Bundle the gRPC impl with libarrow_flight

--- a/cpp/src/arrow/flight/client_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/client_tracing_middleware.cc
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/client_tracing_middleware.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/util/tracing_internal.h"
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/context/propagation/text_map_propagator.h>
+#endif
+
+namespace arrow {
+namespace flight {
+
+namespace {
+#ifdef ARROW_WITH_OPENTELEMETRY
+namespace otel = opentelemetry;
+class FlightClientCarrier : public otel::context::propagation::TextMapCarrier {
+ public:
+  FlightClientCarrier() = default;
+
+  otel::nostd::string_view Get(otel::nostd::string_view key) const noexcept override {
+    return "";
+  }
+
+  void Set(otel::nostd::string_view key,
+           otel::nostd::string_view value) noexcept override {
+    context_.emplace_back(key, value);
+  }
+
+  std::vector<std::pair<std::string, std::string>> context_;
+};
+
+class TracingClientMiddleware : public ClientMiddleware {
+ public:
+  explicit TracingClientMiddleware(FlightClientCarrier carrier)
+      : carrier_(std::move(carrier)) {}
+  virtual ~TracingClientMiddleware() = default;
+
+  void SendingHeaders(AddCallHeaders* outgoing_headers) override {
+    // The exact headers added are not arbitrary and are defined in
+    // the OpenTelemetry specification (see
+    // open-telemetry/opentelemetry-specification api-propagators.md)
+    for (const auto& pair : carrier_.context_) {
+      outgoing_headers->AddHeader(pair.first, pair.second);
+    }
+  }
+  void ReceivedHeaders(const CallHeaders&) override {}
+  void CallCompleted(const Status&) override {}
+
+ private:
+  FlightClientCarrier carrier_;
+};
+
+class TracingClientMiddlewareFactory : public ClientMiddlewareFactory {
+ public:
+  virtual ~TracingClientMiddlewareFactory() = default;
+  void StartCall(const CallInfo& info,
+                 std::unique_ptr<ClientMiddleware>* middleware) override {
+    FlightClientCarrier carrier;
+    auto context = otel::context::RuntimeContext::GetCurrent();
+    auto propagator =
+        otel::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    propagator->Inject(carrier, context);
+    *middleware = std::make_unique<TracingClientMiddleware>(std::move(carrier));
+  }
+};
+#else
+class TracingClientMiddlewareFactory : public ClientMiddlewareFactory {
+ public:
+  virtual ~TracingClientMiddlewareFactory() = default;
+  void StartCall(const CallInfo&, std::unique_ptr<ClientMiddleware>*) override {}
+};
+#endif
+}  // namespace
+
+std::shared_ptr<ClientMiddlewareFactory> MakeTracingClientMiddlewareFactory() {
+  return std::make_shared<TracingClientMiddlewareFactory>();
+}
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/client_tracing_middleware.h
+++ b/cpp/src/arrow/flight/client_tracing_middleware.h
@@ -15,15 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Middleware implementation for propagating OpenTelemetry spans.
+
 #pragma once
 
-#include "arrow/flight/client.h"
-#include "arrow/flight/client_auth.h"
+#include <memory>
+
 #include "arrow/flight/client_middleware.h"
-#include "arrow/flight/client_tracing_middleware.h"
-#include "arrow/flight/middleware.h"
-#include "arrow/flight/server.h"
-#include "arrow/flight/server_auth.h"
-#include "arrow/flight/server_middleware.h"
-#include "arrow/flight/server_tracing_middleware.h"
-#include "arrow/flight/types.h"
+
+namespace arrow {
+namespace flight {
+
+/// \brief Returns a ClientMiddlewareFactory that handles sending OpenTelemetry spans.
+ARROW_FLIGHT_EXPORT std::shared_ptr<ClientMiddlewareFactory>
+MakeTracingClientMiddlewareFactory();
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/middleware.cc
+++ b/cpp/src/arrow/flight/middleware.cc
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/middleware.h"
+
+namespace arrow {
+namespace flight {
+
+std::string ToString(FlightMethod method) {
+  // Technically, we can get this via Protobuf reflection, but in
+  // practice we'd have to hardcode the method names to look up the
+  // method descriptor...
+  switch (method) {
+    case FlightMethod::Handshake:
+      return "Handshake";
+    case FlightMethod::ListFlights:
+      return "ListFlights";
+    case FlightMethod::GetFlightInfo:
+      return "GetFlightInfo";
+    case FlightMethod::GetSchema:
+      return "GetSchema";
+    case FlightMethod::DoGet:
+      return "DoGet";
+    case FlightMethod::DoPut:
+      return "DoPut";
+    case FlightMethod::DoAction:
+      return "DoAction";
+    case FlightMethod::ListActions:
+      return "ListActions";
+    case FlightMethod::DoExchange:
+      return "DoExchange";
+    case FlightMethod::Invalid:
+    default:
+      return "(unknown Flight method)";
+  }
+}
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/middleware.h
+++ b/cpp/src/arrow/flight/middleware.h
@@ -30,7 +30,6 @@
 #include "arrow/status.h"
 
 namespace arrow {
-
 namespace flight {
 
 /// \brief Headers sent from the client or server.
@@ -66,6 +65,10 @@ enum class FlightMethod : char {
   DoExchange = 9,
 };
 
+/// \brief Get a human-readable name for a Flight method.
+ARROW_FLIGHT_EXPORT
+std::string ToString(FlightMethod method);
+
 /// \brief Information about an instance of a Flight RPC.
 struct ARROW_FLIGHT_EXPORT CallInfo {
  public:
@@ -74,5 +77,4 @@ struct ARROW_FLIGHT_EXPORT CallInfo {
 };
 
 }  // namespace flight
-
 }  // namespace arrow

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/server_tracing_middleware.h"
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "arrow/flight/transport/grpc/util_internal.h"
+#include "arrow/util/tracing_internal.h"
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/context/propagation/text_map_propagator.h>
+#include <opentelemetry/trace/context.h>
+#include <opentelemetry/trace/experimental_semantic_conventions.h>
+#include <opentelemetry/trace/propagation/http_trace_context.h>
+#endif
+
+namespace arrow {
+namespace flight {
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+namespace otel = opentelemetry;
+namespace {
+class FlightServerCarrier : public otel::context::propagation::TextMapCarrier {
+ public:
+  explicit FlightServerCarrier(const CallHeaders& incoming_headers)
+      : incoming_headers_(incoming_headers) {}
+
+  otel::nostd::string_view Get(otel::nostd::string_view key) const noexcept override {
+    std::string_view arrow_key(key.data(), key.size());
+    auto it = incoming_headers_.find(arrow_key);
+    if (it == incoming_headers_.end()) return "";
+    std::string_view result = it->second;
+    return {result.data(), result.size()};
+  }
+
+  void Set(otel::nostd::string_view, otel::nostd::string_view) noexcept override {}
+
+  const CallHeaders& incoming_headers_;
+};
+class KeyValueCarrier : public otel::context::propagation::TextMapCarrier {
+ public:
+  explicit KeyValueCarrier(std::vector<TracingServerMiddleware::TraceKey>* items)
+      : items_(items) {}
+  otel::nostd::string_view Get(otel::nostd::string_view key) const noexcept override {
+    return {};
+  }
+  void Set(otel::nostd::string_view key,
+           otel::nostd::string_view value) noexcept override {
+    items_->push_back({std::string(key), std::string(value)});
+  }
+
+ private:
+  std::vector<TracingServerMiddleware::TraceKey>* items_;
+};
+}  // namespace
+
+class TracingServerMiddleware::Impl {
+ public:
+  Impl(otel::trace::Scope scope, otel::nostd::shared_ptr<otel::trace::Span> span)
+      : scope_(std::move(scope)), span_(std::move(span)) {}
+  void CallCompleted(const Status& status) {
+    if (!status.ok()) {
+      auto grpc_status = transport::grpc::ToGrpcStatus(status, /*ctx=*/nullptr);
+      span_->SetStatus(otel::trace::StatusCode::kError, status.ToString());
+      span_->SetAttribute(OTEL_GET_TRACE_ATTR(AttrRpcGrpcStatusCode),
+                          static_cast<int32_t>(grpc_status.error_code()));
+    } else {
+      span_->SetStatus(otel::trace::StatusCode::kOk, "");
+      span_->SetAttribute(OTEL_GET_TRACE_ATTR(AttrRpcGrpcStatusCode), int32_t(0));
+    }
+    span_->End();
+  }
+  std::vector<TraceKey> GetTraceContext() const {
+    std::vector<TraceKey> result;
+    KeyValueCarrier carrier(&result);
+    auto context = otel::context::RuntimeContext::GetCurrent();
+    otel::trace::propagation::HttpTraceContext propagator;
+    propagator.Inject(carrier, context);
+    return result;
+  }
+
+ private:
+  otel::trace::Scope scope_;
+  otel::nostd::shared_ptr<otel::trace::Span> span_;
+};
+
+class TracingServerMiddlewareFactory : public ServerMiddlewareFactory {
+ public:
+  virtual ~TracingServerMiddlewareFactory() = default;
+  Status StartCall(const CallInfo& info, const CallHeaders& incoming_headers,
+                   std::shared_ptr<ServerMiddleware>* middleware) override {
+    constexpr char kRpcSystem[] = "grpc";
+    constexpr char kServiceName[] = "arrow.flight.protocol.FlightService";
+
+    FlightServerCarrier carrier(incoming_headers);
+    auto context = otel::context::RuntimeContext::GetCurrent();
+    auto propagator =
+        otel::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto new_context = propagator->Extract(carrier, context);
+
+    otel::trace::StartSpanOptions options;
+    options.kind = otel::trace::SpanKind::kServer;
+    options.parent = otel::trace::GetSpan(new_context)->GetContext();
+
+    auto* tracer = arrow::internal::tracing::GetTracer();
+    auto method_name = ToString(info.method);
+    auto span = tracer->StartSpan(
+        method_name,
+        {
+            // Attributes from experimental trace semantic conventions spec
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/rpc.yaml
+            {OTEL_GET_TRACE_ATTR(AttrRpcSystem), kRpcSystem},
+            {OTEL_GET_TRACE_ATTR(AttrRpcService), kServiceName},
+            {OTEL_GET_TRACE_ATTR(AttrRpcMethod), method_name},
+        },
+        options);
+    auto scope = tracer->WithActiveSpan(span);
+
+    std::unique_ptr<TracingServerMiddleware::Impl> impl(
+        new TracingServerMiddleware::Impl(std::move(scope), std::move(span)));
+    *middleware = std::shared_ptr<TracingServerMiddleware>(
+        new TracingServerMiddleware(std::move(impl)));
+    return Status::OK();
+  }
+};
+#else
+class TracingServerMiddleware::Impl {
+ public:
+  void CallCompleted(const Status&) {}
+  std::vector<TraceKey> GetTraceContext() const { return {}; }
+};
+class TracingServerMiddlewareFactory : public ServerMiddlewareFactory {
+ public:
+  virtual ~TracingServerMiddlewareFactory() = default;
+  Status StartCall(const CallInfo&, const CallHeaders&,
+                   std::shared_ptr<ServerMiddleware>* middleware) override {
+    std::unique_ptr<TracingServerMiddleware::Impl> impl(
+        new TracingServerMiddleware::Impl());
+    *middleware = std::shared_ptr<TracingServerMiddleware>(
+        new TracingServerMiddleware(std::move(impl)));
+    return Status::OK();
+  }
+};
+#endif
+
+TracingServerMiddleware::TracingServerMiddleware(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+TracingServerMiddleware::~TracingServerMiddleware() = default;
+void TracingServerMiddleware::SendingHeaders(AddCallHeaders*) {}
+void TracingServerMiddleware::CallCompleted(const Status& status) {
+  impl_->CallCompleted(status);
+}
+std::vector<TracingServerMiddleware::TraceKey> TracingServerMiddleware::GetTraceContext()
+    const {
+  return impl_->GetTraceContext();
+}
+constexpr char const TracingServerMiddleware::kMiddlewareName[];
+
+std::shared_ptr<ServerMiddlewareFactory> MakeTracingServerMiddlewareFactory() {
+  return std::make_shared<TracingServerMiddlewareFactory>();
+}
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/server_tracing_middleware.h
+++ b/cpp/src/arrow/flight/server_tracing_middleware.h
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Middleware implementation for propagating OpenTelemetry spans.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/flight/server_middleware.h"
+#include "arrow/flight/visibility.h"
+#include "arrow/status.h"
+
+namespace arrow {
+namespace flight {
+
+/// \brief Returns a ServerMiddlewareFactory that handles receiving OpenTelemetry spans.
+ARROW_FLIGHT_EXPORT std::shared_ptr<ServerMiddlewareFactory>
+MakeTracingServerMiddlewareFactory();
+
+/// \brief A server middleware that provides access to the
+///   OpenTelemetry context, if present.
+///
+/// Used to make the OpenTelemetry span available in Python.
+class ARROW_FLIGHT_EXPORT TracingServerMiddleware : public ServerMiddleware {
+ public:
+  ~TracingServerMiddleware();
+
+  static constexpr char const kMiddlewareName[] =
+      "arrow::flight::TracingServerMiddleware";
+
+  std::string name() const override { return kMiddlewareName; }
+  void SendingHeaders(AddCallHeaders*) override;
+  void CallCompleted(const Status&) override;
+
+  struct TraceKey {
+    std::string key;
+    std::string value;
+  };
+  /// \brief Get the trace context.
+  std::vector<TraceKey> GetTraceContext() const;
+
+ private:
+  class Impl;
+  friend class TracingServerMiddlewareFactory;
+
+  explicit TracingServerMiddleware(std::unique_ptr<Impl> impl);
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace flight
+}  // namespace arrow

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1741,13 +1741,22 @@ cdef class ServerCallContext(_Weakrefable):
             CServerMiddleware* c_middleware = \
                 self.context.GetMiddleware(CPyServerMiddlewareName)
             CPyServerMiddleware* middleware
+            vector[CTracingServerMiddlewareTraceKey] c_trace_context
+        if c_middleware == NULL:
+            c_middleware = self.context.GetMiddleware(tobytes(key))
+
         if c_middleware == NULL:
             return None
-        if c_middleware.name() != CPyServerMiddlewareName:
-            return None
-        middleware = <CPyServerMiddleware*> c_middleware
-        py_middleware = <_ServerMiddlewareWrapper> middleware.py_object()
-        return py_middleware.middleware.get(key)
+        elif c_middleware.name() == CPyServerMiddlewareName:
+            middleware = <CPyServerMiddleware*> c_middleware
+            py_middleware = <_ServerMiddlewareWrapper> middleware.py_object()
+            return py_middleware.middleware.get(key)
+        elif c_middleware.name() == CTracingServerMiddlewareName:
+            c_trace_context = (<CTracingServerMiddleware*> c_middleware
+                               ).GetTraceContext()
+            trace_context = {pair.key: pair.value for pair in c_trace_context}
+            return TracingServerMiddleware(trace_context)
+        return None
 
     @staticmethod
     cdef ServerCallContext wrap(const CServerCallContext& context):
@@ -2528,6 +2537,22 @@ cdef class ServerMiddlewareFactory(_Weakrefable):
         """
 
 
+cdef class TracingServerMiddlewareFactory(ServerMiddlewareFactory):
+    """A factory for tracing middleware instances.
+
+    This enables OpenTelemetry support in Arrow (if Arrow was compiled
+    with OpenTelemetry support enabled). A new span will be started on
+    each RPC call. The TracingServerMiddleware instance can then be
+    retrieved within an RPC handler to get the propagated context,
+    which can be used to start a new span on the Python side.
+
+    Because the Python/C++ OpenTelemetry libraries do not
+    interoperate, spans on the C++ side are not directly visible to
+    the Python side and vice versa.
+
+    """
+
+
 cdef class ServerMiddleware(_Weakrefable):
     """Server-side middleware for a call, instantiated per RPC.
 
@@ -2572,6 +2597,13 @@ cdef class ServerMiddleware(_Weakrefable):
         vtable.sending_headers = _middleware_sending_headers
         vtable.call_completed = _middleware_call_completed
         c_instance[0].reset(new CPyServerMiddleware(py_middleware, vtable))
+
+
+class TracingServerMiddleware(ServerMiddleware):
+    __slots__ = ["trace_context"]
+
+    def __init__(self, trace_context):
+        self.trace_context = trace_context
 
 
 cdef class _ServerMiddlewareFactoryWrapper(ServerMiddlewareFactory):
@@ -2739,7 +2771,27 @@ cdef class FlightServerBase(_Weakrefable):
                 c_options.get().tls_certificates.push_back(c_cert)
 
         if middleware:
-            py_middleware = _ServerMiddlewareFactoryWrapper(middleware)
+            non_tracing_middleware = {}
+            enable_tracing = None
+            for key, factory in middleware.items():
+                if isinstance(factory, TracingServerMiddlewareFactory):
+                    if enable_tracing is not None:
+                        raise ValueError(
+                            "Can only provide "
+                            "TracingServerMiddlewareFactory once")
+                    if tobytes(key) == CPyServerMiddlewareName:
+                        raise ValueError(f"Middleware key cannot be {key}")
+                    enable_tracing = key
+                else:
+                    non_tracing_middleware[key] = factory
+
+            if enable_tracing:
+                c_middleware.first = tobytes(enable_tracing)
+                c_middleware.second = MakeTracingServerMiddlewareFactory()
+                c_options.get().middleware.push_back(c_middleware)
+
+            py_middleware = _ServerMiddlewareFactoryWrapper(
+                non_tracing_middleware)
             c_middleware.first = CPyServerMiddlewareName
             c_middleware.second.reset(new CPyServerMiddlewareFactory(
                 py_middleware,

--- a/python/pyarrow/flight.py
+++ b/python/pyarrow/flight.py
@@ -60,4 +60,5 @@ from pyarrow._flight import (  # noqa:F401
     ServerMiddleware,
     ServerMiddlewareFactory,
     Ticket,
+    TracingServerMiddlewareFactory,
 )

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -22,8 +22,8 @@ from pyarrow.includes.libarrow cimport *
 
 
 cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
-    cdef char* CPyServerMiddlewareName\
-        " arrow::py::flight::kPyServerMiddlewareName"
+    cdef char* CTracingServerMiddlewareName\
+        " arrow::flight::TracingServerMiddleware::kMiddlewareName"
 
     cdef cppclass CActionType" arrow::flight::ActionType":
         c_string type
@@ -322,6 +322,20 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
             " arrow::flight::ClientMiddlewareFactory":
         pass
 
+    cpdef cppclass CTracingServerMiddlewareTraceKey\
+            " arrow::flight::TracingServerMiddleware::TraceKey":
+        CTracingServerMiddlewareTraceKey()
+        c_string key
+        c_string value
+
+    cdef cppclass CTracingServerMiddleware\
+            " arrow::flight::TracingServerMiddleware"(CServerMiddleware):
+        vector[CTracingServerMiddlewareTraceKey] GetTraceContext()
+
+    cdef shared_ptr[CServerMiddlewareFactory] \
+        MakeTracingServerMiddlewareFactory\
+        " arrow::flight::MakeTracingServerMiddlewareFactory"()
+
     cdef cppclass CFlightServerOptions" arrow::flight::FlightServerOptions":
         CFlightServerOptions(const CLocation& location)
         CLocation location
@@ -472,6 +486,9 @@ ctypedef CStatus cb_client_middleware_start_call(
     unique_ptr[CClientMiddleware]*)
 
 cdef extern from "arrow/python/flight.h" namespace "arrow::py::flight" nogil:
+    cdef char* CPyServerMiddlewareName\
+        " arrow::py::flight::kPyServerMiddlewareName"
+
     cdef cppclass PyFlightServerVtable:
         PyFlightServerVtable()
         function[cb_list_flights] list_flights


### PR DESCRIPTION
Adds a client middleware that sends span/trace ID to the server, and a server middleware that gets the span/trace ID and starts a child span.

The middleware are available in builds without OpenTelemetry, they simply do nothing.