### PR TITLE
ARROW-10140: [Python][C++] Add test for map column of a parquet file created from pyarrow and pandas

### DIFF
--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -685,3 +685,26 @@ def test_read_pandas_passthrough_keywords(tempdir):
         filesystem=SubTreeFileSystem(str(tempdir), LocalFileSystem())
     )
     assert result.equals(pa.table(df))
+
+
+@pytest.mark.pandas
+def test_read_pandas_map_fields(tempdir):
+    # ARROW-10140 - table created from Pandas with mapping fields
+    df = pd.DataFrame({
+        'col1': pd.Series([
+            [('id', 'something'), ('value2', 'else')],
+            [('id', 'something2'), ('value', 'else2')],
+        ]),
+        'col2': pd.Series(['foo', 'bar'])
+    })
+
+    filename = tempdir / 'data.parquet'
+
+    udt = pa.map_(pa.string(), pa.string())
+    schema = pa.schema([pa.field('col1', udt), pa.field('col2', pa.string())])
+    arrow_table = pa.Table.from_pandas(df, schema)
+
+    _write_table(arrow_table, filename)
+
+    result = pq.read_pandas(filename).to_pandas()
+    tm.assert_frame_equal(result, df)


### PR DESCRIPTION
Adding a test to `parquet/test_pandas.py` for a case when `pa.Table` is created from Pandas with map column.

cc @jorisvandenbossche 