### PR TITLE
ARROW-13598: [C++] Remove Datum::COLLECTION

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -651,14 +651,9 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   Datum WrapResults(const std::vector<Datum>& inputs,
                     const std::vector<Datum>& outputs) override {
     if (output_descr_.shape == ValueDescr::SCALAR) {
-      DCHECK_GT(outputs.size(), 0);
-      if (outputs.size() == 1) {
-        // Return as SCALAR
-        return outputs[0];
-      } else {
-        // Return as COLLECTION
-        return outputs;
-      }
+      DCHECK_EQ(outputs.size(), 1);
+      // Return as SCALAR
+      return outputs[0];
     } else {
       // If execution yielded multiple chunks (because large arrays were split
       // based on the ExecContext parameters, then the result is a ChunkedArray

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -156,13 +156,9 @@ static inline std::string GenericToString(const Datum& value) {
       ss << value.type()->ToString() << ':' << value.make_array()->ToString();
       return ss.str();
     }
-    case Datum::CHUNKED_ARRAY:
-    case Datum::RECORD_BATCH:
-    case Datum::TABLE:
-    case Datum::COLLECTION:
+    default:
       return value.ToString();
   }
-  return value.ToString();
 }
 
 template <typename T>

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -34,20 +34,6 @@
 
 namespace arrow {
 
-static bool CollectionEquals(const std::vector<Datum>& left,
-                             const std::vector<Datum>& right) {
-  if (left.size() != right.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < left.size(); i++) {
-    if (!left[i].Equals(right[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 Datum::Datum(const Array& value) : Datum(value.data()) {}
 
 Datum::Datum(const std::shared_ptr<Array>& value)
@@ -56,7 +42,6 @@ Datum::Datum(const std::shared_ptr<Array>& value)
 Datum::Datum(std::shared_ptr<ChunkedArray> value) : value(std::move(value)) {}
 Datum::Datum(std::shared_ptr<RecordBatch> value) : value(std::move(value)) {}
 Datum::Datum(std::shared_ptr<Table> value) : value(std::move(value)) {}
-Datum::Datum(std::vector<Datum> value) : value(std::move(value)) {}
 
 Datum::Datum(bool value) : value(std::make_shared<BooleanScalar>(value)) {}
 Datum::Datum(int8_t value) : value(std::make_shared<Int8Scalar>(value)) {}
@@ -188,8 +173,6 @@ bool Datum::Equals(const Datum& other) const {
       return internal::SharedPtrEquals(this->record_batch(), other.record_batch());
     case Datum::TABLE:
       return internal::SharedPtrEquals(this->table(), other.table());
-    case Datum::COLLECTION:
-      return CollectionEquals(this->collection(), other.collection());
     default:
       return false;
   }
@@ -268,19 +251,6 @@ std::string Datum::ToString() const {
       return "RecordBatch";
     case Datum::TABLE:
       return "Table";
-    case Datum::COLLECTION: {
-      std::stringstream ss;
-      ss << "Collection(";
-      const auto& values = this->collection();
-      for (size_t i = 0; i < values.size(); ++i) {
-        if (i > 0) {
-          ss << ", ";
-        }
-        ss << values[i].ToString();
-      }
-      ss << ')';
-      return ss.str();
-    }
     default:
       DCHECK(false);
       return "";

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -103,7 +103,7 @@ ValueDescr::Shape GetBroadcastShape(const std::vector<ValueDescr>& args);
 /// \class Datum
 /// \brief Variant type for various Arrow C++ data structures
 struct ARROW_EXPORT Datum {
-  enum Kind { NONE, SCALAR, ARRAY, CHUNKED_ARRAY, RECORD_BATCH, TABLE, COLLECTION };
+  enum Kind { NONE, SCALAR, ARRAY, CHUNKED_ARRAY, RECORD_BATCH, TABLE };
 
   struct Empty {};
 
@@ -113,7 +113,7 @@ struct ARROW_EXPORT Datum {
 
   util::Variant<Empty, std::shared_ptr<Scalar>, std::shared_ptr<ArrayData>,
                 std::shared_ptr<ChunkedArray>, std::shared_ptr<RecordBatch>,
-                std::shared_ptr<Table>, std::vector<Datum>>
+                std::shared_ptr<Table>>
       value;
 
   /// \brief Empty datum, to be populated elsewhere
@@ -138,7 +138,6 @@ struct ARROW_EXPORT Datum {
   Datum(std::shared_ptr<ChunkedArray> value);  // NOLINT implicit conversion
   Datum(std::shared_ptr<RecordBatch> value);   // NOLINT implicit conversion
   Datum(std::shared_ptr<Table> value);         // NOLINT implicit conversion
-  Datum(std::vector<Datum> value);             // NOLINT implicit conversion
 
   // Explicit constructors from const-refs. Can be expensive, prefer the
   // shared_ptr constructors
@@ -183,8 +182,6 @@ struct ARROW_EXPORT Datum {
         return Datum::RECORD_BATCH;
       case 5:
         return Datum::TABLE;
-      case 6:
-        return Datum::COLLECTION;
       default:
         return Datum::NONE;
     }
@@ -215,10 +212,6 @@ struct ARROW_EXPORT Datum {
     return util::get<std::shared_ptr<Table>>(this->value);
   }
 
-  const std::vector<Datum>& collection() const {
-    return util::get<std::vector<Datum>>(this->value);
-  }
-
   const std::shared_ptr<Scalar>& scalar() const {
     return util::get<std::shared_ptr<Scalar>>(this->value);
   }
@@ -243,8 +236,6 @@ struct ARROW_EXPORT Datum {
 
   /// \brief True if Datum contains a scalar or array-like data
   bool is_value() const { return this->is_arraylike() || this->is_scalar(); }
-
-  bool is_collection() const { return this->kind() == Datum::COLLECTION; }
 
   int64_t null_count() const;
 

--- a/cpp/src/arrow/datum_test.cc
+++ b/cpp/src/arrow/datum_test.cc
@@ -133,16 +133,8 @@ TEST(Datum, ToString) {
   Datum v1(arr);
   Datum v2(std::make_shared<Int8Scalar>(1));
 
-  std::vector<Datum> vec1 = {v1};
-  Datum v3(vec1);
-
-  std::vector<Datum> vec2 = {v1, v2};
-  Datum v4(vec2);
-
   ASSERT_EQ("Array", v1.ToString());
   ASSERT_EQ("Scalar", v2.ToString());
-  ASSERT_EQ("Collection(Array)", v3.ToString());
-  ASSERT_EQ("Collection(Array, Scalar)", v4.ToString());
 }
 
 TEST(Datum, TotalBufferSize) {


### PR DESCRIPTION
It is entirely unused in the codebase and will probably not be used in the future.