### PR TITLE
ARROW-15425: [C++] Add delta dictionaries in file format to integration tests

### DIFF
--- a/cpp/src/arrow/ipc/stream_to_file.cc
+++ b/cpp/src/arrow/ipc/stream_to_file.cc
@@ -35,9 +35,11 @@ Status ConvertToFile() {
   io::StdinStream input;
   io::StdoutStream sink;
 
+  IpcWriteOptions write_options;
+  write_options.emit_dictionary_deltas = true;
   ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchStreamReader::Open(&input));
-  ARROW_ASSIGN_OR_RAISE(
-      auto writer, MakeFileWriter(&sink, reader->schema(), IpcWriteOptions::Defaults()));
+  ARROW_ASSIGN_OR_RAISE(auto writer,
+                        MakeFileWriter(&sink, reader->schema(), write_options));
   std::shared_ptr<RecordBatch> batch;
   while (true) {
     ARROW_ASSIGN_OR_RAISE(batch, reader->Next());


### PR DESCRIPTION
Changes the stream_to_file program to emit delta dictionaries.  This will allow the integration test to test files that contain delta dictionaries

See also: https://github.com/apache/arrow-testing/pull/74