### PR TITLE
ARROW-15047: [R][MINOR] Suggest R command for setting build environment variables

### DIFF
--- a/r/R/util.R
+++ b/r/R/util.R
@@ -113,8 +113,9 @@ read_compressed_error <- function(e) {
       msg,
       "\nIn order to read this file, you will need to reinstall arrow with additional features enabled.",
       "\nSet one of these environment variables before installing:",
-      sprintf("\n\n * LIBARROW_MINIMAL=false (for all optional features, including '%s')", compression),
-      sprintf("\n * ARROW_WITH_%s=ON (for just '%s')", toupper(compression), compression),
+      "\n\n * Sys.setenv(LIBARROW_MINIMAL = \"false\") ",
+      sprintf("(for all optional features, including '%s')", compression),
+      sprintf("\n * Sys.setenv(ARROW_WITH_%s = \"ON\") (for just '%s')", toupper(compression), compression),
       "\n\nSee https://arrow.apache.org/docs/r/articles/install.html for details"
     )
   }

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -235,8 +235,8 @@ test_that("Error messages are shown when the compression algorithm lz4 is not fo
   msg <- paste0(
     ".*",
     "you will need to reinstall arrow with additional features enabled.\nSet one of ",
-    "these environment variables before installing:\n\n \\* LIBARROW_MINIMAL=false ",
-    "\\(for all optional features, including 'lz4'\\)\n \\* ARROW_WITH_LZ4=ON \\(for just 'lz4'\\)",
+    "these environment variables before installing:\n\n \\* Sys.setenv(LIBARROW_MINIMAL = \"false\") ",
+    "\\(for all optional features, including 'lz4'\\)\n \\* Sys.setenv(ARROW_WITH_LZ4 = \"ON\") \\(for just 'lz4'\\)",
     "\n\nSee https://arrow.apache.org/docs/r/articles/install.html for details"
   )
 

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -253,8 +253,8 @@ test_that("Error messages are shown when the compression algorithm snappy is not
   msg <- paste0(
     "NotImplemented: Support for codec 'snappy' not built\nIn order to read this file, ",
     "you will need to reinstall arrow with additional features enabled.\nSet one of these ",
-    "environment variables before installing:\n\n * LIBARROW_MINIMAL=false (for all optional ",
-    "features, including 'snappy')\n * ARROW_WITH_SNAPPY=ON (for just 'snappy')\n\n",
+    "environment variables before installing:\n\n * Sys.setenv(LIBARROW_MINIMAL = \"false\") (for all optional ",
+    "features, including 'snappy')\n * Sys.setenv(ARROW_WITH_SNAPPY = \"ON\") (for just 'snappy')\n\n",
     "See https://arrow.apache.org/docs/r/articles/install.html for details"
   )
 


### PR DESCRIPTION
This is pretty minor improvement to help on Linux install. Presumably if users are installing R package, they are already in an R session. So the help message should provide guidance with R commands. See JIRA ticket for example of user confusion.