### PR TITLE
ARROW-15061: [C++] Add logging for kernel functions and exec plan nodes

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -389,6 +389,7 @@ if(ARROW_COMPUTE)
        compute/exec/key_encode.cc
        compute/exec/key_hash.cc
        compute/exec/key_map.cc
+       compute/exec/options.cc
        compute/exec/order_by_impl.cc
        compute/exec/project_node.cc
        compute/exec/sink_node.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -220,6 +220,7 @@ set(ARROW_SRCS
     util/tdigest.cc
     util/thread_pool.cc
     util/time.cc
+    util/tracing.cc
     util/trie.cc
     util/unreachable.cc
     util/uri.cc

--- a/cpp/src/arrow/compute/exec/aggregate_node.cc
+++ b/cpp/src/arrow/compute/exec/aggregate_node.cc
@@ -174,7 +174,8 @@ class ScalarAggregateNode : public ExecNode {
     for (size_t i = 0; i < kernels_.size(); ++i) {
       util::tracing::Span span;
       START_SPAN(span, aggs_[i].function,
-                 {{"function.options",
+                 {{"function.name", aggs_[i].function},
+                  {"function.options",
                    aggs_[i].options ? aggs_[i].options->ToString() : "<NULLPTR>"},
                   {"function.kind", std::string(kind_name()) + "::Consume"}});
       KernelContext batch_ctx{plan()->exec_context()};
@@ -267,7 +268,8 @@ class ScalarAggregateNode : public ExecNode {
     for (size_t i = 0; i < kernels_.size(); ++i) {
       util::tracing::Span span;
       START_SPAN(span, aggs_[i].function,
-                 {{"function.options",
+                 {{"function.name", aggs_[i].function},
+                  {"function.options",
                    aggs_[i].options ? aggs_[i].options->ToString() : "<NULLPTR>"},
                   {"function.kind", std::string(kind_name()) + "::Finalize"}});
       KernelContext ctx{plan()->exec_context()};
@@ -416,7 +418,8 @@ class GroupByNode : public ExecNode {
     for (size_t i = 0; i < agg_kernels_.size(); ++i) {
       util::tracing::Span span;
       START_SPAN(span, aggs_[i].function,
-                 {{"function.options",
+                 {{"function.name", aggs_[i].function},
+                  {"function.options",
                    aggs_[i].options ? aggs_[i].options->ToString() : "<NULLPTR>"},
                   {"function.kind", std::string(kind_name()) + "::Consume"}});
       KernelContext kernel_ctx{ctx_};
@@ -450,7 +453,8 @@ class GroupByNode : public ExecNode {
       for (size_t i = 0; i < agg_kernels_.size(); ++i) {
         util::tracing::Span span;
         START_SPAN(span, aggs_[i].function,
-                   {{"function.options",
+                   {{"function.name", aggs_[i].function},
+                    {"function.options",
                      aggs_[i].options ? aggs_[i].options->ToString() : "<NULLPTR>"},
                     {"function.kind", std::string(kind_name()) + "::Merge"}});
         KernelContext batch_ctx{ctx_};
@@ -482,7 +486,8 @@ class GroupByNode : public ExecNode {
     for (size_t i = 0; i < agg_kernels_.size(); ++i) {
       util::tracing::Span span;
       START_SPAN(span, aggs_[i].function,
-                 {{"function.options",
+                 {{"function.name", aggs_[i].function},
+                  {"function.options",
                    aggs_[i].options ? aggs_[i].options->ToString() : "<NULLPTR>"},
                   {"function.kind", std::string(kind_name()) + "::Finalize"}});
       KernelContext batch_ctx{ctx_};

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -112,12 +112,7 @@ struct ExecPlanImpl : public ExecPlan {
     }
 
     finished_ = AllFinished(futures);
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
     return st;
   }
 
@@ -350,12 +345,7 @@ Status MapNode::StartProducing() {
       span_, std::string(kind_name()) + ":" + label(),
       {{"node.label", label()}, {"node.detail", ToString()}, {"node.kind", kind_name()}});
   finished_ = Future<>::Make();
-#ifdef ARROW_WITH_OPENTELEMETRY
-  finished_.AddCallback([this](const Status& st) {
-    MARK_SPAN(span_, st);
-    END_SPAN(span_);
-  });
-#endif
+  END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -247,7 +247,10 @@ class ARROW_EXPORT ExecNode {
   int num_outputs_;
   NodeVector outputs_;
 
-  util::tracing::Span span;
+  // Future to sync finished
+  Future<> finished_ = Future<>::MakeFinished();
+
+  util::tracing::Span span_;
 };
 
 /// \brief MapNode is an ExecNode type class which process a task like filter/project
@@ -287,9 +290,6 @@ class MapNode : public ExecNode {
  protected:
   // Counter for the number of batches received
   AtomicCounter input_counter_;
-
-  // Future to sync finished
-  Future<> finished_ = Future<>::Make();
 
   // The task group for the corresponding batches
   util::AsyncTaskGroup task_group_;

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -28,6 +28,7 @@
 #include "arrow/type_fwd.h"
 #include "arrow/util/async_util.h"
 #include "arrow/util/cancel.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/optional.h"
 #include "arrow/util/tracing.h"

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -46,7 +46,9 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
   ExecContext* exec_context() const { return exec_context_; }
 
   /// Make an empty exec plan
-  static Result<std::shared_ptr<ExecPlan>> Make(ExecContext* = default_exec_context());
+  static Result<std::shared_ptr<ExecPlan>> Make(
+      ExecContext* = default_exec_context(),
+      std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
   ExecNode* AddNode(std::unique_ptr<ExecNode> node);
 
@@ -80,6 +82,12 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
 
   /// \brief A future which will be marked finished when all nodes have stopped producing.
   Future<> finished();
+
+  /// \brief Return whether the plan has non-empty metadata
+  bool HasMetadata() const;
+
+  /// \brief Return the plan's attached metadata
+  std::shared_ptr<const KeyValueMetadata> metadata() const;
 
   std::string ToString() const;
 

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -30,7 +30,7 @@
 #include "arrow/util/cancel.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/optional.h"
-#include "arrow/util/tracing_internal.h"
+#include "arrow/util/tracing.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -247,9 +247,7 @@ class ARROW_EXPORT ExecNode {
   int num_outputs_;
   NodeVector outputs_;
 
-#ifdef ARROW_WITH_OPENTELEMETRY
-  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span;
-#endif
+  util::tracing::Span span;
 };
 
 /// \brief MapNode is an ExecNode type class which process a task like filter/project

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -30,6 +30,7 @@
 #include "arrow/util/cancel.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/optional.h"
+#include "arrow/util/tracing_internal.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -245,6 +246,10 @@ class ARROW_EXPORT ExecNode {
   std::shared_ptr<Schema> output_schema_;
   int num_outputs_;
   NodeVector outputs_;
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span;
+#endif
 };
 
 /// \brief MapNode is an ExecNode type class which process a task like filter/project

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -70,6 +70,12 @@ class FilterNode : public MapNode {
     ARROW_ASSIGN_OR_RAISE(Expression simplified_filter,
                           SimplifyWithGuarantee(filter_, target.guarantee));
 
+    util::tracing::Span span;
+    START_SPAN(span, "Filter",
+               {{"filter.expression", ToStringExtra()},
+                {"filter.expression.simplified", simplified_filter.ToString()},
+                {"filter.length", target.length}});
+
     ARROW_ASSIGN_OR_RAISE(Datum mask, ExecuteScalarExpression(simplified_filter, target,
                                                               plan()->exec_context()));
 
@@ -94,15 +100,17 @@ class FilterNode : public MapNode {
   }
 
   void InputReceived(ExecNode* input, ExecBatch batch) override {
-    EVENT(span, "InputReceived", {{"batch.length", batch.length}});
-
+    EVENT(span_, "InputReceived", {{"batch.length", batch.length}});
     DCHECK_EQ(input, inputs_[0]);
     auto func = [this](ExecBatch batch) {
-      util::tracing::Span inner_span;
-      START_SPAN_WITH_PARENT(inner_span, span, "FilterNode::DoFilter");
+      util::tracing::Span span;
+      START_SPAN_WITH_PARENT(span, span_, "InputReceived",
+                             {{"filter", ToStringExtra()},
+                              {"node.label", label()},
+                              {"batch.length", batch.length}});
       auto result = DoFilter(std::move(batch));
-      MARK_SPAN(inner_span, result.status());
-      END_SPAN(inner_span);
+      MARK_SPAN(span, result.status());
+      END_SPAN(span);
       return result;
     };
     this->SubmitTask(std::move(func), std::move(batch));

--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -42,7 +42,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
-    EVENT(span, "InputReceived");
+    EVENT(span_, "InputReceived");
 
     if (QueueBatchIfNeeded(side, batch)) {
       return Status::OK();
@@ -56,7 +56,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
-    EVENT(span, "InputFinished", {{"side", side}});
+    EVENT(span_, "InputFinished", {{"side", side}});
     if (side == 0) {
       bool proceed;
       {
@@ -89,10 +89,10 @@ class HashJoinBasicImpl : public HashJoinImpl {
               TaskScheduler::ScheduleImpl schedule_task_callback) override {
     num_threads = std::max(num_threads, static_cast<size_t>(1));
 
-    START_SPAN(span, "HashJoinBasicImpl",
-               {{"join_type", ToString(join_type)},
-                {"expression", filter.ToString()},
-                {"num_threads", static_cast<uint32_t>(num_threads)}});
+    START_SPAN(span_, "HashJoinBasicImpl",
+               {{"detail", filter.ToString()},
+                {"join.kind", ToString(join_type)},
+                {"join.threads", static_cast<uint32_t>(num_threads)}});
 
     ctx_ = ctx;
     join_type_ = join_type;
@@ -129,8 +129,8 @@ class HashJoinBasicImpl : public HashJoinImpl {
   }
 
   void Abort(TaskScheduler::AbortContinuationImpl pos_abort_callback) override {
-    EVENT(span, "Abort");
-    END_SPAN(span);
+    EVENT(span_, "Abort");
+    END_SPAN(span_);
     cancelled_ = true;
     scheduler_->Abort(std::move(pos_abort_callback));
   }
@@ -784,7 +784,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
-    END_SPAN(span);
+    END_SPAN(span_);
     finished_callback_(num_batches_produced_.load());
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -42,6 +42,10 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
+#ifdef ARROW_WITH_OPENTELEMETRY
+    // Check parent span for details.
+    span->AddEvent("InputReceived");
+#endif
     if (QueueBatchIfNeeded(side, batch)) {
       return Status::OK();
     } else {
@@ -54,6 +58,9 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
+#ifdef ARROW_WITH_OPENTELEMETRY
+    span->AddEvent("InputFinished", {{"side", side}});
+#endif
     if (side == 0) {
       bool proceed;
       {
@@ -85,6 +92,15 @@ class HashJoinBasicImpl : public HashJoinImpl {
               FinishedCallback finished_callback,
               TaskScheduler::ScheduleImpl schedule_task_callback) override {
     num_threads = std::max(num_threads, static_cast<size_t>(1));
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+    auto tracer = arrow::internal::tracing::GetTracer();
+    span = tracer->StartSpan("HashJoinBasicImpl",
+                             {{"join_type", ToString(join_type)},
+                              {"expression", filter.ToString()},
+                              {"num_threads", static_cast<uint32_t>(num_threads)}});
+    auto scope = tracer->WithActiveSpan(span);
+#endif
 
     ctx_ = ctx;
     join_type_ = join_type;
@@ -121,6 +137,10 @@ class HashJoinBasicImpl : public HashJoinImpl {
   }
 
   void Abort(TaskScheduler::AbortContinuationImpl pos_abort_callback) override {
+#ifdef ARROW_WITH_OPENTELEMETRY
+    span->AddEvent("Abort");
+    span->End();
+#endif
     cancelled_ = true;
     scheduler_->Abort(std::move(pos_abort_callback));
   }
@@ -774,6 +794,9 @@ class HashJoinBasicImpl : public HashJoinImpl {
     if (cancelled_) {
       return Status::Cancelled("Hash join cancelled");
     }
+#ifdef ARROW_WITH_OPENTELEMETRY
+    span->End();
+#endif
     finished_callback_(num_batches_produced_.load());
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/exec/hash_join.h
+++ b/cpp/src/arrow/compute/exec/hash_join.h
@@ -115,7 +115,7 @@ class HashJoinImpl {
   static Result<std::unique_ptr<HashJoinImpl>> MakeBasic();
 
  protected:
-  util::tracing::Span span;
+  util::tracing::Span span_;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/hash_join.h
+++ b/cpp/src/arrow/compute/exec/hash_join.h
@@ -115,9 +115,7 @@ class HashJoinImpl {
   static Result<std::unique_ptr<HashJoinImpl>> MakeBasic();
 
  protected:
-#ifdef ARROW_WITH_OPENTELEMETRY
-  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span;
-#endif
+  util::tracing::Span span;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/hash_join.h
+++ b/cpp/src/arrow/compute/exec/hash_join.h
@@ -27,6 +27,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/util/tracing_internal.h"
 
 namespace arrow {
 namespace compute {
@@ -112,6 +113,11 @@ class HashJoinImpl {
   virtual void Abort(TaskScheduler::AbortContinuationImpl pos_abort_callback) = 0;
 
   static Result<std::unique_ptr<HashJoinImpl>> MakeBasic();
+
+ protected:
+#ifdef ARROW_WITH_OPENTELEMETRY
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span;
+#endif
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -547,12 +547,7 @@ class HashJoinNode : public ExecNode {
                 {"node.detail", ToString()},
                 {"node.kind", kind_name()}});
     finished_ = Future<>::Make();
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
 
     bool use_sync_execution = !(plan_->exec_context()->executor());
     size_t num_threads = use_sync_execution ? 1 : thread_indexer_.Capacity();

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -16,9 +16,11 @@
 // under the License.
 
 #include "arrow/compute/exec/options.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace compute {
+
 std::string ToString(JoinType t) {
   switch (t) {
     case JoinType::LEFT_SEMI:
@@ -38,6 +40,9 @@ std::string ToString(JoinType t) {
     case JoinType::FULL_OUTER:
       return "FULL_OUTER";
   }
+  ARROW_LOG(FATAL) << "Invalid variant of arrow::compute::JoinType";
+  std::abort();
 }
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/exec/options.h"
+
+namespace arrow {
+namespace compute {
+std::string ToString(JoinType t) {
+  switch (t) {
+    case JoinType::LEFT_SEMI:
+      return "LEFT_SEMI";
+    case JoinType::RIGHT_SEMI:
+      return "RIGHT_SEMI";
+    case JoinType::LEFT_ANTI:
+      return "LEFT_ANTI";
+    case JoinType::RIGHT_ANTI:
+      return "RIGHT_ANTI";
+    case JoinType::INNER:
+      return "INNER";
+    case JoinType::LEFT_OUTER:
+      return "LEFT_OUTER";
+    case JoinType::RIGHT_OUTER:
+      return "RIGHT_OUTER";
+    case JoinType::FULL_OUTER:
+      return "FULL_OUTER";
+  }
+}
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -164,6 +164,8 @@ enum class JoinType {
   FULL_OUTER
 };
 
+std::string ToString(JoinType t);
+
 enum class JoinKeyCmp { EQ, IS };
 
 /// \brief Make a node which implements join operation using hash join strategy.
@@ -239,12 +241,12 @@ class ARROW_EXPORT HashJoinNodeOptions : public ExecNodeOptions {
   std::vector<FieldRef> left_output;
   // output fields passed from right input
   std::vector<FieldRef> right_output;
-  // key comparison function (determines whether a null key is equal another null key or
-  // not)
+  // key comparison function (determines whether a null key is equal another null
+  // key or not)
   std::vector<JoinKeyCmp> key_cmp;
-  // prefix added to names of output fields coming from left input (used to distinguish,
-  // if necessary, between fields of the same name in left and right input and can be left
-  // empty if there are no name collisions)
+  // prefix added to names of output fields coming from left input (used to
+  // distinguish, if necessary, between fields of the same name in left and right
+  // input and can be left empty if there are no name collisions)
   std::string output_prefix_for_left;
   // prefix added to names of output fields coming from right input
   std::string output_prefix_for_right;

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -89,8 +89,25 @@ class ProjectNode : public MapNode {
   }
 
   void InputReceived(ExecNode* input, ExecBatch batch) override {
+#ifdef ARROW_WITH_OPENTELEMETRY
+    span->AddEvent("InputReceived", {{"batch.length", batch.length}});
+#endif
     DCHECK_EQ(input, inputs_[0]);
-    auto func = [this](ExecBatch batch) { return DoProject(std::move(batch)); };
+    auto func = [this](ExecBatch batch) {
+#ifdef ARROW_WITH_OPENTELEMETRY
+      auto tracer = arrow::internal::tracing::GetTracer();
+      opentelemetry::trace::StartSpanOptions options;
+      options.parent = span->GetContext();
+      auto span = tracer->StartSpan("ProjectNode::DoProject", options);
+      auto scope = tracer->WithActiveSpan(span);
+#endif
+      auto result = DoProject(std::move(batch));
+#ifdef ARROW_WITH_OPENTELEMETRY
+      arrow::internal::tracing::MarkSpan(result.status(), span.get());
+      span->End();
+#endif
+      return result;
+    };
     this->SubmitTask(std::move(func), std::move(batch));
   }
 

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -29,6 +29,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/tracing_internal.h"
 
 namespace arrow {
 
@@ -89,23 +90,14 @@ class ProjectNode : public MapNode {
   }
 
   void InputReceived(ExecNode* input, ExecBatch batch) override {
-#ifdef ARROW_WITH_OPENTELEMETRY
-    span->AddEvent("InputReceived", {{"batch.length", batch.length}});
-#endif
+    EVENT(span, "InputReceived", {{"batch.length", batch.length}});
     DCHECK_EQ(input, inputs_[0]);
     auto func = [this](ExecBatch batch) {
-#ifdef ARROW_WITH_OPENTELEMETRY
-      auto tracer = arrow::internal::tracing::GetTracer();
-      opentelemetry::trace::StartSpanOptions options;
-      options.parent = span->GetContext();
-      auto span = tracer->StartSpan("ProjectNode::DoProject", options);
-      auto scope = tracer->WithActiveSpan(span);
-#endif
+      util::tracing::Span inner_span;
+      START_SPAN_WITH_PARENT(inner_span, span, "ProjectNode::DoProject");
       auto result = DoProject(std::move(batch));
-#ifdef ARROW_WITH_OPENTELEMETRY
-      arrow::internal::tracing::MarkSpan(result.status(), span.get());
-      span->End();
-#endif
+      MARK_SPAN(inner_span, result.status());
+      END_SPAN(inner_span);
       return result;
     };
     this->SubmitTask(std::move(func), std::move(batch));

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -82,12 +82,8 @@ class SinkNode : public ExecNode {
                 {"node.detail", ToString()},
                 {"node.kind", kind_name()}});
     finished_ = Future<>::Make();
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
+
     return Status::OK();
   }
 
@@ -184,12 +180,7 @@ class ConsumingSinkNode : public ExecNode {
                 {"node.detail", ToString()},
                 {"node.kind", kind_name()}});
     finished_ = Future<>::Make();
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -341,6 +341,8 @@ struct OrderBySinkNode final : public SinkNode {
   }
 
   void Finish() override {
+    util::tracing::Span span;
+    START_SPAN_WITH_PARENT(span, span_, "Finish", {{"node.label", label()}});
     Status st = DoFinish();
     if (ErrorIfNotOk(st)) {
       producer_.Push(std::move(st));

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -32,6 +32,7 @@
 #include "arrow/util/logging.h"
 #include "arrow/util/optional.h"
 #include "arrow/util/thread_pool.h"
+#include "arrow/util/tracing_internal.h"
 #include "arrow/util/unreachable.h"
 
 namespace arrow {
@@ -66,6 +67,11 @@ struct SourceNode : ExecNode {
   [[noreturn]] void InputFinished(ExecNode*, int) override { NoInputs(); }
 
   Status StartProducing() override {
+    START_SPAN(span_, std::string(kind_name()) + ":" + label(),
+               {{"node.kind", kind_name()},
+                {"node.label", label()},
+                {"node.output_schema", output_schema()->ToString()},
+                {"node.detail", ToString()}});
     {
       // If another exec node encountered an error during its StartProducing call
       // it might have already called StopProducing on all of its inputs (including this
@@ -140,7 +146,12 @@ struct SourceNode : ExecNode {
           outputs_[0]->InputFinished(this, total_batches);
           return task_group_.End();
         });
-
+#ifdef ARROW_WITH_OPENTELEMETRY
+    finished_.AddCallback([this](const Status& st) {
+      MARK_SPAN(span_, st);
+      END_SPAN(span_);
+    });
+#endif
     return Status::OK();
   }
 
@@ -164,7 +175,6 @@ struct SourceNode : ExecNode {
   std::mutex mutex_;
   bool stop_requested_{false};
   int batch_count_{0};
-  Future<> finished_ = Future<>::MakeFinished();
   util::AsyncTaskGroup task_group_;
   AsyncGenerator<util::optional<ExecBatch>> generator_;
 };

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -146,12 +146,7 @@ struct SourceNode : ExecNode {
           outputs_[0]->InputFinished(this, total_batches);
           return task_group_.End();
         });
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -117,12 +117,7 @@ class UnionNode : public ExecNode {
                 {"node.detail", ToString()},
                 {"node.kind", kind_name()}});
     finished_ = Future<>::Make();
-#ifdef ARROW_WITH_OPENTELEMETRY
-    finished_.AddCallback([this](const Status& st) {
-      MARK_SPAN(span_, st);
-      END_SPAN(span_);
-    });
-#endif
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_, this);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -215,15 +215,9 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
   }
 
   util::tracing::Span span;
-  START_SPAN(
-      span, name(),
-      {{"function.args", std::accumulate(std::begin(args), std::end(args), std::string(),
-                                         [](std::string& ss, const Datum& d) {
-                                           return ss.empty() ? d.ToString()
-                                                             : ss + "," + d.ToString();
-                                         })},
-       {"function.options", options ? options->ToString() : "<NULLPTR>"},
-       {"function.kind", kind()}});
+  START_SPAN(span, name(),
+             {{"function.options", options ? options->ToString() : "<NULLPTR>"},
+              {"function.kind", kind()}});
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -216,7 +216,8 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
 
   util::tracing::Span span;
   START_SPAN(span, name(),
-             {{"function.options", options ? options->ToString() : "<NULLPTR>"},
+             {{"function.name", name()},
+              {"function.options", options ? options->ToString() : "<NULLPTR>"},
               {"function.kind", kind()}});
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -215,9 +215,9 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
   }
 
   util::tracing::Span span;
-  START_SPAN(span, "Function::Execute", {{"function", name()}, {"kind", kind()}});
-  // todo(mb): add options to attributes. Requires fixing Option ToString impls for all
-  // option types.
+  START_SPAN(span, name(),
+             {{"detail", options ? options->ToString() : "<NULLPTR>"},
+              {"function.kind", kind()}});
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -215,9 +215,15 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
   }
 
   util::tracing::Span span;
-  START_SPAN(span, name(),
-             {{"detail", options ? options->ToString() : "<NULLPTR>"},
-              {"function.kind", kind()}});
+  START_SPAN(
+      span, name(),
+      {{"function.args", std::accumulate(std::begin(args), std::end(args), std::string(),
+                                         [](std::string& ss, const Datum& d) {
+                                           return ss.empty() ? d.ToString()
+                                                             : ss + "," + d.ToString();
+                                         })},
+       {"function.options", options ? options->ToString() : "<NULLPTR>"},
+       {"function.kind", kind()}});
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -214,12 +214,9 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
     return Execute(args, options, &default_ctx);
   }
 
-#ifdef ARROW_WITH_OPENTELEMETRY
-  auto tracer = arrow::internal::tracing::GetTracer();
-  auto span = tracer->StartSpan("Function::Execute",
-                                {{"function", name()}, {"kind", kind()}, {"options", options->ToString()}});
-  auto scope = tracer->WithActiveSpan(span);
-#endif
+  util::tracing::Span span;
+  START_SPAN(span, "Function::Execute",
+             {{"function", name()}, {"kind", kind()}, {"options", options->ToString()}});
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -215,8 +215,9 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
   }
 
   util::tracing::Span span;
-  START_SPAN(span, "Function::Execute",
-             {{"function", name()}, {"kind", kind()}, {"options", options->ToString()}});
+  START_SPAN(span, "Function::Execute", {{"function", name()}, {"kind", kind()}});
+  // todo(mb): add options to attributes. Requires fixing Option ToString impls for all
+  // option types.
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible
@@ -259,7 +260,6 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
 }
 
 namespace {
-
 Status ValidateFunctionSummary(const std::string& s) {
   if (s.find('\n') != s.npos) {
     return Status::Invalid("summary contains a newline");

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -215,8 +215,10 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
   }
 
 #ifdef ARROW_WITH_OPENTELEMETRY
-  auto span = arrow::internal::tracing::GetTracer()->StartSpan("Function::Execute", {{"function", name()}});
-  auto scope = opentelemetry::trace::Scope(span);
+  auto tracer = arrow::internal::tracing::GetTracer();
+  auto span = tracer->StartSpan("Function::Execute",
+                                {{"function", name()}, {"kind", kind()}, {"options", options->ToString()}});
+  auto scope = tracer->WithActiveSpan(span);
 #endif
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -31,6 +31,7 @@
 #include "arrow/datum.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/tracing_internal.h"
 
 namespace arrow {
 
@@ -212,6 +213,11 @@ Result<Datum> Function::Execute(const std::vector<Datum>& args,
     ExecContext default_ctx;
     return Execute(args, options, &default_ctx);
   }
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+  auto span = arrow::internal::tracing::GetTracer()->StartSpan("Function::Execute", {{"function", name()}});
+  auto scope = opentelemetry::trace::Scope(span);
+#endif
 
   // type-check Datum arguments here. Really we'd like to avoid this as much as
   // possible

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -125,7 +125,11 @@ static inline std::string GenericToString(const std::shared_ptr<T>& value) {
 
 static inline std::string GenericToString(const std::shared_ptr<Scalar>& value) {
   std::stringstream ss;
-  ss << value->type->ToString() << ":" << value->ToString();
+  if (value) {
+    ss << value->type->ToString() << ":" << value->ToString();
+  } else {
+    ss << "<NULLPTR>";
+  }
   return ss.str();
 }
 

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -626,14 +626,14 @@ class ARROW_MUST_USE_TYPE Future {
   /// returning the future.
   ///
   /// Two callbacks are supported:
-  /// - OnSuccess, called with the result (const ValueType&) on successul completion.
+  /// - OnSuccess, called with the result (const ValueType&) on successful completion.
   ///              for an empty future this will be called with nothing ()
   /// - OnFailure, called with the error (const Status&) on failed completion.
   ///              This callback is optional and defaults to a passthru of any errors.
   ///
   /// Then() returns a Future whose ValueType is derived from the return type of the
   /// callbacks. If a callback returns:
-  /// - void, a Future<> will be returned which will completes successully as soon
+  /// - void, a Future<> will be returned which will completes successfully as soon
   ///   as the callback runs.
   /// - Status, a Future<> will be returned which will complete with the returned Status
   ///   as soon as the callback runs.
@@ -645,7 +645,7 @@ class ARROW_MUST_USE_TYPE Future {
   ///
   /// The continued Future type must be the same for both callbacks.
   ///
-  /// Note that OnFailure can swallow errors, allowing continued Futures to successully
+  /// Note that OnFailure can swallow errors, allowing continued Futures to successfully
   /// complete even if this Future fails.
   ///
   /// If this future is already completed then the callback will be run immediately

--- a/cpp/src/arrow/util/tracing.cc
+++ b/cpp/src/arrow/util/tracing.cc
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/tracing.h"
+#include "arrow/util/make_unique.h"
+#include "arrow/util/tracing_internal.h"
+
+namespace arrow {
+namespace util {
+namespace tracing {
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+
+Span::Impl& Span::set_impl(const Impl& impl) {
+  inner_impl.reset(new Impl(impl));
+  return *inner_impl;
+}
+
+Span::Impl& Span::set_impl(Impl&& impl) {
+  inner_impl.reset(new Impl(std::move(impl)));
+  return *inner_impl;
+}
+
+#endif
+
+// Default destructor when impl type is complete.
+Span::~Span() = default;
+
+}  // namespace tracing
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/tracing.cc
+++ b/cpp/src/arrow/util/tracing.cc
@@ -25,12 +25,12 @@ namespace tracing {
 
 #ifdef ARROW_WITH_OPENTELEMETRY
 
-Span::Impl& Span::set_impl(const Impl& impl) {
+Span::Impl& Span::Set(const Impl& impl) {
   inner_impl.reset(new Impl(impl));
   return *inner_impl;
 }
 
-Span::Impl& Span::set_impl(Impl&& impl) {
+Span::Impl& Span::Set(Impl&& impl) {
   inner_impl.reset(new Impl(std::move(impl)));
   return *inner_impl;
 }

--- a/cpp/src/arrow/util/tracing.h
+++ b/cpp/src/arrow/util/tracing.h
@@ -35,7 +35,7 @@ class SpanImpl;
 namespace util {
 namespace tracing {
 
-class Span {
+class ARROW_EXPORT Span {
  public:
   using Impl = arrow::internal::tracing::SpanImpl;
 

--- a/cpp/src/arrow/util/tracing.h
+++ b/cpp/src/arrow/util/tracing.h
@@ -47,23 +47,17 @@ class ARROW_EXPORT Span {
   Impl& Set(Impl&&);
 
   const Impl& Get() const {
-    if (inner_impl) {
-      return *inner_impl;
-    } else {
-      ARROW_LOG(FATAL) << "Attempted to dereference a null pointer. Use Span::Set before "
-                          "dereferencing.";
-      std::abort();
-    }
+    ARROW_CHECK(inner_impl)
+        << "Attempted to dereference a null pointer. Use Span::Set before "
+           "dereferencing.";
+    return *inner_impl;
   }
 
   Impl& Get() {
-    if (inner_impl) {
-      return *inner_impl;
-    } else {
-      ARROW_LOG(FATAL) << "Attempted to dereference a null pointer. Use Span::Set before "
-                          "dereferencing.";
-      std::abort();
-    }
+    ARROW_CHECK(inner_impl)
+        << "Attempted to dereference a null pointer. Use Span::Set before "
+           "dereferencing.";
+    return *inner_impl;
   }
 
  private:

--- a/cpp/src/arrow/util/tracing.h
+++ b/cpp/src/arrow/util/tracing.h
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/util/logging.h"
+
+namespace arrow {
+
+namespace internal {
+namespace tracing {
+
+// Forward declaration SpanImpl.
+class SpanImpl;
+
+}  // namespace tracing
+}  // namespace internal
+
+namespace util {
+namespace tracing {
+
+class Span {
+ public:
+  using Impl = arrow::internal::tracing::SpanImpl;
+
+  Span() = default;  // Default constructor. The inner_impl is a nullptr.
+  ~Span();  // Destructor. Default destructor defined in tracing.cc where impl is a
+            // complete type.
+
+  Impl& set_impl(const Impl&);
+  Impl& set_impl(Impl&&);
+
+  const Impl& impl() const {
+    if (inner_impl) {
+      return *inner_impl;
+    } else {
+      ARROW_LOG(FATAL) << "Attempted to dereference a nullptr. Use Span::set_impl before "
+                          "dereferencing.";
+      std::abort();
+    }
+  }
+
+  Impl& impl() {
+    if (inner_impl) {
+      return *inner_impl;
+    } else {
+      ARROW_LOG(FATAL) << "Attempted to dereference a nullptr. Use Span::set_impl before "
+                          "dereferencing.";
+      std::abort();
+    }
+  }
+
+ private:
+  std::unique_ptr<Impl> inner_impl;
+};
+
+}  // namespace tracing
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/tracing.h
+++ b/cpp/src/arrow/util/tracing.h
@@ -43,24 +43,24 @@ class Span {
   ~Span();  // Destructor. Default destructor defined in tracing.cc where impl is a
             // complete type.
 
-  Impl& set_impl(const Impl&);
-  Impl& set_impl(Impl&&);
+  Impl& Set(const Impl&);
+  Impl& Set(Impl&&);
 
-  const Impl& impl() const {
+  const Impl& Get() const {
     if (inner_impl) {
       return *inner_impl;
     } else {
-      ARROW_LOG(FATAL) << "Attempted to dereference a nullptr. Use Span::set_impl before "
+      ARROW_LOG(FATAL) << "Attempted to dereference a null pointer. Use Span::Set before "
                           "dereferencing.";
       std::abort();
     }
   }
 
-  Impl& impl() {
+  Impl& Get() {
     if (inner_impl) {
       return *inner_impl;
     } else {
-      ARROW_LOG(FATAL) << "Attempted to dereference a nullptr. Use Span::set_impl before "
+      ARROW_LOG(FATAL) << "Attempted to dereference a null pointer. Use Span::Set before "
                           "dereferencing.";
       std::abort();
     }

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -188,7 +188,7 @@ opentelemetry::trace::Tracer* GetTracer() {
 opentelemetry::trace::StartSpanOptions SpanOptionsWithParent(
     const util::tracing::Span& parent_span) {
   opentelemetry::trace::StartSpanOptions options;
-  options.parent = parent_span.impl().span->GetContext();
+  options.parent = parent_span.Get().span->GetContext();
   return options;
 }
 #endif

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "arrow/util/tracing_internal.h"
+#include "arrow/util/tracing.h"
 
 #include <iostream>
 #include <sstream>
@@ -182,6 +183,15 @@ opentelemetry::trace::Tracer* GetTracer() {
       GetTracerProvider()->GetTracer("arrow");
   return tracer.get();
 }
+
+#ifdef ARROW_WITH_OPENTELEMETRY
+opentelemetry::trace::StartSpanOptions SpanOptionsWithParent(
+    const util::tracing::Span& parent_span) {
+  opentelemetry::trace::StartSpanOptions options;
+  options.parent = parent_span.impl().span->GetContext();
+  return options;
+}
+#endif
 
 }  // namespace tracing
 }  // namespace internal

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -152,9 +152,10 @@ class FlushLog {
   explicit FlushLog(nostd::shared_ptr<sdktrace::TracerProvider> provider)
       : provider_(std::move(provider)) {}
   ~FlushLog() {
-    if (provider_) {
-      provider_->ForceFlush(std::chrono::microseconds(1000000));
-    }
+    // TODO: ForceFlush apparently sends data that OTLP connector can't handle
+    // if (provider_) {
+    //   provider_->ForceFlush(std::chrono::microseconds(1000000));
+    // }
   }
   nostd::shared_ptr<sdktrace::TracerProvider> provider_;
 };

--- a/cpp/src/arrow/util/tracing_internal.cc
+++ b/cpp/src/arrow/util/tracing_internal.cc
@@ -106,7 +106,7 @@ class ThreadIdSpanProcessor : public sdktrace::BatchSpanProcessor {
   void OnEnd(std::unique_ptr<sdktrace::Recordable>&& span) noexcept override {
     std::stringstream thread_id;
     thread_id << std::this_thread::get_id();
-    span->SetAttribute("thread_id", thread_id.str());
+    span->SetAttribute("thread.id", thread_id.str());
     sdktrace::BatchSpanProcessor::OnEnd(std::move(span));
   }
 };

--- a/cpp/src/arrow/util/tracing_internal.h
+++ b/cpp/src/arrow/util/tracing_internal.h
@@ -28,6 +28,7 @@
 #pragma warning(disable : 4522)
 #endif
 #include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/scope.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/cpp/src/arrow/util/tracing_internal.h
+++ b/cpp/src/arrow/util/tracing_internal.h
@@ -113,7 +113,7 @@ opentelemetry::trace::StartSpanOptions SpanOptionsWithParent(
   auto opentelemetry_scope##__LINE__ =                                              \
       ::arrow::internal::tracing::GetTracer()->WithActiveSpan(                      \
           target_span                                                               \
-              .set_impl(::arrow::util::tracing::Span::Impl{                         \
+              .Set(::arrow::util::tracing::Span::Impl{                              \
                   ::arrow::internal::tracing::GetTracer()->StartSpan(__VA_ARGS__)}) \
               .span)
 
@@ -121,18 +121,18 @@ opentelemetry::trace::StartSpanOptions SpanOptionsWithParent(
   auto opentelemetry_scope##__LINE__ =                                                  \
       ::arrow::internal::tracing::GetTracer()->WithActiveSpan(                          \
           target_span                                                                   \
-              .set_impl(::arrow::util::tracing::Span::Impl{                             \
+              .Set(::arrow::util::tracing::Span::Impl{                                  \
                   ::arrow::internal::tracing::GetTracer()->StartSpan(                   \
                       __VA_ARGS__,                                                      \
                       ::arrow::internal::tracing::SpanOptionsWithParent(parent_span))}) \
               .span)
 
-#define EVENT(target_span, ...) target_span.impl().span->AddEvent(__VA_ARGS__)
+#define EVENT(target_span, ...) target_span.Get().span->AddEvent(__VA_ARGS__)
 
 #define MARK_SPAN(target_span, status) \
-  ::arrow::internal::tracing::MarkSpan(status, target_span.impl().span.get())
+  ::arrow::internal::tracing::MarkSpan(status, target_span.Get().span.get())
 
-#define END_SPAN(target_span) target_span.impl().span->End()
+#define END_SPAN(target_span) target_span.Get().span->End()
 
 #else
 


### PR DESCRIPTION
Adds spans and events for exec plan and exec nodes.

I use the following setup to debug traces:

`docker-compose.yml`:
```yml
version: "2"
services:

  jaeger-all-in-one:
    image: jaegertracing/all-in-one:latest
    ports:
      - "16686:16686"
      - "14268"
      - "14250"

  otel-collector:
    image: otel/opentelemetry-collector-contrib-dev:latest
    command: ["--config=/etc/otel-collector-config.yaml"]
    volumes:
      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
      - ./output:/var/output
    ports:
      - "8888:8888"   # Prometheus metrics exposed by the collector
      - "8889:8889"   # Prometheus exporter metrics
      - "4317"        # OTLP gRPC receiver
      - "4318:4318"   # OTLP HTTP receiver
    depends_on:      
      - jaeger-all-in-one

  prometheus:
    container_name: prometheus
    image: prom/prometheus:latest
    volumes:
      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
    ports:
      - "9090:9090"
```

`otel-collector-config.yaml`:
```yml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: "0.0.0.0:4318"
        cors:
          allowed_origins:
            - "*"

processors:
  batch:

exporters:
  logging:
  jaeger:
    endpoint: jaeger-all-in-one:14250
    tls:
      insecure: true
  prometheus:
    endpoint: 0.0.0.0:8889
  parquet:
    path: /var/output/log.parquet

service:
  pipelines:
    traces:
      receivers:
        - otlp
      processors:
        - batch
      exporters:
        - logging
        - jaeger
        - parquet
    metrics:
      receivers:
        - otlp
      processors:
        - batch
      exporters:
        - logging
        - prometheus
        - parquet
```

`prometheus.yaml`:
```yml
scrape_configs:
  - job_name: "otel-collector"
    scrape_interval: 10s
    static_configs:
      - targets: ["otel-collector:8889"]
      - targets: ["otel-collector:8888"]
```

Start the services and then use the instructions from https://github.com/apache/arrow/pull/11906.