### PR TITLE
ARROW-12768: [C++] Stricter signed zero comparison in tests

### DIFF
--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -48,6 +48,16 @@ class EqualOptions {
     return res;
   }
 
+  /// Whether or not zeros with differing signs are considered equal.
+  bool signed_zeros_equal() const { return signed_zeros_equal_; }
+
+  /// Return a new EqualOptions object with the "signed_zeros_equal" property changed.
+  EqualOptions signed_zeros_equal(bool v) const {
+    auto res = EqualOptions(*this);
+    res.signed_zeros_equal_ = v;
+    return res;
+  }
+
   /// The absolute tolerance for approximate comparisons of floating-point values.
   double atol() const { return atol_; }
 
@@ -76,6 +86,8 @@ class EqualOptions {
  protected:
   double atol_ = kDefaultAbsoluteTolerance;
   bool nans_equal_ = false;
+  bool signed_zeros_equal_ = true;
+
   std::ostream* diff_sink_ = NULLPTR;
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -145,9 +145,7 @@ void ValidateBooleanAgg(const std::string& json,
   SCOPED_TRACE(json);
   auto array = ArrayFromJSON(boolean(), json);
   ASSERT_OK_AND_ASSIGN(Datum result, Op(array, options, nullptr));
-
-  auto equal_options = EqualOptions::Defaults().nans_equal(true);
-  AssertScalarsEqual(*expected, *result.scalar(), /*verbose=*/true, equal_options);
+  AssertScalarsEqual(*expected, *result.scalar(), /*verbose=*/true);
 }
 
 TEST(TestBooleanAggregation, Sum) {
@@ -306,8 +304,7 @@ TEST(TestBooleanAggregation, Mean) {
   ASSERT_OK_AND_ASSIGN(
       auto result, Mean(MakeNullScalar(boolean()),
                         ScalarAggregateOptions(/*skip_nulls=*/true, /*min_count=*/0)));
-  AssertDatumsApproxEqual(result, ScalarFromJSON(float64(), "NaN"), /*detailed=*/true,
-                          EqualOptions::Defaults().nans_equal(true));
+  AssertDatumsApproxEqual(result, ScalarFromJSON(float64(), "NaN"), /*detailed=*/true);
   EXPECT_THAT(Mean(MakeNullScalar(boolean()),
                    ScalarAggregateOptions(/*skip_nulls=*/false, /*min_count=*/0)),
               ResultWith(ScalarFromJSON(float64(), "null")));
@@ -1065,8 +1062,7 @@ template <typename ArrowType>
 void ValidateMean(const Array& input, Datum expected,
                   const ScalarAggregateOptions& options) {
   ASSERT_OK_AND_ASSIGN(Datum result, Mean(input, options, nullptr));
-  auto equal_options = EqualOptions::Defaults().nans_equal(true);
-  AssertDatumsApproxEqual(expected, result, /*verbose=*/true, equal_options);
+  AssertDatumsApproxEqual(expected, result, /*verbose=*/true);
 }
 
 template <typename ArrowType>

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -2485,7 +2485,7 @@ TEST(GroupBy, Product) {
                                         }),
                                         R"([
     [-3.25, 1,    null, 1],
-    [0.0,   8,    0.0,  2],
+    [-0.0,  8,    -0.0, 2],
     [null,  9,    null, 3],
     [3.0,   null, null, null]
   ])"),
@@ -2569,7 +2569,7 @@ TEST(GroupBy, SumMeanProductKeepNulls) {
                                         }),
                                         R"([
     [null,   null,   null,       null,       null, null, 1],
-    [-0.125, -0.125, -0.0416667, -0.0416667, 0.0,  0.0,  2],
+    [-0.125, -0.125, -0.0416667, -0.0416667, -0.0, -0.0, 2],
     [null,   null,   null,       null,       null, null, 3],
     [4.75,   null,   2.375,      null,       3.0,  null, null]
   ])"),

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -1147,10 +1147,15 @@ class TestVarArgsCompare : public TestBase {
 
   void Assert(VarArgsFunction func, Datum expected, const std::vector<Datum>& args) {
     auto actual = Eval(func, args);
-    AssertDatumsApproxEqual(expected, actual, /*verbose=*/true);
+    AssertDatumsApproxEqual(expected, actual, /*verbose=*/true, equal_options_);
+  }
+
+  void SetSignedZerosEqual(bool v) {
+    equal_options_ = equal_options_.signed_zeros_equal(v);
   }
 
   ElementWiseAggregateOptions element_wise_aggregate_options_;
+  EqualOptions equal_options_ = EqualOptions::Defaults().nans_equal(true);
 };
 
 template <typename T>
@@ -1367,9 +1372,10 @@ TYPED_TEST(TestVarArgsCompareFloating, MinElementWise) {
   Check("0.0", {"0.0", "0.0"});
   Check("-0.0", {"-0.0", "-0.0"});
   // XXX implementation detail: as signed zeros are equal, we're allowed
-  // to return either value.
+  // to return either value if both are present.
+  this->SetSignedZerosEqual(true);
   Check("0.0", {"-0.0", "0.0"});
-  Check("-0.0", {"0.0", "-0.0"});
+  Check("0.0", {"0.0", "-0.0"});
   Check("0.0", {"1.0", "-0.0", "0.0"});
   Check("-1.0", {"-1.0", "-0.0"});
   Check("0", {"0", "NaN"});
@@ -1677,9 +1683,10 @@ TYPED_TEST(TestVarArgsCompareFloating, MaxElementWise) {
   Check("0.0", {"0.0", "0.0"});
   Check("-0.0", {"-0.0", "-0.0"});
   // XXX implementation detail: as signed zeros are equal, we're allowed
-  // to return either value.
+  // to return either value if both are present.
+  this->SetSignedZerosEqual(true);
   Check("0.0", {"-0.0", "0.0"});
-  Check("-0.0", {"0.0", "-0.0"});
+  Check("0.0", {"0.0", "-0.0"});
   Check("0.0", {"-1.0", "-0.0", "0.0"});
   Check("1.0", {"1.0", "-0.0"});
   Check("0", {"0", "NaN"});

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -39,8 +39,6 @@ class TestReplaceKernel : public ::testing::Test {
   using ReplaceFunction = std::function<Result<Datum>(const Datum&, const Datum&,
                                                       const Datum&, ExecContext*)>;
 
-  void SetUp() override { equal_options_ = equal_options_.nans_equal(true); }
-
   Datum mask_scalar(bool value) { return Datum(std::make_shared<BooleanScalar>(value)); }
 
   Datum null_mask_scalar() {
@@ -80,8 +78,7 @@ class TestReplaceKernel : public ::testing::Test {
     ASSERT_TRUE(actual.is_array());
     ASSERT_OK(actual.make_array()->ValidateFull());
 
-    AssertArraysApproxEqual(*expected, *actual.make_array(), /*verbose=*/true,
-                            equal_options_);
+    AssertArraysApproxEqual(*expected, *actual.make_array(), /*verbose=*/true);
   }
 
   std::shared_ptr<Array> NaiveImpl(
@@ -114,8 +111,6 @@ class TestReplaceKernel : public ::testing::Test {
     EXPECT_OK_AND_ASSIGN(auto expected, builder->Finish());
     return expected;
   }
-
-  EqualOptions equal_options_ = EqualOptions::Defaults();
 };
 
 template <typename T>

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -198,6 +198,10 @@ class TestRealScalar : public ::testing::Test {
     scalar_other_ = std::make_shared<ScalarType>(static_cast<CType>(1.1));
     ASSERT_TRUE(scalar_other_->is_valid);
 
+    scalar_zero_ = std::make_shared<ScalarType>(static_cast<CType>(0.0));
+    scalar_other_zero_ = std::make_shared<ScalarType>(static_cast<CType>(0.0));
+    scalar_neg_zero_ = std::make_shared<ScalarType>(static_cast<CType>(-0.0));
+
     const CType nan_value = std::numeric_limits<CType>::quiet_NaN();
     scalar_nan_ = std::make_shared<ScalarType>(nan_value);
     ASSERT_TRUE(scalar_nan_->is_valid);
@@ -217,6 +221,18 @@ class TestRealScalar : public ::testing::Test {
     ASSERT_FALSE(scalar_nan_->Equals(*scalar_val_, options));
     ASSERT_TRUE(scalar_nan_->Equals(*scalar_nan_, options));
     ASSERT_TRUE(scalar_nan_->Equals(*scalar_other_nan_, options));
+  }
+
+  void TestSignedZeroEquals() {
+    EqualOptions options = EqualOptions::Defaults();
+    ASSERT_FALSE(scalar_zero_->Equals(*scalar_val_, options));
+    ASSERT_TRUE(scalar_zero_->Equals(*scalar_other_zero_, options));
+    ASSERT_TRUE(scalar_zero_->Equals(*scalar_neg_zero_, options));
+
+    options = options.signed_zeros_equal(false);
+    ASSERT_FALSE(scalar_zero_->Equals(*scalar_val_, options));
+    ASSERT_TRUE(scalar_zero_->Equals(*scalar_other_zero_, options));
+    ASSERT_FALSE(scalar_zero_->Equals(*scalar_neg_zero_, options));
   }
 
   void TestApproxEquals() {
@@ -245,6 +261,16 @@ class TestRealScalar : public ::testing::Test {
     ASSERT_FALSE(scalar_other_->ApproxEquals(*scalar_val_, options));
     ASSERT_FALSE(scalar_nan_->ApproxEquals(*scalar_val_, options));
     ASSERT_TRUE(scalar_nan_->ApproxEquals(*scalar_other_nan_, options));
+
+    // Negative zeros
+    ASSERT_FALSE(scalar_zero_->ApproxEquals(*scalar_val_, options));
+    ASSERT_TRUE(scalar_zero_->ApproxEquals(*scalar_other_zero_, options));
+    ASSERT_TRUE(scalar_zero_->ApproxEquals(*scalar_neg_zero_, options));
+
+    options = options.signed_zeros_equal(false);
+    ASSERT_FALSE(scalar_zero_->ApproxEquals(*scalar_val_, options));
+    ASSERT_TRUE(scalar_zero_->ApproxEquals(*scalar_other_zero_, options));
+    ASSERT_FALSE(scalar_zero_->ApproxEquals(*scalar_neg_zero_, options));
   }
 
   void TestStructOf() {
@@ -363,12 +389,15 @@ class TestRealScalar : public ::testing::Test {
 
  protected:
   std::shared_ptr<DataType> type_;
-  std::shared_ptr<Scalar> scalar_val_, scalar_other_, scalar_nan_, scalar_other_nan_;
+  std::shared_ptr<Scalar> scalar_val_, scalar_other_, scalar_nan_, scalar_other_nan_,
+      scalar_zero_, scalar_other_zero_, scalar_neg_zero_;
 };
 
 TYPED_TEST_SUITE(TestRealScalar, RealArrowTypes);
 
 TYPED_TEST(TestRealScalar, NanEquals) { this->TestNanEquals(); }
+
+TYPED_TEST(TestRealScalar, SignedZeroEquals) { this->TestSignedZeroEquals(); }
 
 TYPED_TEST(TestRealScalar, ApproxEquals) { this->TestApproxEquals(); }
 

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -568,6 +568,12 @@ TYPED_TEST_P(TestFloatTensor, Equals) {
   EXPECT_TRUE(tf1.Equals(tnc));
   EXPECT_FALSE(tf3.Equals(tnc));
 
+  // signed zeros
+  c_values[0] = -0.0;
+  c_values_2[0] = 0.0;
+  EXPECT_TRUE(tc1.Equals(tc2));
+  EXPECT_FALSE(tc1.Equals(tc2, EqualOptions().signed_zeros_equal(false)));
+
   // tensors with NaNs
   const c_data_type nan_value = static_cast<c_data_type>(NAN);
   c_values[0] = nan_value;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -200,21 +200,25 @@ std::vector<Type::type> AllTypeIds();
 #define ASSERT_BATCHES_APPROX_EQUAL(lhs, rhs) AssertBatchesApproxEqual((lhs), (rhs))
 #define ASSERT_TABLES_EQUAL(lhs, rhs) AssertTablesEqual((lhs), (rhs))
 
+// Default EqualOptions for testing
+static inline EqualOptions TestingEqualOptions() {
+  return EqualOptions{}.nans_equal(true).signed_zeros_equal(false);
+}
+
 // If verbose is true, then the arrays will be pretty printed
-ARROW_TESTING_EXPORT void AssertArraysEqual(const Array& expected, const Array& actual,
-                                            bool verbose = false,
-                                            const EqualOptions& options = {});
-ARROW_TESTING_EXPORT void AssertArraysApproxEqual(const Array& expected,
-                                                  const Array& actual,
-                                                  bool verbose = false,
-                                                  const EqualOptions& options = {});
+ARROW_TESTING_EXPORT void AssertArraysEqual(
+    const Array& expected, const Array& actual, bool verbose = false,
+    const EqualOptions& options = TestingEqualOptions());
+ARROW_TESTING_EXPORT void AssertArraysApproxEqual(
+    const Array& expected, const Array& actual, bool verbose = false,
+    const EqualOptions& options = TestingEqualOptions());
 // Returns true when values are both null
 ARROW_TESTING_EXPORT void AssertScalarsEqual(
     const Scalar& expected, const Scalar& actual, bool verbose = false,
-    const EqualOptions& options = EqualOptions::Defaults());
+    const EqualOptions& options = TestingEqualOptions());
 ARROW_TESTING_EXPORT void AssertScalarsApproxEqual(
     const Scalar& expected, const Scalar& actual, bool verbose = false,
-    const EqualOptions& options = EqualOptions::Defaults());
+    const EqualOptions& options = TestingEqualOptions());
 ARROW_TESTING_EXPORT void AssertBatchesEqual(const RecordBatch& expected,
                                              const RecordBatch& actual,
                                              bool check_metadata = false);
@@ -229,7 +233,7 @@ ARROW_TESTING_EXPORT void AssertChunkedEquivalent(const ChunkedArray& expected,
                                                   const ChunkedArray& actual);
 ARROW_TESTING_EXPORT void AssertChunkedApproxEquivalent(
     const ChunkedArray& expected, const ChunkedArray& actual,
-    const EqualOptions& equal_options = EqualOptions::Defaults());
+    const EqualOptions& options = TestingEqualOptions());
 ARROW_TESTING_EXPORT void AssertBufferEqual(const Buffer& buffer,
                                             const std::vector<uint8_t>& expected);
 ARROW_TESTING_EXPORT void AssertBufferEqual(const Buffer& buffer,
@@ -279,7 +283,7 @@ ARROW_TESTING_EXPORT void AssertDatumsEqual(const Datum& expected, const Datum& 
                                             bool verbose = false);
 ARROW_TESTING_EXPORT void AssertDatumsApproxEqual(
     const Datum& expected, const Datum& actual, bool verbose = false,
-    const EqualOptions& options = EqualOptions::Defaults());
+    const EqualOptions& options = TestingEqualOptions());
 
 template <typename C_TYPE>
 void AssertNumericDataEqual(const C_TYPE* raw_data,


### PR DESCRIPTION
Add a new parameter to EqualOptions() to choose whether signed zeros should compare equal.

Ensure that said parameter is set to false in unit tests.