### PR TITLE
ARROW-15386: [Integration] Unskip test cases

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1401,9 +1401,8 @@ def generate_nested_case():
                            get_field('item', 'int32'), 4),
         StructField('struct_nullable', [get_field('f1', 'int32'),
                                         get_field('f2', 'utf8')]),
-        # Fails on Go (ARROW-8452)
-        # ListField('list_nonnullable', get_field('item', 'int32'),
-        #           nullable=False),
+        ListField('list_nonnullable', get_field('item', 'int32'),
+                  nullable=False),
     ]
 
     batch_sizes = [7, 10]
@@ -1592,7 +1591,8 @@ def get_generated_json_files(tempdir=None):
         .skip_category('Rust'),
 
         generate_nested_case()
-        .skip_category('C#'),
+        .skip_category('C#')
+        .skip_category('Go'),    # TODO(ARROW-8452)
 
         generate_recursive_nested_case()
         .skip_category('C#'),

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1477,16 +1477,12 @@ def generate_dictionary_unsigned_case():
     dict0 = Dictionary(0, StringField('dictionary0'), size=5, name='DICT0')
     dict1 = Dictionary(1, StringField('dictionary1'), size=5, name='DICT1')
     dict2 = Dictionary(2, StringField('dictionary2'), size=5, name='DICT2')
-
-    # TODO: JavaScript does not support uint64 dictionary indices, so disabled
-    # for now
-
-    # dict3 = Dictionary(3, StringField('dictionary3'), size=5, name='DICT3')
+    dict3 = Dictionary(3, StringField('dictionary3'), size=5, name='DICT3')
     fields = [
         DictionaryField('f0', get_field('', 'uint8'), dict0),
         DictionaryField('f1', get_field('', 'uint16'), dict1),
         DictionaryField('f2', get_field('', 'uint32'), dict2),
-        # DictionaryField('f3', get_field('', 'uint64'), dict3)
+        DictionaryField('f3', get_field('', 'uint64'), dict3)
     ]
     batch_sizes = [7, 10]
     return _generate_file("dictionary_unsigned", fields, batch_sizes,
@@ -1618,10 +1614,13 @@ def get_generated_json_files(tempdir=None):
         .skip_category('Go')
         .skip_category('JS'),
 
-        # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
         generate_dictionary_case()
         .skip_category('C#')
-        .skip_category('Go'),
+        # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
+        .skip_category('Go')
+        # TODO: JavaScript does not support uint64 dictionary indices, so disabled
+        # for now
+        .skip_category("JS"),
 
         generate_dictionary_unsigned_case()
         .skip_category('C#')


### PR DESCRIPTION
Some test cases were not being run because some implementations were not able to handle them. 

When an implementation does not support something, we should "skip" the implementation from the test; we should do not deactivate the particular case for all implementations.