### PR TITLE
PARQUET-2115: [C++] Parquet dictionary bit widths are limited to 32 bits

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1486,8 +1486,9 @@ class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
       return;
     }
     uint8_t bit_width = *data;
-    if (ARROW_PREDICT_FALSE(bit_width >= 64)) {
-      throw ParquetException("Invalid or corrupted bit_width");
+    if (ARROW_PREDICT_FALSE(bit_width > 32)) {
+      throw ParquetException("Invalid or corrupted bit_width " +
+                             std::to_string(bit_width) + ". Maximum allowed is 32.");
     }
     idx_decoder_ = ::arrow::util::RleDecoder(++data, --len, bit_width);
   }


### PR DESCRIPTION
Specification says that maximum bit width is 32bits:
https://github.com/apache/parquet-format/blob/master/Encodings.md#dictionary-encoding-plain_dictionary--2-and-rle_dictionary--8

Fuzzer created a file with a bit width of 35bits, which causes CHECK to
fail during RLE decode.