### PR TITLE
ARROW-15153: [Python] Expose ReferencedBufferSize to python

### DIFF
--- a/cpp/src/arrow/util/byte_size.h
+++ b/cpp/src/arrow/util/byte_size.h
@@ -65,7 +65,7 @@ Result<std::shared_ptr<Array>> ARROW_EXPORT ReferencedRanges(const ArrayData& ar
 /// offsets.
 ///
 /// If buffers are shared between arrays then the shared
-/// portion will only be counted multiple times.
+/// portion will be counted multiple times.
 ///
 /// Dictionary arrays will always be counted in their entirety
 /// even if the array only references a portion of the dictionary.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -988,12 +988,6 @@ cdef class Array(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Total number of bytes consumed by the elements of the array.
-        """
-        return self.get_referenced_buffer_size()
-
-    def get_referenced_buffer_size(self):
-        """
         Returns the sum of bytes from all buffer ranges referenced
 
         Unlike TotalBufferSize this method will account for array

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -996,6 +996,27 @@ cdef class Array(_PandasConvertible):
                 size += buf.size
         return size
 
+    def get_refererenced_buffer_size(self):
+        cdef:
+            shared_ptr[CArray] shd_ptr_c_array
+            CArray *c_array
+            CResult[int64_t] c_res_buffer
+        
+        shd_ptr_c_array = pyarrow_unwrap_array(self)
+        c_array = shd_ptr_c_array.get()
+        c_res_buffer = ReferencedBufferSize(c_array[0])
+        size = GetResultValue(c_res_buffer)
+        return size
+
+    @property
+    def get_buffer_size(self):
+        """
+        Number of bytes associated with the data buffer of the array
+        """
+        size = 0
+        size = self.get_refererenced_buffer_size()
+        return size
+
     def __sizeof__(self):
         return super(Array, self).__sizeof__() + self.nbytes
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -988,16 +988,19 @@ cdef class Array(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Returns the sum of bytes from all buffer ranges referenced
+        Total number of bytes consumed by the elements of the array.
 
-        Unlike TotalBufferSize this method will account for array
+        In other words, the sum of bytes from all buffer 
+        ranges referenced.
+
+        Unlike `get_total_buffer_size` this method will account for array
         offsets.
 
         If buffers are shared between arrays then the shared
         portion will be counted multiple times.
 
-        Dictionary arrays will always be counted in their entirety
-        even if the array only references a portion of the dictionary.
+        The dictionary of dictionary arrays will always be counted in their 
+        entirety even if the array only references a portion of the dictionary.
         """
         cdef:
             shared_ptr[CArray] shd_ptr_c_array
@@ -1012,7 +1015,7 @@ cdef class Array(_PandasConvertible):
 
     def get_total_buffer_size(self):
         """
-        The sum of bytes in each buffer referenced by the array
+        The sum of bytes in each buffer referenced by the array.
 
         An array may only reference a portion of a buffer.
         This method will overestimate in this case and return the

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1003,10 +1003,10 @@ cdef class Array(_PandasConvertible):
         entirety even if the array only references a portion of the dictionary.
         """
         cdef:
-            CResult[int64_t] c_res_buffer
+            CResult[int64_t] c_size_res
 
-        c_res_buffer = ReferencedBufferSize(deref(self.ap))
-        size = GetResultValue(c_res_buffer)
+        c_size_res = ReferencedBufferSize(deref(self.ap))
+        size = GetResultValue(c_size_res)
         return size
 
     def get_total_buffer_size(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -994,7 +994,7 @@ cdef class Array(_PandasConvertible):
         offsets.
 
         If buffers are shared between arrays then the shared
-        portion will only be counted multiple times.
+        portion will be counted multiple times.
 
         Dictionary arrays will always be counted in their entirety
         even if the array only references a portion of the dictionary.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -990,9 +990,9 @@ cdef class Array(_PandasConvertible):
         """
         Total number of bytes consumed by the elements of the array.
         """
-        return self.get_refererenced_buffer_size()
+        return self.get_referenced_buffer_size()
 
-    def get_refererenced_buffer_size(self):
+    def get_referenced_buffer_size(self):
         """
         Returns the sum of bytes from all buffer ranges referenced
 
@@ -1012,7 +1012,7 @@ cdef class Array(_PandasConvertible):
 
         shd_ptr_c_array = pyarrow_unwrap_array(self)
         c_array = shd_ptr_c_array.get()
-        c_res_buffer = ReferencedBufferSize(c_array[0])
+        c_res_buffer = ReferencedBufferSize(deref(c_array))
         size = GetResultValue(c_res_buffer)
         return size
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1003,13 +1003,9 @@ cdef class Array(_PandasConvertible):
         entirety even if the array only references a portion of the dictionary.
         """
         cdef:
-            shared_ptr[CArray] shd_ptr_c_array
-            CArray *c_array
             CResult[int64_t] c_res_buffer
 
-        shd_ptr_c_array = pyarrow_unwrap_array(self)
-        c_array = shd_ptr_c_array.get()
-        c_res_buffer = ReferencedBufferSize(deref(c_array))
+        c_res_buffer = ReferencedBufferSize(deref(self.ap))
         size = GetResultValue(c_res_buffer)
         return size
 
@@ -1025,13 +1021,9 @@ cdef class Array(_PandasConvertible):
         only be counted once.
         """
         cdef:
-            shared_ptr[CArray] shd_ptr_c_array
-            CArray *c_array
             int64_t total_buffer_size
 
-        shd_ptr_c_array = pyarrow_unwrap_array(self)
-        c_array = shd_ptr_c_array.get()
-        total_buffer_size = TotalBufferSize(c_array[0])
+        total_buffer_size = TotalBufferSize(deref(self.ap))
         return total_buffer_size
 
     def __sizeof__(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -992,17 +992,6 @@ cdef class Array(_PandasConvertible):
         """
         return self.get_refererenced_buffer_size()
 
-    def get_total_size_by_buffer(self):
-        """
-        Total size of the buffer calculated by the sum of all buffers 
-        in the array
-        """
-        size = 0
-        for buf in self.buffers():
-            if buf is not None:
-                size += buf.size
-        return size
-
     def get_refererenced_buffer_size(self):
         """
         Returns the sum of bytes from all buffer ranges referenced

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2768,7 +2768,6 @@ cdef extern from "arrow/python/gdb.h" namespace "arrow::gdb" nogil:
     void GdbTestSession "arrow::gdb::TestSession"()
 
 cdef extern from "arrow/util/byte_size.h" namespace "arrow::util" nogil:
-
     CResult[int64_t] ReferencedBufferSize(const CArray& array_data)
     CResult[int64_t] ReferencedBufferSize(const CRecordBatch& record_batch)
     CResult[int64_t] ReferencedBufferSize(const CChunkedArray& chunked_array)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2766,6 +2766,7 @@ cdef extern from "arrow/c/bridge.h" namespace "arrow" nogil:
 
 cdef extern from "arrow/python/gdb.h" namespace "arrow::gdb" nogil:
     void GdbTestSession "arrow::gdb::TestSession"()
-    
+
 cdef extern from "arrow/util/byte_size.h" namespace "arrow::util" nogil:
     CResult[int64_t] ReferencedBufferSize(const CArray& array_data)
+    int64_t TotalBufferSize(const CArray& array)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2766,3 +2766,6 @@ cdef extern from "arrow/c/bridge.h" namespace "arrow" nogil:
 
 cdef extern from "arrow/python/gdb.h" namespace "arrow::gdb" nogil:
     void GdbTestSession "arrow::gdb::TestSession"()
+    
+cdef extern from "arrow/util/byte_size.h" namespace "arrow::util" nogil:
+    CResult[int64_t] ReferencedBufferSize(const CArray& array_data)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2768,5 +2768,12 @@ cdef extern from "arrow/python/gdb.h" namespace "arrow::gdb" nogil:
     void GdbTestSession "arrow::gdb::TestSession"()
 
 cdef extern from "arrow/util/byte_size.h" namespace "arrow::util" nogil:
+
     CResult[int64_t] ReferencedBufferSize(const CArray& array_data)
+    CResult[int64_t] ReferencedBufferSize(const CRecordBatch& record_batch)
+    CResult[int64_t] ReferencedBufferSize(const CChunkedArray& chunked_array)
+    CResult[int64_t] ReferencedBufferSize(const CTable& table)
     int64_t TotalBufferSize(const CArray& array)
+    int64_t TotalBufferSize(const CChunkedArray& array)
+    int64_t TotalBufferSize(const CRecordBatch& record_batch)
+    int64_t TotalBufferSize(const CTable& table)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -144,12 +144,6 @@ cdef class ChunkedArray(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Total number of bytes consumed by the elements of the chunked array.
-        """
-        return self.get_referenced_buffer_size()
-
-    def get_referenced_buffer_size(self):
-        """
         Returns the sum of bytes from all buffer ranges referenced
 
         Unlike TotalBufferSize this method will account for array
@@ -962,12 +956,6 @@ cdef class RecordBatch(_PandasConvertible):
 
     @property
     def nbytes(self):
-        """
-        Total number of bytes consumed by the elements of the record batch.
-        """
-        return self.get_referenced_buffer_size()
-
-    def get_referenced_buffer_size(self):
         """
         Returns the sum of bytes from all buffer ranges referenced
 
@@ -2221,16 +2209,6 @@ cdef class Table(_PandasConvertible):
 
     @property
     def nbytes(self):
-        """
-        Total number of bytes consumed by the elements of the table.
-
-        Returns
-        -------
-        int
-        """
-        return self.get_referenced_buffer_size()
-
-    def get_referenced_buffer_size(self):
         """
         Returns the sum of bytes from all buffer ranges referenced
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -158,13 +158,9 @@ cdef class ChunkedArray(_PandasConvertible):
         entirety even if the array only references a portion of the dictionary.
         """
         cdef:
-            shared_ptr[CChunkedArray] shd_ptr_c_array
-            CChunkedArray *c_array
             CResult[int64_t] c_res_buffer
 
-        shd_ptr_c_array = pyarrow_unwrap_chunked_array(self)
-        c_array = shd_ptr_c_array.get()
-        c_res_buffer = ReferencedBufferSize(deref(c_array))
+        c_res_buffer = ReferencedBufferSize(deref(self.chunked_array))
         size = GetResultValue(c_res_buffer)
         return size
 
@@ -180,13 +176,9 @@ cdef class ChunkedArray(_PandasConvertible):
         only be counted once.
         """
         cdef:
-            shared_ptr[CChunkedArray] shd_ptr_c_array
-            CChunkedArray *c_array
             int64_t total_buffer_size
 
-        shd_ptr_c_array = pyarrow_unwrap_chunked_array(self)
-        c_array = shd_ptr_c_array.get()
-        total_buffer_size = TotalBufferSize(deref(c_array))
+        total_buffer_size = TotalBufferSize(deref(self.chunked_array))
         return total_buffer_size
 
     def __sizeof__(self):
@@ -973,13 +965,9 @@ cdef class RecordBatch(_PandasConvertible):
         entirety even if the array only references a portion of the dictionary.
         """
         cdef:
-            shared_ptr[CRecordBatch] shd_ptr_c_rb
-            CRecordBatch *c_rb
             CResult[int64_t] c_res_buffer
 
-        shd_ptr_c_rb = pyarrow_unwrap_batch(self)
-        c_rb = shd_ptr_c_rb.get()
-        c_res_buffer = ReferencedBufferSize(deref(c_rb))
+        c_res_buffer = ReferencedBufferSize(deref(self.batch))
         size = GetResultValue(c_res_buffer)
         return size
 
@@ -995,13 +983,9 @@ cdef class RecordBatch(_PandasConvertible):
         only be counted once.
         """
         cdef:
-            shared_ptr[CRecordBatch] shd_ptr_c_rb
-            CRecordBatch *c_rb
             int64_t total_buffer_size
 
-        shd_ptr_c_rb = pyarrow_unwrap_batch(self)
-        c_rb = shd_ptr_c_rb.get()
-        total_buffer_size = TotalBufferSize(deref(c_rb))
+        total_buffer_size = TotalBufferSize(deref(self.batch))
         return total_buffer_size
 
     def __sizeof__(self):
@@ -2228,13 +2212,9 @@ cdef class Table(_PandasConvertible):
         entirety even if the array only references a portion of the dictionary.
         """
         cdef:
-            shared_ptr[CTable] shd_ptr_table
-            CTable *c_table
             CResult[int64_t] c_res_buffer
 
-        shd_ptr_table = pyarrow_unwrap_table(self)
-        c_table = shd_ptr_table.get()
-        c_res_buffer = ReferencedBufferSize(deref(c_table))
+        c_res_buffer = ReferencedBufferSize(deref(self.table))
         size = GetResultValue(c_res_buffer)
         return size
 
@@ -2250,13 +2230,9 @@ cdef class Table(_PandasConvertible):
         only be counted once.
         """
         cdef:
-            shared_ptr[CTable] shd_ptr_table
-            CTable *c_table
             int64_t total_buffer_size
 
-        shd_ptr_table = pyarrow_unwrap_table(self)
-        c_table = shd_ptr_table.get()
-        total_buffer_size = TotalBufferSize(deref(c_table))
+        total_buffer_size = TotalBufferSize(deref(self.table))
         return total_buffer_size
 
     def __sizeof__(self):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -146,10 +146,56 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         Total number of bytes consumed by the elements of the chunked array.
         """
-        size = 0
-        for chunk in self.iterchunks():
-            size += chunk.nbytes
+        # size = 0
+        # for chunk in self.iterchunks():
+        #     size += chunk.nbytes
+        # return size
+        return self.get_refererenced_buffer_size()
+
+    def get_refererenced_buffer_size(self):
+        """
+        Returns the sum of bytes from all buffer ranges referenced
+
+        Unlike TotalBufferSize this method will account for array
+        offsets.
+
+        If buffers are shared between arrays then the shared
+        portion will only be counted multiple times.
+
+        Dictionary arrays will always be counted in their entirety
+        even if the array only references a portion of the dictionary.
+        """
+        cdef:
+            shared_ptr[CChunkedArray] shd_ptr_c_array
+            CChunkedArray *c_array
+            CResult[int64_t] c_res_buffer
+
+        shd_ptr_c_array = pyarrow_unwrap_chunked_array(self)
+        c_array = shd_ptr_c_array.get()
+        c_res_buffer = ReferencedBufferSize(deref(c_array))
+        size = GetResultValue(c_res_buffer)
         return size
+
+    def get_total_buffer_size(self):
+        """
+        The sum of bytes in each buffer referenced by the array
+
+        An array may only reference a portion of a buffer.
+        This method will overestimate in this case and return the
+        byte size of the entire buffer.
+
+        If a buffer is referenced multiple times then it will
+        only be counted once.
+        """
+        cdef:
+            shared_ptr[CChunkedArray] shd_ptr_c_array
+            CChunkedArray *c_array
+            int64_t total_buffer_size
+
+        shd_ptr_c_array = pyarrow_unwrap_chunked_array(self)
+        c_array = shd_ptr_c_array.get()
+        total_buffer_size = TotalBufferSize(deref(c_array))
+        return total_buffer_size
 
     def __sizeof__(self):
         return super(ChunkedArray, self).__sizeof__() + self.nbytes

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -146,10 +146,6 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         Total number of bytes consumed by the elements of the chunked array.
         """
-        # size = 0
-        # for chunk in self.iterchunks():
-        #     size += chunk.nbytes
-        # return size
         return self.get_referenced_buffer_size()
 
     def get_referenced_buffer_size(self):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -144,16 +144,18 @@ cdef class ChunkedArray(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Returns the sum of bytes from all buffer ranges referenced
+        Total number of bytes consumed by the elements of the chunked array.
 
-        Unlike TotalBufferSize this method will account for array
+        In other words, the sum of bytes from all buffer ranges referenced.
+
+        Unlike `get_total_buffer_size` this method will account for array
         offsets.
 
         If buffers are shared between arrays then the shared
         portion will only be counted multiple times.
 
-        Dictionary arrays will always be counted in their entirety
-        even if the array only references a portion of the dictionary.
+        The dictionary of dictionary arrays will always be counted in their 
+        entirety even if the array only references a portion of the dictionary.
         """
         cdef:
             shared_ptr[CChunkedArray] shd_ptr_c_array
@@ -168,7 +170,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
     def get_total_buffer_size(self):
         """
-        The sum of bytes in each buffer referenced by the array
+        The sum of bytes in each buffer referenced by the chunked array.
 
         An array may only reference a portion of a buffer.
         This method will overestimate in this case and return the
@@ -957,16 +959,18 @@ cdef class RecordBatch(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Returns the sum of bytes from all buffer ranges referenced
+        Total number of bytes consumed by the elements of the record batch.
 
-        Unlike TotalBufferSize this method will account for array
+        In other words, the sum of bytes from all buffer ranges referenced.
+
+        Unlike `get_total_buffer_size` this method will account for array
         offsets.
 
         If buffers are shared between arrays then the shared
         portion will only be counted multiple times.
 
-        Dictionary arrays will always be counted in their entirety
-        even if the array only references a portion of the dictionary.
+        The dictionary of dictionary arrays will always be counted in their
+        entirety even if the array only references a portion of the dictionary.
         """
         cdef:
             shared_ptr[CRecordBatch] shd_ptr_c_rb
@@ -981,7 +985,7 @@ cdef class RecordBatch(_PandasConvertible):
 
     def get_total_buffer_size(self):
         """
-        The sum of bytes in each buffer referenced by the array
+        The sum of bytes in each buffer referenced by the record batch
 
         An array may only reference a portion of a buffer.
         This method will overestimate in this case and return the
@@ -2210,16 +2214,18 @@ cdef class Table(_PandasConvertible):
     @property
     def nbytes(self):
         """
-        Returns the sum of bytes from all buffer ranges referenced
+        Total number of bytes consumed by the elements of the table.
 
-        Unlike TotalBufferSize this method will account for array
+        In other words, the sum of bytes from all buffer ranges referenced.
+
+        Unlike `get_total_buffer_size` this method will account for array
         offsets.
 
         If buffers are shared between arrays then the shared
         portion will only be counted multiple times.
 
-        Dictionary arrays will always be counted in their entirety
-        even if the array only references a portion of the dictionary.
+        The dictionary of dictionary arrays will always be counted in their
+        entirety even if the array only references a portion of the dictionary.
         """
         cdef:
             shared_ptr[CTable] shd_ptr_table
@@ -2234,7 +2240,7 @@ cdef class Table(_PandasConvertible):
 
     def get_total_buffer_size(self):
         """
-        The sum of bytes in each buffer referenced by the array
+        The sum of bytes in each buffer referenced by the table.
 
         An array may only reference a portion of a buffer.
         This method will overestimate in this case and return the

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2482,6 +2482,11 @@ def test_total_buffer_size():
     a = pa.array([[[5, 6, 7]], [[9, 10]]], type=pa.list_(pa.list_(pa.int8())))
     assert a.get_total_buffer_size() == (4 * 3) + (4 * 3) + (1 * 5)
     assert a.nbytes == 21
+    a = pa.array([[[1, 2], [3, 4]], [[5, 6, 7], None, [8]], [[9, 10]]],
+                 type=pa.list_(pa.list_(pa.int8())))
+    a1 = a.slice(1, 2)
+    assert a1.nbytes == (4 * 2) + 1 + (4 * 4) + (1 * 6)
+    assert a1.get_total_buffer_size() == (4 * 4) + 1 + (4 * 7) + (1 * 10)
 
 
 def test_nbytes_size():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2469,15 +2469,15 @@ def test_buffers_nested():
     assert struct.unpack('4xh', values) == (43,)
 
 
-def test_nbytes_sizeof():
+def test_nbytes_size_from_buffer():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
-    assert a.nbytes == 8 * 3
+    assert a.get_total_size_by_buffer() == 8 * 3
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([1, None, 3], type='int64')
-    assert a.nbytes == 8*3 + 1
+    assert a.get_total_size_by_buffer() == 8*3 + 1
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([[1, 2], None, [3, None, 4, 5]], type=pa.list_(pa.int64()))
-    assert a.nbytes == 1 + 4 * 4 + 1 + 6 * 8
+    assert a.get_total_size_by_buffer() == 1 + 4 * 4 + 1 + 6 * 8
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2471,12 +2471,15 @@ def test_buffers_nested():
 
 def test_total_buffer_size():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
+    assert a.nbytes == 8 * 3
     assert a.get_total_buffer_size() == 8 * 3
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([1, None, 3], type='int64')
+    assert a.nbytes == 8*3 + 1
     assert a.get_total_buffer_size() == 8*3 + 1
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([[1, 2], None, [3, None, 4, 5]], type=pa.list_(pa.int64()))
+    assert a.nbytes == 62
     assert a.get_total_buffer_size() == 1 + 4 * 4 + 1 + 6 * 8
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([[[5, 6, 7]], [[9, 10]]], type=pa.list_(pa.list_(pa.int8())))

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2469,16 +2469,22 @@ def test_buffers_nested():
     assert struct.unpack('4xh', values) == (43,)
 
 
-def test_nbytes_size_from_buffer():
+def test_total_buffer_size():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
-    assert a.get_total_size_by_buffer() == 8 * 3
+    assert a.get_total_buffer_size() == 8 * 3
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([1, None, 3], type='int64')
-    assert a.get_total_size_by_buffer() == 8*3 + 1
+    assert a.get_total_buffer_size() == 8*3 + 1
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
     a = pa.array([[1, 2], None, [3, None, 4, 5]], type=pa.list_(pa.int64()))
-    assert a.get_total_size_by_buffer() == 1 + 4 * 4 + 1 + 6 * 8
+    assert a.get_total_buffer_size() == 1 + 4 * 4 + 1 + 6 * 8
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
+
+
+def test_nbytes_size():
+    a = pa.chunked_array([pa.array([1, None, 3], type=pa.int16()),
+                          pa.array([4, 5, 6], type=pa.int16())])
+    assert a.nbytes == 13
 
 
 def test_invalid_tensor_constructor_repr():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2479,6 +2479,9 @@ def test_total_buffer_size():
     a = pa.array([[1, 2], None, [3, None, 4, 5]], type=pa.list_(pa.int64()))
     assert a.get_total_buffer_size() == 1 + 4 * 4 + 1 + 6 * 8
     assert sys.getsizeof(a) >= object.__sizeof__(a) + a.nbytes
+    a = pa.array([[[5, 6, 7]], [[9, 10]]], type=pa.list_(pa.list_(pa.int8())))
+    assert a.get_total_buffer_size() == (4 * 3) + (4 * 3) + (1 * 5)
+    assert a.nbytes == 21
 
 
 def test_nbytes_size():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -48,8 +48,11 @@ def test_chunked_array_basics():
     assert all(isinstance(c, pa.lib.Int64Array) for c in data.chunks)
     assert all(isinstance(c, pa.lib.Int64Array) for c in data.iterchunks())
     assert len(data.chunks) == 3
-    assert data.nbytes == sum(c.nbytes for c in data.iterchunks())
-    assert sys.getsizeof(data) >= object.__sizeof__(data) + data.nbytes
+    assert data.get_total_buffer_size() == sum(c.get_total_buffer_size()
+                                               for c in data.iterchunks())
+    assert sys.getsizeof(data) >= object.__sizeof__(
+        data) + data.get_total_buffer_size()
+    assert data.nbytes == 3 * 3 * 8  # 3 items per 3 lists with int64 size(8)
     data.validate()
 
     wr = weakref.ref(data)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -822,8 +822,10 @@ def test_table_basics():
     assert table.num_rows == 5
     assert table.num_columns == 2
     assert table.shape == (5, 2)
+    assert table.get_total_buffer_size() == 2 * (5 * 8)
     assert table.nbytes == 2 * (5 * 8)
-    assert sys.getsizeof(table) >= object.__sizeof__(table) + table.nbytes
+    assert sys.getsizeof(table) >= object.__sizeof__(
+        table) + table.get_total_buffer_size()
     pydict = table.to_pydict()
     assert pydict == OrderedDict([
         ('a', [0, 1, 2, 3, 4]),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -460,8 +460,10 @@ def test_recordbatch_basics():
     assert batch.num_rows == 5
     assert batch.num_columns == len(data)
     # (only the second array has a null bitmap)
-    assert batch.nbytes == (5 * 2) + (5 * 4 + 1)
-    assert sys.getsizeof(batch) >= object.__sizeof__(batch) + batch.nbytes
+    assert batch.get_total_buffer_size() == (5 * 2) + (5 * 4 + 1)
+    batch.nbytes == (5 * 2) + (5 * 4 + 1)
+    assert sys.getsizeof(batch) >= object.__sizeof__(
+        batch) + batch.get_total_buffer_size()
     pydict = batch.to_pydict()
     assert pydict == OrderedDict([
         ('c0', [0, 1, 2, 3, 4]),


### PR DESCRIPTION
## Notes on PR 

In this PR, I am working on exposing the ReferencedBufferSize as described here: https://issues.apache.org/jira/browse/ARROW-15065

In this working branch, I am addressing the ARROW-15135 issue (Python bindings) 

Currently this is *work in progress*, but created a draft PR after applying the expected functionality on Array interface where the buffer size is exposed using a new function. The idea is to differentiate the `nbytes` from the actual amount of bytes allocated for data. 

## Tasks

- [x] Figure out best location to place the bindings
- [x] Bindings for
     - [x] Table
     - [ ] ArrayData (N/A)
     - [x] ChunkedArray
     - [x] RecordBatch
- [x] Test cases

## Notes

Also exposed the `TotalBufferSize` function within the same PR. Not sure if that is okay. 
I included it since the issue has some relationship with the existing `nbytes` definition
and `TotalBufferSize` calculation method. 