### PR TITLE
ARROW-15454: [Python] Try to make CSV cancellation test more robust

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ environment:
     ARROW_BUILD_GANDIVA: "OFF"
     ARROW_LLVM_VERSION: "7.0.*"
     ARROW_S3: "OFF"
-    PYTHON: "3.7"
+    PYTHON: "3.8"
     ARCH: "64"
 
   matrix:


### PR DESCRIPTION
Use `signal.set_wakeup_fd` to wait reliably for the signal to get to the Python interpreter.