### PR TITLE
ARROW-15218: [C++] Add decimal support to the indices_nonzero compute function

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2385,14 +2385,14 @@ TYPED_TEST(TestIndicesNonZero, IndicesNonZero) {
   result = actual.make_array();
   AssertArraysEqual(*ArrayFromJSON(uint64(), "[]"), *result);
 
-  // chuncked
+  // chunked
   ChunkedArray chunked_arr(
       {ArrayFromJSON(type, "[1, 0, 3]"), ArrayFromJSON(type, "[4, 0, 6]")});
   ASSERT_OK_AND_ASSIGN(
       actual, CallFunction("indices_nonzero", {static_cast<Datum>(chunked_arr)}));
   AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 2, 3, 5]"), *actual.make_array());
 
-  // empty chuncked
+  // empty chunked
   ChunkedArray chunked_arr_empty({ArrayFromJSON(type, "[1, 0, 3]"),
                                   ArrayFromJSON(type, "[]"),
                                   ArrayFromJSON(type, "[4, 0, 6]")});

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2452,6 +2452,5 @@ TEST(TestIndicesNonZero, IndicesNonZeroDecimal) {
   AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 3]"), *result, true);
 }
 
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2365,39 +2365,93 @@ TEST_F(TestDropNullKernelWithTable, DropNullTableWithSlices) {
   });
 }
 
-TEST(TestIndicesNonZero, IndicesNonZero) {
+template <typename Type>
+class TestIndicesNonZero : public ::testing::Test {};
+
+TYPED_TEST_SUITE(TestIndicesNonZero, NumericArrowTypes);
+TYPED_TEST(TestIndicesNonZero, IndicesNonZero) {
+  Datum actual;
+  std::shared_ptr<Array> result;
+  auto type = TypeTraits<TypeParam>::type_singleton();
+
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("indices_nonzero",
+                                            {ArrayFromJSON(type, "[null, 50, 0, 10]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[1, 3]"), *result);
+
+  // empty
+  ASSERT_OK_AND_ASSIGN(actual,
+                       CallFunction("indices_nonzero", {ArrayFromJSON(type, "[]")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[]"), *result);
+
+  // chuncked
+  ChunkedArray chunked_arr(
+      {ArrayFromJSON(type, "[1, 0, 3]"), ArrayFromJSON(type, "[4, 0, 6]")});
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction("indices_nonzero", {static_cast<Datum>(chunked_arr)}));
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 2, 3, 5]"), *actual.make_array());
+
+  // empty chuncked
+  ChunkedArray chunked_arr_empty({ArrayFromJSON(type, "[1, 0, 3]"),
+                                  ArrayFromJSON(type, "[]"),
+                                  ArrayFromJSON(type, "[4, 0, 6]")});
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction("indices_nonzero", {static_cast<Datum>(chunked_arr_empty)}));
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 2, 3, 5]"), *actual.make_array());
+}
+
+TEST(TestIndicesNonZero, IndicesNonZeroBoolean) {
   Datum actual;
   std::shared_ptr<Array> result;
 
-  ASSERT_OK_AND_ASSIGN(
-      actual,
-      CallFunction("indices_nonzero", {ArrayFromJSON(uint32(), "[null, 50, 0, 10]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
+  // boool
   ASSERT_OK_AND_ASSIGN(
       actual, CallFunction("indices_nonzero",
                            {ArrayFromJSON(boolean(), "[null, true, false, true]")}));
   result = actual.make_array();
   AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
-  ASSERT_OK_AND_ASSIGN(actual,
-                       CallFunction("indices_nonzero",
-                                    {ArrayFromJSON(float64(), "[null, 1.3, 0.0, 5.0]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[1, 3]"));
-
-  ASSERT_OK_AND_ASSIGN(actual,
-                       CallFunction("indices_nonzero", {ArrayFromJSON(float64(), "[]")}));
-  result = actual.make_array();
-  AssertArraysEqual(*result, *ArrayFromJSON(uint64(), "[]"));
-
-  ChunkedArray chunkedarr(
-      {ArrayFromJSON(uint32(), "[1, 0, 3]"), ArrayFromJSON(uint32(), "[4, 0, 6]")});
-  ASSERT_OK_AND_ASSIGN(actual,
-                       CallFunction("indices_nonzero", {static_cast<Datum>(chunkedarr)}));
-  AssertArraysEqual(*actual.make_array(), *ArrayFromJSON(uint64(), "[0, 2, 3, 5]"));
 }
+
+TEST(TestIndicesNonZero, IndicesNonZeroDecimal) {
+  Datum actual;
+  std::shared_ptr<Array> result;
+
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction(
+                  "indices_nonzero",
+                  {DecimalArrayFromJSON(decimal128(2, -2), R"(["12E2",null,"0","0"])")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0]"), *result, true);
+
+  ASSERT_OK_AND_ASSIGN(
+      actual,
+      CallFunction(
+          "indices_nonzero",
+          {DecimalArrayFromJSON(
+              decimal128(6, 9),
+              R"(["765483.999999999","0.000000000",null,"-987645.000000001"])")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 3]"), *result, true);
+
+  ASSERT_OK_AND_ASSIGN(
+      actual, CallFunction(
+                  "indices_nonzero",
+                  {DecimalArrayFromJSON(decimal256(2, -2), R"(["12E2",null,"0","0"])")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0]"), *result, true);
+
+  ASSERT_OK_AND_ASSIGN(
+      actual,
+      CallFunction(
+          "indices_nonzero",
+          {DecimalArrayFromJSON(
+              decimal256(6, 9),
+              R"(["765483.999999999","0.000000000",null,"-987645.000000001"])")}));
+  result = actual.make_array();
+  AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 3]"), *result, true);
+}
+
 
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1587,7 +1587,7 @@ This function returns the indices at which array elements are non-null and non-z
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | Function name         | Arity | Input types                       | Output type    | Options class                   | Notes |
 +=======================+=======+===================================+================+=================================+=======+
-| indices_nonzero       | Unary | Boolean, Null, Numeric            | UInt64         |                                 |       |
+| indices_nonzero       | Unary | Boolean, Null, Numeric, Decimal   | UInt64         |                                 |       |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 
 Sorts and partitions


### PR DESCRIPTION
Adds decimal support to the `indices_nonzero` compute function. This vector function returns the indices of an array that contains values `!=0` or `!=false`. 

This can be used in conjunction with existing functions that return a mask to get back the indices where the mask matches.

Have also added a small enhancement to the `indices_nonzero` tests to use a `TYPED_TEST_SUITE` for numeric primitives.