### PR TITLE
ARROW-10643: [Python] Pandas<->pyarrow roundtrip failing to recreate index for empty dataframe

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -934,7 +934,7 @@ def _reconstruct_index(table, index_descriptors, all_columns):
                                                     descr['stop'],
                                                     step=descr['step'],
                                                     name=index_name)
-            if len(index_level) != len(table) and len(table) != 0:
+            if len(table) > 0 and len(index_level) != len(table):
                 # Possibly the result of munged metadata
                 continue
         else:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -934,7 +934,7 @@ def _reconstruct_index(table, index_descriptors, all_columns):
                                                     descr['stop'],
                                                     step=descr['step'],
                                                     name=index_name)
-            if len(index_level) != len(table):
+            if len(index_level) != len(table) and len(table)!=0:
                 # Possibly the result of munged metadata
                 continue
         else:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -934,7 +934,7 @@ def _reconstruct_index(table, index_descriptors, all_columns):
                                                     descr['stop'],
                                                     step=descr['step'],
                                                     name=index_name)
-            if len(index_level) != len(table) and len(table)!=0:
+            if len(index_level) != len(table) and len(table) != 0:
                 # Possibly the result of munged metadata
                 continue
         else:

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -340,6 +340,19 @@ def test_chunked_array_to_pandas_preserve_name():
 
 
 @pytest.mark.pandas
+def test_table_roundtrip_to_pandas_empty_dataframe():
+    # https://issues.apache.org/jira/browse/ARROW-10643
+    import pandas as pd
+
+    data = pd.DataFrame(index=pd.RangeIndex(0, 10, 1))
+    table = pa.table(data)
+    result = table.to_pandas()
+
+    assert data.shape == (10, 0)
+    assert result.shape == (10, 0)
+
+
+@pytest.mark.pandas
 @pytest.mark.nopandas
 def test_chunked_array_asarray():
     # ensure this is tested both when pandas is present or not (ARROW-6564)


### PR DESCRIPTION
This PR adds a check to the `_reconstruct_index` in `pandas_compat.py ` so that the roundtrip is correct for an empty `pandas.DataFrame` with and index.