### PR TITLE
ARROW-15338: [Python] Add `pyarrow.orc.read_table` API

### DIFF
--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -180,14 +180,14 @@ def write_table(table, where):
 
 def read_table(source, columns=None, filesystem=None):
     """
-    Read a table from ORC format
+    Read a Table from an ORC file.
 
     Parameters
     ----------
     source : str, pyarrow.NativeFile, or file-like object
-        If a string passed, can be a single file name or directory name. For
-        file-like objects, only read a single file. Use pyarrow.BufferReader to
-        read a file contained in a bytes or buffer-like object.
+        If a string passed, can be a single file name. For file-like objects,
+        only read a single file. Use pyarrow.BufferReader to read a file
+        contained in a bytes or buffer-like object.
     columns : list
         If not None, only these columns will be read from the file. A column
         name may be a prefix of a nested field, e.g. 'a' will select 'a.b',
@@ -203,6 +203,9 @@ def read_table(source, columns=None, filesystem=None):
     if filesystem is not None:
         source = filesystem.open_input_file(path)
 
-    dataset = ORCFile(source)
+    if columns is not None and len(columns) == 0:
+        result = ORCFile(source).read().select(columns)
+    else:
+        result = ORCFile(source).read(columns=columns)
 
-    return dataset.read(columns=columns)
+    return result

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -21,6 +21,7 @@ import warnings
 
 from pyarrow.lib import Table
 import pyarrow._orc as _orc
+from pyarrow.fs import _resolve_filesystem_and_path
 
 
 class ORCFile:
@@ -175,3 +176,33 @@ def write_table(table, where):
     writer = ORCWriter(where)
     writer.write(table)
     writer.close()
+
+
+def read_table(source, columns=None, filesystem=None):
+    """
+    Read a table from ORC format
+
+    Parameters
+    ----------
+    source : str, pyarrow.NativeFile, or file-like object
+        If a string passed, can be a single file name or directory name. For
+        file-like objects, only read a single file. Use pyarrow.BufferReader to
+        read a file contained in a bytes or buffer-like object.
+    columns : list
+        If not None, only these columns will be read from the file. A column
+        name may be a prefix of a nested field, e.g. 'a' will select 'a.b',
+        'a.c', and 'a.d.e'. If empty, no columns will be read. Note
+        that the table will still have the correct num_rows set despite having
+        no columns.
+    filesystem : FileSystem, default None
+        If nothing passed, paths assumed to be found in the local on-disk
+        filesystem.
+    """
+
+    filesystem, path = _resolve_filesystem_and_path(source, filesystem)
+    if filesystem is not None:
+        source = filesystem.open_input_file(path)
+
+    dataset = ORCFile(source)
+
+    return dataset.read(columns=columns)

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -181,6 +181,14 @@ def test_readwrite(tmpdir):
     output_table = orc.read_table(file)
     assert table.equals(output_table)
 
+    output_table = orc.read_table(file, [])
+    assert 4 == output_table.num_rows
+    assert 0 == output_table.num_columns
+
+    output_table = orc.read_table(file, columns=["int64"])
+    assert 4 == output_table.num_rows
+    assert 1 == output_table.num_columns
+
 
 def test_filesystem_uri(tmpdir):
     from pyarrow import orc

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -170,6 +170,7 @@ def test_orcfile_empty(datadir):
     ])
     assert table.schema == expected_schema
 
+
 def test_readwrite(tmpdir):
     from pyarrow import orc
     a = pa.array([1, None, 3, None])
@@ -179,6 +180,7 @@ def test_readwrite(tmpdir):
     orc.write_table(table, file)
     output_table = orc.read_table(file)
     assert table.equals(output_table)
+
 
 def test_filesystem_uri(tmpdir):
     from pyarrow import orc
@@ -197,6 +199,7 @@ def test_filesystem_uri(tmpdir):
     result = orc.read_table(
         "data_dir/data.orc", filesystem=util._filesystem_uri(tmpdir))
     assert result.equals(table)
+
 
 def test_orcfile_readwrite():
     from pyarrow import orc


### PR DESCRIPTION
This PR aims to add `pyarrow.orc.read_table` like `pyarrow.parquet.read_table`.

https://github.com/apache/arrow/blob/99f7c3cf3e6c2a9555ceff3d48ef73e485ede546/python/pyarrow/parquet.py#L1943