### PR TITLE
ARROW-14461 [R] write_dataset() allows users to pass invalid additional arguments

### DIFF
--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -337,7 +337,8 @@ FileWriteOptions <- R6Class("FileWriteOptions",
           err_info <- NULL
           arg_info <- paste0(
             "Supported arguments: ",
-            oxford_paste(supported_args, quote_symbol = "`")
+            oxford_paste(supported_args, quote_symbol = "`"),
+            "."
           )
           if ("compression" %in% unsupported_passed_args) {
             err_info <- "You could try using `codec` instead of `compression`."

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -348,7 +348,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
 
       if (self$type == "parquet") {
         args <- list(...)
-        check_additional_args(format = self$type, names(args))
+        check_additional_args(self$type, names(args))
 
         dataset___ParquetFileWriteOptions__update(
           self,
@@ -357,7 +357,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
         )
       } else if (self$type == "ipc") {
         args <- list(...)
-        check_additional_args(format = self$type, names(args))
+        check_additional_args(self$type, names(args))
 
         if (is.null(args$codec)) {
           dataset___IpcFileWriteOptions__update1(
@@ -375,7 +375,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
         }
       } else if (self$type == "csv") {
         args <- list(...)
-        check_additional_args(format = self$type, names(args))
+        check_additional_args(self$type, names(args))
 
         dataset___CsvFileWriteOptions__update(
           self,

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -313,7 +313,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
         if (format == "parquet") {
           supported_args <- names(formals(write_parquet))
           supported_args <- supported_args[supported_args != c("x", "sink")]
-        } else if(format == "ipc") {
+        } else if (format == "ipc") {
           supported_args <- c(
             "use_legacy_format",
             "metadata_version",

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -347,19 +347,16 @@ FileWriteOptions <- R6Class("FileWriteOptions",
         }
       }
 
-      if (self$type == "parquet") {
-        args <- list(...)
-        check_additional_args(self$type, names(args))
+      args <- list(...)
+      check_additional_args(self$type, names(args))
 
+      if (self$type == "parquet") {
         dataset___ParquetFileWriteOptions__update(
           self,
           ParquetWriterProperties$create(table, ...),
           ParquetArrowWriterProperties$create(...)
         )
       } else if (self$type == "ipc") {
-        args <- list(...)
-        check_additional_args(self$type, names(args))
-
         if (is.null(args$codec)) {
           dataset___IpcFileWriteOptions__update1(
             self,
@@ -375,9 +372,6 @@ FileWriteOptions <- R6Class("FileWriteOptions",
           )
         }
       } else if (self$type == "csv") {
-        args <- list(...)
-        check_additional_args(self$type, names(args))
-
         dataset___CsvFileWriteOptions__update(
           self,
           CsvWriteOptions$create(...)

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -328,7 +328,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
 
         if (length(unsupported_passed_args) > 0) {
           err_header <- paste0(
-            oxford_paste(unsupported_passed_args),
+            oxford_paste(unsupported_passed_args, quote_symbol = "`"),
             ngettext(length(unsupported_passed_args),
                      " is not a valid argument ",
                      " are not valid arguments "),
@@ -337,7 +337,7 @@ FileWriteOptions <- R6Class("FileWriteOptions",
           err_info <- NULL
           arg_info <- paste0(
             "Supported arguments: ",
-            oxford_paste(supported_args)
+            oxford_paste(supported_args, quote_symbol = "`")
           )
           if ("compression" %in% unsupported_passed_args) {
             err_info <- "You could try using `codec` instead of `compression`."

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -317,6 +317,30 @@ FileWriteOptions <- R6Class("FileWriteOptions",
         )
       } else if (self$type == "ipc") {
         args <- list(...)
+        supported_args <- c(
+          "use_legacy_format",
+          "metadata_version",
+          "codec",
+          "null_fallback"
+        )
+
+        unsupported_passed_args <- setdiff(
+          names(args),
+          supported_args
+        )
+
+        if (length(unsupported_passed_args)) {
+          stop(
+            "The following ",
+            ngettext(length(unsupported_passed_args),
+                     "argument is ",
+                     "arguments are "),
+            "not valid for your chosen 'format': ",
+            oxford_paste(unsupported_passed_args),
+            call. = FALSE
+          )
+        }
+
         if (is.null(args$codec)) {
           dataset___IpcFileWriteOptions__update1(
             self,

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -51,7 +51,7 @@
 #' @param max_partitions maximum number of partitions any batch may be
 #' written into. Default is 1024L.
 #' @param ... additional format-specific arguments. For available Parquet
-#' options, see [write_parquet()]. The available Feather options are
+#' options, see [write_parquet()]. The available Feather options are:
 #' - `use_legacy_format` logical: write data formatted so that Arrow libraries
 #'   versions 0.14 and lower can read it. Default is `FALSE`. You can also
 #'   enable this by setting the environment variable `ARROW_PRE_0_15_IPC_FORMAT=1`.

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -56,7 +56,7 @@
 #'   versions 0.14 and lower can read it. Default is `FALSE`. You can also
 #'   enable this by setting the environment variable `ARROW_PRE_0_15_IPC_FORMAT=1`.
 #' - `metadata_version`: A string like "V5" or the equivalent integer indicating
-#'   the Arrow IPC MetadataVersion. Default (NULL) will use the latest version,
+#'   the Arrow IPC MetadataVersion. Default (`NULL`) will use the latest version,
 #'   unless the environment variable `ARROW_PRE_1_0_METADATA_VERSION=1`, in
 #'   which case it will be V4.
 #' - `codec`: A [Codec] which will be used to compress body buffers of written

--- a/r/man/ChunkedArray.Rd
+++ b/r/man/ChunkedArray.Rd
@@ -29,6 +29,7 @@ various Arrays or R vectors. \code{chunked_array()} is an alias for it.
 \itemize{
 \item \verb{$length()}: Size in the number of elements this array contains
 \item \verb{$chunk(i)}: Extract an \code{Array} chunk by integer position
+\item `$nbytes() : Total number of bytes consumed by the elements of the array
 \item \verb{$as_vector()}: convert to an R vector
 \item \verb{$Slice(offset, length = NULL)}: Construct a zero-copy slice of the array
 with the indicated offset and length. If length is \code{NULL}, the slice goes

--- a/r/man/RecordBatch.Rd
+++ b/r/man/RecordBatch.Rd
@@ -46,6 +46,7 @@ the following R6 methods that map onto the underlying C++ methods:
 \item \verb{$column(i)}: Extract an \code{Array} by integer position from the batch
 \item \verb{$column_name(i)}: Get a column's name by integer position
 \item \verb{$names()}: Get all column names (called by \code{names(batch)})
+\item \verb{$nbytes()}: Total number of bytes consumed by the elements of the record batch
 \item \verb{$RenameColumns(value)}: Set all column names (called by \code{names(batch) <- value})
 \item \verb{$GetColumnByName(name)}: Extract an \code{Array} by string name
 \item \verb{$RemoveColumn(i)}: Drops a column from the batch by integer position

--- a/r/man/Table.Rd
+++ b/r/man/Table.Rd
@@ -44,6 +44,7 @@ the following R6 methods that map onto the underlying C++ methods:
 \itemize{
 \item \verb{$column(i)}: Extract a \code{ChunkedArray} by integer position from the table
 \item \verb{$ColumnNames()}: Get all column names (called by \code{names(tab)})
+\item \verb{$nbytes()}: Total number of bytes consumed by the elements of the table
 \item \verb{$RenameColumns(value)}: Set all column names (called by \code{names(tab) <- value})
 \item \verb{$GetColumnByName(name)}: Extract a \code{ChunkedArray} by string name
 \item \verb{$field(i)}: Extract a \code{Field} from the table schema by integer position

--- a/r/man/array.Rd
+++ b/r/man/array.Rd
@@ -54,6 +54,7 @@ a == a
 \item \verb{$IsNull(i)}: Return true if value at index is null. Does not boundscheck
 \item \verb{$IsValid(i)}: Return true if value at index is valid. Does not boundscheck
 \item \verb{$length()}: Size in the number of elements this array contains
+\item \verb{$nbytes()}: Total number of bytes consumed by the elements of the array
 \item \verb{$offset}: A relative position into another array's data, to enable zero-copy slicing
 \item \verb{$null_count}: The number of null entries in the array
 \item \verb{$type}: logical type of data

--- a/r/man/write_dataset.Rd
+++ b/r/man/write_dataset.Rd
@@ -57,13 +57,13 @@ partitions which data is not written to.
 written into. Default is 1024L.}
 
 \item{...}{additional format-specific arguments. For available Parquet
-options, see \code{\link[=write_parquet]{write_parquet()}}. The available Feather options are
+options, see \code{\link[=write_parquet]{write_parquet()}}. The available Feather options are:
 \itemize{
 \item \code{use_legacy_format} logical: write data formatted so that Arrow libraries
 versions 0.14 and lower can read it. Default is \code{FALSE}. You can also
 enable this by setting the environment variable \code{ARROW_PRE_0_15_IPC_FORMAT=1}.
 \item \code{metadata_version}: A string like "V5" or the equivalent integer indicating
-the Arrow IPC MetadataVersion. Default (NULL) will use the latest version,
+the Arrow IPC MetadataVersion. Default (\code{NULL}) will use the latest version,
 unless the environment variable \code{ARROW_PRE_1_0_METADATA_VERSION=1}, in
 which case it will be V4.
 \item \code{codec}: A \link{Codec} which will be used to compress body buffers of written

--- a/r/tests/testthat/_snaps/dataset-write.md
+++ b/r/tests/testthat/_snaps/dataset-write.md
@@ -1,0 +1,43 @@
+# write_dataset checks for format-specific arguments
+
+    Code
+      write_dataset(df, dst_dir, format = "feather", compression = "snappy")
+    Error <rlang_error>
+      "compression" is not a valid argument for your chosen `format`.
+      i You could try using `codec` instead of `compression`.
+
+---
+
+    Code
+      write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah")
+    Error <rlang_error>
+      "nonsensical_arg" is not a valid argument for your chosen `format`.
+
+---
+
+    Code
+      write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah")
+    Error <rlang_error>
+      "nonsensical_arg" is not a valid argument for your chosen `format`.
+
+---
+
+    Code
+      write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah")
+    Error <rlang_error>
+      "nonsensical_arg" is not a valid argument for your chosen `format`.
+
+---
+
+    Code
+      write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah")
+    Error <rlang_error>
+      "nonsensical_arg" is not a valid argument for your chosen `format`.
+
+---
+
+    Code
+      write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah")
+    Error <rlang_error>
+      "nonsensical_arg" is not a valid argument for your chosen `format`.
+

--- a/r/tests/testthat/_snaps/dataset-write.md
+++ b/r/tests/testthat/_snaps/dataset-write.md
@@ -5,7 +5,7 @@
     Error <rlang_error>
       `compression` is not a valid argument for your chosen `format`.
       i You could try using `codec` instead of `compression`.
-      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
@@ -13,7 +13,7 @@
       write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       `nonsensical_arg` is not a valid argument for your chosen `format`.
-      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
@@ -21,7 +21,7 @@
       write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       `nonsensical_arg` is not a valid argument for your chosen `format`.
-      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
@@ -29,7 +29,7 @@
       write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       `nonsensical_arg` is not a valid argument for your chosen `format`.
-      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
@@ -37,7 +37,7 @@
       write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       `nonsensical_arg` is not a valid argument for your chosen `format`.
-      i Supported arguments: `include_header` and `batch_size`
+      i Supported arguments: `include_header` and `batch_size`.
 
 ---
 
@@ -45,5 +45,5 @@
       write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       `nonsensical_arg` is not a valid argument for your chosen `format`.
-      i Supported arguments: `chunk_size`, `version`, `compression`, `compression_level`, `use_dictionary`, `write_statistics`, `data_page_size`, `use_deprecated_int96_timestamps`, `coerce_timestamps`, `allow_truncated_timestamps`, `properties`, and `arrow_properties`
+      i Supported arguments: `chunk_size`, `version`, `compression`, `compression_level`, `use_dictionary`, `write_statistics`, `data_page_size`, `use_deprecated_int96_timestamps`, `coerce_timestamps`, `allow_truncated_timestamps`, `properties`, and `arrow_properties`.
 

--- a/r/tests/testthat/_snaps/dataset-write.md
+++ b/r/tests/testthat/_snaps/dataset-write.md
@@ -5,6 +5,7 @@
     Error <rlang_error>
       "compression" is not a valid argument for your chosen `format`.
       i You could try using `codec` instead of `compression`.
+      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
 
 ---
 
@@ -12,6 +13,7 @@
       write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       "nonsensical_arg" is not a valid argument for your chosen `format`.
+      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
 
 ---
 
@@ -19,6 +21,7 @@
       write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       "nonsensical_arg" is not a valid argument for your chosen `format`.
+      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
 
 ---
 
@@ -26,6 +29,7 @@
       write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       "nonsensical_arg" is not a valid argument for your chosen `format`.
+      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
 
 ---
 
@@ -33,6 +37,7 @@
       write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       "nonsensical_arg" is not a valid argument for your chosen `format`.
+      i Supported arguments: "include_header" and "batch_size"
 
 ---
 
@@ -40,4 +45,5 @@
       write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah")
     Error <rlang_error>
       "nonsensical_arg" is not a valid argument for your chosen `format`.
+      i Supported arguments: "chunk_size", "version", "compression", "compression_level", "use_dictionary", "write_statistics", "data_page_size", "use_deprecated_int96_timestamps", "coerce_timestamps", "allow_truncated_timestamps", "properties", and "arrow_properties"
 

--- a/r/tests/testthat/_snaps/dataset-write.md
+++ b/r/tests/testthat/_snaps/dataset-write.md
@@ -3,47 +3,47 @@
     Code
       write_dataset(df, dst_dir, format = "feather", compression = "snappy")
     Error <rlang_error>
-      "compression" is not a valid argument for your chosen `format`.
+      `compression` is not a valid argument for your chosen `format`.
       i You could try using `codec` instead of `compression`.
-      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah")
     Error <rlang_error>
-      "nonsensical_arg" is not a valid argument for your chosen `format`.
-      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
+      `nonsensical_arg` is not a valid argument for your chosen `format`.
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah")
     Error <rlang_error>
-      "nonsensical_arg" is not a valid argument for your chosen `format`.
-      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
+      `nonsensical_arg` is not a valid argument for your chosen `format`.
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah")
     Error <rlang_error>
-      "nonsensical_arg" is not a valid argument for your chosen `format`.
-      i Supported arguments: "use_legacy_format", "metadata_version", "codec", and "null_fallback"
+      `nonsensical_arg` is not a valid argument for your chosen `format`.
+      i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah")
     Error <rlang_error>
-      "nonsensical_arg" is not a valid argument for your chosen `format`.
-      i Supported arguments: "include_header" and "batch_size"
+      `nonsensical_arg` is not a valid argument for your chosen `format`.
+      i Supported arguments: `include_header` and `batch_size`
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah")
     Error <rlang_error>
-      "nonsensical_arg" is not a valid argument for your chosen `format`.
-      i Supported arguments: "chunk_size", "version", "compression", "compression_level", "use_dictionary", "write_statistics", "data_page_size", "use_deprecated_int96_timestamps", "coerce_timestamps", "allow_truncated_timestamps", "properties", and "arrow_properties"
+      `nonsensical_arg` is not a valid argument for your chosen `format`.
+      i Supported arguments: `chunk_size`, `version`, `compression`, `compression_level`, `use_dictionary`, `write_statistics`, `data_page_size`, `use_deprecated_int96_timestamps`, `coerce_timestamps`, `allow_truncated_timestamps`, `properties`, and `arrow_properties`
 

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -522,6 +522,16 @@ test_that("write_dataset checks for format-specific arguments", {
     write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah"),
     "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
   )
+
+  expect_error(
+    write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah"),
+    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+  )
+  expect_error(
+    write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah"),
+    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+  )
+
   expect_error(
     write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah"),
     "nonsensical_arg = \"blah-blah\""

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -505,3 +505,30 @@ test_that("Max partitions fails with non-integer values and less than required p
     "max_partitions must be a positive, non-missing integer"
   )
 })
+
+test_that("write_dataset checks for format-specific arguments", {
+  df <- tibble::tibble(
+    int = 1:10,
+    dbl = as.numeric(1:10),
+    lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 2),
+    chr = letters[1:10],
+  )
+  dst_dir <- make_temp_dir()
+  expect_error(
+    write_dataset(df, dst_dir, format = "feather", compression = "snappy"),
+    "The following argument is not valid for your chosen 'format': \"compression\""
+  )
+  expect_error(
+    write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah"),
+    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+  )
+  expect_error(
+    write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah"),
+    "nonsensical_arg = \"blah-blah\""
+  )
+
+  expect_error(
+    write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah"),
+    "The following argument is not valid for your chosen 'format': \"non_sensical_arg\""
+  )
+})

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -514,31 +514,28 @@ test_that("write_dataset checks for format-specific arguments", {
     chr = letters[1:10],
   )
   dst_dir <- make_temp_dir()
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "feather", compression = "snappy"),
-    "The following argument is not valid for your chosen 'format': \"compression\""
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah"),
-    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+    error = TRUE
   )
-
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah"),
-    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+    error = TRUE
   )
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah"),
-    "The following argument is not valid for your chosen 'format': \"nonsensical_arg\""
+    error = TRUE
   )
-
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah"),
-    "nonsensical_arg = \"blah-blah\""
+    error = TRUE
   )
-
-  expect_error(
+  expect_snapshot(
     write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah"),
-    "The following argument is not valid for your chosen 'format': \"non_sensical_arg\""
+    error = TRUE
   )
 })


### PR DESCRIPTION
This PR aims to add checks to arguments passed to `write_dataset()` via `...`, conditional on the value passed for `format`.

The code below should **not** run without a complaint. 
```r
td <- tempfile()
dir.create(td)
write_dataset(iris, td, format = "feather", arg_that_doesnt_make_sense = "blah-blah")
```

Currently `write_dataset()` supports 5 formats (`"parquet"`, `"feather"`, `"arrow"`, `"ipc"`, `"csv"`). Ultimately all formats use `FileWriteOptions$update()`. `"csv"` is the only one that errors on non-relevant additional arguments passed via `...` (without checks). `"arrow"`, `"ipc"` and `"feather"` all use the same `type`  (`dataset___FileWriteOptions__type_name`).

After the implementation in this PR, the same code will error:
```r
> write_dataset(iris, td, format = "feather", arg_that_doesnt_make_sense = "blah-blah")
Error: `arg_that_doesnt_make_sense` is not a valid argument for your chosen `format`.
ℹ Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
```