### PR TITLE
ARROW-15087: [Python][Docs] Document MapArray and update parent class to ListArray

### DIFF
--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -72,6 +72,7 @@ may expose data type-specific methods or properties.
    ListArray
    FixedSizeListArray
    LargeListArray
+   MapArray
    StructArray
    UnionArray
    ExtensionArray
@@ -123,5 +124,6 @@ classes may expose data type-specific methods or properties.
    DictionaryScalar
    ListScalar
    LargeListScalar
+   MapScalar
    StructScalar
    UnionScalar

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -52,7 +52,7 @@ array data. These include:
 * **Fixed-length primitive types**: numbers, booleans, date and times, fixed
   size binary, decimals, and other values that fit into a given number
 * **Variable-length primitive types**: binary, string
-* **Nested types**: list, struct, and union
+* **Nested types**: list, map, struct, and union
 * **Dictionary type**: An encoded categorical type (more on this later)
 
 Each logical data type in Arrow has a corresponding factory function for
@@ -90,7 +90,7 @@ user-defined metadata:
    f0.name
    f0.type
 
-Arrow supports **nested value types** like list, struct, and union. When
+Arrow supports **nested value types** like list, map, struct, and union. When
 creating these, you must pass types or fields to indicate the data types of the
 types' children. For example, we can define a list of int32 values with:
 
@@ -233,9 +233,15 @@ like lists:
 Struct arrays
 ~~~~~~~~~~~~~
 
-For other kinds of nested arrays, such as struct arrays, you currently need
-to pass the type explicitly.  Struct arrays can be initialized from a
-sequence of Python dicts or tuples:
+``pyarrow.array`` is able to infer the schema of a struct type from arrays of
+dictionaries:
+
+.. ipython:: python
+
+   pa.array([{'x': 1, 'y': True}, {'z': 3.4, 'x': 4}])
+
+Struct arrays can be initialized from a sequence of Python dicts or tuples. For tuples, 
+you must explicitly pass the type:
 
 .. ipython:: python
 
@@ -263,6 +269,32 @@ individual arrays, and no copy is involved:
    arr = pa.StructArray.from_arrays((xs, ys), names=('x', 'y'))
    arr.type
    arr
+
+Map arrays
+~~~~~~~~~~
+
+MapArrays can be constructed from lists of lists of tuples (key-item pairs), but only if
+the type is explicitly passed into :py:meth:`array`:
+
+.. ipython:: python
+
+   data = [[('x', 1), ('y', 0)], [('a', 2), ('b', 45)]]
+   ty = pa.map_(pa.string(), pa.int64())
+   pa.array(data, type=ty)
+
+MapArrays can also be constructed from offset, key, and item arrays. Offsets represent the 
+starting position of each map. Note that the :py:attr:`MapArray.keys` and :py:attr:`MapArray.items`
+properties give the *flattened* keys and items. To keep the keys and items associated to 
+their row, use the :py:meth:`ListArray.from_arrays` constructor with the 
+:py:attr:`MapArray.offsets` property.
+
+.. ipython:: python
+
+   arr = pa.MapArray.from_arrays([0, 2, 3], ['x', 'y', 'z'], [4, 5, 6])
+   arr.keys
+   arr.items
+   pa.ListArray.from_arrays(arr.offsets, arr.keys)
+   pa.ListArray.from_arrays(arr.offsets, arr.items)
 
 Union arrays
 ~~~~~~~~~~~~

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -273,8 +273,8 @@ individual arrays, and no copy is involved:
 Map arrays
 ~~~~~~~~~~
 
-MapArrays can be constructed from lists of lists of tuples (key-item pairs), but only if
-the type is explicitly passed into :py:meth:`array`:
+Map arrays can be constructed from lists of lists of tuples (key-item pairs), but only if
+the type is explicitly passed into :meth:`array`:
 
 .. ipython:: python
 
@@ -283,10 +283,10 @@ the type is explicitly passed into :py:meth:`array`:
    pa.array(data, type=ty)
 
 MapArrays can also be constructed from offset, key, and item arrays. Offsets represent the 
-starting position of each map. Note that the :py:attr:`MapArray.keys` and :py:attr:`MapArray.items`
+starting position of each map. Note that the :attr:`MapArray.keys` and :attr:`MapArray.items`
 properties give the *flattened* keys and items. To keep the keys and items associated to 
-their row, use the :py:meth:`ListArray.from_arrays` constructor with the 
-:py:attr:`MapArray.offsets` property.
+their row, use the :meth:`ListArray.from_arrays` constructor with the 
+:attr:`MapArray.offsets` property.
 
 .. ipython:: python
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1794,7 +1794,7 @@ cdef class LargeListArray(BaseListArray):
         return pyarrow_wrap_array((<CLargeListArray*> self.ap).offsets())
 
 
-cdef class MapArray(Array):
+cdef class MapArray(ListArray):
     """
     Concrete class for Arrow arrays of a map data type.
     """
@@ -1835,10 +1835,12 @@ cdef class MapArray(Array):
 
     @property
     def keys(self):
+        """Flattened array of keys across all maps in array"""
         return pyarrow_wrap_array((<CMapArray*> self.ap).keys())
 
     @property
     def items(self):
+        """Flattened array of items across all maps in array"""
         return pyarrow_wrap_array((<CMapArray*> self.ap).items())
 
 

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -370,7 +370,7 @@ cdef class LargeListArray(BaseListArray):
     pass
 
 
-cdef class MapArray(Array):
+cdef class MapArray(ListArray):
     pass
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2643,7 +2643,7 @@ def test_fixed_size_list_array_flatten():
     assert arr2.flatten().flatten().equals(arr0)
 
 
-def test_map_array_flatten():
+def test_map_array_values_offsets():
     ty = pa.map_(pa.utf8(), pa.int32())
     ty_values = pa.struct([pa.field("key", pa.utf8(), nullable=False),
                            pa.field("value", pa.int32())])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2643,6 +2643,30 @@ def test_fixed_size_list_array_flatten():
     assert arr2.flatten().flatten().equals(arr0)
 
 
+def test_map_array_flatten():
+    ty = pa.map_(pa.utf8(), pa.int32())
+    ty_values = pa.struct([pa.field("key", pa.utf8(), nullable=False),
+                           pa.field("value", pa.int32())])
+    a = pa.array([[('a', 1), ('b', 2)], [('c', 3)]], type=ty)
+
+    assert a.values.type.equals(ty_values)
+    assert a.values == pa.array([
+        {'key': 'a', 'value': 1},
+        {'key': 'b', 'value': 2},
+        {'key': 'c', 'value': 3},
+    ], type=ty_values)
+    assert a.keys.equals(pa.array(['a', 'b', 'c']))
+    assert a.items.equals(pa.array([1, 2, 3], type=pa.int32()))
+
+    assert pa.ListArray.from_arrays(a.offsets, a.keys).equals(
+        pa.array([['a', 'b'], ['c']]))
+    assert pa.ListArray.from_arrays(a.offsets, a.items).equals(
+        pa.array([[1, 2], [3]], type=pa.list_(pa.int32())))
+
+    with pytest.raises(NotImplementedError):
+        a.flatten()
+
+
 def test_struct_array_flatten():
     ty = pa.struct([pa.field('x', pa.int16()),
                     pa.field('y', pa.float32())])


### PR DESCRIPTION
## Summary of Changes

 * MapArray should inherit from ListArray to provide access to offsets property. (C++ class has this inheritance.)
 * Updated StructArray Python tutorial to indicate that schemas can now be inferred in some cases.
 * Create MapArray Python guide to show how to construct and access keys and items. I mention that the `keys` and `items` attributes are flattened, since that surprised me, and shows how to construct the ListArray containing keys and items.

