### PR TITLE
ARROW-15103: [Documentation][C++] Error building docs: "arrow/cpp/src/arrow/csv/options.h:182: error: Found unknown command '\r' "

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -179,7 +179,7 @@ enum class ARROW_EXPORT QuotingStyle {
   /// interpret all values as strings if schema is inferred.
   AllValid,
   /// Do not enclose any values in quotes. Prevents values from containing quotes ("),
-  /// cell delimiters (,) or line endings (\r, \n), (following RFC4180). If values
+  /// cell delimiters (,) or line endings (\\r, \\n), (following RFC4180). If values
   /// contain these characters, an error is caused when attempting to write.
   None
 };


### PR DESCRIPTION
This PR fixes a minor error in the C++ documentation which prevents it from building.

(I would have just submitted the PR as [MINOR] but I'd already opened the ticket!)