### PR TITLE
ARROW-15181: [C++][FlightRPC] Fix race between signal handler and shutdown

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -356,6 +356,24 @@ TEST(TestFlight, BuilderHook) {
   ASSERT_OK(server->Shutdown());
 }
 
+TEST(TestFlight, ServeShutdown) {
+  // Regression test for ARROW-15181
+  constexpr int kIterations = 10;
+  for (int i = 0; i < kIterations; i++) {
+    Location location;
+    std::unique_ptr<FlightServerBase> server = ExampleTestServer();
+
+    ASSERT_OK(Location::ForGrpcTcp("localhost", 0, &location));
+    FlightServerOptions options(location);
+    ASSERT_OK(server->Init(options));
+    ASSERT_GT(server->port(), 0);
+    std::thread t([&]() { ASSERT_OK(server->Serve()); });
+    ASSERT_OK(server->Shutdown());
+    ASSERT_OK(server->Wait());
+    t.join();
+  }
+}
+
 // ----------------------------------------------------------------------
 // Client tests
 

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -826,9 +826,9 @@ class ServerSignalHandler {
         errno != EWOULDBLOCK && errno != EINTR) {
       return arrow::internal::IOErrorFromErrno(errno, "Could not unblock signal thread");
     }
+    handle_signals_.join();
     RETURN_NOT_OK(arrow::internal::FileClose(self_pipe_.rfd));
     RETURN_NOT_OK(arrow::internal::FileClose(self_pipe_.wfd));
-    handle_signals_.join();
     self_pipe_.rfd = 0;
     self_pipe_.wfd = 0;
     return Status::OK();
@@ -1012,6 +1012,7 @@ Status FlightServerBase::Shutdown() {
   if (!server) {
     return Status::Invalid("Shutdown() on uninitialized FlightServerBase");
   }
+  impl_->running_instance_ = nullptr;
   impl_->server_->Shutdown();
   return Status::OK();
 }


### PR DESCRIPTION
The Flight server spawns a background thread that reads from a pipe, then shuts down the server. (The pipe is written to by a signal handler). On normal shutdown, the server would close the pipe, then join the background thread, leading to a race: the background thread might read from the pipe again, getting a "bad fd" error. The fix is simple; just join the thread before closing the pipe.