### PR TITLE
ARROW-15376: [Go][Release] cpu_arm64 needs +build comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,8 +162,6 @@ jobs:
           "
 
   allow_failures:
-    - name: "Go on ARM"
-    - name: "Go on s390x"
     - name: "Java on s390x"
     - name: "Python on s390x"
 

--- a/go/arrow/internal/cpu/cpu_arm64.go
+++ b/go/arrow/internal/cpu/cpu_arm64.go
@@ -2,7 +2,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// NOTE(mtopol): must have both go:build and +build until we drop
+// support for go1.16 as the 'go:build' syntax was introduced in go1.17
+
 //go:build arm64
+// +build arm64
 
 package cpu
 
@@ -34,4 +38,3 @@ func init() {
 		}
 	}
 }
-

--- a/go/arrow/internal/cpu/cpu_arm64.go
+++ b/go/arrow/internal/cpu/cpu_arm64.go
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// NOTE(mtopol): must have both go:build and +build until we drop
-// support for go1.16 as the 'go:build' syntax was introduced in go1.17
-
 //go:build arm64
 // +build arm64
 


### PR DESCRIPTION
The `//go:build` syntax being used in place of `// +build` was introduced in go1.17. Our CI runs with go1.16 so as long as we want to support go1.16 we need both the `//go:build` and `// +build` . Currently only the `cpu_arm64.go` file has the `//go:build` syntax which is only considered when building on an arm64 machine. That's why it only failed on the Apple M1 verification.

Adding the `// +build arm64` line will allow it to pass verification.