### PR TITLE
ARROW-15258: [C++] Easy options to create a source node from a table

### DIFF
--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -55,6 +55,17 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
   std::function<Future<util::optional<ExecBatch>>()> generator;
 };
 
+/// \brief Adapt an Table as a source node
+///
+/// plan->exec_context()->executor() will be used to parallelize pushing to
+/// outputs, if provided.
+class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
+ public:
+  TableSourceNodeOptions(std::shared_ptr<Table> table) : table(table) {}
+
+  std::shared_ptr<Table> table;
+};
+
 /// \brief Make a node which excludes some rows from batches passed through it
 ///
 /// filter_expression will be evaluated against each batch which is pushed to

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -55,7 +55,7 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
   std::function<Future<util::optional<ExecBatch>>()> generator;
 };
 
-/// \brief An extended Source node which accepts a table 
+/// \brief An extended Source node which accepts a table
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
   TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t batch_size)

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -61,9 +61,11 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 /// outputs, if provided.
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
-  TableSourceNodeOptions(std::shared_ptr<Table> table) : table(table) {}
+  TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t max_chunksize)
+      : table(table), max_chunksize(max_chunksize) {}
 
   std::shared_ptr<Table> table;
+  int64_t max_chunksize;
 };
 
 /// \brief Make a node which excludes some rows from batches passed through it

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -55,7 +55,7 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
   std::function<Future<util::optional<ExecBatch>>()> generator;
 };
 
-/// if plan->exec_context()->executor() is not null.
+/// \brief An extended Source node which accepts a table 
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
   TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t batch_size)

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -56,15 +56,19 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 };
 
 /// \brief Adapt an Table as a source node
-///
-/// plan->exec_context()->executor() will be used to parallelize pushing to
-/// outputs, if provided.
+/// The table will be sent through the exec plan in batches.
+/// Each batch will be submitted as a new thread task
+/// if plan->exec_context()->executor() is not null.
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
   TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t batch_size)
       : table(table), batch_size(batch_size) {}
 
+  // arrow table which acts as the data source
   std::shared_ptr<Table> table;
+  // batch size which used to set the chunk_size to
+  // the table batch reader used in building the data source
+  // from the table
   int64_t batch_size;
 };
 

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -61,11 +61,11 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 /// outputs, if provided.
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
-  TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t max_chunksize)
-      : table(table), max_chunksize(max_chunksize) {}
+  TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t batch_size)
+      : table(table), batch_size(batch_size) {}
 
   std::shared_ptr<Table> table;
-  int64_t max_chunksize;
+  int64_t batch_size;
 };
 
 /// \brief Make a node which excludes some rows from batches passed through it

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -56,8 +56,6 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 };
 
 /// \brief Adapt an Table as a source node
-/// The table will be sent through the exec plan in batches.
-/// Each batch will be submitted as a new thread task
 /// if plan->exec_context()->executor() is not null.
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
@@ -72,26 +70,6 @@ class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
   int64_t batch_size;
 };
 
-/// \brief Make a node which excludes some rows from batches passed through it
-///
-/// filter_expression will be evaluated against each batch which is pushed to
-/// this node. Any rows for which filter_expression does not evaluate to `true` will be
-/// excluded in the batch emitted by this node.
-class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
- public:
-  explicit FilterNodeOptions(Expression filter_expression, bool async_mode = true)
-      : filter_expression(std::move(filter_expression)), async_mode(async_mode) {}
-
-  Expression filter_expression;
-  bool async_mode;
-};
-
-/// \brief Make a node which executes expressions on input batches, producing new batches.
-///
-/// Each expression will be evaluated against each batch which is pushed to
-/// this node to produce a corresponding output column.
-///
-/// If names are not provided, the string representations of exprs will be used.
 class ARROW_EXPORT ProjectNodeOptions : public ExecNodeOptions {
  public:
   explicit ProjectNodeOptions(std::vector<Expression> expressions,

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -84,6 +84,12 @@ class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
   bool async_mode;
 };
 
+/// \brief Make a node which executes expressions on input batches, producing new batches.
+///
+/// Each expression will be evaluated against each batch which is pushed to
+/// this node to produce a corresponding output column.
+///
+/// If names are not provided, the string representations of exprs will be used.
 class ARROW_EXPORT ProjectNodeOptions : public ExecNodeOptions {
  public:
   explicit ProjectNodeOptions(std::vector<Expression> expressions,

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -55,7 +55,6 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
   std::function<Future<util::optional<ExecBatch>>()> generator;
 };
 
-/// \brief Adapt an Table as a source node
 /// if plan->exec_context()->executor() is not null.
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
@@ -64,9 +63,9 @@ class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
 
   // arrow table which acts as the data source
   std::shared_ptr<Table> table;
-  // batch size which used to set the chunk_size to
-  // the table batch reader used in building the data source
-  // from the table
+  // Size of batches to emit from this node
+  // If the table is larger the node will emit multiple batches from the
+  // the table to be processed in parallel.
   int64_t batch_size;
 };
 

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -70,6 +70,20 @@ class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
   int64_t batch_size;
 };
 
+/// \brief Make a node which excludes some rows from batches passed through it
+///
+/// filter_expression will be evaluated against each batch which is pushed to
+/// this node. Any rows for which filter_expression does not evaluate to `true` will be
+/// excluded in the batch emitted by this node.
+class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
+ public:
+  explicit FilterNodeOptions(Expression filter_expression, bool async_mode = true)
+      : filter_expression(std::move(filter_expression)), async_mode(async_mode) {}
+
+  Expression filter_expression;
+  bool async_mode;
+};
+
 class ARROW_EXPORT ProjectNodeOptions : public ExecNodeOptions {
  public:
   explicit ProjectNodeOptions(std::vector<Expression> expressions,

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -253,7 +253,7 @@ TEST(ExecPlanExecution, TableSourceSink) {
           auto table, TableFromExecBatches(exec_batches.schema, exec_batches.batches));
 
       ASSERT_OK(Declaration::Sequence({
-                                          {"table", TableSourceNodeOptions{table}},
+                                          {"table", TableSourceNodeOptions{table, 1}},
                                           {"sink", SinkNodeOptions{&sink_gen}},
                                       })
                     .AddToPlan(plan.get()));

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -245,25 +245,45 @@ TEST(ExecPlanExecution, TableSourceSink) {
     for (bool parallel : {false, true}) {
       SCOPED_TRACE(parallel ? "parallel" : "single threaded");
 
-      ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
-      AsyncGenerator<util::optional<ExecBatch>> sink_gen;
+      for (int batch_size : {1, 4}) {
+        ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
+        AsyncGenerator<util::optional<ExecBatch>> sink_gen;
 
-      auto exp_batches = MakeBasicBatches();
-      ASSERT_OK_AND_ASSIGN(auto table,
-                           TableFromExecBatches(exp_batches.schema, exp_batches.batches));
+        auto exp_batches = MakeBasicBatches();
+        ASSERT_OK_AND_ASSIGN(
+            auto table, TableFromExecBatches(exp_batches.schema, exp_batches.batches));
 
-      ASSERT_OK(
-          Declaration::Sequence({
-                                    {"table_source", TableSourceNodeOptions{table, 1}},
-                                    {"sink", SinkNodeOptions{&sink_gen}},
-                                })
-              .AddToPlan(plan.get()));
+        ASSERT_OK(Declaration::Sequence(
+                      {
+                          {"table_source", TableSourceNodeOptions{table, batch_size}},
+                          {"sink", SinkNodeOptions{&sink_gen}},
+                      })
+                      .AddToPlan(plan.get()));
 
-      ASSERT_FINISHES_OK_AND_ASSIGN(auto res, StartAndCollect(plan.get(), sink_gen));
-      ASSERT_OK_AND_ASSIGN(auto out_table, TableFromExecBatches(exp_batches.schema, res));
-      AssertTablesEqual(table, out_table);
+        ASSERT_FINISHES_OK_AND_ASSIGN(auto res, StartAndCollect(plan.get(), sink_gen));
+        ASSERT_OK_AND_ASSIGN(auto out_table,
+                             TableFromExecBatches(exp_batches.schema, res));
+        AssertTablesEqual(table, out_table);
+      }
     }
   }
+}
+
+TEST(ExecPlanExecution, TableSourceSinkError) {
+  ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
+  AsyncGenerator<util::optional<ExecBatch>> sink_gen;
+
+  auto exp_batches = MakeBasicBatches();
+  ASSERT_OK_AND_ASSIGN(auto table,
+                       TableFromExecBatches(exp_batches.schema, exp_batches.batches));
+
+  auto null_table_options = TableSourceNodeOptions{nullptr, 1};
+  ASSERT_THAT(MakeExecNode("table_source", plan.get(), {}, null_table_options),
+              Raises(StatusCode::Invalid, HasSubstr("not null")));
+
+  auto negative_batch_size_options = TableSourceNodeOptions{table, -1};
+  ASSERT_THAT(MakeExecNode("table_source", plan.get(), {}, negative_batch_size_options),
+              Raises(StatusCode::Invalid, HasSubstr("batch_size > 0")));
 }
 
 TEST(ExecPlanExecution, SinkNodeBackpressure) {

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -238,6 +238,32 @@ TEST(ExecPlanExecution, SourceSink) {
   }
 }
 
+TEST(ExecPlanExecution, TableSourceSink) {
+  for (bool slow : {false, true}) {
+    SCOPED_TRACE(slow ? "slowed" : "unslowed");
+
+    for (bool parallel : {false, true}) {
+      SCOPED_TRACE(parallel ? "parallel" : "single threaded");
+
+      ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
+      AsyncGenerator<util::optional<ExecBatch>> sink_gen;
+
+      auto exec_batches = MakeBasicBatches();
+      ASSERT_OK_AND_ASSIGN(
+          auto table, TableFromExecBatches(exec_batches.schema, exec_batches.batches));
+
+      ASSERT_OK(Declaration::Sequence({
+                                          {"table", TableSourceNodeOptions{table}},
+                                          {"sink", SinkNodeOptions{&sink_gen}},
+                                      })
+                    .AddToPlan(plan.get()));
+
+      ASSERT_THAT(StartAndCollect(plan.get(), sink_gen),
+                  Finishes(ResultWith(UnorderedElementsAreArray(exec_batches.batches))));
+    }
+  }
+}
+
 TEST(ExecPlanExecution, SinkNodeBackpressure) {
   constexpr uint32_t kPauseIfAbove = 4;
   constexpr uint32_t kResumeIfBelow = 2;

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -249,14 +249,15 @@ TEST(ExecPlanExecution, TableSourceSink) {
       AsyncGenerator<util::optional<ExecBatch>> sink_gen;
 
       auto exp_batches = MakeBasicBatches();
-      ASSERT_OK_AND_ASSIGN(
-          auto table, TableFromExecBatches(exp_batches.schema, exp_batches.batches));
+      ASSERT_OK_AND_ASSIGN(auto table,
+                           TableFromExecBatches(exp_batches.schema, exp_batches.batches));
 
-      ASSERT_OK(Declaration::Sequence({
-                                          {"table_source", TableSourceNodeOptions{table, 1}},
-                                          {"sink", SinkNodeOptions{&sink_gen}},
-                                      })
-                    .AddToPlan(plan.get()));
+      ASSERT_OK(
+          Declaration::Sequence({
+                                    {"table_source", TableSourceNodeOptions{table, 1}},
+                                    {"sink", SinkNodeOptions{&sink_gen}},
+                                })
+              .AddToPlan(plan.get()));
 
       ASSERT_FINISHES_OK_AND_ASSIGN(auto res, StartAndCollect(plan.get(), sink_gen));
       ASSERT_OK_AND_ASSIGN(auto out_table, TableFromExecBatches(exp_batches.schema, res));

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -220,7 +220,6 @@ struct TableSourceNode : public SourceNode {
     return gen;
   }
 
-<<<<<<< HEAD
   static std::vector<ExecBatch> ConvertTableToExecBatches(const Table& table,
                                                           const int64_t batch_size) {
     std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
@@ -237,15 +236,6 @@ struct TableSourceNode : public SourceNode {
       if (batch_res.ok()) {
         batch = batch_res.ValueOrDie();
       }
-=======
-  arrow::Result<std::vector<ExecBatch>> ConvertTableToExecBatches(const Table& table) {
-    std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
-    std::shared_ptr<arrow::RecordBatch> batch;
-    std::vector<std::shared_ptr<arrow::RecordBatch>> batch_vector;
-    std::vector<ExecBatch> exec_batches;
-    while (true) {
-      ARROW_ASSIGN_OR_RAISE(batch, reader->Next());
->>>>>>> f505d915f (adding table source node)
       if (batch == NULLPTR) {
         break;
       }
@@ -262,11 +252,7 @@ namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry* registry) {
   DCHECK_OK(registry->AddFactory("source", SourceNode::Make));
-<<<<<<< HEAD
   DCHECK_OK(registry->AddFactory("table_source", TableSourceNode::Make));
-=======
-  DCHECK_OK(registry->AddFactory("table", TableSourceNode::Make));
->>>>>>> f505d915f (adding table source node)
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -26,7 +26,6 @@
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/table.h"
-#include "arrow/testing/gtest_util.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/async_util.h"
 #include "arrow/util/checked_cast.h"
@@ -233,7 +232,10 @@ struct TableSourceNode : public SourceNode {
     std::shared_ptr<arrow::RecordBatch> batch;
     std::vector<ExecBatch> exec_batches;
     while (true) {
-      ASSIGN_OR_ABORT(batch, reader->Next());
+      auto batch_res = reader->Next();
+      if (batch_res.ok()) {
+        batch = batch_res.ValueOrDie();
+      }
       if (batch == NULLPTR) {
         break;
       }

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -196,7 +196,7 @@ struct TableSourceNode : public SourceNode {
   const char* kind_name() const override { return "TableSourceNode"; }
 
   static arrow::Status ValidateTableSourceNodeInpute(const std::shared_ptr<Table> table,
-                                                     const int batch_size,
+                                                     const int64_t batch_size,
                                                      const char* kind_name) {
     if (table == nullptr) {
       return Status::Invalid(kind_name, " node requires table which is not null");
@@ -221,7 +221,7 @@ struct TableSourceNode : public SourceNode {
   }
 
   static std::vector<ExecBatch> ConvertTableToExecBatches(const Table& table,
-                                                          const int batch_size) {
+                                                          const int64_t batch_size) {
     std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
 
     // setting chunksize for the batch reader

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -229,7 +229,7 @@ struct TableSourceNode : public SourceNode {
       reader->set_chunksize(batch_size);
     }
 
-    std::shared_ptr<arrow::RecordBatch> batch;
+    std::shared_ptr<RecordBatch> batch;
     std::vector<ExecBatch> exec_batches;
     while (true) {
       auto batch_res = reader->Next();

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -25,6 +25,7 @@
 #include "arrow/compute/exec_internal.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
+#include "arrow/table.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/async_util.h"
 #include "arrow/util/checked_cast.h"
@@ -34,10 +35,12 @@
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/unreachable.h"
+#include "arrow/util/vector.h"
 
 namespace arrow {
 
 using internal::checked_cast;
+using internal::MapVector;
 
 namespace compute {
 namespace {
@@ -174,12 +177,72 @@ struct SourceNode : ExecNode {
   AsyncGenerator<util::optional<ExecBatch>> generator_;
 };
 
+struct TableSourceNode : public SourceNode {
+  TableSourceNode(ExecPlan* plan, std::shared_ptr<Schema> output_schema,
+                  std::shared_ptr<Table> table)
+      : SourceNode(plan, output_schema,
+                   generator(ConvertTableToExecBatches(*table.get()).ValueOrDie())) {}
+
+  static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                                const ExecNodeOptions& options) {
+    RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 0, "TableSourceNode"));
+    const auto& table_options = checked_cast<const TableSourceNodeOptions&>(options);
+    return plan->EmplaceNode<TableSourceNode>(plan, table_options.table->schema(),
+                                              table_options.table);
+  }
+  const char* kind_name() const override { return "TableSourceNode"; }
+
+  [[noreturn]] void InputReceived(ExecNode* input, ExecBatch batch) override {
+    SourceNode::InputReceived(input, batch);
+  }
+  [[noreturn]] void ErrorReceived(ExecNode* input, Status status) override {
+    SourceNode::ErrorReceived(input, status);
+  }
+  [[noreturn]] void InputFinished(ExecNode* input, int total_batches) override {
+    SourceNode::InputFinished(input, total_batches);
+  }
+
+  Status StartProducing() override { return SourceNode::StartProducing(); }
+
+  void PauseProducing(ExecNode* output) override { SourceNode::PauseProducing(output); }
+
+  void StopProducing() override { SourceNode::StopProducing(); }
+
+  Future<> finished() override { return SourceNode::finished(); }
+
+  arrow::AsyncGenerator<util::optional<ExecBatch>> generator(
+      std::vector<ExecBatch> batches) {
+    auto opt_batches = MapVector(
+        [](ExecBatch batch) { return util::make_optional(std::move(batch)); }, batches);
+    AsyncGenerator<util::optional<ExecBatch>> gen;
+    gen = MakeVectorGenerator(std::move(opt_batches));
+    return gen;
+  }
+
+  arrow::Result<std::vector<ExecBatch>> ConvertTableToExecBatches(const Table& table) {
+    std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
+    std::shared_ptr<arrow::RecordBatch> batch;
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batch_vector;
+    std::vector<ExecBatch> exec_batches;
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(batch, reader->Next());
+      if (batch == NULLPTR) {
+        break;
+      }
+      ExecBatch exec_batch{*batch};
+      exec_batches.push_back(exec_batch);
+    }
+    return exec_batches;
+  }
+};
+
 }  // namespace
 
 namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry* registry) {
   DCHECK_OK(registry->AddFactory("source", SourceNode::Make));
+  DCHECK_OK(registry->AddFactory("table", TableSourceNode::Make));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -220,6 +220,7 @@ struct TableSourceNode : public SourceNode {
     return gen;
   }
 
+<<<<<<< HEAD
   static std::vector<ExecBatch> ConvertTableToExecBatches(const Table& table,
                                                           const int64_t batch_size) {
     std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
@@ -236,6 +237,15 @@ struct TableSourceNode : public SourceNode {
       if (batch_res.ok()) {
         batch = batch_res.ValueOrDie();
       }
+=======
+  arrow::Result<std::vector<ExecBatch>> ConvertTableToExecBatches(const Table& table) {
+    std::shared_ptr<TableBatchReader> reader = std::make_shared<TableBatchReader>(table);
+    std::shared_ptr<arrow::RecordBatch> batch;
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batch_vector;
+    std::vector<ExecBatch> exec_batches;
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(batch, reader->Next());
+>>>>>>> f505d915f (adding table source node)
       if (batch == NULLPTR) {
         break;
       }
@@ -252,7 +262,11 @@ namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry* registry) {
   DCHECK_OK(registry->AddFactory("source", SourceNode::Make));
+<<<<<<< HEAD
   DCHECK_OK(registry->AddFactory("table_source", TableSourceNode::Make));
+=======
+  DCHECK_OK(registry->AddFactory("table", TableSourceNode::Make));
+>>>>>>> f505d915f (adding table source node)
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -185,8 +185,8 @@ struct TableSourceNode : public SourceNode {
                                 const ExecNodeOptions& options) {
     RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 0, "TableSourceNode"));
     const auto& table_options = checked_cast<const TableSourceNodeOptions&>(options);
-    auto table = table_options.table;
-    auto batch_size = table_options.batch_size;
+    const auto table = table_options.table;
+    const int64_t batch_size = table_options.batch_size;
 
     RETURN_NOT_OK(ValidateTableSourceNodeInpute(table, batch_size, "TableSourceNode"));
 

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -211,7 +211,7 @@ struct TableSourceNode : public SourceNode {
   }
 
   static arrow::AsyncGenerator<util::optional<ExecBatch>> TableGenerator(
-      const Table& table, const int batch_size) {
+      const Table& table, const int64_t batch_size) {
     auto batches = ConvertTableToExecBatches(table, batch_size);
     auto opt_batches = MapVector(
         [](ExecBatch batch) { return util::make_optional(std::move(batch)); }, batches);


### PR DESCRIPTION
This PR includes the addition of `TableSourceNode` to create a `ExecNode` easily using a table as the data source. 

### TODO

- [x] Fix test case for chunk_size 