### PR TITLE
ARROW-15119: [C++] allow reading directories as files in generic tests

### DIFF
--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -961,7 +961,9 @@ void GenericFileSystemTest::TestOpenInputStream(FileSystem* fs) {
   ASSERT_RAISES(IOError, fs->OpenInputStream("def"));
 
   // Cannot open directory
-  ASSERT_RAISES(IOError, fs->OpenInputStream("AB"));
+  if (!allow_read_dir_as_file()) {
+    ASSERT_RAISES(IOError, fs->OpenInputStream("AB"));
+  }
 }
 
 void GenericFileSystemTest::TestOpenInputStreamWithFileInfo(FileSystem* fs) {
@@ -1029,7 +1031,9 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   ASSERT_RAISES(IOError, fs->OpenInputFile("def"));
 
   // Cannot open directory
-  ASSERT_RAISES(IOError, fs->OpenInputFile("AB"));
+  if (!allow_read_dir_as_file()) {
+    ASSERT_RAISES(IOError, fs->OpenInputFile("AB"));
+  }
 }
 
 void GenericFileSystemTest::TestOpenInputFileAsync(FileSystem* fs) {

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -162,6 +162,8 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_implicit_directories() const { return false; }
   // - Whether the filesystem may allow writing a file "over" a directory
   virtual bool allow_write_file_over_dir() const { return false; }
+  // - Whether the filesystem allows reading a directory
+  virtual bool allow_read_dir_as_file() const { return false; }
   // - Whether the filesystem allows moving a directory
   virtual bool allow_move_dir() const { return true; }
   // - Whether the filesystem allows moving a directory "over" a non-empty destination


### PR DESCRIPTION
This is motivated by GCS, where checking if an object is a directory marker would add too much overhead.
