### PR TITLE
ARROW-15138: [C++] Make ExecPlan::ToString give some additional information

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -157,6 +157,18 @@ struct ExecPlanImpl : public ExecPlan {
     return std::move(Impl{nodes_}.sorted);
   }
 
+  // This function returns a node vector and a vector of integers with the
+  // number of spaces to add as an indentation. The main difference between
+  // this function and the TopoSort function is that here we visit the nodes
+  // in reverse order and we can have repeated nodes if necessary.
+  // For example, in the following plan:
+  // s1 --> s3 -\
+  //   \         \
+  //    \         -> s5 --> s6
+  //     \       /
+  // s2 --> s4 -/
+  // Toposort node vector: s1 s2 s3 s4 s5 s6
+  // OrderedNodes node vector: s6 s5 s3 s1 s4 s2 s1
   std::pair<NodeVector, std::vector<int>> OrderedNodes() const {
     struct Impl {
       const std::vector<std::unique_ptr<ExecNode>>& nodes;

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -212,7 +212,7 @@ struct ExecPlanImpl : public ExecPlan {
     auto sorted = OrderedNodes();
     for (size_t i = sorted.first.size(); i > 0; --i) {
       for (int j = 0; j < sorted.second[i - 1]; ++j) ss << "  ";
-      ss << sorted.first[i - 1]->ToString() << std::endl;
+      ss << sorted.first[i - 1]->ToString(sorted.second[i - 1]) << std::endl;
     }
     return ss.str();
   }
@@ -300,7 +300,7 @@ Status ExecNode::Validate() const {
   return Status::OK();
 }
 
-std::string ExecNode::ToString() const {
+std::string ExecNode::ToString(int indent) const {
   std::stringstream ss;
 
   auto PrintLabelAndKind = [&](const ExecNode* node) {
@@ -310,7 +310,7 @@ std::string ExecNode::ToString() const {
   PrintLabelAndKind(this);
   ss << "{";
 
-  const std::string extra = ToStringExtra();
+  const std::string extra = ToStringExtra(indent);
   if (!extra.empty()) {
     ss << extra;
   }
@@ -319,7 +319,7 @@ std::string ExecNode::ToString() const {
   return ss.str();
 }
 
-std::string ExecNode::ToStringExtra() const { return ""; }
+std::string ExecNode::ToStringExtra(int indent = 0) const { return ""; }
 
 bool ExecNode::ErrorIfNotOk(Status status) {
   if (status.ok()) return false;

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -161,6 +161,7 @@ struct ExecPlanImpl : public ExecPlan {
     struct Impl {
       const std::vector<std::unique_ptr<ExecNode>>& nodes;
       std::unordered_set<ExecNode*> visited;
+      std::unordered_set<ExecNode*> marked;
       NodeVector sorted;
       std::vector<int> indents;
 
@@ -176,13 +177,16 @@ struct ExecPlanImpl : public ExecPlan {
       }
 
       void Visit(ExecNode* node, int indent = 0) {
+        marked.insert(node);
         for (auto input : node->inputs()) {
+          if (marked.count(input) != 0) continue;
           Visit(input, indent + 1);
         }
+        marked.erase(node);
 
-        visited.insert(node);
         indents.push_back(indent);
         sorted.push_back(node);
+        visited.insert(node);
       }
     };
 

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -194,10 +194,9 @@ struct ExecPlanImpl : public ExecPlan {
     std::stringstream ss;
     ss << "ExecPlan with " << nodes_.size() << " nodes:" << std::endl;
     auto sorted = OrderedNodes();
-    int plan_size = sorted.first.size();
-    for (int i = 0; i < plan_size; ++i) {
-      for (int j = 0; j < sorted.second[plan_size - i]; ++j) ss << "  ";
-      ss << sorted.first[plan_size - i]->ToString() << std::endl;
+    for (size_t i = sorted.first.size(); i > 0; --i) {
+      for (int j = 0; j < sorted.second[i - 1]; ++j) ss << "  ";
+      ss << sorted.first[i - 1]->ToString() << std::endl;
     }
     return ss.str();
   }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -162,11 +162,11 @@ struct ExecPlanImpl : public ExecPlan {
   // this function and the TopoSort function is that here we visit the nodes
   // in reverse order and we can have repeated nodes if necessary.
   // For example, in the following plan:
-  // s1 --> s3 -\
-  //   \         \
-  //    \         -> s5 --> s6
-  //     \       /
-  // s2 --> s4 -/
+  // s1 --> s3 -
+  //   -        -
+  //    -        -> s5 --> s6
+  //     -      -
+  // s2 --> s4 -
   // Toposort node vector: s1 s2 s3 s4 s5 s6
   // OrderedNodes node vector: s6 s5 s3 s1 s4 s2 s1
   std::pair<NodeVector, std::vector<int>> OrderedNodes() const {

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -167,7 +167,7 @@ struct ExecPlanImpl : public ExecPlan {
       explicit Impl(const std::vector<std::unique_ptr<ExecNode>>& nodes) : nodes(nodes) {
         visited.reserve(nodes.size());
 
-        for (int i = nodes.size() - 1; i >= 0; --i) {
+        for (size_t i = nodes.size() - 1; i >= 0; --i) {
           if (visited.count(nodes[i].get()) != 0) return;
           Visit(nodes[i].get());
         }
@@ -194,7 +194,7 @@ struct ExecPlanImpl : public ExecPlan {
     std::stringstream ss;
     ss << "ExecPlan with " << nodes_.size() << " nodes:" << std::endl;
     auto sorted = OrderedNodes();
-    for (int i = sorted.first.size() - 1; i >= 0; --i) {
+    for (size_t i = sorted.first.size() - 1; i >= 0; --i) {
       for (int j = 0; j < sorted.second[i]; ++j) ss << "  ";
       ss << sorted.first[i]->ToString() << std::endl;
     }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -167,9 +167,9 @@ struct ExecPlanImpl : public ExecPlan {
       explicit Impl(const std::vector<std::unique_ptr<ExecNode>>& nodes) : nodes(nodes) {
         visited.reserve(nodes.size());
 
-        for (size_t i = nodes.size() - 1; i >= 0; --i) {
-          if (visited.count(nodes[i].get()) != 0) return;
-          Visit(nodes[i].get());
+        for (auto it = nodes.rbegin(); it != nodes.rend(); ++it) {
+          if (visited.count(it->get()) != 0) return;
+          Visit(it->get());
         }
 
         DCHECK_EQ(visited.size(), nodes.size());
@@ -194,9 +194,10 @@ struct ExecPlanImpl : public ExecPlan {
     std::stringstream ss;
     ss << "ExecPlan with " << nodes_.size() << " nodes:" << std::endl;
     auto sorted = OrderedNodes();
-    for (size_t i = sorted.first.size() - 1; i >= 0; --i) {
-      for (int j = 0; j < sorted.second[i]; ++j) ss << "  ";
-      ss << sorted.first[i]->ToString() << std::endl;
+    int plan_size = sorted.first.size();
+    for (int i = 0; i < plan_size; ++i) {
+      for (int j = 0; j < sorted.second[plan_size - i]; ++j) ss << "  ";
+      ss << sorted.first[plan_size - i]->ToString() << std::endl;
     }
     return ss.str();
   }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -168,7 +168,7 @@ struct ExecPlanImpl : public ExecPlan {
         visited.reserve(nodes.size());
 
         for (auto it = nodes.rbegin(); it != nodes.rend(); ++it) {
-          if (visited.count(it->get()) != 0) return;
+          if (visited.count(it->get()) != 0) continue;
           Visit(it->get());
         }
 
@@ -180,9 +180,9 @@ struct ExecPlanImpl : public ExecPlan {
           Visit(input, indent + 1);
         }
 
+        visited.insert(node);
         indents.push_back(indent);
         sorted.push_back(node);
-        visited.insert(node);
       }
     };
 
@@ -294,32 +294,9 @@ std::string ExecNode::ToString() const {
   PrintLabelAndKind(this);
   ss << "{";
 
-  if (!inputs_.empty()) {
-    ss << "inputs=[";
-    for (size_t i = 0; i < inputs_.size(); i++) {
-      if (i > 0) ss << ", ";
-      ss << input_labels_[i] << "=";
-      PrintLabelAndKind(inputs_[i]);
-    }
-    ss << ']';
-  }
-
-  if (!outputs_.empty()) {
-    if (!inputs_.empty()) {
-      ss << ", ";
-    }
-
-    ss << "outputs=[";
-    for (size_t i = 0; i < outputs_.size(); i++) {
-      if (i > 0) ss << ", ";
-      PrintLabelAndKind(outputs_[i]);
-    }
-    ss << ']';
-  }
-
   const std::string extra = ToStringExtra();
   if (!extra.empty()) {
-    ss << ", " << extra;
+    ss << extra;
   }
 
   ss << '}';

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -223,7 +223,7 @@ class ARROW_EXPORT ExecNode {
   /// \brief A future which will be marked finished when this node has stopped producing.
   virtual Future<> finished() = 0;
 
-  std::string ToString() const;
+  std::string ToString(int indent = 0) const;
 
  protected:
   ExecNode(ExecPlan* plan, NodeVector inputs, std::vector<std::string> input_labels,
@@ -234,7 +234,7 @@ class ARROW_EXPORT ExecNode {
   bool ErrorIfNotOk(Status status);
 
   /// Provide extra info to include in the string representation.
-  virtual std::string ToStringExtra() const;
+  virtual std::string ToStringExtra(int indent) const;
 
   ExecPlan* plan_;
   std::string label_;

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/compute/exec/exec_plan.h"
-
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/datum.h"
@@ -99,7 +98,9 @@ class FilterNode : public MapNode {
   }
 
  protected:
-  std::string ToStringExtra() const override { return "filter=" + filter_.ToString(); }
+  std::string ToStringExtra(int indent) const override {
+    return "filter=" + filter_.ToString();
+  }
 
  private:
   Expression filter_;

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -301,11 +301,11 @@ TEST(ExecPlan, ToString) {
                     {"sink", SinkNodeOptions{&sink_gen}},
                 })
                 .AddToPlan(plan.get()));
-  EXPECT_EQ(plan->sources()[0]->ToString(), R"(:SourceNode{outputs=[:SinkNode]})");
-  EXPECT_EQ(plan->sinks()[0]->ToString(), R"(:SinkNode{inputs=[collected=:SourceNode]})");
+  EXPECT_EQ(plan->sources()[0]->ToString(), R"(:SourceNode{})");
+  EXPECT_EQ(plan->sinks()[0]->ToString(), R"(:SinkNode{})");
   EXPECT_EQ(plan->ToString(), R"(ExecPlan with 2 nodes:
-:SinkNode{inputs=[collected=:SourceNode]}
-  :SourceNode{outputs=[:SinkNode]}
+:SinkNode{}
+  :SourceNode{}
 )");
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());
@@ -338,15 +338,15 @@ TEST(ExecPlan, ToString) {
           })
           .AddToPlan(plan.get()));
   EXPECT_EQ(plan->ToString(), R"a(ExecPlan with 6 nodes:
-custom_sink_label:OrderBySinkNode{inputs=[collected=:FilterNode], by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
-  :FilterNode{inputs=[target=:GroupByNode], outputs=[custom_sink_label:OrderBySinkNode], filter=(sum(multiply(i32, 2)) > 10)}
-    :GroupByNode{inputs=[groupby=:ProjectNode], outputs=[:FilterNode], keys=["bool"], aggregates=[
+custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
+  :FilterNode{filter=(sum(multiply(i32, 2)) > 10)}
+    :GroupByNode{keys=["bool"], aggregates=[
 	hash_sum(multiply(i32, 2)),
 	hash_count(multiply(i32, 2), {mode=NON_NULL}),
 ]}
-      :ProjectNode{inputs=[target=:FilterNode], outputs=[:GroupByNode], projection=[bool, multiply(i32, 2)]}
-        :FilterNode{inputs=[target=custom_source_label:SourceNode], outputs=[:ProjectNode], filter=(i32 >= 0)}
-          custom_source_label:SourceNode{outputs=[:FilterNode]}
+      :ProjectNode{projection=[bool, multiply(i32, 2)]}
+        :FilterNode{filter=(i32 >= 0)}
+          custom_source_label:SourceNode{}
 )a");
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());
@@ -374,13 +374,13 @@ custom_sink_label:OrderBySinkNode{inputs=[collected=:FilterNode], by={sort_keys=
           })
           .AddToPlan(plan.get()));
   EXPECT_EQ(plan->ToString(), R"a(ExecPlan with 5 nodes:
-:SinkNode{inputs=[collected=:ScalarAggregateNode]}
-  :ScalarAggregateNode{inputs=[target=:UnionNode], outputs=[:SinkNode], aggregates=[
+:SinkNode{}
+  :ScalarAggregateNode{aggregates=[
 	count(i32, {mode=NON_NULL}),
 ]}
-    :UnionNode{inputs=[input_0_label=lhs:SourceNode, input_1_label=rhs:SourceNode], outputs=[:ScalarAggregateNode]}
-      rhs:SourceNode{outputs=[:UnionNode]}
-      lhs:SourceNode{outputs=[:UnionNode]}
+    :UnionNode{}
+      rhs:SourceNode{}
+      lhs:SourceNode{}
 )a");
 }
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -341,13 +341,15 @@ TEST(ExecPlan, ToString) {
 custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
   :FilterNode{filter=(sum(multiply(i32, 2)) > 10)}
     :GroupByNode{keys=["bool"], aggregates=[
-	hash_sum(multiply(i32, 2)),
-	hash_count(multiply(i32, 2), {mode=NON_NULL}),
-]}
+    	hash_sum(multiply(i32, 2)),
+    	hash_count(multiply(i32, 2), {mode=NON_NULL}),
+    ]}
       :ProjectNode{projection=[bool, multiply(i32, 2)]}
         :FilterNode{filter=(i32 >= 0)}
           custom_source_label:SourceNode{}
 )a");
+
+  std::cout << plan->ToString() << '\n';
 
   ASSERT_OK_AND_ASSIGN(plan, ExecPlan::Make());
 

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/compute/exec/exec_plan.h"
-
 #include <sstream>
 
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/compute/exec/util.h"
@@ -95,7 +94,7 @@ class ProjectNode : public MapNode {
   }
 
  protected:
-  std::string ToStringExtra() const override {
+  std::string ToStringExtra(int indent) const override {
     std::stringstream ss;
     ss << "projection=[";
     for (int i = 0; static_cast<size_t>(i) < exprs_.size(); i++) {

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -16,12 +16,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/compute/exec/exec_plan.h"
-
 #include <mutex>
 
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/compute/exec/order_by_impl.h"
@@ -317,7 +316,7 @@ struct OrderBySinkNode final : public SinkNode {
   }
 
  protected:
-  std::string ToStringExtra() const override {
+  std::string ToStringExtra(int indent) const override {
     return std::string("by=") + impl_->ToString();
   }
 


### PR DESCRIPTION
Add indentation to ToString() function in ExecPlan. 

For example if we have the following graph of execution plan:
![image](https://user-images.githubusercontent.com/40250321/147159958-79ad4ad4-db3d-435e-bf01-bb5ea1162730.png)

The execution plan string will be:
```
6 node
    5 node
         4 node
             2 node
         3 node
             2 node
             1 node
```
 
