### PR TITLE
ARROW-15447: [C++] Avoid conflict between ORC options API and glibc-defined macro

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -737,8 +737,8 @@ Result<liborc::WriterOptions> MakeOrcWriterOptions(
     arrow::adapters::orc::WriteOptions options) {
   liborc::WriterOptions orc_options;
   orc_options.setFileVersion(
-      liborc::FileVersion(static_cast<uint32_t>(options.file_version.major()),
-                          static_cast<uint32_t>(options.file_version.minor())));
+      liborc::FileVersion(static_cast<uint32_t>(options.file_version.major_version()),
+                          static_cast<uint32_t>(options.file_version.minor_version())));
   orc_options.setStripeSize(static_cast<uint64_t>(options.stripe_size));
   orc_options.setCompressionBlockSize(
       static_cast<uint64_t>(options.compression_block_size));

--- a/cpp/src/arrow/adapters/orc/options.cc
+++ b/cpp/src/arrow/adapters/orc/options.cc
@@ -27,7 +27,7 @@ namespace orc {
 
 std::string FileVersion::ToString() const {
   std::stringstream ss;
-  ss << major() << '.' << minor();
+  ss << major_version() << '.' << minor_version();
   return ss.str();
 }
 

--- a/cpp/src/arrow/adapters/orc/options.h
+++ b/cpp/src/arrow/adapters/orc/options.h
@@ -57,28 +57,29 @@ enum class CompressionStrategy : int32_t { kSpeed = 0, kCompression };
 
 class ARROW_EXPORT FileVersion {
  private:
-  int32_t major_version;
-  int32_t minor_version;
+  int32_t major_version_;
+  int32_t minor_version_;
 
  public:
   static const FileVersion& v_0_11();
   static const FileVersion& v_0_12();
 
   FileVersion(int32_t major, int32_t minor)
-      : major_version(major), minor_version(minor) {}
+      : major_version_(major), minor_version_(minor) {}
 
   /**
    * Get major version
    */
-  int32_t major() const { return this->major_version; }
+  int32_t major_version() const { return this->major_version_; }
 
   /**
    * Get minor version
    */
-  int32_t minor() const { return this->minor_version; }
+  int32_t minor_version() const { return this->minor_version_; }
 
   bool operator==(const FileVersion& right) const {
-    return this->major_version == right.major() && this->minor_version == right.minor();
+    return this->major_version() == right.major_version() &&
+           this->minor_version() == right.minor_version();
   }
 
   bool operator!=(const FileVersion& right) const { return !(*this == right); }

--- a/python/pyarrow/_orc.pxd
+++ b/python/pyarrow/_orc.pxd
@@ -67,9 +67,9 @@ cdef extern from "arrow/adapters/orc/options.h" \
         _WriterVersion_MAX" arrow::adapters::orc::WriterVersion::kMax"
 
     cdef cppclass FileVersion" arrow::adapters::orc::FileVersion":
-        FileVersion(uint32_t major, uint32_t minor)
-        uint32_t major()
-        uint32_t minor()
+        FileVersion(uint32_t major_version, uint32_t minor_version)
+        uint32_t major_version()
+        uint32_t minor_version()
         c_string ToString()
 
     cdef struct WriteOptions" arrow::adapters::orc::WriteOptions":

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -299,153 +299,153 @@ def test_orcfile_readwrite_with_bad_writeoptions():
     # batch_size must be a positive integer
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             batch_size=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             batch_size=-100,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             batch_size=1024.23,
         )
 
     # file_version must be 0.11 or 0.12
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             file_version=0.13,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             file_version='1.1',
         )
 
     # stripe_size must be a positive integer
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             stripe_size=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             stripe_size=-400,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             stripe_size=4096.73,
         )
 
     # compression must be among the given options
     with pytest.raises(TypeError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression='none',
         )
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression='zlid',
         )
 
     # compression_block_size must be a positive integer
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_block_size=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_block_size=-200,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_block_size=1096.73,
         )
 
     # compression_strategy must be among the given options
     with pytest.raises(TypeError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_strategy=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_strategy='no',
         )
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             compression_strategy='large',
         )
 
     # row_index_stride must be a positive integer
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             row_index_stride=0,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             row_index_stride=-800,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             row_index_stride=3096.29,
         )
 
     # padding_tolerance must be possible to cast to float
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             padding_tolerance='cat',
         )
 
@@ -453,20 +453,20 @@ def test_orcfile_readwrite_with_bad_writeoptions():
     # float between 0.0 and 1.0
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             dictionary_key_size_threshold='arrow',
         )
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             dictionary_key_size_threshold=1.2,
         )
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             dictionary_key_size_threshold=-3.2,
         )
 
@@ -474,44 +474,44 @@ def test_orcfile_readwrite_with_bad_writeoptions():
     # nonnegative integers
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_columns="string",
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_columns=[0, 1.4],
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_columns={0, 2, -1},
         )
 
     # bloom_filter_fpp must be convertible to a float between 0.0 and 1.0
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_fpp='arrow',
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_fpp=1.1,
         )
 
     with pytest.raises(ValueError):
         orc.write_table(
-            buffer_output_stream,
             table,
+            buffer_output_stream,
             bloom_filter_fpp=-0.1,
         )
 


### PR DESCRIPTION
Fix the following compilation error on Ubuntu 18.04:
```
/arrow/cpp/src/arrow/adapters/orc/options.h:73:13: error: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>. [-Werror]
   int32_t major() const { return this->major_version; }
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```