### PR TITLE
[Java]: Java arrow modules log4j lookup/jmsmessage cve vulnerability

### DIFF
--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -34,18 +34,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.1</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.1</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Current java arrow modules that use log4j dependencies are:
- arrow-performance

Other modules (memory/vector/others) are not using log4j library.

```
> mvn compile dependency:tree
[INFO] -----------------< org.apache.arrow:arrow-performance >-----------------
[INFO] Building Arrow Performance Benchmarks 6.0.0-SNAPSHOT             [16/16]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.1:tree (default-cli) @ arrow-performance ---
[INFO] org.apache.arrow:arrow-performance:jar:6.0.0-SNAPSHOT
[INFO] +- org.openjdk.jmh:jmh-core:jar:1.21:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.1:runtime <<<<<<<<<<<<<<<<<<<<<
```

If some user use this dependency by any reason that project could be affected by [CVE-2021-44228](https://github.com/apache/logging-log4j2/pull/608):
```
<dependency>
	<groupId>org.apache.arrow</groupId>
	<artifactId>arrow-performance</artifactId>
	<version>${arrow.version}</version>
</dependency>
```

This proposal is to remove log4j2 dependencies on performance module base on my initial validation that this library is not used by this module

This is some [PoC](https://github.com/davisusanibar/cve-log/blob/cve-java-arrow-performance/Readme.md#arrow-java-modules) about how a project that use that dependency could by affected by lookup/jmsmessage cve

