### PR TITLE
ARROW-14766: [Python] Mark compute function arguments positional-only

### DIFF
--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -209,7 +209,7 @@ def _make_signature(arg_names, var_arg_names, option_class):
     from inspect import Parameter
     params = []
     for name in arg_names:
-        params.append(Parameter(name, Parameter.POSITIONAL_OR_KEYWORD))
+        params.append(Parameter(name, Parameter.POSITIONAL_ONLY))
     for name in var_arg_names:
         params.append(Parameter(name, Parameter.VAR_POSITIONAL))
     params.append(Parameter("memory_pool", Parameter.KEYWORD_ONLY,

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -695,12 +695,12 @@ def test_generated_signatures():
     # The self-documentation provided by signatures should show acceptable
     # options and their default values.
     sig = inspect.signature(pc.add)
-    assert str(sig) == "(x, y, *, memory_pool=None)"
+    assert str(sig) == "(x, y, /, *, memory_pool=None)"
     sig = inspect.signature(pc.min_max)
-    assert str(sig) == ("(array, *, memory_pool=None, "
+    assert str(sig) == ("(array, /, *, memory_pool=None, "
                         "options=None, skip_nulls=True, min_count=1)")
     sig = inspect.signature(pc.quantile)
-    assert str(sig) == ("(array, *, memory_pool=None, "
+    assert str(sig) == ("(array, /, *, memory_pool=None, "
                         "options=None, q=0.5, interpolation='linear', "
                         "skip_nulls=True, min_count=0)")
     sig = inspect.signature(pc.binary_join_element_wise)


### PR DESCRIPTION
Indicate to the user, in the generated function signature, that the given arguments cannot be passed by name.

Before:
```
Signature: pc.add(x, y, *, memory_pool=None)
Docstring:
Add the arguments element-wise.
[...]
```

After:
```
Signature: pc.add(x, y, /, *, memory_pool=None)
Docstring:
Add the arguments element-wise.
[...]
```