### PR TITLE
ARROW-15265: [C++] Fix hang in dataset writer with kDeleteMatchingPartitions and #partitions >= 8

### DIFF
--- a/c_glib/arrow-dataset-glib/file-format.cpp
+++ b/c_glib/arrow-dataset-glib/file-format.cpp
@@ -249,7 +249,7 @@ gadataset_file_writer_finish(GADatasetFileWriter *writer,
                              GError **error)
 {
   const auto arrow_writer = gadataset_file_writer_get_raw(writer);
-  auto status = arrow_writer->Finish();
+  auto status = arrow_writer->Finish().status();
   return garrow::check(error,
                        status,
                        "[file-writer][finish]");

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -213,16 +213,21 @@ class DatasetWriterFileQueue : public util::AsyncDestroyable {
         io::default_io_context().executor()->Submit(WriteTask{this, std::move(next)}));
   }
 
-  Status DoFinish() {
+  Future<> DoFinish() {
     {
       std::lock_guard<std::mutex> lg(writer_state_->visitors_mutex);
       RETURN_NOT_OK(options_.writer_pre_finish(writer_.get()));
     }
-    RETURN_NOT_OK(writer_->Finish());
-    {
-      std::lock_guard<std::mutex> lg(writer_state_->visitors_mutex);
-      return options_.writer_post_finish(writer_.get());
-    }
+    // Finish() calls Close() on the file and some implementations
+    // (e.g. S3FS) use the IO thread pool in Close(), blocking until
+    // background work completes, so avoid blocking again here.
+    auto writer = writer_;
+    return DeferNotOk(io::default_io_context().executor()->Submit(
+                          [writer]() { return writer->Finish(); }))
+        .Then([this]() {
+          std::lock_guard<std::mutex> lg(writer_state_->visitors_mutex);
+          return options_.writer_post_finish(writer_.get());
+        });
   }
 
   const FileSystemDatasetWriteOptions& options_;
@@ -328,15 +333,14 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
   uint64_t rows_written() const { return rows_written_; }
 
   void PrepareDirectory() {
-    init_future_ = DeferNotOk(
-        write_options_.filesystem->io_context().executor()->Submit([this]() -> Future<> {
-          RETURN_NOT_OK(write_options_.filesystem->CreateDir(directory_));
-          if (write_options_.existing_data_behavior ==
-              ExistingDataBehavior::kDeleteMatchingPartitions) {
-            return write_options_.filesystem->DeleteDirContentsAsync(directory_);
-          }
-          return Status::OK();
-        }));
+    init_future_ = DeferNotOk(write_options_.filesystem->io_context().executor()->Submit(
+        [this]() { return write_options_.filesystem->CreateDir(directory_); }));
+    if (write_options_.existing_data_behavior ==
+        ExistingDataBehavior::kDeleteMatchingPartitions) {
+      init_future_ = init_future_.Then([this]() {
+        return write_options_.filesystem->DeleteDirContentsAsync(directory_);
+      });
+    }
   }
 
   static Result<std::unique_ptr<DatasetWriterDirectoryQueue,

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -328,12 +328,12 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
   uint64_t rows_written() const { return rows_written_; }
 
   void PrepareDirectory() {
-    init_future_ =
-        DeferNotOk(write_options_.filesystem->io_context().executor()->Submit([this] {
+    init_future_ = DeferNotOk(
+        write_options_.filesystem->io_context().executor()->Submit([this]() -> Future<> {
           RETURN_NOT_OK(write_options_.filesystem->CreateDir(directory_));
           if (write_options_.existing_data_behavior ==
               ExistingDataBehavior::kDeleteMatchingPartitions) {
-            return write_options_.filesystem->DeleteDirContents(directory_);
+            return write_options_.filesystem->DeleteDirContentsAsync(directory_);
           }
           return Status::OK();
         }));

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -263,9 +263,8 @@ Status FileWriter::Write(RecordBatchReader* batches) {
   return Status::OK();
 }
 
-Status FileWriter::Finish() {
-  RETURN_NOT_OK(FinishInternal());
-  return destination_->Close();
+Future<> FileWriter::Finish() {
+  return FinishInternal().Then([this]() { return destination_->CloseAsync(); });
 }
 
 namespace {

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -313,7 +313,7 @@ class ARROW_DS_EXPORT FileWriter {
   Status Write(RecordBatchReader* batches);
 
   /// \brief Indicate that writing is done.
-  virtual Status Finish();
+  virtual Future<> Finish();
 
   const std::shared_ptr<FileFormat>& format() const { return options_->format(); }
   const std::shared_ptr<Schema>& schema() const { return schema_; }
@@ -329,7 +329,7 @@ class ARROW_DS_EXPORT FileWriter {
         destination_(std::move(destination)),
         destination_locator_(std::move(destination_locator)) {}
 
-  virtual Status FinishInternal() = 0;
+  virtual Future<> FinishInternal() = 0;
 
   std::shared_ptr<Schema> schema_;
   std::shared_ptr<FileWriteOptions> options_;

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -289,7 +289,10 @@ Status CsvFileWriter::Write(const std::shared_ptr<RecordBatch>& batch) {
   return batch_writer_->WriteRecordBatch(*batch);
 }
 
-Status CsvFileWriter::FinishInternal() { return batch_writer_->Close(); }
+Future<> CsvFileWriter::FinishInternal() {
+  return DeferNotOk(destination_locator_.filesystem->io_context().executor()->Submit(
+      [this]() { return batch_writer_->Close(); }));
+}
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -290,8 +290,9 @@ Status CsvFileWriter::Write(const std::shared_ptr<RecordBatch>& batch) {
 }
 
 Future<> CsvFileWriter::FinishInternal() {
-  return DeferNotOk(destination_locator_.filesystem->io_context().executor()->Submit(
-      [this]() { return batch_writer_->Close(); }));
+  // The CSV writer's Close() is a no-op, so just treat it as synchronous
+  RETURN_NOT_OK(batch_writer_->Close());
+  return Status::OK();
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -104,7 +104,7 @@ class ARROW_DS_EXPORT CsvFileWriter : public FileWriter {
                 std::shared_ptr<CsvFileWriteOptions> options,
                 fs::FileLocator destination_locator);
 
-  Status FinishInternal() override;
+  Future<> FinishInternal() override;
 
   std::shared_ptr<io::OutputStream> destination_;
   std::shared_ptr<ipc::RecordBatchWriter> batch_writer_;

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -349,7 +349,9 @@ TEST_P(TestCsvFileFormat, WriteRecordBatchReaderCustomOptions) {
   options->write_options->include_header = false;
   auto data_schema = schema({field("f64", float64())});
   ASSERT_OK_AND_ASSIGN(auto sink, GetFileSink());
-  ASSERT_OK_AND_ASSIGN(auto writer, format_->MakeWriter(sink, data_schema, options, {}));
+  ASSERT_OK_AND_ASSIGN(auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {}));
+  ASSERT_OK_AND_ASSIGN(auto writer,
+                       format_->MakeWriter(sink, data_schema, options, {fs, "<buffer>"}));
   ASSERT_OK(writer->Write(ConstantArrayGenerator::Zeroes(5, data_schema)));
   ASSERT_FINISHES_OK(writer->Finish());
   ASSERT_OK_AND_ASSIGN(auto written, sink->Finish());

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -351,7 +351,7 @@ TEST_P(TestCsvFileFormat, WriteRecordBatchReaderCustomOptions) {
   ASSERT_OK_AND_ASSIGN(auto sink, GetFileSink());
   ASSERT_OK_AND_ASSIGN(auto writer, format_->MakeWriter(sink, data_schema, options, {}));
   ASSERT_OK(writer->Write(ConstantArrayGenerator::Zeroes(5, data_schema)));
-  ASSERT_OK(writer->Finish());
+  ASSERT_FINISHES_OK(writer->Finish());
   ASSERT_OK_AND_ASSIGN(auto written, sink->Finish());
   ASSERT_EQ("0\n0\n0\n0\n0\n", written->ToString());
 }

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -216,7 +216,10 @@ Status IpcFileWriter::Write(const std::shared_ptr<RecordBatch>& batch) {
   return batch_writer_->WriteRecordBatch(*batch);
 }
 
-Status IpcFileWriter::FinishInternal() { return batch_writer_->Close(); }
+Future<> IpcFileWriter::FinishInternal() {
+  return DeferNotOk(destination_locator_.filesystem->io_context().executor()->Submit(
+      [this]() { return batch_writer_->Close(); }));
+}
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_ipc.h
+++ b/cpp/src/arrow/dataset/file_ipc.h
@@ -106,7 +106,7 @@ class ARROW_DS_EXPORT IpcFileWriter : public FileWriter {
                 std::shared_ptr<IpcFileWriteOptions> options,
                 fs::FileLocator destination_locator);
 
-  Status FinishInternal() override;
+  Future<> FinishInternal() override;
 
   std::shared_ptr<io::OutputStream> destination_;
   std::shared_ptr<ipc::RecordBatchWriter> batch_writer_;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -447,7 +447,10 @@ Status ParquetFileWriter::Write(const std::shared_ptr<RecordBatch>& batch) {
   return parquet_writer_->WriteTable(*table, batch->num_rows());
 }
 
-Status ParquetFileWriter::FinishInternal() { return parquet_writer_->Close(); }
+Future<> ParquetFileWriter::FinishInternal() {
+  return DeferNotOk(destination_locator_.filesystem->io_context().executor()->Submit(
+      [this]() { return parquet_writer_->Close(); }));
+}
 
 //
 // ParquetFileFragment

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -252,7 +252,7 @@ class ARROW_DS_EXPORT ParquetFileWriter : public FileWriter {
                     std::shared_ptr<ParquetFileWriteOptions> options,
                     fs::FileLocator destination_locator);
 
-  Status FinishInternal() override;
+  Future<> FinishInternal() override;
 
   std::shared_ptr<parquet::arrow::FileWriter> parquet_writer_;
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -488,9 +488,11 @@ class FileFormatFixtureMixin : public ::testing::Test {
     auto format = format_;
     SetSchema(schema->fields());
     EXPECT_OK_AND_ASSIGN(auto sink, GetFileSink());
-
     if (!options) options = format->DefaultWriteOptions();
-    EXPECT_OK_AND_ASSIGN(auto writer, format->MakeWriter(sink, schema, options, {}));
+
+    EXPECT_OK_AND_ASSIGN(auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {}));
+    EXPECT_OK_AND_ASSIGN(auto writer,
+                         format->MakeWriter(sink, schema, options, {fs, "<buffer>"}));
     ARROW_EXPECT_OK(writer->Write(GetRecordBatchReader(schema).get()));
     auto fut = writer->Finish();
     EXPECT_FINISHES(fut);

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -492,7 +492,9 @@ class FileFormatFixtureMixin : public ::testing::Test {
     if (!options) options = format->DefaultWriteOptions();
     EXPECT_OK_AND_ASSIGN(auto writer, format->MakeWriter(sink, schema, options, {}));
     ARROW_EXPECT_OK(writer->Write(GetRecordBatchReader(schema).get()));
-    ARROW_EXPECT_OK(writer->Finish());
+    auto fut = writer->Finish();
+    EXPECT_FINISHES(fut);
+    ARROW_EXPECT_OK(fut.status());
     EXPECT_OK_AND_ASSIGN(auto written, sink->Finish());
     return written;
   }

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -190,6 +190,12 @@ Status ValidateInputFileInfo(const FileInfo& info) {
 
 }  // namespace
 
+Future<> FileSystem::DeleteDirContentsAsync(const std::string& path) {
+  return FileSystemDefer(
+      this, default_async_is_sync_,
+      [path](std::shared_ptr<FileSystem> self) { return self->DeleteDirContents(path); });
+}
+
 Result<std::shared_ptr<io::InputStream>> FileSystem::OpenInputStream(
     const FileInfo& info) {
   RETURN_NOT_OK(ValidateInputFileInfo(info));

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -216,6 +216,9 @@ class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> 
   /// Passing an empty path ("" or "/") is disallowed, see DeleteRootDirContents.
   virtual Status DeleteDirContents(const std::string& path) = 0;
 
+  /// Async version of DeleteDirContents.
+  virtual Future<> DeleteDirContentsAsync(const std::string& path);
+
   /// EXPERIMENTAL: Delete the root directory's contents, recursively.
   ///
   /// Implementations may decide to raise an error if this operation is

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -232,6 +232,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Future<> DeleteDirContentsAsync(const std::string& path) override;
   Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -855,6 +855,40 @@ TEST_F(TestS3FS, DeleteDir) {
   ASSERT_RAISES(Invalid, fs_->DeleteDir("s3:empty-bucket"));
 }
 
+TEST_F(TestS3FS, DeleteDirContents) {
+  FileSelector select;
+  select.base_dir = "bucket";
+  std::vector<FileInfo> infos;
+
+  ASSERT_OK(fs_->DeleteDirContents("bucket/emptydir"));
+  ASSERT_OK(fs_->DeleteDirContents("bucket/somedir"));
+  ASSERT_RAISES(IOError, fs_->DeleteDirContents("bucket/somefile"));
+  ASSERT_OK_AND_ASSIGN(infos, fs_->GetFileInfo(select));
+  ASSERT_EQ(infos.size(), 4);
+  SortInfos(&infos);
+  AssertFileInfo(infos[0], "bucket/emptydir", FileType::Directory);
+  AssertFileInfo(infos[1], "bucket/otherdir", FileType::Directory);
+  AssertFileInfo(infos[2], "bucket/somedir", FileType::Directory);
+  AssertFileInfo(infos[3], "bucket/somefile", FileType::File);
+}
+
+TEST_F(TestS3FS, DeleteDirContentsAsync) {
+  FileSelector select;
+  select.base_dir = "bucket";
+  std::vector<FileInfo> infos;
+
+  ASSERT_FINISHES_OK(fs_->DeleteDirContentsAsync("bucket/emptydir"));
+  ASSERT_FINISHES_OK(fs_->DeleteDirContentsAsync("bucket/somedir"));
+  ASSERT_FINISHES_AND_RAISES(IOError, fs_->DeleteDirContentsAsync("bucket/somefile"));
+  ASSERT_OK_AND_ASSIGN(infos, fs_->GetFileInfo(select));
+  ASSERT_EQ(infos.size(), 4);
+  SortInfos(&infos);
+  AssertFileInfo(infos[0], "bucket/emptydir", FileType::Directory);
+  AssertFileInfo(infos[1], "bucket/otherdir", FileType::Directory);
+  AssertFileInfo(infos[2], "bucket/somedir", FileType::Directory);
+  AssertFileInfo(infos[3], "bucket/somefile", FileType::File);
+}
+
 TEST_F(TestS3FS, CopyFile) {
   // "File"
   ASSERT_OK(fs_->CopyFile("bucket/somefile", "bucket/newfile"));

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -64,6 +64,11 @@ Status SetIOThreadPoolCapacity(int threads) {
 
 FileInterface::~FileInterface() = default;
 
+Future<> FileInterface::CloseAsync() {
+  return DeferNotOk(
+      default_io_context().executor()->Submit([this]() { return Close(); }));
+}
+
 Status FileInterface::Abort() { return Close(); }
 
 namespace {

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -113,6 +113,13 @@ class ARROW_EXPORT FileInterface {
   /// available for further operations.
   virtual Status Close() = 0;
 
+  /// \brief Close the stream asynchronously
+  ///
+  /// By default, this will just submit the synchronous Close() to the
+  /// default I/O thread pool. Subclasses may implement this in a more
+  /// efficient manner.
+  virtual Future<> CloseAsync();
+
   /// \brief Close the stream abruptly
   ///
   /// This method does not guarantee that any pending data is flushed.


### PR DESCRIPTION
When the dataset writer is configured to delete existing data before writing, the target directory is on S3, the dataset is partitioned, and there are at least as many partitions as threads in the I/O thread pool, then the writer would hang. The writer spawns a task on the I/O thread pool for each partition to delete existing data. However, S3FS implemented the relevant filesystem call by asynchronously listing the objects using the I/O thread pool, then deleting them, blocking until this is done. Hence, nested asynchrony would cause the program to hang.

The fix is to do this deletion fully asynchronously, so that there is no blocking. It's sufficient to just use the default implementation of async filesystem methods; it just spawns another task on the I/O thread pool, but this lets the writer avoid blocking. However, this PR also refactors the S3FS internals to implement the call truly asynchronously.

This PR also implements FileInterface::CloseAsync. This is required because by default on S3, files do writes asynchronously in the background, and Close() just blocks until those complete. This also consumes the I/O thread pool (both the blocking and the background writes), so we need an async version of this to avoid the deadlock.