### PR TITLE
ARROW-14783: [C++][Python] Fix the write ORC in BytesIO issue

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -720,11 +720,7 @@ class ArrowOutputStream : public liborc::OutputStream {
     return filename;
   }
 
-  void close() override {
-    if (!output_stream_.closed()) {
-      ORC_THROW_NOT_OK(output_stream_.Close());
-    }
-  }
+  void close() override {}
 
   void set_length(int64_t length) { length_ = length; }
 

--- a/cpp/src/arrow/adapters/orc/options.h
+++ b/cpp/src/arrow/adapters/orc/options.h
@@ -92,12 +92,12 @@ struct ARROW_EXPORT WriteOptions {
   int64_t batch_size = 1024;
   /// Which ORC file version to use, default FileVersion(0, 12)
   FileVersion file_version = FileVersion(0, 12);
-  /// Size of each ORC stripe, default 64 MiB
+  /// Size of each ORC stripe in bytes, default 64 MiB
   int64_t stripe_size = 64 * 1024 * 1024;
   /// The compression codec of the ORC file, there is no compression by default
   Compression::type compression = Compression::UNCOMPRESSED;
-  /// The size of each compression block, default 65536
-  int64_t compression_block_size = 65536;
+  /// The size of each compression block in bytes, default 64 KiB
+  int64_t compression_block_size = 64 * 1024;
   /// The compression strategy i.e. speed vs size reduction, default
   /// CompressionStrategy::kSpeed
   CompressionStrategy compression_strategy = CompressionStrategy::kSpeed;

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -37,6 +37,7 @@ from pyarrow.lib cimport (check_status, _Weakrefable,
                           get_reader,
                           get_writer)
 from pyarrow.lib import frombytes, tobytes
+from pyarrow.utils import _stringify_path
 
 
 cdef compression_type_from_enum(CCompressionType compression_type):
@@ -385,13 +386,11 @@ cdef class ORCReader(_Weakrefable):
 
 cdef class ORCWriter(_Weakrefable):
     cdef:
-        object sink
         unique_ptr[ORCFileWriter] writer
-        shared_ptr[COutputStream] rd_handle
-        c_bool close_file
+        shared_ptr[COutputStream] sink
+        c_bool own_sink
 
-    def open(self, object sink, *,
-             close_file=False,
+    def open(self, object where, *,
              file_version=None,
              batch_size=None,
              stripe_size=None,
@@ -405,9 +404,17 @@ cdef class ORCWriter(_Weakrefable):
              bloom_filter_fpp=None):
         cdef:
             shared_ptr[WriteOptions] write_options
-        self.sink = sink
-        self.close_file = close_file
-        get_writer(sink, &self.rd_handle)
+            c_string c_where
+        try:
+            where = _stringify_path(where)
+        except TypeError:
+            get_writer(where, &self.sink)
+            self.own_sink = False
+        else:
+            c_where = tobytes(where)
+            with nogil:
+                self.sink = GetResultValue(FileOutputStream.Open(c_where))
+                self.own_sink = True
 
         write_options = _create_write_options(
             file_version=file_version,
@@ -425,7 +432,7 @@ cdef class ORCWriter(_Weakrefable):
 
         with nogil:
             self.writer = move(GetResultValue(
-                ORCFileWriter.Open(self.rd_handle.get(),
+                ORCFileWriter.Open(self.sink.get(),
                                    deref(write_options))))
 
     def write(self, Table table):
@@ -438,5 +445,5 @@ cdef class ORCWriter(_Weakrefable):
     def close(self):
         with nogil:
             check_status(deref(self.writer).Close())
-            if self.close_file:
-                check_status(deref(self.rd_handle).Close())
+            if self.own_sink:
+                check_status(deref(self.sink).Close())

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -331,7 +331,6 @@ filesystem : FileSystem, default None
 
 
 def write_table(table, where, *,
-                close_file=False,
                 file_version='0.12',
                 batch_size=1024,
                 stripe_size=64 * 1024 * 1024,

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -337,7 +337,7 @@ filesystem : FileSystem, default None
 
 
 def write_table(table, where, *,
-                filesystem=None,
+                close_file=False,
                 file_version='0.12',
                 batch_size=1024,
                 stripe_size=64 * 1024 * 1024,
@@ -358,7 +358,7 @@ def write_table(table, where, *,
         table, where = where, table
     with ORCWriter(
         where,
-        filesystem=filesystem,
+        close_file=close_file,
         file_version=file_version,
         batch_size=batch_size,
         stripe_size=stripe_size,

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -24,6 +24,7 @@ import pyarrow._orc as _orc
 from pyarrow.fs import _resolve_filesystem_and_path
 from pyarrow import filesystem as legacyfs
 
+
 class ORCFile:
     """
     Reader interface for a single ORC file
@@ -318,7 +319,7 @@ where : str or pyarrow.io.NativeFile
         Close the ORC file
         """
         if self.is_open:
-            self.writer.close()    
+            self.writer.close()
             self.is_open = False
         if self.file_handle is not None:
             self.file_handle.close()

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -22,7 +22,7 @@ import warnings
 from pyarrow.lib import Table
 import pyarrow._orc as _orc
 from pyarrow.fs import _resolve_filesystem_and_path
-
+from pyarrow import filesystem as legacyfs
 
 class ORCFile:
     """
@@ -186,7 +186,10 @@ class ORCFile:
         return self.reader.read(columns=columns)
 
 
-_orc_writer_args_docs = """file_version : {"0.11", "0.12"}, default "0.12"
+_orc_writer_args_docs = """filesystem : FileSystem, default None
+    If nothing passed, will be inferred from `where` if path-like, else
+    `where` is already a file-like object so no filesystem is needed.
+file_version : {"0.11", "0.12"}, default "0.12"
     Determine which ORC file version to use.
     `Hive 0.11 / ORC v0 <https://orc.apache.org/specification/ORCv0/>`_
     is the older version
@@ -234,8 +237,11 @@ where : str or pyarrow.io.NativeFile
 """.format(_orc_writer_args_docs)
 
     is_open = False
+    file_handle = None
 
-    def __init__(self, where, *, file_version='0.12',
+    def __init__(self, where, *,
+                 filesystem=None,
+                 file_version='0.12',
                  batch_size=1024,
                  stripe_size=64 * 1024 * 1024,
                  compression='uncompressed',
@@ -248,9 +254,29 @@ where : str or pyarrow.io.NativeFile
                  bloom_filter_fpp=0.05,
                  ):
 
+        # If we open a file using a filesystem, store file handle so we can be
+        # sure to close it when `self.close` is called.
+
+        filesystem, path = _resolve_filesystem_and_path(
+            where, filesystem, allow_legacy_filesystem=True
+        )
+        if filesystem is not None:
+            if isinstance(filesystem, legacyfs.FileSystem):
+                # legacy filesystem (eg custom subclass)
+                # TODO deprecate
+                sink = self.file_handle = filesystem.open(path, 'wb')
+            else:
+                # ARROW-10480: do not auto-detect compression.  While
+                # a filename like foo.parquet.gz is nonconforming, it
+                # shouldn't implicitly apply compression.
+                sink = self.file_handle = filesystem.open_output_stream(
+                    path, compression=None)
+        else:
+            sink = where
+
         self.writer = _orc.ORCWriter()
         self.writer.open(
-            where,
+            sink,
             file_version=file_version,
             batch_size=batch_size,
             stripe_size=stripe_size,
@@ -292,8 +318,10 @@ where : str or pyarrow.io.NativeFile
         Close the ORC file
         """
         if self.is_open:
-            self.writer.close()
+            self.writer.close()    
             self.is_open = False
+        if self.file_handle is not None:
+            self.file_handle.close()
 
 
 def read_table(source, columns=None, filesystem=None):
@@ -330,7 +358,9 @@ filesystem : FileSystem, default None
 """
 
 
-def write_table(table, where, *, file_version='0.12',
+def write_table(table, where, *,
+                filesystem=None,
+                file_version='0.12',
                 batch_size=1024,
                 stripe_size=64 * 1024 * 1024,
                 compression='uncompressed',
@@ -350,6 +380,7 @@ def write_table(table, where, *, file_version='0.12',
         table, where = where, table
     with ORCWriter(
         where,
+        filesystem=filesystem,
         file_version=file_version,
         batch_size=batch_size,
         stripe_size=stripe_size,

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -186,9 +186,7 @@ class ORCFile:
         return self.reader.read(columns=columns)
 
 
-_orc_writer_args_docs = """close_file : boolean, default False
-    Whether we close the file or file-like object after writing to it
-file_version : {"0.11", "0.12"}, default "0.12"
+_orc_writer_args_docs = """file_version : {"0.11", "0.12"}, default "0.12"
     Determine which ORC file version to use.
     `Hive 0.11 / ORC v0 <https://orc.apache.org/specification/ORCv0/>`_
     is the older version
@@ -197,13 +195,13 @@ file_version : {"0.11", "0.12"}, default "0.12"
 batch_size : int, default 1024
     Number of rows the ORC writer writes at a time.
 stripe_size : int, default 64 * 1024 * 1024
-    Size of each ORC stripe.
+    Size of each ORC stripe in bytes.
 compression : string, default 'uncompressed'
     The compression codec.
     Valid values: {'UNCOMPRESSED', 'SNAPPY', 'ZLIB', 'LZ4', 'ZSTD'}
     Note that LZ0 is currently not supported.
 compression_block_size : int, default 64 * 1024
-    Size of each compression block.
+    Size of each compression block in bytes.
 compression_strategy : string, default 'speed'
     The compression strategy i.e. speed vs size reduction.
     Valid values: {'SPEED', 'COMPRESSION'}
@@ -236,10 +234,8 @@ where : str or pyarrow.io.NativeFile
 """.format(_orc_writer_args_docs)
 
     is_open = False
-    close_file = False
 
     def __init__(self, where, *,
-                 close_file=False,
                  file_version='0.12',
                  batch_size=1024,
                  stripe_size=64 * 1024 * 1024,
@@ -252,11 +248,9 @@ where : str or pyarrow.io.NativeFile
                  bloom_filter_columns=None,
                  bloom_filter_fpp=0.05,
                  ):
-        self.close_file = close_file
         self.writer = _orc.ORCWriter()
         self.writer.open(
             where,
-            close_file=close_file,
             file_version=file_version,
             batch_size=batch_size,
             stripe_size=stripe_size,
@@ -358,7 +352,6 @@ def write_table(table, where, *,
         table, where = where, table
     with ORCWriter(
         where,
-        close_file=close_file,
         file_version=file_version,
         batch_size=batch_size,
         stripe_size=stripe_size,

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -209,6 +209,21 @@ def test_filesystem_uri(tmpdir):
     assert result.equals(table)
 
 
+def test_bytesio_readwrite():
+    from pyarrow import orc
+    from io import BytesIO
+
+    buf = BytesIO()
+    a = pa.array([1, None, 3, None])
+    b = pa.array([None, "Arrow", None, "ORC"])
+    table = pa.table({"int64": a, "utf8": b})
+    orc.write_table(table, buf)
+    buf.seek(0)
+    orc_file = orc.ORCFile(buf)
+    output_table = orc_file.read()
+    assert table.equals(output_table)
+
+
 def test_orcfile_readwrite():
     from pyarrow import orc
 

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -189,6 +189,11 @@ def test_filesystem_uri(tmpdir):
         "data_dir/data.orc", filesystem=util._filesystem_uri(tmpdir))
     assert result.equals(table)
 
+    # use the path only
+    result = orc.read_table(
+        util._filesystem_uri(path))
+    assert result.equals(table)
+
 
 def test_orcfile_readwrite(tmpdir):
     from pyarrow import orc

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -171,25 +171,6 @@ def test_orcfile_empty(datadir):
     assert table.schema == expected_schema
 
 
-def test_readwrite(tmpdir):
-    from pyarrow import orc
-    a = pa.array([1, None, 3, None])
-    b = pa.array([None, "Arrow", None, "ORC"])
-    table = pa.table({"int64": a, "utf8": b})
-    file = tmpdir.join("test.orc")
-    orc.write_table(table, file)
-    output_table = orc.read_table(file)
-    assert table.equals(output_table)
-
-    output_table = orc.read_table(file, [])
-    assert 4 == output_table.num_rows
-    assert 0 == output_table.num_columns
-
-    output_table = orc.read_table(file, columns=["int64"])
-    assert 4 == output_table.num_rows
-    assert 1 == output_table.num_columns
-
-
 def test_filesystem_uri(tmpdir):
     from pyarrow import orc
     table = pa.table({"a": [1, 2, 3]})
@@ -209,6 +190,25 @@ def test_filesystem_uri(tmpdir):
     assert result.equals(table)
 
 
+def test_orcfile_readwrite(tmpdir):
+    from pyarrow import orc
+    a = pa.array([1, None, 3, None])
+    b = pa.array([None, "Arrow", None, "ORC"])
+    table = pa.table({"int64": a, "utf8": b})
+    file = tmpdir.join("test.orc")
+    orc.write_table(table, file)
+    output_table = orc.read_table(file)
+    assert table.equals(output_table)
+
+    output_table = orc.read_table(file, [])
+    assert 4 == output_table.num_rows
+    assert 0 == output_table.num_columns
+
+    output_table = orc.read_table(file, columns=["int64"])
+    assert 4 == output_table.num_rows
+    assert 1 == output_table.num_columns
+
+
 def test_bytesio_readwrite():
     from pyarrow import orc
     from io import BytesIO
@@ -224,7 +224,7 @@ def test_bytesio_readwrite():
     assert table.equals(output_table)
 
 
-def test_orcfile_readwrite():
+def test_buffer_readwrite():
     from pyarrow import orc
 
     buffer_output_stream = pa.BufferOutputStream()
@@ -258,7 +258,7 @@ def test_orcfile_readwrite():
 
 
 @pytest.mark.snappy
-def test_orcfile_readwrite_with_writeoptions():
+def test_buffer_readwrite_with_writeoptions():
     from pyarrow import orc
 
     buffer_output_stream = pa.BufferOutputStream()
@@ -305,7 +305,7 @@ def test_orcfile_readwrite_with_writeoptions():
     assert orc_file.compression_size == 16384
 
 
-def test_orcfile_readwrite_with_bad_writeoptions():
+def test_buffer_readwrite_with_bad_writeoptions():
     from pyarrow import orc
     buffer_output_stream = pa.BufferOutputStream()
     a = pa.array([1, None, 3, None])


### PR DESCRIPTION
`pyarrow.orc.ORCWriter` and `pyarrow.orc.write_table` which can be used with paths of ORC files, `pyarrow.BufferOutputStream` should also be able to be used with `io.BytesIO`. However currently this causes errors which make the behavior of the ORC writer different from that of the Parquet and CSV writers. 