### PR TITLE
ARROW-10209: [Python] Support positional options in compute functions

### DIFF
--- a/python/pyarrow/_compute_docstrings.py
+++ b/python/pyarrow/_compute_docstrings.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Custom documentation additions for compute functions.
+"""
+
+function_doc_additions = {}
+
+function_doc_additions["filter"] = """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> arr = pa.array(["a", "b", "c", None, "e"])
+    >>> mask = pa.array([True, False, None, False, True])
+    >>> arr.filter(mask)
+    <pyarrow.lib.StringArray object at 0x7fa826df9200>
+    [
+      "a",
+      "e"
+    ]
+    >>> arr.filter(mask, null_selection_behavior='emit_null')
+    <pyarrow.lib.StringArray object at 0x7fa826df9200>
+    [
+      "a",
+      null,
+      "e"
+    ]
+    """
+
+function_doc_additions["mode"] = """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
+    >>> modes = pc.mode(arr, 2)
+    >>> modes[0]
+    <pyarrow.StructScalar: {'mode': 2, 'count': 5}>
+    >>> modes[1]
+    <pyarrow.StructScalar: {'mode': 1, 'count': 2}>
+    """

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -129,15 +129,7 @@ def _decorate_compute_function(wrapper, exposed_name, func, option_class):
                 Argument to compute function
             """.format(arg_name, arg_type))
 
-    doc_pieces.append("""\
-        memory_pool : pyarrow.MemoryPool, optional
-            If not passed, will allocate memory from the default memory pool.
-        """)
     if option_class is not None:
-        doc_pieces.append("""\
-            options : pyarrow.compute.{0}, optional
-                Parameters altering compute function semantics.
-            """.format(option_class.__name__))
         options_sig = inspect.signature(option_class)
         for p in options_sig.parameters.values():
             doc_pieces.append("""\
@@ -145,6 +137,15 @@ def _decorate_compute_function(wrapper, exposed_name, func, option_class):
                 Parameter for {1} constructor. Either `options`
                 or `{0}` can be passed, but not both at the same time.
             """.format(p.name, option_class.__name__))
+        doc_pieces.append("""\
+            options : pyarrow.compute.{0}, optional
+                Parameters altering compute function semantics.
+            """.format(option_class.__name__))
+
+    doc_pieces.append("""\
+        memory_pool : pyarrow.MemoryPool, optional
+            If not passed, will allocate memory from the default memory pool.
+        """)
 
     wrapper.__doc__ = "".join(dedent(s) for s in doc_pieces)
     return wrapper
@@ -162,13 +163,13 @@ def _get_options_class(func):
         return None
 
 
-def _handle_options(name, option_class, options, kwargs):
-    if kwargs:
+def _handle_options(name, option_class, options, args, kwargs):
+    if args or kwargs:
         if options is None:
-            return option_class(**kwargs)
+            return option_class(*args, **kwargs)
         raise TypeError(
             "Function {!r} called with both an 'options' argument "
-            "and additional named arguments"
+            "and additional arguments"
             .format(name))
 
     if options is not None:
@@ -194,13 +195,18 @@ def _make_generic_wrapper(func_name, func, option_class, arity):
             return func.call(args, None, memory_pool)
     else:
         def wrapper(*args, memory_pool=None, options=None, **kwargs):
-            if arity is not Ellipsis and len(args) != arity:
-                raise TypeError(
-                    f"{func_name} takes {arity} positional argument(s), "
-                    f"but {len(args)} were given"
-                )
+            if arity is not Ellipsis:
+                if len(args) < arity:
+                    raise TypeError(
+                        f"{func_name} takes {arity} positional argument(s), "
+                        f"but {len(args)} were given"
+                    )
+                option_args = args[arity:]
+                args = args[:arity]
+            else:
+                option_args = ()
             options = _handle_options(func_name, option_class, options,
-                                      kwargs)
+                                      option_args, kwargs)
             return func.call(args, options, memory_pool)
     return wrapper
 
@@ -212,16 +218,19 @@ def _make_signature(arg_names, var_arg_names, option_class):
         params.append(Parameter(name, Parameter.POSITIONAL_ONLY))
     for name in var_arg_names:
         params.append(Parameter(name, Parameter.VAR_POSITIONAL))
-    params.append(Parameter("memory_pool", Parameter.KEYWORD_ONLY,
-                            default=None))
     if option_class is not None:
-        params.append(Parameter("options", Parameter.KEYWORD_ONLY,
-                                default=None))
         options_sig = inspect.signature(option_class)
         for p in options_sig.parameters.values():
-            # XXX for now, our generic wrappers don't allow positional
-            # option arguments
-            params.append(p.replace(kind=Parameter.KEYWORD_ONLY))
+            assert p.kind in (Parameter.POSITIONAL_OR_KEYWORD,
+                              Parameter.KEYWORD_ONLY)
+            if var_arg_names:
+                # Cannot have a positional argument after a *args
+                p = p.replace(kind=Parameter.KEYWORD_ONLY)
+            params.append(p)
+        params.append(Parameter("options", Parameter.KEYWORD_ONLY,
+                                default=None))
+    params.append(Parameter("memory_pool", Parameter.KEYWORD_ONLY,
+                            default=None))
     return inspect.Signature(params)
 
 
@@ -324,243 +333,6 @@ def cast(arr, target_type, safe=True):
     else:
         options = CastOptions.unsafe(target_type)
     return call_function("cast", [arr], options)
-
-
-def count_substring(array, pattern, *, ignore_case=False):
-    """
-    Count the occurrences of substring *pattern* in each value of a
-    string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        pattern to search for exact matches
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("count_substring", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def count_substring_regex(array, pattern, *, ignore_case=False):
-    """
-    Count the non-overlapping matches of regex *pattern* in each value
-    of a string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        pattern to search for exact matches
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("count_substring_regex", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def find_substring(array, pattern, *, ignore_case=False):
-    """
-    Find the index of the first occurrence of substring *pattern* in each
-    value of a string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        pattern to search for exact matches
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("find_substring", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def find_substring_regex(array, pattern, *, ignore_case=False):
-    """
-    Find the index of the first match of regex *pattern* in each
-    value of a string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        regex pattern to search for
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("find_substring_regex", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def match_like(array, pattern, *, ignore_case=False):
-    """
-    Test if the SQL-style LIKE pattern *pattern* matches a value of a
-    string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        SQL-style LIKE pattern. '%' will match any number of
-        characters, '_' will match exactly one character, and all
-        other characters match themselves. To match a literal percent
-        sign or underscore, precede the character with a backslash.
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-
-    """
-    return call_function("match_like", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def match_substring(array, pattern, *, ignore_case=False):
-    """
-    Test if substring *pattern* is contained within a value of a string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        pattern to search for exact matches
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("match_substring", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def match_substring_regex(array, pattern, *, ignore_case=False):
-    """
-    Test if regex *pattern* matches at any position a value of a string array.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    pattern : str
-        regex pattern to search
-    ignore_case : bool, default False
-        Ignore case while searching.
-
-    Returns
-    -------
-    result : pyarrow.Array or pyarrow.ChunkedArray
-    """
-    return call_function("match_substring_regex", [array],
-                         MatchSubstringOptions(pattern,
-                                               ignore_case=ignore_case))
-
-
-def mode(array, n=1, *, skip_nulls=True, min_count=0):
-    """
-    Return top-n most common values and number of times they occur in a passed
-    numerical (chunked) array, in descending order of occurrence. If there are
-    multiple values with same count, the smaller one is returned first.
-
-    Parameters
-    ----------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-    n : int, default 1
-        Specify the top-n values.
-    skip_nulls : bool, default True
-        If True, ignore nulls in the input. Else return an empty array
-        if any input is null.
-    min_count : int, default 0
-        If there are fewer than this many values in the input, return
-        an empty array.
-
-    Returns
-    -------
-    An array of <input type "Mode", int64_t "Count"> structs
-
-    Examples
-    --------
-    >>> import pyarrow as pa
-    >>> import pyarrow.compute as pc
-    >>> arr = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
-    >>> modes = pc.mode(arr, 2)
-    >>> modes[0]
-    <pyarrow.StructScalar: {'mode': 2, 'count': 5}>
-    >>> modes[1]
-    <pyarrow.StructScalar: {'mode': 1, 'count': 2}>
-    """
-    options = ModeOptions(n, skip_nulls=skip_nulls, min_count=min_count)
-    return call_function("mode", [array], options)
-
-
-def filter(data, mask, null_selection_behavior='drop'):
-    """
-    Select values (or records) from array- or table-like data given boolean
-    filter, where true values are selected.
-
-    Parameters
-    ----------
-    data : Array, ChunkedArray, RecordBatch, or Table
-    mask : Array, ChunkedArray
-        Must be of boolean type
-    null_selection_behavior : str, default 'drop'
-        Configure the behavior on encountering a null slot in the mask.
-        Allowed values are 'drop' and 'emit_null'.
-
-        - 'drop': nulls will be treated as equivalent to False.
-        - 'emit_null': nulls will result in a null in the output.
-
-    Returns
-    -------
-    result : depends on inputs
-
-    Examples
-    --------
-    >>> import pyarrow as pa
-    >>> arr = pa.array(["a", "b", "c", None, "e"])
-    >>> mask = pa.array([True, False, None, False, True])
-    >>> arr.filter(mask)
-    <pyarrow.lib.StringArray object at 0x7fa826df9200>
-    [
-      "a",
-      "e"
-    ]
-    >>> arr.filter(mask, null_selection_behavior='emit_null')
-    <pyarrow.lib.StringArray object at 0x7fa826df9200>
-    [
-      "a",
-      null,
-      "e"
-    ]
-    """
-    options = FilterOptions(null_selection_behavior)
-    return call_function('filter', [data, mask], options)
 
 
 def index(data, value, start=None, end=None, *, memory_pool=None):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -388,11 +388,11 @@ def test_count_substring():
 
         result = pc.count_substring(arr, "ab")
         expected = pa.array([1, 1, 2, 0, 0, None], type=offset)
-        assert expected.equals(result)
+        assert expected == result
 
         result = pc.count_substring(arr, "ab", ignore_case=True)
         expected = pa.array([1, 1, 2, 0, 1, None], type=offset)
-        assert expected.equals(result)
+        assert expected == result
 
 
 def test_count_substring_regex():
@@ -487,6 +487,10 @@ def test_trim():
     result = pc.utf8_trim(arr, characters=' f\u3000')
     expected = pa.array(["oo", None, "oo bar \t"])
     assert expected.equals(result)
+    # Positional option
+    result = pc.utf8_trim(arr, ' f\u3000')
+    expected = pa.array(["oo", None, "oo bar \t"])
+    assert expected.equals(result)
 
 
 def test_slice_compatibility():
@@ -499,6 +503,9 @@ def test_slice_compatibility():
                 result = pc.utf8_slice_codeunits(
                     arr, start=start, stop=stop, step=step)
                 assert expected.equals(result)
+                # Positional options
+                assert pc.utf8_slice_codeunits(arr,
+                                               start, stop, step) == result
 
 
 def test_split_pattern():
@@ -507,11 +514,11 @@ def test_split_pattern():
     expected = pa.array([["-foo", "bar--"], ["", "foo", "b"]])
     assert expected.equals(result)
 
-    result = pc.split_pattern(arr, pattern="---", max_splits=1)
+    result = pc.split_pattern(arr, "---", max_splits=1)
     expected = pa.array([["-foo", "bar--"], ["", "foo---b"]])
     assert expected.equals(result)
 
-    result = pc.split_pattern(arr, pattern="---", max_splits=1, reverse=True)
+    result = pc.split_pattern(arr, "---", max_splits=1, reverse=True)
     expected = pa.array([["-foo", "bar--"], ["---foo", "b"]])
     assert expected.equals(result)
 
@@ -552,7 +559,7 @@ def test_split_pattern_regex():
     expected = pa.array([["", "foo", "bar", ""], ["", "foo", "b"]])
     assert expected.equals(result)
 
-    result = pc.split_pattern_regex(arr, pattern="-+", max_splits=1)
+    result = pc.split_pattern_regex(arr, "-+", max_splits=1)
     expected = pa.array([["", "foo---bar--"], ["", "foo---b"]])
     assert expected.equals(result)
 
@@ -662,16 +669,16 @@ def test_generated_docstrings():
         ----------
         array : Array-like
             Argument to compute function
-        memory_pool : pyarrow.MemoryPool, optional
-            If not passed, will allocate memory from the default memory pool.
-        options : pyarrow.compute.ScalarAggregateOptions, optional
-            Parameters altering compute function semantics.
         skip_nulls : optional
             Parameter for ScalarAggregateOptions constructor. Either `options`
             or `skip_nulls` can be passed, but not both at the same time.
         min_count : optional
             Parameter for ScalarAggregateOptions constructor. Either `options`
             or `min_count` can be passed, but not both at the same time.
+        options : pyarrow.compute.ScalarAggregateOptions, optional
+            Parameters altering compute function semantics.
+        memory_pool : pyarrow.MemoryPool, optional
+            If not passed, will allocate memory from the default memory pool.
         """)
     assert pc.add.__doc__ == textwrap.dedent("""\
         Add the arguments element-wise.
@@ -697,15 +704,16 @@ def test_generated_signatures():
     sig = inspect.signature(pc.add)
     assert str(sig) == "(x, y, /, *, memory_pool=None)"
     sig = inspect.signature(pc.min_max)
-    assert str(sig) == ("(array, /, *, memory_pool=None, "
-                        "options=None, skip_nulls=True, min_count=1)")
+    assert str(sig) == ("(array, /, *, skip_nulls=True, min_count=1, "
+                        "options=None, memory_pool=None)")
     sig = inspect.signature(pc.quantile)
-    assert str(sig) == ("(array, /, *, memory_pool=None, "
-                        "options=None, q=0.5, interpolation='linear', "
-                        "skip_nulls=True, min_count=0)")
+    assert str(sig) == ("(array, /, q=0.5, *, interpolation='linear', "
+                        "skip_nulls=True, min_count=0, "
+                        "options=None, memory_pool=None)")
     sig = inspect.signature(pc.binary_join_element_wise)
-    assert str(sig) == ("(*strings, memory_pool=None, options=None, "
-                        "null_handling='emit_null', null_replacement='')")
+    assert str(sig) == ("(*strings, null_handling='emit_null', "
+                        "null_replacement='', options=None, "
+                        "memory_pool=None)")
 
 
 # We use isprintable to find about codepoints that Python doesn't know, but
@@ -840,11 +848,17 @@ def test_pad():
     assert pc.ascii_center(arr, width=3).tolist() == [None, ' a ', 'abcd']
     assert pc.ascii_lpad(arr, width=3).tolist() == [None, '  a', 'abcd']
     assert pc.ascii_rpad(arr, width=3).tolist() == [None, 'a  ', 'abcd']
+    assert pc.ascii_center(arr, 3).tolist() == [None, ' a ', 'abcd']
+    assert pc.ascii_lpad(arr, 3).tolist() == [None, '  a', 'abcd']
+    assert pc.ascii_rpad(arr, 3).tolist() == [None, 'a  ', 'abcd']
 
     arr = pa.array([None, 'á', 'abcd'])
     assert pc.utf8_center(arr, width=3).tolist() == [None, ' á ', 'abcd']
     assert pc.utf8_lpad(arr, width=3).tolist() == [None, '  á', 'abcd']
     assert pc.utf8_rpad(arr, width=3).tolist() == [None, 'á  ', 'abcd']
+    assert pc.utf8_center(arr, 3).tolist() == [None, ' á ', 'abcd']
+    assert pc.utf8_lpad(arr, 3).tolist() == [None, '  á', 'abcd']
+    assert pc.utf8_rpad(arr, 3).tolist() == [None, 'á  ', 'abcd']
 
 
 @pytest.mark.pandas
@@ -859,6 +873,8 @@ def test_replace_slice():
             actual = pc.binary_replace_slice(
                 arr, start=start, stop=stop, replacement='XX')
             assert actual.tolist() == expected.tolist()
+            # Positional options
+            assert pc.binary_replace_slice(arr, start, stop, 'XX') == actual
 
     arr = pa.array([None, '', 'π', 'πb', 'πbθ', 'πbθd', 'πbθde'])
     series = arr.to_pandas()
@@ -871,22 +887,37 @@ def test_replace_slice():
 
 
 def test_replace_plain():
-    ar = pa.array(['foo', 'food', None])
-    ar = pc.replace_substring(ar, pattern='foo', replacement='bar')
-    assert ar.tolist() == ['bar', 'bard', None]
+    data = pa.array(['foozfoo', 'food', None])
+    ar = pc.replace_substring(data, pattern='foo', replacement='bar')
+    assert ar.tolist() == ['barzbar', 'bard', None]
+    ar = pc.replace_substring(data, 'foo', 'bar')
+    assert ar.tolist() == ['barzbar', 'bard', None]
+
+    ar = pc.replace_substring(data, pattern='foo', replacement='bar',
+                              max_replacements=1)
+    assert ar.tolist() == ['barzfoo', 'bard', None]
+    ar = pc.replace_substring(data, 'foo', 'bar', max_replacements=1)
+    assert ar.tolist() == ['barzfoo', 'bard', None]
 
 
 def test_replace_regex():
-    ar = pa.array(['foo', 'mood', None])
-    ar = pc.replace_substring_regex(ar, pattern='(.)oo', replacement=r'\100')
-    assert ar.tolist() == ['f00', 'm00d', None]
+    data = pa.array(['foo', 'mood', None])
+    expected = ['f00', 'm00d', None]
+    ar = pc.replace_substring_regex(data, pattern='(.)oo', replacement=r'\100')
+    assert ar.tolist() == expected
+    ar = pc.replace_substring_regex(data, '(.)oo', replacement=r'\100')
+    assert ar.tolist() == expected
+    ar = pc.replace_substring_regex(data, '(.)oo', r'\100')
+    assert ar.tolist() == expected
 
 
 def test_extract_regex():
     ar = pa.array(['a1', 'zb2z'])
+    expected = [{'letter': 'a', 'digit': '1'}, {'letter': 'b', 'digit': '2'}]
     struct = pc.extract_regex(ar, pattern=r'(?P<letter>[ab])(?P<digit>\d)')
-    assert struct.tolist() == [{'letter': 'a', 'digit': '1'}, {
-        'letter': 'b', 'digit': '2'}]
+    assert struct.tolist() == expected
+    struct = pc.extract_regex(ar, r'(?P<letter>[ab])(?P<digit>\d)')
+    assert struct.tolist() == expected
 
 
 def test_binary_join():
@@ -1406,6 +1437,9 @@ def test_round():
         options = pc.RoundOptions(ndigits, "half_towards_infinity")
         result = pc.round(values, options=options)
         np.testing.assert_allclose(result, pa.array(expected), equal_nan=True)
+        assert pc.round(values, ndigits,
+                        round_mode="half_towards_infinity") == result
+        assert pc.round(values, ndigits, "half_towards_infinity") == result
 
 
 def test_round_to_multiple():
@@ -1421,6 +1455,8 @@ def test_round_to_multiple():
         options = pc.RoundToMultipleOptions(multiple, "half_towards_infinity")
         result = pc.round_to_multiple(values, options=options)
         np.testing.assert_allclose(result, pa.array(expected), equal_nan=True)
+        assert pc.round_to_multiple(values, multiple,
+                                    "half_towards_infinity") == result
 
     with pytest.raises(pa.ArrowInvalid, match="multiple must be positive"):
         pc.round_to_multiple(values, multiple=-2)
@@ -1574,6 +1610,8 @@ def test_strptime():
     expected = pa.array([datetime(2020, 5, 1), None, datetime(1900, 12, 13)],
                         type=pa.timestamp('s'))
     assert got == expected
+    # Positional format
+    assert pc.strptime(arr, '%m/%d/%Y', unit='s') == got
 
 
 # TODO: We should test on windows once ARROW-13168 is resolved.
@@ -1647,6 +1685,8 @@ def test_strftime():
     tsa = pa.array(ts, type=pa.timestamp("s"))
     result = pc.strftime(tsa, options=pc.StrftimeOptions(fmt))
     expected = pa.array(_fix_timestamp(ts.strftime(fmt)))
+    # Positional format
+    assert pc.strftime(tsa, fmt) == result
 
     assert result.equals(expected)
     with pytest.raises(pa.ArrowInvalid,
@@ -1789,6 +1829,8 @@ def test_assume_timezone():
         expected = timestamps.tz_localize(timezone)
         result = pc.assume_timezone(ta, options=options)
         assert result.equals(pa.array(expected))
+        result = pc.assume_timezone(ta, timezone)  # Positional option
+        assert result.equals(pa.array(expected))
 
         ta_zoned = pa.array(timestamps, type=pa.timestamp("ns", timezone))
         with pytest.raises(pa.ArrowInvalid, match="already have a timezone:"):
@@ -1854,6 +1896,11 @@ def test_count():
     assert pc.count(arr, mode='only_valid').as_py() == 3
     assert pc.count(arr, mode='only_null').as_py() == 2
     assert pc.count(arr, mode='all').as_py() == 5
+    assert pc.count(arr, 'all').as_py() == 5
+
+    with pytest.raises(ValueError,
+                       match='"something else" is not a valid count mode'):
+        pc.count(arr, 'something else')
 
 
 def test_index():
@@ -1897,6 +1944,8 @@ def test_partition_nth():
     pivot = 10
     indices = pc.partition_nth_indices(data, pivot=pivot)
     check_partition_nth(data, indices, pivot, "at_end")
+    # Positional pivot argument
+    assert pc.partition_nth_indices(data, pivot) == indices
 
 
 def test_partition_nth_null_placement():
@@ -1944,6 +1993,11 @@ def test_select_k_array():
         arr, options=pc.SelectKOptions(k=2, sort_keys=[("dummy", "ascending")])
     )
     validate_select_k(result, arr, "ascending")
+
+    # Position options
+    assert pc.select_k_unstable(arr, 2,
+                                sort_keys=[("dummy", "ascending")]) == result
+    assert pc.select_k_unstable(arr, 2, [("dummy", "ascending")]) == result
 
 
 def test_select_k_table():
@@ -2003,6 +2057,9 @@ def test_array_sort_indices():
     result = pc.array_sort_indices(arr, order="descending",
                                    null_placement="at_start")
     assert result.to_pylist() == [2, 1, 0, 3]
+    result = pc.array_sort_indices(arr, "descending",
+                                   null_placement="at_start")
+    assert result.to_pylist() == [2, 1, 0, 3]
 
     with pytest.raises(ValueError, match="not a valid sort order"):
         pc.array_sort_indices(arr, order="nonscending")
@@ -2017,6 +2074,10 @@ def test_sort_indices_array():
     result = pc.sort_indices(arr, sort_keys=[("dummy", "descending")])
     assert result.to_pylist() == [1, 0, 3, 2]
     result = pc.sort_indices(arr, sort_keys=[("dummy", "descending")],
+                             null_placement="at_start")
+    assert result.to_pylist() == [2, 1, 0, 3]
+    # Positional `sort_keys`
+    result = pc.sort_indices(arr, [("dummy", "descending")],
                              null_placement="at_start")
     assert result.to_pylist() == [2, 1, 0, 3]
     # Using SortOptions
@@ -2046,6 +2107,12 @@ def test_sort_indices_table():
     assert result.to_pylist() == [1, 0, 3, 2]
     result = pc.sort_indices(
         table, sort_keys=[("a", "descending"), ("b", "ascending")],
+        null_placement="at_start"
+    )
+    assert result.to_pylist() == [2, 1, 0, 3]
+    # Positional `sort_keys`
+    result = pc.sort_indices(
+        table, [("a", "descending"), ("b", "ascending")],
         null_placement="at_start"
     )
     assert result.to_pylist() == [2, 1, 0, 3]
@@ -2092,6 +2159,10 @@ def test_index_in():
     result = pc.index_in(arr, value_set=pa.array([1, 3]), skip_nulls=True)
     assert result.to_pylist() == [0, None, None, 0, None, 1]
 
+    # Positional value_set
+    result = pc.index_in(arr, pa.array([1, 3]), skip_nulls=True)
+    assert result.to_pylist() == [0, None, None, 0, None, 1]
+
 
 def test_quantile():
     arr = pa.array([1, 2, 3, 4])
@@ -2126,6 +2197,10 @@ def test_quantile():
     result = pc.quantile(arr, q=[0.25, 0.5, 0.75], interpolation='linear')
     assert result.to_pylist() == [1.25, 1.5, 1.75]
 
+    # Positional `q`
+    result = pc.quantile(arr, [0.25, 0.5, 0.75], interpolation='linear')
+    assert result.to_pylist() == [1.25, 1.5, 1.75]
+
     with pytest.raises(ValueError, match="Quantile must be between 0 and 1"):
         pc.quantile(arr, q=1.1)
     with pytest.raises(ValueError, match="not a valid quantile interpolation"):
@@ -2146,7 +2221,7 @@ def test_tdigest():
     assert result.to_pylist() == [1, 2.5, 4]
 
     arr = pa.chunked_array([pa.array([1, 2]), pa.array([3, 4])])
-    result = pc.tdigest(arr, q=[0, 0.5, 1])
+    result = pc.tdigest(arr, [0, 0.5, 1])  # positional `q`
     assert result.to_pylist() == [1, 2.5, 4]
 
 
@@ -2218,9 +2293,9 @@ def test_struct_fields_options():
 
     assert pc.struct_field(arr,
                            indices=[1, 1]) == pa.array(["bar", None, ""])
-    assert pc.struct_field(arr,
-                           indices=[0]) == pa.array([4, 5, 6], type=pa.int64())
-    assert pc.struct_field(arr, indices=[]) == arr
+    assert pc.struct_field(arr, [1, 1]) == pa.array(["bar", None, ""])
+    assert pc.struct_field(arr, [0]) == pa.array([4, 5, 6], type=pa.int64())
+    assert pc.struct_field(arr, []) == arr
 
     with pytest.raises(TypeError, match="an integer is required"):
         pc.struct_field(arr, indices=['a'])
@@ -2258,9 +2333,7 @@ def test_count_distinct():
     seed = datetime.now()
     samples = [seed.replace(year=y) for y in range(1992, 2092)]
     arr = pa.array(samples, pa.timestamp("ns"))
-    result = pa.compute.count_distinct(arr)
-    expected = pa.scalar(len(samples), type=pa.int64())
-    assert result.equals(expected)
+    assert pc.count_distinct(arr) == pa.scalar(len(samples), type=pa.int64())
 
 
 def test_count_distinct_options():
@@ -2269,12 +2342,15 @@ def test_count_distinct_options():
     assert pc.count_distinct(arr, mode='only_valid').as_py() == 3
     assert pc.count_distinct(arr, mode='only_null').as_py() == 1
     assert pc.count_distinct(arr, mode='all').as_py() == 4
+    assert pc.count_distinct(arr, 'all').as_py() == 4
 
 
 def test_utf8_normalize():
     arr = pa.array(["01²3"])
     assert pc.utf8_normalize(arr, form="NFC") == arr
     assert pc.utf8_normalize(arr, form="NFKC") == pa.array(["0123"])
+    assert pc.utf8_normalize(arr, "NFD") == arr
+    assert pc.utf8_normalize(arr, "NFKD") == pa.array(["0123"])
     with pytest.raises(
             ValueError,
             match='"NFZ" is not a valid Unicode normalization form'):


### PR DESCRIPTION


This makes compute functions easier to use, for example here the required "pattern" option doesn't need to be passed by name:
```
>>> pc.split_pattern("abacab", "a")
<pyarrow.ListScalar: ['', 'b', 'c', 'b']>
```

... and producing the following doc at the prompt:
```
split_pattern(strings, /, pattern, *, max_splits=-1, reverse=False, options=None, memory_pool=None)
    Split string according to separator.

    Split each string according to the exact `pattern` defined in
    SplitPatternOptions.  The output for each string input is a list
    of strings.

    The maximum number of splits and direction of splitting
    (forward, reverse) can optionally be defined in SplitPatternOptions.

    Parameters
    ----------
    strings : Array-like or scalar-like
        Argument to compute function
    pattern : optional
        Parameter for SplitPatternOptions constructor. Either `options`
        or `pattern` can be passed, but not both at the same time.
    max_splits : optional
        Parameter for SplitPatternOptions constructor. Either `options`
        or `max_splits` can be passed, but not both at the same time.
    reverse : optional
        Parameter for SplitPatternOptions constructor. Either `options`
        or `reverse` can be passed, but not both at the same time.
    options : pyarrow.compute.SplitPatternOptions, optional
        Parameters altering compute function semantics.
    memory_pool : pyarrow.MemoryPool, optional
        If not passed, will allocate memory from the default memory pool.
```