### PR TITLE
ARROW-15200: [C++][Gandiva] Enable RTTI when building LLVM dependency using vcpkg

### DIFF
--- a/ci/docker/java-jni-manylinux-201x.dockerfile
+++ b/ci/docker/java-jni-manylinux-201x.dockerfile
@@ -30,7 +30,8 @@ RUN vcpkg install --clean-after-build \
         boost-regex \
         boost-system \
         boost-variant \
-        llvm
+        # Use enable rtti to avoid link problems in Gandiva
+        llvm[clang,default-options,default-targets,lld,tools,enable-rtti]
 
 # Install Java
 ARG java=1.8.0

--- a/dev/tasks/java-jars/README.md
+++ b/dev/tasks/java-jars/README.md
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Jars.
+# Java Jars Task
 
 This directory is responsible to generate the jar files for the Arrow components that depend on C++ shared libraries to execute.
 


### PR DESCRIPTION
When generating Gandiva's jar file it is possible that an error of UnsatisfiedLinkError may occur based on an LLVM's symbol being used, more specific the llvm::ObjectCache.

To fix that problem, it is necessary to compile the LLVM dependency with RTTI enabled when generating the jars in the nightly build.