### PR TITLE
ARROW-15306: [C++] S3FileSystem Should set the content-type header to application/octet-stream if not specified

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1161,6 +1161,13 @@ class ObjectOutputStream final : public io::OutputStream {
       RETURN_NOT_OK(SetObjectMetadata(default_metadata_, &req));
     }
 
+    // If we do not set anything then the SDK will default to application/xml
+    // which confuses some tools (https://github.com/apache/arrow/issues/11934)
+    // So we instead default to application/octet-stream which is less misleading
+    if (!req.ContentTypeHasBeenSet()) {
+      req.SetContentType("application/octet-stream");
+    }
+
     auto outcome = client_->CreateMultipartUpload(req);
     if (!outcome.IsSuccess()) {
       return ErrorToStatus(

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1033,6 +1033,14 @@ TEST_F(TestS3FS, OpenOutputStreamDestructorSyncWrite) {
 TEST_F(TestS3FS, OpenOutputStreamMetadata) {
   std::shared_ptr<io::OutputStream> stream;
 
+  // Create new file with no explicit or default metadata
+  // The Content-Type will still be set
+  auto empty_metadata = KeyValueMetadata::Make({}, {});
+  auto implicit_metadata =
+      KeyValueMetadata::Make({"Content-Type"}, {"application/octet-stream"});
+  AssertMetadataRoundtrip("bucket/mdfile0", empty_metadata,
+                          testing::IsSupersetOf(implicit_metadata->sorted_pairs()));
+
   // Create new file with explicit metadata
   auto metadata = KeyValueMetadata::Make({"Content-Type", "Expires"},
                                          {"x-arrow/test6", "2016-02-05T20:08:35Z"});


### PR DESCRIPTION
This changes the S3 filesystem so that newly created files (with no content-type specified) are given a content-type of application/octet-stream instead of application/xml.  See https://issues.apache.org/jira/browse/ARROW-15306 for more details.