### PR TITLE
ARROW-15318: [C++][Python] Regression reading partition keys of large batches.

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -612,7 +612,8 @@ Status TableBatchReader::ReadNext(std::shared_ptr<RecordBatch>* out) {
   }
 
   // Determine the minimum contiguous slice across all columns
-  int64_t chunksize = std::min(table_.num_rows(), max_chunksize_);
+  int64_t chunksize =
+      std::min(table_.num_rows() - absolute_row_position_, max_chunksize_);
   std::vector<const Array*> chunks(table_.num_columns());
   for (int i = 0; i < table_.num_columns(); ++i) {
     auto chunk = column_data_[i]->chunk(chunk_numbers_[i]).get();

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -770,4 +770,23 @@ TEST_F(TestTableBatchReader, Chunksize) {
   ASSERT_EQ(nullptr, batch);
 }
 
+TEST_F(TestTableBatchReader, NoColumns) {
+  std::shared_ptr<Table> table =
+      Table::Make(schema({}), std::vector<std::shared_ptr<Array>>{}, 100);
+  TableBatchReader reader(*table);
+  reader.set_chunksize(60);
+
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_OK(batch->ValidateFull());
+  ASSERT_EQ(60, batch->num_rows());
+
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_OK(batch->ValidateFull());
+  ASSERT_EQ(40, batch->num_rows());
+
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_EQ(nullptr, batch);
+}
+
 }  // namespace arrow

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1697,6 +1697,31 @@ def test_dictionary_partitioning_outer_nulls_raises(tempdir):
         ds.write_dataset(table, tempdir, format='ipc', partitioning=part)
 
 
+@pytest.mark.parquet
+def test_read_partition_keys_only(tempdir):
+    # This is a regression test for ARROW-15318 which saw issues
+    # reading only the partition keys from files with batches larger
+    # than the default batch size (e.g. so we need to return two chunks)
+    table = pa.table({
+        'key': pa.repeat(0, 2 ** 20 + 1),
+        'value': np.arange(2 ** 20 + 1)})
+    pq.write_to_dataset(
+        table[:2 ** 20],
+        tempdir / 'one', partition_cols=['key'])
+    pq.write_to_dataset(
+        table[:2 ** 20 + 1],
+        tempdir / 'two', partition_cols=['key'])
+
+    table = pq.read_table(tempdir / 'one', columns=['key'])
+    assert table['key'].num_chunks == 1
+
+    table = pq.read_table(tempdir / 'two', columns=['key', 'value'])
+    assert table['key'].num_chunks == 2
+
+    table = pq.read_table(tempdir / 'two', columns=['key'])
+    assert table['key'].num_chunks == 2
+
+
 def _has_subdirs(basedir):
     elements = os.listdir(basedir)
     return any([os.path.isdir(os.path.join(basedir, el)) for el in elements])

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1698,6 +1698,7 @@ def test_dictionary_partitioning_outer_nulls_raises(tempdir):
 
 
 @pytest.mark.parquet
+@pytest.mark.pandas
 def test_read_partition_keys_only(tempdir):
     # This is a regression test for ARROW-15318 which saw issues
     # reading only the partition keys from files with batches larger


### PR DESCRIPTION
Since only partition keys were selected we ended up reading 0 columns from the parquet file (we still need to do this so we can determine the row group sizes to accurately reflect the files, or at least we would still need to determine the total number of rows in each file).

We recently added behavior to the parquet reader to respect a batch size parameter.  So if the row group is larger than the batch size we chop the table up into smaller batches using a TableBatchReader with a max chunksize.  There was a bug in the TableBatchReader so that if there were no columns and the max chunksize was smaller than the size of the table (and not evenly divisible into the table size) then we would hit an infinite loop.