### PR TITLE
ARROW-14592: [C++] list_parent_indices output type should not depend on input type

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -80,15 +80,14 @@ TEST(TestVectorNested, ListParentIndices) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], [], [4, 5]]");
 
-    auto out_ty = ty->id() == Type::LIST ? int32() : int64();
-    auto expected = ArrayFromJSON(out_ty, "[0, 0, 0, 2, 2, 4, 4]");
+    auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 2, 2, 4, 4]");
     CheckVectorUnary("list_parent_indices", input, expected);
   }
 
   // Construct a list with a non-empty null slot
   auto input = ArrayFromJSON(list(int16()), "[[0, null, 1], [0, 0], [2, 3], [], [4, 5]]");
   TweakValidityBit(input, 1, false);
-  auto expected = ArrayFromJSON(int32(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
+  auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
   CheckVectorUnary("list_parent_indices", input, expected);
 }
 
@@ -97,12 +96,11 @@ TEST(TestVectorNested, ListParentIndicesChunkedArray) {
     auto input =
         ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], [], [4, 5]]"});
 
-    auto out_ty = ty->id() == Type::LIST ? int32() : int64();
-    auto expected = ChunkedArrayFromJSON(out_ty, {"[0, 0, 0]", "[2, 2, 4, 4]"});
+    auto expected = ChunkedArrayFromJSON(int64(), {"[0, 0, 0]", "[2, 2, 4, 4]"});
     CheckVectorUnary("list_parent_indices", input, expected);
 
     input = ChunkedArrayFromJSON(ty, {});
-    expected = ChunkedArrayFromJSON(out_ty, {});
+    expected = ChunkedArrayFromJSON(int64(), {});
     CheckVectorUnary("list_parent_indices", input, expected);
   }
 }

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1641,7 +1641,7 @@ Structural transforms
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
 | list_flatten        | Unary      | List-like                           | List value type  |                              | \(2)   |
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
-| list_parent_indices | Unary      | List-like                           | Int32 or Int64   |                              | \(3)   |
+| list_parent_indices | Unary      | List-like                           | Int64            |                              | \(3)   |
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
 | struct_field        | Unary      | Struct or Union                     | Computed         | :struct:`StructFieldOptions` | \(4)   |
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
@@ -1655,8 +1655,7 @@ Structural transforms
 
 * \(3) For each value in the list child array, the index at which it is found
   in the list array is appended to the output.  Nulls in the parent list array
-  are discarded.  Output type is Int32 for List and FixedSizeList, Int64 for
-  LargeList.
+  are discarded.
 
 * \(4) Extract a child value based on a sequence of indices passed in
   the options. The validity bitmap of the result will be the

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2548,9 +2548,8 @@ def test_list_array_flatten(offset_type, list_type_factory):
     assert arr2.values.values.equals(arr0)
 
 
-@pytest.mark.parametrize(('offset_type', 'list_type_factory'),
-                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list)])
-def test_list_value_parent_indices(offset_type, list_type_factory):
+@pytest.mark.parametrize('list_type_factory', [pa.list_, pa.large_list])
+def test_list_value_parent_indices(list_type_factory):
     arr = pa.array(
         [
             [0, 1, 2],
@@ -2558,7 +2557,7 @@ def test_list_value_parent_indices(offset_type, list_type_factory):
             [],
             [3, 4]
         ], type=list_type_factory(pa.int32()))
-    expected = pa.array([0, 0, 0, 3, 3], type=offset_type)
+    expected = pa.array([0, 0, 0, 3, 3], type=pa.int64())
     assert arr.value_parent_indices().equals(expected)
 
 


### PR DESCRIPTION
Changes the type returned by `list_parent_indices` to `int64` regardless of list index type (it used to return `int32` for `list`), as the output refers to row indices rather than list indices.