### PR TITLE
ARROW-15253: [Python] Error in to_pandas for empty dataframe with index with extension type

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -822,10 +822,10 @@ def _get_extension_dtypes(table, columns_metadata, types_mapper=None):
 
     # infer the extension columns from the pandas metadata
     for col_meta in columns_metadata:
-        if col_meta['name']:
-            name = col_meta['name']
-        else:
+        try:
             name = col_meta['field_name']
+        except KeyError:
+            name = col_meta['name']
         dtype = col_meta['numpy_type']
 
         if dtype not in _pandas_supported_numpy_types:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -822,8 +822,12 @@ def _get_extension_dtypes(table, columns_metadata, types_mapper=None):
 
     # infer the extension columns from the pandas metadata
     for col_meta in columns_metadata:
-        name = col_meta['name']
+        if col_meta['name']:
+            name = col_meta['name']
+        else:
+            name = col_meta['field_name']
         dtype = col_meta['numpy_type']
+
         if dtype not in _pandas_supported_numpy_types:
             # pandas_dtype is expensive, so avoid doing this for types
             # that are certainly numpy dtypes

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4082,7 +4082,7 @@ def test_array_to_pandas():
         # tm.assert_series_equal(result, expected)
 
 
-def test_roundtrip_empty_table_with_intervalrange_index():
+def test_roundtrip_empty_table_with_extension_dtype_index():
     if Version(pd.__version__) < Version("1.0.0"):
         pytest.skip("ExtensionDtype to_pandas method missing")
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4082,6 +4082,18 @@ def test_array_to_pandas():
         # tm.assert_series_equal(result, expected)
 
 
+def test_roundtrip_empty_table_with_intervalrange_index():
+    if Version(pd.__version__) < Version("1.0.0"):
+        pytest.skip("ExtensionDtype to_pandas method missing")
+
+    df = pd.DataFrame(index=pd.interval_range(start=0, end=3))
+    table = pa.table(df)
+    table.to_pandas().index == pd.Index([{'left': 0, 'right': 1},
+                                         {'left': 1, 'right': 2},
+                                         {'left': 2, 'right': 3}],
+                                        dtype='object')
+
+
 # ----------------------------------------------------------------------
 # Legacy metadata compatibility tests
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1072,6 +1072,18 @@ def test_empty_table():
     assert table.equals(pa.Table.from_arrays([], []))
 
 
+@pytest.mark.pandas
+def test_roundtrip_empty_table_with_intervalrange_index():
+    import pandas as pd
+
+    df = pd.DataFrame(index=pd.interval_range(start=0, end=3))
+    table = pa.table(df)
+    table.to_pandas().index == pd.Index([{'left': 0, 'right': 1},
+                                         {'left': 1, 'right': 2},
+                                         {'left': 2, 'right': 3}],
+                                        dtype='object')
+
+
 def test_table_rename_columns():
     data = [
         pa.array(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1072,18 +1072,6 @@ def test_empty_table():
     assert table.equals(pa.Table.from_arrays([], []))
 
 
-@pytest.mark.pandas
-def test_roundtrip_empty_table_with_intervalrange_index():
-    import pandas as pd
-
-    df = pd.DataFrame(index=pd.interval_range(start=0, end=3))
-    table = pa.table(df)
-    table.to_pandas().index == pd.Index([{'left': 0, 'right': 1},
-                                         {'left': 1, 'right': 2},
-                                         {'left': 2, 'right': 3}],
-                                        dtype='object')
-
-
 def test_table_rename_columns():
     data = [
         pa.array(range(5)),


### PR DESCRIPTION
This PR adds a check for the name of the column in `_get_extension_dtypes()` from `pandas_compat.py` to fix an error when using `pd.iterval_range` index with empty dataframe in Pandas roundtrip.