### PR TITLE
[RFC] ARROW-15282: [C++][FlightRPC] Support non-grpc data planes

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -234,6 +234,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 
   define_option(ARROW_FLIGHT_SQL "Build the Arrow Flight SQL extension" OFF)
 
+  define_option(ARROW_FLIGHT_DP_SHM "Build the Arrow Flight shared memory data plane" OFF)
+
   define_option(ARROW_GANDIVA "Build the Gandiva libraries" OFF)
 
   define_option(ARROW_GCS

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -151,6 +151,13 @@ endif()
 # </KLUDGE> Restore the CXXFLAGS that were modified above
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BACKUP}")
 
+# Data plane source files
+# TODO(yibo): separate common (serialize.cc) and driver (shm.cc)
+if(ARROW_FLIGHT_DP_SHM)
+  add_definitions(-DFLIGHT_DP_SHM)
+  set(DATAPLANE_SRCS data_plane/serialize.cc data_plane/shm.cc)
+endif()
+
 # Note, we do not compile the generated Protobuf sources directly, instead
 # compiling then via protocol_internal.cc which contains some gRPC template
 # overrides to enable Flight-specific optimizations. See comments in
@@ -164,7 +171,8 @@ set(ARROW_FLIGHT_SRCS
     serialization_internal.cc
     server.cc
     server_auth.cc
-    types.cc)
+    types.cc
+    data_plane/types.cc)
 
 add_arrow_lib(arrow_flight
               CMAKE_PACKAGE_NAME
@@ -175,6 +183,7 @@ add_arrow_lib(arrow_flight
               ARROW_FLIGHT_LIBRARIES
               SOURCES
               ${ARROW_FLIGHT_SRCS}
+              ${DATAPLANE_SRCS}
               PRECOMPILED_HEADERS
               "$<$<COMPILE_LANGUAGE:CXX>:arrow/flight/pch.h>"
               DEPENDENCIES

--- a/cpp/src/arrow/flight/data_plane/internal.h
+++ b/cpp/src/arrow/flight/data_plane/internal.h
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/result.h"
+
+namespace arrow {
+namespace flight {
+namespace internal {
+
+class ClientDataPlane;
+class ServerDataPlane;
+
+enum class StreamType { kGet, kPut, kExchange };
+
+struct DataPlaneMaker {
+  arrow::Result<std::unique_ptr<ClientDataPlane>> (*make_client)(const std::string&);
+  arrow::Result<std::unique_ptr<ServerDataPlane>> (*make_server)(const std::string&);
+};
+
+// data plane makers are defined in data plane drivers
+DataPlaneMaker GetShmDataPlaneMaker();
+DataPlaneMaker GetUcxDataPlaneMaker();
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/data_plane/serialize.cc
+++ b/cpp/src/arrow/flight/data_plane/serialize.cc
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/data_plane/serialize.h"
+#include "arrow/flight/customize_protobuf.h"
+#include "arrow/flight/internal.h"
+#include "arrow/flight/serialization_internal.h"
+#include "arrow/result.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/make_unique.h"
+
+#include <grpc/byte_buffer.h>
+#include <grpc/slice.h>
+
+#include <cstring>
+
+namespace arrow {
+namespace flight {
+namespace internal {
+
+namespace {
+
+void ReleaseBuffer(void* buffer_ptr) {
+  delete reinterpret_cast<std::shared_ptr<Buffer>*>(buffer_ptr);
+}
+
+}  // namespace
+
+Status Deserialize(std::shared_ptr<Buffer> buffer, FlightData* data) {
+  // hold the buffer
+  std::shared_ptr<Buffer>* buffer_ptr = new std::shared_ptr<Buffer>(std::move(buffer));
+
+  const grpc::Slice slice((*buffer_ptr)->mutable_data(),
+                          static_cast<size_t>((*buffer_ptr)->size()), &ReleaseBuffer,
+                          buffer_ptr);
+  grpc::ByteBuffer bbuf = grpc::ByteBuffer(&slice, 1);
+
+  {
+    // make sure GrpcBuffer::Wrap goes the wanted path
+    auto grpc_bbuf = *reinterpret_cast<grpc_byte_buffer**>(&bbuf);
+    DCHECK_EQ(grpc_bbuf->type, GRPC_BB_RAW);
+    DCHECK_EQ(grpc_bbuf->data.raw.compression, GRPC_COMPRESS_NONE);
+    DCHECK_EQ(grpc_bbuf->data.raw.slice_buffer.count, 1);
+    grpc_slice slice = grpc_bbuf->data.raw.slice_buffer.slices[0];
+    DCHECK_NE(slice.refcount, 0);
+  }
+
+  // buffer ownership is transferred to "data" on success
+  const Status st = FromGrpcStatus(FlightDataDeserialize(&bbuf, data));
+  if (!st.ok()) {
+    delete buffer_ptr;
+  }
+  return st;
+}
+
+SerializeSlice::SerializeSlice(grpc::Slice&& slice) {
+  slice_ = arrow::internal::make_unique<grpc::Slice>(std::move(slice));
+}
+SerializeSlice::SerializeSlice(SerializeSlice&&) = default;
+SerializeSlice::~SerializeSlice() = default;
+
+const uint8_t* SerializeSlice::data() const { return slice_->begin(); }
+int64_t SerializeSlice::size() const { return static_cast<int64_t>(slice_->size()); }
+
+arrow::Result<std::vector<SerializeSlice>> Serialize(const FlightPayload& payload,
+                                                     int64_t* total_size) {
+  RETURN_NOT_OK(payload.Validate());
+
+  grpc::ByteBuffer bbuf;
+  bool owner;
+  RETURN_NOT_OK(FromGrpcStatus(FlightDataSerialize(payload, &bbuf, &owner)));
+
+  if (total_size) {
+    *total_size = static_cast<int64_t>(bbuf.Length());
+  }
+
+  // ByteBuffer::Dump doesn't copy data buffer, IIUC
+  std::vector<grpc::Slice> grpc_slices;
+  RETURN_NOT_OK(FromGrpcStatus(bbuf.Dump(&grpc_slices)));
+
+  // move grpc slice life cycle to returned serialize slice
+  std::vector<SerializeSlice> slices;
+  for (auto& grpc_slice : grpc_slices) {
+    SerializeSlice slice(std::move(grpc_slice));
+    slices.emplace_back(std::move(slice));
+  }
+  return slices;
+}
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/data_plane/serialize.h
+++ b/cpp/src/arrow/flight/data_plane/serialize.h
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/buffer.h"
+#include "arrow/result.h"
+
+#include <memory>
+#include <vector>
+
+namespace grpc {
+
+class Slice;
+
+};  // namespace grpc
+
+namespace arrow {
+namespace flight {
+
+struct FlightPayload;
+
+namespace internal {
+
+struct FlightData;
+
+// Reader buffer management
+// # data plane receives data and creates/stores to one reader buffer
+// # Deserialize() creates a new shared_ptr to hold the buffer, creates a
+//   gprc slice per that buffer, and installs destroyer callback, which
+//   deletes the created shared_ptr when grpc slice is freed
+// # Deserialize() calls FlightDataDeserialize() which transfers grpc slice
+//   lifecyce to Buffer object (FlightData->body) managed by the end consumer
+//   * see GrpcBuffer::slice_ in serialization_internal.cc
+// # releasing the reader buffer
+//   # end consumer frees FlightData
+//   # frees Buffer(GrpcBuffer) object
+//   # frees grpc slice GrpcBuffer::slice_
+//   # invokes destroyer to release reader buffer
+
+// Reader buffer must be a continuous memory block, see GrpcBuffer::Wrap
+// - FlightDataDeserialize will copy and flatten non-continuous blocks anyway
+// - it's necessary to get destroyer called
+
+Status Deserialize(std::shared_ptr<Buffer> buffer, FlightData* data);
+
+// Writer buffer management
+// # FlightDataSerialize() holds buffer (FlightPayload.ipc_msg.body_buffer[i])
+//   in returned grpc bbuf
+//   * see SliceFromBuffer in serialization_internal.cc
+// # dump grpc bbuf to a vector of grpc slice, then move to SerializeSlice[]
+// # data plane sends data per returned SerializeSlice[]
+// # releasing the writer buffer
+//   # data plane frees vector<SerializeSlice>
+//   # frees grpc slice SerializeSlice::slice_
+//   # release writer buffer
+
+// a simple wrapper of grpc::Slice, the only purpose is to hide grpc
+// from data plane implementation
+class SerializeSlice {
+ public:
+  explicit SerializeSlice(grpc::Slice&& slice);
+  SerializeSlice(SerializeSlice&&);
+  ~SerializeSlice();
+
+  const uint8_t* data() const;
+  int64_t size() const;
+
+ private:
+  std::unique_ptr<grpc::Slice> slice_;
+};
+
+arrow::Result<std::vector<SerializeSlice>> Serialize(const FlightPayload& payload,
+                                                     int64_t* total_size = NULLPTR);
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/data_plane/shm.cc
+++ b/cpp/src/arrow/flight/data_plane/shm.cc
@@ -1,0 +1,826 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// shared memory data plane driver
+// - client and server use fifo (named pipe) for messaging
+// - client and server mmap one pre-allocated shared buffer for flight payload
+//   exchanging, with best performance
+// - if no shared buffer available, an one-shot buffer is created on demand for
+//   each read/write operation, performance is probably poor
+
+// TODO(yibo):
+// - implement back pressure (common for all data planes)
+// - replace fifo with unix socket for ipc
+//   * current fifo based approach may leave garbage ipc files on crash
+//     with unix socket: unlink ipc files immediately after open, pass fd
+//   * fix a race issue (see ShmFifo:~ShmFifo())
+//   * socket based messaging may be re-usable by other data planes
+// - IS IT POSSIBLE to use existing grpc control path for data plane messaging
+// - improve buffer cache management
+//   * finer de-/allocation, better resource usage, drop one-shot buffer
+//   * better to be re-usable for other data planes
+
+// XXX: performance depends heavily on if the buffer cache is used effectively
+// - if payload size > kBufferSize, cache cannot be used, performance suffers
+// - cache capacity (kBufferCount) limits pending buffers not consumed by the
+//   reader, performance may suffer if reader is slower than the writer as the
+//   buffer cache is used up quickly
+
+// default buffer cache
+static constexpr int kBufferCount = 4;
+static constexpr int kBufferSize = 256 * 1024;
+
+#include "arrow/buffer.h"
+#include "arrow/flight/data_plane/internal.h"
+#include "arrow/flight/data_plane/serialize.h"
+#include "arrow/flight/data_plane/types.h"
+#include "arrow/result.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/counting_semaphore.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/make_unique.h"
+
+#include <atomic>
+#include <cstring>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdatomic.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace arrow {
+namespace flight {
+namespace internal {
+
+namespace {
+
+// stream map keys transferred together with grpc client metadata
+// must be unique, no capital letter
+// - name prefix of fifo and shared memory
+const char kIpcNamePrefix[] = "flight-dataplane-shm-ipc";
+
+// message between client and server
+struct ShmMsg {
+  static constexpr uint32_t kMagic = 0xFEEDCAFE;
+  static constexpr int kShmNameSize = 64;
+  // Get
+  // # server -> client: GetData
+  // # client -> server: GetAck/Nak
+  // # server -> client: GetDone (WritesDone)
+  // Put
+  // # client -> server: PutData
+  // # server -> client: PutAck/Nak
+  // # client -> server: PutDone (WritesDone)
+  enum Type {
+    Min,
+    GetData,
+    PutData,
+    GetAck,
+    PutAck,
+    GetNak,
+    PutNak,
+    GetDone,
+    PutDone,
+    GetInvalid,
+    PutInvalid,
+    Finish,
+    Max
+  };
+
+  ShmMsg() = default;
+
+  ShmMsg(Type type, int64_t size, const char* shm_name)
+      : magic(kMagic), type(type), size(size) {
+    // shm_name strlen is verified in Make
+    const int n = snprintf(this->shm_name, kShmNameSize, "%s", shm_name);
+    DCHECK(n >= 0 && n < kShmNameSize);
+  }
+
+  static arrow::Result<ShmMsg> Make(Type type, int64_t size = 0,
+                                    const std::string& shm_name = "") {
+    DCHECK(type > Type::Min && type < Type::Max);
+    if (shm_name.size() >= kShmNameSize) {
+      return Status::IOError("shared memory name length greater than ",
+                             int(kShmNameSize));
+    }
+    return ShmMsg(type, size, shm_name.c_str());
+  }
+
+  // passed across process, no pointer
+  uint32_t magic = kMagic;
+  Type type = Type::Min;
+  int64_t size = 0;
+  char shm_name[kShmNameSize]{};
+};
+
+// shared memory buffer
+class ShmBuffer : public MutableBuffer {
+ public:
+  // create and map a new shared memory with specified name and size, called by client
+  static arrow::Result<std::shared_ptr<ShmBuffer>> Create(const std::string& name,
+                                                          int64_t size) {
+    DCHECK_GT(size, 0);
+
+    int fd = shm_open(name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0666);
+    if (fd == -1) {
+      return Status::IOError("create shm: ", strerror(errno));
+    }
+    if (ftruncate(fd, size) == -1) {
+      const int saved_errno = errno;
+      close(fd);
+      shm_unlink(name.c_str());
+      return Status::IOError("ftruncate: ", strerror(saved_errno));
+    }
+
+    void* data =
+        mmap(NULL, static_cast<size_t>(size), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    const int saved_errno = errno;
+    close(fd);
+    if (data == MAP_FAILED) {
+      shm_unlink(name.c_str());
+      return Status::IOError("mmap: ", strerror(saved_errno));
+    }
+
+    return std::make_shared<ShmBuffer>(reinterpret_cast<uint8_t*>(data), size);
+  }
+
+  // open and map an existing shared memory, called by server
+  static arrow::Result<std::shared_ptr<ShmBuffer>> Open(const std::string& name,
+                                                        int64_t size) {
+    DCHECK_GT(size, 0);
+
+    int fd = shm_open(name.c_str(), O_RDWR, 0666);
+    if (fd == -1) {
+      return Status::IOError("open shm: ", strerror(errno));
+    }
+
+    void* data =
+        mmap(NULL, static_cast<size_t>(size), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    const int saved_errno = errno;
+    // memory is mapped, we can close shm fd and delete rpc file
+    close(fd);
+    shm_unlink(name.c_str());
+    if (data == MAP_FAILED) {
+      return Status::IOError("mmap: ", strerror(saved_errno));
+    }
+
+    return std::make_shared<ShmBuffer>(reinterpret_cast<uint8_t*>(data), size);
+  }
+
+  ShmBuffer(uint8_t* data, int64_t size) : MutableBuffer(data, size) {}
+
+  ~ShmBuffer() override { munmap(mutable_data(), static_cast<size_t>(size())); }
+};
+
+// per stream buffer cache
+class ShmCache {
+  class CachedBuffer : public MutableBuffer {
+   public:
+    CachedBuffer(std::shared_ptr<Buffer> parent, atomic_uchar* refcnt)
+        : MutableBuffer(parent->mutable_data(), parent->size()),
+          parent_(std::move(parent)),
+          refcnt_(refcnt) {}
+
+    // decreases reference count on destruction
+    ~CachedBuffer() {
+      const uint8_t current = atomic_fetch_sub(refcnt_, 1);
+      DCHECK(current == 1 || current == 2);
+    }
+
+   private:
+    // holds the parent buffer as refcnt_ locates there
+    std::shared_ptr<Buffer> parent_;
+    atomic_uchar* refcnt_;
+  };
+
+ public:
+  static arrow::Result<std::unique_ptr<ShmCache>> Create(const std::string& name_prefix,
+                                                         int buffer_count,
+                                                         int buffer_size) {
+    return CreateOrOpen(name_prefix, buffer_count, buffer_size, /*create=*/true);
+  }
+
+  static arrow::Result<std::unique_ptr<ShmCache>> Open(const std::string& name_prefix,
+                                                       int buffer_count,
+                                                       int buffer_size) {
+    return CreateOrOpen(name_prefix, buffer_count, buffer_size, /*create=*/false);
+  }
+
+  ShmCache(const std::string& name_prefix, int64_t buffer_count, int64_t buffer_size,
+           int64_t buffer_offset, std::shared_ptr<Buffer> buffer, atomic_uchar* refcnt)
+      : name_prefix_(name_prefix),
+        buffer_count_(buffer_count),
+        buffer_size_(buffer_size),
+        buffer_offset_(buffer_offset),
+        buffer_(std::move(buffer)),
+        refcnt_(refcnt) {}
+
+  // called by writer
+  arrow::Result<std::pair<std::string, std::shared_ptr<Buffer>>> CreateBuffer(
+      int64_t size, bool client) {
+    if (size <= buffer_size_) {
+      // acquire free cached buffer
+      for (int i = 0; i < buffer_count_; ++i) {
+        uint8_t expected = 0;
+        if (atomic_compare_exchange_strong(&refcnt_[i], &expected, 1)) {
+          auto buffer = std::make_shared<CachedBuffer>(
+              SliceMutableBuffer(buffer_, buffer_offset_ + buffer_size_ * i, size),
+              &refcnt_[i]);
+          // append buffer index to name
+          return std::make_pair(cached_buffer_prefix() + std::to_string(i),
+                                std::move(buffer));
+        }
+      }
+    }
+    // fallback to one-shot buffer if no cached buffer available
+    static std::atomic<unsigned> counter{0};
+    const std::string name =
+        name_prefix_ + (client ? "c" : "s") + std::to_string(++counter);
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ShmBuffer::Create(name, size));
+    return std::make_pair(name, std::move(buffer));
+  }
+
+  // called by reader
+  arrow::Result<std::shared_ptr<Buffer>> OpenBuffer(const std::string& shm_name,
+                                                    int64_t size) {
+    const std::string name_prefix = cached_buffer_prefix();
+    if (shm_name.find(name_prefix) == 0) {
+      const int i = std::stoi(
+          shm_name.substr(name_prefix.size(), shm_name.size() - name_prefix.size()));
+      if (i < 0 || i >= buffer_count_) {
+        return Status::IOError("invalid buffer index");
+      }
+      // normally, writer is still holding the buffer, refcnt should be 1
+      // but writer stream may have be destroyed which decreased refcnt to 0
+      const uint8_t current = atomic_fetch_add(&refcnt_[i], 1);
+      DCHECK(current == 0 || current == 1);
+      return std::make_shared<CachedBuffer>(
+          SliceMutableBuffer(buffer_, buffer_offset_ + buffer_size_ * i, size),
+          &refcnt_[i]);
+    }
+    return ShmBuffer::Open(shm_name, size);
+  }
+
+ private:
+  static arrow::Result<std::unique_ptr<ShmCache>> CreateOrOpen(
+      const std::string& name_prefix, int64_t buffer_count, int64_t buffer_size,
+      bool create) {
+    if (buffer_count < 0 || buffer_size < 0) {
+      return Status::Invalid("invalid buffer count or size");
+    }
+    if (buffer_count == 0 || buffer_size == 0) {
+      return arrow::internal::make_unique<ShmCache>(name_prefix, 0, 0, 0, nullptr,
+                                                    nullptr);
+    }
+
+    // allocate all buffers at once, prepend refcnt[] array
+    buffer_size = bit_util::RoundUpToPowerOf2(buffer_size, 64);
+    const int64_t buffer_offset = bit_util::RoundUpToPowerOf2(buffer_count, 64);
+    const int64_t total_size = buffer_offset + buffer_size * buffer_count;
+    ARROW_ASSIGN_OR_RAISE(auto buffer,
+                          create ? ShmBuffer::Create(name_prefix + "cc-shm", total_size)
+                                 : ShmBuffer::Open(name_prefix + "cc-shm", total_size));
+    atomic_uchar* refcnt = reinterpret_cast<atomic_uchar*>(buffer->mutable_data());
+    if (create) {
+      std::memset(refcnt, 0, buffer_count);
+    }
+    return arrow::internal::make_unique<ShmCache>(
+        name_prefix, buffer_count, buffer_size, buffer_offset, std::move(buffer), refcnt);
+  }
+
+  std::string cached_buffer_prefix() { return name_prefix_ + "cc-buf"; }
+
+  const std::string name_prefix_;
+  // shared buffer
+  // - all cached buffers are allocate in one continuous buffer
+  // - prepends refcnt[] array with each element refers to one buffer
+  //   * shared and accessed as atomic variables by client/server
+  //   * acquiring steps: 0 - free, 1 - created by writer, 2 - opened by reader
+  //   * releasing steps: both writer and reader decreased refcnt by 1
+  // - memory layout
+  //           +----------------+--------------+-----+------------------+
+  //   content | refcnt[count_] | buffer0      | ... | buffer[count_-1] |
+  //           +----------------+--------------+-----+------------------+
+  //      size | buffer_count_  | buffer_size_ | ... | buffer_size_     |
+  //           +----------------+--------------+-----+------------------+
+  //           ^                ^
+  //           |                |
+  //           0                buffer_offset_
+  const int64_t buffer_count_, buffer_size_, buffer_offset_;
+  std::shared_ptr<Buffer> buffer_;
+  atomic_uchar* refcnt_;
+  static_assert(sizeof(atomic_uchar) == 1, "");
+};
+
+// fifo for client and server messages
+class ShmFifo {
+ public:
+  // create and open two fifos for read/write, called by client
+  static arrow::Result<std::unique_ptr<ShmFifo>> Create(
+      const std::string& fifo_name, std::unique_ptr<ShmCache>&& shm_cache) {
+    const std::string reader_path = "/tmp/" + fifo_name + "s2c";
+    const std::string writer_path = "/tmp/" + fifo_name + "c2s";
+    if (mkfifo(reader_path.c_str(), 0666) == -1) {
+      return Status::IOError("mkfifo: ", strerror(errno));
+    }
+    if (mkfifo(writer_path.c_str(), 0666) == -1) {
+      unlink(reader_path.c_str());
+      return Status::IOError("mkfifo: ", strerror(errno));
+    }
+    // fifo open hangs if RDONLY or WRONLY (until peer opens)
+    int reader_fd = open(reader_path.c_str(), O_RDWR);
+    int writer_fd = open(writer_path.c_str(), O_RDWR);
+    if (reader_fd == -1 || writer_fd == -1) {
+      unlink(reader_path.c_str());
+      unlink(writer_path.c_str());
+      if (reader_fd != -1) close(reader_fd);
+      if (writer_fd != -1) close(writer_fd);
+      return Status::IOError("create fifo");
+    }
+    return arrow::internal::make_unique<ShmFifo>(std::move(shm_cache), reader_fd,
+                                                 writer_fd);
+  }
+
+  // open existing fifos, called by server
+  static arrow::Result<std::unique_ptr<ShmFifo>> Open(
+      const std::string& fifo_name, std::unique_ptr<ShmCache>&& shm_cache) {
+    const std::string reader_path = "/tmp/" + fifo_name + "c2s";
+    const std::string writer_path = "/tmp/" + fifo_name + "s2c";
+    int reader_fd = open(reader_path.c_str(), O_RDWR);
+    int writer_fd = open(writer_path.c_str(), O_RDWR);
+    // we've opened the fifos, unlink fifo files
+    unlink(reader_path.c_str());
+    unlink(writer_path.c_str());
+    if (reader_fd == -1 || writer_fd == -1) {
+      if (reader_fd != -1) close(reader_fd);
+      if (writer_fd != -1) close(writer_fd);
+      return Status::IOError("open fifos");
+    }
+    return arrow::internal::make_unique<ShmFifo>(std::move(shm_cache), reader_fd,
+                                                 writer_fd);
+  }
+
+  ShmFifo(std::unique_ptr<ShmCache>&& shm_cache, int reader_fd, int writer_fd)
+      : shm_cache_(std::move(shm_cache)), reader_fd_(reader_fd), writer_fd_(writer_fd) {
+    pipe(pipe_fds_);
+    reader_thread_ = std::thread([this] { ReaderThread(); });
+  }
+
+  ~ShmFifo() {
+    StopReaderThread();
+    close(pipe_fds_[0]);
+    close(pipe_fds_[1]);
+    close(reader_fd_);
+    // XXX: if writer fifo closes immediately after writing finish message
+    // the reader fifo may not see the messag and timeout (both ends must
+    // be open for fifo to work properly)
+    // it won't happen after replacing fifo with unix socket
+    // below horrible code is a temporary workaround for this issue
+    int writer_fd = writer_fd_;
+    std::thread([writer_fd]() {
+      sleep(1);
+      close(writer_fd);
+    }).detach();
+  }
+
+  Status WriteData(ShmMsg::Type msg_type, std::shared_ptr<Buffer> buffer,
+                   const std::string& shm_name) {
+    DCHECK(msg_type == ShmMsg::GetData || msg_type == ShmMsg::PutData);
+    if (peer_finished_) {
+      return Status::IOError("peer finished or cancelled");
+    }
+
+    const int64_t size = buffer->size();
+    ARROW_ASSIGN_OR_RAISE(ShmMsg msg, ShmMsg::Make(msg_type, size, shm_name));
+
+    // hold write buffer in held_writers_ map to wait for peer response
+    // it must be done before writing os fifo, in case peer responses fast
+    {
+      const std::lock_guard<std::mutex> lock(held_writers_mtx_);
+      DCHECK_EQ(held_writers_.find(shm_name), held_writers_.end());
+      held_writers_[shm_name] = std::move(buffer);
+    }
+
+    // write to os fifo
+    const Status st = OsWriteFifo(msg);
+    if (!st.ok()) {
+      // release the buffer on error
+      const std::lock_guard<std::mutex> lock(held_writers_mtx_);
+      const auto n = held_writers_.erase(shm_name);
+      DCHECK_EQ(n, 1);
+    }
+    return st;
+  }
+
+  Status WriteCtrl(ShmMsg::Type msg_type) {
+    ARROW_ASSIGN_OR_RAISE(ShmMsg msg, ShmMsg::Make(msg_type));
+    return OsWriteFifo(msg);
+  }
+
+  arrow::Result<std::pair<ShmMsg::Type, std::shared_ptr<Buffer>>> ReadMsg() {
+    RETURN_NOT_OK(reader_sem_.Acquire(1));
+    const std::lock_guard<std::mutex> lock(reader_queue_mtx_);
+    auto v = reader_queue_.front();
+    reader_queue_.pop();
+    return std::move(v);
+  }
+
+  arrow::Result<std::pair<std::string, std::shared_ptr<Buffer>>> CreateBuffer(
+      int64_t size, bool client) {
+    return shm_cache_->CreateBuffer(size, client);
+  }
+
+ private:
+  void ReaderThread() {
+    ShmMsg msg;
+    while (OsReadFifo(&msg).ok()) {
+      DCHECK_EQ(msg.magic, ShmMsg::kMagic);
+
+      switch (msg.type) {
+        // data
+        case ShmMsg::GetData:
+        case ShmMsg::PutData:
+          // create buffer per received message, append to reader queue
+          {
+            ShmMsg::Type msg_type = msg.type;
+            std::shared_ptr<Buffer> buffer;
+            auto result = shm_cache_->OpenBuffer(msg.shm_name, msg.size);
+            if (result.ok()) {
+              buffer = result.ValueOrDie();
+            } else {
+              msg_type =
+                  msg.type == ShmMsg::GetData ? ShmMsg::GetInvalid : ShmMsg::PutInvalid;
+            }
+            {
+              std::lock_guard<std::mutex> lock(reader_queue_mtx_);
+              reader_queue_.emplace(msg_type, std::move(buffer));
+            }
+            ARROW_UNUSED(reader_sem_.Release(1));
+            // send response so the writer can free its buffer
+            if (msg.type == ShmMsg::GetData) {
+              msg.type = result.ok() ? ShmMsg::GetAck : ShmMsg::GetNak;
+            } else {
+              msg.type = result.ok() ? ShmMsg::PutAck : ShmMsg::PutNak;
+            }
+            DCHECK_OK(OsWriteFifo(msg));
+          }
+          break;
+        // writes done, error, finish
+        case ShmMsg::GetDone:
+        case ShmMsg::PutDone:
+        case ShmMsg::GetInvalid:
+        case ShmMsg::PutInvalid:
+        case ShmMsg::Finish: {
+          const std::lock_guard<std::mutex> lock(reader_queue_mtx_);
+          reader_queue_.emplace(msg.type, std::shared_ptr<Buffer>());
+        }
+          ARROW_UNUSED(reader_sem_.Release(1));
+          if (msg.type == ShmMsg::Finish) {
+            peer_finished_ = true;
+          }
+          break;
+        // data response
+        case ShmMsg::GetAck:
+        case ShmMsg::GetNak:
+        case ShmMsg::PutAck:
+        case ShmMsg::PutNak:
+          // release according write buffer
+          {
+            const std::lock_guard<std::mutex> lock(held_writers_mtx_);
+            const auto n = held_writers_.erase(msg.shm_name);
+            DCHECK_EQ(n, 1);
+          }
+          break;
+        default:
+          DCHECK(false);
+          break;
+      }
+
+      std::memset(&msg, 0, sizeof(ShmMsg));
+    }
+  }
+
+  // make sure to write/read a full message per call
+  Status OsWriteFifo(const ShmMsg& msg) {
+    if (fifo_write_error_) {
+      return Status::IOError("fifo write error");
+    }
+    const uint8_t* buf = reinterpret_cast<const uint8_t*>(&msg);
+    size_t count = sizeof(ShmMsg);
+    while (count > 0) {
+      ssize_t ret = write(writer_fd_, buf, count);
+      if (ret == -1 && errno != EINTR) {
+        fifo_write_error_ = true;
+        return Status::IOError("write: ", strerror(errno));
+      }
+      count -= ret;
+      buf += ret;
+    }
+    return Status::OK();
+  }
+
+  Status OsReadFifo(ShmMsg* msg) {
+    struct pollfd fds[2];
+    fds[0].fd = reader_fd_;
+    fds[0].events = POLLIN;
+    fds[1].fd = pipe_fds_[0];
+    fds[1].events = POLLIN;
+
+    uint8_t* buf = reinterpret_cast<uint8_t*>(msg);
+    size_t count = sizeof(ShmMsg);
+    while (count > 0) {
+      // force checking stop token every 5 seconds, in case pipe method fails
+      if (poll(fds, 2, 5000) == -1) {
+        if (errno == EINTR) {
+          continue;
+        }
+        return Status::IOError("poll: ", strerror(errno));
+      }
+      if ((fds[1].revents & POLLIN) || stop_) {
+        // exit thread if pipe received something or stop token is set
+        return Status::IOError("stop requested");
+      }
+      if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        return Status::IOError("error polled");
+      }
+      if (fds[0].revents & POLLIN) {
+        ssize_t ret = read(reader_fd_, buf, count);
+        count -= ret;
+        buf += ret;
+      }
+    }
+    return Status::OK();
+  }
+
+  void StopReaderThread() {
+    stop_ = true;
+    while (write(pipe_fds_[1], "s", 1) == -1 && errno == EINTR) {
+    }
+    reader_thread_.join();
+  }
+
+  std::unique_ptr<ShmCache> shm_cache_;
+  // os fifo fd
+  int reader_fd_, writer_fd_;
+  bool fifo_write_error_{false};
+  std::thread reader_thread_;
+  // self pipe to stop reader thread
+  int pipe_fds_[2];
+  // force stoping reader thread in case pipe method fails
+  std::atomic<bool> stop_{false};
+  // read message queue with timeout (XXX: suitable value?)
+  arrow::util::CountingSemaphore reader_sem_{/*initial=*/0, /*timeout_seconds=*/5};
+  std::queue<std::pair<ShmMsg::Type, std::shared_ptr<Buffer>>> reader_queue_;
+  std::mutex reader_queue_mtx_;
+  // write buffers cannot be freed before peer response
+  std::unordered_map<std::string, std::shared_ptr<Buffer>> held_writers_;
+  std::mutex held_writers_mtx_;
+  // received finish or cancel message, cannot write anymore
+  std::atomic<bool> peer_finished_{false};
+};
+
+struct ShmStreamImpl {
+  ShmStreamImpl(bool client, StreamType stream_type, std::unique_ptr<ShmFifo>&& shm_fifo)
+      : client_(client), stream_type_(stream_type), shm_fifo_(std::move(shm_fifo)) {}
+
+  Status Read(FlightData* data) {
+    DCHECK_NE(stream_type_, client_ ? StreamType::kPut : StreamType::kGet);
+    const std::string prefix = client_ ? "client: " : "server: ";
+    if (reads_done_) {
+      return Status::IOError(prefix, "reads done");
+    }
+    ShmMsg::Type msg_type;
+    std::shared_ptr<Buffer> buffer;
+    ARROW_ASSIGN_OR_RAISE(std::tie(msg_type, buffer), shm_fifo_->ReadMsg());
+    switch (msg_type) {
+      case ShmMsg::GetData:
+      case ShmMsg::PutData:
+        DCHECK_EQ(msg_type == ShmMsg::GetData, client_);
+        return Deserialize(std::move(buffer), data);
+      case ShmMsg::GetDone:
+      case ShmMsg::PutDone:
+        DCHECK_EQ(msg_type == ShmMsg::GetDone, client_);
+        reads_done_ = true;
+        return Status::IOError(prefix, "peer done writing");
+      case ShmMsg::GetInvalid:
+      case ShmMsg::PutInvalid:
+        DCHECK_EQ(msg_type == ShmMsg::GetInvalid, client_);
+        return Status::Invalid(prefix, "recevied invalid payload");
+      case ShmMsg::Finish:
+        DCHECK(!client_);
+        reads_done_ = writes_done_ = true;
+        return Status::IOError(prefix, "client finished");
+      default:
+        DCHECK(false);
+        return Status::Invalid(prefix, "received invalid message");
+    }
+  }
+
+  Status Write(const FlightPayload& payload) {
+    DCHECK_NE(stream_type_, client_ ? StreamType::kGet : StreamType::kPut);
+    if (writes_done_) {
+      return Status::IOError(client_ ? "client" : "server", ": writes done");
+    }
+    int64_t total_size;
+    auto result = Serialize(payload, &total_size);
+    if (!result.ok()) {
+      ARROW_UNUSED(
+          shm_fifo_->WriteCtrl(client_ ? ShmMsg::PutInvalid : ShmMsg::GetInvalid));
+      return result.status();
+    }
+    DCHECK_GT(total_size, 0);
+    const std::vector<SerializeSlice>& slices = result.ValueOrDie();
+
+    std::string shm_name;
+    std::shared_ptr<Buffer> buffer;
+    ARROW_ASSIGN_OR_RAISE(std::tie(shm_name, buffer),
+                          shm_fifo_->CreateBuffer(total_size, client_));
+    CopySlicesToBuffer(slices, buffer.get());
+    return shm_fifo_->WriteData(client_ ? ShmMsg::PutData : ShmMsg::GetData,
+                                std::move(buffer), shm_name);
+  }
+
+  Status WritesDone() {
+    DCHECK_NE(stream_type_, client_ ? StreamType::kGet : StreamType::kPut);
+    if (writes_done_) {
+      return Status::OK();
+    }
+    writes_done_ = true;
+    return shm_fifo_->WriteCtrl(client_ ? ShmMsg::PutDone : ShmMsg::GetDone);
+  }
+
+  static void CopySlicesToBuffer(const std::vector<SerializeSlice>& slices,
+                                 Buffer* buffer) {
+    uint8_t* dest_ptr = buffer->mutable_data();
+    for (const auto& slice : slices) {
+      DCHECK_LE(dest_ptr + slice.size(), buffer->data() + buffer->size());
+      std::memcpy(dest_ptr, slice.data(), static_cast<size_t>(slice.size()));
+      dest_ptr += slice.size();
+    }
+    DCHECK_EQ(dest_ptr, buffer->data() + buffer->size());
+  }
+
+  const bool client_;
+  const StreamType stream_type_;
+  std::unique_ptr<ShmFifo> shm_fifo_;
+  std::atomic<bool> reads_done_{false}, writes_done_{false};
+};
+
+class ShmClientStream : public DataClientStream {
+ public:
+  ShmClientStream(StreamType stream_type, std::unique_ptr<ShmFifo>&& shm_fifo)
+      : stream_(/*client=*/true, stream_type, std::move(shm_fifo)) {}
+
+  ~ShmClientStream() { ARROW_UNUSED(Finish()); }
+
+  Status Read(FlightData* data) override { return stream_.Read(data); }
+  Status Write(const FlightPayload& payload) override { return stream_.Write(payload); }
+  Status WritesDone() override { return stream_.WritesDone(); }
+
+  Status Finish() override {
+    stream_.writes_done_ = stream_.reads_done_ = true;
+    return stream_.shm_fifo_->WriteCtrl(ShmMsg::Finish);
+  }
+
+  void TryCancel() override {
+    ARROW_UNUSED(stream_.shm_fifo_->WriteCtrl(ShmMsg::Finish));
+  }
+
+ private:
+  ShmStreamImpl stream_;
+};
+
+class ShmServerStream : public DataServerStream {
+ public:
+  ShmServerStream(StreamType stream_type, std::unique_ptr<ShmFifo>&& shm_fifo)
+      : stream_(/*client=*/false, stream_type, std::move(shm_fifo)) {}
+
+  ~ShmServerStream() {
+    if (stream_.stream_type_ != StreamType::kPut) {
+      ARROW_UNUSED(WritesDone());
+    }
+  }
+
+  Status Read(FlightData* data) override { return stream_.Read(data); }
+  Status Write(const FlightPayload& payload) override { return stream_.Write(payload); }
+  Status WritesDone() override { return stream_.WritesDone(); }
+
+ private:
+  ShmStreamImpl stream_;
+};
+
+class ShmClientDataPlane : public ClientDataPlane {
+ private:
+  ResultClientStream DoGetImpl(StreamMap* map) override {
+    return Do(map, StreamType::kGet);
+  }
+
+  ResultClientStream DoPutImpl(StreamMap* map) override {
+    return Do(map, StreamType::kPut);
+  }
+
+  ResultClientStream DoExchangeImpl(StreamMap* map) override {
+    return Do(map, StreamType::kExchange);
+  }
+
+  ResultClientStream Do(StreamMap* map, StreamType stream_type) {
+    const std::string name_prefix = GenerateNamePrefix();
+    (*map)[kIpcNamePrefix] = name_prefix;
+    ARROW_ASSIGN_OR_RAISE(auto shm_cache,
+                          ShmCache::Create(name_prefix, kBufferCount, kBufferSize));
+    ARROW_ASSIGN_OR_RAISE(auto shm_fifo,
+                          ShmFifo::Create(name_prefix, std::move(shm_cache)));
+    return arrow::internal::make_unique<ShmClientStream>(stream_type,
+                                                         std::move(shm_fifo));
+  }
+
+  // generate system unique name prefix for ipc objects
+  // prefix = "/flight-shm-{client pid}-{stream counter}-"
+  std::string GenerateNamePrefix() {
+    static std::atomic<unsigned> counter{0};
+    std::stringstream name_prefix;
+    name_prefix << "/flight-shm-" << getpid() << '-' << ++counter << '-';
+    return name_prefix.str();
+  }
+};
+
+class ShmServerDataPlane : public ServerDataPlane {
+ private:
+  ResultServerStream DoGetImpl(const StreamMap& map) override {
+    return Do(map, StreamType::kGet);
+  }
+
+  ResultServerStream DoPutImpl(const StreamMap& map) override {
+    return Do(map, StreamType::kPut);
+  }
+
+  ResultServerStream DoExchangeImpl(const StreamMap& map) override {
+    return Do(map, StreamType::kExchange);
+  }
+
+  std::vector<std::string> stream_keys() override { return {kIpcNamePrefix}; }
+
+  ResultServerStream Do(const StreamMap& map, StreamType stream_type) {
+    ARROW_ASSIGN_OR_RAISE(auto name_prefix, GetNamePrefix(map));
+    ARROW_ASSIGN_OR_RAISE(auto shm_cache,
+                          ShmCache::Open(name_prefix, kBufferCount, kBufferSize));
+    ARROW_ASSIGN_OR_RAISE(auto shm_fifo,
+                          ShmFifo::Open(name_prefix, std::move(shm_cache)));
+    return arrow::internal::make_unique<ShmServerStream>(stream_type,
+                                                         std::move(shm_fifo));
+  }
+
+  // extract ipc objecs name prefix from stream map set by client
+  arrow::Result<std::string> GetNamePrefix(const StreamMap& map) {
+    auto it = map.find(kIpcNamePrefix);
+    if (it == map.end()) {
+      return Status::Invalid("key not found: ", kIpcNamePrefix);
+    }
+    return it->second;
+  }
+};
+
+arrow::Result<std::unique_ptr<ClientDataPlane>> MakeShmClientDataPlane(
+    const std::string&) {
+  return arrow::internal::make_unique<ShmClientDataPlane>();
+}
+
+arrow::Result<std::unique_ptr<ServerDataPlane>> MakeShmServerDataPlane(
+    const std::string&) {
+  return arrow::internal::make_unique<ShmServerDataPlane>();
+}
+
+}  // namespace
+
+DataPlaneMaker GetShmDataPlaneMaker() {
+  return {MakeShmClientDataPlane, MakeShmServerDataPlane};
+}
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/data_plane/types.cc
+++ b/cpp/src/arrow/flight/data_plane/types.cc
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/data_plane/types.h"
+#include "arrow/flight/data_plane/internal.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/make_unique.h"
+
+#ifdef GRPCPP_PP_INCLUDE
+#include <grpcpp/grpcpp.h>
+#else
+#include <grpc++/grpc++.h>
+#endif
+
+namespace arrow {
+namespace flight {
+namespace internal {
+
+namespace {
+
+// data plane registry (name -> data plane maker)
+struct Registry {
+  std::map<const std::string, DataPlaneMaker> makers;
+
+  // register all data planes on creation of registry singleton
+  Registry() {
+#ifdef FLIGHT_DP_SHM
+    Register("shm", GetShmDataPlaneMaker());
+#endif
+  }
+
+  static const Registry& instance() {
+    static const Registry registry;
+    return registry;
+  }
+
+  void Register(const std::string& name, const DataPlaneMaker& maker) {
+    DCHECK_EQ(makers.find(name), makers.end());
+    makers[name] = maker;
+  }
+
+  arrow::Result<DataPlaneMaker> GetDataPlaneMaker(const std::string& uri) const {
+    const std::string name = uri.substr(0, uri.find(':'));
+    auto it = makers.find(name);
+    if (it == makers.end()) {
+      return Status::Invalid("unknown data plane: ", name);
+    }
+    return it->second;
+  }
+};
+
+std::string GetGrpcMetadata(const grpc::ServerContext& context, const std::string& key) {
+  const auto client_metadata = context.client_metadata();
+  const auto found = client_metadata.find(key);
+  std::string token;
+  if (found == client_metadata.end()) {
+    DCHECK(false);
+    token = "";
+  } else {
+    token = std::string(found->second.data(), found->second.length());
+  }
+  return token;
+}
+
+// TODO(yibo): getting data plane uri from env var is bad, shall we extend
+// location to support two uri (control, data)? or any better approach to
+// negotiate data plane uri?
+std::string DataUriFromLocation(const Location& /*location*/) {
+  auto result = arrow::internal::GetEnvVar("FLIGHT_DATAPLANE");
+  if (result.ok()) {
+    return result.ValueOrDie();
+  }
+  return "";  // empty uri -> default grpc data plane
+}
+
+}  // namespace
+
+arrow::Result<std::unique_ptr<ClientDataPlane>> ClientDataPlane::Make(
+    const Location& location) {
+  const std::string uri = DataUriFromLocation(location);
+  if (uri.empty()) return arrow::internal::make_unique<ClientDataPlane>();
+  ARROW_ASSIGN_OR_RAISE(auto maker, Registry::instance().GetDataPlaneMaker(uri));
+  return maker.make_client(uri);
+}
+
+arrow::Result<std::unique_ptr<ServerDataPlane>> ServerDataPlane::Make(
+    const Location& location) {
+  const std::string uri = DataUriFromLocation(location);
+  if (uri.empty()) return arrow::internal::make_unique<ServerDataPlane>();
+  ARROW_ASSIGN_OR_RAISE(auto maker, Registry::instance().GetDataPlaneMaker(uri));
+  return maker.make_server(uri);
+}
+
+void ClientDataPlane::AppendStreamMap(
+    grpc::ClientContext* context, const std::map<std::string, std::string>& stream_map) {
+  for (const auto& kv : stream_map) {
+    context->AddMetadata(kv.first, kv.second);
+  }
+}
+
+std::map<std::string, std::string> ServerDataPlane::ExtractStreamMap(
+    const grpc::ServerContext& context) {
+  std::map<std::string, std::string> stream_map;
+  for (const auto& key : stream_keys()) {
+    stream_map[key] = GetGrpcMetadata(context, key);
+  }
+  return stream_map;
+}
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/data_plane/types.h
+++ b/cpp/src/arrow/flight/data_plane/types.h
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/result.h"
+
+namespace grpc {
+
+class ClientContext;
+class ServerContext;
+
+};  // namespace grpc
+
+namespace arrow {
+namespace flight {
+
+struct FlightPayload;
+struct Location;
+
+namespace internal {
+
+struct FlightData;
+
+// Data plane stream simulates grpc::Client|ServerReader[Writer]
+// - DataClientStream is created before DataServerStream
+// - all interfaces should return IOError on data plane related errors
+// - WritesDone closes the writer side, the operation should be idempotent and
+//   after that, the writer should return IOError on "Write", and the reader
+//   should return IOError on "Read" (pending reads on peer is not discarded)
+// - Finish closes the client, no more read/write can be performed, it should
+//   be idempotent and after that, both the client and server should return
+//   IOError on "Read" or "Write" (pending reads on server is not discarded)
+// - TryCancel tells server to stop writing, should be idempotent
+// - data race
+//   * a single data plane may create several client/server stream pairs which
+//     run in parallel
+//   * for a single stream, Read may run in parallel with Write (DoExchange),
+//     Read/Read and Write/Write normally run in sequence (DoGet/DoPut), but
+//     should behave corretly if multiple Reads or Writes run in parallel
+
+// NOTE: grpc defines separated classes for Reader/Writer/ReaderWriter,
+//       data plane implements all the read/write interfaces in one class
+
+struct DataClientStream {
+  virtual ~DataClientStream() = default;
+
+  virtual Status Read(FlightData* data) = 0;
+  virtual Status Write(const FlightPayload& payload) = 0;
+  virtual Status WritesDone() = 0;
+  virtual Status Finish() = 0;
+  virtual void TryCancel() = 0;
+};
+
+struct DataServerStream {
+  virtual ~DataServerStream() = default;
+
+  virtual Status Read(FlightData* data) = 0;
+  virtual Status Write(const FlightPayload& payload) = 0;
+  // grpc doesn't implement server writes done
+  virtual Status WritesDone() = 0;
+};
+
+// Data plane is initialized at client/server startup, it creates data streams
+// to replace grpc streams for flight payload transmission (get/put/exchange).
+
+class ClientDataPlane {
+ public:
+  // client can send a {str:str} map to server together with grpc metadata
+  // this is useful to match client data stream with server data stream
+  using StreamMap = std::map<std::string, std::string>;
+  using ResultClientStream = arrow::Result<std::unique_ptr<DataClientStream>>;
+
+  virtual ~ClientDataPlane() = default;
+
+  static arrow::Result<std::unique_ptr<ClientDataPlane>> Make(const Location& location);
+
+  ResultClientStream DoGet(grpc::ClientContext* context) {
+    StreamMap stream_map;
+    ARROW_ASSIGN_OR_RAISE(auto data_stream, DoGetImpl(&stream_map));
+    AppendStreamMap(context, stream_map);
+    return data_stream;
+  }
+
+  ResultClientStream DoPut(grpc::ClientContext* context) {
+    StreamMap stream_map;
+    ARROW_ASSIGN_OR_RAISE(auto data_stream, DoPutImpl(&stream_map));
+    AppendStreamMap(context, stream_map);
+    return data_stream;
+  }
+
+  ResultClientStream DoExchange(grpc::ClientContext* context) {
+    StreamMap stream_map;
+    ARROW_ASSIGN_OR_RAISE(auto data_stream, DoExchangeImpl(&stream_map));
+    AppendStreamMap(context, stream_map);
+    return data_stream;
+  }
+
+ private:
+  // implement empty data plane in base class
+  virtual ResultClientStream DoGetImpl(StreamMap* stream_map) { return NULLPTR; }
+  virtual ResultClientStream DoPutImpl(StreamMap* stream_map) { return NULLPTR; }
+  virtual ResultClientStream DoExchangeImpl(StreamMap* stream_map) { return NULLPTR; }
+
+  void AppendStreamMap(grpc::ClientContext* context, const StreamMap& stream_map);
+};
+
+class ServerDataPlane {
+ public:
+  using StreamMap = std::map<std::string, std::string>;
+  using ResultServerStream = arrow::Result<std::unique_ptr<DataServerStream>>;
+
+  virtual ~ServerDataPlane() = default;
+
+  static arrow::Result<std::unique_ptr<ServerDataPlane>> Make(const Location& location);
+
+  ResultServerStream DoGet(const grpc::ServerContext& context) {
+    return DoGetImpl(ExtractStreamMap(context));
+  }
+
+  ResultServerStream DoPut(const grpc::ServerContext& context) {
+    return DoPutImpl(ExtractStreamMap(context));
+  }
+
+  ResultServerStream DoExchange(const grpc::ServerContext& context) {
+    return DoExchangeImpl(ExtractStreamMap(context));
+  }
+
+ private:
+  virtual ResultServerStream DoGetImpl(const StreamMap& stream_map) { return NULLPTR; }
+  virtual ResultServerStream DoPutImpl(const StreamMap& stream_map) { return NULLPTR; }
+  virtual ResultServerStream DoExchangeImpl(const StreamMap& stream_map) {
+    return NULLPTR;
+  }
+  virtual std::vector<std::string> stream_keys() { return {}; }
+
+  StreamMap ExtractStreamMap(const grpc::ServerContext& context);
+};
+
+}  // namespace internal
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/perf_server.cc
+++ b/cpp/src/arrow/flight/perf_server.cc
@@ -185,7 +185,7 @@ class FlightPerfServer : public FlightServerBase {
                std::unique_ptr<FlightDataStream>* data_stream) override {
     perf::Token token;
     CHECK_PARSE(token.ParseFromString(request.ticket));
-    return GetPerfBatches(token, perf_schema_, false, data_stream);
+    return GetPerfBatches(token, perf_schema_, /*use_verifier=*/false, data_stream);
   }
 
   Status DoPut(const ServerCallContext& context,

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -43,6 +43,10 @@ namespace flight {
 class ServerMiddleware;
 class ServerMiddlewareFactory;
 
+namespace internal {
+class ServerDataPlane;
+}  // namespace internal
+
 /// \brief Interface that produces a sequence of IPC payloads to be sent in
 /// FlightData protobuf messages
 class ARROW_FLIGHT_EXPORT FlightDataStream {
@@ -179,6 +183,10 @@ class ARROW_FLIGHT_EXPORT FlightServerBase {
   /// non-positive value if no port exists (e.g. when listening on a
   /// domain socket).
   int port() const;
+
+  /// \brief Get the data plane of the Flight server.
+  /// This method must only be called after Init().
+  internal::ServerDataPlane* data_plane() const;
 
   /// \brief Set the server to stop when receiving any of the given signal
   /// numbers.


### PR DESCRIPTION
This patch decouples flightrpc data plane from grpc so we can leverage
optimized data transfer libraries.

The basic idea is to replace grpc stream with a data plane stream for
FlightData transmission in DoGet/DoPut/DoExchange. There's no big change
to current flight client and server implementations. Added a wrapper to
support both grpc stream and data plane stream. By default, grpc stream
is used, which goes the current grpc based code path. If a data plane is
enabled (currently through environment variable), flight payload will go
through the data plane stream instead. See client.cc and server.cc to
review the changes.

**About data plane implementation**

- data_plane/types.{h,cc}
  Defines client/server data plane and data plane stream interfaces.
  It's the only exported api to other component ({client,server}.cc).
- data_plane/serialize.{h,cc}
  De-Serialize FlightData manually as we bypass grpc. Luckly, we already
  implemented related functions to support payload zero-copy.
- shm.cc
  A shared memory driver to verify the data plane approach. The code may
  be a bit hard to read, it's better to focus on data plane interface
  implementations at first before dive deep into details like shared
  memory, ipc and buffer management related code.
  Please note there are still many caveats in current code, see TODO and
  XXX in shm.cc for details.

**To evaluate this patch**

I tested shared memory data plane on Linux (x86, Arm) and MacOS (Arm).
Build with `-DARROW_FLIGHT_DP_SHM=ON` to enable the shared memory data
plane. Set `FLIGHT_DATAPLANE=shm` environment variable to run unit tests
and benchmarks with the shared memory data plane enabled.

```
Build: cmake -DARROW_FLIGHT_DP_SHM=ON -DARROW_FLIGHT=ON ....
Test:  FLIGHT_DATAPLANE=shm release/arrow-flight-test
Bench: FLIGHT_DATAPLANE=shm release/arrow-flight-benchmark \
       -num_streams=1|2|4 -num_threads=1|2|4
```

Benchmark result (throughput, latency) on Xeon Gold 5218.
Test case: DoGet, batch size = 128KiB

| streams | grpc over unix socket | shared memory data plane |
| ------- | --------------------- | ------------------------ |
| 1       |  3324 MB/s,  35 us    |  7045 MB/s,  16 us       |
| 2       |  6289 MB/s,  38 us    | 13311 MB/s,  17 us       |
| 4       | 10037 MB/s,  44 us    | 25012 MB/s,  17 us       |