### PR TITLE
ARROW-15091: [C++][Doc] Document nodes in C++ streaming execution engine

### DIFF
--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -100,4 +100,8 @@ if(ARROW_PARQUET AND ARROW_DATASET)
   add_arrow_example(dataset_documentation_example EXTRA_LINK_LIBS
                     ${DATASET_EXAMPLES_LINK_LIBS})
   add_dependencies(dataset_documentation_example parquet)
+
+  add_arrow_example(exec_plan_examples EXTRA_LINK_LIBS
+                    ${DATASET_EXAMPLES_LINK_LIBS})
+  add_dependencies(dataset_documentation_example parquet)
 endif()

--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -101,7 +101,7 @@ if(ARROW_PARQUET AND ARROW_DATASET)
                     ${DATASET_EXAMPLES_LINK_LIBS})
   add_dependencies(dataset_documentation_example parquet)
 
-  add_arrow_example(exec_plan_examples EXTRA_LINK_LIBS
+  add_arrow_example(execution_plan_documentation_examples EXTRA_LINK_LIBS
                     ${DATASET_EXAMPLES_LINK_LIBS})
   add_dependencies(dataset_documentation_example parquet)
 endif()

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -49,11 +49,6 @@
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
 
-#include "gmock/gmock-matchers.h"
-
-//#include <arrow/testing/future_util.h>
-//#include <arrow/testing/gtest_util.h>
-
 // Demonstrate various operators in Arrow Streaming Execution Engine
 
 #define ABORT_ON_FAILURE(expr)                     \

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -121,167 +121,136 @@ std::shared_ptr<arrow::Table> GetTableFromJSON(
 }
 
 std::shared_ptr<arrow::Table> CreateTable() {
-  auto schema =
-      arrow::schema({arrow::field("a", arrow::int64()), arrow::field("b", arrow::int64()),
-                     arrow::field("c", arrow::int64())});
-  std::shared_ptr<arrow::Array> array_a;
-  std::shared_ptr<arrow::Array> array_b;
-  std::shared_ptr<arrow::Array> array_c;
-  arrow::NumericBuilder<arrow::Int64Type> builder;
-  ABORT_ON_FAILURE(builder.AppendValues({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-  ABORT_ON_FAILURE(builder.Finish(&array_a));
-  builder.Reset();
-  ABORT_ON_FAILURE(builder.AppendValues({9, 8, 7, 6, 5, 4, 3, 2, 1, 0}));
-  ABORT_ON_FAILURE(builder.Finish(&array_b));
-  builder.Reset();
-  ABORT_ON_FAILURE(builder.AppendValues({1, 2, 1, 2, 1, 2, 1, 2, 1, 2}));
-  ABORT_ON_FAILURE(builder.Finish(&array_c));
-  return arrow::Table::Make(schema, {array_a, array_b, array_c});
+    auto schema =
+        arrow::schema({arrow::field("a", arrow::int64()),
+        arrow::field("b", arrow::int64()),
+        arrow::field("c", arrow::int64())});
+    std::shared_ptr<arrow::Array> array_a;
+    std::shared_ptr<arrow::Array> array_b;
+    std::shared_ptr<arrow::Array> array_c;
+    arrow::NumericBuilder<arrow::Int64Type> builder;
+    ABORT_ON_FAILURE(builder.AppendValues({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    ABORT_ON_FAILURE(builder.Finish(&array_a));
+    builder.Reset();
+    ABORT_ON_FAILURE(builder.AppendValues({9, 8, 7, 6, 5, 4, 3, 2, 1, 0}));
+    ABORT_ON_FAILURE(builder.Finish(&array_b));
+    builder.Reset();
+    ABORT_ON_FAILURE(builder.AppendValues({1, 2, 1, 2, 1, 2, 1, 2, 1, 2}));
+    ABORT_ON_FAILURE(builder.Finish(&array_c));
+    return arrow::Table::Make(schema, {array_a, array_b, array_c});
 }
 
 std::shared_ptr<arrow::dataset::Dataset> CreateDataset() {
-  return std::make_shared<arrow::dataset::InMemoryDataset>(
-      GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()),
-                                      arrow::field("b", arrow::boolean())}),
-                       {
-                           R"([{"a": 1,    "b": null},
-                            {"a": 2,    "b": true}])",
-                           R"([{"a": null, "b": true},
-                            {"a": 3,    "b": false}])",
-                           R"([{"a": null, "b": true},
-                            {"a": 4,    "b": false}])",
-                           R"([{"a": 5,    "b": null},
-                            {"a": 6,    "b": false},
-                            {"a": 7,    "b": false},
-                            {"a": 8,    "b": true}])",
-                       }));
+    return std::make_shared<arrow::dataset::InMemoryDataset>(
+        GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()),
+                                        arrow::field("b", arrow::boolean())}),
+                        {
+                            R"([{"a": 1,    "b": null},
+                                {"a": 2,    "b": true}])",
+                            R"([{"a": null, "b": true},
+                                {"a": 3,    "b": false}])",
+                            R"([{"a": null, "b": true},
+                                {"a": 4,    "b": false}])",
+                            R"([{"a": 5,    "b": null},
+                                {"a": 6,    "b": false},
+                                {"a": 7,    "b": false},
+                                {"a": 8,    "b": true}])",
+                        }));
 }
 
 std::shared_ptr<arrow::Table> CreateSimpleTable() {
-  auto schema = arrow::schema(
-      {arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())});
-  std::shared_ptr<arrow::Array> array_a;
-  std::shared_ptr<arrow::Array> array_b;
-  arrow::NumericBuilder<arrow::Int32Type> builder;
-  arrow::BooleanBuilder b_builder;
-  ABORT_ON_FAILURE(builder.AppendValues({1, 2, 3, 4, 5, 6, 7}));
-  ABORT_ON_FAILURE(builder.Finish(&array_a));
-  builder.Reset();
+    auto schema = arrow::schema(
+        {arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())});
+    std::shared_ptr<arrow::Array> array_a;
+    std::shared_ptr<arrow::Array> array_b;
+    arrow::NumericBuilder<arrow::Int32Type> builder;
+    arrow::BooleanBuilder b_builder;
+    ABORT_ON_FAILURE(builder.AppendValues({1, 2, 3, 4, 5, 6, 7}));
+    ABORT_ON_FAILURE(builder.Finish(&array_a));
+    builder.Reset();
 
-  std::vector<bool> bool_vec{false, true, false, true, false, true, false};
-  ABORT_ON_FAILURE(b_builder.AppendValues(bool_vec));
-  ABORT_ON_FAILURE(builder.Finish(&array_b));
-  builder.Reset();
-  return arrow::Table::Make(schema, {array_a, array_b});
+    std::vector<bool> bool_vec{false, true, false, true, false, true, false};
+    ABORT_ON_FAILURE(b_builder.AppendValues(bool_vec));
+    ABORT_ON_FAILURE(builder.Finish(&array_b));
+    builder.Reset();
+    return arrow::Table::Make(schema, {array_a, array_b});
 }
 
 arrow::Status exec_plan_end_to_end_sample() {
-  std::cout << "Initializing" << std::endl;
-  cp::ExecContext exec_context(arrow::default_memory_pool(),
-                               ::arrow::internal::GetCpuThreadPool());
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                ::arrow::internal::GetCpuThreadPool());
 
-  std::cout << "Registry creating" << std::endl;
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
 
-  // ensure arrow::dataset node factories are in the registry
-  arrow::dataset::internal::Initialize();
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+                            cp::ExecPlan::Make(&exec_context));
 
-  std::cout << "Intialized Scanner" << std::endl;
+    std::shared_ptr<arrow::dataset::Dataset> dataset = CreateDataset();
 
-  // A ScanNode is constructed from an ExecPlan (into which it is inserted),
-  // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
-  // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-  std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+    auto options = std::make_shared<arrow::dataset::ScanOptions>();
+    // sync scanning is not supported by ScanNode
+    options->use_async = true;
+    // specify the filter
+    cp::Expression b_is_true = cp::field_ref("b");
+    options->filter = b_is_true;
+    // for now, specify the projection as the full project expression (eventually this can
+    // just be a list of materialized field names)
 
-  auto table = CreateSimpleTable();
+    cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
+    options->projection =
+        cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
 
-  std::cout << "Table created" << std::endl;
+    // // construct the scan node
+    cp::ExecNode* scan;
 
-  std::shared_ptr<arrow::dataset::Dataset>
-      dataset;  // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-  dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
-      GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()),
-                                      arrow::field("b", arrow::boolean())}),
-                       {
-                           R"([{"a": 1,    "b": null},
-                            {"a": 2,    "b": true}])",
-                           R"([{"a": null, "b": true},
-                            {"a": 3,    "b": false}])",
-                           R"([{"a": null, "b": true},
-                            {"a": 4,    "b": false}])",
-                           R"([{"a": 5,    "b": null},
-                            {"a": 6,    "b": false},
-                            {"a": 7,    "b": false},
-                            {"a": 8,    "b": true}])",
-                       }));
+    ARROW_ASSIGN_OR_RAISE(scan,
+                            cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
 
-  std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0)
-            << std::endl;
+    // pipe the scan node into a filter node
+    cp::ExecNode* filter;
+    ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
+                                                    cp::FilterNodeOptions{b_is_true}));
 
-  auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
-  // specify the filter
-  cp::Expression b_is_true = cp::field_ref("b");
-  options->filter = b_is_true;
-  // for now, specify the projection as the full project expression (eventually this can
-  // just be a list of materialized field names)
+    cp::ExecNode* project;
 
-  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
-  options->projection =
-      cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
+    ARROW_ASSIGN_OR_RAISE(project,
+                            cp::MakeExecNode("augmented_project", plan.get(), {filter},
+                                            cp::ProjectNodeOptions{{a_times_2}}));
 
-  // construct the scan node
+    // // finally, pipe the project node into a sink node
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+                            cp::MakeExecNode("sink",
+                            plan.get(), {project},
+                            cp::SinkNodeOptions{&sink_gen}));
+    // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader =
+        cp::MakeGeneratorReader(arrow::schema({arrow::field("a * 2", arrow::int32())}),
+                                std::move(sink_gen), exec_context.memory_pool());
 
-  std::cout << "Initialized Scanning Options" << std::endl;
+    // // validate the plan
+    ABORT_ON_FAILURE(plan->Validate());
+    PRINT_LINE("Exec Plan created: " << plan->ToString());
+    // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
 
-  cp::ExecNode* scan;
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
+    ARROW_ASSIGN_OR_RAISE(response_table,
+                            arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-  std::cout << "Scan node options created" << std::endl;
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+    // // stop producing
+    plan->StopProducing();
 
-  // pipe the scan node into a filter node
-  cp::ExecNode* filter;
-  ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
-                                                 cp::FilterNodeOptions{b_is_true}));
+    // // plan mark finished
+    plan->finished().Wait();
 
-  // // pipe the filter node into a project node
-  // // NB: we're using the project node factory which preserves fragment/batch index
-  // // tagging, so we *can* reorder later if we choose. The tags will not appear in
-  // // our output.
-
-  cp::ExecNode* project;
-
-  ARROW_ASSIGN_OR_RAISE(project,
-                        cp::MakeExecNode("augmented_project", plan.get(), {filter},
-                                         cp::ProjectNodeOptions{{a_times_2}}));
-
-  // // finally, pipe the project node into a sink node
-  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
-                        cp::MakeExecNode("ordered_sink", plan.get(), {project},
-                                         cp::SinkNodeOptions{&sink_gen}));
-
-  // // translate sink_gen (async) to sink_reader (sync)
-  std::shared_ptr<arrow::RecordBatchReader> sink_reader =
-      cp::MakeGeneratorReader(arrow::schema({arrow::field("a * 2", arrow::int32())}),
-                              std::move(sink_gen), exec_context.memory_pool());
-
-  // // start the ExecPlan
-  ABORT_ON_FAILURE(plan->StartProducing());
-
-  // // collect sink_reader into a Table
-  std::shared_ptr<arrow::Table> response_table;
-  ARROW_ASSIGN_OR_RAISE(response_table,
-                        arrow::Table::FromRecordBatchReader(sink_reader.get()));
-
-  std::cout << "Results : " << response_table->ToString() << std::endl;
-  return arrow::Status::OK();
+    return arrow::Status::OK();
 }
 
 cp::Expression Materialize(std::vector<std::string> names,
@@ -301,59 +270,62 @@ cp::Expression Materialize(std::vector<std::string> names,
 }
 
 arrow::Status scan_sink_node_example() {
-  cp::ExecContext exec_context(arrow::default_memory_pool(),
-                               ::arrow::internal::GetCpuThreadPool());
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                ::arrow::internal::GetCpuThreadPool());
 
-  // ensure arrow::dataset node factories are in the registry
-  arrow::dataset::internal::Initialize();
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
 
+    // Execution plan created
+    ARROW_ASSIGN_OR_RAISE(
+        std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
 
-  // Execution plan created
-  ARROW_ASSIGN_OR_RAISE(
-      std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+    std::shared_ptr<arrow::dataset::Dataset> dataset = CreateDataset();
 
-  std::shared_ptr<arrow::dataset::Dataset> dataset = CreateDataset();
+    auto options = std::make_shared<arrow::dataset::ScanOptions>();
+    // sync scanning is not supported by ScanNode
+    options->use_async = true;
+    options->projection = Materialize({});  // create empty projection
 
-  auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
-  options->projection = Materialize({});  // create empty projection
+    // construct the scan node
+    cp::ExecNode* scan;
+    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-  // construct the scan node
-  cp::ExecNode* scan;
-  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+    ARROW_ASSIGN_OR_RAISE(scan,
+                            cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
 
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+    cp::ExecNode* sink;
 
-  cp::ExecNode* sink;
+    ARROW_ASSIGN_OR_RAISE(
+        sink, cp::MakeExecNode("sink", plan.get(), {scan},
+        cp::SinkNodeOptions{&sink_gen}));
 
-  ARROW_ASSIGN_OR_RAISE(
-      sink, cp::MakeExecNode("sink", plan.get(), {scan}, cp::SinkNodeOptions{&sink_gen}));
+    // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+        dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
 
-  // // translate sink_gen (async) to sink_reader (sync)
-  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-      dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
+    // validate the ExecPlan
+    ABORT_ON_FAILURE(plan->Validate());
+    PRINT_LINE("ExecPlan created : " << plan->ToString());
+    // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
 
-  // validate the ExecPlan
-ABORT_ON_FAILURE(plan->Validate());
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
 
-  // // start the ExecPlan
-  ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_ASSIGN_OR_RAISE(response_table,
+                            arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  // // collect sink_reader into a Table
-  std::shared_ptr<arrow::Table> response_table;
+    PRINT_LINE("Results : " << response_table->ToString());
 
-  ARROW_ASSIGN_OR_RAISE(response_table,
-                        arrow::Table::FromRecordBatchReader(sink_reader.get()));
+    // // stop producing
+    plan->StopProducing();
+    // // plan mark finished
+    plan->finished().Wait();
 
-  std::cout << "Results : " << response_table->ToString() << std::endl;
-
-  plan->StopProducing();
-
-  return arrow::Status::OK();
+    return arrow::Status::OK();
 }
 
 cp::ExecBatch GetExecBatchFromJSON(const std::vector<arrow::ValueDescr>& descrs,
@@ -481,28 +453,16 @@ arrow::internal::ThreadPool* GetIOThreadPool() {
 }
 
 arrow::Status source_sink_example() {
-  std::cout << "Initializing" << std::endl;
   cp::ExecContext exec_context(arrow::default_memory_pool(),
                                ::arrow::internal::GetCpuThreadPool());
-
-  std::cout << "Registry creating" << std::endl;
 
   // ensure arrow::dataset node factories are in the registry
   arrow::dataset::internal::Initialize();
 
-  std::cout << "Intialized Scanner" << std::endl;
-
-  // A ScanNode is constructed from an ExecPlan (into which it is inserted),
-  // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
-  // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
-  std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
-  std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+  cp::ExecPlan::Make(&exec_context));
 
   auto basic_data = MakeBasicBatches();
-
-  PRINT_LINE("data created");
-
-  PRINT_LINE("source node options created");
 
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
@@ -512,20 +472,18 @@ arrow::Status source_sink_example() {
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
                         cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-  PRINT_LINE("source node created");
-
-  // arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-
   cp::ExecNode* sink;
 
   ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("sink", plan.get(), {source},
                                                cp::SinkNodeOptions{&sink_gen}));
 
-  PRINT_LINE("sink node created");
   // // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
       basic_data.schema, std::move(sink_gen), exec_context.memory_pool());
 
+  // // validate the ExecPlan
+  ABORT_ON_FAILURE(plan->Validate());
+  PRINT_LINE("Exec Plan Created: " << plan->ToString());
   // // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -535,7 +493,12 @@ arrow::Status source_sink_example() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  std::cout << "Results : " << response_table->ToString() << std::endl;
+  PRINT_LINE("Results : " << response_table->ToString());
+
+  // // plan stop producing
+  plan->StopProducing();
+  // // plan mark finished
+  plan->finished().Wait();
 
   return arrow::Status::OK();
 }
@@ -544,27 +507,13 @@ arrow::Status scan_filter_sink_example() {
   cp::ExecContext exec_context(arrow::default_memory_pool(),
                                ::arrow::internal::GetCpuThreadPool());
 
-  PRINT_LINE("Execution context created.");
-
   // ensure arrow::dataset node factories are in the registry
   arrow::dataset::internal::Initialize();
 
-  PRINT_LINE("Intialized Scanner");
-
-  // A ScanNode is constructed from an ExecPlan (into which it is inserted),
-  // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
-  // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
                         cp::ExecPlan::Make(&exec_context));
-  std::string msg;
-  msg.append("Exec Plan Created : ");
-  msg.append(plan->ToString());
-  PRINT_LINE(msg);
 
   std::shared_ptr<arrow::dataset::Dataset> dataset = CreateDataset();
-
-  std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0)
-            << std::endl;
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
   // sync scanning is not supported by ScanNode
@@ -601,6 +550,9 @@ arrow::Status scan_filter_sink_example() {
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
       dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
 
+  // // validate the ExecPlan
+  ABORT_ON_FAILURE(plan->Validate());
+  PRINT_LINE("Exec Plan created " << plan->ToString());
   // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -609,102 +561,78 @@ arrow::Status scan_filter_sink_example() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  std::cout << "Results : " << response_table->ToString() << std::endl;
+  PRINT_LINE("Results : " << response_table->ToString());
+  // // plan stop producing
+  plan->StopProducing();
+  // /// plan marked finished
+  plan->finished().Wait();
+
   return arrow::Status::OK();
 }
 
-// arrow::Status scan_project_sink_example()
-// {
-//     cp::ExecContext exec_context(arrow::default_memory_pool(),
-//                                  ::arrow::internal::GetCpuThreadPool());
+arrow::Status scan_project_sink_example() {
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                 ::arrow::internal::GetCpuThreadPool());
 
-//     PRINT_LINE("Execution context created.");
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
 
-//     // ensure arrow::dataset node factories are in the registry
-//     arrow::dataset::internal::Initialize();
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-//     PRINT_LINE("Intialized Scanner");
+    std::shared_ptr<arrow::dataset::Dataset> dataset = CreateDataset();
 
-//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
-//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter
-//     for
-//     // predicate pushdown, a projection to skip materialization of unnecessary columns,
-//     ...) ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-//     cp::ExecPlan::Make(&exec_context)); std::string msg; msg.append("Exec Plan Created
-//     : "); msg.append(plan->ToString()); PRINT_LINE(msg);
+    auto options = std::make_shared<arrow::dataset::ScanOptions>();
+    // sync scanning is not supported by ScanNode
+    options->use_async = true;
+    // projection
+    cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
+    cp::literal(2)}); options->projection =
+        cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
 
-//     auto table = CreateSimpleTable();
+    cp::ExecNode *scan;
 
-//     PRINT_LINE("Table created")
+    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-//     std::shared_ptr<arrow::dataset::Dataset> dataset; // =
-//     std::make_shared<arrow::dataset::InMemoryDataset>(table);
+    ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
+    scan_node_options));
 
-//     dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
-//         GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()),
-//         arrow::field("b", arrow::boolean())}),
-//                              {
-//                                  R"([{"a": 1,    "b": null},
-//                             {"a": 2,    "b": true}])",
-//                                  R"([{"a": null, "b": true},
-//                             {"a": 3,    "b": false}])",
-//                                  R"([{"a": null, "b": true},
-//                             {"a": 4,    "b": false}])",
-//                                  R"([{"a": 5,    "b": null},
-//                             {"a": 6,    "b": false},
-//                             {"a": 7,    "b": false},
-//                             {"a": 8,    "b": true}])",
-//                              }));
+    cp::ExecNode *project;
+    ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
+                                                    cp::ProjectNodeOptions{{a_times_2}}));
 
-//     std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) <<
-//     std::endl;
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+                          cp::MakeExecNode("sink", plan.get(), {project},
+                                           cp::SinkNodeOptions{&sink_gen}));
 
-//     auto options = std::make_shared<arrow::dataset::ScanOptions>();
-//     // sync scanning is not supported by ScanNode
-//     options->use_async = true;
-//     // projection
-//     cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
-//     cp::literal(2)}); options->projection =
-//         cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
+    // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+        arrow::schema({arrow::field("a * 2", arrow::int32())}),
+        std::move(sink_gen), exec_context.memory_pool());
 
-//     // construct the scan node
-//     PRINT_LINE("Initialized Scanning Options");
+    // // validate the ExecPlan
+    ABORT_ON_FAILURE(plan->Validate());
 
-//     cp::ExecNode *scan;
+    PRINT_LINE("Exec Plan Created : " << plan->ToString());
 
-//     auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-//     PRINT_LINE("Scan node options created");
+    // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
 
-//     ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
-//     scan_node_options));
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
+    ARROW_ASSIGN_OR_RAISE(response_table,
+    arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-//     //pipe the scan node into a filter node
-//     cp::ExecNode *project;
-//     ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
-//                                                     cp::ProjectNodeOptions{{a_times_2}}));
+    PRINT_LINE("Results : " << response_table->ToString());
 
-//     // // finally, pipe the project node into a sink node
-//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
-//                           cp::MakeExecNode("sink", plan.get(), {project},
-//                                            cp::SinkNodeOptions{&sink_gen}));
+    // // plan stop producing
+    plan->StopProducing();
+    // // plan marked finished
+    plan->finished().Wait();
 
-//     // // translate sink_gen (async) to sink_reader (sync)
-//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-//         arrow::schema({arrow::field("a * 2", arrow::int32())}),
-//         std::move(sink_gen), exec_context.memory_pool());
-
-//     // // start the ExecPlan
-//     ABORT_ON_FAILURE(plan->StartProducing());
-
-//     // // collect sink_reader into a Table
-//     std::shared_ptr<arrow::Table> response_table;
-//     ARROW_ASSIGN_OR_RAISE(response_table,
-//     arrow::Table::FromRecordBatchReader(sink_reader.get()));
-
-//     std::cout << "Results : " << response_table->ToString() << std::endl;
-//     return arrow::Status::OK();
-// }
+    return arrow::Status::OK();
+}
 
 // arrow::Status source_aggregate_sink_example()
 // {
@@ -1260,8 +1188,8 @@ int main(int argc, char** argv) {
   CHECK_AND_CONTINUE(source_sink_example());
   PRINT_BLOCK("Scan Filter Sink Example");
   CHECK_AND_CONTINUE(scan_filter_sink_example());
-  // PRINT_BLOCK("Scan Project Sink Example");
-  // CHECK_AND_CONTINUE(scan_project_sink_example());
+  PRINT_BLOCK("Scan Project Sink Example");
+  CHECK_AND_CONTINUE(scan_project_sink_example());
   // PRINT_BLOCK("Source Aggregate Sink Example");
   // CHECK_AND_CONTINUE(source_aggregate_sink_example());
   // PRINT_BLOCK("Source Consuming-Sink Example");

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -277,7 +277,7 @@ arrow::Status consume(std::shared_ptr<arrow::Schema> schema,
 }
 
 
-arrow::Status scan_sink_node_example() {
+arrow::Status ScanSinkExample() {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
                                 ::arrow::internal::GetCpuThreadPool());
 
@@ -388,6 +388,8 @@ struct BatchesWithSchema {
   }
 };
 
+
+
 BatchesWithSchema MakeBasicBatches() {
   BatchesWithSchema out;
   out.batches = {GetExecBatchFromJSON({arrow::int32(), arrow::boolean()},
@@ -447,20 +449,8 @@ BatchesWithSchema MakeGroupableBatches(int multiplicity = 1) {
   return out;
 }
 
-std::shared_ptr<arrow::internal::ThreadPool> MakeIOThreadPool() {
-  auto maybe_pool = arrow::internal::ThreadPool::MakeEternal(/*threads=*/8);
-  if (!maybe_pool.ok()) {
-    maybe_pool.status().Abort("Failed to create global IO thread pool");
-  }
-  return *std::move(maybe_pool);
-}
 
-arrow::internal::ThreadPool* GetIOThreadPool() {
-  static std::shared_ptr<arrow::internal::ThreadPool> pool = MakeIOThreadPool();
-  return pool.get();
-}
-
-arrow::Status source_sink_example() {
+arrow::Status SourceSinkExample() {
   cp::ExecContext exec_context(arrow::default_memory_pool(),
                                ::arrow::internal::GetCpuThreadPool());
 
@@ -511,7 +501,7 @@ arrow::Status source_sink_example() {
   return arrow::Status::OK();
 }
 
-arrow::Status scan_filter_sink_example() {
+arrow::Status ScanFilterSinkExample() {
   cp::ExecContext exec_context(arrow::default_memory_pool(),
                                ::arrow::internal::GetCpuThreadPool());
 
@@ -579,7 +569,7 @@ arrow::Status scan_filter_sink_example() {
   return arrow::Status::OK();
 }
 
-arrow::Status scan_project_sink_example() {
+arrow::Status ScanProjectSinkExample() {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
                                  ::arrow::internal::GetCpuThreadPool());
 
@@ -645,7 +635,7 @@ arrow::Status scan_project_sink_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_aggregate_sink_example() {
+arrow::Status SourceAggregateSinkExample() {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
                                  ::arrow::internal::GetCpuThreadPool());
 
@@ -712,7 +702,7 @@ arrow::Status source_aggregate_sink_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_consuming_sink_node_example() {
+arrow::Status SourceConsumingSinkExample() {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
                                  ::arrow::internal::GetCpuThreadPool());
 
@@ -775,7 +765,7 @@ arrow::Status source_consuming_sink_node_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_order_by_sink_example() {
+arrow::Status SourceOrderBySinkExample() {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
      ::arrow::internal::GetCpuThreadPool());
 
@@ -822,7 +812,7 @@ arrow::Status source_order_by_sink_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_hash_join_sink_example() {
+arrow::Status SourceHashJoinSinkExample() {
     auto input = MakeGroupableBatches();
 
     cp::ExecContext exec_context(arrow::default_memory_pool(),
@@ -904,7 +894,7 @@ arrow::Status source_hash_join_sink_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_kselect_example() {
+arrow::Status SourceKSelectExample() {
     auto input = MakeGroupableBatches();
 
     cp::ExecContext exec_context(arrow::default_memory_pool(),
@@ -959,7 +949,7 @@ arrow::Status source_kselect_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status scan_filter_write_example() {
+arrow::Status ScanFilterWriteExample(std::string file_path) {
     cp::ExecContext exec_context(arrow::default_memory_pool(),
                                  ::arrow::internal::GetCpuThreadPool());
 
@@ -990,7 +980,7 @@ arrow::Status scan_filter_write_example() {
     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
     std::string root_path = "";
-    std::string uri = "file:///Users/vibhatha/sandbox/test";
+    std::string uri = "file://" + file_path;
     std::shared_ptr<arrow::fs::FileSystem> filesystem =
     arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
 
@@ -1032,7 +1022,7 @@ arrow::Status scan_filter_write_example() {
     return arrow::Status::OK();
 }
 
-arrow::Status source_union_sink_example() {
+arrow::Status SourceUnionSinkExample() {
     auto basic_data = MakeBasicBatches();
 
     cp::ExecContext exec_context(arrow::default_memory_pool(),
@@ -1089,29 +1079,74 @@ arrow::Status source_union_sink_example() {
     return arrow::Status::OK();
 }
 
+enum ExampleMode {
+  SOURCE_SINK = 0,
+  SCAN_SINK = 1,
+  SCAN_FILTER_SINK = 2,
+  SCAN_PROJECT_SINK = 3,
+  SOURCE_AGGREGATE_SINK = 4,
+  SCAN_CONSUMING_SINK = 5,
+  SCAN_ORDER_BY_SINK = 6,
+  SCAN_HASHJOIN_SINK = 7,
+  SCAN_SELECT_SINK = 8,
+  SCAN_FILTER_WRITE = 9,
+  SOURCE_UNION_SINK = 10,
+};
+
 int main(int argc, char** argv) {
-  PRINT_BLOCK("Scan Sink Example");
-  CHECK_AND_CONTINUE(scan_sink_node_example());
-  PRINT_BLOCK("Exec Plan End-to-End Example");
-  CHECK_AND_CONTINUE(exec_plan_end_to_end_sample());
-  PRINT_BLOCK("Source Sink Example")
-  CHECK_AND_CONTINUE(source_sink_example());
-  PRINT_BLOCK("Scan Filter Sink Example");
-  CHECK_AND_CONTINUE(scan_filter_sink_example());
-  PRINT_BLOCK("Scan Project Sink Example");
-  CHECK_AND_CONTINUE(scan_project_sink_example());
-  PRINT_BLOCK("Source Aggregate Sink Example");
-  CHECK_AND_CONTINUE(source_aggregate_sink_example());
-  PRINT_BLOCK("Source Consuming-Sink Example");
-  CHECK_AND_CONTINUE(source_consuming_sink_node_example());
-  PRINT_BLOCK("Source Ordered-By-Sink Example");
-  CHECK_AND_CONTINUE(source_order_by_sink_example());
-  PRINT_BLOCK("Source HashJoin Example");
-  CHECK_AND_CONTINUE(source_hash_join_sink_example());
-  PRINT_BLOCK("Source KSelect Example");
-  CHECK_AND_CONTINUE(source_kselect_example());
-  PRINT_BLOCK("Scan Filter Write Example");
-  CHECK_AND_CONTINUE(scan_filter_write_example());
-  PRINT_LINE("Catalog Source Sink Example");
-  CHECK_AND_RETURN(source_union_sink_example());
+  if (argc < 11) {
+    // Fake success for CI purposes.
+    return EXIT_SUCCESS;
+  }
+
+  std::string base_save_path = argv[1];
+  int mode = argc < 11 ? std::atoi(argv[2]) : 0;
+
+
+  switch (mode) {
+    case SOURCE_SINK:
+      PRINT_BLOCK("Source Sink Example");
+      CHECK_AND_CONTINUE(SourceSinkExample())
+      break;
+    case SCAN_SINK:
+      PRINT_BLOCK("Scan Sink Example");
+      CHECK_AND_CONTINUE(ScanSinkExample())
+      break;
+    case SCAN_FILTER_SINK:
+    PRINT_BLOCK("Scan Filter Example");
+      CHECK_AND_CONTINUE(ScanFilterSinkExample())
+      break;
+    case SCAN_PROJECT_SINK:
+      PRINT_BLOCK("Scan Project Sink Example");
+      CHECK_AND_CONTINUE(ScanProjectSinkExample())
+      break;
+    case SOURCE_AGGREGATE_SINK:
+      PRINT_BLOCK("Source Aggregate Example");
+      CHECK_AND_CONTINUE(SourceAggregateSinkExample())
+      break;
+    case SCAN_CONSUMING_SINK:
+      PRINT_BLOCK("Source Consuming-Sink Example");
+      CHECK_AND_CONTINUE(SourceConsumingSinkExample())
+      break;
+    case SCAN_ORDER_BY_SINK:
+      PRINT_BLOCK("Source Sink Example");
+      CHECK_AND_CONTINUE(SourceOrderBySinkExample())
+      break;
+    case SCAN_HASHJOIN_SINK:
+      CHECK_AND_CONTINUE(SourceHashJoinSinkExample())
+      break;
+    case SCAN_SELECT_SINK:
+      CHECK_AND_CONTINUE(SourceKSelectExample())
+      break;
+    case SCAN_FILTER_WRITE:
+      CHECK_AND_CONTINUE(ScanFilterWriteExample(base_save_path))
+      break;
+    case SOURCE_UNION_SINK:
+      CHECK_AND_CONTINUE(SourceUnionSinkExample());
+      break;
+    default:
+      break;
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -111,35 +111,6 @@ std::shared_ptr<arrow::RecordBatch> GetRecordBatchFromJSON(
   return *arrow::RecordBatch::FromStructArray(struct_array);
 }
 
-std::shared_ptr<arrow::Table> GetTableFromJSON(
-    const std::shared_ptr<arrow::Schema>& schema, const std::vector<std::string>& json) {
-  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-  for (const std::string& batch_json : json) {
-    batches.push_back(GetRecordBatchFromJSON(schema, batch_json));
-  }
-  return *arrow::Table::FromRecordBatches(schema, std::move(batches));
-}
-
-std::shared_ptr<arrow::Table> CreateTable() {
-    auto schema =
-        arrow::schema({arrow::field("a", arrow::int64()),
-        arrow::field("b", arrow::int64()),
-        arrow::field("c", arrow::int64())});
-    std::shared_ptr<arrow::Array> array_a;
-    std::shared_ptr<arrow::Array> array_b;
-    std::shared_ptr<arrow::Array> array_c;
-    arrow::NumericBuilder<arrow::Int64Type> builder;
-    ABORT_ON_FAILURE(builder.AppendValues({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-    ABORT_ON_FAILURE(builder.Finish(&array_a));
-    builder.Reset();
-    ABORT_ON_FAILURE(builder.AppendValues({9, 8, 7, 6, 5, 4, 3, 2, 1, 0}));
-    ABORT_ON_FAILURE(builder.Finish(&array_b));
-    builder.Reset();
-    ABORT_ON_FAILURE(builder.AppendValues({1, 2, 1, 2, 1, 2, 1, 2, 1, 2}));
-    ABORT_ON_FAILURE(builder.Finish(&array_c));
-    return arrow::Table::Make(schema, {array_a, array_b, array_c});
-}
-
 std::string GetDataAsCsvString() {
     std::string data_str = "";
 

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -18,25 +18,25 @@
 #include <memory>
 #include <utility>
 
-#include "arrow/compute/api.h"
-#include "arrow/compute/api_scalar.h"
-#include "arrow/compute/api_vector.h"
-#include "arrow/compute/cast.h"
-#include "arrow/compute/exec/exec_plan.h"
-#include "arrow/compute/exec/ir_consumer.h"
-#include "arrow/compute/exec/test_util.h"
+#include <arrow/compute/api.h>
+#include <arrow/compute/api_scalar.h>
+#include <arrow/compute/api_vector.h>
+#include <arrow/compute/cast.h>
+#include <arrow/compute/exec/exec_plan.h>
+#include <arrow/compute/exec/ir_consumer.h>
+#include <arrow/compute/exec/test_util.h>
 
 #include <arrow/dataset/dataset.h>
 #include <arrow/dataset/file_parquet.h>
-#include "arrow/dataset/file_base.h"
-#include "arrow/dataset/plan.h"
-#include "arrow/dataset/scanner.h"
-#include "arrow/dataset/dataset_writer.h"
+#include <arrow/dataset/file_base.h>
+#include <arrow/dataset/plan.h>
+#include <arrow/dataset/scanner.h>
+#include <arrow/dataset/dataset_writer.h>
 
-#include "arrow/io/interfaces.h"
-#include "arrow/io/memory.h"
-#include "arrow/io/slow.h"
-#include "arrow/io/transform.h"
+#include <arrow/io/interfaces.h>
+#include <arrow/io/memory.h>
+#include <arrow/io/slow.h>
+#include <arrow/io/transform.h>
 
 #include <arrow/result.h>
 #include <arrow/status.h>
@@ -45,9 +45,9 @@
 #include <arrow/ipc/api.h>
 
 #include <arrow/util/future.h>
-#include "arrow/util/range.h"
-#include "arrow/util/thread_pool.h"
-#include "arrow/util/vector.h"
+#include <arrow/util/range.h>
+#include <arrow/util/thread_pool.h>
+#include <arrow/util/vector.h>
 
 // Demonstrate various operators in Arrow Streaming Execution Engine
 

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -1,0 +1,1259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <utility>
+
+#include "arrow/compute/api.h"
+#include "arrow/compute/api_scalar.h"
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/cast.h"
+#include "arrow/compute/exec/exec_plan.h"
+#include "arrow/compute/exec/ir_consumer.h"
+
+#include <arrow/dataset/dataset.h>
+#include "arrow/dataset/scanner.h"
+#include "arrow/dataset/plan.h"
+#include "arrow/dataset/file_base.h"
+#include <arrow/dataset/file_parquet.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/compute/exec/test_util.h"
+#include "arrow/util/range.h"
+#include "arrow/util/thread_pool.h"
+#include "arrow/util/vector.h"
+#include "arrow/io/interfaces.h"
+#include "arrow/io/memory.h"
+#include "arrow/io/slow.h"
+#include "arrow/io/transform.h"
+
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/table.h>
+
+#include <arrow/ipc/api.h>
+
+//#include <arrow/testing/future_util.h>
+//#include <arrow/testing/gtest_util.h>
+
+
+// Demonstrate various operators in Arrow Streaming Execution Engine
+
+#define ABORT_ON_FAILURE(expr)                           \
+    do {                                                    \
+        arrow::Status status_ = (expr);                  \
+        if (!status_.ok()) {                                                \
+            std::cerr << status_.message() << std::endl; \
+            abort();                                     \
+        }                                                \
+    } while (0);
+
+#define CHECK_AND_RETURN(expr)                                  \
+    do {                                                           \
+        arrow::Status status_ = (expr);                         \
+        if (!status_.ok()) {                                                       \
+            std::cerr << status_.message() << std::endl;        \
+            return EXIT_FAILURE;                                \
+        } else {                                                       \
+            return EXIT_SUCCESS;                                \
+        }                                                       \
+    } while (0);
+
+#define CHECK_AND_CONTINUE(expr)                                        \
+    do {                                                                \
+        arrow::Status status_ = (expr);                                 \
+        if (!status_.ok()) {                                            \
+            std::cerr << status_.message() << std::endl;                \
+            return EXIT_FAILURE;                                        \
+        }                                                               \
+    } while (0);
+
+#define SEP_STR "******"
+
+#define PRINT_BLOCK(msg)                                                                \
+    std::cout << "" << std::endl;                                                       \
+    std::cout << "\t" << SEP_STR << " " << msg << " " <<SEP_STR <<  std::endl;          \
+    std::cout << "" << std::endl;                                                       \
+
+#define PRINT_LINE(msg)                                                                \
+    std::cout << msg <<  std::endl;          \
+
+
+namespace cp = ::arrow::compute;
+
+std::shared_ptr<arrow::Array> GetArrayFromJSON(const std::shared_ptr<arrow::DataType>& type,
+                                     arrow::util::string_view json) {
+  std::shared_ptr<arrow::Array> out;
+  
+  ABORT_ON_FAILURE(arrow::ipc::internal::json::ArrayFromJSON(type, json, &out));
+  return out;
+}
+
+std::shared_ptr<arrow::RecordBatch> GetRecordBatchFromJSON(const std::shared_ptr<arrow::Schema>& schema,
+                                                 arrow::util::string_view json) {
+  // Parse as a StructArray
+  auto struct_type = struct_(schema->fields());
+  std::shared_ptr<arrow::Array> struct_array = GetArrayFromJSON(struct_type, json);
+
+  // Convert StructArray to RecordBatch
+  return *arrow::RecordBatch::FromStructArray(struct_array);
+}
+
+std::shared_ptr<arrow::Table> GetTableFromJSON(const std::shared_ptr<arrow::Schema>& schema,
+                                     const std::vector<std::string>& json) {
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+  for (const std::string& batch_json : json) {
+    batches.push_back(GetRecordBatchFromJSON(schema, batch_json));
+  }
+  return *arrow::Table::FromRecordBatches(schema, std::move(batches));
+}
+
+std::shared_ptr<arrow::Table> CreateTable()
+{
+    auto schema =
+        arrow::schema({arrow::field("a", arrow::int64()), arrow::field("b", arrow::int64()),
+                       arrow::field("c", arrow::int64())});
+    std::shared_ptr<arrow::Array> array_a;
+    std::shared_ptr<arrow::Array> array_b;
+    std::shared_ptr<arrow::Array> array_c;
+    arrow::NumericBuilder<arrow::Int64Type> builder;
+    ABORT_ON_FAILURE(builder.AppendValues({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    ABORT_ON_FAILURE(builder.Finish(&array_a));
+    builder.Reset();
+    ABORT_ON_FAILURE(builder.AppendValues({9, 8, 7, 6, 5, 4, 3, 2, 1, 0}));
+    ABORT_ON_FAILURE(builder.Finish(&array_b));
+    builder.Reset();
+    ABORT_ON_FAILURE(builder.AppendValues({1, 2, 1, 2, 1, 2, 1, 2, 1, 2}));
+    ABORT_ON_FAILURE(builder.Finish(&array_c));
+    return arrow::Table::Make(schema, {array_a, array_b, array_c});
+}
+
+std::shared_ptr<arrow::Table> CreateSimpleTable()
+{
+    auto schema =
+        arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())});
+    std::shared_ptr<arrow::Array> array_a;
+    std::shared_ptr<arrow::Array> array_b;
+    arrow::NumericBuilder<arrow::Int32Type> builder;
+    arrow::BooleanBuilder b_builder;
+    ABORT_ON_FAILURE(builder.AppendValues({1, 2, 3, 4, 5, 6, 7}));
+    ABORT_ON_FAILURE(builder.Finish(&array_a));
+    builder.Reset();
+
+    std::vector<bool> bool_vec{false, true, false, true, false, true, false};
+    ABORT_ON_FAILURE(b_builder.AppendValues(bool_vec));
+    ABORT_ON_FAILURE(builder.Finish(&array_b));
+    builder.Reset();
+    return arrow::Table::Make(schema, {array_a, array_b});
+}
+
+arrow::Status exec_plan_end_to_end_sample()
+{
+    std::cout << "Initializing" << std::endl;
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                 ::arrow::internal::GetCpuThreadPool());
+
+    std::cout << "Registry creating" << std::endl;
+
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
+
+    std::cout << "Intialized Scanner" << std::endl;
+
+    // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+    // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+    // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+    auto table = CreateSimpleTable();
+
+    std::cout << "Table created" << std::endl;
+
+    std::shared_ptr<arrow::dataset::Dataset> dataset; // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+
+    dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
+        GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())}),
+                             {
+                                 R"([{"a": 1,    "b": null},
+                            {"a": 2,    "b": true}])",
+                                 R"([{"a": null, "b": true},
+                            {"a": 3,    "b": false}])",
+                                 R"([{"a": null, "b": true},
+                            {"a": 4,    "b": false}])",
+                                 R"([{"a": 5,    "b": null},
+                            {"a": 6,    "b": false},
+                            {"a": 7,    "b": false},
+                            {"a": 8,    "b": true}])",
+                             }));
+
+    std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) << std::endl;
+
+    auto options = std::make_shared<arrow::dataset::ScanOptions>();
+    // sync scanning is not supported by ScanNode
+    options->use_async = true;
+    // specify the filter
+    cp::Expression b_is_true = cp::field_ref("b");
+    options->filter = b_is_true;
+    // for now, specify the projection as the full project expression (eventually this can
+    // just be a list of materialized field names)
+
+    cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
+    options->projection =
+        cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
+
+    // construct the scan node
+
+    std::cout << "Initialized Scanning Options" << std::endl;
+
+    cp::ExecNode *scan;
+
+    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+    std::cout << "Scan node options created" << std::endl;
+
+    ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+
+    //pipe the scan node into a filter node
+    cp::ExecNode *filter;
+    ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
+                                                   cp::FilterNodeOptions{b_is_true}));
+
+    // // pipe the filter node into a project node
+    // // NB: we're using the project node factory which preserves fragment/batch index
+    // // tagging, so we *can* reorder later if we choose. The tags will not appear in
+    // // our output.
+
+    cp::ExecNode *project;
+
+    ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("augmented_project", plan.get(), {filter},
+                                                    cp::ProjectNodeOptions{{a_times_2}}));
+
+    // // finally, pipe the project node into a sink node
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+                          cp::MakeExecNode("ordered_sink", plan.get(), {project},
+                                           cp::SinkNodeOptions{&sink_gen}));
+
+    // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+        arrow::schema({arrow::field("a * 2", arrow::int32())}), std::move(sink_gen), exec_context.memory_pool());
+
+    // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
+
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
+    ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+    std::cout << "Results : " << response_table->ToString() << std::endl;
+    return arrow::Status::OK();
+}
+
+cp::Expression Materialize(std::vector<std::string> names,
+                           bool include_aug_fields = false)
+{
+    if (include_aug_fields)
+    {
+        for (auto aug_name : {"__fragment_index", "__batch_index", "__last_in_fragment"})
+        {
+            names.emplace_back(aug_name);
+        }
+    }
+
+    std::vector<cp::Expression> exprs;
+    for (const auto &name : names)
+    {
+        exprs.push_back(cp::field_ref(name));
+    }
+
+    return cp::project(exprs, names);
+}
+
+arrow::Status scan_sink_node_example()
+{
+
+    std::cout << "Initializing" << std::endl;
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                 ::arrow::internal::GetCpuThreadPool());
+
+    std::cout << "Registry creating" << std::endl;
+
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
+
+    std::cout << "Intialized Scanner" << std::endl;
+
+    // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+    // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+    // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+    std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+    auto table = CreateSimpleTable();
+
+    std::cout << "Table created" << std::endl;
+
+    std::shared_ptr<arrow::dataset::Dataset> dataset; // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+
+    dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
+        GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())}),
+                             {
+                                 R"([{"a": 1,    "b": null},
+                            {"a": 2,    "b": true}])",
+                                 R"([{"a": null, "b": true},
+                            {"a": 3,    "b": false}])",
+                                 R"([{"a": null, "b": true},
+                            {"a": 4,    "b": false}])",
+                                 R"([{"a": 5,    "b": null},
+                            {"a": 6,    "b": false},
+                            {"a": 7,    "b": false},
+                            {"a": 8,    "b": true}])",
+                             }));
+
+    std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) << std::endl;
+
+    auto options = std::make_shared<arrow::dataset::ScanOptions>();
+    // sync scanning is not supported by ScanNode
+    options->use_async = true;
+    options->projection = Materialize({}); // create empty projection
+
+    // construct the scan node
+
+    std::cout << "Initialized Scanning Options" << std::endl;
+
+    cp::ExecNode *scan;
+    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+
+    ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+    std::cout << "Scan node options created" << std::endl;
+
+    // // // finally, pipe the project node into a sink node
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+    cp::ExecNode *sink;
+
+    ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("ordered_sink", plan.get(), {scan},
+                                                 cp::SinkNodeOptions{&sink_gen}));
+
+    // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+        arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())}),
+        std::move(sink_gen), exec_context.memory_pool());
+
+    // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
+
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
+
+    ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+    std::cout << "Results : " << response_table->ToString() << std::endl;
+
+    return arrow::Status::OK();
+}
+
+cp::ExecBatch GetExecBatchFromJSON(const std::vector<arrow::ValueDescr>& descrs,
+                            arrow::util::string_view json) {
+  auto fields = ::arrow::internal::MapVector(
+      [](const arrow::ValueDescr& descr) { return arrow::field("", descr.type); }, descrs);
+
+  cp::ExecBatch batch{*GetRecordBatchFromJSON(schema(std::move(fields)), json)};
+
+  auto value_it = batch.values.begin();
+  for (const auto& descr : descrs) {
+    if (descr.shape == arrow::ValueDescr::SCALAR) {
+      if (batch.length == 0) {
+        *value_it = MakeNullScalar(value_it->type());
+      } else {
+        *value_it = value_it->make_array()->GetScalar(0).ValueOrDie();
+      }
+    }
+    ++value_it;
+  }
+
+  return batch;
+}
+
+cp::BatchesWithSchema MakeBasicBatches()
+{
+    cp::BatchesWithSchema out;
+    out.batches = {
+        GetExecBatchFromJSON({arrow::int32(), arrow::boolean()}, "[[null, true], [4, false]]"),
+        GetExecBatchFromJSON({arrow::int32(), arrow::boolean()}, "[[5, null], [6, false], [7, false]]")};
+    out.schema = arrow::schema({arrow::field("a", arrow::int32()),
+                                arrow::field("b", arrow::boolean())});
+    return out;
+}
+
+cp::BatchesWithSchema MakeSortTestBasicBatches()
+{
+    cp::BatchesWithSchema out;
+    out.batches = {
+        GetExecBatchFromJSON({arrow::int32(), arrow::int32(), arrow::int32(), arrow::int32()},
+                              "[[1, 3, 0, 2], [121, 101, 120, 12], [10, 110, 210, 121], [51, 101, 2, 34]]"),
+        GetExecBatchFromJSON({arrow::int32(), arrow::int32(), arrow::int32(), arrow::int32()},
+                              "[[11, 31, 1, 12], [12, 101, 120, 12], [0, 110, 210, 11], [51, 10, 2, 3]]")
+
+    };
+    out.schema = arrow::schema({arrow::field("a", arrow::int32()),
+                                arrow::field("b", arrow::int32()),
+                                arrow::field("c", arrow::int32()),
+                                arrow::field("d", arrow::int32())});
+    return out;
+}
+
+cp::BatchesWithSchema MakeGroupableBatches(int multiplicity = 1)
+{
+    cp::BatchesWithSchema out;
+
+    out.batches = {GetExecBatchFromJSON({arrow::int32(), arrow::utf8()}, R"([
+                   [12, "alfa"],
+                   [7,  "beta"],
+                   [3,  "alfa"]
+                 ])"),
+                   GetExecBatchFromJSON({arrow::int32(), arrow::utf8()}, R"([
+                   [-2, "alfa"],
+                   [-1, "gama"],
+                   [3,  "alfa"]
+                 ])"),
+                   GetExecBatchFromJSON({arrow::int32(), arrow::utf8()}, R"([
+                   [5,  "gama"],
+                   [3,  "beta"],
+                   [-8, "alfa"]
+                 ])")};
+
+    size_t batch_count = out.batches.size();
+    for (int repeat = 1; repeat < multiplicity; ++repeat)
+    {
+        for (size_t i = 0; i < batch_count; ++i)
+        {
+            out.batches.push_back(out.batches[i]);
+        }
+    }
+
+    out.schema = arrow::schema({arrow::field("i32", arrow::int32()),
+                                arrow::field("str", arrow::utf8())});
+
+    return out;
+}
+
+std::shared_ptr<arrow::internal::ThreadPool> MakeIOThreadPool()
+{
+    auto maybe_pool = arrow::internal::ThreadPool::MakeEternal(/*threads=*/8);
+    if (!maybe_pool.ok())
+    {
+        maybe_pool.status().Abort("Failed to create global IO thread pool");
+    }
+    return *std::move(maybe_pool);
+}
+
+arrow::internal::ThreadPool *GetIOThreadPool()
+{
+    static std::shared_ptr<arrow::internal::ThreadPool> pool = MakeIOThreadPool();
+    return pool.get();
+}
+
+arrow::Status source_sink_example()
+{
+
+    std::cout << "Initializing" << std::endl;
+    cp::ExecContext exec_context(arrow::default_memory_pool(),
+                                 ::arrow::internal::GetCpuThreadPool());
+
+    std::cout << "Registry creating" << std::endl;
+
+    // ensure arrow::dataset node factories are in the registry
+    arrow::dataset::internal::Initialize();
+
+    std::cout << "Intialized Scanner" << std::endl;
+
+    // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+    // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+    // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+    std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+    auto basic_data = MakeBasicBatches();
+
+    PRINT_LINE("data created");
+
+    PRINT_LINE("source node options created");
+
+    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+    auto source_node_options = cp::SourceNodeOptions{
+        basic_data.schema, basic_data.gen(false, false)};
+
+    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+                                                                  plan.get(), {},
+                                                                  source_node_options));
+
+    PRINT_LINE("source node created");
+
+    // arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+    cp::ExecNode *sink;
+
+    ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("sink", plan.get(), {source},
+                                                 cp::SinkNodeOptions{&sink_gen}));
+
+    PRINT_LINE("sink node created");
+    // // // translate sink_gen (async) to sink_reader (sync)
+    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+        basic_data.schema,
+        std::move(sink_gen),
+        exec_context.memory_pool());
+
+    // // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
+
+    // // collect sink_reader into a Table
+    std::shared_ptr<arrow::Table> response_table;
+
+    ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+    std::cout << "Results : " << response_table->ToString() << std::endl;
+
+    return arrow::Status::OK();
+}
+
+// arrow::Status scan_filter_sink_example()
+// {
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     PRINT_LINE("Execution context created.");
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     PRINT_LINE("Intialized Scanner");
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+//     std::string msg;
+//     msg.append("Exec Plan Created : ");
+//     msg.append(plan->ToString());
+//     PRINT_LINE(msg);
+
+//     auto table = CreateSimpleTable();
+
+//     PRINT_LINE("Table created")
+
+//     std::shared_ptr<arrow::dataset::Dataset> dataset; // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+
+//     dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
+//         GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())}),
+//                              {
+//                                  R"([{"a": 1,    "b": null},
+//                             {"a": 2,    "b": true}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 3,    "b": false}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 4,    "b": false}])",
+//                                  R"([{"a": 5,    "b": null},
+//                             {"a": 6,    "b": false},
+//                             {"a": 7,    "b": false},
+//                             {"a": 8,    "b": true}])",
+//                              }));
+
+//     std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) << std::endl;
+
+//     auto options = std::make_shared<arrow::dataset::ScanOptions>();
+//     // sync scanning is not supported by ScanNode
+//     options->use_async = true;
+//     // specify the filter
+//     cp::Expression b_is_true = cp::field_ref("b");
+//     options->filter = b_is_true;
+//     // empty projection
+//     options->projection = Materialize({});
+
+//     // construct the scan node
+//     PRINT_LINE("Initialized Scanning Options");
+
+//     cp::ExecNode *scan;
+
+//     auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+//     PRINT_LINE("Scan node options created");
+
+//     ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+
+//     //pipe the scan node into a filter node
+//     cp::ExecNode *filter;
+//     ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
+//                                                    cp::FilterNodeOptions{b_is_true}));
+
+//     // // finally, pipe the project node into a sink node
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+//                           cp::MakeExecNode("sink", plan.get(), {filter},
+//                                            cp::SinkNodeOptions{&sink_gen}));
+
+//     // // translate sink_gen (async) to sink_reader (sync)
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         table->schema(), std::move(sink_gen), exec_context.memory_pool());
+
+//     // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status scan_project_sink_example()
+// {
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     PRINT_LINE("Execution context created.");
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     PRINT_LINE("Intialized Scanner");
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+//     std::string msg;
+//     msg.append("Exec Plan Created : ");
+//     msg.append(plan->ToString());
+//     PRINT_LINE(msg);
+
+//     auto table = CreateSimpleTable();
+
+//     PRINT_LINE("Table created")
+
+//     std::shared_ptr<arrow::dataset::Dataset> dataset; // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+
+//     dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
+//         GetTableFromJSON(arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())}),
+//                              {
+//                                  R"([{"a": 1,    "b": null},
+//                             {"a": 2,    "b": true}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 3,    "b": false}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 4,    "b": false}])",
+//                                  R"([{"a": 5,    "b": null},
+//                             {"a": 6,    "b": false},
+//                             {"a": 7,    "b": false},
+//                             {"a": 8,    "b": true}])",
+//                              }));
+
+//     std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) << std::endl;
+
+//     auto options = std::make_shared<arrow::dataset::ScanOptions>();
+//     // sync scanning is not supported by ScanNode
+//     options->use_async = true;
+//     // projection
+//     cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
+//     options->projection =
+//         cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
+
+//     // construct the scan node
+//     PRINT_LINE("Initialized Scanning Options");
+
+//     cp::ExecNode *scan;
+
+//     auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+//     PRINT_LINE("Scan node options created");
+
+//     ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+
+//     //pipe the scan node into a filter node
+//     cp::ExecNode *project;
+//     ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
+//                                                     cp::ProjectNodeOptions{{a_times_2}}));
+
+//     // // finally, pipe the project node into a sink node
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+//                           cp::MakeExecNode("sink", plan.get(), {project},
+//                                            cp::SinkNodeOptions{&sink_gen}));
+
+//     // // translate sink_gen (async) to sink_reader (sync)
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         arrow::schema({arrow::field("a * 2", arrow::int32())}),
+//         std::move(sink_gen), exec_context.memory_pool());
+
+//     // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status source_aggregate_sink_example()
+// {
+
+//     std::cout << "Initializing" << std::endl;
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::cout << "Registry creating" << std::endl;
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     std::cout << "Intialized Scanner" << std::endl;
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+//     auto basic_data = MakeBasicBatches();
+
+//     PRINT_LINE("data created");
+
+//     PRINT_LINE("source node options created");
+
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     auto source_node_options = cp::SourceNodeOptions{
+//         basic_data.schema, basic_data.gen(true, true)};
+
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+//                                                                   plan.get(), {},
+//                                                                   source_node_options));
+
+//     PRINT_LINE("source node created");
+//     cp::CountOptions options(cp::CountOptions::ONLY_VALID);
+//     auto aggregate_options = cp::AggregateNodeOptions{
+//         /*aggregates=*/{{"hash_count", &options}},
+//         /*targets=*/{"a"},
+//         /*names=*/{"count(a)"},
+//         /*keys=*/{"b"}};
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * aggregate,
+//                           cp::MakeExecNode("aggregate", plan.get(), {source}, aggregate_options));
+
+//     PRINT_LINE("aggregation node created");
+
+//     cp::ExecNode *sink;
+
+//     ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("sink", plan.get(), {aggregate},
+//                                                  cp::SinkNodeOptions{&sink_gen}));
+
+//     PRINT_LINE("sink node created");
+//     // // // translate sink_gen (async) to sink_reader (sync)
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         arrow::schema({
+//             //arrow::field("a", arrow::int32()),
+//             arrow::field("count(a)", arrow::int32()),
+//             arrow::field("b", arrow::boolean()),
+//         }),
+//         std::move(sink_gen),
+//         exec_context.memory_pool());
+
+//     // // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status source_consuming_sink_node_example()
+// {
+
+//     std::cout << "Initializing" << std::endl;
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::cout << "Registry creating" << std::endl;
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     std::cout << "Intialized Scanner" << std::endl;
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+//     auto basic_data = MakeBasicBatches();
+
+//     PRINT_LINE("data created");
+
+//     PRINT_LINE("source node options created");
+
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     auto source_node_options = cp::SourceNodeOptions{
+//         basic_data.schema, basic_data.gen(true, true)};
+
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+//                                                                   plan.get(), {},
+//                                                                   source_node_options));
+
+//     PRINT_LINE("source node created");
+
+//     std::atomic<uint32_t> batches_seen{0};
+//     arrow::Future<> finish = arrow::Future<>::Make();
+//     struct CustomSinkNodeConsumer : public cp::SinkNodeConsumer
+//     {
+//         CustomSinkNodeConsumer(std::atomic<uint32_t> *batches_seen, arrow::Future<> finish)
+//             : batches_seen(batches_seen), finish(std::move(finish)) {}
+
+//         arrow::Status Consume(cp::ExecBatch batch) override
+//         {
+//             (*batches_seen)++;
+//             return arrow::Status::OK();
+//         }
+
+//         arrow::Future<> Finish() override { return finish; }
+
+//         std::atomic<uint32_t> *batches_seen;
+//         arrow::Future<> finish;
+//     };
+//     std::shared_ptr<CustomSinkNodeConsumer> consumer =
+//         std::make_shared<CustomSinkNodeConsumer>(&batches_seen, finish);
+
+//     cp::ExecNode *consuming_sink;
+
+//     ARROW_ASSIGN_OR_RAISE(consuming_sink, MakeExecNode("consuming_sink", plan.get(), {source},
+//                                                        cp::ConsumingSinkNodeOptions(consumer)));
+
+//     PRINT_LINE("Consuming Sink Node created");
+
+//     ABORT_ON_FAILURE(plan->StartProducing());
+//     PRINT_LINE("Started Producing");
+//     // Source should finish fairly quickly
+//     ABORT_ON_FAILURE(source->finished().status());
+//     PRINT_LINE("Source Finished!");
+
+//     plan->finished();
+
+//     plan->StopProducing();
+//     PRINT_LINE("Plan Finished!");
+//     // Mark consumption complete, plan should finish
+//     arrow::Status finish_status;
+//     finish.MarkFinished(finish_status);
+//     PRINT_LINE("Marked Finish");
+//     ABORT_ON_FAILURE(finish_status);
+//     ABORT_ON_FAILURE(plan->finished().status());
+
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status source_order_by_sink_example()
+// {
+
+//     std::cout << "Initializing" << std::endl;
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::cout << "Registry creating" << std::endl;
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     std::cout << "Intialized Scanner" << std::endl;
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+
+//     auto basic_data = MakeSortTestBasicBatches();
+
+//     PRINT_LINE("data created");
+
+//     PRINT_LINE("source node options created");
+
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     auto source_node_options = cp::SourceNodeOptions{
+//         basic_data.schema, basic_data.gen(true, true)};
+
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+//                                                                   plan.get(), {},
+//                                                                   source_node_options));
+
+//     PRINT_LINE("source node created");
+
+//     // arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     cp::ExecNode *sink;
+
+//     ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("order_by_sink", plan.get(), {source},
+//                                                  cp::OrderBySinkNodeOptions{
+//                                                      cp::SortOptions{
+//                                                          {cp::SortKey{"a",
+//                                                                       cp::SortOrder::Descending}}},
+//                                                      &sink_gen}));
+
+//     PRINT_LINE("sink node created");
+//     // // // translate sink_gen (async) to sink_reader (sync)
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         basic_data.schema,
+//         std::move(sink_gen),
+//         exec_context.memory_pool());
+
+//     // // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status source_hash_join_sink_example()
+// {
+//     auto input = MakeGroupableBatches();
+
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     cp::ExecNode *left_source;
+//     cp::ExecNode *right_source;
+//     for (auto source : {&left_source, &right_source})
+//     {
+//         ARROW_ASSIGN_OR_RAISE(
+//             *source, MakeExecNode("source", plan.get(), {},
+//                                   cp::SourceNodeOptions{input.schema,
+//                                                         input.gen(/*parallel=*/true, /*slow=*/false)}));
+//     }
+//     PRINT_LINE("left and right source nodes created");
+//     // TODO: decide whether to keep the filters or remove
+
+//     // ARROW_ASSIGN_OR_RAISE(
+//     //     auto left_filter,
+//     //     cp::MakeExecNode("filter", plan.get(), {left_source},
+//     //                      cp::FilterNodeOptions{
+//     //                          cp::greater_equal(
+//     //                              cp::field_ref("i32"),
+//     //                              cp::literal(-1))}));
+//     // ARROW_ASSIGN_OR_RAISE(
+//     //     auto right_filter,
+//     //     cp::MakeExecNode("filter", plan.get(), {right_source},
+//     //                      cp::FilterNodeOptions{
+//     //                          cp::less_equal(
+//     //                              cp::field_ref("i32"),
+//     //                              cp::literal(2))}));
+//     // PRINT_LINE("left and right filter nodes created");
+//     // left side: [3,  "alfa"], [3,  "alfa"], [12, "alfa"], [3,  "beta"], [7,  "beta"],
+//     // [-1, "gama"], [5,  "gama"]
+//     // right side: [-2, "alfa"], [-8, "alfa"], [-1, "gama"]
+
+//     cp::HashJoinNodeOptions join_opts{cp::JoinType::INNER,
+//                                       /*left_keys=*/{"str"},
+//                                       /*right_keys=*/{"str"}, cp::literal(true), "l_", "r_"};
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         auto hashjoin,
+//         cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source}, join_opts));
+
+//     PRINT_LINE("Hash Join Node created");
+
+//     ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {hashjoin},
+//                                                         cp::SinkNodeOptions{&sink_gen}));
+//     PRINT_LINE("Sink Node Created");
+//     // expected columns i32, str
+
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         arrow::schema({arrow::field("i32", arrow::int32()),
+//                        arrow::field("str", arrow::utf8()),
+//                        arrow::field("l_str", arrow::utf8()),
+//                        arrow::field("r_str", arrow::utf8())}),
+//         std::move(sink_gen),
+//         exec_context.memory_pool());
+
+//     // // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status source_kselect_example()
+// {
+
+//     auto input = MakeGroupableBatches();
+
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         cp::ExecNode * source, cp::MakeExecNode("source", plan.get(), {},
+//                                                 cp::SourceNodeOptions{input.schema,
+//                                                                       input.gen(/*parallel=*/true,
+//                                                                                 /*slow=*/false)}));
+
+//     cp::SelectKOptions options = cp::SelectKOptions::TopKDefault(/*k=*/2, {"i32"});
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         cp::ExecNode * k_sink_node, cp::MakeExecNode("select_k_sink",
+//                                                      plan.get(), {source},
+//                                                      cp::SelectKSinkNodeOptions{options, &sink_gen}));
+
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         arrow::schema({arrow::field("i32", arrow::int32()),
+//                        arrow::field("str", arrow::utf8())}),
+//         std::move(sink_gen),
+//         exec_context.memory_pool());
+
+//     // // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+
+//     ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status scan_filter_write_example()
+// {
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     PRINT_LINE("Execution context created.");
+
+//     // ensure arrow::dataset node factories are in the registry
+//     arrow::dataset::internal::Initialize();
+
+//     PRINT_LINE("Intialized Scanner");
+
+//     // A ScanNode is constructed from an ExecPlan (into which it is inserted),
+//     // a Dataset (whose batches will be scanned), and ScanOptions (to specify a filter for
+//     // predicate pushdown, a projection to skip materialization of unnecessary columns, ...)
+//     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+//     std::string msg;
+//     msg.append("Exec Plan Created : ");
+//     msg.append(plan->ToString());
+//     PRINT_LINE(msg);
+
+//     auto table = CreateSimpleTable();
+
+//     PRINT_LINE("Table created")
+
+//     std::shared_ptr<arrow::dataset::Dataset> dataset; // = std::make_shared<arrow::dataset::InMemoryDataset>(table);
+//     auto dataset_schema = arrow::schema({arrow::field("a", arrow::int32()), arrow::field("b", arrow::boolean())});
+//     dataset = std::make_shared<arrow::dataset::InMemoryDataset>(
+//         GetTableFromJSON(dataset_schema,
+//                              {
+//                                  R"([{"a": 1,    "b": null},
+//                             {"a": 2,    "b": true}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 3,    "b": false}])",
+//                                  R"([{"a": null, "b": true},
+//                             {"a": 4,    "b": false}])",
+//                                  R"([{"a": 5,    "b": null},
+//                             {"a": 6,    "b": false},
+//                             {"a": 7,    "b": false},
+//                             {"a": 8,    "b": true}])",
+//                              }));
+
+//     std::cout << "Dataset created :: " << dataset->schema()->field_names().at(0) << std::endl;
+
+//     auto options = std::make_shared<arrow::dataset::ScanOptions>();
+//     // sync scanning is not supported by ScanNode
+//     options->use_async = true;
+//     // specify the filter
+//     //cp::Expression b_is_true = cp::field_ref("b");
+//     //options->filter = b_is_true;
+//     // empty projection
+//     options->projection = Materialize({});
+
+//     // construct the scan node
+//     PRINT_LINE("Initialized Scanning Options");
+
+//     cp::ExecNode *scan;
+
+//     auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+//     PRINT_LINE("Scan node options created");
+
+//     ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+
+//     //pipe the scan node into a filter node
+//     // cp::ExecNode *filter;
+//     // ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
+//     //                                                cp::FilterNodeOptions{b_is_true}));
+//     PRINT_LINE("Filter node options created");
+//     // // finally, pipe the project node into a sink node
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     std::string root_path = "";
+//     std::string uri = "file:///Users/vibhatha/sandbox/test";
+//     std::shared_ptr<arrow::fs::FileSystem> filesystem = arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
+
+//     auto base_path = root_path + "/parquet_dataset";
+//     filesystem->CreateDir(base_path);
+
+//     // The partition schema determines which fields are part of the partitioning.
+//     auto partition_schema = arrow::schema({arrow::field("b", arrow::boolean())});
+//     // We'll use Hive-style partitioning, which creates directories with "key=value" pairs.
+
+//     auto partitioning = std::make_shared<arrow::dataset::HivePartitioning>(partition_schema);
+//     // We'll write Parquet files.
+//     auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+
+//     arrow::dataset::FileSystemDatasetWriteOptions write_options;
+//     //write_options.file_write_options = format->DefaultWriteOptions();
+//     //write_options.filesystem = filesystem;
+//     write_options.base_dir = base_path;
+//     //write_options.partitioning = partitioning;
+//     write_options.basename_template = "part{i}.parquet";
+
+//     PRINT_LINE("Write Options created");
+    
+//     ARROW_ASSIGN_OR_RAISE(cp::ExecNode * write,
+//                           cp::MakeExecNode("write", plan.get(), {scan},
+//                                            arrow::dataset::WriteNodeOptions(write_options, 
+//                                            arrow::schema({
+//                                                arrow::field("a", arrow::int32()),
+//                                                arrow::field("b", arrow::boolean())
+//                                            }))));
+
+
+//     PRINT_LINE("Write Node Created");
+//     // // // translate sink_gen (async) to sink_reader (sync)
+//     // std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//     //     table->schema(), std::move(sink_gen), exec_context.memory_pool());
+
+//     // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+//     PRINT_LINE("Started Producing.");
+
+//     // // collect sink_reader into a Table
+//     // std::shared_ptr<arrow::Table> response_table;
+//     // ARROW_ASSIGN_OR_RAISE(response_table, arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     // std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+// arrow::Status catalog_source_sink_example()
+// {
+
+//     auto input = MakeGroupableBatches();
+
+//     cp::ExecContext exec_context(arrow::default_memory_pool(),
+//                                  ::arrow::internal::GetCpuThreadPool());
+
+//     std::shared_ptr<cp::ExecPlan> plan = cp::ExecPlan::Make(&exec_context).ValueOrDie();
+//     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         cp::ExecNode * source, cp::MakeExecNode("source", plan.get(), {},
+//                                                 cp::SourceNodeOptions{input.schema,
+//                                                                       input.gen(/*parallel=*/true,
+//                                                                                 /*slow=*/false)}));
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         cp::ExecNode *catelog_source,
+//         cp::MakeExecNode(
+//             "catalog_source",
+//             plan.get(),
+//             {source},
+//             cp::CatalogSourceNodeOptions{
+//                 "catalog_source_test",
+//                 input.schema
+//             }
+//         )
+//     );                                                                             
+
+//     ARROW_ASSIGN_OR_RAISE(
+//         cp::ExecNode * k_sink_node, cp::MakeExecNode("sink",
+//                                                      plan.get(), {catelog_source},
+//                                                      cp::SinkNodeOptions{&sink_gen}));
+
+//     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+//         input.schema,
+//         std::move(sink_gen),
+//         exec_context.memory_pool());
+
+//     // // // start the ExecPlan
+//     ABORT_ON_FAILURE(plan->StartProducing());
+
+//     // // collect sink_reader into a Table
+//     std::shared_ptr<arrow::Table> response_table;
+
+//     ARROW_ASSIGN_OR_RAISE(response_table, 
+//     arrow::Table::FromRecordBatchReader(sink_reader.get()));
+
+//     std::cout << "Results : " << response_table->ToString() << std::endl;
+//     return arrow::Status::OK();
+// }
+
+int main(int argc, char **argv) {
+    PRINT_BLOCK("Scan Sink Example");
+    CHECK_AND_CONTINUE(scan_sink_node_example());
+    PRINT_BLOCK("Exec Plan End-to-End Example");
+    CHECK_AND_CONTINUE(exec_plan_end_to_end_sample());
+    PRINT_BLOCK("Source Sink Example")
+    CHECK_AND_CONTINUE(source_sink_example());
+    // PRINT_BLOCK("Scan Filter Sink Example");
+    // CHECK_AND_CONTINUE(scan_filter_sink_example());
+    // PRINT_BLOCK("Scan Project Sink Example");
+    // CHECK_AND_CONTINUE(scan_project_sink_example());
+    // PRINT_BLOCK("Source Aggregate Sink Example");
+    // CHECK_AND_CONTINUE(source_aggregate_sink_example());
+    // PRINT_BLOCK("Source Consuming-Sink Example");
+    // //CHECK_AND_CONTINUE(source_consuming_sink_node_example());
+    // PRINT_BLOCK("Source Ordered-By-Sink Example");
+    // CHECK_AND_CONTINUE(source_order_by_sink_example());
+    // PRINT_BLOCK("Source HashJoin Example");
+    // CHECK_AND_CONTINUE(source_hash_join_sink_example());
+    // PRINT_BLOCK("Source KSelect Example");
+    // CHECK_AND_CONTINUE(source_kselect_example());
+    //PRINT_BLOCK("Scan Filter Write Example");
+    //CHECK_AND_RETURN(scan_filter_write_example());
+    //PRINT_LINE("Catalog Source Sink Example");
+    //CHECK_AND_RETURN(catalog_source_sink_example());
+}

--- a/cpp/examples/arrow/exec_plan_examples.cc
+++ b/cpp/examples/arrow/exec_plan_examples.cc
@@ -1036,7 +1036,7 @@ arrow::Status scan_filter_write_example() {
     PRINT_LINE("Execution Plan Created : " << plan->ToString());
     // // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
-    PRINT_LINE("Started Producing.");
+    plan->finished().Wait();
     return arrow::Status::OK();
 }
 
@@ -1114,9 +1114,9 @@ int main(int argc, char** argv) {
   PRINT_BLOCK("Source HashJoin Example");
   CHECK_AND_CONTINUE(source_hash_join_sink_example());
   PRINT_BLOCK("Source KSelect Example");
-  CHECK_AND_RETURN(source_kselect_example());
-  // PRINT_BLOCK("Scan Filter Write Example");
-  // CHECK_AND_RETURN(scan_filter_write_example());
+  CHECK_AND_CONTINUE(source_kselect_example());
+  PRINT_BLOCK("Scan Filter Write Example");
+  CHECK_AND_RETURN(scan_filter_write_example());
   // PRINT_LINE("Catalog Source Sink Example");
   // CHECK_AND_RETURN(catalog_source_sink_example());
 }

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -445,15 +445,6 @@ BatchesWithSchema MakeGroupableBatches(int multiplicity = 1) {
   return out;
 }
 
-// std::shared_ptr<arrow::dataset::InMemoryDataset> GetBatchDataset() {
-  
-//   std::shared_ptr<arrow::dataset::Dataset> dataset = NULLPTR;
-  
-
-//   return dataset;
-// }
-
-
 arrow::Status SourceSinkExample() {
   cp::ExecContext exec_context(arrow::default_memory_pool(),
                                ::arrow::internal::GetCpuThreadPool());
@@ -522,7 +513,6 @@ arrow::Status ScanFilterSinkExample() {
   options->use_async = true;
   // specify the filter
   cp::Expression filter_opt = cp::greater(cp::field_ref("a"), cp::literal(3));
-  
   options->filter = filter_opt;
   // empty projection
   options->projection = Materialize({});
@@ -591,7 +581,7 @@ arrow::Status ScanProjectSinkExample() {
     options->use_async = true;
     // projection
     cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
-    cp::literal(2)}); 
+    cp::literal(2)});
     options->projection =
         cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -130,8 +130,6 @@ arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> GetDataset() {
                                               arrow::field("b", arrow::boolean())}),
                                10, {int64_array, bool_array});
   ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches({record_batch}));
-  std::cout << "DataSet Created : " << std::endl;
-  std::cout << table->ToString() << std::endl;
   auto ds = std::make_shared<arrow::dataset::InMemoryDataset>(table);
   arrow::Result<std::shared_ptr<arrow::dataset::InMemoryDataset>> result(std::move(ds));
   return result;

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -90,7 +90,9 @@ constexpr char kSep[] = "******";
   std::cout << "\t" << kSep << " " << msg << " " << kSep << std::endl; \
   std::cout << "" << std::endl;
 
-#define PRINT_LINE(msg) std::cout << msg << std::endl;
+void PrintLine(std::string msg){
+  std::cout << msg << std::endl;
+} 
 
 namespace cp = ::arrow::compute;
 
@@ -112,20 +114,18 @@ std::shared_ptr<arrow::RecordBatch> GetRecordBatchFromJSON(
 }
 
 std::string GetDataAsCsvString() {
-    std::string data_str = "";
-
-    data_str.append("a,b\n");
-    data_str.append("1,null\n");
-    data_str.append("2,true\n");
-    data_str.append("null,true\n");
-    data_str.append("3,false\n");
-    data_str.append("null,true\n");
-    data_str.append("4,false\n");
-    data_str.append("5,null\n");
-    data_str.append("6,false\n");
-    data_str.append("7,false\n");
-    data_str.append("8,true\n");
-
+    std::string data_str = R"csv(a,b
+1,null
+2,true
+null,true
+3,false
+null,true
+4,false
+5,null
+6,false
+7,false
+8,true
+)csv";
     return data_str;
 }
 
@@ -225,7 +225,7 @@ arrow::Status exec_plan_end_to_end_sample() {
 
     // // validate the plan
     ABORT_ON_FAILURE(plan->Validate());
-    PRINT_LINE("Exec Plan created: " << plan->ToString());
+    PrintLine("Exec Plan created: " + plan->ToString());
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -316,7 +316,7 @@ arrow::Status ScanSinkExample() {
 
     // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
-    PRINT_LINE("ExecPlan created : " << plan->ToString());
+    PrintLine("ExecPlan created : " + plan->ToString());
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -326,7 +326,7 @@ arrow::Status ScanSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
                             arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PRINT_LINE("Results : " << response_table->ToString());
+    PrintLine("Results : " + response_table->ToString());
 
     // // stop producing
     plan->StopProducing();
@@ -489,7 +489,7 @@ arrow::Status SourceSinkExample() {
 
   // // validate the ExecPlan
   ABORT_ON_FAILURE(plan->Validate());
-  PRINT_LINE("Exec Plan Created: " << plan->ToString());
+  PrintLine("Exec Plan Created: " + plan->ToString());
   // // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -499,7 +499,7 @@ arrow::Status SourceSinkExample() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  PRINT_LINE("Results : " << response_table->ToString());
+  PrintLine("Results : " + response_table->ToString());
 
   // // plan stop producing
   plan->StopProducing();
@@ -532,12 +532,12 @@ arrow::Status ScanFilterSinkExample() {
   options->projection = Materialize({});
 
   // construct the scan node
-  PRINT_LINE("Initialized Scanning Options");
+  PrintLine("Initialized Scanning Options");
 
   cp::ExecNode* scan;
 
   auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-  PRINT_LINE("Scan node options created");
+  PrintLine("Scan node options created");
 
   ARROW_ASSIGN_OR_RAISE(scan,
                         cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
@@ -560,7 +560,7 @@ arrow::Status ScanFilterSinkExample() {
 
   // // validate the ExecPlan
   ABORT_ON_FAILURE(plan->Validate());
-  PRINT_LINE("Exec Plan created " << plan->ToString());
+  PrintLine("Exec Plan created " + plan->ToString());
   // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -569,7 +569,7 @@ arrow::Status ScanFilterSinkExample() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  PRINT_LINE("Results : " << response_table->ToString());
+  PrintLine("Results : " + response_table->ToString());
   // // plan stop producing
   plan->StopProducing();
   // /// plan marked finished
@@ -625,7 +625,7 @@ arrow::Status ScanProjectSinkExample() {
     // // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
 
-    PRINT_LINE("Exec Plan Created : " << plan->ToString());
+    PrintLine("Exec Plan Created : " + plan->ToString());
 
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
@@ -635,7 +635,7 @@ arrow::Status ScanProjectSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PRINT_LINE("Results : " << response_table->ToString());
+    PrintLine("Results : " + response_table->ToString());
 
     // // plan stop producing
     plan->StopProducing();
@@ -691,7 +691,7 @@ arrow::Status SourceAggregateSinkExample() {
 
     // // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
-    PRINT_LINE("ExecPlan created : " << plan->ToString());
+    PrintLine("ExecPlan created : " + plan->ToString());
     // // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -701,7 +701,7 @@ arrow::Status SourceAggregateSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PRINT_LINE("Results : " << response_table->ToString());
+    PrintLine("Results : " + response_table->ToString());
 
     //plan stop producing
     plan->StopProducing();
@@ -758,12 +758,12 @@ arrow::Status SourceConsumingSinkExample() {
     ABORT_ON_FAILURE(consuming_sink->Validate());
 
     ABORT_ON_FAILURE(plan->Validate());
-    PRINT_LINE("Exec Plan created: " << plan->ToString());
+    PrintLine("Exec Plan created: " + plan->ToString());
     // plan start producing
     ABORT_ON_FAILURE(plan->StartProducing());
     // Source should finish fairly quickly
     ABORT_ON_FAILURE(source->finished().status());
-    PRINT_LINE("Source Finished!");
+    PrintLine("Source Finished!");
     // Mark consumption complete, plan should finish
     arrow::Status finish_status;
     //finish.Wait();
@@ -858,7 +858,7 @@ arrow::Status SourceHashJoinSinkExample() {
     //                          cp::less_equal(
     //                              cp::field_ref("i32"),
     //                              cp::literal(2))}));
-    // PRINT_LINE("left and right filter nodes created");
+    // PrintLine("left and right filter nodes created");
 
     cp::HashJoinNodeOptions join_opts{cp::JoinType::INNER,
                                       /*left_keys=*/{"str"},
@@ -893,7 +893,7 @@ arrow::Status SourceHashJoinSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PRINT_LINE("Results : " << response_table->ToString());
+    PrintLine("Results : " + response_table->ToString());
 
     // // plan stop producing
     plan->StopProducing();
@@ -948,7 +948,7 @@ arrow::Status SourceKSelectExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PRINT_LINE("Results : " << response_table->ToString());
+    PrintLine("Results : " + response_table->ToString());
 
     // // plan stop proudcing
     plan->StopProducing();
@@ -1017,14 +1017,14 @@ arrow::Status ScanFilterWriteExample(std::string file_path) {
     arrow::dataset::WriteNodeOptions write_node_options {write_options,
     dataset->schema()};
 
-    PRINT_LINE("Write Options created");
+    PrintLine("Write Options created");
 
     ARROW_ASSIGN_OR_RAISE(cp::ExecNode *wr, cp::MakeExecNode("write", plan.get(),
     {scan}, write_node_options));
 
     ABORT_ON_FAILURE(wr->Validate());
     ABORT_ON_FAILURE(plan->Validate());
-    PRINT_LINE("Execution Plan Created : " << plan->ToString());
+    PrintLine("Execution Plan Created : " + plan->ToString());
     // // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
     plan->finished().Wait();

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -17,9 +17,6 @@
 
 // (Doc section: Execution Plan Documentation Example)
 
-#include <memory>
-#include <utility>
-
 #include <arrow/array.h>
 #include <arrow/builder.h>
 
@@ -27,7 +24,6 @@
 #include <arrow/compute/api_vector.h>
 #include <arrow/compute/cast.h>
 #include <arrow/compute/exec/exec_plan.h>
-#include <arrow/compute/exec/test_util.h>
 
 #include <arrow/csv/api.h>
 
@@ -50,6 +46,10 @@
 #include <arrow/util/range.h>
 #include <arrow/util/thread_pool.h>
 #include <arrow/util/vector.h>
+
+#include <iostream>
+#include <memory>
+#include <utility>
 
 // Demonstrate various operators in Arrow Streaming Execution Engine
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -159,6 +159,7 @@ arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData
     return result;
 }
 
+// (Doc section: Materialize)
 cp::Expression Materialize(std::vector<std::string> names,
                            bool include_aug_fields = false) {
     if (include_aug_fields) {
@@ -175,16 +176,18 @@ cp::Expression Materialize(std::vector<std::string> names,
 
     return cp::project(exprs, names);
 }
+// (Doc section: Materialize)
 
+// (Doc section: Scan Example)
 /**
- * @brief 
+ * \brief 
  * Scan-Sink 
  * This example shows how scan operation can be applied on a dataset. 
  * There are operations that can be applied on the scan (project, filter)
  * and the input data can be processed. THe output is obtained as a table
  * via the sink node. 
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
     // Execution plan created
@@ -238,6 +241,7 @@ arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
     futures.Wait();
     return arrow::Status::OK();
 }
+// (Doc section: Scan Example)
 
 arrow::Result<cp::ExecBatch> GetExecBatchFromVectors(
   const arrow::FieldVector &field_vector,
@@ -250,6 +254,7 @@ arrow::Result<cp::ExecBatch> GetExecBatchFromVectors(
     return result;
 }
 
+// (Doc section: BatchesWithSchema Definition)
 struct BatchesWithSchema {
   std::vector<cp::ExecBatch> batches;
   std::shared_ptr<arrow::Schema> schema;
@@ -263,8 +268,10 @@ struct BatchesWithSchema {
     return gen;
   }
 };
+// (Doc section: BatchesWithSchema Definition)
 
 
+// (Doc section: MakeBasicBatches Definition)
 arrow::Result<BatchesWithSchema> MakeBasicBatches() {
   BatchesWithSchema out;
   auto field_vector = {arrow::field("a", arrow::int32()),
@@ -295,6 +302,7 @@ arrow::Result<BatchesWithSchema> MakeBasicBatches() {
   arrow::Result<BatchesWithSchema> result(std::move(out));
   return result;
 }
+// (Doc section: MakeBasicBatches Definition)
 
 arrow::Result<BatchesWithSchema> MakeSortTestBasicBatches() {
   BatchesWithSchema out;
@@ -364,15 +372,16 @@ arrow::Result<BatchesWithSchema> MakeGroupableBatches(int multiplicity = 1) {
   return result;
 }
 
+// (Doc section: Source Example)
 /**
- * @brief 
+ * \brief 
  * Source-Sink Example
  * This example shows how a source and sink can be used
  * in an execution plan. This includes source node receiving data 
  * and the sink node emits the data as an output represented in 
  * a table. 
- * @param exec_context : execution context 
- * @return arrow::Status 
+ * \param exec_context : execution context 
+ * \return arrow::Status 
  */
 arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -418,15 +427,17 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
 
   return arrow::Status::OK();
 }
+// (Doc section: Source Example)
 
+// (Doc section: Filter Example)
 /**
- * @brief 
+ * \brief 
  * Source-Filter-Sink
  * This example shows how a filter can be used in an execution plan, 
  * along with the source and sink operations. The output from the 
  * exeuction plan is obtained as a table via the sink node. 
- * @param exec_context : execution context 
- * @return arrow::Status 
+ * \param exec_context : execution context 
+ * \return arrow::Status 
  */
 arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -440,6 +451,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   options->use_async = true;
   // specify the filter
   cp::Expression filter_opt = cp::greater(cp::field_ref("a"), cp::literal(3));
+  // set filter for scanner : on-disk / push-down filtering.
   options->filter = filter_opt;
   // empty projection
   options->projection = Materialize({});
@@ -456,6 +468,9 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
                         cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
 
   // pipe the scan node into a filter node
+  // // Need to set the filter in scan node options and filter node options. 
+  // // At scan node it is used for on-disk / push-down filtering.
+  // // At filter node it is used for in-memory filtering.
   cp::ExecNode* filter;
   ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
                                                  cp::FilterNodeOptions{filter_opt}));
@@ -491,15 +506,18 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   return arrow::Status::OK();
 }
 
+// (Doc section: Filter Example)
+
+// (Doc section: Project Example)
 /**
- * @brief 
+ * \brief 
  * Scan-Project-Sink
  * This example shows how Scan operation can be used to load the data 
  * into the execution plan, how project operation can be applied on the
  * data stream and how the output is obtained as a table via the sink node. 
  * 
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -562,15 +580,19 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+// (Doc section: Project Example)
+
+
+// (Doc section: Aggregate Example)
 /**
- * @brief 
+ * \brief 
  * Source-Aggregation-Sink
  * This example shows how an aggregation operation can be applied on a 
  * execution plan. The source node loads the data and the aggregation 
  * (counting unique types in column 'a') is applied on this data. The 
  * output is obtained from the sink node as a table. 
- * @param exec_context : execution context 
- * @return arrow::Status 
+ * \param exec_context : execution context 
+ * \return arrow::Status 
  */
 arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -631,14 +653,16 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
 
     return arrow::Status::OK();
 }
+// (Doc section: Aggregate Example)
 
+// (Doc section: ConsumingSink Example)
 /**
- * @brief 
+ * \brief 
  * Source-ConsumingSink 
  * This example shows how the data can be consumed within the execution plan 
  * by using a ConsumingSink node. There is no data output from this execution plan. 
- * @param exec_context : execution context 
- * @return arrow::Status 
+ * \param exec_context : execution context 
+ * \return arrow::Status 
  */
 arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -696,16 +720,19 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
 
     return arrow::Status::OK();
 }
+// (Doc section: ConsumingSink Example)
+
+// (Doc section: OrderBySink Example)
 
 /**
- * @brief 
+ * \brief 
  * Source-OrderBySink
  * In this example, the data enters through the source node
  * and the data is ordered in the sink node. The order can be 
  * ASCENDING or DESCENDING and it is configurable. The output
  * is obtained as a table from the sink node. 
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -750,14 +777,18 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+// (Doc section: OrderBySink Example)
+
+
+// (Doc section: HashJoin Example)
 /**
- * @brief 
+ * \brief 
  * Source-HashJoin-Sink
  * This example shows how source node gets the data and how a self-join
  * is applied on the data. The join options are configurable. The output
  * is obtained as a table via the sink node. 
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
@@ -839,14 +870,18 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+// (Doc section: HashJoin Example)
+
+
+// (Doc section: KSelect Example)
 /**
- * @brief 
+ * \brief 
  * Source-KSelect
  * This example shows how K number of elements can be selected 
  * either from the top or bottom. The output node is a modified
  * sink node where output can be obtained as a table. 
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
@@ -901,14 +936,18 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+// (Doc section: KSelect Example)
+
+// (Doc section: Write Example)
+
 /**
- * @brief 
+ * \brief 
  * Scan-Filter-Write
  * This example shows how scan node can be used to load the data
  * and after processing how it can be written to disk. 
- * @param exec_context : execution context
- * @param file_path : file saving path
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \param file_path : file saving path
+ * \return arrow::Status 
  */
 arrow::Status ScanFilterWriteExample(cp::ExecContext &exec_context,
 const std::string &file_path) {
@@ -982,14 +1021,18 @@ const std::string &file_path) {
     return arrow::Status::OK();
 }
 
+// (Doc section: Write Example)
+
+// (Doc section: Union Example)
+
 /**
- * @brief 
+ * \brief 
  * Source-Union-Sink
  * This example shows how a union operation can be applied on two 
  * data sources. The output is obtained as a table via the sink
  * node.
- * @param exec_context : execution context
- * @return arrow::Status 
+ * \param exec_context : execution context
+ * \return arrow::Status 
  */
 arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
@@ -1047,6 +1090,8 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
     futures.Wait();
     return arrow::Status::OK();
 }
+
+// (Doc section: Union Example)
 
 enum ExampleMode {
   SOURCE_SINK = 0,

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -1010,10 +1010,6 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
       cp::Declaration::Sequence(
           {
               union_node,
-              {"aggregate", cp::AggregateNodeOptions{/*aggregates=*/{{"count", &options}},
-                                                     /*targets=*/{"a"},
-                                                     /*names=*/{"count(a)"},
-                                                     /*keys=*/{}}},
               {"sink", cp::SinkNodeOptions{&sink_gen}},
           })
           .AddToPlan(plan.get()));

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -20,8 +20,8 @@
 #include <memory>
 #include <utility>
 
-#include "arrow/array.h"
-#include "arrow/builder.h"
+#include <arrow/array.h>
+#include <arrow/builder.h>
 
 #include <arrow/compute/api.h>
 #include <arrow/compute/api_scalar.h>
@@ -61,14 +61,13 @@
 
 // Demonstrate various operators in Arrow Streaming Execution Engine
 
+namespace cp = ::arrow::compute;
+
 constexpr char kSep[] = "******";
 
-#define PRINT_BLOCK(msg)                                               \
-  std::cout << "" << std::endl;                                        \
-  std::cout << "\t" << kSep << " " << msg << " " << kSep << std::endl; \
-  std::cout << "" << std::endl;
-
-namespace cp = ::arrow::compute;
+void PrintBlock(std::string msg) {
+  std::cout << "\n\t" << kSep << " " << msg << " " << kSep << "\n" << std::endl;
+}
 
 const char kCsvData[] = R"csv(a,b
 1,null
@@ -125,8 +124,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
 arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData() {
   arrow::io::IOContext io_context = arrow::io::default_io_context();
   std::shared_ptr<arrow::io::InputStream> input;
-  arrow::util::string_view sv = kCsvData;
-  input = std::make_shared<arrow::io::BufferReader>(sv);
+  input = std::make_shared<arrow::io::BufferReader>(arrow::Buffer::FromString(kCsvData));
 
   auto read_options = arrow::csv::ReadOptions::Defaults();
   auto parse_options = arrow::csv::ParseOptions::Defaults();
@@ -850,43 +848,47 @@ int main(int argc, char** argv) {
                                ::arrow::internal::GetCpuThreadPool());
   switch (mode) {
     case SOURCE_SINK:
-      PRINT_BLOCK("Source Sink Example");
+      PrintBlock("Source Sink Example");
       status = SourceSinkExample(exec_context);
       break;
     case SCAN_SINK:
-      PRINT_BLOCK("Scan Sink Example");
+      PrintBlock("Scan Example");
       status = ScanSinkExample(exec_context);
       break;
     case SCAN_FILTER_SINK:
-      PRINT_BLOCK("Scan Filter Example");
+      PrintBlock("Filter Example");
       status = ScanFilterSinkExample(exec_context);
       break;
     case SCAN_PROJECT_SINK:
-      PRINT_BLOCK("Scan Project Sink Example");
+      PrintBlock("Project Example");
       status = ScanProjectSinkExample(exec_context);
       break;
     case SOURCE_AGGREGATE_SINK:
-      PRINT_BLOCK("Source Aggregate Example");
+      PrintBlock("Aggregate Example");
       status = SourceAggregateSinkExample(exec_context);
       break;
     case SCAN_CONSUMING_SINK:
-      PRINT_BLOCK("Source Consuming-Sink Example");
+      PrintBlock("Consuming-Sink Example");
       status = SourceConsumingSinkExample(exec_context);
       break;
     case SOURCE_ORDER_BY_SINK:
-      PRINT_BLOCK("Source OrderBy Sink Example");
+      PrintBlock("OrderBy Example");
       status = SourceOrderBySinkExample(exec_context);
       break;
     case SCAN_HASHJOIN_SINK:
+      PrintBlock("HashJoin Example");
       status = SourceHashJoinSinkExample(exec_context);
       break;
     case SCAN_SELECT_SINK:
+      PrintBlock("KSelect Example");
       status = SourceKSelectExample(exec_context);
       break;
     case SCAN_FILTER_WRITE:
+      PrintBlock("ScanFilter Example");
       status = ScanFilterWriteExample(exec_context, base_save_path);
       break;
     case SOURCE_UNION_SINK:
+      PrintBlock("Union Example");
       status = SourceUnionSinkExample(exec_context);
       break;
     default:

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -208,10 +208,8 @@ arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
 
     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    cp::ExecNode* sink;
-
     ARROW_ASSIGN_OR_RAISE(
-        sink, cp::MakeExecNode("sink", plan.get(), {scan},
+        std::ignore, cp::MakeExecNode("sink", plan.get(), {scan},
         cp::SinkNodeOptions{&sink_gen}));
 
     // // translate sink_gen (async) to sink_reader (sync)
@@ -219,7 +217,7 @@ arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
         dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
 
     // validate the ExecPlan
-    ABORT_ON_FAILURE(plan->Validate());
+    ARROW_RETURN_NOT_OK(plan->Validate());
     std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
     // // start the ExecPlan
     ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -390,9 +388,7 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
                         cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-  cp::ExecNode* sink;
-
-  ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("sink", plan.get(), {source},
+  ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {source},
                                                cp::SinkNodeOptions{&sink_gen}));
 
   // // // translate sink_gen (async) to sink_reader (sync)
@@ -467,10 +463,8 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   // // finally, pipe the project node into a sink node
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
   ARROW_ASSIGN_OR_RAISE(
-      cp::ExecNode * sink,
+      std::ignore,
       cp::MakeExecNode("sink", plan.get(), {filter}, cp::SinkNodeOptions{&sink_gen}));
-
-  ABORT_ON_FAILURE(sink->Validate());
   // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
       dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
@@ -534,11 +528,9 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
                                                     cp::ProjectNodeOptions{{a_times_2}}));
 
     arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * sink,
+    ARROW_ASSIGN_OR_RAISE(std::ignore,
                           cp::MakeExecNode("sink", plan.get(), {project},
                                            cp::SinkNodeOptions{&sink_gen}));
-
-    ABORT_ON_FAILURE(sink->Validate());
 
     // // translate sink_gen (async) to sink_reader (sync)
     std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
@@ -604,9 +596,7 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
                           cp::MakeExecNode("aggregate", plan.get(), {source},
                           aggregate_options));
 
-    cp::ExecNode *sink;
-
-    ARROW_ASSIGN_OR_RAISE(sink, cp::MakeExecNode("sink", plan.get(), {aggregate},
+    ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {aggregate},
                                                  cp::SinkNodeOptions{&sink_gen}));
 
     // // // translate sink_gen (async) to sink_reader (sync)

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -94,18 +94,18 @@ template<typename TYPE,
 	typename = typename std::enable_if<arrow::is_number_type<TYPE>::value |
   arrow::is_boolean_type<TYPE>::value |
   arrow::is_temporal_type<TYPE>::value>::type>
-  arrow::Result<std::shared_ptr<arrow::Array>> GetArrayDataSample(
-    const std::vector<typename TYPE::c_type> &values) {
-    using ARROW_ARRAY_TYPE = typename arrow::TypeTraits<TYPE>::ArrayType;
-    using ARROW_BUILDER_TYPE = typename arrow::TypeTraits<TYPE>::BuilderType;
-    ARROW_BUILDER_TYPE builder;
-    ABORT_ON_FAILURE(builder.Reserve(values.size()));
-    std::shared_ptr<ARROW_ARRAY_TYPE> array;
-    ABORT_ON_FAILURE(builder.AppendValues(values));
-    ABORT_ON_FAILURE(builder.Finish(&array));
-    arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
-  return result;
-  }
+arrow::Result<std::shared_ptr<arrow::Array>> GetArrayDataSample(
+  const std::vector<typename TYPE::c_type> &values) {
+  using ARROW_ARRAY_TYPE = typename arrow::TypeTraits<TYPE>::ArrayType;
+  using ARROW_BUILDER_TYPE = typename arrow::TypeTraits<TYPE>::BuilderType;
+  ARROW_BUILDER_TYPE builder;
+  ABORT_ON_FAILURE(builder.Reserve(values.size()));
+  std::shared_ptr<ARROW_ARRAY_TYPE> array;
+  ABORT_ON_FAILURE(builder.AppendValues(values));
+  ABORT_ON_FAILURE(builder.Finish(&array));
+  arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
+return result;
+}
 
 template<class TYPE>
 arrow::Result<std::shared_ptr<arrow::Array>> GetBinaryArrayDataSample(
@@ -113,68 +113,68 @@ arrow::Result<std::shared_ptr<arrow::Array>> GetBinaryArrayDataSample(
   using ARROW_ARRAY_TYPE = typename arrow::TypeTraits<TYPE>::ArrayType;
   using ARROW_BUILDER_TYPE = typename arrow::TypeTraits<TYPE>::BuilderType;
   ARROW_BUILDER_TYPE builder;
-    ABORT_ON_FAILURE(builder.Reserve(values.size()));
-    std::shared_ptr<ARROW_ARRAY_TYPE> array;
-    ABORT_ON_FAILURE(builder.AppendValues(values));
-    ABORT_ON_FAILURE(builder.Finish(&array));
-    arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
+  ABORT_ON_FAILURE(builder.Reserve(values.size()));
+  std::shared_ptr<ARROW_ARRAY_TYPE> array;
+  ABORT_ON_FAILURE(builder.AppendValues(values));
+  ABORT_ON_FAILURE(builder.Finish(&array));
+  arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
   return result;
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
   const arrow::ArrayVector array_vector,
-const arrow::FieldVector &field_vector) {
+  const arrow::FieldVector &field_vector) {
   std::shared_ptr<arrow::RecordBatch> record_batch;
   ARROW_ASSIGN_OR_RAISE(auto struct_result,
         arrow::StructArray::Make(array_vector, field_vector));
-      return record_batch->FromStructArray(struct_result);
+  return record_batch->FromStructArray(struct_result);
 }
 
 arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData() {
-    arrow::io::IOContext io_context = arrow::io::default_io_context();
-    std::shared_ptr<arrow::io::InputStream> input;
-    std::string csv_data = GetDataAsCsvString();
-    arrow::util::string_view sv = csv_data;
-    input = std::make_shared<arrow::io::BufferReader>(sv);
+  arrow::io::IOContext io_context = arrow::io::default_io_context();
+  std::shared_ptr<arrow::io::InputStream> input;
+  std::string csv_data = GetDataAsCsvString();
+  arrow::util::string_view sv = csv_data;
+  input = std::make_shared<arrow::io::BufferReader>(sv);
 
-    auto read_options = arrow::csv::ReadOptions::Defaults();
-    auto parse_options = arrow::csv::ParseOptions::Defaults();
-    auto convert_options = arrow::csv::ConvertOptions::Defaults();
+  auto read_options = arrow::csv::ReadOptions::Defaults();
+  auto parse_options = arrow::csv::ParseOptions::Defaults();
+  auto convert_options = arrow::csv::ConvertOptions::Defaults();
 
-    // Instantiate TableReader from input stream and options
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::csv::TableReader> table_reader,
-      arrow::csv::TableReader::Make(io_context,
-                                    input,
-                                    read_options,
-                                    parse_options,
-                                    convert_options));
+  // Instantiate TableReader from input stream and options
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::csv::TableReader> table_reader,
+    arrow::csv::TableReader::Make(io_context,
+                                  input,
+                                  read_options,
+                                  parse_options,
+                                  convert_options));
 
-    std::shared_ptr<arrow::csv::TableReader> reader = table_reader;
+  std::shared_ptr<arrow::csv::TableReader> reader = table_reader;
 
-    // Read table from CSV file
-    ARROW_ASSIGN_OR_RAISE(auto maybe_table,
-      reader->Read());
-    auto ds = std::make_shared<arrow::dataset::InMemoryDataset>(maybe_table);
-    arrow::Result<std::shared_ptr<arrow::dataset::InMemoryDataset>> result(std::move(ds));
-    return result;
+  // Read table from CSV file
+  ARROW_ASSIGN_OR_RAISE(auto maybe_table,
+    reader->Read());
+  auto ds = std::make_shared<arrow::dataset::InMemoryDataset>(maybe_table);
+  arrow::Result<std::shared_ptr<arrow::dataset::InMemoryDataset>> result(std::move(ds));
+  return result;
 }
 
 // (Doc section: Materialize)
 cp::Expression Materialize(std::vector<std::string> names,
                            bool include_aug_fields = false) {
-    if (include_aug_fields) {
-        for (auto aug_name : {"__fragment_index",
-            "__batch_index", "__last_in_fragment"}) {
-        names.emplace_back(aug_name);
-        }
-    }
+  if (include_aug_fields) {
+      for (auto aug_name : {"__fragment_index",
+          "__batch_index", "__last_in_fragment"}) {
+      names.emplace_back(aug_name);
+      }
+  }
 
-    std::vector<cp::Expression> exprs;
-    for (const auto& name : names) {
-        exprs.push_back(cp::field_ref(name));
-    }
+  std::vector<cp::Expression> exprs;
+  for (const auto& name : names) {
+      exprs.push_back(cp::field_ref(name));
+  }
 
-    return cp::project(exprs, names);
+  return cp::project(exprs, names);
 }
 // (Doc section: Materialize)
 
@@ -190,68 +190,68 @@ cp::Expression Materialize(std::vector<std::string> names,
  * \return arrow::Status 
  */
 arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
-    // Execution plan created
-    ARROW_ASSIGN_OR_RAISE(
-        std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
+  // Execution plan created
+  ARROW_ASSIGN_OR_RAISE(
+      std::shared_ptr<cp::ExecPlan> plan, cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
-    CreateDataSetFromCSVData());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
+  CreateDataSetFromCSVData());
 
-    auto options = std::make_shared<arrow::dataset::ScanOptions>();
-    // sync scanning is not supported by ScanNode
-    options->use_async = true;
-    options->projection = Materialize({});  // create empty projection
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  // sync scanning is not supported by ScanNode
+  options->use_async = true;
+  options->projection = Materialize({});  // create empty projection
 
-    // construct the scan node
-    cp::ExecNode* scan;
-    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+  // construct the scan node
+  cp::ExecNode* scan;
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-    ARROW_ASSIGN_OR_RAISE(scan,
-                            cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+  ARROW_ASSIGN_OR_RAISE(scan,
+                          cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    ARROW_ASSIGN_OR_RAISE(
-        std::ignore, cp::MakeExecNode("sink", plan.get(), {scan},
-        cp::SinkNodeOptions{&sink_gen}));
+  ARROW_ASSIGN_OR_RAISE(
+      std::ignore, cp::MakeExecNode("sink", plan.get(), {scan},
+      cp::SinkNodeOptions{&sink_gen}));
 
-    // // translate sink_gen (async) to sink_reader (sync)
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
+  // // translate sink_gen (async) to sink_reader (sync)
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
 
-    // validate the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->Validate());
-    std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
-    // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // validate the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->Validate());
+  std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
+  // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-                            arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+                          arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    // // stop producing
-    plan->StopProducing();
-    // // plan mark finished
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
-    return arrow::Status::OK();
+  // // stop producing
+  plan->StopProducing();
+  // // plan mark finished
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
+  return arrow::Status::OK();
 }
 // (Doc section: Scan Example)
 
 arrow::Result<cp::ExecBatch> GetExecBatchFromVectors(
   const arrow::FieldVector &field_vector,
   const arrow::ArrayVector &array_vector) {
-    std::shared_ptr<arrow::RecordBatch> record_batch;
-    ARROW_ASSIGN_OR_RAISE(auto res_batch, GetSampleRecordBatch(
-      array_vector, field_vector));
-    cp::ExecBatch batch{*res_batch};
-    arrow::Result<cp::ExecBatch> result(batch);
-    return result;
+  std::shared_ptr<arrow::RecordBatch> record_batch;
+  ARROW_ASSIGN_OR_RAISE(auto res_batch, GetSampleRecordBatch(
+    array_vector, field_vector));
+  cp::ExecBatch batch{*res_batch};
+  arrow::Result<cp::ExecBatch> result(batch);
+  return result;
 }
 
 // (Doc section: BatchesWithSchema Definition)
@@ -468,7 +468,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
                         cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
 
   // pipe the scan node into a filter node
-  // // Need to set the filter in scan node options and filter node options. 
+  // // Need to set the filter in scan node options and filter node options.
   // // At scan node it is used for on-disk / push-down filtering.
   // // At filter node it is used for in-memory filtering.
   cp::ExecNode* filter;
@@ -520,64 +520,64 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-    cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+  cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
-    CreateDataSetFromCSVData());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
+  CreateDataSetFromCSVData());
 
-    auto options = std::make_shared<arrow::dataset::ScanOptions>();
-    // sync scanning is not supported by ScanNode
-    options->use_async = true;
-    // projection
-    cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
-    cp::literal(2)});
-    options->projection = Materialize({});
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  // sync scanning is not supported by ScanNode
+  options->use_async = true;
+  // projection
+  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
+  cp::literal(2)});
+  options->projection = Materialize({});
 
-    cp::ExecNode *scan;
+  cp::ExecNode *scan;
 
-    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-    ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
-    scan_node_options));
+  ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
+  scan_node_options));
 
-    cp::ExecNode *project;
-    ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
-                                                    cp::ProjectNodeOptions{{a_times_2}}));
+  cp::ExecNode *project;
+  ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
+                                                  cp::ProjectNodeOptions{{a_times_2}}));
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-    ARROW_ASSIGN_OR_RAISE(std::ignore,
-                          cp::MakeExecNode("sink", plan.get(), {project},
-                                           cp::SinkNodeOptions{&sink_gen}));
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  ARROW_ASSIGN_OR_RAISE(std::ignore,
+                        cp::MakeExecNode("sink", plan.get(), {project},
+                                          cp::SinkNodeOptions{&sink_gen}));
 
-    // // translate sink_gen (async) to sink_reader (sync)
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        arrow::schema({arrow::field("a * 2", arrow::int32())}),
-        std::move(sink_gen), exec_context.memory_pool());
+  // // translate sink_gen (async) to sink_reader (sync)
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      arrow::schema({arrow::field("a * 2", arrow::int32())}),
+      std::move(sink_gen), exec_context.memory_pool());
 
-    // // validate the ExecPlan
-    ABORT_ON_FAILURE(plan->Validate());
+  // // validate the ExecPlan
+  ABORT_ON_FAILURE(plan->Validate());
 
-    std::cout << "Exec Plan Created : " << plan->ToString() << std::endl;
+  std::cout << "Exec Plan Created : " << plan->ToString() << std::endl;
 
-    // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    // // plan stop producing
-    plan->StopProducing();
-    // // plan marked finished
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
+  // // plan stop producing
+  plan->StopProducing();
+  // // plan marked finished
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 
 // (Doc section: Project Example)
@@ -595,63 +595,63 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    auto source_node_options = cp::SourceNodeOptions{
-        basic_data.schema, basic_data.gen()};
+  auto source_node_options = cp::SourceNodeOptions{
+      basic_data.schema, basic_data.gen()};
 
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
-                                                                  plan.get(), {},
-                                                                  source_node_options));
-    cp::CountOptions options(cp::CountOptions::ONLY_VALID);
-    auto aggregate_options = cp::AggregateNodeOptions{
-        /*aggregates=*/{{"hash_count", &options}},
-        /*targets=*/{"a"},
-        /*names=*/{"count(a)"},
-        /*keys=*/{"b"}};
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * aggregate,
-                          cp::MakeExecNode("aggregate", plan.get(), {source},
-                          aggregate_options));
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+                                                                plan.get(), {},
+                                                                source_node_options));
+  cp::CountOptions options(cp::CountOptions::ONLY_VALID);
+  auto aggregate_options = cp::AggregateNodeOptions{
+      /*aggregates=*/{{"hash_count", &options}},
+      /*targets=*/{"a"},
+      /*names=*/{"count(a)"},
+      /*keys=*/{"b"}};
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * aggregate,
+                        cp::MakeExecNode("aggregate", plan.get(), {source},
+                        aggregate_options));
 
-    ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {aggregate},
-                                                 cp::SinkNodeOptions{&sink_gen}));
+  ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {aggregate},
+                                                cp::SinkNodeOptions{&sink_gen}));
 
-    // // // translate sink_gen (async) to sink_reader (sync)
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        arrow::schema({
-            arrow::field("count(a)", arrow::int32()),
-            arrow::field("b", arrow::boolean()),
-        }),
-        std::move(sink_gen),
-        exec_context.memory_pool());
+  // // // translate sink_gen (async) to sink_reader (sync)
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      arrow::schema({
+          arrow::field("count(a)", arrow::int32()),
+          arrow::field("b", arrow::boolean()),
+      }),
+      std::move(sink_gen),
+      exec_context.memory_pool());
 
-    // // validate the ExecPlan
-    ABORT_ON_FAILURE(plan->Validate());
-    std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // validate the ExecPlan
+  ABORT_ON_FAILURE(plan->Validate());
+  std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    //plan stop producing
-    plan->StopProducing();
-    // plan mark finished
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
+  //plan stop producing
+  plan->StopProducing();
+  // plan mark finished
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 // (Doc section: Aggregate Example)
 
@@ -665,60 +665,60 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 
-    auto source_node_options = cp::SourceNodeOptions{
-        basic_data.schema, basic_data.gen()};
+  auto source_node_options = cp::SourceNodeOptions{
+      basic_data.schema, basic_data.gen()};
 
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
-                                                                  plan.get(), {},
-                                                                  source_node_options));
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source, cp::MakeExecNode("source",
+                                                                plan.get(), {},
+                                                                source_node_options));
 
-    std::atomic<uint32_t> batches_seen{0};
-    arrow::Future<> finish = arrow::Future<>::Make();
-    struct CustomSinkNodeConsumer : public cp::SinkNodeConsumer {
-        CustomSinkNodeConsumer(std::atomic<uint32_t> *batches_seen, arrow::Future<>
-        finish)
-            : batches_seen(batches_seen), finish(std::move(finish)) {}
+  std::atomic<uint32_t> batches_seen{0};
+  arrow::Future<> finish = arrow::Future<>::Make();
+  struct CustomSinkNodeConsumer : public cp::SinkNodeConsumer {
+      CustomSinkNodeConsumer(std::atomic<uint32_t> *batches_seen, arrow::Future<>
+      finish)
+          : batches_seen(batches_seen), finish(std::move(finish)) {}
 
-        arrow::Status Consume(cp::ExecBatch batch) override {
-            (*batches_seen)++;
-            return arrow::Status::OK();
-        }
+      arrow::Status Consume(cp::ExecBatch batch) override {
+          (*batches_seen)++;
+          return arrow::Status::OK();
+      }
 
-        arrow::Future<> Finish() override { return finish; }
+      arrow::Future<> Finish() override { return finish; }
 
-        std::atomic<uint32_t> *batches_seen;
-        arrow::Future<> finish;
-    };
-    std::shared_ptr<CustomSinkNodeConsumer> consumer =
-        std::make_shared<CustomSinkNodeConsumer>(&batches_seen, finish);
+      std::atomic<uint32_t> *batches_seen;
+      arrow::Future<> finish;
+  };
+  std::shared_ptr<CustomSinkNodeConsumer> consumer =
+      std::make_shared<CustomSinkNodeConsumer>(&batches_seen, finish);
 
-    cp::ExecNode *consuming_sink;
+  cp::ExecNode *consuming_sink;
 
-    ARROW_ASSIGN_OR_RAISE(consuming_sink, MakeExecNode("consuming_sink", plan.get(),
-    {source}, cp::ConsumingSinkNodeOptions(consumer)));
+  ARROW_ASSIGN_OR_RAISE(consuming_sink, MakeExecNode("consuming_sink", plan.get(),
+  {source}, cp::ConsumingSinkNodeOptions(consumer)));
 
-    ABORT_ON_FAILURE(consuming_sink->Validate());
+  ABORT_ON_FAILURE(consuming_sink->Validate());
 
-    ABORT_ON_FAILURE(plan->Validate());
-    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
-    // plan start producing
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
-    // Source should finish fairly quickly
-    ARROW_RETURN_NOT_OK(source->finished().status());
-    std::cout << "Source Finished!" << std::endl;
-    // Mark consumption complete, plan should finish
-    arrow::Status finish_status;
-    //finish.Wait();
-    finish.MarkFinished(finish_status);
-    ARROW_RETURN_NOT_OK(plan->finished().status());
-    ARROW_RETURN_NOT_OK(finish_status);
+  ABORT_ON_FAILURE(plan->Validate());
+  std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
+  // plan start producing
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // Source should finish fairly quickly
+  ARROW_RETURN_NOT_OK(source->finished().status());
+  std::cout << "Source Finished!" << std::endl;
+  // Mark consumption complete, plan should finish
+  arrow::Status finish_status;
+  //finish.Wait();
+  finish.MarkFinished(finish_status);
+  ARROW_RETURN_NOT_OK(plan->finished().status());
+  ARROW_RETURN_NOT_OK(finish_status);
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 // (Doc section: ConsumingSink Example)
 
@@ -735,46 +735,46 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeSortTestBasicBatches());
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeSortTestBasicBatches());
 
-    std::cout << "basic data created" << std::endl;
+  std::cout << "basic data created" << std::endl;
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    auto source_node_options = cp::SourceNodeOptions{
-        basic_data.schema, basic_data.gen()};
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
-    cp::MakeExecNode("source", plan.get(), {}, source_node_options));
+  auto source_node_options = cp::SourceNodeOptions{
+      basic_data.schema, basic_data.gen()};
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
+  cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-    cp::ExecNode *sink;
+  cp::ExecNode *sink;
 
-    ARROW_ASSIGN_OR_RAISE(sink,
-    cp::MakeExecNode("order_by_sink", plan.get(),
-    {source}, cp::OrderBySinkNodeOptions{
-        cp::SortOptions{{cp::SortKey{"a",
-        cp::SortOrder::Descending}}}, &sink_gen}));
+  ARROW_ASSIGN_OR_RAISE(sink,
+  cp::MakeExecNode("order_by_sink", plan.get(),
+  {source}, cp::OrderBySinkNodeOptions{
+      cp::SortOptions{{cp::SortKey{"a",
+      cp::SortOrder::Descending}}}, &sink_gen}));
 
-    // // // translate sink_gen (async) to sink_reader (sync)
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        basic_data.schema,
-        std::move(sink_gen),
-        exec_context.memory_pool());
+  // // // translate sink_gen (async) to sink_reader (sync)
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      basic_data.schema,
+      std::move(sink_gen),
+      exec_context.memory_pool());
 
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 
 // (Doc section: OrderBySink Example)
@@ -791,83 +791,83 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    cp::ExecNode *left_source;
-    cp::ExecNode *right_source;
-    for (auto source : {&left_source, &right_source}) {
-        ARROW_ASSIGN_OR_RAISE(
-            *source,
-            MakeExecNode("source", plan.get(), {},
-                                  cp::SourceNodeOptions{
-                                      input.schema,
-                                      input.gen()}));
-    }
-    // TODO: decide whether to keep the filters or remove
+  cp::ExecNode *left_source;
+  cp::ExecNode *right_source;
+  for (auto source : {&left_source, &right_source}) {
+      ARROW_ASSIGN_OR_RAISE(
+          *source,
+          MakeExecNode("source", plan.get(), {},
+                                cp::SourceNodeOptions{
+                                    input.schema,
+                                    input.gen()}));
+  }
+  // TODO: decide whether to keep the filters or remove
 
-    // ARROW_ASSIGN_OR_RAISE(
-    //     auto left_filter,
-    //     cp::MakeExecNode("filter", plan.get(), {left_source},
-    //                      cp::FilterNodeOptions{
-    //                          cp::greater_equal(
-    //                              cp::field_ref("i32"),
-    //                              cp::literal(-1))}));
-    // ARROW_ASSIGN_OR_RAISE(
-    //     auto right_filter,
-    //     cp::MakeExecNode("filter", plan.get(), {right_source},
-    //                      cp::FilterNodeOptions{
-    //                          cp::less_equal(
-    //                              cp::field_ref("i32"),
-    //                              cp::literal(2))}));
-    // std::cout << "left and right filter nodes created" << std::endl;
+  // ARROW_ASSIGN_OR_RAISE(
+  //     auto left_filter,
+  //     cp::MakeExecNode("filter", plan.get(), {left_source},
+  //                      cp::FilterNodeOptions{
+  //                          cp::greater_equal(
+  //                              cp::field_ref("i32"),
+  //                              cp::literal(-1))}));
+  // ARROW_ASSIGN_OR_RAISE(
+  //     auto right_filter,
+  //     cp::MakeExecNode("filter", plan.get(), {right_source},
+  //                      cp::FilterNodeOptions{
+  //                          cp::less_equal(
+  //                              cp::field_ref("i32"),
+  //                              cp::literal(2))}));
+  // std::cout << "left and right filter nodes created" << std::endl;
 
-    cp::HashJoinNodeOptions join_opts{cp::JoinType::INNER,
-                                      /*left_keys=*/{"str"},
-                                      /*right_keys=*/{"str"}, cp::literal(true), "l_",
-                                      "r_"};
+  cp::HashJoinNodeOptions join_opts{cp::JoinType::INNER,
+                                    /*left_keys=*/{"str"},
+                                    /*right_keys=*/{"str"}, cp::literal(true), "l_",
+                                    "r_"};
 
-    ARROW_ASSIGN_OR_RAISE(
-        auto hashjoin,
-        cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source},
-        join_opts));
+  ARROW_ASSIGN_OR_RAISE(
+      auto hashjoin,
+      cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source},
+      join_opts));
 
-    ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {hashjoin},
-                                                        cp::SinkNodeOptions{&sink_gen}));
-    // expected columns i32, str, l_str, r_str
+  ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {hashjoin},
+                                                      cp::SinkNodeOptions{&sink_gen}));
+  // expected columns i32, str, l_str, r_str
 
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        arrow::schema({arrow::field("i32", arrow::int32()),
-                       arrow::field("str", arrow::utf8()),
-                       arrow::field("l_str", arrow::utf8()),
-                       arrow::field("r_str", arrow::utf8())}),
-        std::move(sink_gen),
-        exec_context.memory_pool());
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      arrow::schema({arrow::field("i32", arrow::int32()),
+                      arrow::field("str", arrow::utf8()),
+                      arrow::field("l_str", arrow::utf8()),
+                      arrow::field("r_str", arrow::utf8())}),
+      std::move(sink_gen),
+      exec_context.memory_pool());
 
-    // // // validate the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->Validate());
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // // validate the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->Validate());
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    // // plan stop producing
-    plan->StopProducing();
-    // // plan mark finished
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
+  // // plan stop producing
+  plan->StopProducing();
+  // // plan mark finished
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 
 // (Doc section: HashJoin Example)
@@ -884,56 +884,56 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
  * \return arrow::Status 
  */
 arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    ARROW_ASSIGN_OR_RAISE(
-        cp::ExecNode * source,
-        cp::MakeExecNode("source",
-            plan.get(), {},
-                cp::SourceNodeOptions{
-                    input.schema,
-                    input.gen()}));
+  ARROW_ASSIGN_OR_RAISE(
+      cp::ExecNode * source,
+      cp::MakeExecNode("source",
+          plan.get(), {},
+              cp::SourceNodeOptions{
+                  input.schema,
+                  input.gen()}));
 
-    cp::SelectKOptions options = cp::SelectKOptions::TopKDefault(/*k=*/2, {"i32"});
+  cp::SelectKOptions options = cp::SelectKOptions::TopKDefault(/*k=*/2, {"i32"});
 
-    ARROW_ASSIGN_OR_RAISE(
-        cp::ExecNode * k_sink_node,
-        cp::MakeExecNode("select_k_sink",
-            plan.get(), {source},
-                cp::SelectKSinkNodeOptions{options, &sink_gen}));
+  ARROW_ASSIGN_OR_RAISE(
+      cp::ExecNode * k_sink_node,
+      cp::MakeExecNode("select_k_sink",
+          plan.get(), {source},
+              cp::SelectKSinkNodeOptions{options, &sink_gen}));
 
-    k_sink_node->finished().Wait();
+  k_sink_node->finished().Wait();
 
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        arrow::schema({arrow::field("i32", arrow::int32()),
-                       arrow::field("str", arrow::utf8())}),
-        std::move(sink_gen),
-        exec_context.memory_pool());
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      arrow::schema({arrow::field("i32", arrow::int32()),
+                      arrow::field("str", arrow::utf8())}),
+      std::move(sink_gen),
+      exec_context.memory_pool());
 
-    // // // validate the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->Validate());
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // // validate the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->Validate());
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
-    // // plan stop proudcing
-    plan->StopProducing();
-    // // plan mark finished
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
+  // // plan stop proudcing
+  plan->StopProducing();
+  // // plan mark finished
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
-    return arrow::Status::OK();
+  return arrow::Status::OK();
 }
 
 // (Doc section: KSelect Example)
@@ -951,74 +951,74 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
  */
 arrow::Status ScanFilterWriteExample(cp::ExecContext &exec_context,
 const std::string &file_path) {
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-     cp::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+    cp::ExecPlan::Make(&exec_context));
 
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
-    CreateDataSetFromCSVData());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset,
+  CreateDataSetFromCSVData());
 
-    auto options = std::make_shared<arrow::dataset::ScanOptions>();
-    // sync scanning is not supported by ScanNode
-    options->use_async = true;
-    // specify the filter
-    //cp::Expression b_is_true = cp::field_ref("b");
-    //options->filter = b_is_true;
-    // empty projection
-    options->projection = Materialize({});
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  // sync scanning is not supported by ScanNode
+  options->use_async = true;
+  // specify the filter
+  //cp::Expression b_is_true = cp::field_ref("b");
+  //options->filter = b_is_true;
+  // empty projection
+  options->projection = Materialize({});
 
-    cp::ExecNode *scan;
+  cp::ExecNode *scan;
 
-    auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-    ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
-    scan_node_options));
+  ARROW_ASSIGN_OR_RAISE(scan, cp::MakeExecNode("scan", plan.get(), {},
+  scan_node_options));
 
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    std::string root_path = "";
-    std::string uri = "file://" + file_path;
-    std::shared_ptr<arrow::fs::FileSystem> filesystem =
-    arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
+  std::string root_path = "";
+  std::string uri = "file://" + file_path;
+  std::shared_ptr<arrow::fs::FileSystem> filesystem =
+  arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
 
-    auto base_path = root_path + "/parquet_dataset";
-    // Uncomment the following line, if run repeatedly
-    //ARROW_RETURN_NOT_OK(filesystem->DeleteDirContents(base_path));
-    ARROW_RETURN_NOT_OK(filesystem->CreateDir(base_path));
+  auto base_path = root_path + "/parquet_dataset";
+  // Uncomment the following line, if run repeatedly
+  //ARROW_RETURN_NOT_OK(filesystem->DeleteDirContents(base_path));
+  ARROW_RETURN_NOT_OK(filesystem->CreateDir(base_path));
 
-    // The partition schema determines which fields are part of the partitioning.
-    auto partition_schema = arrow::schema({arrow::field("a", arrow::int32())});
-    // We'll use Hive-style partitioning,
-    // which creates directories with "key=value" pairs.
+  // The partition schema determines which fields are part of the partitioning.
+  auto partition_schema = arrow::schema({arrow::field("a", arrow::int32())});
+  // We'll use Hive-style partitioning,
+  // which creates directories with "key=value" pairs.
 
-    auto partitioning =
-    std::make_shared<arrow::dataset::HivePartitioning>(partition_schema);
-    // We'll write Parquet files.
-    auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+  auto partitioning =
+  std::make_shared<arrow::dataset::HivePartitioning>(partition_schema);
+  // We'll write Parquet files.
+  auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
 
-    arrow::dataset::FileSystemDatasetWriteOptions write_options;
-    write_options.file_write_options = format->DefaultWriteOptions();
-    write_options.filesystem = filesystem;
-    write_options.base_dir = base_path;
-    write_options.partitioning = partitioning;
-    write_options.basename_template = "part{i}.parquet";
+  arrow::dataset::FileSystemDatasetWriteOptions write_options;
+  write_options.file_write_options = format->DefaultWriteOptions();
+  write_options.filesystem = filesystem;
+  write_options.base_dir = base_path;
+  write_options.partitioning = partitioning;
+  write_options.basename_template = "part{i}.parquet";
 
-    arrow::dataset::WriteNodeOptions write_node_options {write_options,
-    dataset->schema()};
+  arrow::dataset::WriteNodeOptions write_node_options {write_options,
+  dataset->schema()};
 
-    std::cout << "Write Options created" << std::endl;
+  std::cout << "Write Options created" << std::endl;
 
-    ARROW_ASSIGN_OR_RAISE(cp::ExecNode *wr, cp::MakeExecNode("write", plan.get(),
-    {scan}, write_node_options));
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode *wr, cp::MakeExecNode("write", plan.get(),
+  {scan}, write_node_options));
 
-    ABORT_ON_FAILURE(wr->Validate());
-    ABORT_ON_FAILURE(plan->Validate());
-    std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
-    return arrow::Status::OK();
+  ABORT_ON_FAILURE(wr->Validate());
+  ABORT_ON_FAILURE(plan->Validate());
+  std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
+  return arrow::Status::OK();
 }
 
 // (Doc section: Write Example)
@@ -1035,60 +1035,60 @@ const std::string &file_path) {
  * \return arrow::Status 
  */
 arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
-    ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 
-    std::shared_ptr<cp::ExecPlan> plan =
-    cp::ExecPlan::Make(&exec_context).ValueOrDie();
-    arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  std::shared_ptr<cp::ExecPlan> plan =
+  cp::ExecPlan::Make(&exec_context).ValueOrDie();
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-    cp::Declaration union_node{"union", cp::ExecNodeOptions{}};
-    cp::Declaration lhs{"source",
+  cp::Declaration union_node{"union", cp::ExecNodeOptions{}};
+  cp::Declaration lhs{"source",
+                cp::SourceNodeOptions{basic_data.schema,
+                                  basic_data.gen()}};
+  lhs.label = "lhs";
+  cp::Declaration rhs{"source",
                   cp::SourceNodeOptions{basic_data.schema,
                                     basic_data.gen()}};
-    lhs.label = "lhs";
-    cp::Declaration rhs{"source",
-                    cp::SourceNodeOptions{basic_data.schema,
-                                      basic_data.gen()}};
-    rhs.label = "rhs";
-    union_node.inputs.emplace_back(lhs);
-    union_node.inputs.emplace_back(rhs);
+  rhs.label = "rhs";
+  union_node.inputs.emplace_back(lhs);
+  union_node.inputs.emplace_back(rhs);
 
-    cp::CountOptions options(cp::CountOptions::ONLY_VALID);
-    ARROW_ASSIGN_OR_RAISE(auto declr,
-    cp::Declaration::Sequence(
-            {
-                union_node,
-                {"aggregate", cp::AggregateNodeOptions{
-                  /*aggregates=*/{{"count", &options}},
-                  /*targets=*/{"a"},
-                  /*names=*/{"count(a)"},
-                  /*keys=*/{}}},
-                {"sink", cp::SinkNodeOptions{&sink_gen}},
-            })
-            .AddToPlan(plan.get()));
+  cp::CountOptions options(cp::CountOptions::ONLY_VALID);
+  ARROW_ASSIGN_OR_RAISE(auto declr,
+  cp::Declaration::Sequence(
+          {
+              union_node,
+              {"aggregate", cp::AggregateNodeOptions{
+                /*aggregates=*/{{"count", &options}},
+                /*targets=*/{"a"},
+                /*names=*/{"count(a)"},
+                /*keys=*/{}}},
+              {"sink", cp::SinkNodeOptions{&sink_gen}},
+          })
+          .AddToPlan(plan.get()));
 
-    ABORT_ON_FAILURE(declr->Validate());
+  ABORT_ON_FAILURE(declr->Validate());
 
-    ABORT_ON_FAILURE(plan->Validate());
-    std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-        arrow::schema({arrow::field("count(a)", arrow::int32())}),
-        std::move(sink_gen),
-        exec_context.memory_pool());
+  ABORT_ON_FAILURE(plan->Validate());
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      arrow::schema({arrow::field("count(a)", arrow::int32())}),
+      std::move(sink_gen),
+      exec_context.memory_pool());
 
-    // // // start the ExecPlan
-    ARROW_RETURN_NOT_OK(plan->StartProducing());
+  // // // start the ExecPlan
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
-    // // collect sink_reader into a Table
-    std::shared_ptr<arrow::Table> response_table;
+  // // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
 
-    ARROW_ASSIGN_OR_RAISE(response_table,
-    arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(response_table,
+  arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    std::cout << "Results : " << response_table->ToString() << std::endl;
-    auto futures =  plan->finished();
-    ARROW_RETURN_NOT_OK(futures.status());
-    futures.Wait();
-    return arrow::Status::OK();
+  std::cout << "Results : " << response_table->ToString() << std::endl;
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
+  return arrow::Status::OK();
 }
 
 // (Doc section: Union Example)

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -59,15 +59,6 @@
 
 // Demonstrate various operators in Arrow Streaming Execution Engine
 
-#define ABORT_ON_FAILURE(expr)                     \
-  do {                                             \
-    arrow::Status status_ = (expr);                \
-    if (!status_.ok()) {                           \
-      std::cerr << status_.message() << std::endl; \
-      abort();                                     \
-    }                                              \
-  } while (0);
-
 constexpr char kSep[] = "******";
 
 #define PRINT_BLOCK(msg)                                               \
@@ -102,10 +93,10 @@ arrow::Result<std::shared_ptr<arrow::Array>> GetArrayDataSample(
   using ARROW_ARRAY_TYPE = typename arrow::TypeTraits<TYPE>::ArrayType;
   using ARROW_BUILDER_TYPE = typename arrow::TypeTraits<TYPE>::BuilderType;
   ARROW_BUILDER_TYPE builder;
-  ABORT_ON_FAILURE(builder.Reserve(values.size()));
+  ABORT_NOT_OK(builder.Reserve(values.size()));
   std::shared_ptr<ARROW_ARRAY_TYPE> array;
-  ABORT_ON_FAILURE(builder.AppendValues(values));
-  ABORT_ON_FAILURE(builder.Finish(&array));
+  ABORT_NOT_OK(builder.AppendValues(values));
+  ABORT_NOT_OK(builder.Finish(&array));
   arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
   return result;
 }
@@ -116,10 +107,10 @@ arrow::Result<std::shared_ptr<arrow::Array>> GetBinaryArrayDataSample(
   using ARROW_ARRAY_TYPE = typename arrow::TypeTraits<TYPE>::ArrayType;
   using ARROW_BUILDER_TYPE = typename arrow::TypeTraits<TYPE>::BuilderType;
   ARROW_BUILDER_TYPE builder;
-  ABORT_ON_FAILURE(builder.Reserve(values.size()));
+  ABORT_NOT_OK(builder.Reserve(values.size()));
   std::shared_ptr<ARROW_ARRAY_TYPE> array;
-  ABORT_ON_FAILURE(builder.AppendValues(values));
-  ABORT_ON_FAILURE(builder.Finish(&array));
+  ABORT_NOT_OK(builder.AppendValues(values));
+  ABORT_NOT_OK(builder.Finish(&array));
   arrow::Result<std::shared_ptr<ARROW_ARRAY_TYPE>> result(std::move(array));
   return result;
 }
@@ -385,7 +376,7 @@ arrow::Status SourceSinkExample(cp::ExecContext& exec_context) {
       basic_data.schema, std::move(sink_gen), exec_context.memory_pool());
 
   // // validate the ExecPlan
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::cout << "Exec Plan Created: " << plan->ToString() << std::endl;
   // // // start the ExecPlan
   ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -462,7 +453,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
       dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
 
   // // validate the ExecPlan
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::cout << "Exec Plan created " << plan->ToString() << std::endl;
   // // start the ExecPlan
   ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -529,7 +520,7 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
                               std::move(sink_gen), exec_context.memory_pool());
 
   // // validate the ExecPlan
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
 
   std::cout << "Exec Plan Created : " << plan->ToString() << std::endl;
 
@@ -600,7 +591,7 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext& exec_context) {
                               std::move(sink_gen), exec_context.memory_pool());
 
   // // validate the ExecPlan
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
   // // // start the ExecPlan
   ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -669,9 +660,9 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
                         MakeExecNode("consuming_sink", plan.get(), {source},
                                      cp::ConsumingSinkNodeOptions(consumer)));
 
-  ABORT_ON_FAILURE(consuming_sink->Validate());
+  ABORT_NOT_OK(consuming_sink->Validate());
 
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
   // plan start producing
   ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -953,8 +944,8 @@ arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * wr, cp::MakeExecNode("write", plan.get(), {scan},
                                                             write_node_options));
 
-  ABORT_ON_FAILURE(wr->Validate());
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(wr->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
   // // // start the ExecPlan
   ARROW_RETURN_NOT_OK(plan->StartProducing());
@@ -1003,9 +994,9 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
           })
           .AddToPlan(plan.get()));
 
-  ABORT_ON_FAILURE(declr->Validate());
+  ABORT_NOT_OK(declr->Validate());
 
-  ABORT_ON_FAILURE(plan->Validate());
+  ABORT_NOT_OK(plan->Validate());
   std::shared_ptr<arrow::RecordBatchReader> sink_reader =
       cp::MakeGeneratorReader(basic_data.schema,
                               std::move(sink_gen), exec_context.memory_pool());

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -149,14 +149,7 @@ arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData
 }
 
 // (Doc section: Materialize)
-cp::Expression Materialize(std::vector<std::string> names,
-                           bool include_aug_fields = false) {
-  if (include_aug_fields) {
-    for (auto aug_name : {"__fragment_index", "__batch_index", "__last_in_fragment"}) {
-      names.emplace_back(aug_name);
-    }
-  }
-
+cp::Expression Materialize(std::vector<std::string> names) {
   std::vector<cp::Expression> exprs;
   for (const auto& name : names) {
     exprs.push_back(cp::field_ref(name));

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -516,8 +516,7 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     // projection
     cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"),
     cp::literal(2)});
-    options->projection =
-        cp::call("make_struct", {a_times_2}, cp::MakeStructOptions{{"a * 2"}});
+    options->projection = Materialize({});
 
     cp::ExecNode *scan;
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -184,7 +184,7 @@ cp::Expression Materialize(std::vector<std::string> names,
  * There are operations that can be applied on the scan (project, filter)
  * and the input data can be processed. THe output is obtained as a table
  * via the sink node. 
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
@@ -373,7 +373,7 @@ arrow::Result<BatchesWithSchema> MakeGroupableBatches(int multiplicity = 1) {
  * in an execution plan. This includes source node receiving data 
  * and the sink node emits the data as an output represented in 
  * a table. 
- * @param exec_context 
+ * @param exec_context : execution context 
  * @return arrow::Status 
  */
 arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
@@ -427,7 +427,7 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
  * This example shows how a filter can be used in an execution plan, 
  * along with the source and sink operations. The output from the 
  * exeuction plan is obtained as a table via the sink node. 
- * @param exec_context 
+ * @param exec_context : execution context 
  * @return arrow::Status 
  */
 arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
@@ -500,7 +500,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
  * into the execution plan, how project operation can be applied on the
  * data stream and how the output is obtained as a table via the sink node. 
  * 
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
@@ -572,7 +572,7 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
  * execution plan. The source node loads the data and the aggregation 
  * (counting unique types in column 'a') is applied on this data. The 
  * output is obtained from the sink node as a table. 
- * @param exec_context 
+ * @param exec_context : execution context 
  * @return arrow::Status 
  */
 arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
@@ -640,7 +640,7 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
  * Source-ConsumingSink 
  * This example shows how the data can be consumed within the execution plan 
  * by using a ConsumingSink node. There is no data output from this execution plan. 
- * @param exec_context 
+ * @param exec_context : execution context 
  * @return arrow::Status 
  */
 arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
@@ -707,7 +707,7 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
  * and the data is ordered in the sink node. The order can be 
  * ASCENDING or DESCENDING and it is configurable. The output
  * is obtained as a table from the sink node. 
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
@@ -759,7 +759,7 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
  * This example shows how source node gets the data and how a self-join
  * is applied on the data. The join options are configurable. The output
  * is obtained as a table via the sink node. 
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
@@ -846,7 +846,7 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
  * This example shows how K number of elements can be selected 
  * either from the top or bottom. The output node is a modified
  * sink node where output can be obtained as a table. 
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
@@ -905,8 +905,8 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
  * Scan-Filter-Write
  * This example shows how scan node can be used to load the data
  * and after processing how it can be written to disk. 
- * @param exec_context 
- * @param file_path 
+ * @param exec_context : execution context
+ * @param file_path : file saving path
  * @return arrow::Status 
  */
 arrow::Status ScanFilterWriteExample(cp::ExecContext &exec_context,
@@ -984,7 +984,7 @@ const std::string &file_path) {
  * This example shows how a union operation can be applied on two 
  * data sources. The output is obtained as a table via the sink
  * node.
- * @param exec_context 
+ * @param exec_context : execution context
  * @return arrow::Status 
  */
 arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// (Doc section: Execution Plan Documentation Example)
+
 #include <memory>
 #include <utility>
 
@@ -68,8 +70,7 @@ constexpr char kSep[] = "******";
 
 namespace cp = ::arrow::compute;
 
-std::string GetDataAsCsvString() {
-  std::string data_str = R"csv(a,b
+const char kCsvData[] = R"csv(a,b
 1,null
 2,true
 null,true
@@ -81,8 +82,6 @@ null,true
 7,false
 8,true
 )csv";
-  return data_str;
-}
 
 template <typename TYPE,
           typename = typename std::enable_if<arrow::is_number_type<TYPE>::value |
@@ -126,8 +125,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
 arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData() {
   arrow::io::IOContext io_context = arrow::io::default_io_context();
   std::shared_ptr<arrow::io::InputStream> input;
-  std::string csv_data = GetDataAsCsvString();
-  arrow::util::string_view sv = csv_data;
+  arrow::util::string_view sv = kCsvData;
   input = std::make_shared<arrow::io::BufferReader>(sv);
 
   auto read_options = arrow::csv::ReadOptions::Defaults();
@@ -899,3 +897,5 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 }
+
+// (Doc section: Execution Plan Documentation Example)

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -18,6 +18,9 @@
 #include <memory>
 #include <utility>
 
+#include "arrow/array.h"
+#include "arrow/builder.h"
+
 #include <arrow/compute/api.h>
 #include <arrow/compute/api_scalar.h>
 #include <arrow/compute/api_vector.h>

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -592,7 +592,6 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
   std::cout << "Source Finished!" << std::endl;
   // Mark consumption complete, plan should finish
   arrow::Status finish_status;
-
   finish.MarkFinished(arrow::Status::OK());
   ARROW_RETURN_NOT_OK(plan->finished().status());
   ARROW_RETURN_NOT_OK(finish_status);

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -235,8 +235,9 @@ arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
     // // stop producing
     plan->StopProducing();
     // // plan mark finished
-    plan->finished().Wait();
-
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
     return arrow::Status::OK();
 }
 
@@ -415,7 +416,9 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   // // plan stop producing
   plan->StopProducing();
   // // plan mark finished
-  plan->finished().Wait();
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
   return arrow::Status::OK();
 }
@@ -487,7 +490,9 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   // // plan stop producing
   plan->StopProducing();
   // /// plan marked finished
-  plan->finished().Wait();
+  auto futures =  plan->finished();
+  ARROW_RETURN_NOT_OK(futures.status());
+  futures.Wait();
 
   return arrow::Status::OK();
 }
@@ -558,7 +563,9 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     // // plan stop producing
     plan->StopProducing();
     // // plan marked finished
-    plan->finished().Wait();
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
 
     return arrow::Status::OK();
 }
@@ -628,7 +635,9 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
     //plan stop producing
     plan->StopProducing();
     // plan mark finished
-    plan->finished().Wait();
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
 
     return arrow::Status::OK();
 }
@@ -833,7 +842,9 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
     // // plan stop producing
     plan->StopProducing();
     // // plan mark finished
-    plan->finished().Wait();
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
 
     return arrow::Status::OK();
 }
@@ -893,7 +904,9 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
     // // plan stop proudcing
     plan->StopProducing();
     // // plan mark finished
-    plan->finished().Wait();
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
 
     return arrow::Status::OK();
 }
@@ -939,8 +952,9 @@ const std::string &file_path) {
     arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
 
     auto base_path = root_path + "/parquet_dataset";
-    ABORT_ON_FAILURE(filesystem->DeleteDir(base_path));
-    ABORT_ON_FAILURE(filesystem->CreateDir(base_path));
+    // Uncomment the following line, if run repeatedly
+    //ARROW_RETURN_NOT_OK(filesystem->DeleteDirContents(base_path));
+    ARROW_RETURN_NOT_OK(filesystem->CreateDir(base_path));
 
     // The partition schema determines which fields are part of the partitioning.
     auto partition_schema = arrow::schema({arrow::field("a", arrow::int32())});
@@ -972,7 +986,9 @@ const std::string &file_path) {
     std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
     // // // start the ExecPlan
     ARROW_RETURN_NOT_OK(plan->StartProducing());
-    plan->finished().Wait();
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
     return arrow::Status::OK();
 }
 
@@ -1036,6 +1052,9 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
     std::cout << "Results : " << response_table->ToString() << std::endl;
+    auto futures =  plan->finished();
+    ARROW_RETURN_NOT_OK(futures.status());
+    futures.Wait();
     return arrow::Status::OK();
 }
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -412,9 +412,11 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
                         CreateDataSetFromCSVData());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // specify the filter
+  // // specify the filter.  This filter removes all rows where the
+  // value of the "a" column is greater than 3.
   cp::Expression filter_opt = cp::greater(cp::field_ref("a"), cp::literal(3));
   // set filter for scanner : on-disk / push-down filtering.
+  // This step can be skipped if you are not reading from disk.
   options->filter = filter_opt;
   // empty projection
   options->projection = Materialize({});
@@ -438,7 +440,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
   ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
                                                  cp::FilterNodeOptions{filter_opt}));
 
-  // // finally, pipe the project node into a sink node
+  // // finally, pipe the filter node into a sink node
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
   ARROW_RETURN_NOT_OK(
       cp::MakeExecNode("sink", plan.get(), {filter}, cp::SinkNodeOptions{&sink_gen}));

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -463,6 +463,9 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
   cp::ExecNode* project;
   ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
                                                   cp::ProjectNodeOptions{{a_times_2}}));
+  // schema after projection => multiply(a, 2): int64
+  std::cout << "Schema after projection : \n"
+            << project->output_schema()->ToString() << std::endl;
 
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
   ARROW_RETURN_NOT_OK(

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -591,11 +591,8 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
   ARROW_RETURN_NOT_OK(source->finished().status());
   std::cout << "Source Finished!" << std::endl;
   // Mark consumption complete, plan should finish
-  arrow::Status finish_status;
   finish.MarkFinished(arrow::Status::OK());
   ARROW_RETURN_NOT_OK(plan->finished().status());
-  ARROW_RETURN_NOT_OK(finish_status);
-
   return arrow::Status::OK();
 }
 // (Doc section: ConsumingSink Example)

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -195,8 +195,6 @@ arrow::Status ScanSinkExample(cp::ExecContext& exec_context) {
                         CreateDataSetFromCSVData());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
   options->projection = Materialize({});  // create empty projection
 
   // construct the scan node
@@ -429,8 +427,6 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
                         CreateDataSetFromCSVData());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
   // specify the filter
   cp::Expression filter_opt = cp::greater(cp::field_ref("a"), cp::literal(3));
   // set filter for scanner : on-disk / push-down filtering.
@@ -508,8 +504,6 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
                         CreateDataSetFromCSVData());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
   // projection
   cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
   options->projection = Materialize({});
@@ -913,11 +907,6 @@ arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
                         CreateDataSetFromCSVData());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // sync scanning is not supported by ScanNode
-  options->use_async = true;
-  // specify the filter
-  // cp::Expression b_is_true = cp::field_ref("b");
-  // options->filter = b_is_true;
   // empty projection
   options->projection = Materialize({});
 
@@ -1018,7 +1007,7 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
 
   ABORT_ON_FAILURE(plan->Validate());
   std::shared_ptr<arrow::RecordBatchReader> sink_reader =
-      cp::MakeGeneratorReader(arrow::schema({arrow::field("count(a)", arrow::int32())}),
+      cp::MakeGeneratorReader(basic_data.schema,
                               std::move(sink_gen), exec_context.memory_pool());
 
   // // // start the ExecPlan

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -721,10 +721,8 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext& exec_context) {
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
                         cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-  cp::ExecNode* sink;
-
   ARROW_ASSIGN_OR_RAISE(
-      sink,
+      std::ignore,
       cp::MakeExecNode("order_by_sink", plan.get(), {source},
                        cp::OrderBySinkNodeOptions{
                            cp::SortOptions{{cp::SortKey{"a", cp::SortOrder::Descending}}},

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -172,7 +172,7 @@ arrow::Result<cp::ExecBatch> GetExecBatchFromVectors(
 struct BatchesWithSchema {
   std::vector<cp::ExecBatch> batches;
   std::shared_ptr<arrow::Schema> schema;
-  // // This method uses internal arrow utilities to 
+  // // This method uses internal arrow utilities to
   // // convert a vector of record batches to an AsyncGenerator of optional batches
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> gen() const {
     auto opt_batches = ::arrow::internal::MapVector(
@@ -307,8 +307,8 @@ arrow::Status ScanSinkExample(cp::ExecContext& exec_context) {
 
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
 
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {scan},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {scan}, cp::SinkNodeOptions{&sink_gen}));
 
   // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
@@ -362,8 +362,8 @@ arrow::Status SourceSinkExample(cp::ExecContext& exec_context) {
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
                         cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {source},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {source}, cp::SinkNodeOptions{&sink_gen}));
 
   // // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
@@ -440,8 +440,8 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
 
   // // finally, pipe the project node into a sink node
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {filter},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {filter}, cp::SinkNodeOptions{&sink_gen}));
   // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
       dataset->schema(), std::move(sink_gen), exec_context.memory_pool());
@@ -505,8 +505,8 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
                                                   cp::ProjectNodeOptions{{a_times_2}}));
 
   arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {project},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {project}, cp::SinkNodeOptions{&sink_gen}));
 
   // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader =
@@ -573,8 +573,8 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext& exec_context) {
       cp::ExecNode * aggregate,
       cp::MakeExecNode("aggregate", plan.get(), {source}, aggregate_options));
 
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {aggregate},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {aggregate}, cp::SinkNodeOptions{&sink_gen}));
 
   // // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader =
@@ -700,11 +700,10 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext& exec_context) {
   ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
                         cp::MakeExecNode("source", plan.get(), {}, source_node_options));
 
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("order_by_sink", plan.get(), {source},
-                       cp::OrderBySinkNodeOptions{
-                           cp::SortOptions{{cp::SortKey{"a", cp::SortOrder::Descending}}},
-                           &sink_gen}));
+  ARROW_RETURN_NOT_OK(cp::MakeExecNode(
+      "order_by_sink", plan.get(), {source},
+      cp::OrderBySinkNodeOptions{
+          cp::SortOptions{{cp::SortKey{"a", cp::SortOrder::Descending}}}, &sink_gen}));
 
   // // // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
@@ -760,8 +759,8 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext& exec_context) {
       auto hashjoin,
       cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source}, join_opts));
 
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("sink", plan.get(), {hashjoin},
-                                                      cp::SinkNodeOptions{&sink_gen}));
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {hashjoin}, cp::SinkNodeOptions{&sink_gen}));
   // expected columns i32, str, l_str, r_str
 
   std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
@@ -962,20 +961,17 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
 
   cp::CountOptions options(cp::CountOptions::ONLY_VALID);
   ARROW_ASSIGN_OR_RAISE(
-      auto declr,
-      cp::Declaration::Sequence(
-          {
-              union_node,
-              {"sink", cp::SinkNodeOptions{&sink_gen}},
-          })
-          .AddToPlan(plan.get()));
+      auto declr, cp::Declaration::Sequence({
+                                                union_node,
+                                                {"sink", cp::SinkNodeOptions{&sink_gen}},
+                                            })
+                      .AddToPlan(plan.get()));
 
   ABORT_NOT_OK(declr->Validate());
 
   ABORT_NOT_OK(plan->Validate());
-  std::shared_ptr<arrow::RecordBatchReader> sink_reader =
-      cp::MakeGeneratorReader(basic_data.schema,
-                              std::move(sink_gen), exec_context.memory_pool());
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
+      basic_data.schema, std::move(sink_gen), exec_context.memory_pool());
 
   // // // start the ExecPlan
   ARROW_RETURN_NOT_OK(plan->StartProducing());

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -90,10 +90,6 @@ constexpr char kSep[] = "******";
   std::cout << "\t" << kSep << " " << msg << " " << kSep << std::endl; \
   std::cout << "" << std::endl;
 
-void PrintLine(std::string msg){
-  std::cout << msg << std::endl;
-} 
-
 namespace cp = ::arrow::compute;
 
 std::shared_ptr<arrow::Array> GetArrayFromJSON(
@@ -225,7 +221,7 @@ arrow::Status exec_plan_end_to_end_sample() {
 
     // // validate the plan
     ABORT_ON_FAILURE(plan->Validate());
-    PrintLine("Exec Plan created: " + plan->ToString());
+    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -316,7 +312,7 @@ arrow::Status ScanSinkExample() {
 
     // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
-    PrintLine("ExecPlan created : " + plan->ToString());
+    std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -326,7 +322,7 @@ arrow::Status ScanSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
                             arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PrintLine("Results : " + response_table->ToString());
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
     // // stop producing
     plan->StopProducing();
@@ -489,7 +485,7 @@ arrow::Status SourceSinkExample() {
 
   // // validate the ExecPlan
   ABORT_ON_FAILURE(plan->Validate());
-  PrintLine("Exec Plan Created: " + plan->ToString());
+  std::cout << "Exec Plan Created: " << plan->ToString() << std::endl;
   // // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -499,7 +495,7 @@ arrow::Status SourceSinkExample() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  PrintLine("Results : " + response_table->ToString());
+  std::cout << "Results : " << response_table->ToString() << std::endl;
 
   // // plan stop producing
   plan->StopProducing();
@@ -532,12 +528,12 @@ arrow::Status ScanFilterSinkExample() {
   options->projection = Materialize({});
 
   // construct the scan node
-  PrintLine("Initialized Scanning Options");
+  std::cout << "Initialized Scanning Options" << std::endl;
 
   cp::ExecNode* scan;
 
   auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-  PrintLine("Scan node options created");
+  std::cout << "Scan node options created" << std::endl;
 
   ARROW_ASSIGN_OR_RAISE(scan,
                         cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
@@ -560,7 +556,7 @@ arrow::Status ScanFilterSinkExample() {
 
   // // validate the ExecPlan
   ABORT_ON_FAILURE(plan->Validate());
-  PrintLine("Exec Plan created " + plan->ToString());
+  std::cout << "Exec Plan created " << plan->ToString() << std::endl;
   // // start the ExecPlan
   ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -569,7 +565,7 @@ arrow::Status ScanFilterSinkExample() {
   ARROW_ASSIGN_OR_RAISE(response_table,
                         arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-  PrintLine("Results : " + response_table->ToString());
+  std::cout << "Results : " << response_table->ToString() << std::endl;
   // // plan stop producing
   plan->StopProducing();
   // /// plan marked finished
@@ -625,7 +621,7 @@ arrow::Status ScanProjectSinkExample() {
     // // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
 
-    PrintLine("Exec Plan Created : " + plan->ToString());
+    std::cout << "Exec Plan Created : " << plan->ToString() << std::endl;
 
     // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
@@ -635,7 +631,7 @@ arrow::Status ScanProjectSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PrintLine("Results : " + response_table->ToString());
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
     // // plan stop producing
     plan->StopProducing();
@@ -691,7 +687,7 @@ arrow::Status SourceAggregateSinkExample() {
 
     // // validate the ExecPlan
     ABORT_ON_FAILURE(plan->Validate());
-    PrintLine("ExecPlan created : " + plan->ToString());
+    std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
     // // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
 
@@ -701,7 +697,7 @@ arrow::Status SourceAggregateSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PrintLine("Results : " + response_table->ToString());
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
     //plan stop producing
     plan->StopProducing();
@@ -758,12 +754,12 @@ arrow::Status SourceConsumingSinkExample() {
     ABORT_ON_FAILURE(consuming_sink->Validate());
 
     ABORT_ON_FAILURE(plan->Validate());
-    PrintLine("Exec Plan created: " + plan->ToString());
+    std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
     // plan start producing
     ABORT_ON_FAILURE(plan->StartProducing());
     // Source should finish fairly quickly
     ABORT_ON_FAILURE(source->finished().status());
-    PrintLine("Source Finished!");
+    std::cout << "Source Finished!" << std::endl;
     // Mark consumption complete, plan should finish
     arrow::Status finish_status;
     //finish.Wait();
@@ -858,7 +854,7 @@ arrow::Status SourceHashJoinSinkExample() {
     //                          cp::less_equal(
     //                              cp::field_ref("i32"),
     //                              cp::literal(2))}));
-    // PrintLine("left and right filter nodes created");
+    // std::cout << "left and right filter nodes created" << std::endl;
 
     cp::HashJoinNodeOptions join_opts{cp::JoinType::INNER,
                                       /*left_keys=*/{"str"},
@@ -893,7 +889,7 @@ arrow::Status SourceHashJoinSinkExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PrintLine("Results : " + response_table->ToString());
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
     // // plan stop producing
     plan->StopProducing();
@@ -948,7 +944,7 @@ arrow::Status SourceKSelectExample() {
     ARROW_ASSIGN_OR_RAISE(response_table,
     arrow::Table::FromRecordBatchReader(sink_reader.get()));
 
-    PrintLine("Results : " + response_table->ToString());
+    std::cout << "Results : " << response_table->ToString() << std::endl;
 
     // // plan stop proudcing
     plan->StopProducing();
@@ -1017,14 +1013,14 @@ arrow::Status ScanFilterWriteExample(std::string file_path) {
     arrow::dataset::WriteNodeOptions write_node_options {write_options,
     dataset->schema()};
 
-    PrintLine("Write Options created");
+    std::cout << "Write Options created" << std::endl;
 
     ARROW_ASSIGN_OR_RAISE(cp::ExecNode *wr, cp::MakeExecNode("write", plan.get(),
     {scan}, write_node_options));
 
     ABORT_ON_FAILURE(wr->Validate());
     ABORT_ON_FAILURE(plan->Validate());
-    PrintLine("Execution Plan Created : " + plan->ToString());
+    std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
     // // // start the ExecPlan
     ABORT_ON_FAILURE(plan->StartProducing());
     plan->finished().Wait();

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -177,6 +177,16 @@ cp::Expression Materialize(std::vector<std::string> names,
     return cp::project(exprs, names);
 }
 
+/**
+ * @brief 
+ * Scan-Sink 
+ * This example shows how scan operation can be applied on a dataset. 
+ * There are operations that can be applied on the scan (project, filter)
+ * and the input data can be processed. THe output is obtained as a table
+ * via the sink node. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
     // Execution plan created
     ARROW_ASSIGN_OR_RAISE(
@@ -356,6 +366,16 @@ arrow::Result<BatchesWithSchema> MakeGroupableBatches(int multiplicity = 1) {
   return result;
 }
 
+/**
+ * @brief 
+ * Source-Sink Example
+ * This example shows how a source and sink can be used
+ * in an execution plan. This includes source node receiving data 
+ * and the sink node emits the data as an output represented in 
+ * a table. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
   cp::ExecPlan::Make(&exec_context));
@@ -401,6 +421,15 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-Filter-Sink
+ * This example shows how a filter can be used in an execution plan, 
+ * along with the source and sink operations. The output from the 
+ * exeuction plan is obtained as a table via the sink node. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
                         cp::ExecPlan::Make(&exec_context));
@@ -464,6 +493,16 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Scan-Project-Sink
+ * This example shows how Scan operation can be used to load the data 
+ * into the execution plan, how project operation can be applied on the
+ * data stream and how the output is obtained as a table via the sink node. 
+ * 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
     cp::ExecPlan::Make(&exec_context));
@@ -526,6 +565,16 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-Aggregation-Sink
+ * This example shows how an aggregation operation can be applied on a 
+ * execution plan. The source node loads the data and the aggregation 
+ * (counting unique types in column 'a') is applied on this data. The 
+ * output is obtained from the sink node as a table. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
      cp::ExecPlan::Make(&exec_context));
@@ -586,6 +635,14 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-ConsumingSink 
+ * This example shows how the data can be consumed within the execution plan 
+ * by using a ConsumingSink node. There is no data output from this execution plan. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
      cp::ExecPlan::Make(&exec_context));
@@ -643,6 +700,16 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-OrderBySink
+ * In this example, the data enters through the source node
+ * and the data is ordered in the sink node. The order can be 
+ * ASCENDING or DESCENDING and it is configurable. The output
+ * is obtained as a table from the sink node. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
      cp::ExecPlan::Make(&exec_context));
@@ -686,6 +753,15 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-HashJoin-Sink
+ * This example shows how source node gets the data and how a self-join
+ * is applied on the data. The join options are configurable. The output
+ * is obtained as a table via the sink node. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -764,6 +840,15 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-KSelect
+ * This example shows how K number of elements can be selected 
+ * either from the top or bottom. The output node is a modified
+ * sink node where output can be obtained as a table. 
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -815,6 +900,15 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Scan-Filter-Write
+ * This example shows how scan node can be used to load the data
+ * and after processing how it can be written to disk. 
+ * @param exec_context 
+ * @param file_path 
+ * @return arrow::Status 
+ */
 arrow::Status ScanFilterWriteExample(cp::ExecContext &exec_context,
 const std::string &file_path) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
@@ -884,6 +978,15 @@ const std::string &file_path) {
     return arrow::Status::OK();
 }
 
+/**
+ * @brief 
+ * Source-Union-Sink
+ * This example shows how a union operation can be applied on two 
+ * data sources. The output is obtained as a table via the sink
+ * node.
+ * @param exec_context 
+ * @return arrow::Status 
+ */
 arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
     ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -593,7 +593,7 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
   // Mark consumption complete, plan should finish
   arrow::Status finish_status;
 
-  finish.MarkFinished(finish_status);
+  finish.MarkFinished(arrow::Status::OK());
   ARROW_RETURN_NOT_OK(plan->finished().status());
   ARROW_RETURN_NOT_OK(finish_status);
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -121,7 +121,6 @@ arrow::Result<std::shared_ptr<arrow::Array>> GetBinaryArrayDataSample(
   return result;
 }
 
-
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
   const arrow::ArrayVector array_vector,
 const arrow::FieldVector &field_vector) {
@@ -223,7 +222,7 @@ arrow::Status ScanSinkExample(cp::ExecContext &exec_context) {
     ABORT_ON_FAILURE(plan->Validate());
     std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
     // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -403,7 +402,7 @@ arrow::Status SourceSinkExample(cp::ExecContext &exec_context) {
   ABORT_ON_FAILURE(plan->Validate());
   std::cout << "Exec Plan Created: " << plan->ToString() << std::endl;
   // // // start the ExecPlan
-  ABORT_ON_FAILURE(plan->StartProducing());
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
   // // collect sink_reader into a Table
   std::shared_ptr<arrow::Table> response_table;
@@ -477,7 +476,7 @@ arrow::Status ScanFilterSinkExample(cp::ExecContext &exec_context) {
   ABORT_ON_FAILURE(plan->Validate());
   std::cout << "Exec Plan created " << plan->ToString() << std::endl;
   // // start the ExecPlan
-  ABORT_ON_FAILURE(plan->StartProducing());
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
 
   // // collect sink_reader into a Table
   std::shared_ptr<arrow::Table> response_table;
@@ -547,7 +546,7 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext &exec_context) {
     std::cout << "Exec Plan Created : " << plan->ToString() << std::endl;
 
     // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -616,7 +615,7 @@ arrow::Status SourceAggregateSinkExample(cp::ExecContext &exec_context) {
     ABORT_ON_FAILURE(plan->Validate());
     std::cout << "ExecPlan created : " << plan->ToString() << std::endl;
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -685,16 +684,16 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext &exec_context) {
     ABORT_ON_FAILURE(plan->Validate());
     std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
     // plan start producing
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
     // Source should finish fairly quickly
-    ABORT_ON_FAILURE(source->finished().status());
+    ARROW_RETURN_NOT_OK(source->finished().status());
     std::cout << "Source Finished!" << std::endl;
     // Mark consumption complete, plan should finish
     arrow::Status finish_status;
     //finish.Wait();
     finish.MarkFinished(finish_status);
-    ABORT_ON_FAILURE(plan->finished().status());
-    ABORT_ON_FAILURE(finish_status);
+    ARROW_RETURN_NOT_OK(plan->finished().status());
+    ARROW_RETURN_NOT_OK(finish_status);
 
     return arrow::Status::OK();
 }
@@ -739,7 +738,7 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext &exec_context) {
         exec_context.memory_pool());
 
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -819,9 +818,9 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext &exec_context) {
         exec_context.memory_pool());
 
     // // // validate the ExecPlan
-    ABORT_ON_FAILURE(plan->Validate());
+    ARROW_RETURN_NOT_OK(plan->Validate());
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -879,9 +878,9 @@ arrow::Status SourceKSelectExample(cp::ExecContext &exec_context) {
         exec_context.memory_pool());
 
     // // // validate the ExecPlan
-    ABORT_ON_FAILURE(plan->Validate());
+    ARROW_RETURN_NOT_OK(plan->Validate());
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;
@@ -972,7 +971,7 @@ const std::string &file_path) {
     ABORT_ON_FAILURE(plan->Validate());
     std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
     plan->finished().Wait();
     return arrow::Status::OK();
 }
@@ -1028,7 +1027,7 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext &exec_context) {
         exec_context.memory_pool());
 
     // // // start the ExecPlan
-    ABORT_ON_FAILURE(plan->StartProducing());
+    ARROW_RETURN_NOT_OK(plan->StartProducing());
 
     // // collect sink_reader into a Table
     std::shared_ptr<arrow::Table> response_table;

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -34,9 +34,15 @@
 #include "arrow/compute/registry.h"       // IWYU pragma: export
 #include "arrow/datum.h"                  // IWYU pragma: export
 
-/// \defgroup execnode-options Concrete option classes for ExecNode options
+/// \defgroup execnode-expressions Utilities for creating expressions to
+/// use in execution plans
 /// @{
 /// @}
 
 #include "arrow/compute/exec/expression.h"  // IWYU pragma: export
-#include "arrow/compute/exec/options.h"     // IWYU pragma: export
+
+/// \defgroup execnode-options Concrete option classes for ExecNode options
+/// @{
+/// @}
+
+#include "arrow/compute/exec/options.h"  // IWYU pragma: export

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -33,3 +33,9 @@
 #include "arrow/compute/kernel.h"         // IWYU pragma: export
 #include "arrow/compute/registry.h"       // IWYU pragma: export
 #include "arrow/datum.h"                  // IWYU pragma: export
+
+/// \defgroup execnode-options Concrete option classes for ExecNode options
+/// @{
+/// @}
+
+#include "arrow/compute/exec/options.h"   // IWYU pragma: export

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -38,4 +38,4 @@
 /// @{
 /// @}
 
-#include "arrow/compute/exec/options.h"   // IWYU pragma: export
+#include "arrow/compute/exec/options.h"  // IWYU pragma: export

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -38,4 +38,5 @@
 /// @{
 /// @}
 
-#include "arrow/compute/exec/options.h"  // IWYU pragma: export
+#include "arrow/compute/exec/expression.h"  // IWYU pragma: export
+#include "arrow/compute/exec/options.h"     // IWYU pragma: export

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -33,6 +33,10 @@
 namespace arrow {
 namespace compute {
 
+/// \defgroup expression-core Expressions to describe transformations in execution plans
+///
+/// @{
+
 /// An unbound expression which maps a single Datum to another Datum.
 /// An expression is one of
 /// - A literal Datum.
@@ -173,6 +177,8 @@ ARROW_EXPORT
 Result<KnownFieldValues> ExtractKnownFieldValues(
     const Expression& guaranteed_true_predicate);
 
+/// @}
+
 /// \defgroup expression-passes Functions for modification of Expressions
 ///
 /// @{
@@ -239,7 +245,9 @@ Result<std::shared_ptr<Buffer>> Serialize(const Expression&);
 ARROW_EXPORT
 Result<Expression> Deserialize(std::shared_ptr<Buffer>);
 
-// Convenience aliases for factories
+/// \defgroup expression-convenience Functions convenient expression creation
+///
+/// @{
 
 ARROW_EXPORT Expression project(std::vector<Expression> values,
                                 std::vector<std::string> names);
@@ -265,6 +273,8 @@ ARROW_EXPORT Expression and_(const std::vector<Expression>&);
 ARROW_EXPORT Expression or_(Expression lhs, Expression rhs);
 ARROW_EXPORT Expression or_(const std::vector<Expression>&);
 ARROW_EXPORT Expression not_(Expression operand);
+
+/// @}
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -33,6 +33,9 @@
 namespace arrow {
 namespace compute {
 
+/// \addtogroup execnode-options
+/// @{
+
 class ARROW_EXPORT ExecNodeOptions {
  public:
   virtual ~ExecNodeOptions() = default;
@@ -153,6 +156,8 @@ class ARROW_EXPORT OrderBySinkNodeOptions : public SinkNodeOptions {
   SortOptions sort_options;
 };
 
+/// @}
+
 enum class JoinType {
   LEFT_SEMI,
   RIGHT_SEMI,
@@ -165,6 +170,9 @@ enum class JoinType {
 };
 
 enum class JoinKeyCmp { EQ, IS };
+
+/// \addtogroup execnode-options
+/// @{
 
 /// \brief Make a node which implements join operation using hash join strategy.
 class ARROW_EXPORT HashJoinNodeOptions : public ExecNodeOptions {
@@ -269,6 +277,8 @@ class ARROW_EXPORT SelectKSinkNodeOptions : public SinkNodeOptions {
   /// SelectK options
   SelectKOptions select_k_options;
 };
+
+/// @}
 
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/api/compute.rst
+++ b/docs/source/cpp/api/compute.rst
@@ -54,3 +54,37 @@ Concrete options classes
    :undoc-members:
 
 .. TODO: List concrete function invocation shortcuts?
+
+Streaming Execution
+===================
+
+Streaming Execution Operators
+-----------------------------
+
+.. doxygenenum:: arrow::compute::JoinType
+
+.. doxygenenum:: arrow::compute::JoinKeyCmp
+
+.. doxygengroup:: execnode-options
+   :content-only:
+   :members:
+   :undoc-members:
+
+Execution Plan Expressions
+--------------------------
+
+.. doxygenclass:: arrow::FieldRef
+   :members:
+
+.. doxygengroup:: expression-core
+   :content-only:
+   :members:
+
+.. doxygengroup:: expression-convenience
+   :content-only:
+   :members:
+   :undoc-members:
+
+.. doxygengroup:: expression-passes
+   :content-only:
+   :members:

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -187,6 +187,8 @@ If you are unsure whether a function supports a concrete input type, we
 recommend you try it out.  Unsupported input types return a ``TypeError``
 :class:`Status`.
 
+.. _aggregation-option-list:
+
 Aggregations
 ------------
 

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -44,6 +44,8 @@ tabular, potentially larger than memory, and multi-file datasets. This includes:
 The goal is to expand support to other file formats and data sources
 (e.g. database connections) in the future.
 
+.. _cpp-dataset-reading:
+
 Reading Datasets
 ----------------
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -337,7 +337,7 @@ This is the list of operations associated with the execution plan:
    * - ``select_k_sink``
      - :class:`arrow::compute::SelectKSinkNodeOptions`
    * - ``scan``
-     - :class:`arrow::compute::ScanNodeOptions` 
+     - :class:`arrow::dataset::ScanNodeOptions` 
    * - ``hash_join``
      - :class:`arrow::compute::HashJoinNodeOptions`
    * - ``write``

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -401,12 +401,11 @@ Example of using ``source`` (usage of sink is explained in detail in :ref:`sink<
 ``filter``
 ----------
 
-``filter`` operation as the name suggests, provides an option to define a data filtering
-criteria. It keeps only rows matching a given expression. 
+``filter`` operation, as the name suggests, provides an option to define data filtering
+criteria. It selects rows matching a given expression. 
 Filters can be written using :class:`arrow::compute::Expression`. 
-For example, if we wish to keep rows of column ``b`` greater than 3, 
-then we can use the following expression::, can be written using 
-:class:`arrow::compute::FilterNodeOptions` as follows::
+For example, if we wish to keep rows where the value of column ``b``
+is greater than 3,  then we can use the following expression:: 
 
   // a > 3
   arrow::compute::Expression filter_opt = arrow::compute::greater(
@@ -442,9 +441,9 @@ Filter Example;
 ``project`` operation rearranges, deletes, transforms, and creates columns.
 Each output column is computed by evaluating an expression
 against the source record batch. This is exposed via 
-:class:`arrow::compute::ProjectNodeOptions` class which requires, 
-a :class:`arrow::compute::Expression`, names for the output columns (if names are not
-provided, the string representations of exprs will be used). 
+:class:`arrow::compute::ProjectNodeOptions` which requires,
+an :class:`arrow::compute::Expression` and name for each of the output columns (if names are not
+provided, the string representations of exprs will be used).  
 
 Sample Expression for projection::
 
@@ -481,8 +480,14 @@ Project Example;
 
 ``aggregate`` operation provides various data aggregation options. 
 The :class:`arrow::compute::AggregateNodeOptions` is used to 
-define the aggregation criterion. These options can be 
-selected from :ref:`aggregation options <aggregation-option-list>`.
+define the aggregation criteria. An aggregate node can first group data by
+one or more key columns or the keys can be left off to compute aggregates
+across the entire dataset.  Each aggregate node can compute any number of
+aggregation functions.  Each aggregation function will be applied to every
+field specified as a target.  The aggregation functions can be 
+selected from :ref:`this list of aggregation functions <aggregation-option-list>`.
+Note: This node is a "pipeline breaker" and will fully materialize the dataset in memory.
+In the future, spillover mechanisms will be added which should alleviate this constraint.
 
 Example::
 
@@ -502,7 +507,7 @@ An example for creating an aggregate node::
                             cp::MakeExecNode("aggregate", plan.get(), {source},
                             aggregate_options));
 
-Aggregate example;
+Aggregate example:
 
 Filter Example;
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -180,10 +180,10 @@ Constructing ``ExecNode`` using Options
 
 Using the execution plan we can construct varioud execution queries. 
 To construct such queries, we have provided a set of containers or 
-referred as `ExecutionNode` s. These nodes provide the ability to 
+referred as :class:`ExecNode` s. These nodes provide the ability to 
 construct operations like filtering, projection, join, etc. 
 
-This is the list of `ExecutionNode` s exposed;
+This is the list of :class:`ExecutionNode` s exposed;
 
 1. :class:`SourceNode`
 2. :class:`FilterNode`
@@ -204,11 +204,11 @@ in designing a streaming execution plan.
 ``SourceNode``
 --------------
 
-:class:`SourceNode` can be considered as an entry point to create a streaming execution plan. 
+:struct:`arrow::compute::SourceNode` can be considered as an entry point to create a streaming execution plan. 
 A source node can be constructed as follows.
 
-`arrow::compute::SoureNodeOptions` are used to create the :class:`SourceNode`. 
-The `arrow::Schema` of the data passing through and a function to generate data 
+:class:`arrow::compute::SoureNodeOptions` are used to create the :struct:`arrow::compute::SourceNode`. 
+The :class:`Schema` of the data passing through and a function to generate data 
 `std::function<arrow::Future<arrow::util::optional<arrow::compute::ExecBatch>>()>` 
 are required to create this option::
 
@@ -230,9 +230,9 @@ are required to create this option::
 --------------
 
 :class:`FilterNode`, as the name suggests, provide a container to define a data filtering criteria. 
-Filter can be written using `arrow::compute::Expression`. For instance if the row values
+Filter can be written using :class:`arrow::compute::Expression`. For instance if the row values
 of a particular column needs to be filtered by a boundary value, ex: all values of column b
-greater than 3, can be written as follows::
+greater than 3, can be written using :class:`arrow::compute::FilterNodeOptions` as follows::
 
     // a > 3
     arrow::compute::Expression filter_opt = arrow::compute::greater(
@@ -257,8 +257,8 @@ Using this option, the filter node can be constructed as follows::
 :class:`ProjectNode` executes expressions on input batches and produces new batches. 
 Each expression will be evaluated against each batch which is pushed to this 
 node to produce a corresponding output column. This is exposed via 
-`arrow::compute::ProjectNodeOptions` component which requires, 
-a `arrow::compute::Expression`, names of the project columns (names are not provided, 
+:class:`arrow::compute::ProjectNodeOptions` component which requires, 
+a :class:`arrow::compute::Expression`, names of the project columns (names are not provided, 
 the string representations of exprs will be used) and a boolean flag to determine 
 synchronous/asynchronous nature (by default asynchronous option is set to `true`). 
 
@@ -285,7 +285,7 @@ Creating a project node::
 -----------------------
 
 :class:`ScalarAggregateNode` is an :class:`ExecNode` which provides various 
-aggregation options. The `arrow::compute::AggregateNodeOptions` provides the 
+aggregation options. The :class:`arrow::compute::AggregateNodeOptions` provides the 
 container to define the aggregation criterion. These options can be 
 selected from `arrow::compute` options. 
 
@@ -301,7 +301,8 @@ Example::
 
 2. `CountOptions`
    
-`CountOptions` aggregation option provides three sub-options to determine the counting approach. 
+:class:`arrow::compute::CountOptions` aggregation option provides three sub-options to 
+determine the counting approach. 
 
 a. `ONLY_VALID` : Count only non-null values
 b. `ONLY_NULL` : Count both non-null and null values
@@ -313,9 +314,11 @@ Example::
 
 3. `ModeOptions`
 
-`ModeOptions` aggregation option computes mode for a distribution,
+:class:`arrow::compute::ModeOptions` aggregation option computes mode for a distribution,
 by returns top-n common values and counts. 
-By default, returns the most common value and count.
+By default, returns the most common value and count
+
+Example::
 
     // n: top value `n` values
     // skip_nulls: if true (the default), null values are ignored. 
@@ -325,9 +328,10 @@ By default, returns the most common value and count.
 
 4. `VarianceOptions`
 
-This option controls the Delta Degrees of Freedom (ddof) of Variance and Stddev kernel.
-The divisor used in calculations is N - ddof, where N is the number of elements.
-By default, ddof is zero, and population variance or stddev is returned.
+:class:`arrow::compute::VarianceOptions` option controls the Delta Degrees of Freedom 
+(ddof) of Variance and Stddev kernel. The divisor used in calculations is N - ddof, 
+where N is the number of elements. By default, ddof is zero, and population variance 
+or stddev is returned.
 
 Example::
 
@@ -341,10 +345,10 @@ Example::
 
 5. `QuantileOptions`
 
-This option controls the Quantile kernel behavior. By default, returns the median value.
-There is an interpolation method to use when quantile lies between two data points.
-The provided options for interpolation are; `LINEAE`, `LOWER`, 'HIGHER', `NEAREST` 
-and `MIDPOINT`.
+:class:`arrow::compute::QuantileOptions` This option controls the Quantile kernel behavior. 
+By default, returns the median value. There is an interpolation method to use when quantile 
+lies between two data points. The provided options for interpolation are; `LINEAE`, `LOWER`, `HIGHER`,
+`NEAREST` and `MIDPOINT`.
 
 Example::
 
@@ -362,7 +366,7 @@ Example::
 
 6. `TDigestOptions`
 
-This option controls TDigest approximate quantile kernel behavior.
+`arrow::compute::TDigestOptions` option controls TDigest approximate quantile kernel behavior.
 By default, returns the median value.
 
 Example::
@@ -381,8 +385,8 @@ Example::
 
 7. IndexOptions
 
-This option controls Index kernel behavior. This is used to find the
-index of a particular scalar value. 
+:class:`arrow::compute::IndexOptions` This option controls Index kernel behavior. 
+This is used to find the index of a particular scalar value. 
 
 Example::
 
@@ -407,15 +411,15 @@ Scan-Node
 ---------
 
 There is no class or struct defined as ScanNode in the source. 
-But `arrow::compute::ScanNodeOptions` container includes the options
+But :class:`arrow::compute::ScanNodeOptions` container includes the options
 passed to `MakeScanNode` internal function which creates an :class:`ExecNode`
 performing the defined task. This component includes a few options,
-defined in the `ScanNodeOptions` and this requires, 
+defined in the :class:`arrow::compute::ScanNodeOptions` and this requires, 
 `std::shared_ptr<arrow::dataset::Dataset>`, 
 `std::shared_ptr<arrow::compute::ScanOptions>`, 
 `std::shared_ptr<arrow::util::AsyncToggle>`. 
 
-The `arrow::compute::ScanOptions` includes the scaning options::
+The :class:`arrow::compute::ScanOptions` includes the scaning options::
 
     arrow::compute::Expression Materialize(std::vector<std::string> names,
                               bool include_aug_fields = false) {
@@ -455,8 +459,8 @@ The `arrow::compute::ScanOptions` includes the scaning options::
 ------------
 
 :class:`SinkNode` can be considered as the output or final node of an streaming 
-execution definition. `SinkNodeOptions` interface is used to pass the required options. 
-Requires 
+execution definition. :class:`arrow::compute::SinkNodeOptions` interface is used to pass 
+the required options. Requires 
 `std::function<arrow::Future<arrow::util::optional<arrow::compute::ExecBatch>>()>* generator`
 and `arrow::util::BackpressureOptions backpressure`. 
 
@@ -494,10 +498,10 @@ The output can be obtained as a table::
 ``ConsumingSinkNode``
 ---------------------
 
-:class:`ConsumingSinkNode` is a sink node that owns consuming the data and 
+:class:`arrow::compute::ConsumingSinkNode` is a sink node that owns consuming the data and 
 will not finish until the consumption is finished.  Use SinkNode if you are
 transferring the ownership of the data to another system.  
-Use :class:`ConsumingSinkNode` if the data is being consumed within the exec 
+Use :class:`arrow::compute::ConsumingSinkNode` if the data is being consumed within the exec 
 plan (i.e. the exec plan should not complete until the consumption has completed).
 
 Example::
@@ -539,8 +543,9 @@ Example::
 
 This is an extension to the :class:`SinkNode` definition and provides the ability
 to guarantee the ordering of the stream by providing the,
-`arrow::compute::OrderBySinkNodeOptions`. Here the `SortOptions` are provided
-to define which columns are used for sorting and under which criterion.
+:class:`arrow::compute::OrderBySinkNodeOptions`. 
+Here the :class:`arrow::compute::SortOptions` are provided to define which columns 
+are used for sorting and under which criterion.
 
 Example::
 
@@ -563,7 +568,7 @@ SelectK-Node
 ------------
 
 There is no Select-K-SinkNode available as an entity within the source, but the behavior 
-is defined with the options `arrow::compute::SelectKOptions` which is a defined by 
+is defined with the options :class:`arrow::compute::SelectKOptions` which is a defined by 
 using :struct:`OrderBySinkNode` definition. This option returns a sink node that receives 
 inputs and then compute top_k/bottom_k.
 
@@ -582,9 +587,9 @@ Scan-Node
 ---------
 
 There is no definition Scan-Node in the source, but the behavior of is defined using 
-`arrow::dataset::ScanNodeOptions`. This option contains a set of definitions. 
+:class:`arrow::dataset::ScanNodeOptions`. This option contains a set of definitions. 
 
-Option definitions for `ScanNodeOptions`:: 
+Option definitions for :class:`arrow::dataset::ScanNodeOptions`:: 
 
 
     /// A row filter (which will be pushed down to partitioning/reading if supported).
@@ -659,6 +664,114 @@ Creating a Scan `ExecNode`::
                               scan_node_options));
 
 
+Write-Node
+----------
+
+The option to write a result to a file format is provided by this execution node type. 
+A definition doesn't exist as an :class:`ExecNode`, but the write options are provided
+via the :class:`arrow::dataset::WriteNodeOptions` and defined using 
+:class::`arrow::dataset::FileSystemDatasetWriteOptions`, `std::shared_ptr<arrow::Schema>`,
+and `std::shared_ptr<arrow::util::AsyncToggle> backpressure_toggle`. Here the 
+:class::`arrow::dataset::FileSystemDatasetWriteOptions` contains the meta-data required 
+to write the data. 
+
+Creating `WriteNodeOptions`::
+
+    std::string root_path = "";
+    std::string uri = "file://" + '/path/to/file';
+    std::shared_ptr<arrow::fs::FileSystem> filesystem =
+    arrow::fs::FileSystemFromUri(uri, &root_path).ValueOrDie();
+
+    auto base_path = root_path + "/parquet_dataset";
+    ABORT_ON_FAILURE(filesystem->DeleteDir(base_path));
+    ABORT_ON_FAILURE(filesystem->CreateDir(base_path));
+
+    // The partition schema determines which fields are part of the partitioning.
+    auto partition_schema = arrow::schema({arrow::field("a", arrow::int32())});
+    // We'll use Hive-style partitioning,
+    // which creates directories with "key=value" pairs.
+
+    auto partitioning =
+    std::make_shared<arrow::dataset::HivePartitioning>(partition_schema);
+    // We'll write Parquet files.
+    auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+
+    arrow::dataset::FileSystemDatasetWriteOptions write_options;
+    write_options.file_write_options = format->DefaultWriteOptions();
+    write_options.filesystem = filesystem;
+    write_options.base_dir = base_path;
+    write_options.partitioning = partitioning;
+    write_options.basename_template = "part{i}.parquet";
+
+    arrow::dataset::WriteNodeOptions write_node_options {write_options,
+    dataset->schema()};
+
+Creating a `write` `ExecNode`::
+
+    ARROW_ASSIGN_OR_RAISE(cp::ExecNode *wr, cp::MakeExecNode("write", plan.get(),
+        {scan}, write_node_options));
+
+    ABORT_ON_FAILURE(wr->Validate());
+    ABORT_ON_FAILURE(plan->Validate());
+    // // // start the ExecPlan
+    ABORT_ON_FAILURE(plan->StartProducing());
+    plan->finished().Wait(); // make sure to add this method 
+
+``UnionNode``
+-------------
+
+:class:`UnionNode` is the :class:`ExecNode` interface to perform a union 
+operation on two datasets. The union operation can be executed
+on multiple data sources(:class:`ExecNodes`).
+
+The following example demonstrates how this can be achieved using 
+two data sources. Following a union operations the output is obtained using 
+a aggregation operation. 
+
+Example::
+
+    arrow::compute::Declaration union_node{"union", arrow::compute::ExecNodeOptions{}};
+    arrow::compute::Declaration lhs{"source",
+                  arrow::compute::SourceNodeOptions{/*schema of data*/l_schema,
+                                    /*generator*/l_gen()}};
+    lhs.label = "lhs";
+    arrow::compute::Declaration rhs{"source",
+                    arrow::compute::SourceNodeOptions{/*schema of data*/r_schema,
+                                    /*generator*/r_gen()}};
+    rhs.label = "rhs";
+    union_node.inputs.emplace_back(lhs);
+    union_node.inputs.emplace_back(rhs);
+
+    arrow::compute::CountOptions options(arrow::compute::CountOptions::ONLY_VALID);
+    ARROW_ASSIGN_OR_RAISE(auto declr,
+    arrow::compute::Declaration::Sequence(
+            {
+                union_node,
+                {"aggregate", arrow::compute::AggregateNodeOptions{
+                  /*aggregates=*/{{"count", &options}},
+                  /*targets=*/{"a"},
+                  /*names=*/{"count(a)"},
+                  /*keys=*/{}}},
+                {"sink", arrow::compute::SinkNodeOptions{&sink_gen}},
+            })
+            .AddToPlan(plan.get()));
+
+Example List
+============
+
+There a set of examples can be found in ``examples/arrow/execution_plan_documentation_examples.cc``
+
+1. Source-Sink
+2. Scan-Sink
+3. Scan-Filter-Sink
+4. Scan-Project-Sink
+5. Source-Aggregate-Sink
+6. Scan-ConsumingSinkNode
+7. Scan-OrderBySinkNode
+8. Scan-HashJoinNode
+9. Scan-SelectSinkNode
+10. Scan-Filter-WriteNode
+11. Scan-Union-Sink
 
 
 Constructing ``ExecPlan`` objects

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -424,7 +424,7 @@ Using this option, the filter node can be constructed as follows::
                           //filter node options
                           arrow::compute::FilterNodeOptions{filter_opt}));
 
-Filter Example;
+Filter example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -464,7 +464,7 @@ Creating a project node::
           // project node options 
           arrow::compute::ProjectNodeOptions{{a_times_2}}));
 
-Project Example;
+Project example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -488,8 +488,6 @@ field specified as a target.  The aggregation functions can be
 selected from :ref:`this list of aggregation functions <aggregation-option-list>`.
 Note: This node is a "pipeline breaker" and will fully materialize the dataset in memory.
 In the future, spillover mechanisms will be added which should alleviate this constraint.
-
-Example::
 
 An example for creating an aggregate node::
 
@@ -601,7 +599,7 @@ Example::
       {source}, cp::ConsumingSinkNodeOptions(consumer)));
 
 
-Consuming-Sink Example;
+Consuming-Sink example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -640,7 +638,7 @@ Example::
   }}},&sink_gen}));
 
 
-Order-By-Sink Example:
+Order-By-Sink example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -674,7 +672,7 @@ Create SelectK Option::
       arrow::compute::SelectKSinkNodeOptions{options, &sink_gen}));
 
 
-SelectK Example;
+SelectK example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -712,12 +710,32 @@ Creating a Scan `ExecNode`::
                           cp::MakeExecNode("scan", plan.get(), {}, 
                             scan_node_options));
 
-Scan example;
+Scan example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
   :start-after: (Doc section: Scan Example)
   :end-before: (Doc section: Scan Example)
+  :linenos:
+  :lineno-match:
+
+.. _stream_execution_hashjoin_docs:
+
+``hash_join``
+-------------
+
+``hash_join`` operation provides the relational algebra operation, join using hash-based
+algorithm. :class:`arrow::compute::HashJoinNodeOptions` contains the options required in 
+defining a join. JoinType can be one of LEFT_SEMI, RIGHT_SEMI, LEFT_ANTI, RIGHT_ANTI,
+INNER, LEFT_OUTER, RIGHT_OUTER and FULL_OUTER. Also the join-key or by which column/s, 
+and output suffixes can be set via the the join options. 
+
+Hash-Join example:
+
+.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
+  :language: cpp
+  :start-after: (Doc section: HashJoin Example)
+  :end-before: (Doc section: HashJoin Example)
   :linenos:
   :lineno-match:
 
@@ -729,13 +747,11 @@ Scan example;
 ``write`` option enables writing a result to supported file formats (example `parquet`,
 `feather`, `csv`, etc). 
 The write options are provided via the :class:`arrow::dataset::WriteNodeOptions` and 
-defined using :class:`arrow::dataset::FileSystemDatasetWriteOptions`, 
-``std::shared_ptr<arrow::Schema>``, and 
-``std::shared_ptr<arrow::util::AsyncToggle> backpressure_toggle``. Here the 
+defined using :class:`arrow::dataset::FileSystemDatasetWriteOptions`. Here the 
 :class:`arrow::dataset::FileSystemDatasetWriteOptions` contains the meta-data required 
 to write the data. 
 
-Write Example;
+Write example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -756,7 +772,7 @@ sources(:class:`ExecNodes`).
 The following example demonstrates how this can be achieved using 
 two data sources.
 
-Union Example;
+Union example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -770,16 +786,16 @@ Union Example;
 Example List
 ============
 
-There a set of examples can be found in ``examples/arrow/execution_plan_documentation_examples.cc``
+There are examples of these nodes which can be found in ``examples/arrow/execution_plan_documentation_examples.cc``
 
-1. Source-Sink
-2. Scan-Sink
-3. Scan-Filter-Sink
-4. Scan-Project-Sink
-5. Source-Aggregate-Sink
-6. Scan-ConsumingSinkNode
-7. Scan-OrderBySinkNode
-8. Scan-HashJoinNode
-9. Scan-SelectSinkNode
-10. Scan-Filter-WriteNode
-11. Scan-Union-Sink
+1. :ref:`Source-Sink<stream_execution_source_docs>`
+2. :ref:`Filter<stream_execution_filter_docs>`
+3. :ref:`Project<stream_execution_project_docs>`
+4. :ref:`Aggregate<stream_execution_aggregate_docs>`
+5. :ref:`ConsumingSink<stream_execution_consuming_sink_docs>`
+6. :ref:`OrderBySink<stream_execution_order_by_sink_docs>`
+7. :ref:`SelectK<stream_execution_select_k_docs>`
+8. :ref:`Scan<stream_execution_scan_docs>`
+9. :ref:`HashJoin<stream_execution_hashjoin_docs>`
+10. :ref:`Write<stream_execution_write_docs>`
+11. :ref:`Union<stream_execution_union_docs>`

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -688,11 +688,15 @@ SelectK Example;
 ``scan``
 ---------
 
-`scan` is an operation used to load and process data, and the behavior of is defined using 
-:class:`arrow::dataset::ScanNodeOptions`. This option contains a set of definitions. 
-The :ref:`dataset<cpp-dataset-reading>` API also use scanner for processing data.
-In contrast to `source` operation, `scan` operation can load the data and apply scanning
-operations like filter and project to the loaded data. 
+`scan` is an operation used to load and process datasets.  It should be preferred over the
+more generic `source` node when your input is a dataset.  The behavior is defined using 
+:class:`arrow::dataset::ScanNodeOptions`.  More information on datasets and the various
+scan options can be found in :ref:`dataset<cpp-dataset-reading>`.
+
+This node is capable of applying pushdown filters to the file readers which reduce
+the amount of data that needs to be read.  This means you may supply the same
+filter expression to the scan node that you also supply to the FilterNode because
+the filtering is done in two different places.
 
 Creating a Scan `ExecNode`::
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -351,9 +351,9 @@ This is the list of operations associated with the execution plan:
 ``source``
 ----------
 
-A `source` operation can be considered as an entry point to create a streaming execution plan. 
+A ``source`` operation can be considered as an entry point to create a streaming execution plan. 
 :class:`arrow::compute::SourceNodeOptions` are used to create the ``source`` operation.  The
-`source` operation is the most generic and flexible type of source currently available but it can
+``source`` operation is the most generic and flexible type of source currently available but it can
 be quite tricky to configure.  To process data from files the scan operation is likely a simpler choice.
 
 The source node requires some kind of function that can be called to poll for more data.  This
@@ -627,8 +627,8 @@ SelectK example:
 ``scan``
 ---------
 
-`scan` is an operation used to load and process datasets.  It should be preferred over the
-more generic `source` node when your input is a dataset.  The behavior is defined using 
+``scan`` is an operation used to load and process datasets.  It should be preferred over the
+more generic ``source`` node when your input is a dataset.  The behavior is defined using 
 :class:`arrow::dataset::ScanNodeOptions`.  More information on datasets and the various
 scan options can be found in :doc:`./dataset`.
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -491,8 +491,6 @@ In the future, spillover mechanisms will be added which should alleviate this co
 
 Example::
 
-  arrow::compute::IndexOptions index_options(arrow::MakeScalar("1"));
-
 An example for creating an aggregate node::
 
   arrow::compute::CountOptions options(arrow::compute::CountOptions::ONLY_VALID);
@@ -509,8 +507,6 @@ An example for creating an aggregate node::
 
 Aggregate example:
 
-Filter Example;
-
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
   :start-after: (Doc section: Aggregate Example)
@@ -523,12 +519,17 @@ Filter Example;
 ``sink``
 --------
 
-``sink`` operation can be considered as the option providing output or final node of an streaming 
+``sink`` operation provides output and is the final node of a streaming 
 execution definition. :class:`arrow::compute::SinkNodeOptions` interface is used to pass 
-the required options. Requires 
-``arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>>* generator``
-and ``arrow::util::BackpressureOptions backpressure``. 
-An execution plan should only have one "terminal" node (one sink node).
+the required options. Similar to the source operator the sink operator exposes the output
+with a function that returns a record batch future each time it is called.  It is expected the
+caller will repeatedly call this function until the generator function is exhausted (returns
+arrow::util::optional::nullopt).  If this function is not called often enough then record batches
+will accumulate in memory.  An execution plan should only have one
+"terminal" node (one sink node).  An execution plan may "finish" by marking
+`exec_plan->finished()` as complete before the sink generator is fully consumed and the
+execution plan can be safely destroyed without harming the sink generator (which will hold
+references to the unconsumed batches).
 
 Example::
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -556,6 +556,16 @@ As a part of the Source Example, the Sink operation is also included;
 
 ``consuming_sink`` operator is a sink operation containing consuming operation within the
 execution plan (i.e. the exec plan should not complete until the consumption has completed).
+Unlike the `sink` node this node takes in a callback function that is expected to consume the
+batch.  Once this callback has finished the execution plan will no longer hold any reference to
+the batch.
+The consuming function may be called before a previous invocation has completed.  If the consuming
+function does not run quickly enough then many concurrent executions could pile up, blocking the
+CPU thread pool.  The execution plan will not be marked finished until all consuming function callbacks
+have been completed.
+Once all batches have been delivered the execution plan will wait for the `finish` future to complete
+before marking the execution plan finished.  This allows for workflows where the consumption function
+converts batches into async tasks (this is currently done internally for the dataset write node).
 
 Example::
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -723,8 +723,7 @@ The union operation can be executed on multiple data
 sources(:class:`ExecNodes`).
 
 The following example demonstrates how this can be achieved using 
-two data sources. Following a union operations the output is obtained using 
-a aggregation operation. 
+two data sources.
 
 Union Example;
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -620,6 +620,8 @@ This operation provides the ability to guarantee the ordering of the
 stream by providing the :class:`arrow::compute::OrderBySinkNodeOptions`. 
 Here the :class:`arrow::compute::SortOptions` are provided to define which columns 
 are used for sorting and whether to sort by ascending or descending values.
+Note: This node is a "pipeline breaker" and will fully materialize the dataset in memory.
+In the future, spillover mechanisms will be added which should alleviate this constraint.
 
 Example::
 
@@ -657,6 +659,8 @@ Order-By-Sink Example:
 :class:`arrow::compute::SelectKOptions` which is a defined by 
 using :struct:`OrderBySinkNode` definition. This option returns a sink node that receives 
 inputs and then compute top_k/bottom_k.
+Note: This node is a "pipeline breaker" and will fully materialize the input in memory.
+In the future, spillover mechanisms will be added which should alleviate this constraint.
 
 Create SelectK Option::
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -309,9 +309,9 @@ reads and decodes twice.
 Constructing ``ExecNode`` using Options
 =======================================
 
-Using the execution plan we can construct varioud execution queries. 
-To construct such queries, we have provided a set of containers or 
-referred as :class:`ExecNode` s. These nodes provide the ability to 
+Using the execution plan we can construct various queries. 
+To construct such queries, we have provided a set of building blocks
+or referred as :class:`ExecNode` s. These nodes provide the ability to 
 construct operations like filtering, projection, join, etc. 
 
 This is the list of :class:`ExecutionNode` s exposed;

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -633,37 +633,18 @@ Scan example:
   :linenos:
   :lineno-match:
 
-.. _stream_execution_hashjoin_docs:
-
-``hash_join``
--------------
-
-``hash_join`` operation provides the relational algebra operation, join using hash-based
-algorithm. :class:`arrow::compute::HashJoinNodeOptions` contains the options required in 
-defining a join. JoinType can be one of LEFT_SEMI, RIGHT_SEMI, LEFT_ANTI, RIGHT_ANTI,
-INNER, LEFT_OUTER, RIGHT_OUTER and FULL_OUTER. Also the join-key or by which column/s, 
-and output suffixes can be set via the the join options. 
-
-Hash-Join example:
-
-.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
-  :language: cpp
-  :start-after: (Doc section: HashJoin Example)
-  :end-before: (Doc section: HashJoin Example)
-  :linenos:
-  :lineno-match:
-
-.. _stream_execution_write_docs:
 
 ``write``
 ---------
 
-``write`` option enables writing a result to supported file formats (example `parquet`,
-`feather`, `csv`, etc). 
-The write options are provided via the :class:`arrow::dataset::WriteNodeOptions` and 
-defined using :class:`arrow::dataset::FileSystemDatasetWriteOptions`. Here the 
-:class:`arrow::dataset::FileSystemDatasetWriteOptions` contains the meta-data required 
-to write the data. 
+The ``write`` node saves query results as a dataset of files in a
+format like Parquet, Feather, CSV, etc. using the :doc:`./dataset`
+functionality in Arrow. The write options are provided via the
+:class:`arrow::dataset::WriteNodeOptions` which in turn contains
+:class:`arrow::dataset::FileSystemDatasetWriteOptions`.
+:class:`arrow::dataset::FileSystemDatasetWriteOptions` provides
+control over the written dataset, including options like the output
+directory, file naming scheme, and so on.
 
 Write example:
 
@@ -679,9 +660,8 @@ Write example:
 ``union``
 -------------
 
-``union`` is operation performs the union of two datasets. 
-The union operation can be executed on multiple data 
-sources(:class:`ExecNodes`).
+``union`` merges multiple data streams with the same schema into one, similar to 
+a SQL ``UNION ALL`` clause.
 
 The following example demonstrates how this can be achieved using 
 two data sources.
@@ -695,24 +675,34 @@ Union example:
   :linenos:
   :lineno-match:
 
-.. _stream_execution_example_list_docs:
+.. _stream_execution_hashjoin_docs:
 
-Example List
-============
+``hash_join``
+-------------
 
-There are examples of these nodes which can be found in ``examples/arrow/execution_plan_documentation_examples.cc``
+``hash_join`` operation provides the relational algebra operation, join using hash-based
+algorithm. :class:`arrow::compute::HashJoinNodeOptions` contains the options required in 
+defining a join. The hash_join supports left/right/full semi/anti/outerjoins. 
+Also the join-key (i.e. the column(s) to join on), and suffixes (i.e a suffix term like "_x"
+which can be appended as a suffix for column names duplicated in both left and right 
+relations.) can be set via the the join options. 
 
-1. :ref:`Source-Sink<stream_execution_source_docs>`
-2. :ref:`Filter<stream_execution_filter_docs>`
-3. :ref:`Project<stream_execution_project_docs>`
-4. :ref:`Aggregate<stream_execution_aggregate_docs>`
-5. :ref:`ConsumingSink<stream_execution_consuming_sink_docs>`
-6. :ref:`OrderBySink<stream_execution_order_by_sink_docs>`
-7. :ref:`SelectK<stream_execution_select_k_docs>`
-8. :ref:`Scan<stream_execution_scan_docs>`
-9. :ref:`HashJoin<stream_execution_hashjoin_docs>`
-10. :ref:`Write<stream_execution_write_docs>`
-11. :ref:`Union<stream_execution_union_docs>`
+Hash-Join example:
+
+.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
+  :language: cpp
+  :start-after: (Doc section: HashJoin Example)
+  :end-before: (Doc section: HashJoin Example)
+  :linenos:
+  :lineno-match:
+
+.. _stream_execution_write_docs:
+
+Summary
+=======
+
+There are examples of these nodes which can be found in 
+``cpp/examples/arrow/execution_plan_documentation_examples.cc`` in the Arrow source.
 
 Complete Example:
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -358,7 +358,9 @@ A source node can be constructed as follows.
 :class:`arrow::compute::SourceNodeOptions` are used to create the ``source`` operation. 
 The :class:`Schema` of the data passing through and a function to generate data 
 ``arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>>``
-are required to create this option.
+are required to create this option. Additionally, when using `source` operator, 
+the data scanning operations like filter and project may need to be applied
+in a later part of the execution plan. 
 
 Struct to hold the data generator definition;
 
@@ -662,6 +664,8 @@ SelectK Example;
 `scan` is an operation used to load and process data, and the behavior of is defined using 
 :class:`arrow::dataset::ScanNodeOptions`. This option contains a set of definitions. 
 The :ref:`dataset<cpp-dataset-reading>` API also use scanner for processing data.
+In contrast to `source` operation, `scan` operation can load the data and apply scanning
+operations like filter and project to the loaded data. 
 
 Creating a Scan `ExecNode`::
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -410,7 +410,7 @@ Using this option, the filter node can be constructed as follows::
     ARROW_ASSIGN_OR_RAISE(filter, arrow::compute::MakeExecNode("filter", 
                           // plan
                           plan.get(),
-                          // previous input
+                          // previous node
                           {scan}, 
                           //filter node options
                           arrow::compute::FilterNodeOptions{filter_opt}));
@@ -421,10 +421,9 @@ Using this option, the filter node can be constructed as follows::
 ``project`` operation rearranges, deletes, transforms, and creates columns.
 Each output column is computed by evaluating an expression
 against the source record batch. This is exposed via 
-:class:`arrow::compute::ProjectNodeOptions` component which requires, 
-a :class:`arrow::compute::Expression`, names for the output columns (names are not
-provided, the string representations of exprs will be used) and a boolean flag to determine 
-synchronous/asynchronous nature (by default asynchronous option is set to `true`). 
+:class:`arrow::compute::ProjectNodeOptions` class which requires, 
+a :class:`arrow::compute::Expression`, names for the output columns (if names are not
+provided, the string representations of exprs will be used). 
 
 Sample Expression for projection::
 
@@ -435,7 +434,7 @@ Sample Expression for projection::
 
 Creating a project node::
 
-  arrow::compute::ExecNode *project;
+  arrow::compute::ExecNode* project;
       ARROW_ASSIGN_OR_RAISE(project, 
           arrow::compute::MakeExecNode("project", 
           // plan
@@ -600,8 +599,9 @@ Example::
 ``scan``
 ---------
 
-There is no definition Scan-Node in the source, but the behavior of is defined using 
+`scan` is an operation used to load and process data, and the behavior of is defined using 
 :class:`arrow::dataset::ScanNodeOptions`. This option contains a set of definitions. 
+The :ref:`dataset<cpp-dataset-reading>` API also use scanner for processing data.
 
 Option definitions for :class:`arrow::dataset::ScanNodeOptions`:: 
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -309,10 +309,8 @@ reads and decodes twice.
 Constructing ``ExecNode`` using Options
 =======================================
 
-Using the execution plan we can construct various queries. 
-To construct such queries, we have provided a set of building blocks
-referred to as :class:`ExecNode` s. These nodes provide the ability to  
-construct operations like filtering, projection, join, etc. 
+:class:`ExecNode` is the component we use as a building block 
+containing in-built operations with various functionalities. 
 
 This is the list of operations associated with the execution plan:
 
@@ -329,7 +327,7 @@ This is the list of operations associated with the execution plan:
    * - ``project``
      - :class:`arrow::compute::ProjectNodeOptions`
    * - ``aggregate``
-     - :class:`arrow::compute::ScalarAggregateOptions`
+     - :class:`arrow::compute::AggregateNodeOptions`
    * - ``sink``
      - :class:`arrow::compute::SinkNodeOptions`
    * - ``consuming_sink``
@@ -361,7 +359,7 @@ The source node requires some kind of function that can be called to poll for mo
 function should take no arguments and should return an
 ``arrow::Future<std::shared_ptr<arrow::util::optional<arrow::RecordBatch>>>``.
 This function might be reading a file, iterating through an in memory structure, or receiving data
-from a network connection.  The arrow library refers to these functions as `arrow::AsyncGenerator`
+from a network connection.  The arrow library refers to these functions as ``arrow::AsyncGenerator``
 and there are a number of utilities for working with these functions.  For this example we use 
 a vector of record batches that we've already stored in memory.
 In addition, the schema of the data must be known up front.  Arrow's streaming execution
@@ -799,3 +797,12 @@ There are examples of these nodes which can be found in ``examples/arrow/executi
 9. :ref:`HashJoin<stream_execution_hashjoin_docs>`
 10. :ref:`Write<stream_execution_write_docs>`
 11. :ref:`Union<stream_execution_union_docs>`
+
+Complete Example:
+
+.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
+  :language: cpp
+  :start-after: (Doc section: Execution Plan Documentation Example)
+  :end-before: (Doc section: Execution Plan Documentation Example)
+  :linenos:
+  :lineno-match:

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -314,7 +314,7 @@ To construct such queries, we have provided a set of building blocks
 referred to as :class:`ExecNode` s. These nodes provide the ability to  
 construct operations like filtering, projection, join, etc. 
 
-This is the list of operations associated with the execution plan;
+This is the list of operations associated with the execution plan:
 
 .. list-table:: Operations and Options
    :widths: 50 50
@@ -353,16 +353,23 @@ This is the list of operations associated with the execution plan;
 ``source``
 ----------
 
-`source` operation can be considered as an entry point to create a streaming execution plan. 
-A source node can be constructed as follows.
-:class:`arrow::compute::SourceNodeOptions` are used to create the ``source`` operation. 
-The :class:`Schema` of the data passing through and a function to generate data 
-``arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>>``
-are required to create this option. Additionally, when using `source` operator, 
-the data scanning operations like filter and project may need to be applied
-in a later part of the execution plan. 
+A `source` operation can be considered as an entry point to create a streaming execution plan. 
+:class:`arrow::compute::SourceNodeOptions` are used to create the ``source`` operation.  The
+`source` operation is the most generic and flexible type of source currently available but it can
+be quite tricky to configure.  To process data from files the scan operation is likely a simpler choice.
+The source node requires some kind of function that can be called to poll for more data.  This
+function should take no arguments and should return an
+``arrow::Future<std::shared_ptr<arrow::util::optional<arrow::RecordBatch>>>``.
+This function might be reading a file, iterating through an in memory structure, or receiving data
+from a network connection.  The arrow library refers to these functions as `arrow::AsyncGenerator`
+and there are a number of utilities for working with these functions.  For this example we use 
+a vector of record batches that we've already stored in memory.
+In addition, the schema of the data must be known up front.  Arrow's streaming execution
+engine must know the schema of the data at each stage of the execution graph before any
+processing has begun.  This means we must supply the schema for a source node separately
+from the data itself.
 
-Struct to hold the data generator definition;
+Struct to hold the data generator definition:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -371,7 +378,7 @@ Struct to hold the data generator definition;
   :linenos:
   :lineno-match:
 
-Generating Batches for computation;
+Generating sample Batches for computation:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
@@ -380,7 +387,7 @@ Generating Batches for computation;
   :linenos:
   :lineno-match:
 
-Example of using ``source`` (usage of sink is explained in detail in :ref:`sink<stream_execution_sink_docs>`);
+Example of using ``source`` (usage of sink is explained in detail in :ref:`sink<stream_execution_sink_docs>`):
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -391,10 +391,12 @@ are required to create this option::
 ``filter``
 ----------
 
-``filter`` operation as the name suggests, provides an option to define a data filtering criteria. 
-Filter can be written using :class:`arrow::compute::Expression`. For instance if the row values
-of a particular column needs to be filtered by a boundary value, ex: all values of column b
-greater than 3, can be written using :class:`arrow::compute::FilterNodeOptions` as follows::
+``filter`` operation as the name suggests, provides an option to define a data filtering
+criteria. It keeps only rows matching a given expression. 
+Filters can be written using :class:`arrow::compute::Expression`. 
+For example, if we wish to keep rows of column ``b`` greater than 3, 
+then we can use the following expression::, can be written using 
+:class:`arrow::compute::FilterNodeOptions` as follows::
 
   // a > 3
   arrow::compute::Expression filter_opt = arrow::compute::greater(

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -464,12 +464,25 @@ can be selected from :ref:`this list of aggregation functions
           the dataset in memory.  In the future, spillover mechanisms
           will be added which should alleviate this constraint.
 
-Aggregate example:
+The aggregation can provide results as a group or scalar. For instances,
+an operation like `hash_count` provides the counts per each unique record
+as a grouped result while an operation like `sum` provides a single record. 
+
+Scalar Aggregation example:
 
 .. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
   :language: cpp
-  :start-after: (Doc section: Aggregate Example)
-  :end-before: (Doc section: Aggregate Example)
+  :start-after: (Doc section: Scalar Aggregate Example)
+  :end-before: (Doc section: Scalar Aggregate Example)
+  :linenos:
+  :lineno-match:
+
+Group Aggregation example:
+
+.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
+  :language: cpp
+  :start-after: (Doc section: Group Aggregate Example)
+  :end-before: (Doc section: Group Aggregate Example)
   :linenos:
   :lineno-match:
 
@@ -682,10 +695,14 @@ Union example:
 
 ``hash_join`` operation provides the relational algebra operation, join using hash-based
 algorithm. :class:`arrow::compute::HashJoinNodeOptions` contains the options required in 
-defining a join. The hash_join supports left/right/full semi/anti/outerjoins. 
+defining a join. The hash_join supports 
+`left/right/full semi/anti/outerjoins
+<https://en.wikipedia.org/wiki/Join_(SQL)>`_. 
 Also the join-key (i.e. the column(s) to join on), and suffixes (i.e a suffix term like "_x"
 which can be appended as a suffix for column names duplicated in both left and right 
 relations.) can be set via the the join options. 
+`Read more on hash-joins
+<https://en.wikipedia.org/wiki/Hash_join>`_. 
 
 Hash-Join example:
 


### PR DESCRIPTION
This PR's objective is to create a detailed documentation on using ExecPlan and available options. The task is divided into two sub-components. The first component is to work on a set of examples showing how to use these options with sample data. 

## Examples

- [x] Source-Sink
- [x] Scan-Sink
- [x] Scan-Filter-Sink
- [x] Scan-Project-Sink
- [x] Source-Aggregate-Sink
- [x] Scan-ConsumingSink
- [x] Scan-OrderBySink
- [x] Scan-HashJoin
- [x] Scan-SelectSink
- [x] Scan-Filter-Write
- [x] Scan-Union-Sink

## Documentation

- [x] General Description 
- [x] Option Description with code snippets

## Notes 

Some of the util functions were referred from the `test_utils`. 
There is a potential duplication of code due to that. Need 
feedback on best way to handle this. 