### PR TITLE
ARROW-15101: [Python] Fix build failure on CSV writer

### DIFF
--- a/cpp/src/arrow/csv/api.h
+++ b/cpp/src/arrow/csv/api.h
@@ -21,6 +21,7 @@
 #include "arrow/csv/reader.h"
 
 // The writer depends on compute module for casting.
+#include "arrow/util/config.h"  // for ARROW_COMPUTE definition
 #ifdef ARROW_COMPUTE
 #include "arrow/csv/writer.h"
 #endif

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "arrow/util/bit_util.h"
+#include "arrow/util/config.h"  // for ARROW_USE_NATIVE_INT128
 #include "arrow/util/endian.h"
 #include "arrow/util/int128_internal.h"
 #include "arrow/util/int_util_internal.h"

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -408,7 +408,3 @@ endif()
 if(ARROW_WITH_ZSTD)
   add_definitions(-DARROW_WITH_ZSTD)
 endif()
-
-if(ARROW_CSV)
-  add_definitions(-DARROW_CSV)
-endif()

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -45,6 +45,7 @@
 #include "arrow/testing/util.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/config.h"  // for ARROW_CSV definition
 #include "arrow/util/decimal.h"
 #include "arrow/util/future.h"
 #include "arrow/util/logging.h"


### PR DESCRIPTION
On some combination of configuration options, I would get the following errors:
```
/home/antoine/arrow/dev/python/build/temp.linux-x86_64-3.9/_csv.cpp:16716:70: error: no member named 'WriteCSV' in namespace 'arrow::csv'
          __pyx_t_4 = __pyx_f_7pyarrow_3lib_check_status(arrow::csv::WriteCSV((*__pyx_v_batch), __pyx_v_c_write_options, __pyx_v_stream.get())); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(0, 1040, __pyx_L5_error)
                                                         ~~~~~~~~~~~~^
/home/antoine/arrow/dev/python/build/temp.linux-x86_64-3.9/_csv.cpp:16797:70: error: no member named 'WriteCSV' in namespace 'arrow::csv'
          __pyx_t_4 = __pyx_f_7pyarrow_3lib_check_status(arrow::csv::WriteCSV((*__pyx_v_table), __pyx_v_c_write_options, __pyx_v_stream.get())); if (unlikely(__pyx_t_4 == ((int)-1))) __PYX_ERR(0, 1044, __pyx_L8_error)
                                                         ~~~~~~~~~~~~^
/home/antoine/arrow/dev/python/build/temp.linux-x86_64-3.9/_csv.cpp:17089:109: error: no member named 'MakeCSVWriter' in namespace 'arrow::csv'
        __pyx_t_2 = arrow::py::GetResultValue<std::shared_ptr< arrow::ipc::RecordBatchWriter> >(arrow::csv::MakeCSVWriter(__pyx_v_c_stream, __pyx_v_c_schema, __pyx_v_c_write_options)); if (unlikely(__Pyx_ErrOccurredWithGIL())) __PYX_ERR(0, 1076, __pyx_L4_error)
                                                                                                ~~~~~~~~~~~~^
3 errors generated.
```