### PR TITLE
PARQUET-2109: [C++] Check if Parquet page has too few values

### DIFF
--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -280,8 +280,8 @@ class DataPageBuilder {
       ParquetException::NYI("only rle encoding currently implemented");
     }
 
-    // TODO: compute a more precise maximum size for the encoded levels
-    std::vector<uint8_t> encode_buffer(levels.size() * 2);
+    std::vector<uint8_t> encode_buffer(LevelEncoder::MaxBufferSize(
+        Encoding::RLE, max_level, static_cast<int>(levels.size())));
 
     // We encode into separate memory from the output stream because the
     // RLE-encoded bytes have to be preceded in the stream by their absolute
@@ -338,7 +338,7 @@ static std::shared_ptr<DataPageV1> MakeDataPage(
 
   if (encoding == Encoding::PLAIN) {
     page_builder.AppendValues(d, values, encoding);
-    num_values = page_builder.num_values();
+    num_values = std::max(page_builder.num_values(), num_vals);
   } else {  // DICTIONARY PAGES
     PARQUET_THROW_NOT_OK(page_stream->Write(indices, indices_size));
     num_values = std::max(page_builder.num_values(), num_vals);


### PR DESCRIPTION
Column reader uses the values reported in the page header to gauge
if there are more values left to read. However, corrupted page headers
might overstate the number of values. This can cause an infinite loop
when reading a column when doing something like:
while(reader.HasNext()) {
  reader.ReadBatch(...);
}

Ideally HasNext() would return false in these cases, but that seems
non-trivial. Instead, we change ReadBatch to throw an exception in these
cases.