### PR TITLE
ARROW-15203: [GLib] garrow_struct_scalar_get_value() for scalar from C++ returns value

### DIFF
--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -2039,6 +2039,16 @@ GList *
 garrow_struct_scalar_get_value(GArrowStructScalar *scalar)
 {
   auto priv = GARROW_STRUCT_SCALAR_GET_PRIVATE(scalar);
+  if (!priv->value) {
+    auto arrow_scalar =
+      std::static_pointer_cast<arrow::StructScalar>(
+        garrow_scalar_get_raw(GARROW_SCALAR(scalar)));
+    for (auto arrow_element : arrow_scalar->value) {
+      priv->value = g_list_prepend(priv->value,
+                                   garrow_scalar_new_raw(&arrow_element));
+    }
+    priv->value = g_list_reverse(priv->value);
+  }
   return priv->value;
 }
 

--- a/c_glib/test/test-struct-scalar.rb
+++ b/c_glib/test/test-struct-scalar.rb
@@ -16,6 +16,8 @@
 # under the License.
 
 class TestStructScalar < Test::Unit::TestCase
+  include Helper::Buildable
+
   def setup
     fields = [
       Arrow::Field.new("score", Arrow::Int8DataType.new),
@@ -51,5 +53,18 @@ class TestStructScalar < Test::Unit::TestCase
 
   def test_value
     assert_equal(@value, @scalar.value)
+  end
+
+  def test_from_cpp
+    min_max = Arrow::Function.find("min_max")
+    args = [
+      Arrow::ArrayDatum.new(build_int8_array([0, 2, -4])),
+    ]
+    scalar = min_max.execute(args).value
+    assert_equal([
+                   Arrow::Int8Scalar.new(-4),
+                   Arrow::Int8Scalar.new(2),
+                 ],
+                 scalar.value)
   end
 end


### PR DESCRIPTION
We need to convert C++ scalars lazy because there is no change to
convert C++ scalars to GLib scalars.