### PR TITLE
ARROW-15268: [Packaging][deb] Don't use gi shortcut

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -159,7 +159,7 @@ ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
 ${APT_INSTALL} ruby-gobject-introspection
-ruby -r gi -e "p GI.load('Arrow')"
+ruby -r gobject-introspection "p GObjectIntrospection.load('Arrow')"
 echo "::endgroup::"
 
 
@@ -167,7 +167,7 @@ if [ "${have_flight}" = "yes" ]; then
   echo "::group::Test Apache Arrow Flight"
   ${APT_INSTALL} libarrow-flight-glib-dev=${package_version}
   ${APT_INSTALL} libarrow-flight-glib-doc=${package_version}
-  ruby -r gi -e "p GI.load('ArrowFlight')"
+  ruby -r gobject-introspection "p GObjectIntrospection.load('ArrowFlight')"
   echo "::endgroup::"
 fi
 
@@ -182,7 +182,7 @@ if [ "${have_plasma}" = "yes" ]; then
   ${APT_INSTALL} libplasma-glib-dev=${package_version}
   ${APT_INSTALL} libplasma-glib-doc=${package_version}
   ${APT_INSTALL} plasma-store-server=${package_version}
-  ruby -r gi -e "p GI.load('Plasma')"
+  ruby -r gobject-introspection "p GObjectIntrospection.load('Plasma')"
   echo "::endgroup::"
 fi
 
@@ -190,19 +190,19 @@ fi
 echo "::group::Test Gandiva"
 ${APT_INSTALL} libgandiva-glib-dev=${package_version}
 ${APT_INSTALL} libgandiva-glib-doc=${package_version}
-ruby -r gi -e "p GI.load('Gandiva')"
+ruby -r gobject-introspection "p GObjectIntrospection.load('Gandiva')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Parquet"
 ${APT_INSTALL} libparquet-glib-dev=${package_version}
 ${APT_INSTALL} libparquet-glib-doc=${package_version}
-ruby -r gi -e "p GI.load('Parquet')"
+ruby -r gobject-introspection "p GObjectIntrospection.load('Parquet')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Arrow Dataset"
 ${APT_INSTALL} libarrow-dataset-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-dataset-glib-doc=${package_version}
-ruby -r gi -e "p GI.load('ArrowDataset')"
+ruby -r gobject-introspection "p GObjectIntrospection.load('ArrowDataset')"
 echo "::endgroup::"

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -159,7 +159,7 @@ ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
 ${APT_INSTALL} ruby-gobject-introspection
-ruby -r gobject-introspection "p GObjectIntrospection.load('Arrow')"
+ruby -r gobject-introspection -e "p GObjectIntrospection.load('Arrow')"
 echo "::endgroup::"
 
 
@@ -167,7 +167,7 @@ if [ "${have_flight}" = "yes" ]; then
   echo "::group::Test Apache Arrow Flight"
   ${APT_INSTALL} libarrow-flight-glib-dev=${package_version}
   ${APT_INSTALL} libarrow-flight-glib-doc=${package_version}
-  ruby -r gobject-introspection "p GObjectIntrospection.load('ArrowFlight')"
+  ruby -r gobject-introspection -e "p GObjectIntrospection.load('ArrowFlight')"
   echo "::endgroup::"
 fi
 
@@ -182,7 +182,7 @@ if [ "${have_plasma}" = "yes" ]; then
   ${APT_INSTALL} libplasma-glib-dev=${package_version}
   ${APT_INSTALL} libplasma-glib-doc=${package_version}
   ${APT_INSTALL} plasma-store-server=${package_version}
-  ruby -r gobject-introspection "p GObjectIntrospection.load('Plasma')"
+  ruby -r gobject-introspection -e "p GObjectIntrospection.load('Plasma')"
   echo "::endgroup::"
 fi
 
@@ -190,19 +190,19 @@ fi
 echo "::group::Test Gandiva"
 ${APT_INSTALL} libgandiva-glib-dev=${package_version}
 ${APT_INSTALL} libgandiva-glib-doc=${package_version}
-ruby -r gobject-introspection "p GObjectIntrospection.load('Gandiva')"
+ruby -r gobject-introspection -e "p GObjectIntrospection.load('Gandiva')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Parquet"
 ${APT_INSTALL} libparquet-glib-dev=${package_version}
 ${APT_INSTALL} libparquet-glib-doc=${package_version}
-ruby -r gobject-introspection "p GObjectIntrospection.load('Parquet')"
+ruby -r gobject-introspection -e "p GObjectIntrospection.load('Parquet')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Arrow Dataset"
 ${APT_INSTALL} libarrow-dataset-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-dataset-glib-doc=${package_version}
-ruby -r gobject-introspection "p GObjectIntrospection.load('ArrowDataset')"
+ruby -r gobject-introspection -e "p GObjectIntrospection.load('ArrowDataset')"
 echo "::endgroup::"

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -51,10 +51,6 @@ jobs:
           ARROW_VERSION: {{ arrow.version }}
           REPO: {{ '${{ secrets.REPO }}' }}
           YUM_TARGETS: {{ target }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: packages
-          path: packages/*/{{ task_namespace }}/repositories/
       - name: Docker Push
         continue-on-error: true
         shell: bash


### PR DESCRIPTION
It doesn't work on old Debian/Ubuntu because of a packaging bug of
ruby-gobject-introspection deb.