### PR TITLE
ARROW-12590: [C++][R] Update copies of Homebrew files to reflect recent updates [WIP]

### DIFF
--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://github.com/autobrew/homebrew-cran/blob/master/Formula/apache-arrow.rb
+class ApacheArrowStatic < Formula
+  desc "Columnar in-memory analytics layer designed to accelerate big data"
+  homepage "https://arrow.apache.org/"
+  url "https://downloads.apache.org/arrow/arrow-6.0.1/apache-arrow-6.0.1.tar.gz"
+  # Uncomment and update to test on a release candidate
+  mirror "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-6.0.1-rc1/apache-arrow-6.0.1.tar.gz"
+  sha256 "3786b3d2df954d078b3e68f98d2e5aecbaa3fa2accf075d7a3a13c187b9c5294"
+  head "https://github.com/apache/arrow.git"
+
+  bottle do
+    root_url "https://github.com/autobrew/homebrew-cran/releases/download/apache-arrow-static-6.0.1"
+    sha256 cellar: :any, arm64_big_sur: "c6a7a85eb0747ddfe1eb389e9234a9658ae8dbed948f3d2a08ae0dd3061d4a5c"
+    sha256 cellar: :any, big_sur:       "767142d88b6be9a36de8d1c5f6f3b64f22284c4bc3c22c9916a65a0b016fd286"
+    sha256 cellar: :any, catalina:      "2579168ae3c3266091b8801477fa30355e9095724c9600b72d321fe7b831701f"
+  end
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "aws-sdk-cpp-static"
+  depends_on "lz4"
+  depends_on "snappy"
+  depends_on "thrift"
+  depends_on "zstd"
+
+  conflicts_with "apache-arrow", because: "both install Arrow"
+
+  def install
+    ENV.cxx11
+    args = %W[
+      -DARROW_COMPUTE=ON
+      -DARROW_CSV=ON
+      -DARROW_DATASET=ON
+      -DARROW_FILESYSTEM=ON
+      -DARROW_HDFS=OFF
+      -DARROW_JSON=ON
+      -DARROW_PARQUET=ON
+      -DARROW_BUILD_SHARED=OFF
+      -DARROW_JEMALLOC=ON
+      -DARROW_USE_GLOG=OFF
+      -DARROW_PYTHON=OFF
+      -DARROW_S3=ON
+      -DARROW_WITH_LZ4=ON
+      -DARROW_WITH_SNAPPY=ON
+      -DARROW_WITH_ZLIB=ON
+      -DARROW_WITH_ZSTD=ON
+      -DARROW_BUILD_UTILITIES=ON
+      -DCMAKE_UNITY_BUILD=OFF
+      -DPARQUET_BUILD_EXECUTABLES=ON
+      -DLZ4_HOME=#{Formula["lz4"].prefix}
+      -DTHRIFT_HOME=#{Formula["thrift"].prefix}
+    ]
+
+    args << "-DARROW_MIMALLOC=ON" unless Hardware::CPU.arm?
+
+    mkdir "build"
+    cd "build" do
+      system "cmake", "../cpp", *std_cmake_args, *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include "arrow/api.h"
+      int main(void) {
+        arrow::int64();
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", \
+      "-larrow", "-larrow_bundled_dependencies", "-o", "test"
+    system "./test"
+  end
+end

--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
@@ -43,7 +43,6 @@ class ApacheArrowStatic < Formula
   conflicts_with "apache-arrow", because: "both install Arrow"
 
   def install
-    ENV.runtime_cpu_detection if Hardware::CPU.intel?
     ENV.cxx11
     args = %W[
       -DARROW_COMPUTE=ON

--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
@@ -43,6 +43,7 @@ class ApacheArrowStatic < Formula
   conflicts_with "apache-arrow", because: "both install Arrow"
 
   def install
+    ENV.runtime_cpu_detection if Hardware::CPU.intel?
     ENV.cxx11
     args = %W[
       -DARROW_COMPUTE=ON

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           _R_CHECK_CRAN_INCOMING_: false
           ARROW_USE_PKG_CONFIG: false
+          ARROW_R_DEV: true
         run: arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -23,11 +23,11 @@ jobs:
   autobrew:
     name: "Autobrew {{ "${{ matrix.platform }}" }}"
     runs-on: {{ "${{ matrix.platform }}" }}
-    matrix:
-        platform:
-          - macos-11
-          - macos-10.15
-
+    strategy:
+      matrix:
+          platform:
+            - macos-11
+            - macos-10.15
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -37,10 +37,13 @@ jobs:
           cd arrow/r
           # Put the formula inside r/ so that it's included in the package build
           cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
+          cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb tools/apache-arrow-static.rb
           # Pin the current commit in the formula to test so that we're not always pulling from master
           sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}.git", :revision => "{{ arrow.head }}"@' tools/apache-arrow.rb && rm -f tools/apache-arrow.rb.bak
+          sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}.git", :revision => "{{ arrow.head }}"@' tools/apache-arrow-static.rb && rm -f tools/apache-arrow-static.rb.bak
           # Sometimes crossbow gives a remote URL with .git and sometimes not. Make sure there's only one
           sed -i.bak -E -e 's@.git.git@.git@' tools/apache-arrow.rb && rm -f tools/apache-arrow.rb.bak
+          sed -i.bak -E -e 's@.git.git@.git@' tools/apache-arrow-static.rb && rm -f tools/apache-arrow-static.rb.bak
           # Get minio for S3 testing
           brew install minio
       - uses: r-lib/actions/setup-r@v1

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -21,10 +21,16 @@
 
 jobs:
   autobrew:
-    name: "Autobrew"
-    runs-on: macOS-latest
+    name: "Autobrew {{ "${{ matrix.platform }}" }}"
+    runs-on: {{ "${{ matrix.platform }}" }}
+    matrix:
+        platform:
+          - macos-11
+          - macos-10.15
+
     steps:
       {{ macros.github_checkout_arrow()|indent }}
+
 
       - name: Configure autobrew script
         run: |

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -21,7 +21,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 
 if [[ ${OSTYPE:6} -ge 20 ]]; then
   # We are on a modern enough macOS, we can use the real brew
-  UPSTREAM_ORG="brew"
+  UPSTREAM_ORG="homebrew"
   PKG_BREW_NAME="$PKG_BREW_NAME-static"
 else
   # Official Homebrew no longer supports El-Capitan

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -19,8 +19,15 @@
 export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-# Official Homebrew no longer supports El-Capitan
-UPSTREAM_ORG="autobrew"
+if [[ ${OSTYPE:6} -ge 20 ]]; then
+  # We are on a modern enough macOS, we can use the real brew
+  UPSTREAM_ORG="brew"
+  PKG_BREW_NAME="$PKG_BREW_NAME-static"
+else
+  # Official Homebrew no longer supports El-Capitan
+  # so We need to use the forked autobrew version of brew that supports old macOSes
+  UPSTREAM_ORG="autobrew"
+fi
 
 if [ "$DISABLE_AUTOBREW" ]; then return 0; fi
 AUTOBREW=${TMPDIR-/tmp}
@@ -36,6 +43,11 @@ curl -fsSL https://github.com/$UPSTREAM_ORG/brew/tarball/master | tar xz --strip
 export HOMEBREW_CACHE="$AUTOBREW"
 LOCAL_FORMULA="tools/${PKG_BREW_NAME}.rb"
 if [ -f "$LOCAL_FORMULA" ]; then
+  if [[ ${OSTYPE:6} -ge 20 ]]; then
+  # Tap https://github.com/autobrew/homebrew-cran so that we can get dependencies from there
+  $BREW tap autobrew/cran
+  fi
+
   # Use the local brew formula and install --HEAD
   $BREW deps -n "$LOCAL_FORMULA" 2>/dev/null
   BREW_DEPS=$($BREW deps -n "$LOCAL_FORMULA" 2>/dev/null)

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -44,7 +44,6 @@ export HOMEBREW_CACHE="$AUTOBREW"
 LOCAL_FORMULA="tools/${PKG_BREW_NAME}.rb"
 if [ -f "$LOCAL_FORMULA" ]; then
   if [[ ${OSTYPE:6} -ge 20 ]]; then
-  echo "************ In the tap if"
   $BREW tap
 
   # Tap https://github.com/autobrew/homebrew-cran so that we can get dependencies from there
@@ -52,13 +51,9 @@ if [ -f "$LOCAL_FORMULA" ]; then
   fi
 
   # Use the local brew formula and install --HEAD
-  echo "************ 1"
   $BREW deps -n "$LOCAL_FORMULA" 2>/dev/null
-  echo "************ 2"
   BREW_DEPS=$($BREW deps -n "$LOCAL_FORMULA" 2>/dev/null)
-  echo "************ 3"
   $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
-  echo "************ 4"
   $BREW install -v --build-from-source --HEAD "$LOCAL_FORMULA" 2>&1 | perl -pe 's/Warning/Note/gi'
 else
   $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -44,14 +44,21 @@ export HOMEBREW_CACHE="$AUTOBREW"
 LOCAL_FORMULA="tools/${PKG_BREW_NAME}.rb"
 if [ -f "$LOCAL_FORMULA" ]; then
   if [[ ${OSTYPE:6} -ge 20 ]]; then
+  echo "************ In the tap if"
+  $BREW tap
+
   # Tap https://github.com/autobrew/homebrew-cran so that we can get dependencies from there
   $BREW tap autobrew/cran
   fi
 
   # Use the local brew formula and install --HEAD
+  echo "************ 1"
   $BREW deps -n "$LOCAL_FORMULA" 2>/dev/null
+  echo "************ 2"
   BREW_DEPS=$($BREW deps -n "$LOCAL_FORMULA" 2>/dev/null)
+  echo "************ 3"
   $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
+  echo "************ 4"
   $BREW install -v --build-from-source --HEAD "$LOCAL_FORMULA" 2>&1 | perl -pe 's/Warning/Note/gi'
 else
   $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'


### PR DESCRIPTION
This is not totally resolved (I'm getting illegal op codes on the macos 11 job). And might not be the right approach regardless. The crux of this is that our (source) nightly builds bundle the apache-arrow.rb formula, and that formula works with [autobrew/homebrew-core](https://github.com/autobrew/homebrew-core) which isn't compatible with macos 11. (Of course, we need to keep apache-arrow.rb around and use autobrew/homebrew-core for macos 10.11/10.13 which cran uses!) The approach here is to _also_ bundle (and test!) the formula that is in [autobrew/homebrew-cran](https://github.com/autobrew/homebrew-cran) on a modern macos to ensure that _that_ works.

These should only really matter for nightly (source) builds (or someone who otherwise tries to use these formulae) since releases [will use](https://github.com/apache/arrow/blob/master/r/configure#L120) the [autobrew/scripts](https://github.com/autobrew/scripts/blob/master/apache-arrow) script without using brew at all.

I have confirmed that without the formula from autobrew/homebrew-cran, running on macos 11 runners [fails with:](https://github.com/ursacomputing/crossbow/runs/4809178100?check_suite_focus=true)

<details>

```
==> Installing thrift dependency: boost
==> Downloading https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
curl: (22) The requested URL returned error: 502 Bad Gateway
Error: Error: An exception occured within a child process:
  DownloadError: Failed to download resource "boost"
Download failed: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2

==> Installing dependencies for apache-arrow: boost, thrift, zstd
==> Installing apache-arrow dependency: boost
/usr/bin/sandbox-exec -f /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/hbtmp/homebrew20220113-77625-5t1tdb.sb nice /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby -W0 -I /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/ruby-macho-2.0.0/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/plist-3.4.0/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/backports-3.11.4/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/activesupport-5.2.1/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/tzinfo-1.2.5/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/thread_safe-0.3.6/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/minitest-5.11.3/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/i18n-1.1.0/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/bundle-standalone/bundler/../ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/site_ruby/2.3.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/site_ruby/2.3.0/x86_64-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/site_ruby/2.3.0/universal-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/site_ruby:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/vendor_ruby/2.3.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/vendor_ruby/2.3.0/x86_64-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/vendor_ruby/2.3.0/universal-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/vendor_ruby:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/x86_64-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/universal-darwin9.0:/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew -- /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Homebrew/build.rb /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/build-apache-arrow/Library/Taps/autobrew/homebrew-core/Formula/boost.rb --verbose
==> Downloading https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
/usr/bin/curl -q --show-error --insecure --user-agent Homebrew/1.X.Y\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 11.6.2\)\ curl/7.64.1 --fail --silent --location --remote-time --continue-at 0 --output /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/downloads/d08cab6533547504db34623190d93eb217086eb76b2f39ad79d3e9301b40b41e--boost_1_67_0.tar.bz2.incomplete https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
curl: (22) The requested URL returned error: 502 Bad Gateway
Error: Error: An exception occured within a child process:
  DownloadError: Failed to download resource "boost"
Download failed: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2

created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-auth.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-cal.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-common.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-compression.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-event-stream.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-http.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-io.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-mqtt.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-c-s3.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-checksums.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-cognito-identity.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-config.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-core.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-identity-management.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-s3.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-sts.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-cpp-sdk-transfer.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewaws-crt-cpp.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewtesting-resources.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewy.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewlz4.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewcrypto.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewssl.a
created /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//build-apache-arrow/lib/libbrewsnappy.a
------------------------- NOTE ---------------------------
There was an issue preparing the Arrow C++ libraries.
See https://arrow.apache.org/docs/r/articles/install.html
---------------------------------------------------------
ERROR: configuration failed for package ‘arrow’
* removing ‘/Users/runner/work/crossbow/crossbow/arrow/r/check/arrow.Rcheck/arrow’

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```

</details>

Note: this also does not (yet) get the formulae in sync or add a check that they are still in sync with the homebrew / autobrew repos.