### PR TITLE
ARROW-15324: [C++] Avoid crashing when HDFS file fails closing

### DIFF
--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -244,7 +244,7 @@ HdfsReadableFile::HdfsReadableFile(const io::IOContext& io_context) {
   impl_.reset(new HdfsReadableFileImpl(io_context.pool()));
 }
 
-HdfsReadableFile::~HdfsReadableFile() { DCHECK_OK(impl_->Close()); }
+HdfsReadableFile::~HdfsReadableFile() { ARROW_WARN_NOT_OK(impl_->Close()); }
 
 Status HdfsReadableFile::Close() { return impl_->Close(); }
 
@@ -330,7 +330,7 @@ class HdfsOutputStream::HdfsOutputStreamImpl : public HdfsAnyFileImpl {
 
 HdfsOutputStream::HdfsOutputStream() { impl_.reset(new HdfsOutputStreamImpl()); }
 
-HdfsOutputStream::~HdfsOutputStream() { DCHECK_OK(impl_->Close()); }
+HdfsOutputStream::~HdfsOutputStream() { ARROW_WARN_NOT_OK(impl_->Close()); }
 
 Status HdfsOutputStream::Close() { return impl_->Close(); }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1648,6 +1648,9 @@ services:
       - impala:impala
     environment:
       <<: *ccache
+      ARROW_ENGINE: "OFF"
+      ARROW_FLIGHT: "OFF"
+      ARROW_FLIGHT_SQL: "OFF"
       ARROW_HDFS: "ON"
       ARROW_HDFS_TEST_HOST: impala
       ARROW_HDFS_TEST_PORT: 8020


### PR DESCRIPTION
When a HDFS file destructor fails closing the underlying file, warn about the error instead of crashing.