### PR TITLE
MINOR: [GLib][Doc] Fix wrong build directory in README.md

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -92,7 +92,7 @@ Others:
 ```console
 $ meson setup c_glib.build c_glib --buildtype=release
 $ meson compile -C c_glib.build
-$ sudo meson install -C build
+$ sudo meson install -C c_glib.build
 ```
 
 ### How to build by developers


### PR DESCRIPTION
The "How to build by users"->"Others" section in `c_glib/README.md` states the wrong directory when installing.