### PR TITLE
ARROW-15483: [Release] Exercise source verification builds on a nightly basis

### DIFF
--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -27,15 +27,25 @@ if not exist "C:\tmp\arrow-verify-release" mkdir C:\tmp\arrow-verify-release
 set _VERIFICATION_DIR=C:\tmp\arrow-verify-release
 set _VERIFICATION_DIR_UNIX=C:/tmp/arrow-verify-release
 set _VERIFICATION_CONDA_ENV=%_VERIFICATION_DIR%\conda-env
-set _DIST_URL=https://dist.apache.org/repos/dist/dev/arrow
-set _TARBALL=apache-arrow-%1.tar.gz
 set ARROW_SOURCE=%_VERIFICATION_DIR%\apache-arrow-%1
 set INSTALL_DIR=%_VERIFICATION_DIR%\install
 
-@rem Requires GNU Wget for Windows
-wget --no-check-certificate -O %_TARBALL% %_DIST_URL%/apache-arrow-%1-rc%2/%_TARBALL% || exit /B 1
+set VERSION=%1
+set RC_NUMBER=%2
 
-tar xf %_TARBALL% -C %_VERIFICATION_DIR_UNIX%
+if "%RC_NUMBER%"=="" (
+    @rem verify a specific git revision
+    if "%SOURCE_REPOSITORY%"=="" set SOURCE_REPOSITORY="https://github.com/apache/arrow.git"
+    git clone --recurse-submodules %SOURCE_REPOSITORY% %ARROW_SOURCE%
+    git -C %ARROW_SOURCE% checkout %VERSION%
+) else (
+    @rem verify a release candidate tarball
+    @rem Requires GNU Wget for Windows
+    set TARBALL_NAME=apache-arrow-%VERSION%.tar.gz
+    set TARBALL_URL=https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-%VERSION%-rc%RC_NUMBER%/%TARBALL_NAME%
+    wget --no-check-certificate -O %TARBALL_NAME% %TARBALL_URL% || exit /B 1
+    tar xf %TARBALL_NAME% -C %_VERIFICATION_DIR_UNIX%
+)
 
 set PYTHON=3.8
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -377,9 +377,14 @@ test_csharp() {
   fi
 
   dotnet test
-  mv dummy.git ../.git
-  dotnet pack -c Release
-  mv ../.git dummy.git
+
+  if [ "${SOURCE_KIND}" = "git" ]; then
+    dotnet pack -c Release
+  else
+    mv dummy.git ../.git
+    dotnet pack -c Release
+    mv ../.git dummy.git
+  fi
 
   if ! which sourcelink > /dev/null 2>&1; then
     dotnet tool install --tool-path ${csharp_bin} sourcelink

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -39,8 +39,6 @@ jobs:
         run: |
           archery docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
-            -e VERIFY_VERSION="{{ release|default("") }}" \
-            -e VERIFY_RC="{{ rc|default("") }}" \
             {{ flags|default("") }} \
             {{ image }} \
             {{ command|default("") }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -876,7 +876,7 @@ tasks:
 
   verify-rc-source-{{ target }}-linux-{{ distribution }}-{{ version }}-amd64:
     ci: github
-    template: docker-tests/github.linux.amd64.docker.yml
+    template: verify-rc/github.linux.amd64.docker.yml
     params:
       target: {{ target }}
       distro: {{ distribution }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -876,12 +876,10 @@ tasks:
 
   verify-rc-source-{{ target }}-linux-{{ distribution }}-{{ version }}-amd64:
     ci: github
-    template: docker-tests/github.linux.yml
+    template: docker-tests/github.linux.amd64.docker.yml
     params:
-      flags: >-
-        -e TEST_DEFAULT=0
-        -e TEST_{{ target|upper }}=1
-      image: {{ distribution }}-verify-rc-source
+      target: {{ target }}
+      distro: {{ distribution }}
   {% endfor %}
 {% endfor %}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -131,6 +131,7 @@ groups:
 {######################## Tasks to run regularly #############################}
 
   nightly:
+    - verify-rc-source-*
     - almalinux-*
     - amazon-linux-*
     - debian-*

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -35,5 +35,5 @@ jobs:
             -e VERIFY_VERSION="{{ release|default(arrow.head) }}" \
             -e VERIFY_RC="{{ rc|default("") }}" \
             -e TEST_DEFAULT=0 \
-            -e TEST_{{ target|upper }}=1
+            -e TEST_{{ target|upper }}=1 \
             {{ distro }}-verify-rc-source

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -20,31 +20,21 @@
 {{ macros.github_header() }}
 
 jobs:
-  verify:
-    name: "Verify release candidate macOS {{ artifact }}"
-    runs-on: {{ github_runner }}
-    {% if env is defined %}
-    env:
-    {% for key, value in env.items() %}
-      {{ key }}: {{ value }}
-    {% endfor %}
-    {% endif %}
-
+  test:
+    name: |
+      Docker Test {{ flags|default("") }} {{ image }} {{ command|default("") }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Cleanup
-        shell: bash
-        run: rm -rf arrow
+      {{ macros.github_checkout_arrow(fetch_depth=fetch_depth if fetch_depth is defined else 1)|indent }}
+      {{ macros.github_install_archery()|indent }}
 
-      {{ macros.github_checkout_arrow()|indent }}
-
-      - name: Run verification
+      - name: Execute Docker Build
         shell: bash
-        env:
-          SOURCE_REPOSITORY: {{ arrow.repo }}
         run: |
-          export PATH="$(brew --prefix node@16)/bin:$PATH"
-          export PATH="$(brew --prefix ruby)/bin:$PATH"
-          export PKG_CONFIG_PATH="$(brew --prefix ruby)/lib/pkgconfig"
-          arch -{{ arch_emulation|default("arm64") }} arrow/dev/release/verify-release-candidate.sh \
-            {{ artifact }} \
-            {{ release|arrow.head }} {{ rc|default("") }}
+          archery docker run \
+            -e SOURCE_REPOSITORY="{{ arrow.repo }}" \
+            -e VERIFY_VERSION="{{ release|arrow.head }}" \
+            -e VERIFY_RC="{{ rc|default("") }}" \
+            -e TEST_DEFAULT=0 \
+            -e TEST_{{ target|upper }}=1
+            {{ distro }}-verify-rc-source

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -21,8 +21,7 @@
 
 jobs:
   test:
-    name: |
-      Docker Test {{ flags|default("") }} {{ image }} {{ command|default("") }}
+    name: "Verify release candidate {{ distro }} source"
     runs-on: ubuntu-latest
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth if fetch_depth is defined else 1)|indent }}
@@ -32,8 +31,8 @@ jobs:
         shell: bash
         run: |
           archery docker run \
-            -e SOURCE_REPOSITORY="{{ arrow.repo }}" \
-            -e VERIFY_VERSION="{{ release|arrow.head }}" \
+            -e SOURCE_REPOSITORY="{{ arrow.remote }}" \
+            -e VERIFY_VERSION="{{ release|default(arrow.head) }}" \
             -e VERIFY_RC="{{ rc|default("") }}" \
             -e TEST_DEFAULT=0 \
             -e TEST_{{ target|upper }}=1

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -71,7 +71,9 @@ jobs:
           node-version: '16'
       - name: Run verification
         shell: bash
+        env:
+          SOURCE_REPOSITORY: {{ arrow.repo }}
         run: |
           arrow/dev/release/verify-release-candidate.sh \
             {{ artifact }} \
-            {{ release|default("1.0.0") }} {{ rc|default("0") }}
+            {{ release|arrow.head }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Run verification
         shell: bash
         env:
-          SOURCE_REPOSITORY: {{ arrow.repo }}
+          SOURCE_REPOSITORY: {{ arrow.remote }}
         run: |
           arrow/dev/release/verify-release-candidate.sh \
             {{ artifact }} \
-            {{ release|arrow.head }} {{ rc|default("") }}
+            {{ release|default(arrow.head) }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Run verification
         shell: bash
         env:
-          SOURCE_REPOSITORY: {{ arrow.repo }}
+          SOURCE_REPOSITORY: {{ arrow.remote }}
         run: |
           arrow/dev/release/verify-release-candidate.sh \
             {{ artifact }} \
-            {{ release|arrow.head }} {{ rc|default("") }}
+            {{ release|default(arrow.head) }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -44,7 +44,9 @@ jobs:
           node-version: '16'
       - name: Run verification
         shell: bash
+        env:
+          SOURCE_REPOSITORY: {{ arrow.repo }}
         run: |
           arrow/dev/release/verify-release-candidate.sh \
             {{ artifact }} \
-            {{ release|default("1.0.0") }} {{ rc|default("0") }}
+            {{ release|arrow.head }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.macos.arm64.yml
+++ b/dev/tasks/verify-rc/github.macos.arm64.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Run verification
         shell: bash
         env:
-          SOURCE_REPOSITORY: {{ arrow.repo }}
+          SOURCE_REPOSITORY: {{ arrow.remote }}
         run: |
           export PATH="$(brew --prefix node@16)/bin:$PATH"
           export PATH="$(brew --prefix ruby)/bin:$PATH"
           export PKG_CONFIG_PATH="$(brew --prefix ruby)/lib/pkgconfig"
           arch -{{ arch_emulation|default("arm64") }} arrow/dev/release/verify-release-candidate.sh \
             {{ artifact }} \
-            {{ release|arrow.head }} {{ rc|default("") }}
+            {{ release|default(arrow.head) }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -40,6 +40,6 @@ jobs:
           choco install wget
       - name: Run verification
         shell: cmd
-        run: |
-          cd arrow
-          dev/release/{{ script }} {{ release|default("1.0.0") }} {{ rc|default("0") }}
+        env:
+          SOURCE_REPOSITORY: {{ arrow.repo }}
+        run: arrow/dev/release/{{ script }} {{ release|arrow.head }} {{ rc|default("") }}

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Run verification
         shell: cmd
         env:
-          SOURCE_REPOSITORY: {{ arrow.repo }}
-        run: arrow/dev/release/{{ script }} {{ release|arrow.head }} {{ rc|default("") }}
+          SOURCE_REPOSITORY: {{ arrow.remote }}
+        run: arrow/dev/release/{{ script }} {{ release|default(arrow.head) }} {{ rc|default("") }}


### PR DESCRIPTION
Support running the source verification scripts on specific git revisions rather than RC tarballs.

We can verify any git revision using:

```bash
dev/release/verify-release-candidate.sh source <git-revision>
```

While the previous arguments are supported to verify a release candidate tarball:

```bash
dev/release/verify-release-candidate.sh source <versio> <rc-number>
```

