### PR TITLE
ARROW-15147: [CI][C++][Gandiva] Fix broken nigthly builds related to boost dependencies

### DIFF
--- a/ci/docker/java-jni-manylinux-201x.dockerfile
+++ b/ci/docker/java-jni-manylinux-201x.dockerfile
@@ -20,16 +20,17 @@ FROM ${base}
 
 # Install the libaries required by the Gandiva to run
 RUN vcpkg install --clean-after-build \
-        llvm \
-        boost-system \
-        boost-date-time \
-        boost-regex \
-        boost-predef \
         boost-algorithm \
-        boost-locale \
+        boost-crc \
+        boost-date-time \
         boost-format \
+        boost-locale \
+        boost-multiprecision \
+        boost-predef \
+        boost-regex \
+        boost-system \
         boost-variant \
-        boost-multiprecision
+        llvm
 
 # Install Java
 ARG java=1.8.0

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: macos-latest
     needs: [build-cpp-macos, build-cpp-ubuntu]
     steps:
-      {{ macros.github_checkout_arrow()|indent }}
+      {{ macros.github_checkout_arrow(fetch_depth=0)|indent }}
       - name: Download Linux C++ Libraries
         uses: actions/download-artifact@v2
         with:

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -25,13 +25,14 @@ on:
       - "*-github-*"
 {% endmacro %}
 
-{%- macro github_checkout_arrow() -%}
+{%- macro github_checkout_arrow(fetch_depth=1) -%}
   - name: Checkout Arrow
     uses: actions/checkout@v2
     with:
+      fetch-depth: {{ fetch_depth }}
+      path: arrow
       repository: {{ arrow.github_repo }}
       ref: {{ arrow.head }}
-      path: arrow
       submodules: recursive
 {% endmacro %}
 


### PR DESCRIPTION
Fix the broken nightly builds for the missing CRC dependency.