### PR TITLE
ARROW-15220: [C++] Remove bool specializations of bit block counter operations

### DIFF
--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -48,23 +48,23 @@ inline uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
 // These templates are here to help with unit tests
 
 template <typename T>
+inline T BitNot(T x) {
+  return ~x;
+}
+
+template <>
+inline bool BitNot(bool x) {
+  return !x;
+}
+
+template <typename T>
 struct BitBlockAnd {
   static T Call(T left, T right) { return left & right; }
 };
 
-template <>
-struct BitBlockAnd<bool> {
-  static bool Call(bool left, bool right) { return left && right; }
-};
-
 template <typename T>
 struct BitBlockAndNot {
-  static T Call(T left, T right) { return left & ~right; }
-};
-
-template <>
-struct BitBlockAndNot<bool> {
-  static bool Call(bool left, bool right) { return left && !right; }
+  static T Call(T left, T right) { return left & BitNot(right); }
 };
 
 template <typename T>
@@ -72,19 +72,9 @@ struct BitBlockOr {
   static T Call(T left, T right) { return left | right; }
 };
 
-template <>
-struct BitBlockOr<bool> {
-  static bool Call(bool left, bool right) { return left || right; }
-};
-
 template <typename T>
 struct BitBlockOrNot {
-  static T Call(T left, T right) { return left | ~right; }
-};
-
-template <>
-struct BitBlockOrNot<bool> {
-  static bool Call(bool left, bool right) { return left || !right; }
+  static T Call(T left, T right) { return left | BitNot(right); }
 };
 
 }  // namespace detail

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -34,12 +34,15 @@ namespace arrow {
 namespace internal {
 namespace detail {
 
-constexpr uint64_t LoadWord(const uint8_t* bytes) {
+inline uint64_t LoadWord(const uint8_t* bytes) {
   return bit_util::ToLittleEndian(util::SafeLoadAs<uint64_t>(bytes));
 }
 
-constexpr uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
-  return (shift == 0) ? current : (current >> shift) | (next << (64 - shift));
+inline uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
+  if (shift == 0) {
+    return current;
+  }
+  return (current >> shift) | (next << (64 - shift));
 }
 
 // These templates are here to help with unit tests

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -48,33 +48,33 @@ inline uint64_t ShiftWord(uint64_t current, uint64_t next, int64_t shift) {
 // These templates are here to help with unit tests
 
 template <typename T>
-inline T BitNot(T x) {
+constexpr T BitNot(T x) {
   return ~x;
 }
 
 template <>
-inline bool BitNot(bool x) {
+constexpr bool BitNot(bool x) {
   return !x;
 }
 
 template <typename T>
 struct BitBlockAnd {
-  static T Call(T left, T right) { return left & right; }
+  static constexpr T Call(T left, T right) { return left & right; }
 };
 
 template <typename T>
 struct BitBlockAndNot {
-  static T Call(T left, T right) { return left & BitNot(right); }
+  static constexpr T Call(T left, T right) { return left & BitNot(right); }
 };
 
 template <typename T>
 struct BitBlockOr {
-  static T Call(T left, T right) { return left | right; }
+  static constexpr T Call(T left, T right) { return left | right; }
 };
 
 template <typename T>
 struct BitBlockOrNot {
-  static T Call(T left, T right) { return left | BitNot(right); }
+  static constexpr T Call(T left, T right) { return left | BitNot(right); }
 };
 
 }  // namespace detail

--- a/cpp/src/arrow/util/bit_block_counter_test.cc
+++ b/cpp/src/arrow/util/bit_block_counter_test.cc
@@ -206,7 +206,7 @@ TEST_F(TestBitBlockCounter, FourWordsRandomData) {
   }
 }
 
-template <template <typename T> class Op, typename NextWordFunc>
+template <class Op, typename NextWordFunc>
 void CheckBinaryBitBlockOp(NextWordFunc&& get_next_word) {
   const int64_t nbytes = 1024;
   auto left = *AllocateBuffer(nbytes);
@@ -224,8 +224,8 @@ void CheckBinaryBitBlockOp(NextWordFunc&& get_next_word) {
       int expected_popcount = 0;
       for (int j = 0; j < block.length; ++j) {
         expected_popcount += static_cast<int>(
-            Op<bool>::Call(bit_util::GetBit(left->data(), position + left_offset + j),
-                           bit_util::GetBit(right->data(), position + right_offset + j)));
+            Op::Call(bit_util::GetBit(left->data(), position + left_offset + j),
+                     bit_util::GetBit(right->data(), position + right_offset + j)));
       }
       ASSERT_EQ(block.popcount, expected_popcount);
       position += block.length;


### PR DESCRIPTION
Reduces the number of bitwise classes/structs used in util/bit_block_counter.h by removing the bool specialization because C++ guarantees `(bool)(a & b) == (a && b)` for bool types. A bool specialization is added for bitwise negation because `~(bool)(a)` will always return true, so need to explicitly use `!a`.