### PR TITLE
ARROW-15243: [CI][Python] Make PyArrow installation more robust in CI

### DIFF
--- a/ci/docker/linux-apt-python-3.dockerfile
+++ b/ci/docker/linux-apt-python-3.dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update -y -q && \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip
 
-RUN pip install -U pip setuptools
+RUN pip install -U pip setuptools wheel
 
 COPY python/requirements-build.txt \
      python/requirements-test.txt \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -90,6 +90,8 @@ COPY ci/scripts/r_deps.sh /arrow/ci/scripts/
 COPY r/DESCRIPTION /arrow/r/
 RUN /arrow/ci/scripts/r_deps.sh /arrow
 
+RUN pip install -U pip setuptools wheel
+
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_minio.sh latest /usr/local
 

--- a/ci/docker/linux-dnf-python-3.dockerfile
+++ b/ci/docker/linux-dnf-python-3.dockerfile
@@ -26,6 +26,8 @@ RUN dnf install -y \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip
 
+RUN pip install -U pip setuptools wheel
+
 COPY python/requirements-build.txt \
      python/requirements-test.txt \
      /arrow/python/

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -27,6 +27,21 @@ python_build_dir=${build_dir}/python
 
 : ${BUILD_DOCS_PYTHON:=OFF}
 
+case "$(uname)" in
+  Linux)
+    n_jobs=$(nproc)
+    ;;
+  Darwin)
+    n_jobs=$(sysctl -n hw.ncpu)
+    ;;
+  MINGW*)
+    n_jobs=${NUMBER_OF_PROCESSORS:-1}
+    ;;
+  *)
+    n_jobs=${NPROC:-1}
+    ;;
+esac
+
 if [ ! -z "${CONDA_PREFIX}" ]; then
   echo -e "===\n=== Conda environment for build\n==="
   conda list
@@ -44,19 +59,17 @@ export PYARROW_WITH_GANDIVA=${ARROW_GANDIVA:-OFF}
 export PYARROW_WITH_PARQUET=${ARROW_PARQUET:-OFF}
 export PYARROW_WITH_DATASET=${ARROW_DATASET:-OFF}
 
+export PYARROW_PARALLEL=${n_jobs}
+
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 
+# Build and install from source distribution to avoid leaving build artifacts
+# in the source directory.
+rm -f /tmp/pyarrow*.tar.gz
 pushd ${source_dir}
-
-relative_build_dir=$(realpath --relative-to=. $python_build_dir)
-
-# not nice, but prevents mutating the mounted the source directory for docker
-${PYTHON:-python} \
-  setup.py build --build-base $python_build_dir \
-           install --single-version-externally-managed \
-                   --record $relative_build_dir/record.txt
-
+${PYTHON:-python} setup.py sdist --dist-dir /tmp
 popd
+${PYTHON:-python} -m pip install -vv /tmp/pyarrow*.tar.gz
 
 if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
   ncpus=$(python -c "import os; print(os.cpu_count())")


### PR DESCRIPTION
On Debian/Ubuntu, the system-provided setuptools is patched to install into
the system-specific `dist-packages` directory.
However, the newer setuptools from upstream would install PyArrow in the wrong location (`site-packages`).

Therefore, use "pip install" instead of "python setup.py build" to get the right behaviour.