### PR TITLE
ARROW-15297: [C++] The write node options shouldn't require a schema [WIP]

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -771,7 +771,7 @@ arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
   write_options.partitioning = partitioning;
   write_options.basename_template = "part{i}.parquet";
 
-  arrow::dataset::WriteNodeOptions write_node_options{write_options, dataset->schema()};
+  arrow::dataset::WriteNodeOptions write_node_options{write_options};
 
   ARROW_RETURN_NOT_OK(cp::MakeExecNode("write", plan.get(), {scan}, write_node_options));
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -359,9 +359,7 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
               {"filter", compute::FilterNodeOptions{scanner->options()->filter}},
               {"project",
                compute::ProjectNodeOptions{std::move(exprs), std::move(names)}},
-              {"write",
-               WriteNodeOptions{write_options, scanner->options()->projected_schema,
-                                backpressure_toggle}},
+              {"write", WriteNodeOptions{write_options, backpressure_toggle}},
           })
           .AddToPlan(plan.get()));
 
@@ -380,7 +378,8 @@ Result<compute::ExecNode*> MakeWriteNode(compute::ExecPlan* plan,
   const WriteNodeOptions write_node_options =
       checked_cast<const WriteNodeOptions&>(options);
   const FileSystemDatasetWriteOptions& write_options = write_node_options.write_options;
-  const std::shared_ptr<Schema>& schema = write_node_options.schema;
+  // write schema should be the output schema of the input to the write node.
+  const std::shared_ptr<Schema>& schema = inputs[0]->output_schema();
   const std::shared_ptr<util::AsyncToggle>& backpressure_toggle =
       write_node_options.backpressure_toggle;
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -408,14 +408,12 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
 class ARROW_DS_EXPORT WriteNodeOptions : public compute::ExecNodeOptions {
  public:
   explicit WriteNodeOptions(
-      FileSystemDatasetWriteOptions options, std::shared_ptr<Schema> schema,
+      FileSystemDatasetWriteOptions options,
       std::shared_ptr<util::AsyncToggle> backpressure_toggle = NULLPTR)
       : write_options(std::move(options)),
-        schema(std::move(schema)),
         backpressure_toggle(std::move(backpressure_toggle)) {}
 
   FileSystemDatasetWriteOptions write_options;
-  std::shared_ptr<Schema> schema;
   std::shared_ptr<util::AsyncToggle> backpressure_toggle;
 };
 


### PR DESCRIPTION
The Execution node for write operation doesn't require the schema, the schema can be obtained from the
input node. The required modification is done. 

## TODO

- [ ] Verify the output readability 