### PR TITLE
ARROW-15150: [Doc] Add guidance on partitioning datasets

### DIFF
--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -363,7 +363,7 @@ cardinality 1,000 will make that 365,365 calls.
 The most optimal partitioning layout will depend on your data, access patterns, and which
 systems will be reading the data. Most systems, including Arrow, should work across a 
 range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
-avoid pathological behavior, keep to these guidelines:
+avoid worst case behavior, keep to these guidelines:
 
  * Avoid files smaller than 20MB and larger than 2GB
  * Avoid partitioning layouts with more than 10,000 distinct partitions.
@@ -371,7 +371,7 @@ avoid pathological behavior, keep to these guidelines:
 For file formats that have a notion of groups within a file, such as Parquet, similar
 guidelines apply. Row groups can provide parallelism when reading and allow data skipping
 based on statistics, but very small groups can cause metadata to be a significant portion
-of file size. Arrow's file writer provide sensible defaults for group sizing in most cases.
+of file size. Arrow's file writer provides sensible defaults for group sizing in most cases.
  
 
 Different partitioning schemes

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -395,11 +395,11 @@ cardinality 1,000 will make that 365,365 calls.
 
 The most optimal partitioning layout will depend on your data, access patterns, and which
 systems will be reading the data. Most systems, including Arrow, should work across a 
-range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
-avoid worst case behavior, keep to these guidelines:
+range of file sizes and partitioning layouts, but there are extremes you should avoid. These
+guidelines can help avoid some known worst cases:
 
- * Avoid files smaller than 20MB and larger than 2GB
- * Avoid partitioning layouts with more than 10,000 distinct partitions.
+* Avoid files smaller than 20MB and larger than 2GB.
+* Avoid partitioning layouts with more than 10,000 distinct partitions.
 
 For file formats that have a notion of groups within a file, such as Parquet, similar
 guidelines apply. Row groups can provide parallelism when reading and allow data skipping

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -334,46 +334,6 @@ altogether if they do not match the filter:
    :linenos:
    :lineno-match:
 
-Partitioning performance considerations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Partitioning datasets has two aspects that affect performance: it increases the number of
-files and it creates a directory structure around the files. Both of these have benefits
-as well as costs. Depending on the configuration and the size of your dataset, the costs 
-can outweigh the benefits. 
-
-Because partitions split up the dataset into multiple files, partitioned datasets can be 
-read and written with parallelism. However, each additional file adds a little overhead in 
-processing for filesystem interaction. It also increases the overall dataset size since 
-each file has some shared metadata. For example, each parquet file contains the schema and
-group-level statistics. The number of partitions is a floor for the number of files. If 
-you partition a dataset by date with a year of data, you will have at least 365 files. If 
-you further partition by another dimension with 1,000 unique values, you will have up to 
-365,000 files. This fine of partitioning often leads to small files that mostly consist of
-metadata.
-
-Partitioned datasets create nested folder structures, and those allow us to prune which 
-files are loaded in a scan. However, this adds overhead to discovering files in the dataset,
-as we'll need to recursively "list directory" to find the data files. These operations may 
-be particularly expensive if you are using an object store filesystem such as S3. Too fine
-partitions can cause problems here: Partitioning a dataset by date for a years worth
-of data will require 365 list calls to find all the files; adding another column with 
-cardinality 1,000 will make that 365,365 calls.
-
-The most optimal partitioning layout will depend on your data, access patterns, and which
-systems will be reading the data. Most systems, including Arrow, should work across a 
-range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
-avoid worst case behavior, keep to these guidelines:
-
- * Avoid files smaller than 20MB and larger than 2GB
- * Avoid partitioning layouts with more than 10,000 distinct partitions.
-
-For file formats that have a notion of groups within a file, such as Parquet, similar
-guidelines apply. Row groups can provide parallelism when reading and allow data skipping
-based on statistics, but very small groups can cause metadata to be a significant portion
-of file size. Arrow's file writer provides sensible defaults for group sizing in most cases.
- 
-
 Different partitioning schemes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -407,6 +367,44 @@ when constructing a directory partitioning:
 
 Directory partitioning also supports providing a full schema rather than inferring
 types from file paths.
+
+Partitioning performance considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Partitioning datasets has two aspects that affect performance: it increases the number of
+files and it creates a directory structure around the files. Both of these have benefits
+as well as costs. Depending on the configuration and the size of your dataset, the costs 
+can outweigh the benefits. 
+
+Because partitions split up the dataset into multiple files, partitioned datasets can be 
+read and written with parallelism. However, each additional file adds a little overhead in 
+processing for filesystem interaction. It also increases the overall dataset size since 
+each file has some shared metadata. For example, each parquet file contains the schema and
+group-level statistics. The number of partitions is a floor for the number of files. If 
+you partition a dataset by date with a year of data, you will have at least 365 files. If 
+you further partition by another dimension with 1,000 unique values, you will have up to 
+365,000 files. This fine of partitioning often leads to small files that mostly consist of
+metadata.
+
+Partitioned datasets create nested folder structures, and those allow us to prune which 
+files are loaded in a scan. However, this adds overhead to discovering files in the dataset,
+as we'll need to recursively "list directory" to find the data files. Too fine
+partitions can cause problems here: Partitioning a dataset by date for a years worth
+of data will require 365 list calls to find all the files; adding another column with 
+cardinality 1,000 will make that 365,365 calls.
+
+The most optimal partitioning layout will depend on your data, access patterns, and which
+systems will be reading the data. Most systems, including Arrow, should work across a 
+range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
+avoid worst case behavior, keep to these guidelines:
+
+ * Avoid files smaller than 20MB and larger than 2GB
+ * Avoid partitioning layouts with more than 10,000 distinct partitions.
+
+For file formats that have a notion of groups within a file, such as Parquet, similar
+guidelines apply. Row groups can provide parallelism when reading and allow data skipping
+based on statistics, but very small groups can cause metadata to be a significant portion
+of file size. Arrow's file writer provides sensible defaults for group sizing in most cases.
 
 Reading from other data sources
 -------------------------------

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -334,6 +334,25 @@ altogether if they do not match the filter:
    :linenos:
    :lineno-match:
 
+Partitioning performance considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Partitioning datasets can improve performance when reading datasets, but have several 
+potential costs when reading and writing:
+
+#. Can significantly increase the number of files to write. The number of partitions is a
+   floor for the number of files in a dataset. If you partition a dataset by date with a 
+   year of data, you will have at least 365 files. If you further partition by another
+   dimension with 1,000 unique values, you will have 365,000 files. This can make it slower
+   to write and increase the size of the overall dataset because each file has some fixed
+   overhead. For example, each file in parquet dataset contains the schema.
+#. Multiple partitioning columns can produce deeply nested folder structures which are slow
+   to navigate because they require many recusive "list directory" calls to discover files.
+   These operations may be particularly expensive if you are using an object store 
+   filesystem such as S3. One workaround is to combine multiple columns into one for
+   partitioning. For example, instead of a schema like /year/month/day/ use /YYYY-MM-DD/.
+ 
+
 Different partitioning schemes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -340,7 +340,7 @@ Partitioning performance considerations
 Partitioning datasets has two aspects that affect performance: it increases the number of
 files and it creates a directory structure around the files. Both of these have benefits
 as well as costs. Depending on the configuration and the size of your dataset, the costs 
-can outweight the benefits. 
+can outweigh the benefits. 
 
 Because partitions split up the dataset into multiple files, partitioned datasets can be 
 read and written with parallelism. However, each additional file adds a little overhead in 
@@ -367,6 +367,11 @@ avoid pathological behavior, keep to these guidelines:
 
  * Avoid files smaller than 20MB and larger than 2GB
  * Avoid partitioning layouts with more than 10,000 distinct partitions.
+
+For file formats that have a notion of groups within a file, such as Parquet, similar
+guidelines apply. Row groups can provide parallelism when reading and allow data skipping
+based on statistics, but very small groups can cause metadata to be a significant portion
+of file size. Arrow's file writer provide sensible defaults for group sizing in most cases.
  
 
 Different partitioning schemes

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -575,6 +575,44 @@ dataset to be partitioned.  For example:
 This will create two files.  Half our data will be in the dataset_root/c=1 directory and
 the other half will be in the dataset_root/c=2 directory.
 
+Partitioning performance considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Partitioning datasets has two aspects that affect performance: it increases the number of
+files and it creates a directory structure around the files. Both of these have benefits
+as well as costs. Depending on the configuration and the size of your dataset, the costs 
+can outweigh the benefits. 
+
+Because partitions split up the dataset into multiple files, partitioned datasets can be 
+read and written with parallelism. However, each additional file adds a little overhead in 
+processing for filesystem interaction. It also increases the overall dataset size since 
+each file has some shared metadata. For example, each parquet file contains the schema and
+group-level statistics. The number of partitions is a floor for the number of files. If 
+you partition a dataset by date with a year of data, you will have at least 365 files. If 
+you further partition by another dimension with 1,000 unique values, you will have up to 
+365,000 files. This fine of partitioning often leads to small files that mostly consist of
+metadata.
+
+Partitioned datasets create nested folder structures, and those allow us to prune which 
+files are loaded in a scan. However, this adds overhead to discovering files in the dataset,
+as we'll need to recursively "list directory" to find the data files. Too fine
+partitions can cause problems here: Partitioning a dataset by date for a years worth
+of data will require 365 list calls to find all the files; adding another column with 
+cardinality 1,000 will make that 365,365 calls.
+
+The most optimal partitioning layout will depend on your data, access patterns, and which
+systems will be reading the data. Most systems, including Arrow, should work across a 
+range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
+avoid worst case behavior, keep to these guidelines:
+
+ * Avoid files smaller than 20MB and larger than 2GB
+ * Avoid partitioning layouts with more than 10,000 distinct partitions.
+
+For file formats that have a notion of groups within a file, such as Parquet, similar
+guidelines apply. Row groups can provide parallelism when reading and allow data skipping
+based on statistics, but very small groups can cause metadata to be a significant portion
+of file size. Arrow's file writer provides sensible defaults for group sizing in most cases.
+
 Writing large amounts of data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -602,11 +602,11 @@ cardinality 1,000 will make that 365,365 calls.
 
 The most optimal partitioning layout will depend on your data, access patterns, and which
 systems will be reading the data. Most systems, including Arrow, should work across a 
-range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
-avoid worst case behavior, keep to these guidelines:
+range of file sizes and partitioning layouts, but there are extremes you should avoid. These
+guidelines can help avoid some known worst cases:
 
- * Avoid files smaller than 20MB and larger than 2GB
- * Avoid partitioning layouts with more than 10,000 distinct partitions.
+* Avoid files smaller than 20MB and larger than 2GB.
+* Avoid partitioning layouts with more than 10,000 distinct partitions.
 
 For file formats that have a notion of groups within a file, such as Parquet, similar
 guidelines apply. Row groups can provide parallelism when reading and allow data skipping

--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -448,10 +448,10 @@ cardinality 1,000 will make that 365,365 calls.
 
 The most optimal partitioning layout will depend on your data, access patterns, and which
 systems will be reading the data. Most systems, including Arrow, should work across a 
-range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
-avoid worst case behavior, keep to these guidelines:
+range of file sizes and partitioning layouts, but there are extremes you should avoid. These
+guidelines can help avoid some known worst cases:
 
- * Avoid files smaller than 20MB and larger than 2GB
+ * Avoid files smaller than 20MB and larger than 2GB.
  * Avoid partitioning layouts with more than 10,000 distinct partitions.
 
 For file formats that have a notion of groups within a file, such as Parquet, similar

--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -422,6 +422,43 @@ ds %>%
 Note that while you can select a subset of columns,
 you cannot currently rename columns when writing a dataset.
 
+## Partitioning performance considerations
+
+Partitioning datasets has two aspects that affect performance: it increases the number of
+files and it creates a directory structure around the files. Both of these have benefits
+as well as costs. Depending on the configuration and the size of your dataset, the costs 
+can outweigh the benefits. 
+
+Because partitions split up the dataset into multiple files, partitioned datasets can be 
+read and written with parallelism. However, each additional file adds a little overhead in 
+processing for filesystem interaction. It also increases the overall dataset size since 
+each file has some shared metadata. For example, each parquet file contains the schema and
+group-level statistics. The number of partitions is a floor for the number of files. If 
+you partition a dataset by date with a year of data, you will have at least 365 files. If 
+you further partition by another dimension with 1,000 unique values, you will have up to 
+365,000 files. This fine of partitioning often leads to small files that mostly consist of
+metadata.
+
+Partitioned datasets create nested folder structures, and those allow us to prune which 
+files are loaded in a scan. However, this adds overhead to discovering files in the dataset,
+as we'll need to recursively "list directory" to find the data files. Too fine
+partitions can cause problems here: Partitioning a dataset by date for a years worth
+of data will require 365 list calls to find all the files; adding another column with 
+cardinality 1,000 will make that 365,365 calls.
+
+The most optimal partitioning layout will depend on your data, access patterns, and which
+systems will be reading the data. Most systems, including Arrow, should work across a 
+range of file sizes and partitioning layouts, but there are extremes you should avoid. To 
+avoid worst case behavior, keep to these guidelines:
+
+ * Avoid files smaller than 20MB and larger than 2GB
+ * Avoid partitioning layouts with more than 10,000 distinct partitions.
+
+For file formats that have a notion of groups within a file, such as Parquet, similar
+guidelines apply. Row groups can provide parallelism when reading and allow data skipping
+based on statistics, but very small groups can cause metadata to be a significant portion
+of file size. Arrow's file writer provides sensible defaults for group sizing in most cases.
+
 ## Transactions / ACID guarantees
 
 The dataset API offers no transaction support or any ACID guarantees.  This affects


### PR DESCRIPTION
This guidance is here to help users avoid creating datasets that have poor partitioning structure. I've duplicated the same language in C++, R, and Python docs.