### PR TITLE
MINOR: [Docs] Add fill_null functions to docs

### DIFF
--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1687,10 +1687,15 @@ replaced, based on the remaining inputs.
 +--------------------------+------------+-----------------------+--------------+--------------+--------------+-------+
 | Function name            | Arity      | Input type 1          | Input type 2 | Input type 3 | Output type  | Notes |
 +==========================+============+=======================+==============+==============+==============+=======+
-| replace_with_mask        | Ternary    | Fixed-width or binary | Boolean      | Input type 1 | Input type 1 | \(1)  |
+| fill_null_backward       | Unary      | Fixed-width or binary | N/A          | N/A          | N/A          | \(1)  |
++--------------------------+------------+-----------------------+--------------+--------------+--------------+-------+
+| fill_null_forward        | Unary      | Fixed-width or binary | N/A          | N/A          | N/A          | \(1)  |
++--------------------------+------------+-----------------------+--------------+--------------+--------------+-------+
+| replace_with_mask        | Ternary    | Fixed-width or binary | Boolean      | Input type 1 | Input type 1 | \(2)  |
 +--------------------------+------------+-----------------------+--------------+--------------+--------------+-------+
 
-* \(1) Each element in input 1 for which the corresponding Boolean in input 2
+* \(1) Valid values are carried forward/backward to fill null values.
+* \(2) Each element in input 1 for which the corresponding Boolean in input 2
   is true is replaced with the next value from input 3. A null in input 2
   results in a corresponding null in the output.
 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -475,6 +475,8 @@ Structural Transforms
 .. autosummary::
    :toctree: ../generated/
 
+   fill_null_backward
+   fill_null_forward
    list_element
    list_flatten
    list_parent_indices


### PR DESCRIPTION
Add the docs for the functions from ARROW-1699/PR #11853 since they were omitted in the PR.