### PR TITLE
ARROW-15435: [C++][Doc] Improve API docs coverage

### DIFF
--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -31,6 +31,10 @@
 
 namespace arrow {
 
+/// \addtogroup numeric-builders
+///
+/// @{
+
 namespace internal {
 
 class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
@@ -199,5 +203,7 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
   template <typename new_type>
   Status ExpandIntSizeN();
 };
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -35,6 +35,26 @@
 
 namespace arrow {
 
+/// \defgroup numeric-builders Concrete builder subclasses for numeric types
+/// @{
+/// @}
+
+/// \defgroup temporal-builders Concrete builder subclasses for temporal types
+/// @{
+/// @}
+
+/// \defgroup binary-builders Concrete builder subclasses for binary types
+/// @{
+/// @}
+
+/// \defgroup nested-builders Concrete builder subclasses for nested types
+/// @{
+/// @}
+
+/// \defgroup dictionary-builders Concrete builder subclasses for dictionary types
+/// @{
+/// @}
+
 constexpr int64_t kMinBuilderCapacity = 1 << 5;
 constexpr int64_t kListMaximumElements = std::numeric_limits<int32_t>::max() - 1;
 

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -41,6 +41,10 @@
 
 namespace arrow {
 
+/// \addtogroup binary-builders
+///
+/// @{
+
 // ----------------------------------------------------------------------
 // Binary and String
 
@@ -610,6 +614,8 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 
   void CheckValueSize(int64_t size);
 };
+
+/// @}
 
 // ----------------------------------------------------------------------
 // Chunked builders: build a sequence of BinaryArray or StringArray that are

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -29,6 +29,10 @@
 
 namespace arrow {
 
+/// \addtogroup numeric-builders
+///
+/// @{
+
 class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
  public:
   using TypeClass = Decimal128Type;
@@ -90,5 +94,7 @@ class ARROW_EXPORT Decimal256Builder : public FixedSizeBinaryBuilder {
 };
 
 using DecimalBuilder = Decimal128Builder;
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -119,6 +119,14 @@ class ARROW_EXPORT DictionaryMemoTable {
   std::unique_ptr<DictionaryMemoTableImpl> impl_;
 };
 
+}  // namespace internal
+
+/// \addtogroup dictionary-builders
+///
+/// @{
+
+namespace internal {
+
 /// \brief Array builder for created encoded DictionaryArray from
 /// dense array
 ///
@@ -708,5 +716,7 @@ using BinaryDictionaryBuilder = DictionaryBuilder<BinaryType>;
 using StringDictionaryBuilder = DictionaryBuilder<StringType>;
 using BinaryDictionary32Builder = Dictionary32Builder<BinaryType>;
 using StringDictionary32Builder = Dictionary32Builder<StringType>;
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -35,6 +35,10 @@
 
 namespace arrow {
 
+/// \addtogroup nested-builders
+///
+/// @{
+
 // ----------------------------------------------------------------------
 // List builder
 
@@ -551,5 +555,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
  private:
   std::shared_ptr<DataType> type_;
 };
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -68,6 +68,10 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
   Status Finish(std::shared_ptr<NullArray>* out) { return FinishTyped(out); }
 };
 
+/// \addtogroup numeric-builders
+///
+/// @{
+
 /// Base class for all Builders that emit an Array of a scalar numerical type.
 template <typename T>
 class NumericBuilder : public ArrayBuilder {
@@ -318,6 +322,22 @@ using Int64Builder = NumericBuilder<Int64Type>;
 using HalfFloatBuilder = NumericBuilder<HalfFloatType>;
 using FloatBuilder = NumericBuilder<FloatType>;
 using DoubleBuilder = NumericBuilder<DoubleType>;
+
+/// @}
+
+/// \addtogroup temporal-builders
+///
+/// @{
+
+using Date32Builder = NumericBuilder<Date32Type>;
+using Date64Builder = NumericBuilder<Date64Type>;
+using Time32Builder = NumericBuilder<Time32Type>;
+using Time64Builder = NumericBuilder<Time64Type>;
+using TimestampBuilder = NumericBuilder<TimestampType>;
+using MonthIntervalBuilder = NumericBuilder<MonthIntervalType>;
+using DurationBuilder = NumericBuilder<DurationType>;
+
+/// @}
 
 class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
  public:

--- a/cpp/src/arrow/array/builder_time.h
+++ b/cpp/src/arrow/array/builder_time.h
@@ -26,6 +26,10 @@
 
 namespace arrow {
 
+/// \addtogroup temporal-builders
+///
+/// @{
+
 // TODO(ARROW-7938): this class is untested
 
 class ARROW_EXPORT DayTimeIntervalBuilder : public NumericBuilder<DayTimeIntervalType> {
@@ -52,5 +56,7 @@ class ARROW_EXPORT MonthDayNanoIntervalBuilder
                                        MemoryPool* pool = default_memory_pool())
       : NumericBuilder<MonthDayNanoIntervalType>(type, pool) {}
 };
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -33,6 +33,10 @@
 
 namespace arrow {
 
+/// \addtogroup nested-builders
+///
+/// @{
+
 /// \brief Base class for union array builds.
 ///
 /// Note that while we subclass ArrayBuilder, as union types do not have a
@@ -238,5 +242,7 @@ class ARROW_EXPORT SparseUnionBuilder : public BasicUnionBuilder {
   Status AppendArraySlice(const ArrayData& array, int64_t offset,
                           int64_t length) override;
 };
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/csv/writer.h
+++ b/cpp/src/arrow/csv/writer.h
@@ -27,6 +27,7 @@
 
 namespace arrow {
 namespace csv {
+
 // Functionality for converting Arrow data to Comma separated value text.
 // This library supports all primitive types that can be cast to a StringArrays.
 // It applies to following formatting rules:
@@ -36,20 +37,28 @@ namespace csv {
 //  with an additional quote).
 //    Null values are empty and unquoted.
 
-/// \brief Converts table to a CSV and writes the results to output.
+/// \defgroup csv-write-functions High-level functions for writing CSV files
+/// @{
+
+/// \brief Convert table to CSV and write the result to output.
 /// Experimental
 ARROW_EXPORT Status WriteCSV(const Table& table, const WriteOptions& options,
                              arrow::io::OutputStream* output);
-/// \brief Converts batch to CSV and writes the results to output.
+/// \brief Convert batch to CSV and write the result to output.
 /// Experimental
 ARROW_EXPORT Status WriteCSV(const RecordBatch& batch, const WriteOptions& options,
                              arrow::io::OutputStream* output);
-/// \brief Converts batches read through a RecordBatchReader
-/// to CSV and writes the results to output.
+/// \brief Convert batches read through a RecordBatchReader
+/// to CSV and write the results to output.
 /// Experimental
 ARROW_EXPORT Status WriteCSV(const std::shared_ptr<RecordBatchReader>& reader,
                              const WriteOptions& options,
                              arrow::io::OutputStream* output);
+
+/// @}
+
+/// \defgroup csv-writer-factories Functions for creating an incremental CSV writer
+/// @{
 
 /// \brief Create a new CSV writer. User is responsible for closing the
 /// actual OutputStream.
@@ -73,6 +82,8 @@ ARROW_EXPORT
 Result<std::shared_ptr<ipc::RecordBatchWriter>> MakeCSVWriter(
     io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
     const WriteOptions& options = WriteOptions::Defaults());
+
+/// @}
 
 }  // namespace csv
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -25,8 +25,7 @@
 
 namespace arrow {
 namespace fs {
-class GcsFileSystem;
-struct GcsOptions;
+
 struct GcsCredentials;
 
 /// Options for the GcsFileSystem implementation.

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -180,6 +180,7 @@ Status jemalloc_set_decay_ms(int ms);
 /// May return NotImplemented if mimalloc is not available.
 ARROW_EXPORT Status mimalloc_memory_pool(MemoryPool** out);
 
+/// \brief Return the names of the backends supported by this Arrow build.
 ARROW_EXPORT std::vector<std::string> SupportedMemoryBackendNames();
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -750,6 +750,9 @@ inline typename Future<internal::Empty>::SyncType FutureToSync<internal::Empty>(
   return fut.status();
 }
 
+template <>
+inline Future<>::Future(Status s) : Future(internal::Empty::ToResult(std::move(s))) {}
+
 template <typename T>
 class WeakFuture {
  public:
@@ -760,6 +763,10 @@ class WeakFuture {
  private:
   std::weak_ptr<FutureImpl> impl_;
 };
+
+
+/// \defgroup future-utilities Functions for working with Futures
+/// @{
 
 /// If a Result<Future> holds an error instead of a Future, construct a finished Future
 /// holding that error.
@@ -829,9 +836,6 @@ Future<std::vector<Result<T>>> All(std::vector<Future<T>> futures) {
   return out;
 }
 
-template <>
-inline Future<>::Future(Status s) : Future(internal::Empty::ToResult(std::move(s))) {}
-
 /// \brief Create a Future which completes when all of `futures` complete.
 ///
 /// The future will be marked complete if all `futures` complete
@@ -874,6 +878,8 @@ inline std::vector<int> WaitForAny(const std::vector<Future<T>*>& futures,
   waiter->Wait(seconds);
   return waiter->MoveFinishedFutures();
 }
+
+/// @}
 
 struct Continue {
   template <typename T>

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -764,7 +764,6 @@ class WeakFuture {
   std::weak_ptr<FutureImpl> impl_;
 };
 
-
 /// \defgroup future-utilities Functions for working with Futures
 /// @{
 

--- a/docs/source/cpp/api.rst
+++ b/docs/source/cpp/api.rst
@@ -33,6 +33,7 @@ API Reference
    api/compute
    api/tensor
    api/utilities
+   api/async
    api/io
    api/ipc
    api/formats

--- a/docs/source/cpp/api/async.rst
+++ b/docs/source/cpp/api/async.rst
@@ -15,44 +15,15 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-=========
-Utilities
-=========
+========================
+Asynchronous programming
+========================
 
-Decimal Numbers
-===============
+Futures
+=======
 
-.. doxygenclass:: arrow::BasicDecimal128
+.. doxygenclass:: arrow::Future
    :members:
 
-.. doxygenclass:: arrow::Decimal128
-   :members:
-
-.. doxygenclass:: arrow::BasicDecimal256
-   :members:
-
-.. doxygenclass:: arrow::Decimal256
-   :members:
-
-Iterators
-=========
-
-.. doxygenclass:: arrow::Iterator
-   :members:
-
-.. doxygenclass:: arrow::VectorIterator
-   :members:
-
-Compression
-===========
-
-.. doxygenenum:: arrow::Compression::type
-
-.. doxygenclass:: arrow::util::Codec
-   :members:
-
-.. doxygenclass:: arrow::util::Compressor
-   :members:
-
-.. doxygenclass:: arrow::util::Decompressor
-   :members:
+.. doxygengroup:: future-utilities
+   :content-only:

--- a/docs/source/cpp/api/builder.rst
+++ b/docs/source/cpp/api/builder.rst
@@ -25,32 +25,42 @@ Array Builders
 Concrete builder subclasses
 ===========================
 
+Primitive
+---------
+
 .. doxygenclass:: arrow::NullBuilder
    :members:
 
 .. doxygenclass:: arrow::BooleanBuilder
    :members:
 
-.. doxygenclass:: arrow::NumericBuilder
+.. doxygengroup:: numeric-builders
+   :content-only:
    :members:
 
-.. doxygenclass:: arrow::BinaryBuilder
+Temporal
+--------
+
+.. doxygengroup:: temporal-builders
+   :content-only:
    :members:
 
-.. doxygenclass:: arrow::StringBuilder
+Binary-like
+-----------
+
+.. doxygengroup:: binary-builders
+   :content-only:
    :members:
 
-.. doxygenclass:: arrow::FixedSizeBinaryBuilder
+Nested
+------
+
+.. doxygengroup:: nested-builders
+   :content-only:
    :members:
 
-.. doxygenclass:: arrow::Decimal128Builder
-   :members:
-
-.. doxygenclass:: arrow::ListBuilder
-   :members:
-
-.. doxygenclass:: arrow::StructBuilder
-   :members:
+Dictionary-encoded
+------------------
 
 .. doxygenclass:: arrow::DictionaryBuilder
    :members:

--- a/docs/source/cpp/api/datatype.rst
+++ b/docs/source/cpp/api/datatype.rst
@@ -33,7 +33,6 @@ These functions are recommended for creating data types.  They may return
 new objects or existing singletons, depending on the type requested.
 
 .. doxygengroup:: type-factories
-   :project: arrow_cpp
    :content-only:
 
 Concrete type subclasses
@@ -92,7 +91,6 @@ Fields and Schemas
 ==================
 
 .. doxygengroup:: schema-factories
-   :project: arrow_cpp
    :content-only:
 
 .. doxygenclass:: arrow::Field
@@ -102,4 +100,12 @@ Fields and Schemas
    :members:
 
 .. doxygenclass:: arrow::KeyValueMetadata
+
+Helpers for looking up fields
+-----------------------------
+
+.. doxygenclass:: arrow::FieldPath
+   :members:
+
+.. doxygenclass:: arrow::FieldRef
    :members:

--- a/docs/source/cpp/api/filesystem.rst
+++ b/docs/source/cpp/api/filesystem.rst
@@ -42,8 +42,14 @@ High-level factory function
 Concrete implementations
 ========================
 
+"Subtree" filesystem wrapper
+----------------------------
+
 .. doxygenclass:: arrow::fs::SubTreeFileSystem
    :members:
+
+Local filesystem
+----------------
 
 .. doxygenstruct:: arrow::fs::LocalFileSystemOptions
    :members:
@@ -51,14 +57,29 @@ Concrete implementations
 .. doxygenclass:: arrow::fs::LocalFileSystem
    :members:
 
+S3 filesystem
+-------------
+
 .. doxygenstruct:: arrow::fs::S3Options
    :members:
 
 .. doxygenclass:: arrow::fs::S3FileSystem
    :members:
 
+Hadoop filesystem
+-----------------
+
 .. doxygenstruct:: arrow::fs::HdfsOptions
    :members:
 
 .. doxygenclass:: arrow::fs::HadoopFileSystem
+   :members:
+
+Google Cloud Storage filesystem
+-------------------------------
+
+.. doxygenstruct:: arrow::fs::GcsOptions
+   :members:
+
+.. doxygenclass:: arrow::fs::GcsFileSystem
    :members:

--- a/docs/source/cpp/api/formats.rst
+++ b/docs/source/cpp/api/formats.rst
@@ -21,8 +21,8 @@ File Formats
 
 .. _cpp-api-csv:
 
-CSV
-===
+CSV reader
+==========
 
 .. doxygenstruct:: arrow::csv::ConvertOptions
    :members:
@@ -33,19 +33,23 @@ CSV
 .. doxygenstruct:: arrow::csv::ReadOptions
    :members:
 
-.. doxygenstruct:: arrow::csv::WriteOptions
-   :members:
-
 .. doxygenclass:: arrow::csv::TableReader
    :members:
 
-.. doxygenfunction:: arrow::csv::MakeCSVWriter(io::OutputStream *, const std::shared_ptr<Schema>&, const WriteOptions&)
+.. doxygenclass:: arrow::csv::StreamingReader
+   :members:
 
-.. doxygenfunction:: arrow::csv::MakeCSVWriter(std::shared_ptr<io::OutputStream>, const std::shared_ptr<Schema>&, const WriteOptions&)
+CSV writer
+==========
 
-.. doxygenfunction:: arrow::csv::WriteCSV(const RecordBatch&, const WriteOptions&, arrow::io::OutputStream *)
+.. doxygenstruct:: arrow::csv::WriteOptions
+   :members:
 
-.. doxygenfunction:: arrow::csv::WriteCSV(const Table&, const WriteOptions&, arrow::io::OutputStream *)
+.. doxygengroup:: csv-write-functions
+   :content-only:
+
+.. doxygengroup:: csv-writer-factories
+   :content-only:
 
 .. _cpp-api-json:
 

--- a/docs/source/cpp/api/io.rst
+++ b/docs/source/cpp/api/io.rst
@@ -93,3 +93,9 @@ Compressed input / output wrappers
 
 .. doxygenclass:: arrow::io::CompressedOutputStream
    :members:
+
+Transforming input wrapper
+--------------------------
+
+.. doxygenclass:: arrow::io::TransformInputStream
+   :members:

--- a/docs/source/cpp/api/memory.rst
+++ b/docs/source/cpp/api/memory.rst
@@ -47,43 +47,35 @@ Buffers
 -------
 
 .. doxygenclass:: arrow::Buffer
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::MutableBuffer
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::ResizableBuffer
-   :project: arrow_cpp
    :members:
 
 Memory Pools
 ------------
 
 .. doxygenfunction:: arrow::default_memory_pool
-   :project: arrow_cpp
 
 .. doxygenfunction:: arrow::jemalloc_memory_pool
-   :project: arrow_cpp
 
 .. doxygenfunction:: arrow::mimalloc_memory_pool
-   :project: arrow_cpp
 
 .. doxygenfunction:: arrow::system_memory_pool
-   :project: arrow_cpp
 
 .. doxygenclass:: arrow::MemoryPool
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::LoggingMemoryPool
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::ProxyMemoryPool
-   :project: arrow_cpp
    :members:
+
+.. doxygenfunction:: arrow::SupportedMemoryBackendNames
 
 Allocation Functions
 --------------------
@@ -91,34 +83,28 @@ Allocation Functions
 These functions allocate a buffer from a particular memory pool.
 
 .. doxygengroup:: buffer-allocation-functions
-   :project: arrow_cpp
    :content-only:
 
 Slicing
 -------
 
 .. doxygengroup:: buffer-slicing-functions
-   :project: arrow_cpp
    :content-only:
 
 Buffer Builders
 ---------------
 
 .. doxygenclass:: arrow::BufferBuilder
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::TypedBufferBuilder
-   :project: arrow_cpp
    :members:
 
 STL Integration
 ---------------
 
 .. doxygenclass:: arrow::stl::allocator
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::stl::STLMemoryPool
-   :project: arrow_cpp
    :members:

--- a/docs/source/cpp/api/support.rst
+++ b/docs/source/cpp/api/support.rst
@@ -15,38 +15,81 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
+.. default-domain:: cpp
+.. highlight:: cpp
+
 ===================
 Programming Support
 ===================
 
 General information
--------------------
+===================
 
 .. doxygenfunction:: arrow::GetBuildInfo
-   :project: arrow_cpp
 
 .. doxygenstruct:: arrow::BuildInfo
-   :project: arrow_cpp
    :members:
 
+.. doxygenfunction:: arrow::GetRuntimeInfo
+
+.. doxygenstruct:: arrow::RuntimeInfo
+   :members:
+
+Macro definitions
+-----------------
+
+These can be useful if you need to decide between different blocks of code
+*at compile time* (for example to conditionally take advantage of a recently
+introduced API).
+
+.. c:macro:: ARROW_VERSION_MAJOR
+
+   The Arrow major version number, for example ``7`` for Arrow 7.0.1.
+
+.. c:macro:: ARROW_VERSION_MINOR
+
+   The Arrow minor version number, for example ``0`` for Arrow 7.0.1.
+
+.. c:macro:: ARROW_VERSION_PATCH
+
+   The Arrow patch version number, for example ``1`` for Arrow 7.0.1.
+
+.. c:macro:: ARROW_VERSION
+
+   A consolidated integer representing the full Arrow version in an easily
+   comparable form, computed with the formula:
+   ``((ARROW_VERSION_MAJOR * 1000) + ARROW_VERSION_MINOR) * 1000 + ARROW_VERSION_PATCH``.
+
+   For example, this would choose a different block of code if the code is
+   being compiled against a Arrow version equal to or greater than 7.0.1::
+
+      #if ARROW_VERSION >= 7000001
+      // Arrow 7.0.1 or later...
+      #endif
+
+.. c:macro:: ARROW_VERSION_STRING
+
+   A human-readable string representation of the Arrow version, such as
+   ``"7.0.1"``.
+
+
 Error return and reporting
---------------------------
+==========================
 
 .. doxygenclass:: arrow::Status
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::StatusDetail
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: arrow::Result
-   :project: arrow_cpp
    :members:
 
 .. doxygenclass:: parquet::ParquetException
-   :project: arrow_cpp
    :members:
+
+Functional macros for error-based control flow
+----------------------------------------------
 
 .. doxygendefine:: ARROW_RETURN_NOT_OK
 


### PR DESCRIPTION
Add some classes or functions that were missing.

Some parts of the public API, such as pretty-printing, are still uncovered and should be handled in individual JIRAs.