### PR TITLE
ARROW-15277: [Python] Use Make to create ChunkedArray and remove checks

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -748,6 +748,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CChunkedArray(const vector[shared_ptr[CArray]]& arrays)
         CChunkedArray(const vector[shared_ptr[CArray]]& arrays,
                       const shared_ptr[CDataType]& type)
+
+        @staticmethod
+        CResult[shared_ptr[CChunkedArray]] Make(vector[shared_ptr[CArray]] chunks, shared_ptr[CDataType] type)
         int64_t length()
         int64_t null_count()
         int num_chunks()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1300,7 +1300,7 @@ def chunked_array(arrays, type=None):
     cdef:
         Array arr
         vector[shared_ptr[CArray]] c_arrays
-        shared_ptr[CChunkedArray] sp_chunked_array
+        shared_ptr[CChunkedArray] c_result
 
     type = ensure_type(type, allow_none=True)
 
@@ -1309,31 +1309,11 @@ def chunked_array(arrays, type=None):
 
     for x in arrays:
         arr = x if isinstance(x, Array) else array(x, type=type)
-
-        if type is None:
-            # it allows more flexible chunked array construction from to coerce
-            # subsequent arrays to the firstly inferred array type
-            # it also spares the inference overhead after the first chunk
-            type = arr.type
-        else:
-            if arr.type != type:
-                raise TypeError(
-                    "All array chunks must have type {}".format(type)
-                )
-
         c_arrays.push_back(arr.sp_array)
 
-    if c_arrays.size() == 0 and type is None:
-        raise ValueError("When passing an empty collection of arrays "
-                         "you must also pass the data type")
-
-    sp_chunked_array.reset(
-        new CChunkedArray(c_arrays, pyarrow_unwrap_data_type(type))
-    )
-    with nogil:
-        check_status(sp_chunked_array.get().Validate())
-
-    return pyarrow_wrap_chunked_array(sp_chunked_array)
+    c_result = GetResultValue(CChunkedArray.Make(
+        c_arrays, pyarrow_unwrap_data_type(type)))
+    return pyarrow_wrap_chunked_array(c_result)
 
 
 cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1301,6 +1301,7 @@ def chunked_array(arrays, type=None):
         Array arr
         vector[shared_ptr[CArray]] c_arrays
         shared_ptr[CChunkedArray] c_result
+        shared_ptr[CDataType] c_type
 
     type = ensure_type(type, allow_none=True)
 
@@ -1311,8 +1312,10 @@ def chunked_array(arrays, type=None):
         arr = x if isinstance(x, Array) else array(x, type=type)
         c_arrays.push_back(arr.sp_array)
 
-    c_result = GetResultValue(CChunkedArray.Make(
-        c_arrays, pyarrow_unwrap_data_type(type)))
+    c_type = pyarrow_unwrap_data_type(type)
+    with nogil:
+        c_result = GetResultValue(CChunkedArray.Make(
+            c_arrays, c_type))
     return pyarrow_wrap_chunked_array(c_result)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1187,7 +1187,7 @@ def test_drop_null(ty, values):
 
 
 def test_drop_null_chunked_array():
-    arr = pa.chunked_array([[None], [None], []])
+    arr = pa.chunked_array([[None, None], [None], []])
     expected_drop = pa.chunked_array([[]])
 
     result = arr.drop_null()

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1187,8 +1187,8 @@ def test_drop_null(ty, values):
 
 
 def test_drop_null_chunked_array():
-    arr = pa.chunked_array([["a", None], ["c", "d", None], [None], []])
-    expected_drop = pa.chunked_array([["a"], ["c", "d"], [], []])
+    arr = pa.chunked_array([[None], [None], []])
+    expected_drop = pa.chunked_array([[]])
 
     result = arr.drop_null()
     assert result.equals(expected_drop)


### PR DESCRIPTION
Replace Python explicit type/size checks for ChunkedArray with C++ `ChunkedArray::Make()`.