### PR TITLE
ARROW-15219: [Python] Export the random compute function

### DIFF
--- a/cpp/src/arrow/util/pcg_random.h
+++ b/cpp/src/arrow/util/pcg_random.h
@@ -26,6 +26,8 @@ using pcg32 = ::arrow_vendored::pcg32;
 using pcg64 = ::arrow_vendored::pcg64;
 using pcg32_fast = ::arrow_vendored::pcg32_fast;
 using pcg64_fast = ::arrow_vendored::pcg64_fast;
+using pcg32_oneseq = ::arrow_vendored::pcg32_oneseq;
+using pcg64_oneseq = ::arrow_vendored::pcg64_oneseq;
 
 }  // namespace random
 }  // namespace arrow

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1331,6 +1331,32 @@ class Utf8NormalizeOptions(_Utf8NormalizeOptions):
         self._set_options(form)
 
 
+cdef class _RandomOptions(FunctionOptions):
+    def _set_options(self, length, initializer):
+        if initializer == 'system':
+            self.wrapped.reset(new CRandomOptions(
+                CRandomOptions.FromSystemRandom(length)))
+            return
+
+        if not isinstance(initializer, int):
+            try:
+                initializer = hash(initializer)
+            except TypeError:
+                raise TypeError(
+                    f"initializer should be 'system', an integer, "
+                    f"or a hashable object; got {initializer!r}")
+
+        if initializer < 0:
+            initializer += 2**64
+        self.wrapped.reset(new CRandomOptions(
+            CRandomOptions.FromSeed(length, initializer)))
+
+
+class RandomOptions(_RandomOptions):
+    def __init__(self, length, *, initializer='system'):
+        self._set_options(length, initializer)
+
+
 def _group_by(args, keys, aggregations):
     cdef:
         vector[CDatum] c_args

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -47,6 +47,7 @@ from pyarrow._compute import (  # noqa
     PadOptions,
     PartitionNthOptions,
     QuantileOptions,
+    RandomOptions,
     ReplaceSliceOptions,
     ReplaceSubstringOptions,
     RoundOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2210,6 +2210,22 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CUtf8NormalizeOptions(CUtf8NormalizeForm form)
         CUtf8NormalizeForm form
 
+    cdef cppclass CSetLookupOptions \
+            "arrow::compute::SetLookupOptions"(CFunctionOptions):
+        CSetLookupOptions(CDatum value_set, c_bool skip_nulls)
+        CDatum value_set
+        c_bool skip_nulls
+
+    cdef cppclass CRandomOptions \
+            "arrow::compute::RandomOptions"(CFunctionOptions):
+        CRandomOptions(CRandomOptions)
+
+        @staticmethod
+        CRandomOptions FromSystemRandom(int64_t length)
+
+        @staticmethod
+        CRandomOptions FromSeed(int64_t length, uint64_t seed)
+
     cdef enum DatumType" arrow::Datum::type":
         DatumType_NONE" arrow::Datum::NONE"
         DatumType_SCALAR" arrow::Datum::SCALAR"
@@ -2235,12 +2251,6 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         const shared_ptr[CRecordBatch]& record_batch() const
         const shared_ptr[CTable]& table() const
         const shared_ptr[CScalar]& scalar() const
-
-    cdef cppclass CSetLookupOptions \
-            "arrow::compute::SetLookupOptions"(CFunctionOptions):
-        CSetLookupOptions(CDatum value_set, c_bool skip_nulls)
-        CDatum value_set
-        c_bool skip_nulls
 
 
 cdef extern from * namespace "arrow::compute":


### PR DESCRIPTION
Also change the underlying generator as successive seeds (e.g. 0, 1, 2, 3) could produce the same output.