### PR TITLE
ARROW-15520: [C++] Qualify `arrow_vendored::date::format()` for C++20 compatibility

### DIFF
--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -639,41 +639,42 @@ class MakeFormatterImpl {
       auto fmt = fmt_str.c_str();
       auto unit = checked_cast<const T&>(*array.type()).unit();
       auto value = checked_cast<const NumericArray<T>&>(array).Value(index);
+      namespace avd = arrow_vendored::date;
       using std::chrono::nanoseconds;
       using std::chrono::microseconds;
       using std::chrono::milliseconds;
       using std::chrono::seconds;
       if (AddEpoch) {
-        static arrow_vendored::date::sys_days epoch{arrow_vendored::date::jan / 1 / 1970};
+        static avd::sys_days epoch{avd::jan / 1 / 1970};
 
         switch (unit) {
           case TimeUnit::NANO:
-            *os << arrow_vendored::date::format(fmt, static_cast<nanoseconds>(value) + epoch);
+            *os << avd::format(fmt, static_cast<nanoseconds>(value) + epoch);
             break;
           case TimeUnit::MICRO:
-            *os << arrow_vendored::date::format(fmt, static_cast<microseconds>(value) + epoch);
+            *os << avd::format(fmt, static_cast<microseconds>(value) + epoch);
             break;
           case TimeUnit::MILLI:
-            *os << arrow_vendored::date::format(fmt, static_cast<milliseconds>(value) + epoch);
+            *os << avd::format(fmt, static_cast<milliseconds>(value) + epoch);
             break;
           case TimeUnit::SECOND:
-            *os << arrow_vendored::date::format(fmt, static_cast<seconds>(value) + epoch);
+            *os << avd::format(fmt, static_cast<seconds>(value) + epoch);
             break;
         }
         return;
       }
       switch (unit) {
         case TimeUnit::NANO:
-          *os << arrow_vendored::date::format(fmt, static_cast<nanoseconds>(value));
+          *os << avd::format(fmt, static_cast<nanoseconds>(value));
           break;
         case TimeUnit::MICRO:
-          *os << arrow_vendored::date::format(fmt, static_cast<microseconds>(value));
+          *os << avd::format(fmt, static_cast<microseconds>(value));
           break;
         case TimeUnit::MILLI:
-          *os << arrow_vendored::date::format(fmt, static_cast<milliseconds>(value));
+          *os << avd::format(fmt, static_cast<milliseconds>(value));
           break;
         case TimeUnit::SECOND:
-          *os << arrow_vendored::date::format(fmt, static_cast<seconds>(value));
+          *os << avd::format(fmt, static_cast<seconds>(value));
           break;
       }
     };

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -639,7 +639,6 @@ class MakeFormatterImpl {
       auto fmt = fmt_str.c_str();
       auto unit = checked_cast<const T&>(*array.type()).unit();
       auto value = checked_cast<const NumericArray<T>&>(array).Value(index);
-      using arrow_vendored::date::format;
       using std::chrono::nanoseconds;
       using std::chrono::microseconds;
       using std::chrono::milliseconds;
@@ -649,32 +648,32 @@ class MakeFormatterImpl {
 
         switch (unit) {
           case TimeUnit::NANO:
-            *os << format(fmt, static_cast<nanoseconds>(value) + epoch);
+            *os << arrow_vendored::date::format(fmt, static_cast<nanoseconds>(value) + epoch);
             break;
           case TimeUnit::MICRO:
-            *os << format(fmt, static_cast<microseconds>(value) + epoch);
+            *os << arrow_vendored::date::format(fmt, static_cast<microseconds>(value) + epoch);
             break;
           case TimeUnit::MILLI:
-            *os << format(fmt, static_cast<milliseconds>(value) + epoch);
+            *os << arrow_vendored::date::format(fmt, static_cast<milliseconds>(value) + epoch);
             break;
           case TimeUnit::SECOND:
-            *os << format(fmt, static_cast<seconds>(value) + epoch);
+            *os << arrow_vendored::date::format(fmt, static_cast<seconds>(value) + epoch);
             break;
         }
         return;
       }
       switch (unit) {
         case TimeUnit::NANO:
-          *os << format(fmt, static_cast<nanoseconds>(value));
+          *os << arrow_vendored::date::format(fmt, static_cast<nanoseconds>(value));
           break;
         case TimeUnit::MICRO:
-          *os << format(fmt, static_cast<microseconds>(value));
+          *os << arrow_vendored::date::format(fmt, static_cast<microseconds>(value));
           break;
         case TimeUnit::MILLI:
-          *os << format(fmt, static_cast<milliseconds>(value));
+          *os << arrow_vendored::date::format(fmt, static_cast<milliseconds>(value));
           break;
         case TimeUnit::SECOND:
-          *os << format(fmt, static_cast<seconds>(value));
+          *os << arrow_vendored::date::format(fmt, static_cast<seconds>(value));
           break;
       }
     };

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -639,6 +639,8 @@ class MakeFormatterImpl {
       auto fmt = fmt_str.c_str();
       auto unit = checked_cast<const T&>(*array.type()).unit();
       auto value = checked_cast<const NumericArray<T>&>(array).Value(index);
+      // Using unqualified `format` directly would produce ambiguous
+      // lookup because of `std::format` (ARROW-15520).
       namespace avd = arrow_vendored::date;
       using std::chrono::nanoseconds;
       using std::chrono::microseconds;


### PR DESCRIPTION
As explained in ARROW-15520, these unqualified calls to `format()` are ambiguous in the C++20 Standard.

The `using`-declaration `using arrow_vendored::date::format;` makes the compiler consider the desired overload, but it doesn't automatically win. Argument-Dependent Lookup also considers `std::format()` because the arguments are `std::chrono::duration` types (and `<chrono>` includes `<format>` in MSVC's implementation). A very recent change to `std::format()`'s signature in a C++20 Defect Report makes it an equally good match as the desired `arrow_vendored::date::format()` overload, so the compiler emits an ambiguity error.

The fix is simple, although slightly verbose - the code simply needs to explicitly qualify each call, in order to defend against Argument-Dependent Lookup. The fix is also perfectly backwards-compatible (i.e. it works in previous Standard versions, and with all other platforms).

(Also as mentioned in ARROW-15520, although this requires building Apache Arrow with non-default settings to use the latest C++ Standard version, this change is good for future-proofing and will make it easier for the MSVC team to continue validation that prevents toolset regressions that could affect Apache Arrow and other projects.)