### PR TITLE
ARROW-10643: [Python] Pandas<->pyarrow roundtrip failing to recreate index for empty dataframe

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -800,6 +800,12 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
             const vector[shared_ptr[CChunkedArray]]& columns)
 
         @staticmethod
+        shared_ptr[CTable] MakeWithRows "Make"(
+            const shared_ptr[CSchema]& schema,
+            const vector[shared_ptr[CChunkedArray]]& columns,
+            int64_t num_rows)
+
+        @staticmethod
         shared_ptr[CTable] MakeFromArrays" Make"(
             const shared_ptr[CSchema]& schema,
             const vector[shared_ptr[CArray]]& arrays)

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -626,7 +626,7 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
     # If dataframe is empty but with RangeIndex ->
     # remember the length of the indexes
     n_rows = None
-    if len(arrays) == 0 and schema is not None:
+    if len(arrays) == 0:
         try:
             kind = index_descriptors[0]["kind"]
             if kind == "range":

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -623,7 +623,21 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
     metadata.update(pandas_metadata)
     schema = schema.with_metadata(metadata)
 
-    return arrays, schema
+    # If dataframe is empty but with RangeIndex ->
+    # remember the length of the indexes
+    n_rows = None
+    if len(arrays) == 0 and schema is not None:
+        try:
+            kind = index_descriptors[0]["kind"]
+            if kind == "range":
+                start = index_descriptors[0]["start"]
+                stop = index_descriptors[0]["stop"]
+                step = index_descriptors[0]["step"]
+                n_rows = (stop - start - 1)//step + 1
+        except IndexError:
+            pass
+
+    return arrays, schema, n_rows
 
 
 def get_datetimetz_type(values, dtype, type_):

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -633,7 +633,7 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
                 start = index_descriptors[0]["start"]
                 stop = index_descriptors[0]["stop"]
                 step = index_descriptors[0]["step"]
-                n_rows = (stop - start - 1)//step + 1
+                n_rows = len(range(start, stop, step))
         except IndexError:
             pass
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1185,7 +1185,7 @@ cdef class RecordBatch(_PandasConvertible):
             Array arr
             shared_ptr[CSchema] c_schema
             vector[shared_ptr[CArray]] c_arrays
-
+        # If df is empty but row index is not, create empty RecordBatch with rows >0
         if n_rows:
             names = None
             metadata = None
@@ -1808,7 +1808,7 @@ cdef class Table(_PandasConvertible):
         cdef:
             vector[shared_ptr[CChunkedArray]] arr
             shared_ptr[CSchema] c_schema
-
+        # If df is empty but row index is not, create empty Table with rows >0
         if n_rows:
             names = None
             metadata = None

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1182,8 +1182,7 @@ cdef class RecordBatch(_PandasConvertible):
         )
 
         # If df is empty but row index is not, create empty RecordBatch with rows >0
-        cdef:
-            vector[shared_ptr[CArray]] c_arrays
+        cdef vector[shared_ptr[CArray]] c_arrays
         if n_rows:
             return pyarrow_wrap_batch(CRecordBatch.Make((<Schema> schema).sp_schema,
                                                         n_rows, c_arrays))
@@ -1797,8 +1796,7 @@ cdef class Table(_PandasConvertible):
         )
 
         # If df is empty but row index is not, create empty Table with rows >0
-        cdef:
-            vector[shared_ptr[CChunkedArray]] c_arrays
+        cdef vector[shared_ptr[CChunkedArray]] c_arrays
         if n_rows:
             return pyarrow_wrap_table(
                 CTable.MakeWithRows((<Schema> schema).sp_schema, c_arrays, n_rows))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1834,7 +1834,7 @@ cdef class Table(_PandasConvertible):
 
         # In case of an empty dataframe with RangeIndex -> create an empty Table with
         # number of rows equal to Index length
-        if arrays == [] and schema is not None:
+        if len(arrays) == 0 and schema is not None:
             try:
                 kind = schema.pandas_metadata["index_columns"][0]["kind"]
                 if kind =="range":

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -356,6 +356,7 @@ def test_table_roundtrip_to_pandas_empty_dataframe():
     assert table.num_rows == 10
     assert data.shape == (10, 0)
     assert result.shape == (10, 0)
+    assert result.index.equals(data.index)
 
     data = pd.DataFrame(index=pd.RangeIndex(0, 10, 3))
     table = pa.table(data)
@@ -364,6 +365,7 @@ def test_table_roundtrip_to_pandas_empty_dataframe():
     assert table.num_rows == 4
     assert data.shape == (4, 0)
     assert result.shape == (4, 0)
+    assert result.index.equals(data.index)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -342,22 +342,28 @@ def test_chunked_array_to_pandas_preserve_name():
         tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail
 @pytest.mark.pandas
 def test_table_roundtrip_to_pandas_empty_dataframe():
     # https://issues.apache.org/jira/browse/ARROW-10643
+    # The conversion should not results in a table with 0 rows if the original
+    # DataFrame has a RangeIndex but is empty.
     import pandas as pd
 
     data = pd.DataFrame(index=pd.RangeIndex(0, 10, 1))
     table = pa.table(data)
     result = table.to_pandas()
 
-    # TODO the conversion results in a table with 0 rows if the original
-    # DataFrame has a RangeIndex (i.e. no index column in the converted
-    # Arrow table)
     assert table.num_rows == 10
     assert data.shape == (10, 0)
     assert result.shape == (10, 0)
+
+    data = pd.DataFrame(index=pd.RangeIndex(0, 10, 3))
+    table = pa.table(data)
+    result = table.to_pandas()
+
+    assert table.num_rows == 4
+    assert data.shape == (4, 0)
+    assert result.shape == (4, 0)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -369,6 +369,32 @@ def test_table_roundtrip_to_pandas_empty_dataframe():
 
 
 @pytest.mark.pandas
+def test_recordbatch_roundtrip_to_pandas_empty_dataframe():
+    # https://issues.apache.org/jira/browse/ARROW-10643
+    # The conversion should not results in a RecordBatch with 0 rows if
+    #  the original DataFrame has a RangeIndex but is empty.
+    import pandas as pd
+
+    data = pd.DataFrame(index=pd.RangeIndex(0, 10, 1))
+    batch = pa.RecordBatch.from_pandas(data)
+    result = batch.to_pandas()
+
+    assert batch.num_rows == 10
+    assert data.shape == (10, 0)
+    assert result.shape == (10, 0)
+    assert result.index.equals(data.index)
+
+    data = pd.DataFrame(index=pd.RangeIndex(0, 10, 3))
+    batch = pa.RecordBatch.from_pandas(data)
+    result = batch.to_pandas()
+
+    assert batch.num_rows == 4
+    assert data.shape == (4, 0)
+    assert result.shape == (4, 0)
+    assert result.index.equals(data.index)
+
+
+@pytest.mark.pandas
 def test_to_pandas_empty_table():
     # https://issues.apache.org/jira/browse/ARROW-15370
     import pandas as pd


### PR DESCRIPTION
This PR tries to correct the roundtrip of an empty `pandas.DataFrame` with `RangeIndex` (so no columns, but a non-zero shape for the rows) by adding a check for empty columns and a `pandas.RangeIndex` in the `from_arrays` method called from `from_pandas` and then creating an empty table with schema and `num_rows`.