### PR TITLE
ARROW-13087: [R] Expose Parquet ArrowReaderProperties::coerce_int96_timestamp_unit_

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1364,6 +1364,14 @@ parquet___arrow___ArrowReaderProperties__set_read_dictionary <- function(propert
   invisible(.Call(`_arrow_parquet___arrow___ArrowReaderProperties__set_read_dictionary`, properties, column_index, read_dict))
 }
 
+parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit <- function(properties, unit) {
+  invisible(.Call(`_arrow_parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit`, properties, unit))
+}
+
+parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit <- function(properties) {
+  .Call(`_arrow_parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit`, properties)
+}
+
 parquet___arrow___FileReader__OpenFile <- function(file, props) {
   .Call(`_arrow_parquet___arrow___FileReader__OpenFile`, file, props)
 }

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -577,6 +577,12 @@ ParquetArrowReaderProperties <- R6Class("ParquetArrowReaderProperties",
     },
     set_read_dictionary = function(column_index, read_dict) {
       parquet___arrow___ArrowReaderProperties__set_read_dictionary(self, column_index, read_dict)
+    },
+    coerce_int96_timestamp_unit = function() {
+      parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(self)
+    },
+    set_coerce_int96_timestamp_unit = function(unit) {
+      parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(self, unit)
     }
   ),
   active = list(

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -5353,6 +5353,38 @@ extern "C" SEXP _arrow_parquet___arrow___ArrowReaderProperties__set_read_diction
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_PARQUET)
+void parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(const std::shared_ptr<parquet::ArrowReaderProperties>& properties, arrow::TimeUnit::type unit);
+extern "C" SEXP _arrow_parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(SEXP properties_sexp, SEXP unit_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<parquet::ArrowReaderProperties>&>::type properties(properties_sexp);
+	arrow::r::Input<arrow::TimeUnit::type>::type unit(unit_sexp);
+	parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(properties, unit);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(SEXP properties_sexp, SEXP unit_sexp){
+	Rf_error("Cannot call parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// parquet.cpp
+#if defined(ARROW_R_WITH_PARQUET)
+arrow::TimeUnit::type parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(const std::shared_ptr<parquet::ArrowReaderProperties>& properties);
+extern "C" SEXP _arrow_parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(SEXP properties_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<parquet::ArrowReaderProperties>&>::type properties(properties_sexp);
+	return cpp11::as_sexp(parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(properties));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(SEXP properties_sexp){
+	Rf_error("Cannot call parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// parquet.cpp
+#if defined(ARROW_R_WITH_PARQUET)
 std::shared_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(const std::shared_ptr<arrow::io::RandomAccessFile>& file, const std::shared_ptr<parquet::ArrowReaderProperties>& props);
 extern "C" SEXP _arrow_parquet___arrow___FileReader__OpenFile(SEXP file_sexp, SEXP props_sexp){
 BEGIN_CPP11
@@ -7618,6 +7650,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_parquet___arrow___ArrowReaderProperties__get_use_threads", (DL_FUNC) &_arrow_parquet___arrow___ArrowReaderProperties__get_use_threads, 2}, 
 		{ "_arrow_parquet___arrow___ArrowReaderProperties__get_read_dictionary", (DL_FUNC) &_arrow_parquet___arrow___ArrowReaderProperties__get_read_dictionary, 2}, 
 		{ "_arrow_parquet___arrow___ArrowReaderProperties__set_read_dictionary", (DL_FUNC) &_arrow_parquet___arrow___ArrowReaderProperties__set_read_dictionary, 3}, 
+		{ "_arrow_parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit", (DL_FUNC) &_arrow_parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit, 2}, 
+		{ "_arrow_parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit", (DL_FUNC) &_arrow_parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit, 1}, 
 		{ "_arrow_parquet___arrow___FileReader__OpenFile", (DL_FUNC) &_arrow_parquet___arrow___FileReader__OpenFile, 2}, 
 		{ "_arrow_parquet___arrow___FileReader__ReadTable1", (DL_FUNC) &_arrow_parquet___arrow___FileReader__ReadTable1, 1}, 
 		{ "_arrow_parquet___arrow___FileReader__ReadTable2", (DL_FUNC) &_arrow_parquet___arrow___FileReader__ReadTable2, 2}, 

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -71,12 +71,14 @@ void parquet___arrow___ArrowReaderProperties__set_read_dictionary(
 
 // [[parquet::export]]
 void parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(
-    const std::shared_ptr<parquet::ArrowReaderProperties>& properties, arrow::TimeUnit::type unit) {
+    const std::shared_ptr<parquet::ArrowReaderProperties>& properties,
+    arrow::TimeUnit::type unit) {
   properties->set_coerce_int96_timestamp_unit(unit);
 }
 
 // [[parquet::export]]
-arrow::TimeUnit::type parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(
+arrow::TimeUnit::type
+parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(
     const std::shared_ptr<parquet::ArrowReaderProperties>& properties) {
   return properties->coerce_int96_timestamp_unit();
 }

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -70,6 +70,18 @@ void parquet___arrow___ArrowReaderProperties__set_read_dictionary(
 }
 
 // [[parquet::export]]
+void parquet___arrow___ArrowReaderProperties__set_coerce_int96_timestamp_unit(
+    const std::shared_ptr<parquet::ArrowReaderProperties>& properties, arrow::TimeUnit::type unit) {
+  properties->set_coerce_int96_timestamp_unit(unit);
+}
+
+// [[parquet::export]]
+arrow::TimeUnit::type parquet___arrow___ArrowReaderProperties__get_coerce_int96_timestamp_unit(
+    const std::shared_ptr<parquet::ArrowReaderProperties>& properties) {
+  return properties->coerce_int96_timestamp_unit();
+}
+
+// [[parquet::export]]
 std::shared_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(
     const std::shared_ptr<arrow::io::RandomAccessFile>& file,
     const std::shared_ptr<parquet::ArrowReaderProperties>& props) {

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -330,7 +330,7 @@ test_that("deprecated int96 timestamp unit can be specified when reading Parquet
   on.exit(unlink(tf))
 
   table <- Table$create(
-    some_datetime = as.POSIXct("2001-01-01 12:34:56.789", tz = "UTC")
+    some_datetime = as.POSIXct("2001-01-01 12:34:56.789")
   )
 
   write_parquet(

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -330,7 +330,7 @@ test_that("deprecated int96 timestamp unit can be specified when reading Parquet
   on.exit(unlink(tf))
 
   table <- Table$create(
-    some_datetime = as.POSIXct("2001-01-01 12:34:56.789")
+    some_datetime = as.POSIXct("2001-01-01 12:34:56.789", tz = "UTC")
   )
 
   write_parquet(


### PR DESCRIPTION
This PR adds a setter and getter for `ArrowReaderProperties::coerce_int96_timestamp_unit_`.

Reprex:

``` r
library(arrow, warn.conflicts = FALSE)

tf <- tempfile()
write_parquet(
  data.frame(a = as.POSIXct("2001-01-01 12:34:56.789", tz = "UTC")),
  tf,
  use_deprecated_int96_timestamps = TRUE, version = "1.0"
)

props <- ParquetArrowReaderProperties$create()
props$set_coerce_int96_timestamp_unit(TimeUnit$MILLI)
props$coerce_int96_timestamp_unit() == TimeUnit$MILLI
#> [1] TRUE

(p <- read_parquet(tf, props = props, as_data_frame = FALSE))
#> Table
#> 1 rows x 1 columns
#> $a <timestamp[ms]>
#> 
#> See $metadata for additional Schema metadata
p$a
#> ChunkedArray
#> [
#>   [
#>     2001-01-01 12:34:56.789
#>   ]
#> ]
```
