### PR TITLE
ARROW-15020: [R] Add bindings for new dataset writing options

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     utils,
     vctrs
 Roxygen: list(markdown = TRUE, r6 = FALSE, load = "source")
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.2.9000
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Suggests:

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     utils,
     vctrs
 Roxygen: list(markdown = TRUE, r6 = FALSE, load = "source")
-RoxygenNote: 7.1.2.9000
+RoxygenNote: 7.1.2
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Suggests:

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -720,8 +720,8 @@ dataset___Scanner__schema <- function(sc) {
   .Call(`_arrow_dataset___Scanner__schema`, sc)
 }
 
-dataset___Dataset__Write <- function(file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions) {
-  invisible(.Call(`_arrow_dataset___Dataset__Write`, file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions))
+dataset___Dataset__Write <- function(file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions, max_open_files, max_rows_per_file, min_rows_per_group, max_rows_per_group) {
+  invisible(.Call(`_arrow_dataset___Dataset__Write`, file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions, max_open_files, max_rows_per_file, min_rows_per_group, max_rows_per_group))
 }
 
 dataset___Scanner__TakeRows <- function(scanner, indices) {

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -111,6 +111,10 @@ write_dataset <- function(dataset,
                           hive_style = TRUE,
                           existing_data_behavior = c("overwrite", "error", "delete_matching"),
                           max_partitions = 1024L,
+                          max_open_files = 900L,
+                          max_rows_per_file = 0L,
+                          min_rows_per_group = 0L, 
+                          max_rows_per_group = bitwShiftL(1, 20),
                           ...) {
   format <- match.arg(format)
   if (inherits(dataset, "arrow_dplyr_query")) {
@@ -146,6 +150,8 @@ write_dataset <- function(dataset,
   dataset___Dataset__Write(
     options, path_and_fs$fs, path_and_fs$path,
     partitioning, basename_template, scanner,
-    existing_data_behavior, max_partitions
+    existing_data_behavior, max_partitions,
+    max_open_files, max_rows_per_file, 
+    min_rows_per_group, max_rows_per_group
   )
 }

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -50,6 +50,16 @@
 #'   partitions which data is not written to.
 #' @param max_partitions maximum number of partitions any batch may be
 #' written into. Default is 1024L.
+#' @param max_open_files maximum number of files that can be left opened
+#' during a write operation. Default is 900L.
+#' @param max_rows_per_file maximum limit how many rows are placed in 
+#' any single file
+#' @param min_rows_per_group write the row groups to the disk when sufficient 
+#' rows have accumulated.
+#' @param max_rows_per_group maximum number of row groups allowed in a single 
+#' group and when the rows execeeds, it is splitted and excess is written to 
+#' another group. This value must be set such that it is greater than 
+#' min_rows_per_group. 
 #' @param ... additional format-specific arguments. For available Parquet
 #' options, see [write_parquet()]. The available Feather options are:
 #' - `use_legacy_format` logical: write data formatted so that Arrow libraries

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -58,13 +58,13 @@
 #' into many small files. The default is 900 which also allows some # of files to be 
 #' open by the scanner before hitting the default Linux limit of 1024.
 #' @param max_rows_per_file maximum number of rows to be placed in
-#' any single file
+#' any single file. Default is 0L. 
 #' @param min_rows_per_group write the row groups to the disk when this number of 
-#' rows have accumulated.
+#' rows have accumulated. Default is 0L. 
 #' @param max_rows_per_group maximum rows allowed in a single 
 #' group and when this number of rows is exceeded, it is split and the next set 
 #' of rows is written to the next group. This value must be set such that it is 
-#' greater than `min_rows_per_group`.
+#' greater than `min_rows_per_group`. Default is 1024 * 1024. 
 #' @param ... additional format-specific arguments. For available Parquet
 #' options, see [write_parquet()]. The available Feather options are:
 #' - `use_legacy_format` logical: write data formatted so that Arrow libraries

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -51,15 +51,20 @@
 #' @param max_partitions maximum number of partitions any batch may be
 #' written into. Default is 1024L.
 #' @param max_open_files maximum number of files that can be left opened
-#' during a write operation. Default is 900L.
-#' @param max_rows_per_file maximum limit how many rows are placed in 
+#' during a write operation. If greater than 0 then this will limit the 
+#' maximum number of files that can be left open. If an attempt is made to open 
+#' too many files then the least recently used file will be closed.  
+#' If this setting is set too low you may end up fragmenting your data
+#' into many small files. The default is 900 which also allows some # of files to be 
+#' open by the scanner before hitting the default Linux limit of 1024.
+#' @param max_rows_per_file maximum number of rows to be placed in
 #' any single file
-#' @param min_rows_per_group write the row groups to the disk when sufficient 
+#' @param min_rows_per_group write the row groups to the disk when this number of 
 #' rows have accumulated.
-#' @param max_rows_per_group maximum number of row groups allowed in a single 
-#' group and when the rows execeeds, it is splitted and excess is written to 
-#' another group. This value must be set such that it is greater than 
-#' min_rows_per_group. 
+#' @param max_rows_per_group maximum rows allowed in a single 
+#' group and when this number of rows is exceeded, it is split and the next set 
+#' of rows is written to the next group. This value must be set such that it is 
+#' greater than `min_rows_per_group`.
 #' @param ... additional format-specific arguments. For available Parquet
 #' options, see [write_parquet()]. The available Feather options are:
 #' - `use_legacy_format` logical: write data formatted so that Arrow libraries
@@ -122,8 +127,8 @@ write_dataset <- function(dataset,
                           existing_data_behavior = c("overwrite", "error", "delete_matching"),
                           max_partitions = 1024L,
                           max_open_files = 900L,
-                          max_rows_per_file = 0L,
-                          min_rows_per_group = 0L, 
+                          max_rows_per_file = NULL,
+                          min_rows_per_group = 0L,
                           max_rows_per_group = bitwShiftL(1, 20),
                           ...) {
   format <- match.arg(format)
@@ -161,7 +166,7 @@ write_dataset <- function(dataset,
     options, path_and_fs$fs, path_and_fs$path,
     partitioning, basename_template, scanner,
     existing_data_behavior, max_partitions,
-    max_open_files, max_rows_per_file, 
+    max_open_files, max_rows_per_file,
     min_rows_per_group, max_rows_per_group
   )
 }

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -51,20 +51,20 @@
 #' @param max_partitions maximum number of partitions any batch may be
 #' written into. Default is 1024L.
 #' @param max_open_files maximum number of files that can be left opened
-#' during a write operation. If greater than 0 then this will limit the 
-#' maximum number of files that can be left open. If an attempt is made to open 
-#' too many files then the least recently used file will be closed.  
+#' during a write operation. If greater than 0 then this will limit the
+#' maximum number of files that can be left open. If an attempt is made to open
+#' too many files then the least recently used file will be closed.
 #' If this setting is set too low you may end up fragmenting your data
-#' into many small files. The default is 900 which also allows some # of files to be 
+#' into many small files. The default is 900 which also allows some # of files to be
 #' open by the scanner before hitting the default Linux limit of 1024.
 #' @param max_rows_per_file maximum number of rows to be placed in
-#' any single file. Default is 0L. 
-#' @param min_rows_per_group write the row groups to the disk when this number of 
-#' rows have accumulated. Default is 0L. 
-#' @param max_rows_per_group maximum rows allowed in a single 
-#' group and when this number of rows is exceeded, it is split and the next set 
-#' of rows is written to the next group. This value must be set such that it is 
-#' greater than `min_rows_per_group`. Default is 1024 * 1024. 
+#' any single file. Default is 0L.
+#' @param min_rows_per_group write the row groups to the disk when this number of
+#' rows have accumulated. Default is 0L.
+#' @param max_rows_per_group maximum rows allowed in a single
+#' group and when this number of rows is exceeded, it is split and the next set
+#' of rows is written to the next group. This value must be set such that it is
+#' greater than `min_rows_per_group`. Default is 1024 * 1024.
 #' @param ... additional format-specific arguments. For available Parquet
 #' options, see [write_parquet()]. The available Feather options are:
 #' - `use_legacy_format` logical: write data formatted so that Arrow libraries
@@ -158,9 +158,10 @@ write_dataset <- function(dataset,
   existing_data_behavior_opts <- c("delete_matching", "overwrite", "error")
   existing_data_behavior <- match(match.arg(existing_data_behavior), existing_data_behavior_opts) - 1L
 
-  if (!is_integerish(max_partitions, n = 1) || is.na(max_partitions) || max_partitions < 0) {
-    abort("max_partitions must be a positive, non-missing integer")
-  }
+  validate_positive_int_value(max_partitions, "max_partitions must be a positive, non-missing integer")
+  validate_positive_int_value(max_open_files, "max_open_files must be a positive, non-missing integer")
+  validate_positive_int_value(min_rows_per_group, "min_rows_per_group must be a positive, non-missing integer")
+  validate_positive_int_value(max_rows_per_group, "max_rows_per_group must be a positive, non-missing integer")
 
   dataset___Dataset__Write(
     options, path_and_fs$fs, path_and_fs$path,
@@ -169,4 +170,10 @@ write_dataset <- function(dataset,
     max_open_files, max_rows_per_file,
     min_rows_per_group, max_rows_per_group
   )
+}
+
+validate_positive_int_value <- function(value, msg) {
+  if (!is_integerish(value, n = 1) || is.na(value) || value < 0) {
+    abort(msg)
+  }
 }

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -127,7 +127,7 @@ write_dataset <- function(dataset,
                           existing_data_behavior = c("overwrite", "error", "delete_matching"),
                           max_partitions = 1024L,
                           max_open_files = 900L,
-                          max_rows_per_file = NULL,
+                          max_rows_per_file = NA,
                           min_rows_per_group = 0L,
                           max_rows_per_group = bitwShiftL(1, 20),
                           ...) {

--- a/r/man/write_dataset.Rd
+++ b/r/man/write_dataset.Rd
@@ -13,6 +13,10 @@ write_dataset(
   hive_style = TRUE,
   existing_data_behavior = c("overwrite", "error", "delete_matching"),
   max_partitions = 1024L,
+  max_open_files = 900L,
+  max_rows_per_file = NA,
+  min_rows_per_group = 0L,
+  max_rows_per_group = bitwShiftL(1, 20),
   ...
 )
 }
@@ -55,6 +59,25 @@ partitions which data is not written to.
 
 \item{max_partitions}{maximum number of partitions any batch may be
 written into. Default is 1024L.}
+
+\item{max_open_files}{maximum number of files that can be left opened
+during a write operation. If greater than 0 then this will limit the
+maximum number of files that can be left open. If an attempt is made to open
+too many files then the least recently used file will be closed.
+If this setting is set too low you may end up fragmenting your data
+into many small files. The default is 900 which also allows some # of files to be
+open by the scanner before hitting the default Linux limit of 1024.}
+
+\item{max_rows_per_file}{maximum number of rows to be placed in
+any single file}
+
+\item{min_rows_per_group}{write the row groups to the disk when this number of
+rows have accumulated.}
+
+\item{max_rows_per_group}{maximum rows allowed in a single
+group and when this number of rows is exceeded, it is split and the next set
+of rows is written to the next group. This value must be set such that it is
+greater than \code{min_rows_per_group}.}
 
 \item{...}{additional format-specific arguments. For available Parquet
 options, see \code{\link[=write_parquet]{write_parquet()}}. The available Feather options are:

--- a/r/man/write_dataset.Rd
+++ b/r/man/write_dataset.Rd
@@ -69,15 +69,15 @@ into many small files. The default is 900 which also allows some # of files to b
 open by the scanner before hitting the default Linux limit of 1024.}
 
 \item{max_rows_per_file}{maximum number of rows to be placed in
-any single file}
+any single file. Default is 0L.}
 
 \item{min_rows_per_group}{write the row groups to the disk when this number of
-rows have accumulated.}
+rows have accumulated. Default is 0L.}
 
 \item{max_rows_per_group}{maximum rows allowed in a single
 group and when this number of rows is exceeded, it is split and the next set
 of rows is written to the next group. This value must be set such that it is
-greater than \code{min_rows_per_group}.}
+greater than \code{min_rows_per_group}. Default is 1024 * 1024.}
 
 \item{...}{additional format-specific arguments. For available Parquet
 options, see \code{\link[=write_parquet]{write_parquet()}}. The available Feather options are:

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2847,8 +2847,8 @@ extern "C" SEXP _arrow_dataset___Scanner__schema(SEXP sc_sexp){
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-void dataset___Dataset__Write(const std::shared_ptr<ds::FileWriteOptions>& file_write_options, const std::shared_ptr<fs::FileSystem>& filesystem, std::string base_dir, const std::shared_ptr<ds::Partitioning>& partitioning, std::string basename_template, const std::shared_ptr<ds::Scanner>& scanner, arrow::dataset::ExistingDataBehavior existing_data_behavior, int max_partitions);
-extern "C" SEXP _arrow_dataset___Dataset__Write(SEXP file_write_options_sexp, SEXP filesystem_sexp, SEXP base_dir_sexp, SEXP partitioning_sexp, SEXP basename_template_sexp, SEXP scanner_sexp, SEXP existing_data_behavior_sexp, SEXP max_partitions_sexp){
+void dataset___Dataset__Write(const std::shared_ptr<ds::FileWriteOptions>& file_write_options, const std::shared_ptr<fs::FileSystem>& filesystem, std::string base_dir, const std::shared_ptr<ds::Partitioning>& partitioning, std::string basename_template, const std::shared_ptr<ds::Scanner>& scanner, arrow::dataset::ExistingDataBehavior existing_data_behavior, int max_partitions, uint32_t max_open_files, uint64_t max_rows_per_file, uint64_t min_rows_per_group, uint64_t max_rows_per_group);
+extern "C" SEXP _arrow_dataset___Dataset__Write(SEXP file_write_options_sexp, SEXP filesystem_sexp, SEXP base_dir_sexp, SEXP partitioning_sexp, SEXP basename_template_sexp, SEXP scanner_sexp, SEXP existing_data_behavior_sexp, SEXP max_partitions_sexp, SEXP max_open_files_sexp, SEXP max_rows_per_file_sexp, SEXP min_rows_per_group_sexp, SEXP max_rows_per_group_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<ds::FileWriteOptions>&>::type file_write_options(file_write_options_sexp);
 	arrow::r::Input<const std::shared_ptr<fs::FileSystem>&>::type filesystem(filesystem_sexp);
@@ -2858,12 +2858,16 @@ BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<ds::Scanner>&>::type scanner(scanner_sexp);
 	arrow::r::Input<arrow::dataset::ExistingDataBehavior>::type existing_data_behavior(existing_data_behavior_sexp);
 	arrow::r::Input<int>::type max_partitions(max_partitions_sexp);
-	dataset___Dataset__Write(file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions);
+	arrow::r::Input<uint32_t>::type max_open_files(max_open_files_sexp);
+	arrow::r::Input<uint64_t>::type max_rows_per_file(max_rows_per_file_sexp);
+	arrow::r::Input<uint64_t>::type min_rows_per_group(min_rows_per_group_sexp);
+	arrow::r::Input<uint64_t>::type max_rows_per_group(max_rows_per_group_sexp);
+	dataset___Dataset__Write(file_write_options, filesystem, base_dir, partitioning, basename_template, scanner, existing_data_behavior, max_partitions, max_open_files, max_rows_per_file, min_rows_per_group, max_rows_per_group);
 	return R_NilValue;
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_dataset___Dataset__Write(SEXP file_write_options_sexp, SEXP filesystem_sexp, SEXP base_dir_sexp, SEXP partitioning_sexp, SEXP basename_template_sexp, SEXP scanner_sexp, SEXP existing_data_behavior_sexp, SEXP max_partitions_sexp){
+extern "C" SEXP _arrow_dataset___Dataset__Write(SEXP file_write_options_sexp, SEXP filesystem_sexp, SEXP base_dir_sexp, SEXP partitioning_sexp, SEXP basename_template_sexp, SEXP scanner_sexp, SEXP existing_data_behavior_sexp, SEXP max_partitions_sexp, SEXP max_open_files_sexp, SEXP max_rows_per_file_sexp, SEXP min_rows_per_group_sexp, SEXP max_rows_per_group_sexp){
 	Rf_error("Cannot call dataset___Dataset__Write(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -7761,7 +7765,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___Scanner__ToRecordBatchReader", (DL_FUNC) &_arrow_dataset___Scanner__ToRecordBatchReader, 1}, 
 		{ "_arrow_dataset___Scanner__head", (DL_FUNC) &_arrow_dataset___Scanner__head, 2}, 
 		{ "_arrow_dataset___Scanner__schema", (DL_FUNC) &_arrow_dataset___Scanner__schema, 1}, 
-		{ "_arrow_dataset___Dataset__Write", (DL_FUNC) &_arrow_dataset___Dataset__Write, 8}, 
+		{ "_arrow_dataset___Dataset__Write", (DL_FUNC) &_arrow_dataset___Dataset__Write, 12}, 
 		{ "_arrow_dataset___Scanner__TakeRows", (DL_FUNC) &_arrow_dataset___Scanner__TakeRows, 2}, 
 		{ "_arrow_dataset___Scanner__CountRows", (DL_FUNC) &_arrow_dataset___Scanner__CountRows, 1}, 
 		{ "_arrow_Int8__initialize", (DL_FUNC) &_arrow_Int8__initialize, 0}, 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -517,7 +517,9 @@ void dataset___Dataset__Write(
     const std::shared_ptr<fs::FileSystem>& filesystem, std::string base_dir,
     const std::shared_ptr<ds::Partitioning>& partitioning, std::string basename_template,
     const std::shared_ptr<ds::Scanner>& scanner,
-    arrow::dataset::ExistingDataBehavior existing_data_behavior, int max_partitions) {
+    arrow::dataset::ExistingDataBehavior existing_data_behavior, int max_partitions,
+    uint32_t max_open_files, uint64_t max_rows_per_file, uint64_t min_rows_per_group, 
+    uint64_t max_rows_per_group) {
   ds::FileSystemDatasetWriteOptions opts;
   opts.file_write_options = file_write_options;
   opts.existing_data_behavior = existing_data_behavior;
@@ -526,6 +528,10 @@ void dataset___Dataset__Write(
   opts.partitioning = partitioning;
   opts.basename_template = basename_template;
   opts.max_partitions = max_partitions;
+  opts.max_open_files = max_open_files;
+  opts.max_rows_per_file = max_rows_per_file;
+  opts.min_rows_per_group = min_rows_per_group;
+  opts.max_rows_per_group = max_rows_per_group;
   StopIfNotOk(ds::FileSystemDataset::Write(opts, scanner));
 }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -518,7 +518,7 @@ void dataset___Dataset__Write(
     const std::shared_ptr<ds::Partitioning>& partitioning, std::string basename_template,
     const std::shared_ptr<ds::Scanner>& scanner,
     arrow::dataset::ExistingDataBehavior existing_data_behavior, int max_partitions,
-    uint32_t max_open_files, uint64_t max_rows_per_file, uint64_t min_rows_per_group, 
+    uint32_t max_open_files, uint64_t max_rows_per_file, uint64_t min_rows_per_group,
     uint64_t max_rows_per_group) {
   ds::FileSystemDatasetWriteOptions opts;
   opts.file_write_options = file_write_options;

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -538,4 +538,42 @@ test_that("write_dataset checks for format-specific arguments", {
     write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah"),
     error = TRUE
   )
+)}
+
+test_that("Dataset write max open files", {
+  skip_if_not_available("parquet") 
+  # test default partitioning
+  dst_dir <- make_temp_dir()
+  file_format <- "parquet"
+  partitioning <- c("c2")
+  num_of_unique_c2_groups = 5
+
+  get_num_of_files = function(dir, format) {
+    files <-  list.files(dir, pattern = paste('.', format, sep=""), 
+    all.files = FALSE, recursive = TRUE, full.names = TRUE)
+    length(files)
+  }
+
+  record_batch_1 <- record_batch(c1=c(1, 2, 3, 4, 0, 10),
+                                     c2=c('a', 'b', 'c', 'd', 'e', 'a'))
+  record_batch_2 <- record_batch(c1=c(5, 6, 7, 8, 0, 1),
+                                    c2=c('a', 'b', 'c', 'd', 'e', 'c'))
+  record_batch_3 <- record_batch(c1=c(9, 10, 11, 12, 0, 1),
+                                    c2=c('a', 'b', 'c', 'd', 'e', 'd'))
+  record_batch_4 <- record_batch(c1=c(13, 14, 15, 16, 0, 1),
+                                    c2=c('a', 'b', 'c', 'd', 'e', 'b'))
+
+  table = Table$create(d1=record_batch_1, d2=record_batch_2,
+                                  d3=record_batch_3, d4=record_batch_4)
+
+  write_dataset(table, path=dst_dir, format=file_format, partitioning=partitioning)
+
+  # reduce 1 from the length of list of directories, since it list the search path)
+  expect_equal(length(list.dirs(dst_dir)) - 1, num_of_unique_c2_groups)
+
+  max_open_files = 3
+  dst_dir <- make_temp_dir()
+  write_dataset(table, path=dst_dir, format=file_format, partitioning=partitioning, max_open_files=max_open_files)
+
+  expect_gt(get_num_of_files(dst_dir, file_format), max_open_files)
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -613,7 +613,47 @@ test_that("Dataset write max rows per files", {
   expect_equal(total_records, num_of_records)
 })
 
-test_that("Dataset write max rows per files", {
+test_that("Dataset min_rows_per_group", {
+  skip_if_not_available("parquet")
+  rb1 <- record_batch(c1=c(1, 2, 3, 4),
+                               c2=c('a', 'b', 'e', 'a'))
+  rb2 <- record_batch(c1=c(5, 6, 7, 8, 9),
+                                c2=c('a', 'b', 'c', 'd', 'h'))
+  rb3 <- record_batch(c1=c(9, 10, 11, 12, 0, 1, 100, 200, 300),
+                                c2=c('a', 'b', 'c', 'd', 'e', 'd', 'g', 'h', 'i'))
+  rb4 <- record_batch(c1=c(13, 14, 15, 16, 0, 1),
+                                c2=c('a', 'b', 'c', 'd', 'e', 'b'))
+
+  dataset = Table$create(d1=rb1, d2=rb2, d3=rb3, d4=rb4)
+
+  dst_dir <- make_temp_dir()
+  min_rows_per_group = 4
+  max_rows_per_group = 5
+
+  write_dataset(dataset, 
+                min_rows_per_group = min_rows_per_group, 
+                max_rows_per_group = max_rows_per_group, 
+                path = dst_dir)
+
+  ds = open_dataset(file_path)
+
+  row_group_sizes <- ds %>%
+    select() %>%
+    map_batches(~ .$num_rows, .data.frame = FALSE) %>%
+    unlist()
+  index = 1
+  for(row_group_size in row_group_sizes) {
+    if (length(row_group_sizes) < index) {
+      expect_gte(row_group_size, min_rows_per_group)
+      expect_lte(row_group_size, max_rows_per_group)
+    } else {
+      expect_lte(row_group_size, max_rows_per_group)
+    }
+    index = index + 1
+  }
+})
+
+test_that("Dataset write max rows per group", {
   skip_if_not_available("parquet") 
   num_of_records = 30
   max_rows_per_group = 18

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -541,75 +541,84 @@ test_that("write_dataset checks for format-specific arguments", {
 })
 
 get_num_of_files <- function(dir, format) {
-    files <-  list.files(dir, pattern = paste(".", format, sep = ""), 
-    all.files = FALSE, recursive = TRUE, full.names = TRUE)
-    length(files)
+  files <- list.files(dir, pattern = paste(".", format, sep = ""), recursive = TRUE, full.names = TRUE)
+  length(files)
 }
 
 test_that("Dataset write max open files", {
-  skip_if_not_available("parquet") 
+  skip_if_not_available("parquet")
   # test default partitioning
   dst_dir <- make_temp_dir()
   file_format <- "parquet"
-  partitioning <- c("c2")
-  num_of_unique_c2_groups = 5
+  partitioning <- "c2"
+  num_of_unique_c2_groups <- 5
 
   record_batch_1 <- record_batch(c1 = c(1, 2, 3, 4, 0, 10),
-                                     c2 = c("a", "b", "c", "d", "e", "a"))
+                                 c2 = c("a", "b", "c", "d", "e", "a"))
   record_batch_2 <- record_batch(c1 = c(5, 6, 7, 8, 0, 1),
-                                    c2 = c("a", "b", "c", "d", "e", "c"))
+                                 c2 = c("a", "b", "c", "d", "e", "c"))
   record_batch_3 <- record_batch(c1 = c(9, 10, 11, 12, 0, 1),
-                                    c2 = c("a", "b", "c", "d", "e", "d"))
+                                 c2 = c("a", "b", "c", "d", "e", "d"))
   record_batch_4 <- record_batch(c1 = c(13, 14, 15, 16, 0, 1),
-                                    c2 = c("a", "b", "c", "d", "e", "b"))
+                                 c2 = c("a", "b", "c", "d", "e", "b"))
 
-  table = Table$create(d1 = record_batch_1, d2 = record_batch_2,
-                                  d3 = record_batch_3, d4 = record_batch_4)
+  table <- Table$create(d1 = record_batch_1, d2 = record_batch_2,
+                        d3 = record_batch_3, d4 = record_batch_4)
 
   write_dataset(table, path = dst_dir, format = file_format, partitioning = partitioning)
 
   # reduce 1 from the length of list of directories, since it list the search path)
   expect_equal(length(list.dirs(dst_dir)) - 1, num_of_unique_c2_groups)
 
-  max_open_files = 3
+  max_open_files <- 3
   dst_dir <- make_temp_dir()
-  write_dataset(table, path = dst_dir, format = file_format, partitioning = partitioning,
-   max_open_files = max_open_files)
+  write_dataset(
+    table,
+    path = dst_dir,
+    format = file_format,
+    partitioning = partitioning,
+    max_open_files = max_open_files
+  )
 
   expect_gt(get_num_of_files(dst_dir, file_format), max_open_files)
 })
 
 
 test_that("Dataset write max rows per files", {
-  skip_if_not_available("parquet") 
-  num_of_records = 35
+  skip_if_not_available("parquet")
+  num_of_records <- 35
   df <- tibble::tibble(
     int = 1:num_of_records,
     dbl = as.numeric(1:num_of_records),
     lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 7),
     chr = rep(letters[1:7], 5),
   )
-  table = Table$create(df)
-  max_rows_per_file = 10
-  max_rows_per_group = 10
+  table <- Table$create(df)
+  max_rows_per_file <- 10
+  max_rows_per_group <- 10
   dst_dir <- make_temp_dir()
   file_format <- "parquet"
-  
-  write_dataset(table, path = dst_dir, format = file_format, max_rows_per_file = max_rows_per_file, 
-  max_rows_per_group=max_rows_per_group)
 
-  expected_partitions = num_of_records %/% max_rows_per_file + 1
-  written_files = list.files(dst_dir)
-  result_partitions = length(written_files)
+  write_dataset(
+    table,
+    path = dst_dir,
+    format = file_format,
+    max_rows_per_file = max_rows_per_file,
+    max_rows_per_group = max_rows_per_group
+  )
+
+  expected_partitions <- num_of_records %/% max_rows_per_file + 1
+  written_files <- list.files(dst_dir)
+  result_partitions <- length(written_files)
 
   expect_equal(expected_partitions, result_partitions)
-  total_records = 0
+  total_records <- 0
   for (file in written_files) {
-    file_path = paste(dst_dir, file, sep="/")
-    ds = read_parquet(file_path)
-    cur_records = nrow(ds)
+    file_path <- paste(dst_dir, file, sep = "/")
+    ds <- read_parquet(file_path)
+    cur_records <- nrow(ds)
     expect_lte(cur_records, max_rows_per_file)
-    total_records = total_records + cur_records
+    total_records <- total_records + cur_records
   }
   expect_equal(total_records, num_of_records)
 })
@@ -617,68 +626,73 @@ test_that("Dataset write max rows per files", {
 test_that("Dataset min_rows_per_group", {
   skip_if_not_available("parquet")
   rb1 <- record_batch(c1 = c(1, 2, 3, 4),
-                               c2 = c("a", "b", "e", "a"))
+                      c2 = c("a", "b", "e", "a"))
   rb2 <- record_batch(c1 = c(5, 6, 7, 8, 9),
-                                c2 = c("a", "b", "c", "d", "h"))
+                      c2 = c("a", "b", "c", "d", "h"))
   rb3 <- record_batch(c1 = c(9, 10, 11, 12, 0, 1, 100, 200, 300),
-                                c2 = c("a", "b", "c", "d", "e", "d", "g", "h", "i"))
+                      c2 = c("a", "b", "c", "d", "e", "d", "g", "h", "i"))
   rb4 <- record_batch(c1 = c(13, 14, 15, 16, 0, 1),
-                                c2 = c("a", "b", "c", "d", "e", "b"))
+                      c2 = c("a", "b", "c", "d", "e", "b"))
 
-  dataset = Table$create(d1 = rb1, d2 = rb2, d3 = rb3, d4 = rb4)
+  dataset <- Table$create(d1 = rb1, d2 = rb2, d3 = rb3, d4 = rb4)
 
   dst_dir <- make_temp_dir()
-  min_rows_per_group = 4
-  max_rows_per_group = 5
+  min_rows_per_group <- 4
+  max_rows_per_group <- 5
 
-  write_dataset(dataset, 
-                min_rows_per_group = min_rows_per_group, 
-                max_rows_per_group = max_rows_per_group, 
-                path = dst_dir)
+  write_dataset(
+    dataset,
+    min_rows_per_group = min_rows_per_group,
+    max_rows_per_group = max_rows_per_group,
+    path = dst_dir
+  )
 
-  ds = open_dataset(file_path)
+  ds <- open_dataset(dst_dir)
 
   row_group_sizes <- ds %>%
     select() %>%
     map_batches(~ .$num_rows, .data.frame = FALSE) %>%
     unlist()
-  index = 1
-  for(row_group_size in row_group_sizes) {
-    if (length(row_group_sizes) < index) {
-      expect_gte(row_group_size, min_rows_per_group)
-      expect_lte(row_group_size, max_rows_per_group)
-    } else {
-      expect_lte(row_group_size, max_rows_per_group)
-    }
-    index = index + 1
-  }
+  index <- 1
+
+  # We expect there to be 6 row groups
+  expect_length(row_group_sizes, 6L)
+
+  # We have all the rows
+  expect_equal(sum(row_group_sizes), nrow(ds))
+
+  # We expect that 5 of those will be between the two bounds
+  in_bounds <- row_group_sizes >= min_rows_per_group & row_group_sizes <= max_rows_per_group
+  expect_equal(sum(in_bounds), 5)
+  # and the last one that is not is less than the max:
+  expect_lte(row_group_sizes[!in_bounds], max_rows_per_group)
 })
 
 test_that("Dataset write max rows per group", {
-  skip_if_not_available("parquet") 
-  num_of_records = 30
-  max_rows_per_group = 18
+  skip_if_not_available("parquet")
+  num_of_records <- 30
+  max_rows_per_group <- 18
   df <- tibble::tibble(
-      int = 1:num_of_records,
-      dbl = as.numeric(1:num_of_records),
-  )  
-  table = Table$create(df)
+    int = 1:num_of_records,
+    dbl = as.numeric(1:num_of_records),
+  )
+  table <- Table$create(df)
   dst_dir <- make_temp_dir()
   file_format <- "parquet"
 
   write_dataset(table, path = dst_dir, format = file_format, max_rows_per_group = max_rows_per_group)
 
-  written_files = list.files(dst_dir)
-  record_combination = list()
-  
+  written_files <- list.files(dst_dir)
+  record_combination <- list()
+
   # writes only to a single file with multiple groups
-  file_path = paste(dst_dir, written_files[[1]], sep="/")
-  ds = open_dataset(file_path)
+  file_path <- paste(dst_dir, written_files[[1]], sep = "/")
+  ds <- open_dataset(file_path)
   row_group_sizes <- ds %>%
     select() %>%
     map_batches(~ .$num_rows, .data.frame = FALSE) %>%
     unlist() %>% # Returns list because .data.frame is FALSE
     sort()
-    
+
   expect_equal(row_group_sizes, c(12, 18))
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -538,7 +538,7 @@ test_that("write_dataset checks for format-specific arguments", {
     write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah"),
     error = TRUE
   )
-)}
+})
 
 get_num_of_files <- function(dir, format) {
     files <-  list.files(dir, pattern = paste(".", format, sep = ""), 

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -629,12 +629,10 @@ test_that("Dataset min_rows_per_group", {
                       c2 = c("a", "b", "e", "a"))
   rb2 <- record_batch(c1 = c(5, 6, 7, 8, 9),
                       c2 = c("a", "b", "c", "d", "h"))
-  rb3 <- record_batch(c1 = c(9, 10, 11, 12, 0, 1, 100, 200, 300),
-                      c2 = c("a", "b", "c", "d", "e", "d", "g", "h", "i"))
-  rb4 <- record_batch(c1 = c(13, 14, 15, 16, 0, 1),
-                      c2 = c("a", "b", "c", "d", "e", "b"))
+  rb3 <- record_batch(c1 = c(10, 11),
+                      c2 = c("a", "b"))
 
-  dataset <- Table$create(d1 = rb1, d2 = rb2, d3 = rb3, d4 = rb4)
+  dataset <- Table$create(d1 = rb1, d2 = rb2, d3 = rb3)
 
   dst_dir <- make_temp_dir()
   min_rows_per_group <- 4
@@ -655,15 +653,15 @@ test_that("Dataset min_rows_per_group", {
     unlist()
   index <- 1
 
-  # We expect there to be 6 row groups
-  expect_length(row_group_sizes, 6L)
+  # We expect there to be 3 row groups since 11/5 = 2.2 and 11/4 = 2.75
+  expect_length(row_group_sizes, 3L)
 
   # We have all the rows
   expect_equal(sum(row_group_sizes), nrow(ds))
 
-  # We expect that 5 of those will be between the two bounds
+  # We expect that 2 of those will be between the two bounds
   in_bounds <- row_group_sizes >= min_rows_per_group & row_group_sizes <= max_rows_per_group
-  expect_equal(sum(in_bounds), 5)
+  expect_equal(sum(in_bounds), 2)
   # and the last one that is not is less than the max:
   expect_lte(row_group_sizes[!in_bounds], max_rows_per_group)
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -602,10 +602,42 @@ test_that("Dataset write max rows per files", {
   result_partitions = length(written_files)
 
   expect_equal(expected_partitions, result_partitions)
-
+  total_records = 0
   for (file in written_files) {
     file_path = paste(dst_dir, file, sep="/")
     ds = read_parquet(file_path)
-    expect_lte(length(ds), max_rows_per_file)
+    cur_records = nrow(ds)
+    expect_lte(cur_records, max_rows_per_file)
+    total_records = total_records + cur_records
   }
+  expect_equal(total_records, num_of_records)
+})
+
+test_that("Dataset write max rows per files", {
+  skip_if_not_available("parquet") 
+  num_of_records = 30
+  max_rows_per_group = 18
+  df <- tibble::tibble(
+      int = 1:num_of_records,
+      dbl = as.numeric(1:num_of_records),
+  )  
+  table = Table$create(df)
+  dst_dir <- make_temp_dir()
+  file_format <- "parquet"
+
+  write_dataset(table, path=dst_dir, format=file_format, max_rows_per_group=max_rows_per_group)
+
+  written_files = list.files(dst_dir)
+  record_combination = list()
+  
+  # writes only to a single file with multiple groups
+  file_path = paste(dst_dir, written_files[[1]], sep="/")
+  ds = open_dataset(file_path)
+  row_group_sizes <- ds %>%
+    select() %>%
+    map_batches(~ .$num_rows, .data.frame = FALSE) %>%
+    unlist() %>% # Returns list because .data.frame is FALSE
+    sort()
+    
+  expect_equal(row_group_sizes, c(12, 18))
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -540,6 +540,12 @@ test_that("write_dataset checks for format-specific arguments", {
   )
 )}
 
+get_num_of_files = function(dir, format) {
+    files <-  list.files(dir, pattern = paste('.', format, sep=""), 
+    all.files = FALSE, recursive = TRUE, full.names = TRUE)
+    length(files)
+}
+
 test_that("Dataset write max open files", {
   skip_if_not_available("parquet") 
   # test default partitioning
@@ -547,12 +553,6 @@ test_that("Dataset write max open files", {
   file_format <- "parquet"
   partitioning <- c("c2")
   num_of_unique_c2_groups = 5
-
-  get_num_of_files = function(dir, format) {
-    files <-  list.files(dir, pattern = paste('.', format, sep=""), 
-    all.files = FALSE, recursive = TRUE, full.names = TRUE)
-    length(files)
-  }
 
   record_batch_1 <- record_batch(c1=c(1, 2, 3, 4, 0, 10),
                                      c2=c('a', 'b', 'c', 'd', 'e', 'a'))
@@ -576,4 +576,36 @@ test_that("Dataset write max open files", {
   write_dataset(table, path=dst_dir, format=file_format, partitioning=partitioning, max_open_files=max_open_files)
 
   expect_gt(get_num_of_files(dst_dir, file_format), max_open_files)
+})
+
+
+test_that("Dataset write max rows per files", {
+  skip_if_not_available("parquet") 
+  num_of_records = 35
+  df <- tibble::tibble(
+    int = 1:num_of_records,
+    dbl = as.numeric(1:num_of_records),
+    lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 7),
+    chr = rep(letters[1:7], 5),
+  )
+  table = Table$create(df)
+  max_rows_per_file = 10
+  max_rows_per_group = 10
+  dst_dir <- make_temp_dir()
+  file_format <- "parquet"
+  
+  write_dataset(table, path=dst_dir, format=file_format, max_rows_per_file=max_rows_per_file, 
+  max_rows_per_group=max_rows_per_group)
+
+  expected_partitions = num_of_records %/% max_rows_per_file + 1
+  written_files = list.files(dst_dir)
+  result_partitions = length(written_files)
+
+  expect_equal(expected_partitions, result_partitions)
+
+  for (file in written_files) {
+    file_path = paste(dst_dir, file, sep="/")
+    ds = read_parquet(file_path)
+    expect_lte(length(ds), max_rows_per_file)
+  }
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -540,8 +540,8 @@ test_that("write_dataset checks for format-specific arguments", {
   )
 )}
 
-get_num_of_files = function(dir, format) {
-    files <-  list.files(dir, pattern = paste('.', format, sep=""), 
+get_num_of_files <- function(dir, format) {
+    files <-  list.files(dir, pattern = paste(".", format, sep = ""), 
     all.files = FALSE, recursive = TRUE, full.names = TRUE)
     length(files)
 }
@@ -554,26 +554,27 @@ test_that("Dataset write max open files", {
   partitioning <- c("c2")
   num_of_unique_c2_groups = 5
 
-  record_batch_1 <- record_batch(c1=c(1, 2, 3, 4, 0, 10),
-                                     c2=c('a', 'b', 'c', 'd', 'e', 'a'))
-  record_batch_2 <- record_batch(c1=c(5, 6, 7, 8, 0, 1),
-                                    c2=c('a', 'b', 'c', 'd', 'e', 'c'))
-  record_batch_3 <- record_batch(c1=c(9, 10, 11, 12, 0, 1),
-                                    c2=c('a', 'b', 'c', 'd', 'e', 'd'))
-  record_batch_4 <- record_batch(c1=c(13, 14, 15, 16, 0, 1),
-                                    c2=c('a', 'b', 'c', 'd', 'e', 'b'))
+  record_batch_1 <- record_batch(c1 = c(1, 2, 3, 4, 0, 10),
+                                     c2 = c("a", "b", "c", "d", "e", "a"))
+  record_batch_2 <- record_batch(c1 = c(5, 6, 7, 8, 0, 1),
+                                    c2 = c("a", "b", "c", "d", "e", "c"))
+  record_batch_3 <- record_batch(c1 = c(9, 10, 11, 12, 0, 1),
+                                    c2 = c("a", "b", "c", "d", "e", "d"))
+  record_batch_4 <- record_batch(c1 = c(13, 14, 15, 16, 0, 1),
+                                    c2 = c("a", "b", "c", "d", "e", "b"))
 
-  table = Table$create(d1=record_batch_1, d2=record_batch_2,
-                                  d3=record_batch_3, d4=record_batch_4)
+  table = Table$create(d1 = record_batch_1, d2 = record_batch_2,
+                                  d3 = record_batch_3, d4 = record_batch_4)
 
-  write_dataset(table, path=dst_dir, format=file_format, partitioning=partitioning)
+  write_dataset(table, path = dst_dir, format = file_format, partitioning = partitioning)
 
   # reduce 1 from the length of list of directories, since it list the search path)
   expect_equal(length(list.dirs(dst_dir)) - 1, num_of_unique_c2_groups)
 
   max_open_files = 3
   dst_dir <- make_temp_dir()
-  write_dataset(table, path=dst_dir, format=file_format, partitioning=partitioning, max_open_files=max_open_files)
+  write_dataset(table, path = dst_dir, format = file_format, partitioning = partitioning,
+   max_open_files = max_open_files)
 
   expect_gt(get_num_of_files(dst_dir, file_format), max_open_files)
 })
@@ -594,7 +595,7 @@ test_that("Dataset write max rows per files", {
   dst_dir <- make_temp_dir()
   file_format <- "parquet"
   
-  write_dataset(table, path=dst_dir, format=file_format, max_rows_per_file=max_rows_per_file, 
+  write_dataset(table, path = dst_dir, format = file_format, max_rows_per_file = max_rows_per_file, 
   max_rows_per_group=max_rows_per_group)
 
   expected_partitions = num_of_records %/% max_rows_per_file + 1
@@ -615,16 +616,16 @@ test_that("Dataset write max rows per files", {
 
 test_that("Dataset min_rows_per_group", {
   skip_if_not_available("parquet")
-  rb1 <- record_batch(c1=c(1, 2, 3, 4),
-                               c2=c('a', 'b', 'e', 'a'))
-  rb2 <- record_batch(c1=c(5, 6, 7, 8, 9),
-                                c2=c('a', 'b', 'c', 'd', 'h'))
-  rb3 <- record_batch(c1=c(9, 10, 11, 12, 0, 1, 100, 200, 300),
-                                c2=c('a', 'b', 'c', 'd', 'e', 'd', 'g', 'h', 'i'))
-  rb4 <- record_batch(c1=c(13, 14, 15, 16, 0, 1),
-                                c2=c('a', 'b', 'c', 'd', 'e', 'b'))
+  rb1 <- record_batch(c1 = c(1, 2, 3, 4),
+                               c2 = c("a", "b", "e", "a"))
+  rb2 <- record_batch(c1 = c(5, 6, 7, 8, 9),
+                                c2 = c("a", "b", "c", "d", "h"))
+  rb3 <- record_batch(c1 = c(9, 10, 11, 12, 0, 1, 100, 200, 300),
+                                c2 = c("a", "b", "c", "d", "e", "d", "g", "h", "i"))
+  rb4 <- record_batch(c1 = c(13, 14, 15, 16, 0, 1),
+                                c2 = c("a", "b", "c", "d", "e", "b"))
 
-  dataset = Table$create(d1=rb1, d2=rb2, d3=rb3, d4=rb4)
+  dataset = Table$create(d1 = rb1, d2 = rb2, d3 = rb3, d4 = rb4)
 
   dst_dir <- make_temp_dir()
   min_rows_per_group = 4
@@ -665,7 +666,7 @@ test_that("Dataset write max rows per group", {
   dst_dir <- make_temp_dir()
   file_format <- "parquet"
 
-  write_dataset(table, path=dst_dir, format=file_format, max_rows_per_group=max_rows_per_group)
+  write_dataset(table, path = dst_dir, format = file_format, max_rows_per_group = max_rows_per_group)
 
   written_files = list.files(dst_dir)
   record_combination = list()


### PR DESCRIPTION
Adding R bindings for `write_dataset` with options 

- [x] `max_open_files` 
- [x] `max_rows_per_file` 
- [x] `min_rows_per_group` 
- [x]  `max_rows_per_group`

Test cases 

- [x] `max_open_files` 
- [x] `max_rows_per_file` 
- [x] `min_rows_per_group` 
- [x]  `max_rows_per_group`