### PR TITLE
ARROW-15207: [GLib] Use the Meson's default -Dwerror=

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -110,8 +110,8 @@ jobs:
       ARROW_BUILD_TESTS: OFF
       ARROW_FLIGHT: ON
       ARROW_GANDIVA: ON
-      ARROW_GLIB_DEVELOPMENT_MODE: true
       ARROW_GLIB_GTK_DOC: true
+      ARROW_GLIB_WERROR: true
       ARROW_HOME: /usr/local
       ARROW_JEMALLOC: OFF
       ARROW_ORC: OFF

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -122,13 +122,6 @@ endif
 
 cxx = meson.get_compiler('cpp')
 cxx_flags = []
-if get_option('development_mode')
-  if cxx.get_id() == 'msvc'
-    cxx_flags += ['/WX']
-  else
-    cxx_flags += ['-Werror']
-  endif
-endif
 if cxx.get_id() != 'msvc'
   cxx_flags += ['-Wmissing-declarations']
 endif

--- a/c_glib/meson_options.txt
+++ b/c_glib/meson_options.txt
@@ -27,11 +27,6 @@ option('arrow_cpp_build_type',
        value: 'release',
        description: '-DCMAKE_BUILD_TYPE option value for Arrow C++')
 
-option('development_mode',
-       type: 'boolean',
-       value: false,
-       description: 'Build in development mode')
-
 option('gtk_doc',
        type: 'boolean',
        value: false,

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -23,7 +23,7 @@ source_dir=${1}/c_glib
 build_dir=${2}/c_glib
 build_root=${2}
 
-: ${ARROW_GLIB_DEVELOPMENT_MODE:=false}
+: ${ARROW_GLIB_WERROR:=false}
 : ${BUILD_DOCS_C_GLIB:=OFF}
 with_gtk_doc=$([ "${BUILD_DOCS_C_GLIB}" == "ON" ] && echo "true" || echo "false")
 
@@ -37,8 +37,8 @@ mkdir -p ${build_dir}
 # Build with Meson
 meson --prefix=$ARROW_HOME \
       --libdir=lib \
-      -Ddevelopment_mode=${ARROW_GLIB_DEVELOPMENT_MODE} \
       -Dgtk_doc=${with_gtk_doc} \
+      -Dwerror=${ARROW_GLIB_WERROR} \
       ${build_dir} \
       ${source_dir}
 


### PR DESCRIPTION
Instead of custom -Ddevelopment_mode.