### PR TITLE
ARROW-14609 [R] left_join by argument error message mismatch

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -29,6 +29,7 @@ Biarch: true
 Imports:
     assertthat,
     bit64 (>= 0.9-7),
+    glue,
     methods,
     purrr,
     R6,

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -29,7 +29,6 @@ Biarch: true
 Imports:
     assertthat,
     bit64 (>= 0.9-7),
-    glue,
     methods,
     purrr,
     R6,

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -138,8 +138,8 @@ handle_join_by <- function(by, x, y) {
   }
 
   if (length(missing_x_cols) > 0 || length(missing_y_cols) > 0) {
-    header <- "Join columns must be present in data."
-    abort(c(header, x = message_x, x = message_y))
+    err_header <- "Join columns must be present in data."
+    abort(c(err_header, x = message_x, x = message_y))
   }
 
   by

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -127,7 +127,7 @@ handle_join_by <- function(by, x, y) {
     message_x <- paste(
       oxford_paste(missing_x_cols, quote_symbol = "`"),
       "not present in x."
-      )
+    )
   }
 
   if (length(missing_y_cols) > 0) {

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -119,31 +119,28 @@ handle_join_by <- function(by, x, y) {
   }
 
   missing_x_cols <- setdiff(names(by), names(x))
+  missing_y_cols <- setdiff(by, names(y))
+  message_x <- NULL
+  message_y <- NULL
+
   if (length(missing_x_cols) > 0) {
-    message <- paste(
-      "Join",
-      ngettext(length(missing_x_cols), "column", "columns"),
-      "must be present in data."
-    )
     message_x <- paste(
       oxford_paste(missing_x_cols, quote_symbol = "`"),
       "not present in x."
       )
-    abort(c(message, x = message_x))
   }
 
-  missing_y_cols <- setdiff(by, names(y))
   if (length(missing_y_cols) > 0) {
-    message <- paste(
-      "Join",
-      ngettext(length(missing_y_cols), "column", "columns"),
-      "must be present in data."
-    )
     message_y <- paste(
       oxford_paste(missing_y_cols, quote_symbol = "`"),
       "not present in y."
     )
-    abort(c(message, x = message_y))
   }
+
+  if (length(missing_x_cols) > 0 || length(missing_y_cols) > 0) {
+    header <- "Join columns must be present in data."
+    abort(c(header, x = message_x, x = message_y))
+  }
+
   by
 }

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -117,10 +117,29 @@ handle_join_by <- function(by, x, y) {
   if (is.null(names(by))) {
     by <- set_names(by)
   }
-  # TODO: nicer messages?
-  stopifnot(
-    all(names(by) %in% names(x)),
-    all(by %in% names(y))
-  )
+
+  missing_x_cols <- setdiff(names(by), names(x))
+  if (length(missing_x_cols) > 0) {
+    message <- glue::glue(
+      "Join {ngettext(length(missing_x_cols), 'column', 'columns')} must be \\
+      present in data."
+    )
+    message_x <- glue::glue(
+      "{oxford_paste(missing_x_cols, quote_symbol = '`')} not present in x."
+      )
+    abort(c(message, x = message_x))
+  }
+
+  missing_y_cols <- setdiff(by, names(y))
+  if (length(missing_y_cols) > 0) {
+    message <- glue::glue(
+      "Join {ngettext(length(missing_y_cols), 'column', 'columns')} must be \\
+      present in data."
+    )
+    message_y <- glue::glue(
+      "{oxford_paste(missing_y_cols, quote_symbol = '`')} not present in y."
+    )
+    abort(c(message, x = message_y))
+  }
   by
 }

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -122,11 +122,11 @@ handle_join_by <- function(by, x, y) {
   if (length(missing_x_cols) > 0) {
     message <- paste(
       "Join",
-      ngettext(length(missing_x_cols), 'column', 'columns'),
+      ngettext(length(missing_x_cols), "column", "columns"),
       "must be present in data."
     )
     message_x <- paste(
-      oxford_paste(missing_x_cols, quote_symbol = '`'),
+      oxford_paste(missing_x_cols, quote_symbol = "`"),
       "not present in x."
       )
     abort(c(message, x = message_x))
@@ -136,11 +136,11 @@ handle_join_by <- function(by, x, y) {
   if (length(missing_y_cols) > 0) {
     message <- paste(
       "Join",
-      ngettext(length(missing_y_cols), 'column', 'columns'),
+      ngettext(length(missing_y_cols), "column", "columns"),
       "must be present in data."
     )
     message_y <- paste(
-      oxford_paste(missing_y_cols, quote_symbol = '`'),
+      oxford_paste(missing_y_cols, quote_symbol = "`"),
       "not present in y."
     )
     abort(c(message, x = message_y))

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -120,24 +120,28 @@ handle_join_by <- function(by, x, y) {
 
   missing_x_cols <- setdiff(names(by), names(x))
   if (length(missing_x_cols) > 0) {
-    message <- glue::glue(
-      "Join {ngettext(length(missing_x_cols), 'column', 'columns')} must be \\
-      present in data."
+    message <- paste(
+      "Join",
+      ngettext(length(missing_x_cols), 'column', 'columns'),
+      "must be present in data."
     )
-    message_x <- glue::glue(
-      "{oxford_paste(missing_x_cols, quote_symbol = '`')} not present in x."
+    message_x <- paste(
+      oxford_paste(missing_x_cols, quote_symbol = '`'),
+      "not present in x."
       )
     abort(c(message, x = message_x))
   }
 
   missing_y_cols <- setdiff(by, names(y))
   if (length(missing_y_cols) > 0) {
-    message <- glue::glue(
-      "Join {ngettext(length(missing_y_cols), 'column', 'columns')} must be \\
-      present in data."
+    message <- paste(
+      "Join",
+      ngettext(length(missing_y_cols), 'column', 'columns'),
+      "must be present in data."
     )
-    message_y <- glue::glue(
-      "{oxford_paste(missing_y_cols, quote_symbol = '`')} not present in y."
+    message_y <- paste(
+      oxford_paste(missing_y_cols, quote_symbol = '`'),
+      "not present in y."
     )
     abort(c(message, x = message_y))
   }

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -29,9 +29,12 @@ if (!exists("str2lang")) {
   }
 }
 
-oxford_paste <- function(x, conjunction = "and", quote = TRUE) {
+oxford_paste <- function(x,
+                         conjunction = "and",
+                         quote = TRUE,
+                         quote_symbol = '"') {
   if (quote && is.character(x)) {
-    x <- paste0('"', x, '"')
+    x <- paste0(quote_symbol, x, quote_symbol)
   }
   if (length(x) < 2) {
     return(x)

--- a/r/tests/testthat/_snaps/dplyr-join.md
+++ b/r/tests/testthat/_snaps/dplyr-join.md
@@ -1,0 +1,50 @@
+# Error handling
+
+    Code
+      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
+      by = "made_up_colname")))
+    Output
+      <error/rlang_error>
+      Join column must be present in data.
+      x `made_up_colname` not present in x.
+
+---
+
+    Code
+      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
+      by = c(int = "made_up_colname"))))
+    Output
+      <error/rlang_error>
+      Join column must be present in data.
+      x `made_up_colname` not present in y.
+
+---
+
+    Code
+      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
+      by = c(made_up_colname = "int"))))
+    Output
+      <error/rlang_error>
+      Join column must be present in data.
+      x `made_up_colname` not present in x.
+
+---
+
+    Code
+      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
+      by = c("made_up_colname1", "made_up_colname2"))))
+    Output
+      <error/rlang_error>
+      Join columns must be present in data.
+      x `made_up_colname1` and `made_up_colname2` not present in x.
+
+---
+
+    Code
+      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
+      by = c(made_up_colname1 = "made_up_colname2"))))
+    Output
+      <error/rlang_error>
+      Join column must be present in data.
+      x `made_up_colname1` not present in x.
+

--- a/r/tests/testthat/_snaps/dplyr-join.md
+++ b/r/tests/testthat/_snaps/dplyr-join.md
@@ -1,10 +1,8 @@
 # Error handling
 
     Code
-      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
-      by = "made_up_colname")))
-    Output
-      <error/rlang_error>
+      left_join(arrow_table(example_data), arrow_table(example_data), by = "made_up_colname")
+    Error <rlang_error>
       Join columns must be present in data.
       x `made_up_colname` not present in x.
       x `made_up_colname` not present in y.
@@ -12,30 +10,26 @@
 ---
 
     Code
-      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
-      by = c(int = "made_up_colname"))))
-    Output
-      <error/rlang_error>
+      left_join(arrow_table(example_data), arrow_table(example_data), by = c(int = "made_up_colname"))
+    Error <rlang_error>
       Join columns must be present in data.
       x `made_up_colname` not present in y.
 
 ---
 
     Code
-      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
-      by = c(made_up_colname = "int"))))
-    Output
-      <error/rlang_error>
+      left_join(arrow_table(example_data), arrow_table(example_data), by = c(
+        made_up_colname = "int"))
+    Error <rlang_error>
       Join columns must be present in data.
       x `made_up_colname` not present in x.
 
 ---
 
     Code
-      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
-      by = c("made_up_colname1", "made_up_colname2"))))
-    Output
-      <error/rlang_error>
+      left_join(arrow_table(example_data), arrow_table(example_data), by = c(
+        "made_up_colname1", "made_up_colname2"))
+    Error <rlang_error>
       Join columns must be present in data.
       x `made_up_colname1` and `made_up_colname2` not present in x.
       x `made_up_colname1` and `made_up_colname2` not present in y.
@@ -43,10 +37,9 @@
 ---
 
     Code
-      (expect_error(left_join(arrow_table(example_data), arrow_table(example_data),
-      by = c(made_up_colname1 = "made_up_colname2"))))
-    Output
-      <error/rlang_error>
+      left_join(arrow_table(example_data), arrow_table(example_data), by = c(
+        made_up_colname1 = "made_up_colname2"))
+    Error <rlang_error>
       Join columns must be present in data.
       x `made_up_colname1` not present in x.
       x `made_up_colname2` not present in y.

--- a/r/tests/testthat/_snaps/dplyr-join.md
+++ b/r/tests/testthat/_snaps/dplyr-join.md
@@ -5,8 +5,9 @@
       by = "made_up_colname")))
     Output
       <error/rlang_error>
-      Join column must be present in data.
+      Join columns must be present in data.
       x `made_up_colname` not present in x.
+      x `made_up_colname` not present in y.
 
 ---
 
@@ -15,7 +16,7 @@
       by = c(int = "made_up_colname"))))
     Output
       <error/rlang_error>
-      Join column must be present in data.
+      Join columns must be present in data.
       x `made_up_colname` not present in y.
 
 ---
@@ -25,7 +26,7 @@
       by = c(made_up_colname = "int"))))
     Output
       <error/rlang_error>
-      Join column must be present in data.
+      Join columns must be present in data.
       x `made_up_colname` not present in x.
 
 ---
@@ -37,6 +38,7 @@
       <error/rlang_error>
       Join columns must be present in data.
       x `made_up_colname1` and `made_up_colname2` not present in x.
+      x `made_up_colname1` and `made_up_colname2` not present in y.
 
 ---
 
@@ -45,6 +47,7 @@
       by = c(made_up_colname1 = "made_up_colname2"))))
     Output
       <error/rlang_error>
-      Join column must be present in data.
+      Join columns must be present in data.
       x `made_up_colname1` not present in x.
+      x `made_up_colname2` not present in y.
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -94,58 +94,53 @@ test_that("Error handling", {
   )
 
   # we print both message_x and message_y with an unnamed `by` vector
-  expect_snapshot({
-    (expect_error(
-      left_join(
-        arrow_table(example_data),
-        arrow_table(example_data),
-        by = "made_up_colname"
-      )
-    ))
-  })
+  expect_snapshot(
+    left_join(
+      arrow_table(example_data),
+      arrow_table(example_data),
+      by = "made_up_colname"
+    ),
+    error = TRUE
+  )
 
   # we only print message_y as `int` is a column of x
-  expect_snapshot({
-    (expect_error(
-      left_join(
-        arrow_table(example_data),
-        arrow_table(example_data),
-        by = c("int" = "made_up_colname")
-      )
-    ))
-  })
+  expect_snapshot(
+    left_join(
+      arrow_table(example_data),
+      arrow_table(example_data),
+      by = c("int" = "made_up_colname")
+    ),
+    error = TRUE
+  )
 
   # we only print message_x as `int` is a column of y
-  expect_snapshot({
-    (expect_error(
-      left_join(
-        arrow_table(example_data),
-        arrow_table(example_data),
-        by = c("made_up_colname" = "int")
-      )
-    ))
-  })
+  expect_snapshot(
+    left_join(
+      arrow_table(example_data),
+      arrow_table(example_data),
+      by = c("made_up_colname" = "int")
+    ),
+    error = TRUE
+  )
 
   # we print both message_x and message_y
-  expect_snapshot({
-    (expect_error(
-      left_join(
-        arrow_table(example_data),
-        arrow_table(example_data),
-        by = c("made_up_colname1", "made_up_colname2")
-      )
-    ))
-  })
+  expect_snapshot(
+    left_join(
+      arrow_table(example_data),
+      arrow_table(example_data),
+      by = c("made_up_colname1", "made_up_colname2")
+    ),
+    error = TRUE
+  )
 
-  expect_snapshot({
-    (expect_error(
-      left_join(
-        arrow_table(example_data),
-        arrow_table(example_data),
-        by = c("made_up_colname1" = "made_up_colname2")
-      )
-    ))
-  })
+  expect_snapshot(
+    left_join(
+      arrow_table(example_data),
+      arrow_table(example_data),
+      by = c("made_up_colname1" = "made_up_colname2")
+    ),
+    error = TRUE
+  )
 })
 
 # TODO: test duplicate col names

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -90,9 +90,57 @@ test_that("Error handling", {
     left_tab %>%
       left_join(to_join, by = "not_a_col") %>%
       collect(),
-    "all(names(by) %in% names(x)) is not TRUE",
-    fixed = TRUE
+    "Join column must be present in data"
   )
+  expect_snapshot({
+    (expect_error(
+      left_join(
+        arrow_table(example_data),
+        arrow_table(example_data),
+        by = "made_up_colname"
+      )
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      left_join(
+        arrow_table(example_data),
+        arrow_table(example_data),
+        by = c("int" = "made_up_colname")
+      )
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      left_join(
+        arrow_table(example_data),
+        arrow_table(example_data),
+        by = c("made_up_colname" = "int")
+      )
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      left_join(
+        arrow_table(example_data),
+        arrow_table(example_data),
+        by = c("made_up_colname1", "made_up_colname2")
+      )
+    ))
+  })
+
+  expect_snapshot({
+    (expect_error(
+      left_join(
+        arrow_table(example_data),
+        arrow_table(example_data),
+        by = c("made_up_colname1" = "made_up_colname2")
+      )
+    ))
+  })
 })
 
 # TODO: test duplicate col names

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -90,8 +90,10 @@ test_that("Error handling", {
     left_tab %>%
       left_join(to_join, by = "not_a_col") %>%
       collect(),
-    "Join column must be present in data"
+    "Join columns must be present in data"
   )
+
+  # we print both message_x and message_y with an unnamed `by` vector
   expect_snapshot({
     (expect_error(
       left_join(
@@ -102,6 +104,7 @@ test_that("Error handling", {
     ))
   })
 
+  # we only print message_y as `int` is a column of x
   expect_snapshot({
     (expect_error(
       left_join(
@@ -112,6 +115,7 @@ test_that("Error handling", {
     ))
   })
 
+  # we only print message_x as `int` is a column of y
   expect_snapshot({
     (expect_error(
       left_join(
@@ -122,6 +126,7 @@ test_that("Error handling", {
     ))
   })
 
+  # we print both message_x and message_y
   expect_snapshot({
     (expect_error(
       left_join(

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -218,7 +218,7 @@ test_that("ParquetFileWriter raises an error for non-OutputStream sink", {
   # ARROW-9946
   expect_error(
     ParquetFileWriter$create(schema = sch, sink = tempfile()),
-    regex = "OutputStream"
+    regexp = "OutputStream"
   )
 })
 


### PR DESCRIPTION
This PR makes {arrow} join error messages triggered by wrong column specification in `by` closer to the {dplyr} ones
```r
# {dplyr} error message
> left_join(iris, iris, by  = "made_up_colname")
Error: Join columns must be present in data.
x Problem with `made_up_colname`.
Run `rlang::last_error()` to see where the error occurred.

# current {arrow} error message
> left_join(arrow_table(iris), arrow_table(iris), by = "made_up_colname")
Error in handle_join_by(by, x, y) : 
  all(names(by) %in% names(x)) is not TRUE

# error message after this PR
> left_join(arrow_table(iris), arrow_table(iris), by = "made_up_colname")
Error: Join column must be present in data.
x `made_up_colname` not present in x.
x `made_up_colname` not present in y.
Run `rlang::last_error()` to see where the error occurred.
```

~This PR also introduces another dependency for {arrow}, namely {glue}. I don't think this to be an issue for the following reasons:~
* ~{glue} is already a second order dependency (via {vctrs} and {tidyselect})~
* ~{glue} is dependency-free, so making it a first order dependency adds a lot of useful functionality without making the {arrow} dependency tree more complex~

**Update**: this PR no longer introduces a dependency on {glue} - it has been split out into a discussion in [Jira](https://issues.apache.org/jira/browse/ARROW-15359). 