### PR TITLE
ARROW-15438: [Python] Flaky test test_write_dataset_max_open_files

### DIFF
--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -337,9 +337,10 @@ class DatasetWritingSinkNodeConsumer : public compute::SinkNodeConsumer {
 Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_options,
                                 std::shared_ptr<Scanner> scanner) {
   const io::IOContext& io_context = scanner->options()->io_context;
+  auto cpu_executor =
+      scanner->options()->use_threads ? ::arrow::internal::GetCpuThreadPool() : nullptr;
   std::shared_ptr<compute::ExecContext> exec_context =
-      std::make_shared<compute::ExecContext>(io_context.pool(),
-                                             ::arrow::internal::GetCpuThreadPool());
+      std::make_shared<compute::ExecContext>(io_context.pool(), cpu_executor);
 
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context.get()));
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3799,7 +3799,7 @@ def test_write_dataset_max_open_files(tempdir):
 
     ds.write_dataset(data=table, base_dir=data_source_2,
                      partitioning=partitioning, format=file_format,
-                     max_open_files=max_open_files)
+                     max_open_files=max_open_files, use_threads=False)
 
     num_of_files_generated, number_of_partitions \
         = _get_compare_pair(data_source_2, record_batch_1, file_format,


### PR DESCRIPTION
The test could fail when writing due to a race condition.  If the batches were delivered `AAAAABBBBBCCCCC...` then by the time we need to close a file to make space we can close an already completed file (and so we won't have to open up a new one later) and we end up with 5 files for 5 partitions.

Adding `use_threads=False` to the `write_dataset` call was not sufficient.  The `arrow::dataset::FileSystemDataset::Write` method was always using the CPU executor for the exec plan.  In other scanner methods we base the CPU executor on the scan options (`nullptr` if `scan_options->use_threads` is `false`).  Making both of these changes together seems to make the test reliably pass.
