### PR TITLE
ARROW-15170 [R] ignore attributes when testing Array$create error messages

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -818,7 +818,7 @@ test_that("Array$create() should have helpful error", {
   # the captured conditions (errors) are not identical, but their messages should be
   expect_s3_class(a, "rlang_error")
   expect_s3_class(b, "simpleError")
-  expect_equal(a$message, b$message)
+  expect_equal(a$message, b$message, ignore_attr = TRUE)
 })
 
 test_that("Array$View() (ARROW-6542)", {


### PR DESCRIPTION
This addresses the failing tests (on CentOS and Windows) introduced by the `decimal256()` implementation (PR #11898).

The failure was due to a mismatch in names between `actual` and `expected`. On some systems one is an empty character vector, while the other one is `NULL`.