### PR TITLE
ARROW-14338: [Docs] Add version dropdown to the pkgdown (R) docs

### DIFF
--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "6.0.1.9000 (dev)",
-        "version": "dev"
+        "version": "dev/"
     },
     {
         "name": "6.0.1 (release)",

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -1,30 +1,30 @@
 [
     {
-        "name": "7.0 (dev)",
+        "name": "6.0.1.9000 (dev)",
         "version": "dev"
     },
     {
-        "name": "6.0 (stable)",
+        "name": "6.0.1 (release)",
         "version": ""
     },
     {
-        "name": "5.0",
+        "name": "5.0.0",
         "version": "5.0/"
     },
     {
-        "name": "4.0",
+        "name": "4.0.1",
         "version": "4.0/"
     },
     {
-        "name": "3.0",
+        "name": "3.0.0",
         "version": "3.0/"
     },
     {
-        "name": "2.0",
+        "name": "2.0.0",
         "version": "2.0/"
     },
     {
-        "name": "1.0",
+        "name": "1.0.1",
         "version": "1.0/"
     }
 ]

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -1,0 +1,30 @@
+[
+    {
+        "name": "7.0 (dev)",
+        "version": "dev"
+    },
+    {
+        "name": "6.0 (stable)",
+        "version": ""
+    },
+    {
+        "name": "5.0",
+        "version": "5.0/"
+    },
+    {
+        "name": "4.0",
+        "version": "4.0/"
+    },
+    {
+        "name": "3.0",
+        "version": "3.0/"
+    },
+    {
+        "name": "2.0",
+        "version": "2.0/"
+    },
+    {
+        "name": "1.0",
+        "version": "1.0/"
+    }
+]

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -94,10 +94,7 @@ function check_page_exists_and_redirect(event) {
       	  return current_path.match("(?<=\/r).*");
         }
 
-        // Load the versions JSON and construct the select items
-        versions_path = window.location.href.match(".+(\/r\/)")[0] + "versions.json";
-
-        $.getJSON(versions_path, function( data ) {
+        $.getJSON("https://arrow.apache.org/docs/r/versions.json", function( data ) {
           // get the current page's version number:
 		  var displayed_version = $('.version').text();
           const sel = document.createElement("select");

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -59,6 +59,57 @@
       var empty_ul = $("#toc").find("ul").filter(":empty");
       empty_ul.remove();
     });
+
+    $(document).ready(function () {
+      /**
+       * This replaces the package version number in the docs with a
+       * dropdown where you can select the version of the docs to view.
+       */
+
+      $pathStart = function(){
+    	  return window.location.origin + "/docs/";
+      }
+
+      $pathEnd  = function(){
+      	var current_path = window.location.pathname;
+      	return current_path.match("(?<=\/r).*");
+      }
+
+      /**
+       * Load the versions JSON and construct the select items
+      */
+      $.getJSON("./versions.json", function( data ) {
+
+      	var items = [];
+      	// get the current page's version number:
+      	var current_version = $('.version').text();
+      	$.each( data, function( key, val ) {
+
+      		//get the two item version number
+      		var version_array = current_version.split(".");
+      		var version_major_minor = version_array[0] + "." + version_array[1];
+
+      		// need an extra slash if it's the dev docs
+      		var dev_path_string = (val.version == "dev" ? "/" : "");
+
+      		var selected_string = (val.name.match("[0-9.*]\.[0-9.*]") == version_major_minor ? "selected" : "");
+
+      		items.push(
+      			"<option value='" + $pathStart() + val.version +
+      			dev_path_string + "r" + $pathEnd() + "'" +
+      			selected_string +
+      			">" + val.name + "</option>"
+      		);
+      	});
+
+      	// Replace the version button with a selector with the doc versions
+      	$("span.version").replaceWith(
+      		'<select name="version-selector" class = "navbar-default" '+
+      		'onchange="location = this.value;"> ' + items.join("") + '</select> '
+      	);
+      });
+    });
+
   };
 
   document.head.appendChild(script);

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -15,20 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function checkPageExistsAndRedirect(event) {
+function check_page_exists_and_redirect(event) {
 
-    console.log(event.target.getAttribute("value"));
-    console.log(event.target);
-
-    const path_to_try = event.target.selectedOptions()[0].getAttributes("value");
-    //$( "#version-selector" ).val();
+    const path_to_try = event.target.value;
 
     const base_path = path_to_try.match("(.*\/r\/)?")[0];
     let tryUrl = path_to_try;
     $.ajax({
         type: 'HEAD',
         url: tryUrl,
-        // if the page exists, go there
         success: function() {
             location.href = tryUrl;
         }
@@ -104,58 +99,22 @@ function checkPageExistsAndRedirect(event) {
       //$.getJSON("./versions.json", function( data ) {
       $.getJSON("https://raw.githubusercontent.com/thisisnic/arrow/ec8c60d97eb489f0c19297e8d9b3f48e44db5afb/r/pkgdown/assets/versions.json", function( data ) {
 
-        var items = [];
         // get the current page's version number:
 				var displayed_version = $('.version').text();
 				const sel = document.createElement("select");
 				sel.name = "version-selector";
 				sel.id = "version-selector";
 				sel.class = "navbar-default";
-				sel.onchange = checkPageExistsAndRedirect;
+				sel.onchange = check_page_exists_and_redirect;
 
 				$.each( data, function( key, val ) {
-
-					var selected_string = (
-						val.name.match("[0-9.]*")[0] === displayed_version ?
-						"selected" :
-						""
-					 );
-
-          var item_path = $pathStart() + val.version + "r" + $pathEnd();
-
-/***
-          var corrected_path = $.ajax({
-            type: 'GET',
-            url: item_path,
-            success: function() {
-              console.log("win")
-              return item_path;
-            },
-            error: function() {
-              // everything up to the /r/
-              console.log("fail")
-              return item_path.match("(.*\/r\/)?")[0];
-
-            }
-          });
-          console.log(corrected_path);
-          */
-
-          //root_path = $pathStart() + val.version + "r";
-
           const opt = document.createElement("option");
-          opt.value = item_path;
-          opt.selected = selected_string.length > 0;
+          opt.value = $pathStart() + val.version + "r" + $pathEnd();
+          opt.selected = val.name.match("[0-9.]*")[0] === displayed_version;
           opt.text = val.name;
-          // Argh!!!!  Options don't have hyperlinks!!!!
-          // Do them as list items with hyperlinks instead - see the code for e.g. the project docs dropdown and con
           sel.append(opt);
-          //items.push(opt);
-
-					//items.push("<option value='" + item_path +  "'" + selected_string +	">" + val.name + "</option>");
 				});
 
-				// Replace the version button with a selector with the doc versions
 				$("span.version").replaceWith(sel);
 			});
 		});

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -15,6 +15,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
+function checkPageExistsAndRedirect(event) {
+
+    console.log(event.target.getAttribute("value"));
+    console.log(event.target);
+
+    const path_to_try = event.target.selectedOptions()[0].getAttributes("value");
+    //$( "#version-selector" ).val();
+
+    const base_path = path_to_try.match("(.*\/r\/)?")[0];
+    let tryUrl = path_to_try;
+    $.ajax({
+        type: 'HEAD',
+        url: tryUrl,
+        // if the page exists, go there
+        success: function() {
+            location.href = tryUrl;
+        }
+    }).fail(function() {
+        location.href = base_path;
+    });
+    return false;
+}
+
 (function () {
   // Load the rmarkdown tabset script
   var script = document.createElement("script");
@@ -84,6 +107,12 @@
         var items = [];
         // get the current page's version number:
 				var displayed_version = $('.version').text();
+				const sel = document.createElement("select");
+				sel.name = "version-selector";
+				sel.id = "version-selector";
+				sel.class = "navbar-default";
+				sel.onchange = checkPageExistsAndRedirect;
+
 				$.each( data, function( key, val ) {
 
 					var selected_string = (
@@ -94,14 +123,40 @@
 
           var item_path = $pathStart() + val.version + "r" + $pathEnd();
 
-					items.push("<option value='" + item_path +  "'" + selected_string +	">" + val.name + "</option>");
+/***
+          var corrected_path = $.ajax({
+            type: 'GET',
+            url: item_path,
+            success: function() {
+              console.log("win")
+              return item_path;
+            },
+            error: function() {
+              // everything up to the /r/
+              console.log("fail")
+              return item_path.match("(.*\/r\/)?")[0];
+
+            }
+          });
+          console.log(corrected_path);
+          */
+
+          //root_path = $pathStart() + val.version + "r";
+
+          const opt = document.createElement("option");
+          opt.value = item_path;
+          opt.selected = selected_string.length > 0;
+          opt.text = val.name;
+          // Argh!!!!  Options don't have hyperlinks!!!!
+          // Do them as list items with hyperlinks instead - see the code for e.g. the project docs dropdown and con
+          sel.append(opt);
+          //items.push(opt);
+
+					//items.push("<option value='" + item_path +  "'" + selected_string +	">" + val.name + "</option>");
 				});
 
 				// Replace the version button with a selector with the doc versions
-				$("span.version").replaceWith(
-					'<select name="version-selector" class = "navbar-default" '+
-					'onchange="location = this.value;"> ' + items.join("") + '</select> '
-				);
+				$("span.version").replaceWith(sel);
 			});
 		});
 

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -79,7 +79,7 @@ function check_page_exists_and_redirect(event) {
     });
 
     $(document).ready(function () {
-  
+
       /**
        * This replaces the package version number in the docs with a
        * dropdown where you can select the version of the docs to view.
@@ -95,7 +95,9 @@ function check_page_exists_and_redirect(event) {
         }
 
         // Load the versions JSON and construct the select items
-        $.getJSON("./versions.json", function( data ) {
+        versions_path = window.location.href.match(".+(\/r\/)")[0] + "versions.json";
+
+        $.getJSON(versions_path, function( data ) {
           // get the current page's version number:
 		  var displayed_version = $('.version').text();
           const sel = document.createElement("select");

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -94,11 +94,7 @@ function check_page_exists_and_redirect(event) {
       }
 
       // Load the versions JSON and construct the select items
-      // Delete below line before merging
-      // You can test with https://raw.githubusercontent.com/thisisnic/arrow/ARROW-14338_pkgdown_versioning/r/pkgdown/assets/versions.json
-      //$.getJSON("./versions.json", function( data ) {
-      $.getJSON("https://raw.githubusercontent.com/thisisnic/arrow/ec8c60d97eb489f0c19297e8d9b3f48e44db5afb/r/pkgdown/assets/versions.json", function( data ) {
-
+      $.getJSON("./versions.json", function( data ) {
         // get the current page's version number:
 				var displayed_version = $('.version').text();
 				const sel = document.createElement("select");

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -79,37 +79,37 @@
       // You can test with $pathStart() + "/_static/versions.json"
       $.getJSON("./versions.json", function( data ) {
 
-      	var items = [];
-      	// get the current page's version number:
-      	var displayed_version = $('.version').text();
-      	$.each( data, function( key, val ) {
+        var items = [];
+        // get the current page's version number:
+				var displayed_version = $('.version').text();
+				$.each( data, function( key, val ) {
 
-      		// need an extra slash if it's the dev docs
-      		var dev_path_string = (val.version == "dev" ? "/" : "");
+					// need an extra slash if it's the dev docs
+					var dev_path_string = (val.version == "dev" ? "/" : "");
 
-      	  var selected_string = (
-      	    val.name.match("[0-9.]*")[0] === displayed_version ?
-      	    "selected" :
-      	    ""
-      	   );
+					var selected_string = (
+						val.name.match("[0-9.]*")[0] === displayed_version ?
+						"selected" :
+						""
+					 );
 
-      		items.push(
-      			"<option value='" + $pathStart() + val.version +
-      			dev_path_string + "r" + $pathEnd() + "'" +
-      			selected_string +
-      			">" + val.name + "</option>"
-      		);
-      	});
+					items.push(
+						"<option value='" + $pathStart() + val.version +
+						dev_path_string + "r" + $pathEnd() + "'" +
+						selected_string +
+						">" + val.name + "</option>"
+					);
+				});
 
-      	// Replace the version button with a selector with the doc versions
-      	$("span.version").replaceWith(
-      		'<select name="version-selector" class = "navbar-default" '+
-      		'onchange="location = this.value;"> ' + items.join("") + '</select> '
-      	);
-      });
-    });
+				// Replace the version button with a selector with the doc versions
+				$("span.version").replaceWith(
+					'<select name="version-selector" class = "navbar-default" '+
+					'onchange="location = this.value;"> ' + items.join("") + '</select> '
+				);
+			});
+		});
 
-  };
+	};
 
-  document.head.appendChild(script);
+	document.head.appendChild(script);
 })();

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -60,7 +60,7 @@
       empty_ul.remove();
     });
 
-    $(document).ready(function () {
+  $(document).ready(function () {
       /**
        * This replaces the package version number in the docs with a
        * dropdown where you can select the version of the docs to view.
@@ -75,24 +75,23 @@
       	return current_path.match("(?<=\/r).*");
       }
 
-      /**
-       * Load the versions JSON and construct the select items
-      */
+      // Load the versions JSON and construct the select items
+      // You can test with $pathStart() + "/_static/versions.json"
       $.getJSON("./versions.json", function( data ) {
 
       	var items = [];
       	// get the current page's version number:
-      	var current_version = $('.version').text();
+      	var displayed_version = $('.version').text();
       	$.each( data, function( key, val ) {
-
-      		//get the two item version number
-      		var version_array = current_version.split(".");
-      		var version_major_minor = version_array[0] + "." + version_array[1];
 
       		// need an extra slash if it's the dev docs
       		var dev_path_string = (val.version == "dev" ? "/" : "");
 
-      		var selected_string = (val.name.match("[0-9.*]\.[0-9.*]") == version_major_minor ? "selected" : "");
+      	  var selected_string = (
+      	    val.name.match("[0-9.]*")[0] === displayed_version ?
+      	    "selected" :
+      	    ""
+      	   );
 
       		items.push(
       			"<option value='" + $pathStart() + val.version +

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -78,44 +78,45 @@ function check_page_exists_and_redirect(event) {
       empty_ul.remove();
     });
 
-  $(document).ready(function () {
+    $(document).ready(function () {
+  
       /**
        * This replaces the package version number in the docs with a
        * dropdown where you can select the version of the docs to view.
        */
 
-      $pathStart = function(){
+        $pathStart = function(){
     	  return window.location.origin + "/docs/";
-      }
+        }
 
-      $pathEnd  = function(){
-      	var current_path = window.location.pathname;
-      	return current_path.match("(?<=\/r).*");
-      }
+        $pathEnd  = function(){
+      	  var current_path = window.location.pathname;
+      	  return current_path.match("(?<=\/r).*");
+        }
 
-      // Load the versions JSON and construct the select items
-      $.getJSON("./versions.json", function( data ) {
-        // get the current page's version number:
-				var displayed_version = $('.version').text();
-				const sel = document.createElement("select");
-				sel.name = "version-selector";
-				sel.id = "version-selector";
-				sel.class = "navbar-default";
-				sel.onchange = check_page_exists_and_redirect;
+        // Load the versions JSON and construct the select items
+        $.getJSON("./versions.json", function( data ) {
+          // get the current page's version number:
+		  var displayed_version = $('.version').text();
+          const sel = document.createElement("select");
+          sel.name = "version-selector";
+          sel.id = "version-selector";
+          sel.class = "navbar-default";
+          sel.onchange = check_page_exists_and_redirect;
 
-				$.each( data, function( key, val ) {
-          const opt = document.createElement("option");
-          opt.value = $pathStart() + val.version + "r" + $pathEnd();
-          opt.selected = val.name.match("[0-9.]*")[0] === displayed_version;
-          opt.text = val.name;
-          sel.append(opt);
-				});
+		  $.each( data, function( key, val ) {
+            const opt = document.createElement("option");
+            opt.value = $pathStart() + val.version + "r" + $pathEnd();
+            opt.selected = val.name.match("[0-9.]*")[0] === displayed_version;
+            opt.text = val.name;
+            sel.append(opt);
+		  });
 
-				$("span.version").replaceWith(sel);
-			});
-		});
+          $("span.version").replaceWith(sel);
+        });
+    });
 
-	};
+  };
 
-	document.head.appendChild(script);
+  document.head.appendChild(script);
 })();

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -101,7 +101,7 @@ function check_page_exists_and_redirect(event) {
           const sel = document.createElement("select");
           sel.name = "version-selector";
           sel.id = "version-selector";
-          sel.class = "navbar-default";
+          sel.classList.add("navbar-default");
           sel.onchange = check_page_exists_and_redirect;
 
 		  $.each( data, function( key, val ) {

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -76,16 +76,15 @@
       }
 
       // Load the versions JSON and construct the select items
-      // You can test with $pathStart() + "/_static/versions.json"
-      $.getJSON("./versions.json", function( data ) {
+      // Delete below line before merging
+      // You can test with https://raw.githubusercontent.com/thisisnic/arrow/ARROW-14338_pkgdown_versioning/r/pkgdown/assets/versions.json
+      //$.getJSON("./versions.json", function( data ) {
+      $.getJSON("https://raw.githubusercontent.com/thisisnic/arrow/ec8c60d97eb489f0c19297e8d9b3f48e44db5afb/r/pkgdown/assets/versions.json", function( data ) {
 
         var items = [];
         // get the current page's version number:
 				var displayed_version = $('.version').text();
 				$.each( data, function( key, val ) {
-
-					// need an extra slash if it's the dev docs
-					var dev_path_string = (val.version == "dev" ? "/" : "");
 
 					var selected_string = (
 						val.name.match("[0-9.]*")[0] === displayed_version ?
@@ -93,12 +92,9 @@
 						""
 					 );
 
-					items.push(
-						"<option value='" + $pathStart() + val.version +
-						dev_path_string + "r" + $pathEnd() + "'" +
-						selected_string +
-						">" + val.name + "</option>"
-					);
+          var item_path = $pathStart() + val.version + "r" + $pathEnd();
+
+					items.push("<option value='" + item_path +  "'" + selected_string +	">" + val.name + "</option>");
 				});
 
 				// Replace the version button with a selector with the doc versions


### PR DESCRIPTION
**Implemented**:
- Version switcher replaces package version on pkgdown
- Package versions and URLs stored in `arrow/r/pkgdown/assets/versions.json`
- Tested with a web browser and JS console
- functionality to check URL can be retrieved and redirect to root dir if not (thanks @jorisvandenbossche for your previous work on this which constitutes 90% of this!)

![](https://user-images.githubusercontent.com/13715823/150108943-d58a0ca0-4840-4995-903b-3e9d4950705e.png)

**Suggestion for testing without putting together a complex Docker script:**
- copy script from `extra.js`
- as the `versions.json` file is not deployed yet, replace `./versions.json` in line `$.getJSON("./versions.json", function( data ) {` with `https://raw.githubusercontent.com/thisisnic/arrow/ARROW-14338_pkgdown_versioning/r/pkgdown/assets/versions.json`
- open R docs page and paste into JS console