### PR TITLE
ARROW-15506: [C++][Compute] Support Null type in hash_sum/hash_product/hash_mean

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1025,7 +1025,7 @@ struct GroupedSumNullImpl final : public GroupedNullImpl {
   std::shared_ptr<DataType> out_type() const override { return int64(); }
 
   void output_empty(const std::shared_ptr<Buffer>& data) override {
-    std::memset(data->mutable_data(), 0, num_groups_ * sizeof(int64_t));
+    std::fill_n(reinterpret_cast<int64_t*>(data->mutable_data()), num_groups_, 0);
   }
 };
 
@@ -1157,7 +1157,7 @@ struct GroupedMeanNullImpl final : public GroupedNullImpl {
   std::shared_ptr<DataType> out_type() const override { return float64(); }
 
   void output_empty(const std::shared_ptr<Buffer>& data) override {
-    std::memset(data->mutable_data(), 0, num_groups_ * sizeof(double));
+    std::fill_n(reinterpret_cast<double*>(data->mutable_data()), num_groups_, 0);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -914,7 +914,45 @@ struct GroupedReducingAggregator : public GroupedAggregator {
   MemoryPool* pool_;
 };
 
-template <template <typename> class Impl, const char* kFriendlyName>
+struct GroupedNullImpl : public GroupedAggregator {
+  Status Init(ExecContext* ctx, const std::vector<ValueDescr>&,
+              const FunctionOptions* options) override {
+    pool_ = ctx->memory_pool();
+    options_ = checked_cast<const ScalarAggregateOptions&>(*options);
+    return Status::OK();
+  }
+
+  Status Resize(int64_t new_num_groups) override {
+    num_groups_ = new_num_groups;
+    return Status::OK();
+  }
+
+  Status Consume(const ExecBatch& batch) override { return Status::OK(); }
+
+  Status Merge(GroupedAggregator&& raw_other,
+               const ArrayData& group_id_mapping) override {
+    return Status::OK();
+  }
+
+  Result<Datum> Finalize() override {
+    if (options_.skip_nulls && options_.min_count == 0) {
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> data,
+                            AllocateBuffer(num_groups_ * sizeof(int64_t), pool_));
+      output_empty(data);
+      return ArrayData::Make(out_type(), num_groups_, {nullptr, std::move(data)});
+    } else {
+      return MakeArrayOfNull(out_type(), num_groups_, pool_);
+    }
+  }
+
+  virtual void output_empty(const std::shared_ptr<Buffer>& data) = 0;
+
+  int64_t num_groups_;
+  ScalarAggregateOptions options_;
+  MemoryPool* pool_;
+};
+
+template <template <typename> class Impl, const char* kFriendlyName, class NullImpl>
 struct GroupedReducingFactory {
   template <typename T, typename AccType = typename FindAccumulatorType<T>::Type>
   Status Visit(const T&) {
@@ -927,9 +965,15 @@ struct GroupedReducingFactory {
         MakeKernel(std::move(argument_type), HashAggregateInit<Impl<Decimal128Type>>);
     return Status::OK();
   }
+
   Status Visit(const Decimal256Type&) {
     kernel =
         MakeKernel(std::move(argument_type), HashAggregateInit<Impl<Decimal256Type>>);
+    return Status::OK();
+  }
+
+  Status Visit(const NullType&) {
+    kernel = MakeKernel(std::move(argument_type), HashAggregateInit<NullImpl>);
     return Status::OK();
   }
 
@@ -942,7 +986,7 @@ struct GroupedReducingFactory {
   }
 
   static Result<HashAggregateKernel> Make(const std::shared_ptr<DataType>& type) {
-    GroupedReducingFactory<Impl, kFriendlyName> factory;
+    GroupedReducingFactory<Impl, kFriendlyName, NullImpl> factory;
     factory.argument_type = InputType::Array(type->id());
     RETURN_NOT_OK(VisitTypeInline(*type, &factory));
     return std::move(factory.kernel);
@@ -977,8 +1021,17 @@ struct GroupedSumImpl : public GroupedReducingAggregator<Type, GroupedSumImpl<Ty
   using Base::Finish;
 };
 
+struct GroupedSumNullImpl final : public GroupedNullImpl {
+  std::shared_ptr<DataType> out_type() const override { return int64(); }
+
+  void output_empty(const std::shared_ptr<Buffer>& data) override {
+    std::memset(data->mutable_data(), 0, num_groups_ * sizeof(int64_t));
+  }
+};
+
 static constexpr const char kSumName[] = "sum";
-using GroupedSumFactory = GroupedReducingFactory<GroupedSumImpl, kSumName>;
+using GroupedSumFactory =
+    GroupedReducingFactory<GroupedSumImpl, kSumName, GroupedSumNullImpl>;
 
 // ----------------------------------------------------------------------
 // Product implementation
@@ -1008,8 +1061,17 @@ struct GroupedProductImpl final
   using Base::Finish;
 };
 
+struct GroupedProductNullImpl final : public GroupedNullImpl {
+  std::shared_ptr<DataType> out_type() const override { return int64(); }
+
+  void output_empty(const std::shared_ptr<Buffer>& data) override {
+    std::fill_n(reinterpret_cast<int64_t*>(data->mutable_data()), num_groups_, 1);
+  }
+};
+
 static constexpr const char kProductName[] = "product";
-using GroupedProductFactory = GroupedReducingFactory<GroupedProductImpl, kProductName>;
+using GroupedProductFactory =
+    GroupedReducingFactory<GroupedProductImpl, kProductName, GroupedProductNullImpl>;
 
 // ----------------------------------------------------------------------
 // Mean implementation
@@ -1091,8 +1153,17 @@ struct GroupedMeanImpl : public GroupedReducingAggregator<Type, GroupedMeanImpl<
   }
 };
 
+struct GroupedMeanNullImpl final : public GroupedNullImpl {
+  std::shared_ptr<DataType> out_type() const override { return float64(); }
+
+  void output_empty(const std::shared_ptr<Buffer>& data) override {
+    std::memset(data->mutable_data(), 0, num_groups_ * sizeof(double));
+  }
+};
+
 static constexpr const char kMeanName[] = "mean";
-using GroupedMeanFactory = GroupedReducingFactory<GroupedMeanImpl, kMeanName>;
+using GroupedMeanFactory =
+    GroupedReducingFactory<GroupedMeanImpl, kMeanName, GroupedMeanNullImpl>;
 
 // Variance/Stdev implementation
 
@@ -2768,6 +2839,7 @@ void RegisterHashAggregateBasic(FunctionRegistry* registry) {
     // Type parameters are ignored
     DCHECK_OK(AddHashAggKernels({decimal128(1, 1), decimal256(1, 1)},
                                 GroupedSumFactory::Make, func.get()));
+    DCHECK_OK(AddHashAggKernels({null()}, GroupedSumFactory::Make, func.get()));
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 
@@ -2785,6 +2857,7 @@ void RegisterHashAggregateBasic(FunctionRegistry* registry) {
     // Type parameters are ignored
     DCHECK_OK(AddHashAggKernels({decimal128(1, 1), decimal256(1, 1)},
                                 GroupedProductFactory::Make, func.get()));
+    DCHECK_OK(AddHashAggKernels({null()}, GroupedProductFactory::Make, func.get()));
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 
@@ -2800,6 +2873,7 @@ void RegisterHashAggregateBasic(FunctionRegistry* registry) {
     // Type parameters are ignored
     DCHECK_OK(AddHashAggKernels({decimal128(1, 1), decimal256(1, 1)},
                                 GroupedMeanFactory::Make, func.get()));
+    DCHECK_OK(AddHashAggKernels({null()}, GroupedMeanFactory::Make, func.get()));
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -3070,5 +3070,234 @@ TEST(GroupBy, MultipleKeysIncludesNullType) {
     }
   }
 }
+
+TEST(GroupBy, SumNullType) {
+  auto table =
+      TableFromJSON(schema({field("argument", null()), field("key", int64())}), {R"([
+    [null,  1],
+    [null,  1]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, 3],
+    [null, null],
+    [null, 1],
+    [null, 2]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, null],
+    [null, 3]
+                        ])"});
+
+  ScalarAggregateOptions no_min(/*skip_nulls=*/true, /*min_count=*/0);
+  ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
+  ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false, /*min_count=*/0);
+  ScalarAggregateOptions keep_nulls_min_count(/*skip_nulls=*/false, /*min_count=*/3);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_sum", &no_min},
+                                   {"hash_sum", &keep_nulls},
+                                   {"hash_sum", &min_count},
+                                   {"hash_sum", &keep_nulls_min_count},
+                               },
+                               use_threads, use_exec_plan));
+      SortBy({"key_0"}, &aggregated_and_grouped);
+
+      AssertDatumsEqual(ArrayFromJSON(struct_({
+                                          field("hash_sum", int64()),
+                                          field("hash_sum", int64()),
+                                          field("hash_sum", int64()),
+                                          field("hash_sum", int64()),
+                                          field("key_0", int64()),
+                                      }),
+                                      R"([
+    [0, null, null, null, 1],
+    [0, null, null, null, 2],
+    [0, null, null, null, 3],
+    [0, null, null, null, null]
+  ])"),
+                        aggregated_and_grouped,
+                        /*verbose=*/true);
+    }
+  }
+}
+
+TEST(GroupBy, ProductNullType) {
+  auto table =
+      TableFromJSON(schema({field("argument", null()), field("key", int64())}), {R"([
+    [null,  1],
+    [null,  1]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, 3],
+    [null, null],
+    [null, 1],
+    [null, 2]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, null],
+    [null, 3]
+                        ])"});
+
+  ScalarAggregateOptions no_min(/*skip_nulls=*/true, /*min_count=*/0);
+  ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
+  ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false, /*min_count=*/0);
+  ScalarAggregateOptions keep_nulls_min_count(/*skip_nulls=*/false, /*min_count=*/3);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_product", &no_min},
+                                   {"hash_product", &keep_nulls},
+                                   {"hash_product", &min_count},
+                                   {"hash_product", &keep_nulls_min_count},
+                               },
+                               use_threads, use_exec_plan));
+      SortBy({"key_0"}, &aggregated_and_grouped);
+
+      AssertDatumsEqual(ArrayFromJSON(struct_({
+                                          field("hash_product", int64()),
+                                          field("hash_product", int64()),
+                                          field("hash_product", int64()),
+                                          field("hash_product", int64()),
+                                          field("key_0", int64()),
+                                      }),
+                                      R"([
+    [1, null, null, null, 1],
+    [1, null, null, null, 2],
+    [1, null, null, null, 3],
+    [1, null, null, null, null]
+  ])"),
+                        aggregated_and_grouped,
+                        /*verbose=*/true);
+    }
+  }
+}
+
+TEST(GroupBy, MeanNullType) {
+  auto table =
+      TableFromJSON(schema({field("argument", null()), field("key", int64())}), {R"([
+    [null,  1],
+    [null,  1]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, 3],
+    [null, null],
+    [null, 1],
+    [null, 2]
+                        ])",
+                                                                                 R"([
+    [null, 2],
+    [null, null],
+    [null, 3]
+                        ])"});
+
+  ScalarAggregateOptions no_min(/*skip_nulls=*/true, /*min_count=*/0);
+  ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
+  ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false, /*min_count=*/0);
+  ScalarAggregateOptions keep_nulls_min_count(/*skip_nulls=*/false, /*min_count=*/3);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_mean", &no_min},
+                                   {"hash_mean", &keep_nulls},
+                                   {"hash_mean", &min_count},
+                                   {"hash_mean", &keep_nulls_min_count},
+                               },
+                               use_threads, use_exec_plan));
+      SortBy({"key_0"}, &aggregated_and_grouped);
+
+      AssertDatumsEqual(ArrayFromJSON(struct_({
+                                          field("hash_mean", float64()),
+                                          field("hash_mean", float64()),
+                                          field("hash_mean", float64()),
+                                          field("hash_mean", float64()),
+                                          field("key_0", int64()),
+                                      }),
+                                      R"([
+    [0, null, null, null, 1],
+    [0, null, null, null, 2],
+    [0, null, null, null, 3],
+    [0, null, null, null, null]
+  ])"),
+                        aggregated_and_grouped,
+                        /*verbose=*/true);
+    }
+  }
+}
+
+TEST(GroupBy, NullTypeEmptyTable) {
+  auto table = TableFromJSON(schema({field("argument", null()), field("key", int64())}),
+                             {R"([])"});
+
+  ScalarAggregateOptions no_min(/*skip_nulls=*/true, /*min_count=*/0);
+  ScalarAggregateOptions min_count(/*skip_nulls=*/true, /*min_count=*/3);
+  ScalarAggregateOptions keep_nulls(/*skip_nulls=*/false, /*min_count=*/0);
+  ScalarAggregateOptions keep_nulls_min_count(/*skip_nulls=*/false, /*min_count=*/3);
+
+  for (bool use_exec_plan : {false, true}) {
+    for (bool use_threads : {true, false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                           GroupByTest(
+                               {
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                                   table->GetColumnByName("argument"),
+                               },
+                               {table->GetColumnByName("key")},
+                               {
+                                   {"hash_sum", &no_min},
+                                   {"hash_product", &min_count},
+                                   {"hash_mean", &keep_nulls},
+                               },
+                               use_threads, use_exec_plan));
+      auto struct_arr = aggregated_and_grouped.array_as<StructArray>();
+      AssertDatumsEqual(ArrayFromJSON(int64(), "[]"), struct_arr->field(0),
+                        /*verbose=*/true);
+      AssertDatumsEqual(ArrayFromJSON(int64(), "[]"), struct_arr->field(1),
+                        /*verbose=*/true);
+      AssertDatumsEqual(ArrayFromJSON(float64(), "[]"), struct_arr->field(2),
+                        /*verbose=*/true);
+    }
+  }
+}
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
- If min_count == 0 and skip_nulls == true `hash_sum` returns an int64 scalar of 0, otherwise return a int64 scalar of null
- If min_count == 0 and skip_nulls == true `hash_product` returns an int64 scalar of 1, otherwise return a int64 scalar of null
- If min_count == 0 and skip_nulls == true `hash_mean` returns an float64 scalar of 0, otherwise return a float64 scalar of null