### PR TITLE
ARROW-15335: [Java] Fix setPosition call in UnionListReader for empty List

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionListReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionListReader.java
@@ -56,8 +56,13 @@ public class UnionListReader extends AbstractFieldReader {
   @Override
   public void setPosition(int index) {
     super.setPosition(index);
-    currentOffset = vector.getOffsetBuffer().getInt(index * OFFSET_WIDTH) - 1;
-    maxOffset = vector.getOffsetBuffer().getInt((index + 1) * OFFSET_WIDTH);
+    if (vector.getOffsetBuffer().capacity() == 0) {
+      currentOffset = 0;
+      maxOffset = 0;
+    } else {
+      currentOffset = vector.getOffsetBuffer().getInt(index * OFFSET_WIDTH) - 1;
+      maxOffset = vector.getOffsetBuffer().getInt((index + 1) * OFFSET_WIDTH);
+    }
   }
 
   @Override


### PR DESCRIPTION
UnionListReader#setPosition can be called on an empty list from SingleStructReaderImpl when calling the reader on an empty struct of list vector. This results in calling getInt() on an emptyOffsetBuffer.