### PR TITLE
ARROW-15200: [C++][Gandiva] Fix UnsatisfiedLinkError when using Gandiva's generated jar files

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -95,6 +95,9 @@ set(SRC_FILES
     random_generator_holder.cc
     ${GANDIVA_PRECOMPILED_CC_PATH})
 
+# fix possible UnsatisfiedLinkError after jars are generated and used in JNI
+set_source_files_properties(gandiva_object_cache.cc PROPERTIES COMPILE_FLAGS -fno-rtti)
+
 set(GANDIVA_SHARED_PRIVATE_LINK_LIBS arrow_shared LLVM::LLVM_INTERFACE
                                      ${GANDIVA_OPENSSL_LIBS})
 


### PR DESCRIPTION
When generating Gandiva's jar file it is possible that an error of UnsatisfiedLinkError may occur based on a LLVM's symbol being used, more specific the llvm::ObjectCache.

To fix that, the flag `-fno-rtti` was passed only to the file that uses the llvm::ObjectCache.
