### PR TITLE
ARROW-15326: [C++] Fix Gandiva crashes

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -1062,7 +1062,7 @@ const char* gdv_mask_last_n_utf8_int32(int64_t context, const char* data,
   utf8proc_int32_t utf8_char_buffer;
   int num_of_chars = static_cast<int>(
       utf8proc_decompose(reinterpret_cast<const utf8proc_uint8_t*>(data), data_len,
-                         &utf8_char_buffer, 4, UTF8PROC_STABLE));
+                         &utf8_char_buffer, 1, UTF8PROC_STABLE));
 
   if (num_of_chars < 0) {
     gdv_fn_context_set_error_msg(context, utf8proc_errmsg(num_of_chars));

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1722,8 +1722,8 @@ gdv_int32 levenshtein(int64_t context, const char* in1, int32_t in1_len, const c
     arr_smaller = in2;
   }
 
-  int* ptr =
-      reinterpret_cast<int*>(gdv_fn_context_arena_malloc(context, (len_smaller + 1) * 2));
+  int* ptr = reinterpret_cast<int*>(
+      gdv_fn_context_arena_malloc(context, (len_smaller + 1) * 2 * sizeof(int)));
   if (ptr == nullptr) {
     gdv_fn_context_set_error_msg(context, "String length must be greater than 0");
     return 0;


### PR DESCRIPTION
- Stack smashing crash because of excessive size given to utf8proc.
- Heap access crash because of insufficient scratch space in levenshtein calculation.