### PR TITLE
ARROW-15295: [R] Add 6.0.0 to our old versions to check

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -64,6 +64,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
+        - { old_arrow_version: '6.0.0', r: '4.1' }
         - { old_arrow_version: '5.0.0', r: '4.1' }
         - { old_arrow_version: '4.0.0', r: '4.0' }
         - { old_arrow_version: '3.0.0', r: '4.0' }

--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -64,7 +64,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
-        - { old_arrow_version: '6.0.0', r: '4.1' }
+        - { old_arrow_version: '6.0.1', r: '4.1' }
         - { old_arrow_version: '5.0.0', r: '4.1' }
         - { old_arrow_version: '4.0.0', r: '4.0' }
         - { old_arrow_version: '3.0.0', r: '4.0' }


### PR DESCRIPTION
Adds 6.0.0 (which should have been done just after the last release) to our backwards compatibility matrix