### PR TITLE
ARROW-15477: [C++][Python] Allow to create (FixedSize/Large)ListArray from arrays and type

### DIFF
--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -129,6 +129,10 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
       const Array& offsets, const Array& values,
       MemoryPool* pool = default_memory_pool());
 
+  static Result<std::shared_ptr<ListArray>> FromArrays(
+      std::shared_ptr<DataType> type, const Array& offsets, const Array& values,
+      MemoryPool* pool = default_memory_pool());
+
   /// \brief Return an Array that is a concatenation of the lists in this array.
   ///
   /// Note that it's different from `values()` in that it takes into
@@ -172,6 +176,10 @@ class ARROW_EXPORT LargeListArray : public BaseListArray<LargeListType> {
   /// allocated because of null values
   static Result<std::shared_ptr<LargeListArray>> FromArrays(
       const Array& offsets, const Array& values,
+      MemoryPool* pool = default_memory_pool());
+
+  static Result<std::shared_ptr<LargeListArray>> FromArrays(
+      std::shared_ptr<DataType> type, const Array& offsets, const Array& values,
       MemoryPool* pool = default_memory_pool());
 
   /// \brief Return an Array that is a concatenation of the lists in this array.
@@ -310,6 +318,14 @@ class ARROW_EXPORT FixedSizeListArray : public Array {
   /// \return Will have length equal to values.length() / list_size
   static Result<std::shared_ptr<Array>> FromArrays(const std::shared_ptr<Array>& values,
                                                    int32_t list_size);
+
+  /// \brief Construct FixedSizeListArray from child value array and type
+  ///
+  /// \param[in] values Array containing list values
+  /// \param[in] type The fixed sized list type
+  /// \return Will have length equal to values.length() / type.list_size()
+  static Result<std::shared_ptr<Array>> FromArrays(const std::shared_ptr<Array>& values,
+                                                   std::shared_ptr<DataType> type);
 
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data);

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -334,7 +334,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CMemoryPool** out)
     cdef CStatus c_mimalloc_memory_pool" arrow::mimalloc_memory_pool"(
         CMemoryPool** out)
-    cdef vector[c_string] c_supported_memory_backends" arrow::SupportedMemoryBackendNames"()
+    cdef vector[c_string] c_supported_memory_backends \
+        " arrow::SupportedMemoryBackendNames"()
 
     CStatus c_jemalloc_set_decay_ms" arrow::jemalloc_set_decay_ms"(int ms)
 
@@ -591,6 +592,11 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CResult[shared_ptr[CArray]] FromArrays(
             const CArray& offsets, const CArray& values, CMemoryPool* pool)
 
+        @staticmethod
+        CResult[shared_ptr[CArray]] FromArraysAndType" FromArrays"(
+            shared_ptr[CDataType], const CArray& offsets, const CArray& values,
+            CMemoryPool* pool)
+
         const int32_t* raw_value_offsets()
         int32_t value_offset(int i)
         int32_t value_length(int i)
@@ -603,6 +609,11 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CResult[shared_ptr[CArray]] FromArrays(
             const CArray& offsets, const CArray& values, CMemoryPool* pool)
 
+        @staticmethod
+        CResult[shared_ptr[CArray]] FromArraysAndType" FromArrays"(
+            shared_ptr[CDataType], const CArray& offsets, const CArray& values,
+            CMemoryPool* pool)
+
         int64_t value_offset(int i)
         int64_t value_length(int i)
         shared_ptr[CArray] values()
@@ -613,6 +624,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         @staticmethod
         CResult[shared_ptr[CArray]] FromArrays(
             const shared_ptr[CArray]& values, int32_t list_size)
+
+        @staticmethod
+        CResult[shared_ptr[CArray]] FromArraysAndType" FromArrays"(
+            const shared_ptr[CArray]& values, shared_ptr[CDataType])
 
         int64_t value_offset(int i)
         int64_t value_length(int i)


### PR DESCRIPTION
This enables to create a ListArray in this way with a custom type (eg non-default field name). Mimics the interface we already have for `MapArray::FromArrays` as well.