### PR TITLE
ARROW-15437: [Python][FlightRPC] Fix flaky test test_interrupt

### DIFF
--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -1941,9 +1941,10 @@ def test_interrupt():
             # In case KeyboardInterrupt didn't interrupt read_all
             # above, at least prevent it from stopping the test suite
             pytest.fail("KeyboardInterrupt didn't interrupt Flight read_all")
-        e = exc_info.value.__context__
-        assert isinstance(e, pa.ArrowCancelled) or \
-            isinstance(e, KeyboardInterrupt)
+        # __context__ is sometimes None
+        e = exc_info.value
+        assert isinstance(e, (pa.ArrowCancelled, KeyboardInterrupt)) or \
+            isinstance(e.__context__, (pa.ArrowCancelled, KeyboardInterrupt))
 
     with CancelFlightServer() as server:
         client = FlightClient(("localhost", server.port))


### PR DESCRIPTION
This test tends to be flaky under pytest --pdb because the
exception it's looking for may either be the exception pytest
captured, or the __context__ of said exception. Test both to be
sure.