### PR TITLE
ARROW-15109: [Python] Add show_info() to print build, component, and system info

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -30,9 +30,9 @@ For more information see the official page at https://arrow.apache.org
 """
 
 import gc as _gc
-import importlib
+import importlib as _importlib
 import os as _os
-import platform
+import platform as _platform
 import sys as _sys
 import warnings as _warnings
 
@@ -94,7 +94,7 @@ def show_versions():
 
 def _module_is_available(module):
     try:
-        importlib.import_module(f'pyarrow.{module}')
+        _importlib.import_module(f'pyarrow.{module}')
     except ImportError:
         return False
     else:
@@ -125,7 +125,7 @@ def show_info():
         print(f"  {label: <20}: {value: <8}")
 
     print("\nPlatform:")
-    print_entry("OS / Arch", f"{platform.system()} {platform.machine()}")
+    print_entry("OS / Arch", f"{_platform.system()} {_platform.machine()}")
     print_entry("SIMD Level", runtime_info().simd_level)
     print_entry("Detected SIMD Level", runtime_info().detected_simd_level)
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -144,7 +144,7 @@ def show_info():
         print(f"  {module: <20}: {status: <8}")
 
     print("\nFilesystems:")
-    filesystems = ["GcsFileSystem","HadoopFileSystem", "S3FileSystem"]
+    filesystems = ["GcsFileSystem", "HadoopFileSystem", "S3FileSystem"]
     for fs in filesystems:
         status = "Enabled" if _filesystem_is_available(fs) else "-"
         print(f"  {fs: <20}: {status: <8}")

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -32,6 +32,7 @@ For more information see the official page at https://arrow.apache.org
 import gc as _gc
 import importlib
 import os as _os
+import platform
 import sys as _sys
 import warnings as _warnings
 
@@ -76,32 +77,52 @@ def show_versions():
     """
     Print various version information, to help with error reporting.
     """
-    # TODO: CPU information and flags
+    def print_entry(label, value):
+        print(f"{label: <26}: {value: <8}")
+
     print("pyarrow version info\n--------------------")
-    print("Package kind: {}".format(cpp_build_info.package_kind
-                                    if len(cpp_build_info.package_kind) > 0
-                                    else "not indicated"))
-    print("Arrow C++ library version: {0}".format(cpp_build_info.version))
-    print("Arrow C++ compiler: {0} {1}"
-          .format(cpp_build_info.compiler_id, cpp_build_info.compiler_version))
-    print("Arrow C++ compiler flags: {0}"
-          .format(cpp_build_info.compiler_flags))
-    print("Arrow C++ git revision: {0}".format(cpp_build_info.git_id))
-    print("Arrow C++ git description: {0}"
-          .format(cpp_build_info.git_description))
+    print_entry("Package kind", cpp_build_info.package_kind
+                if len(cpp_build_info.package_kind) > 0
+                else "not indicated")
+    print_entry("Arrow C++ library version", cpp_build_info.version)
+    print_entry("Arrow C++ compiler",
+                f"{cpp_build_info.compiler_id} {cpp_build_info.compiler_version}")
+    print_entry("Arrow C++ compiler flags", cpp_build_info.compiler_flags)
+    print_entry("Arrow C++ git revision", cpp_build_info.git_id)
+    print_entry("Arrow C++ git description", cpp_build_info.git_description)
+
+
+def arrow_info():
+    """
+    Print detailed version and platform information, for error reporting
+    """
+    show_versions()
+
+    def print_entry(label, value):
+        print(f"  {label: <20}: {value: <8}")
+
+    print("\nPlatform:")
+    print_entry("OS / Arch", f"{platform.system()} {platform.machine()}")
+    print_entry("SIMD Level", runtime_info().simd_level)
+    print_entry("Detected SIMD Level", runtime_info().detected_simd_level)
+
+    pool = default_memory_pool()
+    print("\nMemory:")
+    print_entry("Default backend", pool.backend_name)
+    print_entry("Bytes allocated", f"{pool.bytes_allocated()} bytes")
+    print_entry("Max memory", f"{pool.max_memory()} bytes")
+    print_entry("Supported Backends", ', '.join(supported_memory_backends()))
 
     print("\nOptional modules:")
-    
     modules = ["csv", "cuda", "dataset", "feather", "flight", "fs", "gandiva", "json",
                "orc", "parquet", "plasma"]
-
     for module in modules:
         try:
             importlib.import_module(f'pyarrow.{module}')
         except ImportError:
-            print(f"  {module: <18}: -")
+            print(f"  {module: <20}: -")
         else:
-            print(f"  {module: <18}: Enabled")
+            print(f"  {module: <20}: Enabled")
 
     print("\nFilesystems:")
     filesystems = ["HadoopFileSystem", "S3FileSystem", "GcsFileSystem"]
@@ -109,7 +130,7 @@ def show_versions():
         import pyarrow.fs
     except ImportError:
         for filesystem in filesystems:
-            print(f"  {filesystem: <18}: -")
+            print(f"  {filesystem: <20}: -")
     else:
         for filesystem in filesystems:
             try:
@@ -117,13 +138,13 @@ def show_versions():
                 status = 'Enabled'
             except (ImportError, AttributeError):
                 status = '-'
-            print(f"  {filesystem: <18}: {status: <8}")
+            print(f"  {filesystem: <20}: {status: <8}")
 
     print("\nCompression Codecs:")
     codecs = ["brotli", "bz2", "gzip", "lz4_frame", "lz4", "snappy", "zstd"]
     for codec in codecs:
         status = "Enabled" if Codec.is_available(codec) else "-"
-        print(f"  {codec: <18}: {status: <8}")
+        print(f"  {codec: <20}: {status: <8}")
 
 
 from pyarrow.lib import (null, bool_,
@@ -202,7 +223,8 @@ from pyarrow.lib import (MemoryPool, LoggingMemoryPool, ProxyMemoryPool,
                          default_memory_pool, system_memory_pool,
                          jemalloc_memory_pool, mimalloc_memory_pool,
                          logging_memory_pool, proxy_memory_pool,
-                         log_memory_allocations, jemalloc_set_decay_ms)
+                         log_memory_allocations, jemalloc_set_decay_ms,
+                         supported_memory_backends)
 
 # I/O
 from pyarrow.lib import (NativeFile, PythonFile,

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -30,6 +30,7 @@ For more information see the official page at https://arrow.apache.org
 """
 
 import gc as _gc
+import importlib
 import os as _os
 import sys as _sys
 import warnings as _warnings
@@ -88,6 +89,25 @@ def show_versions():
     print("Arrow C++ git revision: {0}".format(cpp_build_info.git_id))
     print("Arrow C++ git description: {0}"
           .format(cpp_build_info.git_description))
+
+    print("\nOptional modules:")
+    
+    modules = ["csv", "cuda", "dataset", "feather", "flight", "fs", "gandiva", "hdfs",
+               "json", "orc", "parquet", "plasma", "s3fs"]
+
+    for module in modules:
+        try:
+            importlib.import_module(f'pyarrow.{module}')
+        except ImportError:
+            print(f"  {module: <10}: -")
+        else:
+            print(f"  {module: <10}: Enabled")
+
+    print("\nCompression Codecs:")
+    codecs = ["brotli", "bz2", "gzip", "lz4_frame", "lz4", "snappy", "zstd"]
+    for codec in codecs:
+        status = "Enabled" if Codec.is_available(codec) else "-"
+        print(f"  {codec: <10}: {status: <8}")
 
 
 from pyarrow.lib import (null, bool_,

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -144,7 +144,7 @@ def show_info():
         print(f"  {module: <20}: {status: <8}")
 
     print("\nFilesystems:")
-    filesystems = ["HadoopFileSystem", "S3FileSystem", "GcsFileSystem"]
+    filesystems = ["GcsFileSystem","HadoopFileSystem", "S3FileSystem"]
     for fs in filesystems:
         status = "Enabled" if _filesystem_is_available(fs) else "-"
         print(f"  {fs: <20}: {status: <8}")

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -92,22 +92,38 @@ def show_versions():
 
     print("\nOptional modules:")
     
-    modules = ["csv", "cuda", "dataset", "feather", "flight", "fs", "gandiva", "hdfs",
-               "json", "orc", "parquet", "plasma", "s3fs"]
+    modules = ["csv", "cuda", "dataset", "feather", "flight", "fs", "gandiva", "json",
+               "orc", "parquet", "plasma"]
 
     for module in modules:
         try:
             importlib.import_module(f'pyarrow.{module}')
         except ImportError:
-            print(f"  {module: <10}: -")
+            print(f"  {module: <18}: -")
         else:
-            print(f"  {module: <10}: Enabled")
+            print(f"  {module: <18}: Enabled")
+
+    print("\nFilesystems:")
+    filesystems = ["HadoopFileSystem", "S3FileSystem", "GcsFileSystem"]
+    try:
+        import pyarrow.fs
+    except ImportError:
+        for filesystem in filesystems:
+            print(f"  {filesystem: <18}: -")
+    else:
+        for filesystem in filesystems:
+            try:
+                getattr(pyarrow.fs, filesystem)
+                status = 'Enabled'
+            except (ImportError, AttributeError):
+                status = '-'
+            print(f"  {filesystem: <18}: {status: <8}")
 
     print("\nCompression Codecs:")
     codecs = ["brotli", "bz2", "gzip", "lz4_frame", "lz4", "snappy", "zstd"]
     for codec in codecs:
         status = "Enabled" if Codec.is_available(codec) else "-"
-        print(f"  {codec: <10}: {status: <8}")
+        print(f"  {codec: <18}: {status: <8}")
 
 
 from pyarrow.lib import (null, bool_,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -333,6 +333,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CMemoryPool** out)
     cdef CStatus c_mimalloc_memory_pool" arrow::mimalloc_memory_pool"(
         CMemoryPool** out)
+    cdef vector[c_string] c_supported_memory_backends" arrow::SupportedMemoryBackendNames"()
 
     CStatus c_jemalloc_set_decay_ms" arrow::jemalloc_set_decay_ms"(int ms)
 

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -247,3 +247,11 @@ def jemalloc_set_decay_ms(decay_ms):
         that this change will only affect future memory arenas
     """
     check_status(c_jemalloc_set_decay_ms(decay_ms))
+
+
+def supported_memory_backends():
+    """
+    Return a list of available memory pool backends
+    """
+    cdef vector[c_string] backends = c_supported_memory_backends()
+    return [backend.decode() for backend in backends]

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -159,3 +159,13 @@ def test_specific_memory_pools():
           can_fail=not should_have_jemalloc)
     check(pa.mimalloc_memory_pool, "mimalloc",
           can_fail=not should_have_mimalloc)
+
+
+def test_supported_memory_backends():
+    backends = pa.supported_memory_backends()
+
+    assert "system" in backends
+    if should_have_jemalloc:
+        assert "jemalloc" in backends
+    if should_have_mimalloc:
+        assert "mimalloc" in backends


### PR DESCRIPTION
It's helpful to know which optional components are enabled, particularly if the user has done a custom build of PyArrow. This is inspired by the `arrow_info()` function in the R bindings.

I'm open to other suggestions of info to include.

## Example Output

<details open>
  <summary>Before</summary>
  
```sh
pyarrow version info
--------------------
Package kind: not indicated
Arrow C++ library version: 6.0.1
Arrow C++ compiler: Clang 11.1.0
Arrow C++ compiler flags: -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -isystem /Users/willjones/.pyenv/versions/miniforge3/include -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/arrow-cpp-ext_1637415641039/work=/usr/local/src/conda/arrow-cpp-6.0.1 -fdebug-prefix-map=/Users/willjones/.pyenv/versions/miniforge3=/usr/local/src/conda-prefix -Qunused-arguments -fcolor-diagnostics -O3 -DNDEBUG
Arrow C++ git revision: 
Arrow C++ git description:
```
</details>

<details open>
  <summary>After</summary>

```sh
❯ python -c "import pyarrow; pyarrow.show_info()"
pyarrow version info
--------------------
Package kind              : not indicated
Arrow C++ library version : 7.0.0-SNAPSHOT
Arrow C++ compiler        : AppleClang 13.0.0.13000027
Arrow C++ compiler flags  :  -Qunused-arguments -fcolor-diagnostics -ggdb -O0
Arrow C++ git revision    : f738b7d025546d594f4196707aed946b3ee3c4c0
Arrow C++ git description : apache-arrow-7.0.0.dev-422-gf738b7d02-dirty

Platform:
  OS / Arch           : Darwin arm64
  SIMD Level          : none    
  Detected SIMD Level : none    

Memory:
  Default backend     : mimalloc
  Bytes allocated     : 0 bytes 
  Max memory          : 0 bytes 
  Supported Backends  : mimalloc, jemalloc, system

Optional modules:
  csv                 : Enabled
  cuda                : -
  dataset             : Enabled
  feather             : Enabled
  flight              : Enabled
  fs                  : Enabled
  gandiva             : Enabled
  json                : Enabled
  orc                 : -
  parquet             : Enabled
  plasma              : Enabled

Filesystems:
  HadoopFileSystem    : -       
  S3FileSystem        : -       
  GcsFileSystem       : -       

Compression Codecs:
  brotli              : Enabled 
  bz2                 : Enabled 
  gzip                : Enabled 
  lz4_frame           : Enabled 
  lz4                 : Enabled 
  snappy              : Enabled 
  zstd                : Enabled 
```
</details>