### PR TITLE
ARROW-15504: [Python][CI] Ensure that optional components are tested

### DIFF
--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -30,4 +30,23 @@ export ARROW_GDB_SCRIPT=${arrow_dir}/cpp/gdb_arrow.py
 # Enable some checks inside Python itself
 export PYTHONDEVMODE=1
 
-pytest -r s -v ${PYTEST_ARGS} --pyargs pyarrow
+# By default, force-test all optional components
+: ${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}
+: ${PYARROW_TEST_DATASET:=${ARROW_DATASET:-ON}}
+: ${PYARROW_TEST_FLIGHT:=${ARROW_FLIGHT:-ON}}
+: ${PYARROW_TEST_GANDIVA:=${ARROW_GANDIVA:-ON}}
+: ${PYARROW_TEST_HDFS:=${ARROW_HDFS:-ON}}
+: ${PYARROW_TEST_ORC:=${ARROW_ORC:-ON}}
+: ${PYARROW_TEST_PARQUET:=${ARROW_PARQUET:-ON}}
+: ${PYARROW_TEST_S3:=${ARROW_S3:-ON}}
+
+export PYARROW_TEST_CUDA
+export PYARROW_TEST_DATASET
+export PYARROW_TEST_FLIGHT
+export PYARROW_TEST_GANDIVA
+export PYARROW_TEST_HDFS
+export PYARROW_TEST_ORC
+export PYARROW_TEST_PARQUET
+export PYARROW_TEST_S3
+
+pytest -r s -v ${PYTEST_ARGS} --pyargs pyarrow.tests.test_orc

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -177,7 +177,7 @@ def pytest_addoption(parser):
     # Create options to selectively enable test groups
     def bool_env(name, default=None):
         value = os.environ.get(name.upper())
-        if value is None:
+        if not value:  # missing or empty
             return default
         value = value.lower()
         if value in {'1', 'true', 'on', 'yes', 'y'}:


### PR DESCRIPTION
Tests for optional components could be silently skipped if by accident the component would fail importing despite being built.