### PR TITLE
ARROW-14853: [C++][Python] Improve error message for missing function options

### DIFF
--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -139,14 +139,22 @@ struct ARROW_EXPORT FunctionDoc {
   /// \brief Name of the options class, if any.
   std::string options_class;
 
+  /// \brief Whether options are required for function execution
+  ///
+  /// If false, then either the function does not have an options class
+  /// or there is a usable default options value.
+  bool options_required;
+
   FunctionDoc() = default;
 
   FunctionDoc(std::string summary, std::string description,
-              std::vector<std::string> arg_names, std::string options_class = "")
+              std::vector<std::string> arg_names, std::string options_class = "",
+              bool options_required = false)
       : summary(std::move(summary)),
         description(std::move(description)),
         arg_names(std::move(arg_names)),
-        options_class(std::move(options_class)) {}
+        options_class(std::move(options_class)),
+        options_required(options_required) {}
 
   static const FunctionDoc& Empty();
 };

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -894,7 +894,8 @@ const FunctionDoc index_doc{"Find the index of the first occurrence of a given v
                             ("-1 is returned if the value is not found in the array.\n"
                              "The search value is specified in IndexOptions."),
                             {"array"},
-                            "IndexOptions"};
+                            "IndexOptions",
+                            /*options_required=*/true};
 
 }  // namespace
 

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -372,7 +372,7 @@ struct ModeExecutor {
     }
     const ModeOptions& options = ModeState::Get(ctx);
     if (options.n <= 0) {
-      return Status::Invalid("ModeOption::n must be strictly positive");
+      return Status::Invalid("ModeOptions::n must be strictly positive");
     }
 
     if (batch[0].is_scalar()) {

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -2267,7 +2267,7 @@ TYPED_TEST(TestNumericIndexKernel, Basics) {
   this->AssertIndexIs(chunked_input4, value, 5);
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, ::testing::HasSubstr("Must provide IndexOptions"),
+      Invalid, ::testing::HasSubstr("Function 'index' cannot be called without options"),
       CallFunction("index", {ArrayFromJSON(this->type_singleton(), "[0]")}));
 }
 TYPED_TEST(TestNumericIndexKernel, Random) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -766,7 +766,7 @@ TEST_F(TestIfElseKernel, ParameterizedTypes) {
   // match)
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       NotImplemented,
-      ::testing::HasSubstr("Function if_else has no kernel matching input types "
+      ::testing::HasSubstr("Function 'if_else' has no kernel matching input types "
                            "(array[bool], array[timestamp[ms, tz=America/New_York]], "
                            "array[timestamp[s, tz=America/Phoenix]]"),
       CallFunction("if_else",

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -335,7 +335,7 @@ const FunctionDoc struct_field_doc(
      "child is always index 0.\n"
      "\n"
      "An empty list of indices returns the argument unchanged."),
-    {"values"}, "StructFieldOptions");
+    {"values"}, "StructFieldOptions", /*options_required=*/true);
 
 Result<ValueDescr> MakeStructResolve(KernelContext* ctx,
                                      const std::vector<ValueDescr>& descrs) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -452,7 +452,8 @@ const FunctionDoc is_in_doc{
      "By default, nulls are matched against the value set, this can be\n"
      "changed in SetLookupOptions."),
     {"values"},
-    "SetLookupOptions"};
+    "SetLookupOptions",
+    /*options_required=*/true};
 
 const FunctionDoc is_in_meta_doc{
     "Find each element in a set of values",
@@ -468,7 +469,8 @@ const FunctionDoc index_in_doc{
      "By default, nulls are matched against the value set, this can be\n"
      "changed in SetLookupOptions."),
     {"values"},
-    "SetLookupOptions"};
+    "SetLookupOptions",
+    /*options_required=*/true};
 
 const FunctionDoc index_in_meta_doc{
     "Return index of each element in a set of values",

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1491,7 +1491,7 @@ const FunctionDoc match_substring_doc(
      "Null inputs emit null.\n"
      "The pattern must be given in MatchSubstringOptions.\n"
      "If ignore_case is set, only simple case folding is performed."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 const FunctionDoc starts_with_doc(
     "Check if strings start with a literal pattern",
@@ -1500,7 +1500,7 @@ const FunctionDoc starts_with_doc(
      "If ignore_case is set, only simple case folding is performed.\n"
      "\n"
      "Null inputs emit null."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 const FunctionDoc ends_with_doc(
     "Check if strings end with a literal pattern",
@@ -1509,7 +1509,7 @@ const FunctionDoc ends_with_doc(
      "If ignore_case is set, only simple case folding is performed.\n"
      "\n"
      "Null inputs emit null."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 #ifdef ARROW_WITH_RE2
 const FunctionDoc match_substring_regex_doc(
@@ -1519,7 +1519,7 @@ const FunctionDoc match_substring_regex_doc(
      "If ignore_case is set, only simple case folding is performed.\n"
      "\n"
      "Null inputs emit null."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 // SQL LIKE match
 
@@ -1630,7 +1630,7 @@ const FunctionDoc match_like_doc(
      "match exactly one character, and any other character matches itself.\n"
      "To match a literal '%', '_', or '\\', precede the character with a backslash.\n"
      "Null inputs emit null.  The pattern must be given in MatchSubstringOptions."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 #endif
 
@@ -1755,7 +1755,7 @@ const FunctionDoc find_substring_doc(
     ("For each string in `strings`, emit the index in bytes of the first occurrence\n"
      "of the given literal pattern, or -1 if not found.\n"
      "Null inputs emit null. The pattern must be given in MatchSubstringOptions."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 #ifdef ARROW_WITH_RE2
 template <typename InputType>
@@ -1774,7 +1774,7 @@ const FunctionDoc find_substring_regex_doc(
     ("For each string in `strings`, emit the index in bytes of the first occurrence\n"
      "of the given literal pattern, or -1 if not found.\n"
      "Null inputs emit null. The pattern must be given in MatchSubstringOptions."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 #endif
 
 void AddFindSubstring(FunctionRegistry* registry) {
@@ -1914,7 +1914,7 @@ const FunctionDoc count_substring_doc(
     ("For each string in `strings`, emit the number of occurrences of the given\n"
      "literal pattern.\n"
      "Null inputs emit null. The pattern must be given in MatchSubstringOptions."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 
 #ifdef ARROW_WITH_RE2
 const FunctionDoc count_substring_regex_doc(
@@ -1922,7 +1922,7 @@ const FunctionDoc count_substring_regex_doc(
     ("For each string in `strings`, emit the number of occurrences of the given\n"
      "regular expression pattern.\n"
      "Null inputs emit null. The pattern must be given in MatchSubstringOptions."),
-    {"strings"}, "MatchSubstringOptions");
+    {"strings"}, "MatchSubstringOptions", /*options_required=*/true);
 #endif
 
 void AddCountSubstring(FunctionRegistry* registry) {
@@ -2146,7 +2146,7 @@ const FunctionDoc utf8_slice_codeunits_doc(
      "If `step` is negative, the string will be advanced in reversed order.\n"
      "An error is raised if `step` is zero.\n"
      "Null inputs emit null."),
-    {"strings"}, "SliceOptions");
+    {"strings"}, "SliceOptions", /*options_required=*/true);
 
 void AddSlice(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("utf8_slice_codeunits", Arity::Unary(),
@@ -2644,7 +2644,7 @@ const FunctionDoc split_pattern_doc(
      "\n"
      "The maximum number of splits and direction of splitting\n"
      "(forward, reverse) can optionally be defined in SplitPatternOptions."),
-    {"strings"}, "SplitPatternOptions");
+    {"strings"}, "SplitPatternOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_split_whitespace_doc(
     "Split string according to any ASCII whitespace",
@@ -2860,7 +2860,7 @@ const FunctionDoc split_pattern_regex_doc(
      "\n"
      "The maximum number of splits and direction of splitting\n"
      "(forward, reverse) can optionally be defined in SplitPatternOptions."),
-    {"strings"}, "SplitPatternOptions");
+    {"strings"}, "SplitPatternOptions", /*options_required=*/true);
 
 void AddSplitRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern_regex", Arity::Unary(),
@@ -3236,7 +3236,7 @@ const FunctionDoc replace_substring_doc(
      "If `max_replacements` is given and not equal to -1, it limits the\n"
      "maximum amount replacements per input, counted from the left.\n"
      "Null values emit null."),
-    {"strings"}, "ReplaceSubstringOptions");
+    {"strings"}, "ReplaceSubstringOptions", /*options_required=*/true);
 
 #ifdef ARROW_WITH_RE2
 template <typename Type>
@@ -3249,7 +3249,7 @@ const FunctionDoc replace_substring_regex_doc(
      "If `max_replacements` is given and not equal to -1, it limits the\n"
      "maximum amount replacements per input, counted from the left.\n"
      "Null values emit null."),
-    {"strings"}, "ReplaceSubstringOptions");
+    {"strings"}, "ReplaceSubstringOptions", /*options_required=*/true);
 #endif
 
 // ----------------------------------------------------------------------
@@ -3400,7 +3400,7 @@ const FunctionDoc binary_replace_slice_doc(
      "and `stop` indices with the given `replacement`. `start` is inclusive\n"
      "and `stop` is exclusive, and both are measured in bytes.\n"
      "Null values emit null."),
-    {"strings"}, "ReplaceSliceOptions");
+    {"strings"}, "ReplaceSliceOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_replace_slice_doc(
     "Replace a slice of a string",
@@ -3408,7 +3408,7 @@ const FunctionDoc utf8_replace_slice_doc(
      "and `stop` indices with the given `replacement`. `start` is inclusive\n"
      "and `stop` is exclusive, and both are measured in UTF8 characters.\n"
      "Null values emit null."),
-    {"strings"}, "ReplaceSliceOptions");
+    {"strings"}, "ReplaceSliceOptions", /*options_required=*/true);
 
 void AddReplaceSlice(FunctionRegistry* registry) {
   {
@@ -3607,7 +3607,7 @@ const FunctionDoc extract_regex_doc(
      "regular expression fails matching, a null output value is emitted.\n"
      "\n"
      "Regular expression matching is done using the Google RE2 library."),
-    {"strings"}, "ExtractRegexOptions");
+    {"strings"}, "ExtractRegexOptions", /*options_required=*/true);
 
 void AddExtractRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("extract_regex", Arity::Unary(),
@@ -4012,37 +4012,37 @@ const FunctionDoc utf8_center_doc(
     "Center strings by padding with a given character",
     ("For each string in `strings`, emit a centered string by padding both sides \n"
      "with the given UTF8 codeunit.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_lpad_doc(
     "Right-align strings by padding with a given character",
     ("For each string in `strings`, emit a right-aligned string by prepending \n"
      "the given UTF8 codeunit.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_rpad_doc(
     "Left-align strings by padding with a given character",
     ("For each string in `strings`, emit a left-aligned string by appending \n"
      "the given UTF8 codeunit.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_center_doc(
     utf8_center_doc.summary,
     ("For each string in `strings`, emit a centered string by padding both sides \n"
      "with the given ASCII character.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_lpad_doc(
     utf8_lpad_doc.summary,
     ("For each string in `strings`, emit a right-aligned string by prepending \n"
      "the given ASCII character.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_rpad_doc(
     utf8_rpad_doc.summary,
     ("For each string in `strings`, emit a left-aligned string by appending \n"
      "the given ASCII character.\nNull values emit null."),
-    {"strings"}, "PadOptions");
+    {"strings"}, "PadOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_trim_whitespace_doc(
     "Trim leading and trailing whitespace characters",
@@ -4091,42 +4091,42 @@ const FunctionDoc utf8_trim_doc(
     ("For each string in `strings`, remove any leading or trailing characters\n"
      "from the `characters` option (as given in TrimOptions).\n"
      "Null values emit null."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_ltrim_doc(
     "Trim leading characters",
     ("For each string in `strings`, remove any leading characters\n"
      "from the `characters` option (as given in TrimOptions).\n"
      "Null values emit null."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc utf8_rtrim_doc(
     "Trim trailing characters",
     ("For each string in `strings`, remove any trailing characters\n"
      "from the `characters` option (as given in TrimOptions).\n"
      "Null values emit null."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_trim_doc(
     utf8_trim_doc.summary,
     utf8_trim_doc.description +
         ("\nBoth the `strings` and the `characters` are interpreted as\n"
          "ASCII; to trim non-ASCII characters, use `utf8_trim`."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_ltrim_doc(
     utf8_ltrim_doc.summary,
     utf8_ltrim_doc.description +
         ("\nBoth the `strings` and the `characters` are interpreted as\n"
          "ASCII; to trim non-ASCII characters, use `utf8_ltrim`."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc ascii_rtrim_doc(
     utf8_rtrim_doc.summary,
     utf8_rtrim_doc.description +
         ("\nBoth the `strings` and the `characters` are interpreted as\n"
          "ASCII; to trim non-ASCII characters, use `utf8_rtrim`."),
-    {"strings"}, "TrimOptions");
+    {"strings"}, "TrimOptions", /*options_required=*/true);
 
 const FunctionDoc strptime_doc(
     "Parse timestamps",
@@ -4134,7 +4134,7 @@ const FunctionDoc strptime_doc(
      "The timestamp unit and the expected string pattern must be given\n"
      "in StrptimeOptions.  Null inputs emit null.  If a non-null string\n"
      "fails parsing, an error is returned."),
-    {"strings"}, "StrptimeOptions");
+    {"strings"}, "StrptimeOptions", /*options_required=*/true);
 
 const FunctionDoc binary_length_doc(
     "Compute string lengths",
@@ -5129,7 +5129,7 @@ const FunctionDoc utf8_normalize_doc(
     ("For each string in `strings`, return the normal form.\n\n"
      "The normalization form must be given in the options.\n"
      "Null inputs emit null."),
-    {"strings"}, "Utf8NormalizeOptions");
+    {"strings"}, "Utf8NormalizeOptions", /*options_required=*/true);
 
 #endif  // ARROW_WITH_UTF8PROC
 

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -2024,7 +2024,8 @@ TYPED_TEST(TestStringKernels, SliceCodeunitsBasic) {
   auto input = ArrayFromJSON(this->type(), R"(["𝑓öõḍš"])");
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       Invalid,
-      testing::HasSubstr("Attempted to initialize KernelState from null FunctionOptions"),
+      testing::HasSubstr(
+          "Function 'utf8_slice_codeunits' cannot be called without options"),
       CallFunction("utf8_slice_codeunits", {input}));
 
   SliceOptions options_invalid{2, 4, 0};

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -987,7 +987,8 @@ const FunctionDoc assume_timezone_doc{
      "\"timezone-aware\" timestamps. An error is returned if the timestamps\n"
      "already have a defined timezone."),
     {"timestamps"},
-    "AssumeTimezoneOptions"};
+    "AssumeTimezoneOptions",
+    /*options_required=*/true};
 
 }  // namespace
 

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -529,7 +529,7 @@ const FunctionDoc partition_nth_indices_doc(
      "\n"
      "The pivot index `N` must be given in PartitionNthOptions.\n"
      "The handling of nulls and NaNs can also be changed in PartitionNthOptions."),
-    {"array"}, "PartitionNthOptions");
+    {"array"}, "PartitionNthOptions", /*options_required=*/true);
 
 }  // namespace
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -1324,7 +1324,7 @@ const FunctionDoc select_k_unstable_doc(
      "Null values are considered greater than any other value and are\n"
      "therefore ordered at the end. For floating-point types, NaNs are considered\n"
      "greater than any other non-null value, but smaller than null values."),
-    {"input"}, "SelectKOptions");
+    {"input"}, "SelectKOptions", /*options_required=*/true);
 
 Result<std::shared_ptr<ArrayData>> MakeMutableUInt64Array(
     std::shared_ptr<DataType> out_type, int64_t length, MemoryPool* memory_pool) {

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -194,7 +194,8 @@ cdef class HashAggregateKernel(Kernel):
 
 FunctionDoc = namedtuple(
     "FunctionDoc",
-    ("summary", "description", "arg_names", "options_class"))
+    ("summary", "description", "arg_names", "options_class",
+     "options_required"))
 
 
 cdef class Function(_Weakrefable):
@@ -297,7 +298,8 @@ cdef class Function(_Weakrefable):
         return FunctionDoc(frombytes(c_doc.summary),
                            frombytes(c_doc.description),
                            [frombytes(s) for s in c_doc.arg_names],
-                           frombytes(c_doc.options_class))
+                           frombytes(c_doc.options_class),
+                           c_doc.options_required)
 
     @property
     def num_kernels(self):
@@ -958,7 +960,7 @@ cdef class _MakeStructOptions(FunctionOptions):
 
 
 class MakeStructOptions(_MakeStructOptions):
-    def __init__(self, field_names, *, field_nullability=None,
+    def __init__(self, field_names=(), *, field_nullability=None,
                  field_metadata=None):
         if field_nullability is None:
             field_nullability = [True] * len(field_names)
@@ -1243,7 +1245,7 @@ cdef class _SortOptions(FunctionOptions):
 
 
 class SortOptions(_SortOptions):
-    def __init__(self, sort_keys, *, null_placement="at_end"):
+    def __init__(self, sort_keys=(), *, null_placement="at_end"):
         self._set_options(sort_keys, null_placement)
 
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1780,6 +1780,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         c_string description
         vector[c_string] arg_names
         c_string options_class
+        c_bool options_required
 
     cdef cppclass CFunctionOptionsType" arrow::compute::FunctionOptionsType":
         const char* type_name() const

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -174,7 +174,7 @@ test_that("filter scalar validation doesn't crash (ARROW-7772)", {
     ds %>%
       filter(int == "fff", part == 1) %>%
       collect(),
-    "equal has no kernel matching input types .array.int32., scalar.string.."
+    "'equal' has no kernel matching input types .array.int32., scalar.string.."
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -50,7 +50,7 @@ test_that("if_else and ifelse", {
         y = if_else(int > 5, 1, FALSE)
       ) %>%
       collect(),
-    "NotImplemented: Function if_else has no kernel matching input types"
+    "NotImplemented: Function 'if_else' has no kernel matching input types"
   )
 
   compare_dplyr_binding(


### PR DESCRIPTION
Some compute function have required options (because there is no reasonable default value).

Currently they would raise a cryptic error:
```
>>> pc.partition_nth_indices([1,2,3])
Traceback (most recent call last):
  ...
ArrowInvalid: Attempted to initialize KernelState from null FunctionOptions
```

With this PR, the error becomes slightly more insightful:
```
>>> pc.partition_nth_indices([1,2,3])
Traceback (most recent call last):
  ...
ArrowInvalid: Function 'partition_nth_indices' cannot be called without options
```