### PR TITLE
ARROW-15334: [CI][GLib][Windows] Use Ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -189,7 +189,7 @@ jobs:
       ARROW_FLIGHT: ON
       ARROW_GANDIVA: ON
       ARROW_HDFS: OFF
-      ARROW_HOME: /mingw${{ matrix.mingw-n-bits }}
+      ARROW_HOME: /ucrt${{ matrix.mingw-n-bits }}
       ARROW_JEMALLOC: OFF
       ARROW_PARQUET: ON
       ARROW_PYTHON: OFF
@@ -205,7 +205,7 @@ jobs:
       # -DBoost_NO_BOOST_CMAKE=ON
       BOOST_ROOT: ""
       CMAKE_ARGS: >-
-        -DARROW_PACKAGE_PREFIX=/mingw${{ matrix.mingw-n-bits }}
+        -DARROW_PACKAGE_PREFIX=/ucrt${{ matrix.mingw-n-bits }}
         -DBoost_NO_BOOST_CMAKE=ON
       CMAKE_UNITY_BUILD: ON
     steps:
@@ -240,8 +240,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache
-          key: ruby-ccache-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
-          restore-keys: ruby-ccache-mingw${{ matrix.mingw-n-bits }}-
+          key: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
+          restore-keys: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}-
       - name: Build C++
         run: |
           $Env:CMAKE_BUILD_PARALLEL_LEVEL = $Env:NUMBER_OF_PROCESSORS
@@ -264,8 +264,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.rubygems-info.outputs.gem-dir }}
-          key: ruby-rubygems-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('**/Gemfile', 'ruby/*/*.gemspec') }}
-          restore-keys: ruby-rubygems-mingw${{ matrix.mingw-n-bits }}-
+          key: ruby-rubygems-ucrt${{ matrix.mingw-n-bits }}-${{ hashFiles('**/Gemfile', 'ruby/*/*.gemspec') }}
+          restore-keys: ruby-rubygems-ucrt${{ matrix.mingw-n-bits }}-
       - name: Install test dependencies
         run: |
           bundle install --gemfile c_glib\Gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -230,9 +230,9 @@ jobs:
         run: |
           ridk exec bash ci\scripts\msys2_system_upgrade.sh
           taskkill /F /FI "MODULES eq msys-2.0.dll"
-      # - name: Clean MSYS2
-      #   run: |
-      #     ridk exec bash ci\scripts\msys2_system_clean.sh
+      - name: Clean MSYS2
+        run: |
+          ridk exec bash ci\scripts\msys2_system_clean.sh
       - name: Setup MSYS2
         run: |
           ridk exec bash ci\scripts\msys2_setup.sh ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -230,9 +230,9 @@ jobs:
         run: |
           ridk exec bash ci\scripts\msys2_system_upgrade.sh
           taskkill /F /FI "MODULES eq msys-2.0.dll"
-      - name: Clean MSYS2
-        run: |
-          ridk exec bash ci\scripts\msys2_system_clean.sh
+      # - name: Clean MSYS2
+      #   run: |
+      #     ridk exec bash ci\scripts\msys2_system_clean.sh
       - name: Setup MSYS2
         run: |
           ridk exec bash ci\scripts\msys2_setup.sh ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -180,7 +180,7 @@ jobs:
         mingw-n-bits:
           - 64
         ruby-version:
-          - "3.0"
+          - "3.1"
     env:
       ARROW_BUILD_SHARED: ON
       ARROW_BUILD_STATIC: OFF

--- a/ci/scripts/msys2_system_clean.sh
+++ b/ci/scripts/msys2_system_clean.sh
@@ -19,15 +19,19 @@
 
 set -eux
 
-pacman \
-  --cascade \
-  --noconfirm \
-  --nosave \
-  --recursive \
-  --remove \
-  ${MINGW_PACKAGE_PREFIX}-clang-tools-extra \
-  ${MINGW_PACKAGE_PREFIX}-gcc-ada \
-  ${MINGW_PACKAGE_PREFIX}-gcc-fortran \
-  ${MINGW_PACKAGE_PREFIX}-gcc-libgfortran \
-  ${MINGW_PACKAGE_PREFIX}-gcc-objc \
-  ${MINGW_PACKAGE_PREFIX}-libgccjit
+case "${MINGW_PACKAGE_PREFIX}" in
+  mingw*)
+    pacman \
+      --cascade \
+      --noconfirm \
+      --nosave \
+      --recursive \
+      --remove \
+      ${MINGW_PACKAGE_PREFIX}-clang-tools-extra \
+      ${MINGW_PACKAGE_PREFIX}-gcc-ada \
+      ${MINGW_PACKAGE_PREFIX}-gcc-fortran \
+      ${MINGW_PACKAGE_PREFIX}-gcc-libgfortran \
+      ${MINGW_PACKAGE_PREFIX}-gcc-objc \
+      ${MINGW_PACKAGE_PREFIX}-libgccjit
+      ;;
+esac

--- a/ci/scripts/msys2_system_clean.sh
+++ b/ci/scripts/msys2_system_clean.sh
@@ -20,7 +20,10 @@
 set -eux
 
 case "${MINGW_PACKAGE_PREFIX}" in
-  mingw*)
+  mingw-w64-urcrt-x86_64)
+    :
+    ;;
+  *)
     pacman \
       --cascade \
       --noconfirm \

--- a/ci/scripts/msys2_system_clean.sh
+++ b/ci/scripts/msys2_system_clean.sh
@@ -20,7 +20,7 @@
 set -eux
 
 case "${MINGW_PACKAGE_PREFIX}" in
-  mingw-w64-urcrt-x86_64)
+  mingw-w64-ucrt-x86_64)
     :
     ;;
   *)

--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -38,24 +38,7 @@ namespace red_arrow {
   ID id_to_datetime;
 }
 
-#ifdef _WIN32
-extern "C" BOOL WINAPI
-DllMain(G_GNUC_UNUSED HINSTANCE hinstDLL,
-        G_GNUC_UNUSED DWORD fdwReason,
-        G_GNUC_UNUSED LPVOID lpvReserved);
-
-extern "C" BOOL WINAPI
-DllMain(G_GNUC_UNUSED HINSTANCE hinstDLL,
-        G_GNUC_UNUSED DWORD fdwReason,
-        G_GNUC_UNUSED LPVOID lpvReserved)
-{
-  return TRUE;
-}
-#endif
-
-extern "C"
-void Init_arrow()
-{
+extern "C" void Init_arrow() {
   auto mArrow = rb_const_get_at(rb_cObject, rb_intern("Arrow"));
 
   auto cArrowArray = rb_const_get_at(mArrow, rb_intern("Array"));

--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -38,7 +38,24 @@ namespace red_arrow {
   ID id_to_datetime;
 }
 
-extern "C" void Init_arrow() {
+#ifdef _WIN32
+extern "C" BOOL WINAPI
+DllMain(G_GNUC_UNUSED HINSTANCE hinstDLL,
+        G_GNUC_UNUSED DWORD fdwReason,
+        G_GNUC_UNUSED LPVOID lpvReserved);
+
+extern "C" BOOL WINAPI
+DllMain(G_GNUC_UNUSED HINSTANCE hinstDLL,
+        G_GNUC_UNUSED DWORD fdwReason,
+        G_GNUC_UNUSED LPVOID lpvReserved)
+{
+  return TRUE;
+}
+#endif
+
+extern "C"
+void Init_arrow()
+{
   auto mArrow = rb_const_get_at(rb_cObject, rb_intern("Arrow"));
 
   auto cArrowArray = rb_const_get_at(mArrow, rb_intern("Array"));


### PR DESCRIPTION
RubyInstaller bundles libintl-8.dll but libintl-8.dll's ABI in MSYS2 is changed since
mingw-w64-x86_64-gettext 0.21-1. It requires DllMain() but bundled libintl-8.dll doesn't
provide DllMain() yet. So we build glib2 gem that depends on gettext with new gettext,
we need to use new libintl-8.dll too. But bundled libintl-8.dll is used.

Ruby 3.1 based RubyInstaller doesn't bundle libintl-8.dll. So we can avoid this error
by using Ruby 3.1.

The next Ruby 3.0 based RubyInstaller release will bundle new libintl-8.dll. So it will
be solved eventually.
