### PR TITLE
ARROW-15387 [R] Un-skip chunked array test for decimal256()

### DIFF
--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -211,8 +211,7 @@ test_that("ChunkedArray supports empty arrays (ARROW-13761)", {
     int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(),
     uint64(), float32(), float64(), timestamp("ns"), binary(),
     large_binary(), fixed_size_binary(32), date32(), date64(),
-    decimal128(4, 2), #decimal256(4, 2), # un-comment once ARROW-15166 is solved
-    dictionary(), struct(x = int32())
+    decimal128(4, 2), decimal256(4, 2), dictionary(), struct(x = int32())
   )
 
   empty_filter <- ChunkedArray$create(type = bool())
@@ -233,29 +232,6 @@ test_that("ChunkedArray supports empty arrays (ARROW-13761)", {
     } else {
       expect_identical(length(as.vector(zero_empty_chunks)), 1L)
     }
-  }
-
-  skip("array_filter has no kernel matching input types `(array[decimal256(4, 2)], array[bool])`")
-  # TODO once ARROW-15166 is addressed decimal256() can be moved together with
-  # the other types (separated to be able to skip). this whole chunk can be
-  # deleted
-  type <- decimal256(4, 2)
-  empty_filter <- ChunkedArray$create(type = bool())
-  one_empty_chunk <- ChunkedArray$create(type = type)
-  expect_type_equal(one_empty_chunk$type, type)
-  if (type != struct(x = int32())) {
-    expect_identical(length(one_empty_chunk), length(as.vector(one_empty_chunk)))
-  } else {
-    # struct -> tbl and length(tbl) is num_columns instead of num_rows
-    expect_identical(length(as.vector(one_empty_chunk)), 1L)
-  }
-  zero_empty_chunks <- one_empty_chunk$Filter(empty_filter)
-  expect_equal(zero_empty_chunks$num_chunks, 0)
-  expect_type_equal(zero_empty_chunks$type, type)
-  if (type != struct(x = int32())) {
-    expect_identical(length(zero_empty_chunks), length(as.vector(zero_empty_chunks)))
-  } else {
-    expect_identical(length(as.vector(zero_empty_chunks)), 1L)
   }
 })
 

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -211,7 +211,8 @@ test_that("ChunkedArray supports empty arrays (ARROW-13761)", {
     int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(),
     uint64(), float32(), float64(), timestamp("ns"), binary(),
     large_binary(), fixed_size_binary(32), date32(), date64(),
-    decimal128(4, 2), decimal256(4, 2), dictionary(), struct(x = int32())
+    decimal128(4, 2), decimal256(4, 2),
+    dictionary(), struct(x = int32())
   )
 
   empty_filter <- ChunkedArray$create(type = bool())


### PR DESCRIPTION
This PR cleans-up unit tests that were dependent upon the implementation of `array_filter` kernel for `decimal256()` [ARROW-15166](https://issues.apache.org/jira/browse/ARROW-15166).