### PR TITLE
ARROW-15173: [R] Provide backward compatibility for bridge to older versions of pyarrow

### DIFF
--- a/r/R/python.R
+++ b/r/R/python.R
@@ -23,7 +23,15 @@ py_to_r.pyarrow.lib.Array <- function(x, ...) {
     delete_arrow_array(array_ptr)
   })
 
-  x$`_export_to_c`(array_ptr, schema_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(array_ptr, schema_ptr)
+  } else {
+    x$`_export_to_c`(
+      external_pointer_addr_double(array_ptr),
+      external_pointer_addr_double(schema_ptr)
+    )
+  }
+
   Array$import_from_c(array_ptr, schema_ptr)
 }
 
@@ -38,7 +46,16 @@ r_to_py.Array <- function(x, convert = FALSE) {
   # Import with convert = FALSE so that `_import_from_c` returns a Python object
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(array_ptr, schema_ptr)
-  out <- pa$Array$`_import_from_c`(array_ptr, schema_ptr)
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$Array$`_import_from_c`(array_ptr, schema_ptr)
+  } else {
+    out <- pa$Array$`_import_from_c`(
+      external_pointer_addr_double(array_ptr),
+      external_pointer_addr_double(schema_ptr)
+    )
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -52,7 +69,15 @@ py_to_r.pyarrow.lib.RecordBatch <- function(x, ...) {
     delete_arrow_array(array_ptr)
   })
 
-  x$`_export_to_c`(array_ptr, schema_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(array_ptr, schema_ptr)
+  } else {
+    x$`_export_to_c`(
+      external_pointer_addr_double(array_ptr),
+      external_pointer_addr_double(schema_ptr)
+    )
+  }
+
   RecordBatch$import_from_c(array_ptr, schema_ptr)
 }
 
@@ -67,7 +92,16 @@ r_to_py.RecordBatch <- function(x, convert = FALSE) {
   # Import with convert = FALSE so that `_import_from_c` returns a Python object
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(array_ptr, schema_ptr)
-  out <- pa$RecordBatch$`_import_from_c`(array_ptr, schema_ptr)
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$RecordBatch$`_import_from_c`(array_ptr, schema_ptr)
+  } else {
+    out <- pa$RecordBatch$`_import_from_c`(
+      external_pointer_addr_double(array_ptr),
+      external_pointer_addr_double(schema_ptr)
+    )
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -106,7 +140,12 @@ py_to_r.pyarrow.lib.Schema <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  x$`_export_to_c`(schema_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(schema_ptr)
+  } else {
+    x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
+  }
+
   Schema$import_from_c(schema_ptr)
 }
 
@@ -117,7 +156,13 @@ r_to_py.Schema <- function(x, convert = FALSE) {
   # Import with convert = FALSE so that `_import_from_c` returns a Python object
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
-  out <- pa$Schema$`_import_from_c`(schema_ptr)
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$Schema$`_import_from_c`(schema_ptr)
+  } else {
+    out <- pa$Schema$`_import_from_c`(external_pointer_addr_double(schema_ptr))
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -127,7 +172,12 @@ py_to_r.pyarrow.lib.Field <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  x$`_export_to_c`(schema_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(schema_ptr)
+  } else {
+    x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
+  }
+
   Field$import_from_c(schema_ptr)
 }
 
@@ -138,7 +188,13 @@ r_to_py.Field <- function(x, convert = FALSE) {
   # Import with convert = FALSE so that `_import_from_c` returns a Python object
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
-  out <- pa$Field$`_import_from_c`(schema_ptr)
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$Field$`_import_from_c`(schema_ptr)
+  } else {
+    out <- pa$Field$`_import_from_c`(external_pointer_addr_double(schema_ptr))
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -148,7 +204,12 @@ py_to_r.pyarrow.lib.DataType <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  x$`_export_to_c`(schema_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(schema_ptr)
+  } else {
+    x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
+  }
+
   DataType$import_from_c(schema_ptr)
 }
 
@@ -159,7 +220,15 @@ r_to_py.DataType <- function(x, convert = FALSE) {
   # Import with convert = FALSE so that `_import_from_c` returns a Python object
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
-  out <- pa$DataType$`_import_from_c`(schema_ptr)
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$DataType$`_import_from_c`(schema_ptr)
+  } else {
+    out <- pa$DataType$`_import_from_c`(
+      external_pointer_addr_double(schema_ptr)
+    )
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -169,7 +238,14 @@ py_to_r.pyarrow.lib.RecordBatchReader <- function(x, ...) {
   stream_ptr <- allocate_arrow_array_stream()
   on.exit(delete_arrow_array_stream(stream_ptr))
 
-  x$`_export_to_c`(stream_ptr)
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    x$`_export_to_c`(stream_ptr)
+  } else {
+    x$`_export_to_c`(
+      external_pointer_addr_double(stream_ptr)
+    )
+  }
+
   RecordBatchReader$import_from_c(stream_ptr)
 }
 
@@ -181,9 +257,15 @@ r_to_py.RecordBatchReader <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(stream_ptr)
   # TODO: handle subclasses of RecordBatchReader?
-  out <- pa$lib$RecordBatchReader$`_import_from_c`(
-    stream_ptr
-  )
+
+  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+    out <- pa$lib$RecordBatchReader$`_import_from_c`(stream_ptr)
+  } else {
+    out <- pa$lib$RecordBatchReader$`_import_from_c`(
+      external_pointer_addr_double(stream_ptr)
+    )
+  }
+
   # But set the convert attribute on the return object to the requested value
   assign("convert", convert, out)
   out
@@ -223,4 +305,15 @@ install_pyarrow <- function(envname = NULL, nightly = FALSE, ...) {
   } else {
     reticulate::py_install("pyarrow", envname = envname, ...)
   }
+}
+
+pyarrow_version <- function() {
+  pa <- reticulate::import("pyarrow")
+  version_string <- pa$`__version__`
+  # remove trailing .devXXX because it won't work with package_version()
+  package_version(gsub("\\.dev.*?$", "", version_string))
+}
+
+pyarrow_version_pointers_changed <- function() {
+  "7.0.0"
 }

--- a/r/R/python.R
+++ b/r/R/python.R
@@ -23,7 +23,7 @@ py_to_r.pyarrow.lib.Array <- function(x, ...) {
     delete_arrow_array(array_ptr)
   })
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(array_ptr, schema_ptr)
   } else {
     x$`_export_to_c`(
@@ -47,7 +47,7 @@ r_to_py.Array <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(array_ptr, schema_ptr)
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$Array$`_import_from_c`(array_ptr, schema_ptr)
   } else {
     out <- pa$Array$`_import_from_c`(
@@ -69,7 +69,7 @@ py_to_r.pyarrow.lib.RecordBatch <- function(x, ...) {
     delete_arrow_array(array_ptr)
   })
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(array_ptr, schema_ptr)
   } else {
     x$`_export_to_c`(
@@ -93,7 +93,7 @@ r_to_py.RecordBatch <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(array_ptr, schema_ptr)
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$RecordBatch$`_import_from_c`(array_ptr, schema_ptr)
   } else {
     out <- pa$RecordBatch$`_import_from_c`(
@@ -140,7 +140,7 @@ py_to_r.pyarrow.lib.Schema <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(schema_ptr)
   } else {
     x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
@@ -157,7 +157,7 @@ r_to_py.Schema <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$Schema$`_import_from_c`(schema_ptr)
   } else {
     out <- pa$Schema$`_import_from_c`(external_pointer_addr_double(schema_ptr))
@@ -172,7 +172,7 @@ py_to_r.pyarrow.lib.Field <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(schema_ptr)
   } else {
     x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
@@ -189,7 +189,7 @@ r_to_py.Field <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$Field$`_import_from_c`(schema_ptr)
   } else {
     out <- pa$Field$`_import_from_c`(external_pointer_addr_double(schema_ptr))
@@ -204,7 +204,7 @@ py_to_r.pyarrow.lib.DataType <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
   on.exit(delete_arrow_schema(schema_ptr))
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(schema_ptr)
   } else {
     x$`_export_to_c`(external_pointer_addr_double(schema_ptr))
@@ -221,7 +221,7 @@ r_to_py.DataType <- function(x, convert = FALSE) {
   pa <- reticulate::import("pyarrow", convert = FALSE)
   x$export_to_c(schema_ptr)
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$DataType$`_import_from_c`(schema_ptr)
   } else {
     out <- pa$DataType$`_import_from_c`(
@@ -238,7 +238,7 @@ py_to_r.pyarrow.lib.RecordBatchReader <- function(x, ...) {
   stream_ptr <- allocate_arrow_array_stream()
   on.exit(delete_arrow_array_stream(stream_ptr))
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     x$`_export_to_c`(stream_ptr)
   } else {
     x$`_export_to_c`(
@@ -258,7 +258,7 @@ r_to_py.RecordBatchReader <- function(x, convert = FALSE) {
   x$export_to_c(stream_ptr)
   # TODO: handle subclasses of RecordBatchReader?
 
-  if (pyarrow_version() >= pyarrow_version_pointers_changed()) {
+  if (pyarrow_version() >= pyarrow_version_pointers_changed) {
     out <- pa$lib$RecordBatchReader$`_import_from_c`(stream_ptr)
   } else {
     out <- pa$lib$RecordBatchReader$`_import_from_c`(
@@ -314,6 +314,4 @@ pyarrow_version <- function() {
   package_version(gsub("\\.dev.*?$", "", version_string))
 }
 
-pyarrow_version_pointers_changed <- function() {
-  "7.0.0"
-}
+pyarrow_version_pointers_changed <- "7.0.0"


### PR DESCRIPTION
This PR updates the pointer logic that changed in #12011 (ARROW-15169) to make sure that users can use the arrow R package to communicate with pyarrow that hasn't been upgraded yet.

Should work with:

``` bash
pip3 install pyarrow
```

``` r
pa <- reticulate::import("pyarrow", convert = FALSE)
py <- pa$array(c(1, 2, 3))
reticulate::py_to_r(py)
#> [
#>   1,
#>   2,
#>   3
#> ]
```

and:

``` bash
pip3 install pyarrow --extra-index-url https://repo.fury.io/arrow-nightlies/ --pre --upgrade
```

``` r
pa <- reticulate::import("pyarrow", convert = FALSE)
py <- pa$array(c(1, 2, 3))
reticulate::py_to_r(py)
#> [
#>   1,
#>   2,
#>   3
#> ]
```

...but we don't have a good way to test against the old pyarrow version in our tests (unless @jonkeane can think of one!)