### PR TITLE
ARROW-14679: [R] [C++] Handle suffix argument in joins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -432,8 +432,8 @@ ExecNode_Aggregate <- function(input, options, target_names, out_field_names, ke
   .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
 }
 
-ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_output, right_output) {
-  .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output)
+ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right) {
+  .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right)
 }
 
 ExecNode_SourceNode <- function(plan, reader) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -432,8 +432,8 @@ ExecNode_Aggregate <- function(input, options, target_names, out_field_names, ke
   .Call(`_arrow_ExecNode_Aggregate`, input, options, target_names, out_field_names, key_names)
 }
 
-ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right) {
-  .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right)
+ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_output, right_output, output_suffix_for_left, output_suffix_for_right) {
+  .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output, output_suffix_for_left, output_suffix_for_right)
 }
 
 ExecNode_SourceNode <- function(plan, reader) {
@@ -1927,4 +1927,3 @@ SetIOThreadPoolCapacity <- function(threads) {
 Array__infer_type <- function(x) {
   .Call(`_arrow_Array__infer_type`, x)
 }
-

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -94,6 +94,22 @@ collapse.Dataset <- collapse.ArrowTabular <- collapse.RecordBatchReader <- funct
   arrow_dplyr_query(x)
 }
 
+# helper method to add suffix
+add_suffix <- function(fields, common_cols, suffix) {
+  # helper function which adds the suffixes to the
+  # selected column names
+  # for join relation the selected columns are the
+  # columns with same name in left and right relation
+  col_names <- names(fields)
+  new_col_names <- col_names %>% map(function(x) {
+    if (is.element(x, common_cols)) {
+      paste0(x, suffix)
+    } else {
+      x
+    }
+  })
+  set_names(fields, new_col_names)
+}
 
 implicit_schema <- function(.data) {
   .data <- ensure_group_vars(.data)
@@ -114,23 +130,6 @@ implicit_schema <- function(.data) {
       left_cols_ex_by <- left_cols[setdiff(names(left_cols), .data$join$by)]
       # find the common column names in left and right tables
       common_cols <- intersect(names(right_cols_ex_by), names(left_cols_ex_by))
-
-      # helper method to add suffix
-      add_suffix <- function(fields, common_cols, suffix) {
-        # helper function which adds the suffixes to the
-        # selected column names
-        # for join relation the selected columns are the
-        # columns with same name in left and right relation
-        col_names <- names(fields)
-        new_col_names <- col_names %>% map(function(x) {
-          if (is.element(x, common_cols)) {
-            paste(x, suffix, sep = "")
-          } else {
-            x
-          }
-        })
-        rlang::set_names(fields, new_col_names)
-      }
       # adding suffixes to the common columns in left and right tables
       left_fields <- add_suffix(new_fields, common_cols, .data$join$suffix[[1]])
       right_fields <- add_suffix(right_fields, common_cols, .data$join$suffix[[2]])

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -94,21 +94,6 @@ collapse.Dataset <- collapse.ArrowTabular <- collapse.RecordBatchReader <- funct
   arrow_dplyr_query(x)
 }
 
-add_suffix <- function(fields, common_cols, suffix) {
-  # helper function which adds the suffixes to the
-  # selected column names
-  # for join relation the selected columns are the
-  # columns with same name in left and right relation
-  col_names <- names(fields)
-  new_col_names <- col_names %>% map(function(x) {
-    if (is.element(x, common_cols)) {
-      paste(x, suffix, sep = "")
-    } else {
-      x
-    }
-  })
-  rlang::set_names(fields, new_col_names)
-}
 
 implicit_schema <- function(.data) {
   .data <- ensure_group_vars(.data)
@@ -129,6 +114,23 @@ implicit_schema <- function(.data) {
       left_cols_ex_by <- left_cols[setdiff(names(left_cols), .data$join$by)]
       # find the common column names in left and right tables
       common_cols <- intersect(names(right_cols_ex_by), names(left_cols_ex_by))
+
+      # helper method to add suffix
+      add_suffix <- function(fields, common_cols, suffix) {
+        # helper function which adds the suffixes to the
+        # selected column names
+        # for join relation the selected columns are the
+        # columns with same name in left and right relation
+        col_names <- names(fields)
+        new_col_names <- col_names %>% map(function(x) {
+          if (is.element(x, common_cols)) {
+            paste(x, suffix, sep = "")
+          } else {
+            x
+          }
+        })
+        rlang::set_names(fields, new_col_names)
+      }
       # adding suffixes to the common columns in left and right tables
       left_fields <- add_suffix(new_fields, common_cols, .data$join$suffix[[1]])
       right_fields <- add_suffix(right_fields, common_cols, .data$join$suffix[[2]])

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -22,7 +22,7 @@ do_join <- function(x,
                     y,
                     by = NULL,
                     copy = FALSE,
-                    suffix = c(".x", ".y"),
+                    suffix = c("x.", "y."),
                     ...,
                     keep = FALSE,
                     na_matches,
@@ -38,7 +38,8 @@ do_join <- function(x,
   x$join <- list(
     type = JoinType[[join_type]],
     right_data = y,
-    by = by
+    by = by,
+    suffix = suffix
   )
   collapse.arrow_dplyr_query(x)
 }
@@ -47,7 +48,7 @@ left_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
+                                        suffix = c("x.", "y."),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_OUTER")
@@ -58,7 +59,7 @@ right_join.arrow_dplyr_query <- function(x,
                                          y,
                                          by = NULL,
                                          copy = FALSE,
-                                         suffix = c(".x", ".y"),
+                                         suffix = c("x.", "y."),
                                          ...,
                                          keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "RIGHT_OUTER")
@@ -69,7 +70,7 @@ inner_join.arrow_dplyr_query <- function(x,
                                          y,
                                          by = NULL,
                                          copy = FALSE,
-                                         suffix = c(".x", ".y"),
+                                         suffix = c("x.", "y."),
                                          ...,
                                          keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "INNER")
@@ -80,7 +81,7 @@ full_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
+                                        suffix = c("x.", "y."),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "FULL_OUTER")
@@ -91,7 +92,7 @@ semi_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
+                                        suffix = c("x.", "y."),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_SEMI")
@@ -102,7 +103,7 @@ anti_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
+                                        suffix = c("x.", "y."),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_ANTI")

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -34,7 +34,6 @@ do_join <- function(x,
   x <- as_adq(x)
   y <- as_adq(y)
   by <- handle_join_by(by, x, y)
-
   x$join <- list(
     type = JoinType[[join_type]],
     right_data = y,

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -22,7 +22,7 @@ do_join <- function(x,
                     y,
                     by = NULL,
                     copy = FALSE,
-                    suffix = c("x.", "y."),
+                    suffix = c(".x", ".y"),
                     ...,
                     keep = FALSE,
                     na_matches,
@@ -47,7 +47,7 @@ left_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c("x.", "y."),
+                                        suffix = c(".x", ".y"),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_OUTER")
@@ -58,7 +58,7 @@ right_join.arrow_dplyr_query <- function(x,
                                          y,
                                          by = NULL,
                                          copy = FALSE,
-                                         suffix = c("x.", "y."),
+                                         suffix = c(".x", ".y"),
                                          ...,
                                          keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "RIGHT_OUTER")
@@ -69,7 +69,7 @@ inner_join.arrow_dplyr_query <- function(x,
                                          y,
                                          by = NULL,
                                          copy = FALSE,
-                                         suffix = c("x.", "y."),
+                                         suffix = c(".x", ".y"),
                                          ...,
                                          keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "INNER")
@@ -80,7 +80,7 @@ full_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c("x.", "y."),
+                                        suffix = c(".x", ".y"),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "FULL_OUTER")
@@ -91,7 +91,7 @@ semi_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c("x.", "y."),
+                                        suffix = c(".x", ".y"),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_SEMI")
@@ -102,7 +102,7 @@ anti_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c("x.", "y."),
+                                        suffix = c(".x", ".y"),
                                         ...,
                                         keep = FALSE) {
   do_join(x, y, by, copy, suffix, ..., keep = keep, join_type = "LEFT_ANTI")

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -173,7 +173,9 @@ ExecPlan <- R6Class("ExecPlan",
             right_node = self$Build(.data$join$right_data),
             by = .data$join$by,
             left_output = names(.data),
-            right_output = setdiff(names(.data$join$right_data), .data$join$by)
+            right_output = setdiff(names(.data$join$right_data), .data$join$by),
+            left_prefix = .data$join$suffix[[1]],
+            right_prefix = .data$join$suffix[[2]]
           )
         }
       }
@@ -283,7 +285,7 @@ ExecNode <- R6Class("ExecNode",
         ExecNode_Aggregate(self, options, target_names, out_field_names, key_names)
       )
     },
-    Join = function(type, right_node, by, left_output, right_output) {
+    Join = function(type, right_node, by, left_output, right_output, left_prefix, right_prefix) {
       self$preserve_sort(
         ExecNode_Join(
           self,
@@ -292,7 +294,9 @@ ExecNode <- R6Class("ExecNode",
           left_keys = names(by),
           right_keys = by,
           left_output = left_output,
-          right_output = right_output
+          right_output = right_output,
+          output_prefix_for_left = left_prefix,
+          output_prefix_for_right = right_prefix
         )
       )
     }

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -16,10 +16,22 @@
 # under the License.
 
 do_exec_plan <- function(.data) {
+  print(">>>> Do Exec Plan Start")
+  print(">>>> Create Exec Plan Start")
   plan <- ExecPlan$create()
+  print(">>>> Create Exec Plan End")
+  print(">>>> Plan Build Start")
+  print("Data")
+  print(.data)
+  print("names")
+  print(names(.data))
+  print("data.selected_columns")
+  print(.data$selected_columns)
   final_node <- plan$Build(.data)
+  print(">>>> Plan Build End")
+  print(">>>> Plan Run Start")
   tab <- plan$Run(final_node)
-
+  print(">>>> Plan Run End")
   # TODO (ARROW-14289): make the head/tail methods return RBR not Table
   if (inherits(tab, "RecordBatchReader")) {
     tab <- tab$read_table()
@@ -61,8 +73,10 @@ ExecPlan <- R6Class("ExecPlan",
   inherit = ArrowObject,
   public = list(
     Scan = function(dataset) {
+      print("Scan")
       # Handle arrow_dplyr_query
       if (inherits(dataset, "arrow_dplyr_query")) {
+        print("Scan.arrow_dplyr_query")
         if (inherits(dataset$.data, "RecordBatchReader")) {
           return(ExecNode_SourceNode(self, dataset$.data))
         } else if (inherits(dataset$.data, "ArrowTabular")) {
@@ -84,6 +98,7 @@ ExecPlan <- R6Class("ExecPlan",
         dataset <- dataset$.data
         assert_is(dataset, "Dataset")
       } else {
+        print("Scan.ArrowTabular")
         if (inherits(dataset, "ArrowTabular")) {
           dataset <- InMemoryDataset$create(dataset)
         }
@@ -97,29 +112,39 @@ ExecPlan <- R6Class("ExecPlan",
       ExecNode_Scan(self, dataset, filter, colnames %||% character(0))
     },
     Build = function(.data) {
+      print("BUILD Start")
       # This method takes an arrow_dplyr_query and chains together the
       # ExecNodes that they produce. It does not evaluate them--that is Run().
       group_vars <- dplyr::group_vars(.data)
       grouped <- length(group_vars) > 0
 
       # Collect the target names first because we have to add back the group vars
+      print(".data$temp_columns")
+      print(.data$temp_columns)
+      print(".data$selected_columns")
+      print(.data$selected_columns)
       target_names <- names(.data)
       .data <- ensure_group_vars(.data)
       .data <- ensure_arrange_vars(.data) # this sets .data$temp_columns
 
       if (inherits(.data$.data, "arrow_dplyr_query")) {
         # We have a nested query. Recurse.
+        print("Nested Build Start")
         node <- self$Build(.data$.data)
+        print("Nested Build End")
       } else {
+        print("Build.scan")
         node <- self$Scan(.data)
       }
 
       # ARROW-13498: Even though Scan takes the filter, apparently we have to do it again
       if (inherits(.data$filtered_rows, "Expression")) {
+        print("Build.filter")
         node <- node$Filter(.data$filtered_rows)
       }
 
       if (!is.null(.data$aggregations)) {
+        print("Build.aggregate")
         # Project to include just the data required for each aggregation,
         # plus group_by_vars (last)
         # TODO: validate that none of names(aggregations) are the same as names(group_by_vars)
@@ -142,6 +167,7 @@ ExecPlan <- R6Class("ExecPlan",
         )
 
         if (grouped) {
+          print("Build.grouped")
           # The result will have result columns first then the grouping cols.
           # dplyr orders group cols first, so adapt the result to meet that expectation.
           node <- node$Project(
@@ -164,19 +190,42 @@ ExecPlan <- R6Class("ExecPlan",
         # __fragment_index, __batch_index, __last_in_fragment
         # Presumably extraneous repeated projection of the same thing
         # (as when we've done collapse() and not projected after) is cheap/no-op
+        print("Projection Prior to Join")
+        print("P1: > ")
+        print(.data$selected_columns)
         projection <- c(.data$selected_columns, .data$temp_columns)
         node <- node$Project(projection)
-
+        print("P2: > ")
+        print(.data$temp_columns)
+        print("Projection Done!")      
         if (!is.null(.data$join)) {
+          print("Build.join")
+          print("Build Right Node")
+          right_node =  self$Build(.data$join$right_data) 
+          print("Set Left output")
+          left_output = names(.data)
+          print(left_output)
+          print("Set Right output")
+          right_output = setdiff(names(.data$join$right_data), .data$join$by)
+          print(right_output)
+          print("Do Join")
           node <- node$Join(
             type = .data$join$type,
-            right_node = self$Build(.data$join$right_data),
+            right_node = right_node,
             by = .data$join$by,
-            left_output = names(.data),
-            right_output = setdiff(names(.data$join$right_data), .data$join$by),
+            left_output = left_output,
+            right_output = right_output ,
             left_prefix = .data$join$suffix[[1]],
             right_prefix = .data$join$suffix[[2]]
           )
+          print("Done Join")
+          print("Names")
+          print(names(node))
+          print("Attributes")
+          print(attributes(node))
+          print("node.schema")
+          print(node$schema)
+          print("data")
         }
       }
 
@@ -186,6 +235,7 @@ ExecPlan <- R6Class("ExecPlan",
       # (1) arrange > summarize > arrange
       # (2) ARROW-13779: arrange then operation where order matters (e.g. cumsum)
       if (length(.data$arrange_vars)) {
+        print("Apply Sorting")
         node$sort <- list(
           names = names(.data$arrange_vars),
           orders = .data$arrange_desc,
@@ -201,10 +251,11 @@ ExecPlan <- R6Class("ExecPlan",
       if (!is.null(.data$tail)) {
         node$tail <- .data$tail
       }
-
+      print("Build End")
       node
     },
     Run = function(node) {
+      print(">>> RUN Start >>>")
       assert_is(node, "ExecNode")
 
       # Sorting and head/tail (if sorted) are handled in the SinkNode,
@@ -242,7 +293,7 @@ ExecPlan <- R6Class("ExecPlan",
         out <- out$read_table()
         out <- out[rev(seq_len(nrow(out))), , drop = FALSE]
       }
-
+      print(">>> RUN End >>>")
       out
     },
     Stop = function() ExecPlan_StopProducing(self)
@@ -263,13 +314,19 @@ ExecNode <- R6Class("ExecNode",
     head = NULL,
     tail = NULL,
     preserve_sort = function(new_node) {
+      print("**preserve_sort**")
       new_node$sort <- self$sort
       new_node$head <- self$head
       new_node$tail <- self$tail
       new_node
     },
     Project = function(cols) {
+      print("**Project**")
       if (length(cols)) {
+        print("Length Cols")
+        print(cols)
+        print("----")
+        print(names(cols))
         assert_is_list_of(cols, "Expression")
         self$preserve_sort(ExecNode_Project(self, cols, names(cols)))
       } else {
@@ -277,15 +334,18 @@ ExecNode <- R6Class("ExecNode",
       }
     },
     Filter = function(expr) {
+      print("**Filter**")
       assert_is(expr, "Expression")
       self$preserve_sort(ExecNode_Filter(self, expr))
     },
     Aggregate = function(options, target_names, out_field_names, key_names) {
+      print("**Aggregate**")
       self$preserve_sort(
         ExecNode_Aggregate(self, options, target_names, out_field_names, key_names)
       )
     },
     Join = function(type, right_node, by, left_output, right_output, left_prefix, right_prefix) {
+      print("**Join**")
       self$preserve_sort(
         ExecNode_Join(
           self,

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -16,22 +16,22 @@
 # under the License.
 
 do_exec_plan <- function(.data) {
-  print(">>>> Do Exec Plan Start")
-  print(">>>> Create Exec Plan Start")
+  # print(">>>> Do Exec Plan Start")
+  # print(">>>> Create Exec Plan Start")
   plan <- ExecPlan$create()
-  print(">>>> Create Exec Plan End")
-  print(">>>> Plan Build Start")
-  print("Data")
-  print(.data)
-  print("names")
-  print(names(.data))
-  print("data.selected_columns")
-  print(.data$selected_columns)
+  # print(">>>> Create Exec Plan End")
+  # print(">>>> Plan Build Start")
+  # print("Data")
+  # print(.data)
+  # print("names")
+  # print(names(.data))
+  # print("data.selected_columns")
+  # print(.data$selected_columns)
   final_node <- plan$Build(.data)
-  print(">>>> Plan Build End")
-  print(">>>> Plan Run Start")
+  # print(">>>> Plan Build End")
+  # print(">>>> Plan Run Start")
   tab <- plan$Run(final_node)
-  print(">>>> Plan Run End")
+  # print(">>>> Plan Run End")
   # TODO (ARROW-14289): make the head/tail methods return RBR not Table
   if (inherits(tab, "RecordBatchReader")) {
     tab <- tab$read_table()
@@ -73,10 +73,10 @@ ExecPlan <- R6Class("ExecPlan",
   inherit = ArrowObject,
   public = list(
     Scan = function(dataset) {
-      print("Scan")
+      # print("Scan")
       # Handle arrow_dplyr_query
       if (inherits(dataset, "arrow_dplyr_query")) {
-        print("Scan.arrow_dplyr_query")
+        # print("Scan.arrow_dplyr_query")
         if (inherits(dataset$.data, "RecordBatchReader")) {
           return(ExecNode_SourceNode(self, dataset$.data))
         } else if (inherits(dataset$.data, "ArrowTabular")) {
@@ -98,7 +98,7 @@ ExecPlan <- R6Class("ExecPlan",
         dataset <- dataset$.data
         assert_is(dataset, "Dataset")
       } else {
-        print("Scan.ArrowTabular")
+        # print("Scan.ArrowTabular")
         if (inherits(dataset, "ArrowTabular")) {
           dataset <- InMemoryDataset$create(dataset)
         }
@@ -112,39 +112,39 @@ ExecPlan <- R6Class("ExecPlan",
       ExecNode_Scan(self, dataset, filter, colnames %||% character(0))
     },
     Build = function(.data) {
-      print("BUILD Start")
+      # print("BUILD Start")
       # This method takes an arrow_dplyr_query and chains together the
       # ExecNodes that they produce. It does not evaluate them--that is Run().
       group_vars <- dplyr::group_vars(.data)
       grouped <- length(group_vars) > 0
 
       # Collect the target names first because we have to add back the group vars
-      print(".data$temp_columns")
-      print(.data$temp_columns)
-      print(".data$selected_columns")
-      print(.data$selected_columns)
+      # print(".data$temp_columns")
+      # print(.data$temp_columns)
+      # print(".data$selected_columns")
+      # print(.data$selected_columns)
       target_names <- names(.data)
       .data <- ensure_group_vars(.data)
       .data <- ensure_arrange_vars(.data) # this sets .data$temp_columns
 
       if (inherits(.data$.data, "arrow_dplyr_query")) {
         # We have a nested query. Recurse.
-        print("Nested Build Start")
+        # print("Nested Build Start")
         node <- self$Build(.data$.data)
-        print("Nested Build End")
+        # print("Nested Build End")
       } else {
-        print("Build.scan")
+        # print("Build.scan")
         node <- self$Scan(.data)
       }
 
       # ARROW-13498: Even though Scan takes the filter, apparently we have to do it again
       if (inherits(.data$filtered_rows, "Expression")) {
-        print("Build.filter")
+        # print("Build.filter")
         node <- node$Filter(.data$filtered_rows)
       }
 
       if (!is.null(.data$aggregations)) {
-        print("Build.aggregate")
+        # print("Build.aggregate")
         # Project to include just the data required for each aggregation,
         # plus group_by_vars (last)
         # TODO: validate that none of names(aggregations) are the same as names(group_by_vars)
@@ -167,7 +167,7 @@ ExecPlan <- R6Class("ExecPlan",
         )
 
         if (grouped) {
-          print("Build.grouped")
+          # print("Build.grouped")
           # The result will have result columns first then the grouping cols.
           # dplyr orders group cols first, so adapt the result to meet that expectation.
           node <- node$Project(
@@ -190,25 +190,25 @@ ExecPlan <- R6Class("ExecPlan",
         # __fragment_index, __batch_index, __last_in_fragment
         # Presumably extraneous repeated projection of the same thing
         # (as when we've done collapse() and not projected after) is cheap/no-op
-        print("Projection Prior to Join")
-        print("P1: > ")
-        print(.data$selected_columns)
+        # print("Projection Prior to Join")
+        # print("P1: > ")
+        # print(.data$selected_columns)
         projection <- c(.data$selected_columns, .data$temp_columns)
         node <- node$Project(projection)
-        print("P2: > ")
-        print(.data$temp_columns)
-        print("Projection Done!")      
+        # print("P2: > ")
+        # print(.data$temp_columns)
+        # print("Projection Done!")      
         if (!is.null(.data$join)) {
-          print("Build.join")
-          print("Build Right Node")
+          # print("Build.join")
+          # print("Build Right Node")
           right_node =  self$Build(.data$join$right_data) 
-          print("Set Left output")
+          # print("Set Left output")
           left_output = names(.data)
-          print(left_output)
-          print("Set Right output")
+          # print(left_output)
+          # print("Set Right output")
           right_output = setdiff(names(.data$join$right_data), .data$join$by)
-          print(right_output)
-          print("Do Join")
+          # print(right_output)
+          # print("Do Join")
           node <- node$Join(
             type = .data$join$type,
             right_node = right_node,
@@ -218,14 +218,14 @@ ExecPlan <- R6Class("ExecPlan",
             left_prefix = .data$join$suffix[[1]],
             right_prefix = .data$join$suffix[[2]]
           )
-          print("Done Join")
-          print("Names")
-          print(names(node))
-          print("Attributes")
-          print(attributes(node))
-          print("node.schema")
-          print(node$schema)
-          print("data")
+          # print("Done Join")
+          # print("Names")
+          # print(names(node))
+          # print("Attributes")
+          # print(attributes(node))
+          # print("node.schema")
+          # print(node$schema)
+          # print("data")
         }
       }
 
@@ -235,7 +235,7 @@ ExecPlan <- R6Class("ExecPlan",
       # (1) arrange > summarize > arrange
       # (2) ARROW-13779: arrange then operation where order matters (e.g. cumsum)
       if (length(.data$arrange_vars)) {
-        print("Apply Sorting")
+        # print("Apply Sorting")
         node$sort <- list(
           names = names(.data$arrange_vars),
           orders = .data$arrange_desc,
@@ -251,11 +251,11 @@ ExecPlan <- R6Class("ExecPlan",
       if (!is.null(.data$tail)) {
         node$tail <- .data$tail
       }
-      print("Build End")
+      # print("Build End")
       node
     },
     Run = function(node) {
-      print(">>> RUN Start >>>")
+      # print(">>> RUN Start >>>")
       assert_is(node, "ExecNode")
 
       # Sorting and head/tail (if sorted) are handled in the SinkNode,
@@ -293,7 +293,7 @@ ExecPlan <- R6Class("ExecPlan",
         out <- out$read_table()
         out <- out[rev(seq_len(nrow(out))), , drop = FALSE]
       }
-      print(">>> RUN End >>>")
+      # print(">>> RUN End >>>")
       out
     },
     Stop = function() ExecPlan_StopProducing(self)
@@ -314,19 +314,19 @@ ExecNode <- R6Class("ExecNode",
     head = NULL,
     tail = NULL,
     preserve_sort = function(new_node) {
-      print("**preserve_sort**")
+      # print("**preserve_sort**")
       new_node$sort <- self$sort
       new_node$head <- self$head
       new_node$tail <- self$tail
       new_node
     },
     Project = function(cols) {
-      print("**Project**")
+      # print("**Project**")
       if (length(cols)) {
-        print("Length Cols")
-        print(cols)
-        print("----")
-        print(names(cols))
+        # print("Length Cols")
+        # print(cols)
+        # print("----")
+        # print(names(cols))
         assert_is_list_of(cols, "Expression")
         self$preserve_sort(ExecNode_Project(self, cols, names(cols)))
       } else {
@@ -334,18 +334,18 @@ ExecNode <- R6Class("ExecNode",
       }
     },
     Filter = function(expr) {
-      print("**Filter**")
+      # print("**Filter**")
       assert_is(expr, "Expression")
       self$preserve_sort(ExecNode_Filter(self, expr))
     },
     Aggregate = function(options, target_names, out_field_names, key_names) {
-      print("**Aggregate**")
+      # print("**Aggregate**")
       self$preserve_sort(
         ExecNode_Aggregate(self, options, target_names, out_field_names, key_names)
       )
     },
     Join = function(type, right_node, by, left_output, right_output, left_prefix, right_prefix) {
-      print("**Join**")
+      # print("**Join**")
       self$preserve_sort(
         ExecNode_Join(
           self,

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -175,8 +175,8 @@ ExecPlan <- R6Class("ExecPlan",
             by = .data$join$by,
             left_output = left_output,
             right_output = right_output,
-            left_prefix = .data$join$suffix[[1]],
-            right_prefix = .data$join$suffix[[2]]
+            left_suffix = .data$join$suffix[[1]],
+            right_suffix = .data$join$suffix[[2]]
           )
         }
       }
@@ -284,7 +284,7 @@ ExecNode <- R6Class("ExecNode",
         ExecNode_Aggregate(self, options, target_names, out_field_names, key_names)
       )
     },
-    Join = function(type, right_node, by, left_output, right_output, left_prefix, right_prefix) {
+    Join = function(type, right_node, by, left_output, right_output, left_suffix, right_suffix) {
       self$preserve_sort(
         ExecNode_Join(
           self,
@@ -294,8 +294,8 @@ ExecNode <- R6Class("ExecNode",
           right_keys = by,
           left_output = left_output,
           right_output = right_output,
-          output_prefix_for_left = left_prefix,
-          output_prefix_for_right = right_prefix
+          output_suffix_for_left = left_suffix,
+          output_suffix_for_right = right_suffix
         )
       )
     }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1706,13 +1706,13 @@ BEGIN_CPP11
 	arrow::r::Input<std::vector<std::string>>::type right_keys(right_keys_sexp);
 	arrow::r::Input<std::vector<std::string>>::type left_output(left_output_sexp);
 	arrow::r::Input<std::vector<std::string>>::type right_output(right_output_sexp);
-	arrow::r::Input<std::string>::type output_prefix_for_left(output_prefix_for_left_sexp);
-	arrow::r::Input<std::string>::type output_prefix_for_right(output_prefix_for_right_sexp);
-	return cpp11::as_sexp(ExecNode_Join(input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right));
+	arrow::r::Input<std::string>::type output_suffix_for_left(output_suffix_for_left_sexp);
+	arrow::r::Input<std::string>::type output_suffix_for_right(output_suffix_for_right_sexp);
+	return cpp11::as_sexp(ExecNode_Join(input, type, right_data, left_keys, right_keys, left_output, right_output, output_suffix_for_left, output_suffix_for_right));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp, SEXP output_prefix_for_left_sexp, SEXP output_prefix_for_right_sexp){
+extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp, SEXP output_suffix_for_left_sexp, SEXP output_suffix_for_right_sexp){
 	Rf_error("Cannot call ExecNode_Join(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1696,8 +1696,8 @@ extern "C" SEXP _arrow_ExecNode_Aggregate(SEXP input_sexp, SEXP options_sexp, SE
 
 // compute-exec.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<compute::ExecNode> ExecNode_Join(const std::shared_ptr<compute::ExecNode>& input, int type, const std::shared_ptr<compute::ExecNode>& right_data, std::vector<std::string> left_keys, std::vector<std::string> right_keys, std::vector<std::string> left_output, std::vector<std::string> right_output);
-extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp){
+std::shared_ptr<compute::ExecNode> ExecNode_Join(const std::shared_ptr<compute::ExecNode>& input, int type, const std::shared_ptr<compute::ExecNode>& right_data, std::vector<std::string> left_keys, std::vector<std::string> right_keys, std::vector<std::string> left_output, std::vector<std::string> right_output, std::string output_suffix_for_left, std::string output_suffix_for_right);
+ extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp, SEXP output_suffix_for_left_sexp, SEXP output_suffix_for_right_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::ExecNode>&>::type input(input_sexp);
 	arrow::r::Input<int>::type type(type_sexp);
@@ -7749,11 +7749,9 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ExecNode_Filter", (DL_FUNC) &_arrow_ExecNode_Filter, 2}, 
 		{ "_arrow_ExecNode_Project", (DL_FUNC) &_arrow_ExecNode_Project, 3}, 
 		{ "_arrow_ExecNode_Aggregate", (DL_FUNC) &_arrow_ExecNode_Aggregate, 5}, 
-		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 7}, 
+		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 9}, 
 		{ "_arrow_ExecNode_SourceNode", (DL_FUNC) &_arrow_ExecNode_SourceNode, 2}, 
 		{ "_arrow_ExecNode_TableSourceNode", (DL_FUNC) &_arrow_ExecNode_TableSourceNode, 2}, 
-		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 9}, 
-		{ "_arrow_ExecNode_ReadFromRecordBatchReader", (DL_FUNC) &_arrow_ExecNode_ReadFromRecordBatchReader, 2}, 
 		{ "_arrow_RecordBatch__cast", (DL_FUNC) &_arrow_RecordBatch__cast, 3}, 
 		{ "_arrow_Table__cast", (DL_FUNC) &_arrow_Table__cast, 3}, 
 		{ "_arrow_compute__CallFunction", (DL_FUNC) &_arrow_compute__CallFunction, 3}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1706,11 +1706,13 @@ BEGIN_CPP11
 	arrow::r::Input<std::vector<std::string>>::type right_keys(right_keys_sexp);
 	arrow::r::Input<std::vector<std::string>>::type left_output(left_output_sexp);
 	arrow::r::Input<std::vector<std::string>>::type right_output(right_output_sexp);
-	return cpp11::as_sexp(ExecNode_Join(input, type, right_data, left_keys, right_keys, left_output, right_output));
+	arrow::r::Input<std::string>::type output_prefix_for_left(output_prefix_for_left_sexp);
+	arrow::r::Input<std::string>::type output_prefix_for_right(output_prefix_for_right_sexp);
+	return cpp11::as_sexp(ExecNode_Join(input, type, right_data, left_keys, right_keys, left_output, right_output, output_prefix_for_left, output_prefix_for_right));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp){
+extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp, SEXP output_prefix_for_left_sexp, SEXP output_prefix_for_right_sexp){
 	Rf_error("Cannot call ExecNode_Join(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -7750,6 +7752,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 7}, 
 		{ "_arrow_ExecNode_SourceNode", (DL_FUNC) &_arrow_ExecNode_SourceNode, 2}, 
 		{ "_arrow_ExecNode_TableSourceNode", (DL_FUNC) &_arrow_ExecNode_TableSourceNode, 2}, 
+		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 9}, 
+		{ "_arrow_ExecNode_ReadFromRecordBatchReader", (DL_FUNC) &_arrow_ExecNode_ReadFromRecordBatchReader, 2}, 
 		{ "_arrow_RecordBatch__cast", (DL_FUNC) &_arrow_RecordBatch__cast, 3}, 
 		{ "_arrow_Table__cast", (DL_FUNC) &_arrow_Table__cast, 3}, 
 		{ "_arrow_compute__CallFunction", (DL_FUNC) &_arrow_compute__CallFunction, 3}, 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -217,7 +217,8 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
     const std::shared_ptr<compute::ExecNode>& input, int type,
     const std::shared_ptr<compute::ExecNode>& right_data,
     std::vector<std::string> left_keys, std::vector<std::string> right_keys,
-    std::vector<std::string> left_output, std::vector<std::string> right_output) {
+    std::vector<std::string> left_output, std::vector<std::string> right_output,
+    std::string output_prefix_for_left, std::string output_prefix_for_right) {
   std::vector<arrow::FieldRef> left_refs, right_refs, left_out_refs, right_out_refs;
   for (auto&& name : left_keys) {
     left_refs.emplace_back(std::move(name));
@@ -262,7 +263,8 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
   return MakeExecNodeOrStop(
       "hashjoin", input->plan(), {input.get(), right_data.get()},
       compute::HashJoinNodeOptions{join_type, std::move(left_refs), std::move(right_refs),
-                                   std::move(left_out_refs), std::move(right_out_refs)});
+                                   std::move(left_out_refs), std::move(right_out_refs),
+                                   std::move(output_prefix_for_left), std::move(output_prefix_for_right)});
 }
 
 // [[arrow::export]]

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -264,6 +264,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
       "hashjoin", input->plan(), {input.get(), right_data.get()},
       compute::HashJoinNodeOptions{join_type, std::move(left_refs), std::move(right_refs),
                                    std::move(left_out_refs), std::move(right_out_refs),
+                                   compute::literal(true),
                                    std::move(output_prefix_for_left), std::move(output_prefix_for_right)});
 }
 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -218,7 +218,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
     const std::shared_ptr<compute::ExecNode>& right_data,
     std::vector<std::string> left_keys, std::vector<std::string> right_keys,
     std::vector<std::string> left_output, std::vector<std::string> right_output,
-    std::string output_prefix_for_left, std::string output_prefix_for_right) {
+    std::string output_suffix_for_left, std::string output_suffix_for_right) {
   std::vector<arrow::FieldRef> left_refs, right_refs, left_out_refs, right_out_refs;
   for (auto&& name : left_keys) {
     left_refs.emplace_back(std::move(name));
@@ -265,7 +265,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
       compute::HashJoinNodeOptions{
           join_type, std::move(left_refs), std::move(right_refs),
           std::move(left_out_refs), std::move(right_out_refs), compute::literal(true),
-          std::move(output_prefix_for_left), std::move(output_prefix_for_right)});
+          std::move(output_suffix_for_left), std::move(output_suffix_for_right)});
 }
 
 // [[arrow::export]]

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -262,10 +262,10 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
 
   return MakeExecNodeOrStop(
       "hashjoin", input->plan(), {input.get(), right_data.get()},
-      compute::HashJoinNodeOptions{join_type, std::move(left_refs), std::move(right_refs),
-                                   std::move(left_out_refs), std::move(right_out_refs),
-                                   compute::literal(true),
-                                   std::move(output_prefix_for_left), std::move(output_prefix_for_right)});
+      compute::HashJoinNodeOptions{
+          join_type, std::move(left_refs), std::move(right_refs),
+          std::move(left_out_refs), std::move(right_out_refs), compute::literal(true),
+          std::move(output_prefix_for_left), std::move(output_prefix_for_right)});
 }
 
 // [[arrow::export]]

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -245,6 +245,22 @@ test_that("arrow dplyr query correctly filters then joins", {
       dos = 1:2,
       three = c(NA, FALSE)
     )
+})
+
+
+test_that("self join", {
+  out <- Table$create(left) %>%
+    left_join(Table$create(left[4:8]), by = "some_grouping") %>%
+    collect()
+
+  expect_equal(
+    out,
+    left %>%
+      left_join(left[4:8], by = "some_grouping") %>%
+      rename_with(.fn = function(x) {
+        x <- gsub("(.*)\\.x", "x.\\1", x)
+        x <- gsub("(.*)\\.y", "y.\\1", x)
+      })
   )
 })
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -139,8 +139,8 @@ test_that("Error handling", {
   )
 })
 
-# TODO: test duplicate col names
-# TODO: casting: int and float columns?
+# # TODO: test duplicate col names
+# # TODO: casting: int and float columns?
 
 test_that("right_join", {
   compare_dplyr_binding(
@@ -247,17 +247,24 @@ test_that("arrow dplyr query correctly filters then joins", {
   )
 })
 
+test_that("suffix", {
+  left_suf <- Table$create(
+    key = c(1, 2),
+    left_unique = c(2.1, 3.1),
+    shared = c(10.1, 10.3)
+  )
 
-test_that("self join", {
-  out <- Table$create(left) %>%
-    left_join(Table$create(left[4:8]), by = "some_grouping") %>%
-    collect()
+  right_suf <- Table$create(
+    key = c(1, 2, 3, 10, 20),
+    right_unique = c(1.1, 1.2, 3.1, 4.1, 4.3),
+    shared = c(20.1, 30, 40, 50, 60)
+  )
 
-  expect_equal(
-    out,
-    left %>%
-      left_join(left[4:8], by = "some_grouping")
-    )
+  join_op <- inner_join(left_suf, right_suf, by = "key", suffix = c("_left", "_right"))
+  output <- collect(join_op)
+  res_col_names <- names(output)
+  expected_col_names <- c("key", "left_unique", "shared_left", "right_unique", "shared_right")
+  expect_equal(expected_col_names, res_col_names)
 })
 
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -28,7 +28,6 @@ to_join <- tibble::tibble(
   another_column = TRUE
 )
 
-
 test_that("left_join", {
   expect_message(
     compare_dplyr_binding(
@@ -245,6 +244,7 @@ test_that("arrow dplyr query correctly filters then joins", {
       dos = 1:2,
       three = c(NA, FALSE)
     )
+  )
 })
 
 
@@ -256,12 +256,8 @@ test_that("self join", {
   expect_equal(
     out,
     left %>%
-      left_join(left[4:8], by = "some_grouping") %>%
-      rename_with(.fn = function(x) {
-        x <- gsub("(.*)\\.x", "x.\\1", x)
-        x <- gsub("(.*)\\.y", "y.\\1", x)
-      })
-  )
+      left_join(left[4:8], by = "some_grouping")
+    )
 })
 
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -139,8 +139,8 @@ test_that("Error handling", {
   )
 })
 
-# # TODO: test duplicate col names
-# # TODO: casting: int and float columns?
+# TODO: test duplicate col names
+# TODO: casting: int and float columns?
 
 test_that("right_join", {
   compare_dplyr_binding(


### PR DESCRIPTION
ARROW-14679 [R] [C++] Handle suffix argument in joins

This PR is introducing suffix-aware joins for R API. 

TODO:

- [x] refactor prefix to suffix (this was the old wording used since Arrow supported prefixes before merging ARROW-15212)