### PR TITLE
ARROW-15044: [C++] Add OpenTelemetry exporters for debugging use

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -766,9 +766,15 @@ if(ARROW_S3)
 endif()
 
 if(ARROW_WITH_OPENTELEMETRY)
-  list(APPEND ARROW_LINK_LIBS opentelemetry-cpp::trace
+  list(APPEND
+       ARROW_LINK_LIBS
+       opentelemetry-cpp::trace
+       opentelemetry-cpp::ostream_span_exporter
        opentelemetry-cpp::otlp_http_exporter)
-  list(APPEND ARROW_STATIC_LINK_LIBS opentelemetry-cpp::trace
+  list(APPEND
+       ARROW_STATIC_LINK_LIBS
+       opentelemetry-cpp::trace
+       opentelemetry-cpp::ostream_span_exporter
        opentelemetry-cpp::otlp_http_exporter)
 endif()
 

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -25,13 +25,20 @@
 #pragma warning(push)
 #pragma warning(disable : 4522)
 #endif
+#include <google/protobuf/util/json_util.h>
+
 #include <opentelemetry/exporters/ostream/span_exporter.h>
 #include <opentelemetry/exporters/otlp/otlp_http_exporter.h>
+#include <opentelemetry/exporters/otlp/otlp_recordable_utils.h>
 #include <opentelemetry/sdk/trace/batch_span_processor.h>
 #include <opentelemetry/sdk/trace/recordable.h>
 #include <opentelemetry/sdk/trace/span_data.h>
 #include <opentelemetry/sdk/trace/tracer_provider.h>
 #include <opentelemetry/trace/provider.h>
+
+#include <opentelemetry/exporters/otlp/protobuf_include_prefix.h>
+#include <opentelemetry/exporters/otlp/protobuf_include_suffix.h>
+#include <opentelemetry/proto/collector/trace/v1/trace_service.pb.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -52,6 +59,43 @@ constexpr char kTracingBackendEnvVar[] = "ARROW_TRACING_BACKEND";
 namespace {
 
 namespace sdktrace = opentelemetry::sdk::trace;
+
+// Custom JSON stdout exporter. Leverages the OTLP HTTP exporter's
+// utilities to log the same format that would be sent to OTLP.
+class OtlpStdoutExporter final : public sdktrace::SpanExporter {
+ public:
+  OtlpStdoutExporter() { protobuf_json_options_.add_whitespace = false; }
+
+  std::unique_ptr<sdktrace::Recordable> MakeRecordable() noexcept override {
+    // The header for the Recordable definition is not installed, work around that
+    return exporter_.MakeRecordable();
+  }
+  otel::sdk::common::ExportResult Export(
+      const nostd::span<std::unique_ptr<sdktrace::Recordable>>& spans) noexcept override {
+    opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
+    otel::exporter::otlp::OtlpRecordableUtils::PopulateRequest(spans, &request);
+
+    for (const auto& spans : request.resource_spans()) {
+      std::string output;
+      auto status = google::protobuf::util::MessageToJsonString(spans, &output,
+                                                                protobuf_json_options_);
+      if (ARROW_PREDICT_FALSE(!status.ok())) {
+        return otel::sdk::common::ExportResult::kFailure;
+      }
+      std::cout << output << std::endl;
+    }
+
+    return otel::sdk::common::ExportResult::kSuccess;
+  }
+  bool Shutdown(std::chrono::microseconds timeout =
+                    std::chrono::microseconds(0)) noexcept override {
+    return exporter_.Shutdown(timeout);
+  }
+
+ private:
+  opentelemetry::exporter::otlp::OtlpHttpExporter exporter_;
+  google::protobuf::util::JsonPrintOptions protobuf_json_options_;
+};
 
 class ThreadIdSpanProcessor : public sdktrace::BatchSpanProcessor {
  public:
@@ -74,6 +118,8 @@ std::unique_ptr<sdktrace::SpanExporter> InitializeExporter() {
       namespace otlp = opentelemetry::exporter::otlp;
       otlp::OtlpHttpExporterOptions opts;
       return arrow::internal::make_unique<otlp::OtlpHttpExporter>(opts);
+    } else if (env_var == "arrow_otlp_stdout") {
+      return arrow::internal::make_unique<OtlpStdoutExporter>();
     } else if (!env_var.empty()) {
       ARROW_LOG(WARNING) << "Requested unknown backend " << kTracingBackendEnvVar << "="
                          << env_var;

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -64,7 +64,7 @@ namespace sdktrace = opentelemetry::sdk::trace;
 // to log the same format that would be sent to OTLP.
 class OtlpOStreamExporter final : public sdktrace::SpanExporter {
  public:
-  OtlpOStreamExporter(std::basic_ostream<char>* out) : out_(out) {
+  explicit OtlpOStreamExporter(std::basic_ostream<char>* out) : out_(out) {
     protobuf_json_options_.add_whitespace = false;
   }
 


### PR DESCRIPTION
This adds two exporters that can be toggled with an environment variable, for debug use. One is the standard ostream exporter, which logs a human-friendly but machine-unfriendly format. The other uses a trick to log the JSON OTLP request format, which is easily parsable JSON but not very readable.