### PR TITLE
ARROW-15078: [C++] Silence CMake error "includes non-existent path" with bundled OpenTelemetry

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4109,6 +4109,10 @@ macro(build_opentelemetry)
   foreach(_OPENTELEMETRY_LIB ${_OPENTELEMETRY_LIBS})
     add_dependencies(opentelemetry-cpp::${_OPENTELEMETRY_LIB} opentelemetry_ep)
   endforeach()
+
+  # Work around https://gitlab.kitware.com/cmake/cmake/issues/15052
+  file(MAKE_DIRECTORY ${OPENTELEMETRY_INCLUDE_DIR})
+
 endmacro()
 
 if(ARROW_WITH_OPENTELEMETRY)


### PR DESCRIPTION
This prevents:
```
CMake Error in src/arrow/CMakeLists.txt:
  Imported target "opentelemetry-cpp::trace" includes non-existent path

    "<path>/build/opentelemetry_ep-install/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```