### PR TITLE
MINOR: [C++][FlightRPC] Remove gtest dependency in FlightSqlClient

### DIFF
--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -25,7 +25,6 @@
 #include "arrow/io/memory.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/result.h"
-#include "arrow/testing/gtest_util.h"
 #include "arrow/util/logging.h"
 
 namespace flight_sql_pb = arrow::flight::protocol::sql;


### PR DESCRIPTION
Remove an unneeded dependency on gtest in FlightSQL's client.
This header incorrectly requires gtest headers to be available when
building without tests (ARROW_BUILD_TESTS=OFF)