### PR TITLE
ARROW-15493: [C++][Gandiva] Init ExpressionCacheKey.mode_

### DIFF
--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -52,7 +52,10 @@ class ExpressionCacheKey {
 
   ExpressionCacheKey(SchemaPtr schema, std::shared_ptr<Configuration> configuration,
                      Expression& expression)
-      : schema_(schema), uniqifier_(0), configuration_(configuration) {
+      : schema_(schema),
+        mode_(SelectionVector::MODE_NONE),
+        uniqifier_(0),
+        configuration_(configuration) {
     static const int kSeedValue = 4;
     size_t result = kSeedValue;
     expressions_as_strings_.push_back(expression.ToString());


### PR DESCRIPTION
Class member mode_ is not initialized in one of ExpressionCacheKey
constructors, but it is used to compare equality of two instances.
It causes flaky gandiva-filter-test failures.