### PR TITLE
ARROW-6001 [Python]: Add from_pylist() and to_pylist() to pyarrow.Table to convert list of records

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1082,7 +1082,8 @@ cdef class RecordBatch(_PandasConvertible):
             names = index
         else:
             names = self.schema.names
-        pylist = [{column: pydict[column][row] if column in pydict else None for column in names} for row in range(self.num_rows)]
+        pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
+                  for row in range(self.num_rows)]
         return pylist
 
     def _to_pandas(self, options, **kwargs):
@@ -1999,7 +2000,8 @@ cdef class Table(_PandasConvertible):
             names = index
         else:
             names = self.schema.names
-        pylist = [{column: pydict[column][row] if column in pydict else None for column in names} for row in range(self.num_rows)]
+        pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
+                  for row in range(self.num_rows)]
         return pylist
 
     @property

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -690,14 +690,15 @@ cdef class RecordBatch(_PandasConvertible):
     @staticmethod
     def from_pylist(mapping, schema=None, metadata=None):
         """
-        Construct a RecordBatch from list of dictionary of rows.
+        Construct a RecordBatch from list of rows / dictionaries.
 
         Parameters
         ----------
         mapping : list of dicts of rows
             A mapping of strings to row values.
         schema : Schema, default None
-            If not passed, will be inferred from the Mapping values.
+            If not passed, will be inferred from the first row of the
+            mapping values.
         metadata : dict or Mapping, default None
             Optional metadata for the schema (if inferred).
 
@@ -1817,14 +1818,15 @@ cdef class Table(_PandasConvertible):
     @staticmethod
     def from_pylist(mapping, schema=None, metadata=None):
         """
-        Construct a Table from list of dictionary of rows.
+        Construct a Table from list of rows / dictionaries.
 
         Parameters
         ----------
         mapping : list of dicts of rows
             A mapping of strings to row values.
         schema : Schema, default None
-            If not passed, will be inferred from the Mapping values.
+            If not passed, will be inferred from the first row of the
+            mapping values.
         metadata : dict or Mapping, default None
             Optional metadata for the schema (if inferred).
 
@@ -2604,7 +2606,7 @@ def _from_pydict(cls, mapping, schema, metadata):
 
 def _from_pylist(cls, mapping, schema, metadata):
     """
-    Construct a Table/RecordBatch from list of dictionary of rows.
+    Construct a Table/RecordBatch from list of rows / dictionaries.
 
     Parameters
     ----------
@@ -2612,7 +2614,8 @@ def _from_pylist(cls, mapping, schema, metadata):
     mapping : list of dicts of rows
         A mapping of strings to row values.
     schema : Schema, default None
-        If not passed, will be inferred from the Mapping values.
+        If not passed, will be inferred from the first row of the
+        mapping values.
     metadata : dict or Mapping, default None
         Optional metadata for the schema (if inferred).
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1987,7 +1987,7 @@ cdef class Table(_PandasConvertible):
         """
         pydict = self.to_pydict()
         names = self.schema.names
-        pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
+        pylist = [{column: pydict[column][row] for column in names}
                   for row in range(self.num_rows)]
         return pylist
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1076,7 +1076,7 @@ cdef class RecordBatch(_PandasConvertible):
 
         pydict = self.to_pydict()
         names = self.schema.names
-        pylist = [{column: pydict[column][row] for column in names} 
+        pylist = [{column: pydict[column][row] for column in names}
                   for row in range(self.num_rows)]
         return pylist
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -676,13 +676,10 @@ cdef class RecordBatch(_PandasConvertible):
         --------
         >>> import pyarrow as pa
         >>> pydict = {'int': [1, 2], 'str': ['a', 'b']}
-        >>> pa.Table.from_pydict(pydict)
-        pyarrow.Table
+        >>> pa.RecordBatch.from_pydict(pydict)
+        pyarrow.RecordBatch
         int: int64
         str: string
-        ----
-        int: [[1,2]]
-        str: [["a","b"]]
         """
 
         return _from_pydict(cls=RecordBatch,
@@ -712,13 +709,10 @@ cdef class RecordBatch(_PandasConvertible):
         --------
         >>> import pyarrow as pa
         >>> pylist = [{'int': [1, 2]}, {'str': ['a', 'b']}]
-        >>> pa.Table.from_pylist(pylist)
-        pyarrow.Table
+        >>> pa.RecordBatch.from_pylist(pylist)
+        pyarrow.RecordBatch
         int: int64
         str: string
-        ----
-        int: [[1,2]]
-        str: [["a","b"]]
         """
 
         return _from_pylist(cls=RecordBatch,
@@ -1788,6 +1782,18 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pydict = {'int': [1, 2], 'str': ['a', 'b']}
+        >>> pa.Table.from_pydict(pydict)
+        pyarrow.Table
+        int: int64
+        str: string
+        ----
+        int: [[1,2]]
+        str: [["a","b"]]
         """
 
         return _from_pydict(cls=Table,
@@ -1812,6 +1818,18 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pylist = [{'int': [1, 2]}, {'str': ['a', 'b']}]
+        >>> pa.Table.from_pylist(pylist)
+        pyarrow.Table
+        int: int64
+        str: string
+        ----
+        int: [[1,2]]
+        str: [["a","b"]]
         """
 
         return _from_pylist(cls=Table,

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1076,7 +1076,7 @@ cdef class RecordBatch(_PandasConvertible):
 
         pydict = self.to_pydict()
         names = self.schema.names
-        pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
+        pylist = [{column: pydict[column][row] for column in names} 
                   for row in range(self.num_rows)]
         return pylist
 
@@ -2615,13 +2615,13 @@ def _from_pylist(cls, mapping, schema, metadata):
         if mapping:
             names = list(mapping[0].keys())
         for n in names:
-            v = [i[n] if n in i else None for i in mapping]
+            v = [row[n] if n in row else None for row in mapping]
             arrays.append(v)
         return cls.from_arrays(arrays, names, metadata=metadata)
     else:
         if isinstance(schema, Schema):
             for n in schema.names:
-                v = [i[n] if n in i else None for i in mapping]
+                v = [row[n] if n in row else None for row in mapping]
                 arrays.append(v)
             # Will raise if metadata is not None
             return cls.from_arrays(arrays, schema=schema, metadata=metadata)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1065,24 +1065,17 @@ cdef class RecordBatch(_PandasConvertible):
             entries.append((name, column))
         return ordered_dict(entries)
 
-    def to_pylist(self, index=None):
+    def to_pylist(self):
         """
-        Convert the RecordBatch to a list of dictionaries of rows.
-
-        Parameters
-        ----------
-        index: list
-            A list of column names to index.
+        Convert the RecordBatch to a list of rows / dictionaries.
 
         Returns
         -------
         list
         """
+
         pydict = self.to_pydict()
-        if index:
-            names = index
-        else:
-            names = self.schema.names
+        names = self.schema.names
         pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
                   for row in range(self.num_rows)]
         return pylist
@@ -1974,14 +1967,9 @@ cdef class Table(_PandasConvertible):
 
         return ordered_dict(entries)
 
-    def to_pylist(self, index=None):
+    def to_pylist(self):
         """
-        Convert the Table to a list of dictionaries of rows.
-
-        Parameters
-        ----------
-        index: list
-            A list of column names to index.
+        Convert the Table to a list of rows / dictionaries.
 
         Returns
         -------
@@ -1998,10 +1986,7 @@ cdef class Table(_PandasConvertible):
         [{'int': 1, 'str': 'a'}, {'int': 2, 'str': 'b'}]
         """
         pydict = self.to_pydict()
-        if index:
-            names = index
-        else:
-            names = self.schema.names
+        names = self.schema.names
         pylist = [{column: pydict[column][row] if column in pydict else None for column in names}
                   for row in range(self.num_rows)]
         return pylist

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1066,11 +1066,11 @@ cdef class RecordBatch(_PandasConvertible):
         -------
         list
         """
-        entries = []
-        for i in range(self.batch.num_columns()):
-            name = bytes(self.batch.column_name(i)).decode('utf8')
-            column = self[i].to_pylist()
-            entries.append({name: column})
+        if self.schema.names:
+            entries = [{column: self[column].to_pylist()}
+                       for column in self.schema.names]
+        else:
+            entries = []
         return entries
 
     def _to_pandas(self, options, **kwargs):
@@ -1977,16 +1977,11 @@ cdef class Table(_PandasConvertible):
         >>> table.to_pylist()
         [{'int': [1, 2]}, {'str': ['a', 'b']}]
         """
-        cdef:
-            size_t i
-            size_t num_columns = self.table.num_columns()
-            list entries = []
-            ChunkedArray column
-
-        for i in range(num_columns):
-            column = self.column(i)
-            entries.append({self.field(i).name: column.to_pylist()})
-
+        if self.schema.names:
+            entries = [{column: self[column].to_pylist()}
+                       for column in self.schema.names]
+        else:
+            entries = []
         return entries
 
     @property

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -671,6 +671,18 @@ cdef class RecordBatch(_PandasConvertible):
         Returns
         -------
         RecordBatch
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pydict = {'int': [1, 2], 'str': ['a', 'b']}
+        >>> pa.Table.from_pydict(pydict)
+        pyarrow.Table
+        int: int64
+        str: string
+        ----
+        int: [[1,2]]
+        str: [["a","b"]]
         """
 
         return _from_pydict(cls=RecordBatch,
@@ -695,6 +707,18 @@ cdef class RecordBatch(_PandasConvertible):
         Returns
         -------
         RecordBatch
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pylist = [{'int': [1, 2]}, {'str': ['a', 'b']}]
+        >>> pa.Table.from_pylist(pylist)
+        pyarrow.Table
+        int: int64
+        str: string
+        ----
+        int: [[1,2]]
+        str: [["a","b"]]
         """
 
         return _from_pylist(cls=RecordBatch,
@@ -1894,6 +1918,16 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         dict
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> table = pa.table([
+        ...     pa.array([1, 2]),
+        ...     pa.array(["a", "b"])
+        ... ], names=["int", "str"])
+        >>> table.to_pydict()
+        {'int': [1, 2], 'str': ['a', 'b']}
         """
         cdef:
             size_t i
@@ -1914,6 +1948,16 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         list
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> table = pa.table([
+        ...     pa.array([1, 2]),
+        ...     pa.array(["a", "b"])
+        ... ], names=["int", "str"])
+        >>> table.to_pylist()
+        [{'int': [1, 2]}, {'str': ['a', 'b']}]
         """
         cdef:
             size_t i

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2616,14 +2616,13 @@ def _from_pylist(cls, mapping, schema, metadata):
             names = list(mapping[0].keys())
         for n in names:
             v = [i[n] if n in i else None for i in mapping]
-            arrays.append(asarray(v))
+            arrays.append(v)
         return cls.from_arrays(arrays, names, metadata=metadata)
     else:
         if isinstance(schema, Schema):
             for n in schema.names:
                 v = [i[n] if n in i else None for i in mapping]
-                n_type = schema.types[schema.get_field_index(n)]
-                arrays.append(asarray(v, type=n_type))
+                arrays.append(v)
             # Will raise if metadata is not None
             return cls.from_arrays(arrays, schema=schema, metadata=metadata)
         else:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2627,7 +2627,8 @@ def _from_pylist(cls, mapping, schema, metadata):
         if mapping:
             names = list(mapping[0].keys())
         for n in names:
-            arrays.append(asarray([i[n] for i in mapping]))
+            v = [i[n] if n in i else None for i in mapping]
+            arrays.append(asarray(v))
         return cls.from_arrays(arrays, names, metadata=metadata)
     else:
         if isinstance(schema, Schema):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1541,6 +1541,29 @@ def test_table_from_pylist(cls):
     with pytest.raises(TypeError):
         cls.from_pylist([{'a': 1}, {'a': 2}, {'a': 3}], schema={})
 
+    # If the dictionaries of rows are not same length
+    data = [{'strs': '', 'floats': 4.5},
+            {'floats': 5},
+            {'strs': 'bar'}]
+    data2 = [{'strs': '', 'floats': 4.5},
+             {'strs': None, 'floats': 5},
+             {'strs': 'bar', 'floats': None}]
+    table = cls.from_pylist(data)
+    assert table.num_columns == 2
+    assert table.num_rows == 3
+    assert table.to_pylist() == data2
+
+    data = [{'strs': ''},
+            {'strs': 'foo', 'floats': 5},
+            {'floats': None}]
+    data2 = [{'strs': ''},
+             {'strs': 'foo'},
+             {'strs': None}]
+    table = cls.from_pylist(data)
+    assert table.num_columns == 1
+    assert table.num_rows == 3
+    assert table.to_pylist() == data2
+
 
 @pytest.mark.parametrize(
     ('cls'),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1490,7 +1490,9 @@ def test_table_from_pylist(cls):
     schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
 
     # With lists as values
-    data = [{'strs': '', 'floats': 4.5}, {'strs': 'foo', 'floats': 5}, {'strs': 'bar', 'floats': None}]
+    data = [{'strs': '', 'floats': 4.5},
+            {'strs': 'foo', 'floats': 5},
+            {'strs': 'bar', 'floats': None}]
     table = cls.from_pylist(data)
     assert table.num_columns == 2
     assert table.num_rows == 3
@@ -1526,10 +1528,12 @@ def test_table_from_pylist(cls):
                         ('d', pa.int16())
                         ])
     table = cls.from_pylist(
-            [{'a': 1, 'b': 3}, {'a': 2, 'b': 4}, {'a': 3, 'b': 5}],
-            schema=schema
-        )
-    data = [{'a': 1, 'c': None, 'd': None}, {'a': 2, 'c': None, 'd': None}, {'a': 3, 'c': None, 'd': None}]
+        [{'a': 1, 'b': 3}, {'a': 2, 'b': 4}, {'a': 3, 'b': 5}],
+        schema=schema
+    )
+    data = [{'a': 1, 'c': None, 'd': None},
+            {'a': 2, 'c': None, 'd': None},
+            {'a': 3, 'c': None, 'd': None}]
     assert table.schema == schema
     assert table.to_pylist() == data
 
@@ -1546,7 +1550,9 @@ def test_table_from_pylist(cls):
     ]
 )
 def test_table_to_pylist(cls):
-    data = [{'strs': '', 'floats': 4.5}, {'strs': 'foo', 'floats': 5}, {'strs': 'bar', 'floats': None}]
+    data = [{'strs': '', 'floats': 4.5},
+            {'strs': 'foo', 'floats': 5},
+            {'strs': 'bar', 'floats': None}]
 
     index = {'floats'}
     data_index = [{'floats': 4.5}, {'floats': 5}, {'floats': None}]
@@ -1554,7 +1560,9 @@ def test_table_to_pylist(cls):
     assert table.to_pylist(index=index) == data_index
 
     index = {'floats', 'bools'}
-    data_index= [{'floats': 4.5, 'bools': None}, {'floats': 5, 'bools': None}, {'floats': None, 'bools': None}]
+    data_index = [{'floats': 4.5, 'bools': None},
+                  {'floats': 5, 'bools': None},
+                  {'floats': None, 'bools': None}]
     table = cls.from_pylist(data)
     assert table.to_pylist(index=index) == data_index
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1565,31 +1565,6 @@ def test_table_from_pylist(cls):
     assert table.to_pylist() == data2
 
 
-@pytest.mark.parametrize(
-    ('cls'),
-    [
-        (pa.Table),
-        (pa.RecordBatch)
-    ]
-)
-def test_table_to_pylist(cls):
-    data = [{'strs': '', 'floats': 4.5},
-            {'strs': 'foo', 'floats': 5},
-            {'strs': 'bar', 'floats': None}]
-
-    index = {'floats'}
-    data_index = [{'floats': 4.5}, {'floats': 5}, {'floats': None}]
-    table = cls.from_pylist(data)
-    assert table.to_pylist(index=index) == data_index
-
-    index = {'floats', 'bools'}
-    data_index = [{'floats': 4.5, 'bools': None},
-                  {'floats': 5, 'bools': None},
-                  {'floats': None, 'bools': None}]
-    table = cls.from_pylist(data)
-    assert table.to_pylist(index=index) == data_index
-
-
 @pytest.mark.pandas
 def test_table_from_pandas_schema():
     # passed schema is source of truth for the columns

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1473,6 +1473,127 @@ def test_table_from_pydict_schema(data, klass):
     assert table.column_names == ['strs']
 
 
+@pytest.mark.parametrize(
+    ('cls'),
+    [
+        (pa.Table),
+        (pa.RecordBatch)
+    ]
+)
+def test_table_from_pylist(cls):
+    table = cls.from_pylist([])
+    assert table.num_columns == 0
+    assert table.num_rows == 0
+    assert table.schema == pa.schema([])
+    assert table.to_pylist() == []
+
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
+
+    # With lists as values
+    data = [{'strs': ['', 'foo', 'bar']}, {'floats': [4.5, 5, None]}]
+    table = cls.from_pylist(data)
+    assert table.num_columns == 2
+    assert table.num_rows == 3
+    assert table.schema == schema
+    assert table.to_pylist() == data
+
+    # With metadata and inferred schema
+    metadata = {b'foo': b'bar'}
+    schema = schema.with_metadata(metadata)
+    table = cls.from_pylist(data, metadata=metadata)
+    assert table.schema == schema
+    assert table.schema.metadata == metadata
+    assert table.to_pylist() == data
+
+    # With explicit schema
+    table = cls.from_pylist(data, schema=schema)
+    assert table.schema == schema
+    assert table.schema.metadata == metadata
+    assert table.to_pylist() == data
+
+    # Cannot pass both schema and metadata
+    with pytest.raises(ValueError):
+        cls.from_pylist(data, schema=schema, metadata=metadata)
+
+    # Non-convertible values given schema
+    with pytest.raises(TypeError):
+        cls.from_pylist([{'c0': [0, 1, 2]}],
+                        schema=pa.schema([("c0", pa.string())]))
+
+    # Missing schema fields from the passed mapping
+    with pytest.raises(KeyError, match="doesn\'t contain.* c, d"):
+        cls.from_pylist(
+            [{'a': [1, 2, 3]}, {'b': [3, 4, 5]}],
+            schema=pa.schema([
+                ('a', pa.int64()),
+                ('c', pa.int32()),
+                ('d', pa.int16())
+            ])
+        )
+
+    # Passed wrong schema type
+    with pytest.raises(TypeError):
+        cls.from_pylist([{'a': [1, 2, 3]}], schema={})
+
+
+@pytest.mark.parametrize('data, klass', [
+    ((['', 'foo', 'bar'], [4.5, 5, None]), pa.array),
+    (([[''], ['foo', 'bar']], [[4.5], [5., None]]), pa.chunked_array),
+])
+def test_table_from_pylist_arrow_arrays(data, klass):
+    data = [{'strs': klass(data[0])}, {'floats': klass(data[1])}]
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
+
+    # With arrays as values
+    table = pa.Table.from_pylist(data)
+    assert table.num_columns == 2
+    assert table.num_rows == 3
+    assert table.schema == schema
+
+    # With explicit (matching) schema
+    table = pa.Table.from_pylist(data, schema=schema)
+    assert table.num_columns == 2
+    assert table.num_rows == 3
+    assert table.schema == schema
+
+    # with different but compatible schema
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float32())])
+    table = pa.Table.from_pylist(data, schema=schema)
+    assert pa.types.is_float32(table.column('floats').type)
+    assert table.num_columns == 2
+    assert table.num_rows == 3
+    assert table.schema == schema
+
+    # with different and incompatible schema
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.timestamp('s'))])
+    with pytest.raises((NotImplementedError, TypeError)):
+        pa.Table.from_pylist(data, schema=schema)
+
+
+@pytest.mark.parametrize('data, klass', [
+    ((['', 'foo', 'bar'], [4.5, 5, None]), list),
+    ((['', 'foo', 'bar'], [4.5, 5, None]), pa.array),
+    (([[''], ['foo', 'bar']], [[4.5], [5., None]]), pa.chunked_array),
+])
+def test_table_from_pylist_schema(data, klass):
+    # passed schema is source of truth for the columns
+
+    data = [{'strs': klass(data[0])}, {'floats': klass(data[1])}]
+
+    # schema has columns not present in data -> error
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64()),
+                        ('ints', pa.int64())])
+    with pytest.raises(KeyError, match='ints'):
+        pa.Table.from_pylist(data, schema=schema)
+
+    # data has columns not present in schema -> ignored
+    schema = pa.schema([('strs', pa.utf8())])
+    table = pa.Table.from_pylist(data, schema=schema)
+    assert table.num_columns == 1
+    assert table.schema == schema
+    assert table.column_names == ['strs']
+
+
 @pytest.mark.pandas
 def test_table_from_pandas_schema():
     # passed schema is source of truth for the columns


### PR DESCRIPTION
Add `to_pylist` and `from_pylist` to `Table` and `RecordBatch`.

`to_pylist` returns a list of dicts
`from_pylist` returns Table/RecordBatch from a list of dicts (named mapping in the code)