### PR TITLE
ARROW-14590: [R] Implement lubridate::week

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -101,6 +101,10 @@ register_bindings_datetime <- function() {
     Expression$create("day_of_week", x, options = list(count_from_zero = FALSE, week_start = week_start))
   })
 
+  register_binding("week", function(x) {
+    (call_binding("yday", x) - 1) %/% 7 + 1
+  })
+
   register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {
     if (label) {
       if (abbr) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -102,7 +102,7 @@ register_bindings_datetime <- function() {
   })
 
   register_binding("week", function(x) {
-    call_binding("%/%", (call_binding("yday", x) - 1), 7) + 1
+    (call_binding("yday", x) - 1) %/% 7 + 1
   })
 
   register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -102,7 +102,7 @@ register_bindings_datetime <- function() {
   })
 
   register_binding("week", function(x) {
-    (call_binding("yday", x) - 1) %/% 7 + 1
+    call_binding("%/%", (call_binding("yday", x) - 1), 7) + 1
   })
 
   register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -538,6 +538,15 @@ test_that("extract epiweek from date", {
   )
 })
 
+test_that("extract week from date", {
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = week(date)) %>%
+      collect(),
+    test_df
+  )
+})
+
 test_that("extract month from date", {
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -385,6 +385,15 @@ test_that("extract epiweek from timestamp", {
   )
 })
 
+test_that("extract week from timestamp", {
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = week(datetime)) %>%
+      collect(),
+    test_df
+  )
+})
+
 test_that("extract day from timestamp", {
   compare_dplyr_binding(
     .input %>%


### PR DESCRIPTION
This PR adds the implementation of `lubridate::week` following the way it is calculated in [lubridate](https://github.com/tidyverse/lubridate/blob/9cece5680d0280c5cd1ccdbc9309ccb4724b3a34/R/accessors-week.r#L26-L27).