### PR TITLE
ARROW-15461: [C++] Avoid clang bug in ReverseBitmap

### DIFF
--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -98,7 +98,7 @@ uint8_t ReverseUint8(uint8_t num) {
 // part of a left block and right block, length indicates the number of bits
 // to be taken from the right block
 uint8_t GetReversedBlock(uint8_t block_left, uint8_t block_right, uint8_t length) {
-  return ReverseUint8(block_left >> (length) | block_right << (8 - length));
+  return ReverseUint8(((block_right << 8) + block_left) >> length);
 }
 
 template <TransferMode mode>


### PR DESCRIPTION
Clang 12 would generate buggy code for the `GetReversedBlock` utility function.
(see report in https://github.com/llvm/llvm-project/issues/53421)

Rewrite it in a more optimized way, also circumventing the code generation bug.