### PR TITLE
ARROW-15192: [Java] Allow use of Jackson 2.12 and higher

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -530,19 +530,11 @@
         <version>${dep.netty.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${dep.jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${dep.jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${dep.jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.10</version>

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
@@ -31,16 +31,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
 
-  private static ObjectMapper mapper;
-
-  static {
-    mapper = new ObjectMapper();
-  }
+  private static final ObjectMapper MAPPER = ObjectMapperFactory.newObjectMapper();
 
   @Override
   public final String toString() {
     try {
-      return mapper.writeValueAsString(this);
+      return MAPPER.writeValueAsString(this);
     } catch (JsonProcessingException e) {
       throw new IllegalStateException("Cannot serialize hash map to JSON string", e);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ObjectMapperFactory.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ObjectMapperFactory.java
@@ -17,35 +17,24 @@
 
 package org.apache.arrow.vector.util;
 
-import java.util.ArrayList;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
- * Extension of {@link ArrayList} that {@link #toString()} method returns the serialized JSON
- * version of its members (or throws an exception if they can't be converted to JSON).
- *
- * @param <E> Type of value held in the list.
+ * A {@link ObjectMapper} factory to read/write JSON.
  */
-public class JsonStringArrayList<E> extends ArrayList<E> {
+public final class ObjectMapperFactory {
 
-  private static final ObjectMapper MAPPER = ObjectMapperFactory.newObjectMapper();
+  private ObjectMapperFactory() {}
 
-  public JsonStringArrayList() {
-    super();
-  }
-
-  public JsonStringArrayList(int size) {
-    super(size);
-  }
-
-  @Override
-  public final String toString() {
-    try {
-      return MAPPER.writeValueAsString(this);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException("Cannot serialize array list to JSON string", e);
-    }
+  /**
+   * Creates a new {@link ObjectMapper} instance.
+   */
+  public static ObjectMapper newObjectMapper() {
+    return JsonMapper.builder()
+       .addModule(new JavaTimeModule())
+       .build();
   }
 }
+


### PR DESCRIPTION
Jackson 2.12 does not enable by default (de)serializers for Java
Date/Time java.time.* classes and require the jsr310 module to be added
to the object mapper. The absence of this module causes vector module to
stop working with newer versions of Jackson.

Address this by adding a ObjectMapper factory class which register the
jsr310 module with the objectmapper used by vector classes.