### PR TITLE
ARROW-15232: [Packaging][deb] Disable DWARF optimization for libarrow.so

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -102,5 +102,9 @@ override_dh_auto_test:
 # libarrow.so: avoid failing with "Unknown DWARF DW_OP_172"
 # libgandiva.so: avoid failing with "Unknown DWARF DW_OP_255"
 #   See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949296
+# plasma-store-server: avoid failing with "Unknown DWARF DW_OP_1"
 override_dh_dwz:
-	dh_dwz --exclude=libarrow.so --exclude=libgandiva.so
+	dh_dwz \
+	  --exclude=libarrow.so \
+	  --exclude=libgandiva.so \
+	  --exclude=plasma-store-server

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -99,6 +99,8 @@ override_dh_auto_test:
 	#     PARQUET_TEST_DATA=$(CURDIR)/parquet-testing/data			\
 	#       ctest --exclude-regex 'arrow-cuda-test|plasma-client_tests'
 
-# skip file failing with "Unknown DWARF DW_OP_255" (see bug#949296)
+# libarrow.so: avoid failing with "Unknown DWARF DW_OP_172"
+# libgandiva.so: avoid failing with "Unknown DWARF DW_OP_255"
+#   See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949296
 override_dh_dwz:
-	dh_dwz --exclude=libgandiva.so
+	dh_dwz --exclude=libarrow.so --exclude=libgandiva.so


### PR DESCRIPTION
libarrow.so uses unknown operators such as DW_OP_0 and DW_OP_172 since
ceaed97f010b4e1c67a34f73b683b1ca3df16930 but dwz doesn't support it.