### PR TITLE
[CPP] Add missing metadata on Arrow schemas returned by Flight SQL #11999 

### DIFF
--- a/cpp/src/arrow/flight/sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/CMakeLists.txt
@@ -36,8 +36,12 @@ set_source_files_properties(${FLIGHT_SQL_GENERATED_PROTO_FILES} PROPERTIES GENER
 
 add_custom_target(flight_sql_protobuf_gen ALL DEPENDS ${FLIGHT_SQL_GENERATED_PROTO_FILES})
 
-set(ARROW_FLIGHT_SQL_SRCS server.cc sql_info_internal.cc client.cc
-                          "${CMAKE_CURRENT_BINARY_DIR}/FlightSql.pb.cc")
+set(ARROW_FLIGHT_SQL_SRCS
+    server.cc
+    sql_info_internal.cc
+    column_metadata.cc
+    client.cc
+    "${CMAKE_CURRENT_BINARY_DIR}/FlightSql.pb.cc")
 
 add_arrow_lib(arrow_flight_sql
               CMAKE_PACKAGE_NAME

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -41,15 +41,15 @@ namespace arrow {
 namespace flight {
 namespace sql {
 
-const char* ColumnMetadata::CATALOG_NAME = "CATALOG_NAME";
-const char* ColumnMetadata::SCHEMA_NAME = "SCHEMA_NAME";
-const char* ColumnMetadata::TABLE_NAME = "TABLE_NAME";
-const char* ColumnMetadata::PRECISION = "PRECISION";
-const char* ColumnMetadata::SCALE = "SCALE";
-const char* ColumnMetadata::IS_AUTO_INCREMENT = "IS_AUTO_INCREMENT";
-const char* ColumnMetadata::IS_CASE_SENSITIVE = "IS_CASE_SENSITIVE";
-const char* ColumnMetadata::IS_READ_ONLY = "IS_READ_ONLY";
-const char* ColumnMetadata::IS_SEARCHABLE = "IS_SEARCHABLE";
+const char* ColumnMetadata::CATALOG_NAME = "ARROW:FLIGHT:SQL:CATALOG_NAME";
+const char* ColumnMetadata::SCHEMA_NAME = "ARROW:FLIGHT:SQL:SCHEMA_NAME";
+const char* ColumnMetadata::TABLE_NAME = "ARROW:FLIGHT:SQL:TABLE_NAME";
+const char* ColumnMetadata::PRECISION = "ARROW:FLIGHT:SQL:PRECISION";
+const char* ColumnMetadata::SCALE = "ARROW:FLIGHT:SQL:SCALE";
+const char* ColumnMetadata::IS_AUTO_INCREMENT = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
+const char* ColumnMetadata::IS_CASE_SENSITIVE = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE";
+const char* ColumnMetadata::IS_READ_ONLY = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
+const char* ColumnMetadata::IS_SEARCHABLE = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
 
 ColumnMetadata::ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map) :
   metadata_map_(std::move(metadata_map)) {

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -35,68 +35,73 @@ namespace {
            BOOLEAN_FALSE_STR;
   }
 
-const char* ColumnMetadata::CATALOG_NAME = "ARROW:FLIGHT:SQL:CATALOG_NAME";
-const char* ColumnMetadata::SCHEMA_NAME = "ARROW:FLIGHT:SQL:SCHEMA_NAME";
-const char* ColumnMetadata::TABLE_NAME = "ARROW:FLIGHT:SQL:TABLE_NAME";
-const char* ColumnMetadata::PRECISION = "ARROW:FLIGHT:SQL:PRECISION";
-const char* ColumnMetadata::SCALE = "ARROW:FLIGHT:SQL:SCALE";
-const char* ColumnMetadata::IS_AUTO_INCREMENT = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
-const char* ColumnMetadata::IS_CASE_SENSITIVE = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE";
-const char* ColumnMetadata::IS_READ_ONLY = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
-const char* ColumnMetadata::IS_SEARCHABLE = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
+  bool StringToBoolean(const std::string& string_value) {
+    return string_value == BOOLEAN_TRUE_STR;
+  }
+}  // namespace
+
+const char* ColumnMetadata::kCatalogName = "ARROW:FLIGHT:SQL:CATALOG_NAME";
+const char* ColumnMetadata::kSchemaName = "ARROW:FLIGHT:SQL:SCHEMA_NAME";
+const char* ColumnMetadata::kTableName = "ARROW:FLIGHT:SQL:TABLE_NAME";
+const char* ColumnMetadata::kPrecision = "ARROW:FLIGHT:SQL:PRECISION";
+const char* ColumnMetadata::kScale = "ARROW:FLIGHT:SQL:SCALE";
+const char* ColumnMetadata::kIsAutoIncrement = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
+const char* ColumnMetadata::kIsCaseSensitive = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE";
+const char* ColumnMetadata::kIsReadOnly = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
+const char* ColumnMetadata::kIsSearchable = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
 
 ColumnMetadata::ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map) :
   metadata_map_(std::move(metadata_map)) {
 }
 
-arrow::Result<std::string> ColumnMetadata::GetCatalogName() {
-  return metadata_map_->Get(CATALOG_NAME);
+arrow::Result<std::string> ColumnMetadata::GetCatalogName() const {
+  return metadata_map_->Get(kCatalogName);
 }
 
-arrow::Result<std::string> ColumnMetadata::GetSchemaName() {
-  return metadata_map_->Get(SCHEMA_NAME);
+arrow::Result<std::string> ColumnMetadata::GetSchemaName() const {
+  return metadata_map_->Get(kSchemaName);
 }
 
-arrow::Result<std::string> ColumnMetadata::GetTableName() {
-  return metadata_map_->Get(TABLE_NAME);
+arrow::Result<std::string> ColumnMetadata::GetTableName() const {
+  return metadata_map_->Get(kTableName);
 }
 
-arrow::Result<int32_t> ColumnMetadata::GetPrecision() {
-  const Result <std::string> &result = metadata_map_->Get(PRECISION);
+arrow::Result<int32_t> ColumnMetadata::GetPrecision() const {
+  const Result <std::string> &result = metadata_map_->Get(kPrecision);
   std::string precision_string;
   ARROW_ASSIGN_OR_RAISE(precision_string, result);
 
   return std::stoi(precision_string);
 }
 
-arrow::Result<int32_t> ColumnMetadata::GetScale() {
+arrow::Result<int32_t> ColumnMetadata::GetScale() const {
   std::string scale_string;
-  ARROW_ASSIGN_OR_RAISE(scale_string, metadata_map_->Get(SCALE));
+  ARROW_ASSIGN_OR_RAISE(scale_string, metadata_map_->Get(kScale));
 
   return std::stoi(scale_string);
 }
 
-arrow::Result<bool> ColumnMetadata::GetIsAutoIncrement() {
+arrow::Result<bool> ColumnMetadata::GetIsAutoIncrement() const {
   std::string auto_increment_string;
-  ARROW_ASSIGN_OR_RAISE(auto_increment_string, metadata_map_->Get(IS_AUTO_INCREMENT));
+  ARROW_ASSIGN_OR_RAISE(auto_increment_string, metadata_map_->Get(kIsAutoIncrement));
   return StringToBoolean(auto_increment_string);
 }
 
-arrow::Result<bool> ColumnMetadata::GetIsCaseSensitive() {
+arrow::Result<bool> ColumnMetadata::GetIsCaseSensitive() const {
   std::string is_case_sensitive;
-  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(IS_AUTO_INCREMENT));
+  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(kIsAutoIncrement));
   return StringToBoolean(is_case_sensitive);
 }
 
-arrow::Result<bool> ColumnMetadata::GetIsReadOnly() {
+arrow::Result<bool> ColumnMetadata::GetIsReadOnly() const {
   std::string is_read_only;
-  ARROW_ASSIGN_OR_RAISE(is_read_only, metadata_map_->Get(IS_AUTO_INCREMENT));
+  ARROW_ASSIGN_OR_RAISE(is_read_only, metadata_map_->Get(kIsAutoIncrement));
   return StringToBoolean(is_read_only);
 }
 
-arrow::Result<bool> ColumnMetadata::GetIsSearchable() {
+arrow::Result<bool> ColumnMetadata::GetIsSearchable() const {
   std::string is_case_sensitive;
-  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(IS_AUTO_INCREMENT));
+  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(kIsAutoIncrement));
   return StringToBoolean(is_case_sensitive);
 }
 
@@ -111,61 +116,61 @@ std::shared_ptr<arrow::KeyValueMetadata> ColumnMetadata::GetMetadataMap() const 
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::CatalogName(std::string &catalog_name) {
-  metadata_map_->Append(ColumnMetadata::CATALOG_NAME, catalog_name);
+  metadata_map_->Append(ColumnMetadata::kCatalogName, catalog_name);
   return *this;
 }
 
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::SchemaName(std::string &schema_name) {
-  metadata_map_->Append(ColumnMetadata::SCHEMA_NAME, schema_name);
+  metadata_map_->Append(ColumnMetadata::kSchemaName, schema_name);
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::TableName(std::string &table_name) {
-  metadata_map_->Append(ColumnMetadata::TABLE_NAME, table_name);
+  metadata_map_->Append(ColumnMetadata::kTableName, table_name);
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::Precision(int32_t precision) {
   metadata_map_->Append(
-    ColumnMetadata::PRECISION, std::to_string(precision));
+    ColumnMetadata::kPrecision, std::to_string(precision));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::Scale(int32_t scale) {
   metadata_map_->Append(
-    ColumnMetadata::SCALE, std::to_string(scale));
+    ColumnMetadata::kScale, std::to_string(scale));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder &
 ColumnMetadata::ColumnMetadataBuilder::IsAutoIncrement(bool is_auto_increment) {
-  metadata_map_->Append(ColumnMetadata::IS_AUTO_INCREMENT,
+  metadata_map_->Append(ColumnMetadata::kIsAutoIncrement,
                                             BooleanToString(is_auto_increment));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder &
 ColumnMetadata::ColumnMetadataBuilder::IsCaseSensitive(bool is_case_sensitive) {
-  metadata_map_->Append(ColumnMetadata::IS_CASE_SENSITIVE,
+  metadata_map_->Append(ColumnMetadata::kIsCaseSensitive,
                                             BooleanToString(is_case_sensitive));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::IsReadOnly(bool is_read_only) {
-  metadata_map_->Append(ColumnMetadata::IS_READ_ONLY,
+  metadata_map_->Append(ColumnMetadata::kIsReadOnly,
                                             BooleanToString(is_read_only));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder
 &ColumnMetadata::ColumnMetadataBuilder::IsSearchable(bool is_searchable) {
-  metadata_map_->Append(ColumnMetadata::IS_SEARCHABLE,
+  metadata_map_->Append(ColumnMetadata::kIsSearchable,
                                             BooleanToString(is_searchable));
   return *this;
 }

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -19,6 +19,9 @@
 
 #include <utility>
 
+namespace arrow {
+namespace flight {
+namespace sql {
 namespace {
   /// \brief Constant variable used to convert boolean true value
   ///        to a string.
@@ -31,15 +34,6 @@ namespace {
     return boolean_value ? BOOLEAN_TRUE_STR :
            BOOLEAN_FALSE_STR;
   }
-
-  bool StringToBoolean(const std::string& string_value) {
-    return string_value == BOOLEAN_TRUE_STR;
-  }
-}  // namespace
-
-namespace arrow {
-namespace flight {
-namespace sql {
 
 const char* ColumnMetadata::CATALOG_NAME = "ARROW:FLIGHT:SQL:CATALOG_NAME";
 const char* ColumnMetadata::SCHEMA_NAME = "ARROW:FLIGHT:SQL:SCHEMA_NAME";

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/sql/column_metadata.h"
+
+#include <utility>
+
+namespace {
+  /// \brief Constant variable used to convert boolean true value
+  ///        to a string.
+  const char* BOOLEAN_TRUE_STR = "YES";
+  /// \brief Constant variable used to convert boolean false value
+  ///        to a string.
+  const char* BOOLEAN_FALSE_STR = "NO";
+
+  std::string BooleanToString(bool boolean_value) {
+    return boolean_value ? BOOLEAN_TRUE_STR :
+           BOOLEAN_FALSE_STR;
+  }
+
+  bool StringToBoolean(const std::string& string_value) {
+    return string_value == BOOLEAN_TRUE_STR;
+  }
+}  // namespace
+
+namespace arrow {
+namespace flight {
+namespace sql {
+
+const char* ColumnMetadata::CATALOG_NAME = "CATALOG_NAME";
+const char* ColumnMetadata::SCHEMA_NAME = "SCHEMA_NAME";
+const char* ColumnMetadata::TABLE_NAME = "TABLE_NAME";
+const char* ColumnMetadata::PRECISION = "PRECISION";
+const char* ColumnMetadata::SCALE = "SCALE";
+const char* ColumnMetadata::IS_AUTO_INCREMENT = "IS_AUTO_INCREMENT";
+const char* ColumnMetadata::IS_CASE_SENSITIVE = "IS_CASE_SENSITIVE";
+const char* ColumnMetadata::IS_READ_ONLY = "IS_READ_ONLY";
+const char* ColumnMetadata::IS_SEARCHABLE = "IS_SEARCHABLE";
+
+ColumnMetadata::ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map) :
+  metadata_map_(std::move(metadata_map)) {
+}
+
+arrow::Result<std::string> ColumnMetadata::GetCatalogName() {
+  return metadata_map_->Get(CATALOG_NAME);
+}
+
+arrow::Result<std::string> ColumnMetadata::GetSchemaName() {
+  return metadata_map_->Get(SCHEMA_NAME);
+}
+
+arrow::Result<std::string> ColumnMetadata::GetTableName() {
+  return metadata_map_->Get(TABLE_NAME);
+}
+
+arrow::Result<int32_t> ColumnMetadata::GetPrecision() {
+  const Result <std::string> &result = metadata_map_->Get(PRECISION);
+  std::string precision_string;
+  ARROW_ASSIGN_OR_RAISE(precision_string, result);
+
+  return std::stoi(precision_string);
+}
+
+arrow::Result<int32_t> ColumnMetadata::GetScale() {
+  std::string scale_string;
+  ARROW_ASSIGN_OR_RAISE(scale_string, metadata_map_->Get(SCALE));
+
+  return std::stoi(scale_string);
+}
+
+arrow::Result<bool> ColumnMetadata::GetIsAutoIncrement() {
+  std::string auto_increment_string;
+  ARROW_ASSIGN_OR_RAISE(auto_increment_string, metadata_map_->Get(IS_AUTO_INCREMENT));
+  return StringToBoolean(auto_increment_string);
+}
+
+arrow::Result<bool> ColumnMetadata::GetIsCaseSensitive() {
+  std::string is_case_sensitive;
+  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(IS_AUTO_INCREMENT));
+  return StringToBoolean(is_case_sensitive);
+}
+
+arrow::Result<bool> ColumnMetadata::GetIsReadOnly() {
+  std::string is_read_only;
+  ARROW_ASSIGN_OR_RAISE(is_read_only, metadata_map_->Get(IS_AUTO_INCREMENT));
+  return StringToBoolean(is_read_only);
+}
+
+arrow::Result<bool> ColumnMetadata::GetIsSearchable() {
+  std::string is_case_sensitive;
+  ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(IS_AUTO_INCREMENT));
+  return StringToBoolean(is_case_sensitive);
+}
+
+ColumnMetadata::ColumnMetadataBuilder ColumnMetadata::Builder() {
+  const ColumnMetadataBuilder &builder = ColumnMetadataBuilder{};
+  return builder;
+}
+
+std::shared_ptr<arrow::KeyValueMetadata> ColumnMetadata::GetMetadataMap() const {
+  return metadata_map_;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::CatalogName(std::string &catalog_name) {
+  metadata_map_->Append(ColumnMetadata::CATALOG_NAME, catalog_name);
+  return *this;
+}
+
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::SchemaName(std::string &schema_name) {
+  metadata_map_->Append(ColumnMetadata::SCHEMA_NAME, schema_name);
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::TableName(std::string &table_name) {
+  metadata_map_->Append(ColumnMetadata::TABLE_NAME, table_name);
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::Precision(int32_t precision) {
+  metadata_map_->Append(
+    ColumnMetadata::PRECISION, std::to_string(precision));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::Scale(int32_t scale) {
+  metadata_map_->Append(
+    ColumnMetadata::SCALE, std::to_string(scale));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder &
+ColumnMetadata::ColumnMetadataBuilder::IsAutoIncrement(bool is_auto_increment) {
+  metadata_map_->Append(ColumnMetadata::IS_AUTO_INCREMENT,
+                                            BooleanToString(is_auto_increment));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder &
+ColumnMetadata::ColumnMetadataBuilder::IsCaseSensitive(bool is_case_sensitive) {
+  metadata_map_->Append(ColumnMetadata::IS_CASE_SENSITIVE,
+                                            BooleanToString(is_case_sensitive));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::IsReadOnly(bool is_read_only) {
+  metadata_map_->Append(ColumnMetadata::IS_READ_ONLY,
+                                            BooleanToString(is_read_only));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder
+&ColumnMetadata::ColumnMetadataBuilder::IsSearchable(bool is_searchable) {
+  metadata_map_->Append(ColumnMetadata::IS_SEARCHABLE,
+                                            BooleanToString(is_searchable));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder::ColumnMetadataBuilder() : metadata_map_(
+  std::make_shared<arrow::KeyValueMetadata>()) {
+}
+
+ColumnMetadata ColumnMetadata::ColumnMetadataBuilder::Build() const {
+  return ColumnMetadata{metadata_map_};
+}
+}  // namespace sql
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -36,70 +36,70 @@ class ColumnMetadata {
 
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* CATALOG_NAME;
+  static const char* kCatalogName;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* SCHEMA_NAME;
+  static const char* kSchemaName;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* TABLE_NAME;
+  static const char* kTableName;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* PRECISION;
+  static const char* kPrecision;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* SCALE;
+  static const char* kScale;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* IS_AUTO_INCREMENT;
+  static const char* kIsAutoIncrement;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* IS_CASE_SENSITIVE;
+  static const char* kIsCaseSensitive;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* IS_READ_ONLY;
+  static const char* kIsReadOnly;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
-  static const char* IS_SEARCHABLE;
+  static const char* kIsSearchable;
 
   /// \brief Static initializer.
   static ColumnMetadataBuilder Builder();
 
   /// \brief  Return the catalog name set in the KeyValueMetadata.
   /// \return The catalog name.
-  arrow::Result<std::string> GetCatalogName();
+  arrow::Result<std::string> GetCatalogName() const;
 
   /// \brief  Return the schema name set in the KeyValueMetadata.
   /// \return The schema name.
-  arrow::Result<std::string> GetSchemaName();
+  arrow::Result<std::string> GetSchemaName() const;
 
   /// \brief  Return the table name set in the KeyValueMetadata.
   /// \return The table name.
-  arrow::Result<std::string> GetTableName();
+  arrow::Result<std::string> GetTableName() const;
 
   /// \brief  Return the precision set in the KeyValueMetadata.
   /// \return The precision.
-  arrow::Result<int32_t> GetPrecision();
+  arrow::Result<int32_t> GetPrecision() const;
 
   /// \brief  Return the scale set in the KeyValueMetadata.
   /// \return The scale.
-  arrow::Result<int32_t> GetScale();
+  arrow::Result<int32_t> GetScale() const;
 
   /// \brief  Return the IsAutoIncrement set in the KeyValueMetadata.
   /// \return The IsAutoIncrement.
-  arrow::Result<bool> GetIsAutoIncrement();
+  arrow::Result<bool> GetIsAutoIncrement() const;
 
   /// \brief  Return the IsCaseSensitive set in the KeyValueMetadata.
   /// \return The IsCaseSensitive.
-  arrow::Result<bool> GetIsCaseSensitive();
+  arrow::Result<bool> GetIsCaseSensitive() const;
 
   /// \brief  Return the IsReadOnly set in the KeyValueMetadata.
   /// \return The IsReadOnly.
-  arrow::Result<bool> GetIsReadOnly();
+  arrow::Result<bool> GetIsReadOnly() const;
 
   /// \brief  Return the IsSearchable set in the KeyValueMetadata.
   /// \return The IsSearchable.
-  arrow::Result<bool> GetIsSearchable();
+  arrow::Result<bool> GetIsSearchable() const;
 
   /// \brief  Return the KeyValueMetadata.
   /// \return The KeyValueMetadata.

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include "arrow/util/key_value_metadata.h"
+
+namespace arrow {
+namespace flight {
+namespace sql {
+
+/// \brief Helper class to set column metadata.
+class ColumnMetadata {
+ private:
+  std::shared_ptr<arrow::KeyValueMetadata> metadata_map_;
+  explicit ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map);
+
+ public:
+  class ColumnMetadataBuilder;
+
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* CATALOG_NAME;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* SCHEMA_NAME;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* TABLE_NAME;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* PRECISION;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* SCALE;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* IS_AUTO_INCREMENT;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* IS_CASE_SENSITIVE;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* IS_READ_ONLY;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* IS_SEARCHABLE;
+
+  /// \brief Static initializer.
+  static ColumnMetadataBuilder Builder();
+
+  /// \brief  Return the catalog name set in the KeyValueMetadata.
+  /// \return The catalog name.
+  arrow::Result<std::string> GetCatalogName();
+
+  /// \brief  Return the schema name set in the KeyValueMetadata.
+  /// \return The schema name.
+  arrow::Result<std::string> GetSchemaName();
+
+  /// \brief  Return the table name set in the KeyValueMetadata.
+  /// \return The table name.
+  arrow::Result<std::string> GetTableName();
+
+  /// \brief  Return the precision set in the KeyValueMetadata.
+  /// \return The precision.
+  arrow::Result<int32_t> GetPrecision();
+
+  /// \brief  Return the scale set in the KeyValueMetadata.
+  /// \return The scale.
+  arrow::Result<int32_t> GetScale();
+
+  /// \brief  Return the IsAutoIncrement set in the KeyValueMetadata.
+  /// \return The IsAutoIncrement.
+  arrow::Result<bool> GetIsAutoIncrement();
+
+  /// \brief  Return the IsCaseSensitive set in the KeyValueMetadata.
+  /// \return The IsCaseSensitive.
+  arrow::Result<bool> GetIsCaseSensitive();
+
+  /// \brief  Return the IsReadOnly set in the KeyValueMetadata.
+  /// \return The IsReadOnly.
+  arrow::Result<bool> GetIsReadOnly();
+
+  /// \brief  Return the IsSearchable set in the KeyValueMetadata.
+  /// \return The IsSearchable.
+  arrow::Result<bool> GetIsSearchable();
+
+  /// \brief  Return the KeyValueMetadata.
+  /// \return The KeyValueMetadata.
+  std::shared_ptr<arrow::KeyValueMetadata> GetMetadataMap() const;
+
+  /// \brief A builder class to construct the ColumnMetadata object.
+  class ColumnMetadataBuilder {
+    std::shared_ptr<arrow::KeyValueMetadata> metadata_map_;
+
+    /// \brief Default constructor.
+    ColumnMetadataBuilder();
+
+   public:
+    friend class ColumnMetadata;
+
+    /// \brief Set the catalog name in the KeyValueMetadata object.
+    /// \param[in] catalog_name The catalog name.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& CatalogName(std::string &catalog_name);
+
+    /// \brief Set the schema_name in the KeyValueMetadata object.
+    /// \param[in] schema_name The schema_name.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& SchemaName(std::string& schema_name);
+
+    /// \brief Set the table name in the KeyValueMetadata object.
+    /// \param[in] table_name The table name.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& TableName(std::string& table_name);
+
+    /// \brief Set the precision in the KeyValueMetadata object.
+    /// \param[in] precision    The precision.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& Precision(int32_t precision);
+
+    /// \brief Set the scale in the KeyValueMetadata object.
+    /// \param[in] scale  The scale.
+    /// \return           A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& Scale(int32_t scale);
+
+    /// \brief Set the IsAutoIncrement in the KeyValueMetadata object.
+    /// \param[in] IsAutoIncrement  The IsAutoIncrement.
+    /// \return                     A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& IsAutoIncrement(bool is_auto_increment);
+
+    /// \brief Set the IsCaseSensitive in the KeyValueMetadata object.
+    /// \param[in] IsCaseSensitive The IsCaseSensitive.
+    /// \return                    A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& IsCaseSensitive(bool is_case_sensitive);
+
+    /// \brief Set the IsReadOnly in the KeyValueMetadata object.
+    /// \param[in] IsReadOnly   The IsReadOnly.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& IsReadOnly(bool is_read_only);
+
+    /// \brief Set the IsSearchable in the KeyValueMetadata object.
+    /// \param[in] IsSearchable The IsSearchable.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& IsSearchable(bool is_searchable);
+
+    ColumnMetadata Build() const;
+  };
+};
+}  // namespace sql
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -215,6 +215,27 @@ std::shared_ptr<DataType> GetArrowType(const char* sqlite_type) {
   }
 }
 
+int32_t GetSqlTypeFromTypeName(const char* sqlite_type) {
+  if (sqlite_type == NULLPTR) {
+    // SQLite may not know the column type yet.
+    return SQLITE_NULL;
+  }
+
+  if (boost::iequals(sqlite_type, "int") || boost::iequals(sqlite_type, "integer")) {
+    return SQLITE_INTEGER;
+  } else if (boost::iequals(sqlite_type, "REAL")) {
+    return SQLITE_FLOAT;
+  } else if (boost::iequals(sqlite_type, "BLOB")) {
+    return SQLITE_BLOB;
+  } else if (boost::iequals(sqlite_type, "TEXT") ||
+             boost::istarts_with(sqlite_type, "char") ||
+             boost::istarts_with(sqlite_type, "varchar")) {
+    return SQLITE_TEXT;
+  } else {
+    return SQLITE_NULL;
+  }
+}
+
 class SQLiteFlightSqlServer::Impl {
   sqlite3* db_;
   std::map<std::string, std::shared_ptr<SqliteStatement>> prepared_statements_;

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.h
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.h
@@ -37,6 +37,11 @@ namespace example {
 /// \return            The equivalent ArrowType.
 std::shared_ptr<DataType> GetArrowType(const char* sqlite_type);
 
+/// \brief Convert a column type name to SQLite type.
+/// \param type_name the type name.
+/// \return          The equivalent SQLite type.
+int32_t GetSqlTypeFromTypeName(const char* type_name);
+
 /// \brief  Get the DataType used when parameter type is not known.
 /// \return DataType used when parameter type is not known.
 inline std::shared_ptr<DataType> GetUnknownColumnDataType() {

--- a/cpp/src/arrow/flight/sql/example/sqlite_statement.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_statement.cc
@@ -21,6 +21,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "arrow/flight/sql/column_metadata.h"
 #include "arrow/flight/sql/example/sqlite_server.h"
 
 namespace arrow {
@@ -42,6 +43,37 @@ std::shared_ptr<DataType> GetDataTypeFromSqliteType(const int column_type) {
     default:
       return null();
   }
+}
+
+int32_t GetPrecisionFromColumn(int column_type) {
+  switch (column_type) {
+    case SQLITE_INTEGER:
+      return 10;
+    case SQLITE_FLOAT:
+      return 15;
+    case SQLITE_NULL:
+    default:
+      return 0;
+  }
+}
+
+ColumnMetadata GetColumnMetadata(int column_type, const char* table) {
+  ColumnMetadata::ColumnMetadataBuilder builder = ColumnMetadata::Builder();
+
+  builder.Scale(15)
+    .IsAutoIncrement(false)
+    .IsReadOnly(false);
+  if (table == NULLPTR) {
+    return builder.Build();
+  } else if (column_type == SQLITE_TEXT || column_type == SQLITE_BLOB) {
+    std::string table_name(table);
+    builder.TableName(table_name);
+  } else {
+    std::string table_name(table);
+      builder.TableName(table_name)
+      .Precision(GetPrecisionFromColumn(column_type));
+  }
+  return builder.Build();
 }
 
 arrow::Result<std::shared_ptr<SqliteStatement>> SqliteStatement::Create(
@@ -83,6 +115,7 @@ arrow::Result<std::shared_ptr<Schema>> SqliteStatement::GetSchema() const {
     // prepared statements, in this case it returns a dense_union type covering any type
     // SQLite supports.
     const int column_type = sqlite3_column_type(stmt_, i);
+    const char* table = sqlite3_column_table_name(stmt_, i);
     std::shared_ptr<DataType> data_type = GetDataTypeFromSqliteType(column_type);
     if (data_type->id() == Type::NA) {
       // Try to retrieve column type from sqlite3_column_decltype
@@ -95,8 +128,10 @@ arrow::Result<std::shared_ptr<Schema>> SqliteStatement::GetSchema() const {
         data_type = GetUnknownColumnDataType();
       }
     }
+    ColumnMetadata column_metadata = GetColumnMetadata(column_type, table);
 
-    fields.push_back(arrow::field(column_name, data_type));
+    fields.push_back(arrow::field(column_name, data_type,
+                                  column_metadata.GetMetadataMap()));
   }
 
   return arrow::schema(fields);

--- a/cpp/src/arrow/flight/sql/example/sqlite_statement.h
+++ b/cpp/src/arrow/flight/sql/example/sqlite_statement.h
@@ -22,12 +22,21 @@
 #include <memory>
 #include <string>
 
+#include "arrow/flight/sql/column_metadata.h"
 #include "arrow/type_fwd.h"
 
 namespace arrow {
 namespace flight {
 namespace sql {
 namespace example {
+
+
+/// \brief Create an object ColumnMetadata using the column type and
+///        table name.
+/// \param column_type  The SQLite type.
+/// \param table        The table name.
+/// \return             A Column Metadata object.
+ColumnMetadata GetColumnMetadata(int column_type, const char* table);
 
 class SqliteStatement {
  public:

--- a/cpp/src/arrow/flight/sql/example/sqlite_tables_schema_batch_reader.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_tables_schema_batch_reader.cc
@@ -21,6 +21,7 @@
 
 #include <sstream>
 
+#include "arrow/flight/sql/column_metadata.h"
 #include "arrow/flight/sql/example/sqlite_server.h"
 #include "arrow/flight/sql/example/sqlite_statement.h"
 #include "arrow/flight/sql/server.h"
@@ -77,8 +78,11 @@ Status SqliteTablesWithSchemaBatchReader::ReadNext(std::shared_ptr<RecordBatch>*
             sqlite3_column_text(schema_statement->GetSqlite3Stmt(), 2));
         int nullable = sqlite3_column_int(schema_statement->GetSqlite3Stmt(), 3);
 
+        const ColumnMetadata &column_metadata = GetColumnMetadata(
+          GetSqlTypeFromTypeName(column_type), sqlite_table_name.c_str());
         column_fields.push_back(
-            arrow::field(column_name, GetArrowType(column_type), nullable == 0, NULL));
+            arrow::field(column_name, GetArrowType(column_type),
+                         nullable == 0, column_metadata.GetMetadataMap()));
       }
     }
     const arrow::Result<std::shared_ptr<Buffer>>& value =

--- a/cpp/src/arrow/flight/sql/server_test.cc
+++ b/cpp/src/arrow/flight/sql/server_test.cc
@@ -21,6 +21,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <sqlite3.h>
+
 #include <condition_variable>
 #include <thread>
 
@@ -31,6 +33,7 @@
 #include "arrow/flight/test_util.h"
 #include "arrow/flight/types.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/flight/sql/column_metadata.h"
 
 using ::testing::_;
 using ::testing::Ref;
@@ -359,14 +362,25 @@ TEST_F(TestFlightSqlServer, TestCommandGetTablesWithIncludedSchemas) {
   std::shared_ptr<Table> table;
   ASSERT_OK(stream->ReadAll(&table));
 
+  const char* db_table_name = "intTable";
+
   const auto catalog_name = ArrayFromJSON(utf8(), R"([null])");
   const auto schema_name = ArrayFromJSON(utf8(), R"([null])");
   const auto table_name = ArrayFromJSON(utf8(), R"(["intTable"])");
   const auto table_type = ArrayFromJSON(utf8(), R"(["table"])");
 
   const std::shared_ptr<Schema> schema_table = arrow::schema(
-      {arrow::field("id", int64(), true), arrow::field("keyName", utf8(), true),
-       arrow::field("value", int64(), true), arrow::field("foreignId", int64(), true)});
+  {arrow::field("id", int64(), true,
+   example::GetColumnMetadata(SQLITE_INTEGER, db_table_name).GetMetadataMap()),
+   arrow::field("keyName", utf8(), true,
+                example::GetColumnMetadata(
+                  SQLITE_TEXT, db_table_name).GetMetadataMap()),
+   arrow::field("value", int64(), true,
+                example::GetColumnMetadata(
+                  SQLITE_INTEGER, db_table_name).GetMetadataMap()),
+   arrow::field("foreignId", int64(), true,
+                example::GetColumnMetadata(
+                  SQLITE_INTEGER, db_table_name).GetMetadataMap())});
 
   ASSERT_OK_AND_ASSIGN(auto schema_buffer, ipc::SerializeSchema(*schema_table));
 
@@ -403,7 +417,8 @@ TEST_F(TestFlightSqlServer, TestCommandGetDbSchemas) {
                        sql_client->GetDbSchemas(options, catalog, schema_filter_pattern));
 
   ASSERT_OK_AND_ASSIGN(auto stream,
-                       sql_client->DoGet({}, flight_info->endpoints()[0].ticket));
+                       sql_client->
+                       DoGet({}, flight_info->endpoints()[0].ticket));
 
   std::shared_ptr<Table> table;
   ASSERT_OK(stream->ReadAll(&table));
@@ -463,9 +478,22 @@ TEST_F(TestFlightSqlServer, TestCommandPreparedStatementQuery) {
   std::shared_ptr<Table> table;
   ASSERT_OK(stream->ReadAll(&table));
 
+  const char * db_table_name = "intTable";
+
   const std::shared_ptr<Schema>& expected_schema =
-      arrow::schema({arrow::field("id", int64()), arrow::field("keyName", utf8()),
-                     arrow::field("value", int64()), arrow::field("foreignId", int64())});
+      arrow::schema({
+        arrow::field("id", int64(),
+                     example::GetColumnMetadata(
+                       SQLITE_INTEGER, db_table_name).GetMetadataMap()),
+        arrow::field("keyName", utf8(),
+                     example::GetColumnMetadata(
+                       SQLITE_TEXT, db_table_name).GetMetadataMap()),
+        arrow::field("value", int64(),
+                     example::GetColumnMetadata(
+                       SQLITE_INTEGER, db_table_name).GetMetadataMap()),
+        arrow::field("foreignId", int64(),
+                     example::GetColumnMetadata(
+                       SQLITE_INTEGER, db_table_name).GetMetadataMap())});
 
   const auto id_array = ArrayFromJSON(int64(), R"([1, 2, 3, 4])");
   const auto keyname_array =

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -55,7 +55,7 @@ message CommandGetSqlInfo {
    * Initially, Flight SQL will support the following information types:
    * - Server Information - Range [0-500)
    * - Syntax Information - Range [500-1000)
-   * Range [0-10,000] is reserved for defaults (see SqlInfo enum for default options).
+   * Range [0-10,000) is reserved for defaults (see SqlInfo enum for default options).
    * Custom options should start at 10,000.
    *
    * If omitted, then all metadata will be retrieved.
@@ -934,15 +934,15 @@ message CommandGetDbSchemas {
  *                                           it is serialized as an IPC message.)
  * >
  * Fields on table_schema may contain the following metadata:
- *  - CATALOG_NAME      - Table's catalog name
- *  - SCHEMA_NAME       - Table's schema name
- *  - TABLE_NAME        - Table name
- *  - PRECISION         - Column precision/size
- *  - SCALE             - Column scale/decimal digits
- *  - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
- *  - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
- *  - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
- *  - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
+ *  - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+ *  - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+ *  - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+ *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits
+ *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+ *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+ *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+ *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
@@ -1273,15 +1273,15 @@ message ActionClosePreparedStatementRequest {
  * for the following RPC calls:
  *  - GetSchema: return the Arrow schema of the query.
  *    Fields on this schema may contain the following metadata:
- *     - CATALOG_NAME      - Table's catalog name
- *     - SCHEMA_NAME       - Table's schema name
- *     - TABLE_NAME        - Table name
- *     - PRECISION         - Column precision/size
- *     - SCALE             - Column scale/decimal digits
- *     - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
- *     - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
- *     - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
- *     - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+ *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+ *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+ *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits
+ *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1307,15 +1307,15 @@ message TicketStatementQuery {
  * the following RPC calls:
  *  - GetSchema: return the Arrow schema of the query.
  *    Fields on this schema may contain the following metadata:
- *     - CATALOG_NAME      - Table's catalog name
- *     - SCHEMA_NAME       - Table's schema name
- *     - TABLE_NAME        - Table name
- *     - PRECISION         - Column precision/size
- *     - SCALE             - Column scale/decimal digits
- *     - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
- *     - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
- *     - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
- *     - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
+ *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
+ *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
+ *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits
+ *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case sensitive, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
  *  - DoPut: bind parameter values. All of the bound parameter sets will be executed as a single atomic execution.
  *  - GetFlightInfo: execute the prepared statement instance.
  */

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -55,7 +55,7 @@ message CommandGetSqlInfo {
    * Initially, Flight SQL will support the following information types:
    * - Server Information - Range [0-500)
    * - Syntax Information - Range [500-1000)
-   * Range [0-10,000) is reserved for defaults (see SqlInfo enum for default options). 
+   * Range [0-10,000] is reserved for defaults (see SqlInfo enum for default options).
    * Custom options should start at 10,000.
    *
    * If omitted, then all metadata will be retrieved.
@@ -80,7 +80,7 @@ enum SqlInfo {
   // Retrieves a UTF-8 string with the Arrow format version of the Flight SQL Server.
   FLIGHT_SQL_SERVER_ARROW_VERSION = 2;
 
-  /* 
+  /*
    * Retrieves a boolean value indicating whether the Flight SQL Server is read only.
    *
    * Returns:
@@ -441,7 +441,7 @@ enum SqlInfo {
    * - return 3   (\b11)    => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS];
    * - return 4   (\b100)   => [SQL_SUBQUERIES_IN_INS];
    * - return 5   (\b101)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_INS];
-   * - return 6   (\b110)   => [SQL_SUBQUERIES_IN_INS, SQL_SUBQUERIES_IN_EXISTS];
+   * - return 6   (\b110)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS];
    * - return 7   (\b111)   => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_EXISTS, SQL_SUBQUERIES_IN_INS];
    * - return 8   (\b1000)  => [SQL_SUBQUERIES_IN_QUANTIFIEDS];
    * - return 9   (\b1001)  => [SQL_SUBQUERIES_IN_COMPARISONS, SQL_SUBQUERIES_IN_QUANTIFIEDS];
@@ -933,6 +933,16 @@ message CommandGetDbSchemas {
  *  [optional] table_schema: bytes not null (schema of the table as described in Schema.fbs::Schema,
  *                                           it is serialized as an IPC message.)
  * >
+ * Fields on table_schema may contain the following metadata:
+ *  - CATALOG_NAME      - Table's catalog name
+ *  - SCHEMA_NAME       - Table's schema name
+ *  - TABLE_NAME        - Table name
+ *  - PRECISION         - Column precision/size
+ *  - SCALE             - Column scale/decimal digits
+ *  - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
+ *  - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
+ *  - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
+ *  - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
@@ -1235,11 +1245,11 @@ message ActionCreatePreparedStatementResult {
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
 
-  // If a result set generating query was provided, dataset_schema contains the 
+  // If a result set generating query was provided, dataset_schema contains the
   // schema of the dataset as described in Schema.fbs::Schema, it is serialized as an IPC message.
   bytes dataset_schema = 2;
 
-  // If the query provided contained parameters, parameter_schema contains the 
+  // If the query provided contained parameters, parameter_schema contains the
   // schema of the expected parameters as described in Schema.fbs::Schema, it is serialized as an IPC message.
   bytes parameter_schema = 3;
 }
@@ -1262,6 +1272,16 @@ message ActionClosePreparedStatementRequest {
  * Represents a SQL query. Used in the command member of FlightDescriptor
  * for the following RPC calls:
  *  - GetSchema: return the Arrow schema of the query.
+ *    Fields on this schema may contain the following metadata:
+ *     - CATALOG_NAME      - Table's catalog name
+ *     - SCHEMA_NAME       - Table's schema name
+ *     - TABLE_NAME        - Table name
+ *     - PRECISION         - Column precision/size
+ *     - SCALE             - Column scale/decimal digits
+ *     - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
+ *     - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
+ *     - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
+ *     - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1285,6 +1305,17 @@ message TicketStatementQuery {
 /*
  * Represents an instance of executing a prepared statement. Used in the command member of FlightDescriptor for
  * the following RPC calls:
+ *  - GetSchema: return the Arrow schema of the query.
+ *    Fields on this schema may contain the following metadata:
+ *     - CATALOG_NAME      - Table's catalog name
+ *     - SCHEMA_NAME       - Table's schema name
+ *     - TABLE_NAME        - Table name
+ *     - PRECISION         - Column precision/size
+ *     - SCALE             - Column scale/decimal digits
+ *     - IS_AUTO_INCREMENT - "1" if column is auto incremented, "0" otherwise.
+ *     - IS_CASE_SENSITIVE - "1" if column is case sensitive, "0" otherwise.
+ *     - IS_READ_ONLY      - "1" if column is read only, "0" otherwise.
+ *     - IS_SEARCHABLE     - "1" if column is searchable, "0" otherwise.
  *  - DoPut: bind parameter values. All of the bound parameter sets will be executed as a single atomic execution.
  *  - GetFlightInfo: execute the prepared statement instance.
  */


### PR DESCRIPTION
This add an auxiliary class FlightSqlColumnMetadata meant to read and write known metadata for Arrow schema fields, such as CATALOG_NAME, SCHEMA_NAME, TABLE_NAME, PRECISION, SCALE, IS_AUTO_INCREMENT, IS_CASE_SENSITIVE, IS_READ_ONLY and IS_SEARCHABLE.