### PR TITLE
ARROW-15183: [Python][Docs] Add Missing Dataset Write Options

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -651,8 +651,7 @@ file will be created in each output directory unless files need to be closed to 
 For workloads writing a lot of data, files can get very large without a
 row count cap, leading to out-of-memory errors in downstream readers. The
 relationship between row count and file size depends on the dataset schema
-and how well compressed (if at all) the data is. For most applications,
-it's best to keep file sizes below 1GB.
+and how well compressed (if at all) the data is.
 
 Configuring rows per group during a write
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -658,23 +658,25 @@ Configuring rows per group during a write
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The volume of data written to the disk per each group can be configured.
-This configuration includes a lower and an upper bound. 
-Set the minimum number of rows required to form a row group. 
-Defined with the ``min_rows_per_group`` parameter of :meth:`write_dataset`.
+This configuration includes a lower and an upper bound.
+The minimum number of rows required to form a row group is 
+defined with the ``min_rows_per_group`` parameter of :meth:`write_dataset`.
 
-Note: if ``min_rows_per_group`` is set greater than 0 then this will cause the 
-dataset writer to batch incoming data and only write the row groups to the 
-disk when sufficient rows have accumulated. The final row group size may be 
-less than this value if other options such as ``max_open_files`` or 
-``max_rows_per_file`` force smaller row group sizes.
+.. note::
+    If ``min_rows_per_group`` is set greater than 0 then this will cause the 
+    dataset writer to batch incoming data and only write the row groups to the 
+    disk when sufficient rows have accumulated. The final row group size may be 
+    less than this value if other options such as ``max_open_files`` or 
+    ``max_rows_per_file`` force smaller row group sizes.
 
-Set the maximum number of rows allowed per group. Defined as ``max_rows_per_group`` parameter of
-:meth:`write_dataset`.
+The maximum number of rows allowed per group is defined with the
+``max_rows_per_group`` parameter of :meth:`write_dataset`.
 
-Note: if ``max_rows_per_group`` is set greater than 0 then the dataset writer may split 
+If ``max_rows_per_group`` is set greater than 0 then the dataset writer may split 
 up large incoming batches into multiple row groups.  If this value is set then 
 ``min_rows_per_group`` should also be set or else you may end up with very small 
 row groups (e.g. if the incoming row group size is just barely larger than this value).
+
 Row groups are built into the Parquet and IPC/Feather formats but don't affect JSON or CSV.
 When reading back Parquet and IPC formats in Arrow, the row group boundaries become the
 record batch boundaries, determining the default batch size of downstream readers.

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -699,3 +699,46 @@ Parquet files:
 
     # also clean-up custom base directory used in some examples
     shutil.rmtree(str(base), ignore_errors=True)
+
+
+Configuring files open during a write
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When writing data to the disk, there are a few parameters that can be 
+important to optimize the writes, i.e number of rows per file and
+number of files open during write. 
+
+The number of files opened at during the write time can be set as follows;
+
+.. ipython:: python
+
+    ds.write_dataset(data=table, base_dir="data_dir", max_open_files=max_open_files)
+
+The maximum number of rows per file can be set as follows;
+
+.. ipython:: pythoin
+    ds.write_dataset(record_batch, "data_dir", format="parquet",
+                     max_rows_per_file=10)
+
+
+Configuring rows per group during a write
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When writing data to disk, depending on the volume of data obtained, 
+(in a mini-batch setting where, records are obtained in batch by batch)
+the volume of data written to disk per each group can be configured. 
+This can be configured using a minimum and maximum parameter. 
+
+Set minimum rows per group;
+
+.. ipython:: python
+    ds.write_dataset(data=record_batches, base_dir="data_dir",
+                     min_rows_per_group=5,
+                     format="parquet")
+
+Set maximum rows per group;
+
+.. ipython:: python
+    ds.write_dataset(data=record_batches, base_dir="data_dir",
+                     max_rows_per_group=10,
+                     format="parquet")

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -617,8 +617,8 @@ Configuring files open during a write
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When writing data to the disk, there are a few parameters that can be 
-important to optimize the writes, i.e number of rows per file and
-number of files open during write. 
+important to optimize the writes, such as the number of rows per file and
+the number of files open during write.
 
 Set the maximum number of files opened with the ``max_open_files`` parameter of
 :meth:`write_dataset`.
@@ -645,11 +645,11 @@ Set the maximum number of rows written in each file with the ``max_rows_per_file
 parameter of :meth:`write_dataset`.
 
 If ``max_rows_per_file`` is set greater than 0 then this will limit how many 
-rows are placed in any single file. Otherwise there will be no limit and one 
-file will be created in each output directory unless files need to be closed to respect 
-``max_open_files``. This setting is the primary way to control file size. 
-For workloads writing a lot of data files can get very large without a 
-row count cap, leading to out-of-memory errors in downstream readers. The 
+rows are placed in any single file. Otherwise there will be no limit and one
+file will be created in each output directory unless files need to be closed to respect
+``max_open_files``. This setting is the primary way to control file size.
+For workloads writing a lot of data, files can get very large without a
+row count cap, leading to out-of-memory errors in downstream readers. The
 relationship between row count and file size depends on the dataset schema
 and how well compressed (if at all) the data is. For most applications,
 it's best to keep file sizes below 1GB.
@@ -678,6 +678,11 @@ Note: if ``max_rows_per_group`` is set greater than 0 then the dataset writer ma
 up large incoming batches into multiple row groups.  If this value is set then 
 ``min_rows_per_group`` should also be set or else you may end up with very small 
 row groups (e.g. if the incoming row group size is just barely larger than this value).
+In addition row_groups are a factor which impacts write/read of Parquest, Feather and IPC
+formats. The main purpose of these formats are to provide high performance data structures
+for I/O operations on larger datasets. The row_group concept allows the write/read operations
+to be optimized and gather a defined number of rows at once and execute the I/O operation. 
+But row_groups are not integrated to support JSON or CSV formats. 
 
 Writing large amounts of data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR includes a minor documentation update for showing how `max_open_files`, `min_rows_per_group` and `max_rows_per_group` parameters can be used in Python dataset API. 

The disucssion on the issue: https://issues.apache.org/jira/browse/ARROW-15183