### PR TITLE
ARROW-15532: [C++] Fix unused warning for StringClassifyDoc

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -213,7 +213,7 @@ static FunctionDoc StringPredicateDoc(std::string summary, std::string descripti
   return FunctionDoc{std::move(summary), std::move(description), {"strings"}};
 }
 
-static FunctionDoc StringClassifyDoc(std::string class_summary, std::string class_desc,
+static inline FunctionDoc StringClassifyDoc(std::string class_summary, std::string class_desc,
                                      bool non_empty) {
   std::string summary, description;
   {

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -214,7 +214,7 @@ static FunctionDoc StringPredicateDoc(std::string summary, std::string descripti
 }
 
 static inline FunctionDoc StringClassifyDoc(std::string class_summary,
-                                                                     std::string class_desc, bool non_empty) {
+                                            std::string class_desc, bool non_empty) {
   std::string summary, description;
   {
     std::stringstream ss;

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -213,8 +213,8 @@ static FunctionDoc StringPredicateDoc(std::string summary, std::string descripti
   return FunctionDoc{std::move(summary), std::move(description), {"strings"}};
 }
 
-static inline FunctionDoc StringClassifyDoc(std::string class_summary, std::string class_desc,
-                                     bool non_empty) {
+static inline FunctionDoc StringClassifyDoc(std::string class_summary,
+                                                                     std::string class_desc, bool non_empty) {
   std::string summary, description;
   {
     std::stringstream ss;


### PR DESCRIPTION
Following conversion with @lidavidm on mailing list. This should get rid of the warning:

```
/Users/icexelloss/workspace/arrow/cpp/src/arrow/compute/kernels/scalar_string_internal.h:216:20: error: unused function 'StringClassifyDoc' [-Werror,-Wunused-function]

static FunctionDoc StringClassifyDoc(std::string class_summary, std::string class_desc,
```