### PR TITLE
ARROW-15049: [R] arrowExports.cpp generation changed with glue package 1.5.1

### DIFF
--- a/r/data-raw/codegen.R
+++ b/r/data-raw/codegen.R
@@ -124,14 +124,13 @@ ifdef_wrap <- function(cpp11_wrapped, name, sexp_signature, decoration) {
   #   return(cpp11_wrapped)
   # }
   glue('
-  #if defined(ARROW_R_WITH_{toupper(decoration)})
-  {cpp11_wrapped}
-  #else
-  extern "C" SEXP {sexp_signature}{{
-  \tRf_error("Cannot call {name}(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-  }}
-  #endif
-  \n')
+#if defined(ARROW_R_WITH_{toupper(decoration)})
+{cpp11_wrapped}
+#else
+extern "C" SEXP {sexp_signature}{{
+\tRf_error("Cannot call {name}(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}}
+#endif\n\n')
 }
 
 cpp_functions_definitions <- arrow_exports %>%


### PR DESCRIPTION
This PR fixes the code that creates arrowExports.cpp so that a regression in glue 1.5.1 does not cause massive diffs whenever somebody runs the configure script with `ARROW_R_DEV=true`. I'll also file an issue with glue since this is probably not intended behaviour; however, it's a small fix to make it work with both versions and will probably save some PR headache since a new release might not occur immediately.

How I tested this:

```r
# this
remotes::install_github("cran/glue@1.5.1")
Sys.setenv(ARROW_R_DEV = "true")
remotes::install_github("paleolimbot/arrow/r@r-codegen")
# ...nor this
remotes::install_github("cran/glue@1.5.0")
Sys.setenv(ARROW_R_DEV = "true")
remotes::install_github("paleolimbot/arrow/r@r-codegen")
# ...should cause any diffs in arrowExports.cpp
```