### PR TITLE
ARROW-15199: [Java] Update protobuf-maven-plugin to avoid 'Text file busy' failure

### DIFF
--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -230,7 +230,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.0</version>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <clearOutputDirectory>false</clearOutputDirectory>

--- a/java/flight/flight-grpc/pom.xml
+++ b/java/flight/flight-grpc/pom.xml
@@ -103,7 +103,7 @@
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
-          <version>0.5.0</version>
+          <version>0.6.1</version>
           <configuration>
             <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
             <clearOutputDirectory>false</clearOutputDirectory>

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -131,6 +131,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
         <executions>
           <execution>
             <id>proto-compile</id>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>


### PR DESCRIPTION
Occasionally, we see this in CI: `An error occurred while invoking protoc. Error while executing process. Cannot run program "/arrow/java/flight/flight-core/target/protoc-plugins/protoc-3.17.3-linux-x86_64.exe": error=26, Text file busy`

This appears to be due to a JDK bug: https://github.com/xolstice/protobuf-maven-plugin/issues/34

A workaround was added to recent versions of the Protobuf plugin, but we aren't using the newest version consistently. This PR updates the versions to use 0.6.1 everywhere.