### PR TITLE
ARROW-15391: [C++][Gandiva] Deal with functions that have lock contention

### DIFF
--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 
 #include <thread>
 
@@ -29,6 +29,11 @@
 #include "gandiva/visibility.h"
 
 namespace gandiva {
+
+static const std::string func_with_re2_patterns[] = {
+    " like("
+    " ilike("
+    " regexp_replace("};
 
 class ExpressionCacheKey {
  public:
@@ -68,8 +73,11 @@ class ExpressionCacheKey {
     if (uniqifier_ == 0) {
       // caching of expressions with re2 patterns causes lock contention. So, use
       // multiple instances to reduce contention.
-      if (expr.find(" like(") != std::string::npos) {
-        uniqifier_ = std::hash<std::thread::id>()(std::this_thread::get_id()) % 16;
+      for (const std::string& function : func_with_re2_patterns) {
+        if (expr.find(function) != std::string::npos) {
+          uniqifier_ = std::hash<std::thread::id>()(std::this_thread::get_id()) % 16;
+          break;
+        }
       }
     }
   }

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 
+#include <array>
 #include <thread>
 
 #include "arrow/util/hash_util.h"
@@ -30,7 +31,7 @@
 
 namespace gandiva {
 
-static const std::string func_with_re2_patterns[] = {
+static const std::array<std::string, 3> func_with_re2_patterns = {
     " like("
     " ilike("
     " regexp_replace("};


### PR DESCRIPTION
The Gandiva Cache code deal with expressions that contains RE2 patterns in a different way than the other expressions, as one can see in this line in code: https://github.com/apache/arrow/blob/188c94a9820ef3377573b835c9dc9dcb96ceafe4/cpp/src/gandiva/expression_cache_key.h#L68

But it is not dealing with all available functions with RE2 patterns, it is missing the following ones:
- ILIKE
- REGEXP_REPLACE