### PR TITLE
ARROW-15198: [C++][FlightRPC] Fix conda-python-hdfs build error on flight-sql branch

### DIFF
--- a/cpp/src/arrow/flight/sql/example/sqlite_statement_batch_reader.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_statement_batch_reader.cc
@@ -93,8 +93,8 @@ SqliteStatementBatchReader::SqliteStatementBatchReader(
       rc_(SQLITE_OK),
       already_executed_(false) {}
 
-Result<std::shared_ptr<SqliteStatementBatchReader>> SqliteStatementBatchReader::Create(
-    const std::shared_ptr<SqliteStatement>& statement_) {
+arrow::Result<std::shared_ptr<SqliteStatementBatchReader>>
+SqliteStatementBatchReader::Create(const std::shared_ptr<SqliteStatement>& statement_) {
   ARROW_RETURN_NOT_OK(statement_->Step());
 
   ARROW_ASSIGN_OR_RAISE(auto schema, statement_->GetSchema());


### PR DESCRIPTION
This should fix Crossbow build `conda-python-hdfs` on `flight-sql`:
https://github.com/ursacomputing/crossbow/runs/4612261742?check_suite_focus=true

Using `arrow::Result` on `SqliteStatementBatchReader::Create` to avoid confusing with `arrow::flight::Result`.
