### PR TITLE
ARROW-15374: [C++][FlightRPC] Add support for MemoryManager in data methods

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -245,6 +245,19 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   add_dependencies(arrow_flight flight-test-server)
 endif()
 
+if(ARROW_CUDA AND ARROW_BUILD_TESTS)
+  add_arrow_test(flight_cuda_test
+                 STATIC_LINK_LIBS
+                 ${ARROW_FLIGHT_TEST_LINK_LIBS}
+                 LABELS
+                 "arrow_flight")
+  if(ARROW_FLIGHT_TEST_LINKAGE STREQUAL "static")
+    target_link_libraries(arrow-flight-cuda-test PUBLIC arrow_cuda_static)
+  else()
+    target_link_libraries(arrow-flight-cuda-test PUBLIC arrow_cuda_shared)
+  endif()
+endif()
+
 if(ARROW_BUILD_BENCHMARKS)
   # Perf server for benchmarks
   set(PERF_PROTO_GENERATED_FILES "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.cc"

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -73,6 +73,9 @@ class ARROW_FLIGHT_EXPORT FlightCallOptions {
 
   /// \brief A token to enable interactive user cancellation of long-running requests.
   StopToken stop_token;
+
+  /// \brief An optional memory manager to control where to allocate incoming data.
+  std::shared_ptr<MemoryManager> memory_manager;
 };
 
 /// \brief Indicate that the client attempted to write a message

--- a/cpp/src/arrow/flight/flight_cuda_test.cc
+++ b/cpp/src/arrow/flight/flight_cuda_test.cc
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "arrow/array.h"
+#include "arrow/flight/client.h"
+#include "arrow/flight/server.h"
+#include "arrow/flight/test_util.h"
+#include "arrow/gpu/cuda_api.h"
+#include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow {
+namespace flight {
+
+Status CheckBuffersOnDevice(const Array& array, const Device& device) {
+  if (array.num_fields() != 0) {
+    return Status::NotImplemented("Nested arrays");
+  }
+  for (const auto& buffer : array.data()->buffers) {
+    if (!buffer) continue;
+    if (!buffer->device()->Equals(device)) {
+      return Status::Invalid("Expected buffer on device: ", device.ToString(),
+                             ". Was allocated on device: ", buffer->device()->ToString());
+    }
+  }
+  return Status::OK();
+}
+
+// Copy a record batch to host memory.
+arrow::Result<std::shared_ptr<RecordBatch>> CopyBatchToHost(const RecordBatch& batch) {
+  auto mm = CPUDevice::Instance()->default_memory_manager();
+  ArrayVector arrays;
+  for (const auto& column : batch.columns()) {
+    std::shared_ptr<ArrayData> data = column->data()->Copy();
+    if (data->child_data.size() != 0) {
+      return Status::NotImplemented("Nested arrays");
+    }
+
+    for (size_t i = 0; i < data->buffers.size(); i++) {
+      const auto& buffer = data->buffers[i];
+      if (!buffer || buffer->is_cpu()) continue;
+      ARROW_ASSIGN_OR_RAISE(data->buffers[i], Buffer::Copy(buffer, mm));
+    }
+    arrays.push_back(MakeArray(data));
+  }
+  return RecordBatch::Make(batch.schema(), batch.num_rows(), std::move(arrays));
+}
+
+class CudaTestServer : public FlightServerBase {
+ public:
+  explicit CudaTestServer(std::shared_ptr<Device> device) : device_(std::move(device)) {}
+
+  Status DoGet(const ServerCallContext&, const Ticket&,
+               std::unique_ptr<FlightDataStream>* data_stream) override {
+    BatchVector batches;
+    RETURN_NOT_OK(ExampleIntBatches(&batches));
+    auto batch_reader = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
+    *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader));
+    return Status::OK();
+  }
+
+  Status DoPut(const ServerCallContext&, std::unique_ptr<FlightMessageReader> reader,
+               std::unique_ptr<FlightMetadataWriter> writer) override {
+    BatchVector batches;
+    RETURN_NOT_OK(reader->ReadAll(&batches));
+    for (const auto& batch : batches) {
+      for (const auto& column : batch->columns()) {
+        RETURN_NOT_OK(CheckBuffersOnDevice(*column, *device_));
+      }
+    }
+    return Status::OK();
+  }
+
+  Status DoExchange(const ServerCallContext& context,
+                    std::unique_ptr<FlightMessageReader> reader,
+                    std::unique_ptr<FlightMessageWriter> writer) override {
+    FlightStreamChunk chunk;
+    bool begun = false;
+    while (true) {
+      RETURN_NOT_OK(reader->Next(&chunk));
+      if (!chunk.data) break;
+      if (!begun) {
+        begun = true;
+        RETURN_NOT_OK(writer->Begin(chunk.data->schema()));
+      }
+      for (const auto& column : chunk.data->columns()) {
+        RETURN_NOT_OK(CheckBuffersOnDevice(*column, *device_));
+      }
+      RETURN_NOT_OK(writer->WriteRecordBatch(*chunk.data));
+    }
+    return Status::OK();
+  }
+
+ private:
+  std::shared_ptr<Device> device_;
+};
+
+class TestCuda : public ::testing::Test {
+ public:
+  void SetUp() {
+    ASSERT_OK_AND_ASSIGN(manager_, cuda::CudaDeviceManager::Instance());
+    ASSERT_OK_AND_ASSIGN(device_, manager_->GetDevice(0));
+    ASSERT_OK_AND_ASSIGN(context_, device_->GetContext());
+
+    ASSERT_OK(MakeServer<CudaTestServer>(
+        &server_, &client_,
+        [this](FlightServerOptions* options) {
+          options->memory_manager = device_->default_memory_manager();
+          return Status::OK();
+        },
+        [](FlightClientOptions* options) { return Status::OK(); }, device_));
+  }
+  void TearDown() { ASSERT_OK(server_->Shutdown()); }
+
+ protected:
+  cuda::CudaDeviceManager* manager_;
+  std::shared_ptr<cuda::CudaDevice> device_;
+  std::shared_ptr<cuda::CudaContext> context_;
+
+  std::unique_ptr<FlightClient> client_;
+  std::unique_ptr<FlightServerBase> server_;
+};
+
+TEST_F(TestCuda, DoGet) {
+  // Check that we can allocate the results of DoGet with a custom
+  // memory manager.
+  FlightCallOptions options;
+  options.memory_manager = device_->default_memory_manager();
+
+  Ticket ticket{""};
+  std::unique_ptr<FlightStreamReader> stream;
+  ASSERT_OK(client_->DoGet(options, ticket, &stream));
+  std::shared_ptr<Table> table;
+  ASSERT_OK(stream->ReadAll(&table));
+
+  for (const auto& column : table->columns()) {
+    for (const auto& chunk : column->chunks()) {
+      ASSERT_OK(CheckBuffersOnDevice(*chunk, *device_));
+    }
+  }
+}
+
+TEST_F(TestCuda, DoPut) {
+  // Check that we can send a record batch containing references to
+  // GPU buffers.
+  BatchVector batches;
+  ASSERT_OK(ExampleIntBatches(&batches));
+
+  std::unique_ptr<FlightStreamWriter> writer;
+  std::unique_ptr<FlightMetadataReader> reader;
+  auto descriptor = FlightDescriptor::Path({""});
+  ASSERT_OK(client_->DoPut(descriptor, batches[0]->schema(), &writer, &reader));
+
+  ipc::DictionaryMemo memo;
+  for (const auto& batch : batches) {
+    ASSERT_OK_AND_ASSIGN(auto buffer, cuda::SerializeRecordBatch(*batch, context_.get()));
+    ASSERT_OK_AND_ASSIGN(auto cuda_batch,
+                         cuda::ReadRecordBatch(batch->schema(), &memo, buffer));
+
+    for (const auto& column : cuda_batch->columns()) {
+      ASSERT_OK(CheckBuffersOnDevice(*column, *device_));
+    }
+
+    ASSERT_OK(writer->WriteRecordBatch(*cuda_batch));
+  }
+  ASSERT_OK(writer->Close());
+}
+
+TEST_F(TestCuda, DoExchange) {
+  // Check that we can send a record batch containing references to
+  // GPU buffers.
+  FlightCallOptions options;
+  options.memory_manager = device_->default_memory_manager();
+
+  BatchVector batches;
+  ASSERT_OK(ExampleIntBatches(&batches));
+
+  std::unique_ptr<FlightStreamWriter> writer;
+  std::unique_ptr<FlightStreamReader> reader;
+  auto descriptor = FlightDescriptor::Path({""});
+  ASSERT_OK(client_->DoExchange(options, descriptor, &writer, &reader));
+  ASSERT_OK(writer->Begin(batches[0]->schema()));
+
+  ipc::DictionaryMemo write_memo;
+  ipc::DictionaryMemo read_memo;
+  for (const auto& batch : batches) {
+    ASSERT_OK_AND_ASSIGN(auto buffer, cuda::SerializeRecordBatch(*batch, context_.get()));
+    ASSERT_OK_AND_ASSIGN(auto cuda_batch,
+                         cuda::ReadRecordBatch(batch->schema(), &write_memo, buffer));
+
+    for (const auto& column : cuda_batch->columns()) {
+      ASSERT_OK(CheckBuffersOnDevice(*column, *device_));
+    }
+
+    ASSERT_OK(writer->WriteRecordBatch(*cuda_batch));
+
+    FlightStreamChunk chunk;
+    ASSERT_OK(reader->Next(&chunk));
+    for (const auto& column : chunk.data->columns()) {
+      ASSERT_OK(CheckBuffersOnDevice(*column, *device_));
+    }
+
+    // Bounce record batch back to host memory
+    ASSERT_OK_AND_ASSIGN(auto host_batch, CopyBatchToHost(*chunk.data));
+    AssertBatchesEqual(*batch, *host_batch);
+  }
+  ASSERT_OK(writer->Close());
+}
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -377,27 +377,6 @@ TEST(TestFlight, ServeShutdown) {
 // ----------------------------------------------------------------------
 // Client tests
 
-// Helper to initialize a server and matching client with callbacks to
-// populate options.
-template <typename T, typename... Args>
-Status MakeServer(std::unique_ptr<FlightServerBase>* server,
-                  std::unique_ptr<FlightClient>* client,
-                  std::function<Status(FlightServerOptions*)> make_server_options,
-                  std::function<Status(FlightClientOptions*)> make_client_options,
-                  Args&&... server_args) {
-  Location location;
-  RETURN_NOT_OK(Location::ForGrpcTcp("localhost", 0, &location));
-  *server = arrow::internal::make_unique<T>(std::forward<Args>(server_args)...);
-  FlightServerOptions server_options(location);
-  RETURN_NOT_OK(make_server_options(&server_options));
-  RETURN_NOT_OK((*server)->Init(server_options));
-  Location real_location;
-  RETURN_NOT_OK(Location::ForGrpcTcp("localhost", (*server)->port(), &real_location));
-  FlightClientOptions client_options = FlightClientOptions::Defaults();
-  RETURN_NOT_OK(make_client_options(&client_options));
-  return FlightClient::Connect(real_location, client_options, client);
-}
-
 class TestFlightClient : public ::testing::Test {
  public:
   void SetUp() {

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -149,6 +149,9 @@ class ARROW_FLIGHT_EXPORT FlightServerOptions {
   std::vector<std::pair<std::string, std::shared_ptr<ServerMiddlewareFactory>>>
       middleware;
 
+  /// \brief An optional memory manager to control where to allocate incoming data.
+  std::shared_ptr<MemoryManager> memory_manager;
+
   /// \brief A Flight implementation-specific callback to customize
   /// transport-specific options.
   ///


### PR DESCRIPTION
This enables using Flight with something like CUDA without having to manually copy data. Given the work around UCX on the mailing list, this would enable alternative backends to optimize based on where data is allocated.