### PR TITLE
ARROW-15441: [C++][Compute] Fix incorrect result of hash_count a null type column

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -2811,5 +2811,98 @@ TEST(GroupBy, SmallChunkSizeSumOnly) {
                     /*verbose=*/true);
 }
 
+TEST(GroupBy, CountWithNullType) {
+  auto table =
+      TableFromJSON(schema({field("argument", null()), field("key", int64())}), {R"([
+    [null,  1],
+    [null,  1]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, 3],
+    [null, null],
+    [null, 1],
+    [null, 2]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, null],
+    [null, 3]
+                        ])"});
+
+  CountOptions all(CountOptions::ALL);
+  CountOptions only_valid(CountOptions::ONLY_VALID);
+  CountOptions only_null(CountOptions::ONLY_NULL);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_count", &all},
+                                   {"hash_count", &only_valid},
+                                   {"hash_count", &only_null},
+                               },
+                               use_threads, use_exec_plan));
+      SortBy({"key_0"}, &aggregated_and_grouped);
+
+      AssertDatumsEqual(ArrayFromJSON(struct_({
+                                          field("hash_count", int64()),
+                                          field("hash_count", int64()),
+                                          field("hash_count", int64()),
+                                          field("key_0", int64()),
+                                      }),
+                                      R"([
+    [3, 0, 3, 1],
+    [3, 0, 3, 2],
+    [2, 0, 2, 3],
+    [2, 0, 2, null]
+  ])"),
+                        aggregated_and_grouped,
+                        /*verbose=*/true);
+    }
+  }
+}
+
+TEST(GroupBy, CountWithNullTypeEmptyTable) {
+  auto table = TableFromJSON(schema({field("argument", null()), field("key", int64())}),
+                             {R"([])"});
+
+  CountOptions all(CountOptions::ALL);
+  CountOptions only_valid(CountOptions::ONLY_VALID);
+  CountOptions only_null(CountOptions::ONLY_NULL);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_count", &all},
+                                   {"hash_count", &only_valid},
+                                   {"hash_count", &only_null},
+                               },
+                               use_threads, use_exec_plan));
+      auto struct_arr = aggregated_and_grouped.array_as<StructArray>();
+      auto all_arr = checked_pointer_cast<Array>(struct_arr->field(0));
+      for (auto& field : struct_arr->fields()) {
+        AssertDatumsEqual(ArrayFromJSON(int64(), "[]"), field, /*verbose=*/true);
+      }
+    }
+  }
+}
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -2897,7 +2897,6 @@ TEST(GroupBy, CountWithNullTypeEmptyTable) {
                                },
                                use_threads, use_exec_plan));
       auto struct_arr = aggregated_and_grouped.array_as<StructArray>();
-      auto all_arr = checked_pointer_cast<Array>(struct_arr->field(0));
       for (auto& field : struct_arr->fields()) {
         AssertDatumsEqual(ArrayFromJSON(int64(), "[]"), field, /*verbose=*/true);
       }


### PR DESCRIPTION
The result of hash_count such array is incorrect.
For a table like this:
<table>
<thead>
<tr>
<th>argument</th>
<th>key</th>
</tr>
</thead>
<tbody>
<tr>
<td>NULL</td>
<td>1</td>
</tr>
<tr>
<td>NULL</td>
<td>1</td>
</tr>
</tbody>
</table>

The result is :
<table>
<thead>
<tr>
<th>CountOptions</th>
<th>Expected</th>
<th>Actual</th>
</tr>
</thead>
<tbody>
<tr>
<td>ONLY_VALID</td>
<td>0</td>
<td>2</td>
</tr>
<tr>
<td>ONLY_NULL</td>
<td>2</td>
<td>0</td>
</tr>
</tbody>
</table>

This PR handles null type with different count options.

