### PR TITLE
ARROW-15424: [C++][GLib] Fix CUDA bindings

### DIFF
--- a/c_glib/arrow-cuda-glib/cuda.cpp
+++ b/c_glib/arrow-cuda-glib/cuda.cpp
@@ -286,11 +286,11 @@ garrow_cuda_buffer_new(GArrowCUDAContext *context,
                        GError **error)
 {
   auto arrow_context = garrow_cuda_context_get_raw(context);
-  auto arrow_buffer = arrow_context->Allocate(size);
-  if (garrow::check(error, arrow_buffer, "[cuda][buffer][new]")) {
-    std::shared_ptr<arrow::cuda::CudaBuffer> cuda_buffer =
-      arrow_buffer.MoveValueUnsafe();
-    return garrow_cuda_buffer_new_raw(&cuda_buffer);
+  auto arrow_buffer_result = arrow_context->Allocate(size);
+  if (garrow::check(error, arrow_buffer_result, "[cuda][buffer][new]")) {
+    std::shared_ptr<arrow::cuda::CudaBuffer> arrow_buffer =
+        std::move(*arrow_buffer_result);
+    return garrow_cuda_buffer_new_raw(&arrow_buffer);
   } else {
     return NULL;
   }

--- a/c_glib/arrow-cuda-glib/cuda.cpp
+++ b/c_glib/arrow-cuda-glib/cuda.cpp
@@ -288,7 +288,9 @@ garrow_cuda_buffer_new(GArrowCUDAContext *context,
   auto arrow_context = garrow_cuda_context_get_raw(context);
   auto arrow_buffer = arrow_context->Allocate(size);
   if (garrow::check(error, arrow_buffer, "[cuda][buffer][new]")) {
-    return garrow_cuda_buffer_new_raw(&(*arrow_buffer));
+    std::shared_ptr<arrow::cuda::CudaBuffer> cuda_buffer =
+      arrow_buffer.MoveValueUnsafe();
+    return garrow_cuda_buffer_new_raw(&cuda_buffer);
   } else {
     return NULL;
   }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -344,7 +344,8 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
   if (from->is_cpu()) {
     // CPU-to-device copy
     ARROW_ASSIGN_OR_RAISE(auto to_context, cuda_device()->GetContext());
-    ARROW_ASSIGN_OR_RAISE(auto dest, to_context->Allocate(buf->size()));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> dest,
+                          to_context->Allocate(buf->size()));
     RETURN_NOT_OK(
         to_context->CopyHostToDevice(dest->address(), buf->data(), buf->size()));
     return dest;
@@ -355,7 +356,8 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
     ARROW_ASSIGN_OR_RAISE(
         auto from_context,
         checked_cast<const CudaMemoryManager&>(*from).cuda_device()->GetContext());
-    ARROW_ASSIGN_OR_RAISE(auto dest, to_context->Allocate(buf->size()));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> dest,
+                          to_context->Allocate(buf->size()));
     if (to_context->handle() == from_context->handle()) {
       // Same context
       RETURN_NOT_OK(


### PR DESCRIPTION
ARROW-15373 changed MemoryManager::AllocateBuffer to return
unique_ptr; the GLib bindings needed updating for this, however.
Also, tweaked the C++ since some compilers don't implicitly
convert unique_ptr to shared_ptr on return.