### PR TITLE
ARROW-14816: [R] Implement bindings for lubridate::mday

### DIFF
--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -70,6 +70,7 @@
   "quarter" = "quarter",
   # second is defined in dplyr-functions.R
   # wday is defined in dplyr-functions.R
+  "mday" = "day",
   "yday" = "day_of_year",
   "year" = "year",
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -444,6 +444,15 @@ test_that("extract wday from timestamp", {
   )
 })
 
+test_that("extract mday from timestamp", {
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = mday(datetime)) %>%
+      collect(),
+    test_df
+  )
+})
+
 test_that("extract yday from timestamp", {
   compare_dplyr_binding(
     .input %>%
@@ -621,6 +630,15 @@ test_that("extract wday from date", {
     .input %>%
       mutate(x = wday(date, label = TRUE)) %>%
       mutate(x = as.character(x)) %>%
+      collect(),
+    test_df
+  )
+})
+
+test_that("extract mday from date", {
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = mday(date)) %>%
       collect(),
     test_df
   )


### PR DESCRIPTION
Adding a binding for `lubridate::mday` in _expressions.R_ and a test for date and timestamp.

Note: `day()` is an aliase for `mday()` in lubridate.