### PR TITLE
ARROW-13467: [C++] Support delta dictionaries in the IPC file format

### DIFF
--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -93,8 +93,8 @@ struct ARROW_EXPORT IpcWriteOptions {
   ///
   /// If this option is true, RecordBatchWriter::WriteTable will attempt
   /// to unify dictionaries across each table column.  If this option is
-  /// false, unequal dictionaries across a table column will simply raise
-  /// an error.
+  /// false, incompatible dictionaries across a table column will simply
+  /// raise an error.
   ///
   /// Note that enabling this option has a runtime cost. Also, not all types
   /// currently support dictionary unification.

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -87,9 +87,9 @@ struct ARROW_EXPORT IpcWriteOptions {
 
   /// \brief Whether to unify dictionaries for the IPC file format
   ///
-  /// The IPC file format doesn't support dictionary replacements or deltas.
+  /// The IPC file format doesn't support dictionary replacements.
   /// Therefore, chunks of a column with a dictionary type must have the same
-  /// dictionary in each record batch.
+  /// dictionary in each record batch (or an extended dictionary + delta).
   ///
   /// If this option is true, RecordBatchWriter::WriteTable will attempt
   /// to unify dictionaries across each table column.  If this option is

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -2369,7 +2369,7 @@ class TestDictionaryReplacement : public ::testing::Test {
 
     for (const auto& batch : in_batches) {
       ArrayVector expanded_columns;
-      for (std::size_t col_index = 0; col_index < batch->num_columns(); col_index++) {
+      for (int col_index = 0; col_index < batch->num_columns(); col_index++) {
         std::shared_ptr<Array> column = batch->column(col_index);
         std::shared_ptr<DictionaryArray> dict_array =
             checked_pointer_cast<DictionaryArray>(column);

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -2051,6 +2051,7 @@ class TestDictionaryReplacement : public ::testing::Test {
         MakeBatch(ArrayFromJSON(type, R"(["foo", "bar", "quux", "zzz", "foo"])"));
     auto batch4 = MakeBatch(ArrayFromJSON(type, R"(["bar", null, "quux", "foo"])"));
     RecordBatchVector batches{batch1, batch2, batch3, batch4};
+    RecordBatchVector only_deltas{batch1, batch2, batch3};
 
     // Emit replacements
     if (WriterHelper::kIsFileFormat) {
@@ -2067,7 +2068,9 @@ class TestDictionaryReplacement : public ::testing::Test {
     // Emit deltas
     write_options_.emit_dictionary_deltas = true;
     if (WriterHelper::kIsFileFormat) {
-      CheckWritingFails(batches, 1);
+      // batch4 is incompatible with the previous batches and would emit
+      // a replacement
+      CheckWritingFails(batches, 3);
     } else {
       CheckRoundtrip(batches);
       EXPECT_EQ(read_stats_.num_messages, 9);  // including schema message
@@ -2076,6 +2079,14 @@ class TestDictionaryReplacement : public ::testing::Test {
       EXPECT_EQ(read_stats_.num_replaced_dictionaries, 1);
       EXPECT_EQ(read_stats_.num_dictionary_deltas, 2);
     }
+
+    CheckRoundtrip(only_deltas,
+                   /*expect_expanded_dictionary=*/WriterHelper::kIsFileFormat);
+    EXPECT_EQ(read_stats_.num_messages, 7);  // including schema message
+    EXPECT_EQ(read_stats_.num_record_batches, 3);
+    EXPECT_EQ(read_stats_.num_dictionary_batches, 3);
+    EXPECT_EQ(read_stats_.num_replaced_dictionaries, 0);
+    EXPECT_EQ(read_stats_.num_dictionary_deltas, 2);
 
     // IPC file format: WriteTable should unify dicts
     RecordBatchVector actual;
@@ -2346,11 +2357,43 @@ class TestDictionaryReplacement : public ::testing::Test {
     AssertTablesEqual(*expected_table, *actual_table);
   }
 
-  void CheckRoundtrip(const RecordBatchVector& in_batches) {
+  RecordBatchVector ExpandDictionaries(const RecordBatchVector& in_batches) {
+    RecordBatchVector out;
+    ArrayVector full_dictionaries;
+    std::shared_ptr<RecordBatch> last_batch = in_batches[in_batches.size() - 1];
+    for (const auto& column : last_batch->columns()) {
+      std::shared_ptr<DictionaryArray> dict_array =
+          checked_pointer_cast<DictionaryArray>(column);
+      full_dictionaries.push_back(dict_array->dictionary());
+    }
+
+    for (const auto& batch : in_batches) {
+      ArrayVector expanded_columns;
+      for (std::size_t col_index = 0; col_index < batch->num_columns(); col_index++) {
+        std::shared_ptr<Array> column = batch->column(col_index);
+        std::shared_ptr<DictionaryArray> dict_array =
+            checked_pointer_cast<DictionaryArray>(column);
+        std::shared_ptr<Array> full_dict = full_dictionaries[col_index];
+        std::shared_ptr<Array> expanded = std::make_shared<DictionaryArray>(
+            dict_array->type(), dict_array->indices(), full_dict);
+        expanded_columns.push_back(expanded);
+      }
+      out.push_back(
+          RecordBatch::Make(batch->schema(), batch->num_rows(), expanded_columns));
+    }
+    return out;
+  }
+
+  void CheckRoundtrip(const RecordBatchVector& in_batches,
+                      bool expect_expanded_dictionary = false) {
     RecordBatchVector out_batches;
     ASSERT_OK(RoundTrip(in_batches, &out_batches));
     CheckStatsConsistent();
-    CheckBatches(in_batches, out_batches);
+    if (expect_expanded_dictionary) {
+      CheckBatches(ExpandDictionaries(in_batches), out_batches);
+    } else {
+      CheckBatches(in_batches, out_batches);
+    }
   }
 
   void CheckRoundtripTable(const RecordBatchVector& in_batches) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1054,10 +1054,8 @@ static Status ReadOneDictionary(Message* message, const IpcReadContext& context)
   ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
   DictionaryKind kind;
   RETURN_NOT_OK(ReadDictionary(*message->metadata(), context, &kind, reader.get()));
-  if (kind != DictionaryKind::New) {
-    return Status::Invalid(
-        "Unsupported dictionary replacement or "
-        "dictionary delta in IPC file");
+  if (kind == DictionaryKind::Replacement) {
+    return Status::Invalid("Unsupported dictionary replacement in IPC file");
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1049,17 +1049,6 @@ static Future<std::shared_ptr<Message>> ReadMessageFromBlockAsync(
                           io_context);
 }
 
-static Status ReadOneDictionary(Message* message, const IpcReadContext& context) {
-  CHECK_HAS_BODY(*message);
-  ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
-  DictionaryKind kind;
-  RETURN_NOT_OK(ReadDictionary(*message->metadata(), context, &kind, reader.get()));
-  if (kind == DictionaryKind::Replacement) {
-    return Status::Invalid("Unsupported dictionary replacement in IPC file");
-  }
-  return Status::OK();
-}
-
 class RecordBatchFileReaderImpl;
 
 /// A generator of record batches.
@@ -1376,6 +1365,19 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
       ARROW_ASSIGN_OR_RAISE(auto message, ReadMessageFromBlock(GetDictionaryBlock(i)));
       RETURN_NOT_OK(ReadOneDictionary(message.get(), context));
       ++stats_.num_dictionary_batches;
+    }
+    return Status::OK();
+  }
+
+  Status ReadOneDictionary(Message* message, const IpcReadContext& context) {
+    CHECK_HAS_BODY(*message);
+    ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
+    DictionaryKind kind;
+    RETURN_NOT_OK(ReadDictionary(*message->metadata(), context, &kind, reader.get()));
+    if (kind == DictionaryKind::Replacement) {
+      return Status::Invalid("Unsupported dictionary replacement in IPC file");
+    } else if (kind == DictionaryKind::Delta) {
+      ++stats_.num_dictionary_deltas;
     }
     return Status::OK();
   }
@@ -1818,7 +1820,7 @@ Status WholeIpcFileRecordBatchGenerator::ReadDictionaries(
     std::vector<std::shared_ptr<Message>> dictionary_messages) {
   IpcReadContext context(&state->dictionary_memo_, state->options_, state->swap_endian_);
   for (const auto& message : dictionary_messages) {
-    RETURN_NOT_OK(ReadOneDictionary(message.get(), context));
+    RETURN_NOT_OK(state->ReadOneDictionary(message.get(), context));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1080,12 +1080,6 @@ class ARROW_EXPORT IpcFormatWriter : public RecordBatchWriter {
           //  for the IPC file format)
           continue;
         }
-        if (is_file_format_) {
-          return Status::Invalid(
-              "Dictionary replacement detected when writing IPC file format. "
-              "Arrow IPC files only support a single dictionary for a given field "
-              "across all batches.");
-        }
 
         // (the read path doesn't support outer dictionary deltas, don't emit them)
         if (new_length > last_length && options_.emit_dictionary_deltas &&
@@ -1094,6 +1088,13 @@ class ARROW_EXPORT IpcFormatWriter : public RecordBatchWriter {
                  ->RangeEquals(dictionary, 0, last_length, 0, equal_options))) {
           // New dictionary starts with the current dictionary
           delta_start = last_length;
+        }
+
+        if (is_file_format_ && !delta_start) {
+          return Status::Invalid(
+              "Dictionary replacement detected when writing IPC file format. "
+              "Arrow IPC files only support a single non-delta dictionary for "
+              "a given field across all batches.");
         }
       }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1138,7 +1138,7 @@ class ARROW_EXPORT IpcFormatWriter : public RecordBatchWriter {
   // A map of last-written dictionaries by id.
   // This is required to avoid the same dictionary again and again,
   // and also for correctness when writing the IPC file format
-  // (where replacements and deltas are unsupported).
+  // (where replacements are unsupported).
   // The latter is also why we can't use weak_ptr.
   std::unordered_map<int64_t, std::shared_ptr<Array>> last_dictionaries_;
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1437,6 +1437,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         shared_ptr[CCodec] codec
         c_bool use_threads
         c_bool emit_dictionary_deltas
+        c_bool unify_dictionaries
 
         @staticmethod
         CIpcWriteOptions Defaults()

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -131,8 +131,8 @@ cdef class IpcWriteOptions(_Weakrefable):
         but requires computing the unified dictionary and then remapping
         the indices arrays.
 
-        This property is ignored when writing to the streaming format as
-        the streaming format can support replacement dictionaries.
+        This parameter is ignored when writing to the IPC stream format as
+        the IPC stream format can support replacement dictionaries.
     """
     __slots__ = ()
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -124,6 +124,15 @@ cdef class IpcWriteOptions(_Weakrefable):
     emit_dictionary_deltas : bool
         Whether to emit dictionary deltas.  Default is false for maximum
         stream compatibility.
+    unify_dictionaries : bool
+        If true then calls to write_table will attempt to unify dictionaries
+        across all batches in the table.  This can help avoid the need for
+        replacement dictionaries (which the file format does not support)
+        but requires computing the unified dictionary and then remapping
+        the indices arrays.
+
+        This property is ignored when writing to the streaming format as
+        the streaming format can support replacement dictionaries.
     """
     __slots__ = ()
 
@@ -132,7 +141,8 @@ cdef class IpcWriteOptions(_Weakrefable):
     def __init__(self, *, metadata_version=MetadataVersion.V5,
                  bint allow_64bit=False, use_legacy_format=False,
                  compression=None, bint use_threads=True,
-                 bint emit_dictionary_deltas=False):
+                 bint emit_dictionary_deltas=False,
+                 bint unify_dictionaries=False):
         self.c_options = CIpcWriteOptions.Defaults()
         self.allow_64bit = allow_64bit
         self.use_legacy_format = use_legacy_format
@@ -141,6 +151,7 @@ cdef class IpcWriteOptions(_Weakrefable):
             self.compression = compression
         self.use_threads = use_threads
         self.emit_dictionary_deltas = emit_dictionary_deltas
+        self.unify_dictionaries = unify_dictionaries
 
     @property
     def allow_64bit(self):
@@ -201,6 +212,14 @@ cdef class IpcWriteOptions(_Weakrefable):
     @emit_dictionary_deltas.setter
     def emit_dictionary_deltas(self, bint value):
         self.c_options.emit_dictionary_deltas = value
+
+    @property
+    def unify_dictionaries(self):
+        return self.c_options.unify_dictionaries
+
+    @unify_dictionaries.setter
+    def unify_dictionaries(self, bint value):
+        self.c_options.unify_dictionaries = value
 
 
 cdef class Message(_Weakrefable):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -77,8 +77,11 @@ class IpcFixture:
 
 class FileFormatFixture(IpcFixture):
 
+    is_file = True
+    options = None
+
     def _get_writer(self, sink, schema):
-        return pa.ipc.new_file(sink, schema)
+        return pa.ipc.new_file(sink, schema, options=self.options)
 
     def _check_roundtrip(self, as_table=False):
         batches = self.write_batches(as_table=as_table)
@@ -105,6 +108,7 @@ class StreamFormatFixture(IpcFixture):
     use_legacy_ipc_format = False
     # ARROW-9395, for testing writing old metadata version
     options = None
+    is_file = False
 
     def _get_writer(self, sink, schema):
         return pa.ipc.new_stream(
@@ -134,6 +138,22 @@ def file_fixture():
 @pytest.fixture
 def stream_fixture():
     return StreamFormatFixture()
+
+
+@pytest.fixture(params=[
+    FileFormatFixture(),
+    StreamFormatFixture()
+    # pytest.param(
+    #     pytest.lazy_fixture('file_fixture'),
+    #     id='File Format'
+    # ),
+    # pytest.param(
+    #     pytest.lazy_fixture('stream_fixture'),
+    #     id='Stream Format'
+    # )
+])
+def format_fixture(request):
+    return request.param
 
 
 def test_empty_file():
@@ -450,40 +470,79 @@ def test_stream_options_roundtrip(stream_fixture, options):
         reader.read_next_batch()
 
 
-def test_dictionary_delta(stream_fixture):
+def test_dictionary_delta(format_fixture):
     ty = pa.dictionary(pa.int8(), pa.utf8())
     data = [["foo", "foo", None],
             ["foo", "bar", "foo"],  # potential delta
-            ["foo", "bar"],
+            ["foo", "bar"],  # nothing new
             ["foo", None, "bar", "quux"],  # potential delta
             ["bar", "quux"],  # replacement
             ]
     batches = [
         pa.RecordBatch.from_arrays([pa.array(v, type=ty)], names=['dicts'])
         for v in data]
+    batches_delta_only = batches[:4]
     schema = batches[0].schema
 
-    def write_batches():
-        with stream_fixture._get_writer(pa.MockOutputStream(),
+    def write_batches(batches, as_table=False):
+        with format_fixture._get_writer(pa.MockOutputStream(),
                                         schema) as writer:
-            for batch in batches:
-                writer.write_batch(batch)
+            if as_table:
+                table = pa.Table.from_batches(batches)
+                writer.write_table(table)
+            else:
+                for batch in batches:
+                    writer.write_batch(batch)
             return writer.stats
 
-    st = write_batches()
-    assert st.num_record_batches == 5
-    assert st.num_dictionary_batches == 4
-    assert st.num_replaced_dictionaries == 3
-    assert st.num_dictionary_deltas == 0
+    if format_fixture.is_file:
+        # File format cannot handle replacement
+        with pytest.raises(pa.ArrowInvalid):
+            write_batches(batches)
+        # File format cannot handle delta if emit_deltas
+        # is not provided
+        with pytest.raises(pa.ArrowInvalid):
+            write_batches(batches_delta_only)
+    else:
+        st = write_batches(batches)
+        assert st.num_record_batches == 5
+        assert st.num_dictionary_batches == 4
+        assert st.num_replaced_dictionaries == 3
+        assert st.num_dictionary_deltas == 0
 
-    stream_fixture.use_legacy_ipc_format = None
-    stream_fixture.options = pa.ipc.IpcWriteOptions(
+    format_fixture.use_legacy_ipc_format = None
+    format_fixture.options = pa.ipc.IpcWriteOptions(
         emit_dictionary_deltas=True)
-    st = write_batches()
-    assert st.num_record_batches == 5
-    assert st.num_dictionary_batches == 4
-    assert st.num_replaced_dictionaries == 1
+    if format_fixture.is_file:
+        # File format cannot handle replacement
+        with pytest.raises(pa.ArrowInvalid):
+            write_batches(batches)
+    else:
+        st = write_batches(batches)
+        assert st.num_record_batches == 5
+        assert st.num_dictionary_batches == 4
+        assert st.num_replaced_dictionaries == 1
+        assert st.num_dictionary_deltas == 2
+
+    st = write_batches(batches_delta_only)
+    assert st.num_record_batches == 4
+    assert st.num_dictionary_batches == 3
+    assert st.num_replaced_dictionaries == 0
     assert st.num_dictionary_deltas == 2
+
+    format_fixture.options = pa.ipc.IpcWriteOptions(
+        unify_dictionaries=True
+    )
+    st = write_batches(batches, as_table=True)
+    assert st.num_record_batches == 5
+    if format_fixture.is_file:
+        assert st.num_dictionary_batches == 1
+        assert st.num_replaced_dictionaries == 0
+        assert st.num_dictionary_deltas == 0
+    else:
+        assert st.num_dictionary_batches == 4
+        assert st.num_replaced_dictionaries == 3
+        assert st.num_dictionary_deltas == 0
 
 
 def test_envvar_set_legacy_ipc_format():

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -141,16 +141,14 @@ def stream_fixture():
 
 
 @pytest.fixture(params=[
-    FileFormatFixture(),
-    StreamFormatFixture()
-    # pytest.param(
-    #     pytest.lazy_fixture('file_fixture'),
-    #     id='File Format'
-    # ),
-    # pytest.param(
-    #     pytest.lazy_fixture('stream_fixture'),
-    #     id='Stream Format'
-    # )
+    pytest.param(
+        pytest.lazy_fixture('file_fixture'),
+        id='File Format'
+    ),
+    pytest.param(
+        pytest.lazy_fixture('stream_fixture'),
+        id='Stream Format'
+    )
 ])
 def format_fixture(request):
     return request.param


### PR DESCRIPTION
Permits reading and writing delta dictionaries in IPC with the file format.  Previously this was only allowed with the streaming format but the spec only prohibits replacements:

> Further more, it is invalid to have more than one non-delta dictionary batch per dictionary ID (i.e. dictionary replacement is not supported). 

This suggests that delta dictionaries are permissible in the file format.