### PR TITLE
ARROW-9235: [R] Support for `connection` class when reading and writing files

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1384,6 +1384,18 @@ io___BufferOutputStream__Write <- function(stream, bytes) {
   invisible(.Call(`_arrow_io___BufferOutputStream__Write`, stream, bytes))
 }
 
+MakeRConnectionInputStream <- function(con) {
+  .Call(`_arrow_MakeRConnectionInputStream`, con)
+}
+
+MakeRConnectionOutputStream <- function(con) {
+  .Call(`_arrow_MakeRConnectionOutputStream`, con)
+}
+
+MakeRConnectionRandomAccessFile <- function(con) {
+  .Call(`_arrow_MakeRConnectionRandomAccessFile`, con)
+}
+
 MakeReencodeInputStream <- function(wrapped, from) {
   .Call(`_arrow_MakeReencodeInputStream`, wrapped, from)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1112,12 +1112,12 @@ ipc___feather___Reader__version <- function(reader) {
   .Call(`_arrow_ipc___feather___Reader__version`, reader)
 }
 
-ipc___feather___Reader__Read <- function(reader, columns) {
-  .Call(`_arrow_ipc___feather___Reader__Read`, reader, columns)
+ipc___feather___Reader__Read <- function(reader, columns, on_old_windows) {
+  .Call(`_arrow_ipc___feather___Reader__Read`, reader, columns, on_old_windows)
 }
 
-ipc___feather___Reader__Open <- function(stream) {
-  .Call(`_arrow_ipc___feather___Reader__Open`, stream)
+ipc___feather___Reader__Open <- function(stream, on_old_windows) {
+  .Call(`_arrow_ipc___feather___Reader__Open`, stream, on_old_windows)
 }
 
 ipc___feather___Reader__schema <- function(reader) {

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -194,7 +194,7 @@ FeatherReader <- R6Class("FeatherReader",
   inherit = ArrowObject,
   public = list(
     Read = function(columns) {
-      ipc___feather___Reader__Read(self, columns)
+      ipc___feather___Reader__Read(self, columns, on_old_windows())
     },
     print = function(...) {
       cat("FeatherReader:\n")
@@ -215,5 +215,5 @@ names.FeatherReader <- function(x) x$column_names
 
 FeatherReader$create <- function(file) {
   assert_is(file, "RandomAccessFile")
-  ipc___feather___Reader__Open(file)
+  ipc___feather___Reader__Open(file, on_old_windows())
 }

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -279,7 +279,7 @@ make_readable_file <- function(file, mmap = TRUE, compression = NULL, filesystem
 
     # Try to create a RandomAccessFile first because some readers need this
     # (e.g., feather, parquet) but fall back on an InputStream for the readers
-    # that don't.
+    # that don't (e.g., IPC, CSV)
     file <- tryCatch(
       MakeRConnectionRandomAccessFile(file),
       error = function(e) MakeRConnectionInputStream(file)

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -277,9 +277,9 @@ make_readable_file <- function(file, mmap = TRUE, compression = NULL, filesystem
       open(file, "rb")
     }
 
-    # isSeekable() is not sufficient to check for seekability
-    # because we rely on seek(whence = "end") to get the size
-    # of the stream and a gzfile() is "seekable".
+    # Try to create a RandomAccessFile first because some readers need this
+    # (e.g., feather, parquet) but fall back on an InputStream for the readers
+    # that don't.
     file <- tryCatch(
       MakeRConnectionRandomAccessFile(file),
       error = function(e) MakeRConnectionInputStream(file)

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -200,6 +200,7 @@ BufferReader$create <- function(x) {
   io___BufferReader__initialize(x)
 }
 
+
 #' Create a new read/write memory mapped file of a given size
 #'
 #' @param path file path
@@ -244,32 +245,59 @@ make_readable_file <- function(file, mmap = TRUE, compression = NULL, filesystem
   }
   if (is.string(file)) {
     if (is_url(file)) {
-      fs_and_path <- FileSystem$from_uri(file)
-      filesystem <- fs_and_path$fs
-      file <- fs_and_path$path
+      file <- tryCatch({
+        fs_and_path <- FileSystem$from_uri(file)
+        filesystem <- fs_and_path$fs
+        fs_and_path$path
+      }, error = function(e) {
+        MakeRConnectionInputStream(url(file, open = "rb"))
+      })
     }
+
     if (is.null(compression)) {
       # Infer compression from the file path
       compression <- detect_compression(file)
     }
+
     if (!is.null(filesystem)) {
       file <- filesystem$OpenInputFile(file)
-    } else if (isTRUE(mmap)) {
+    } else if (is.string(file) && isTRUE(mmap)) {
       file <- mmap_open(file)
-    } else {
+    } else if (is.string(file)) {
       file <- ReadableFile$create(file)
     }
+
     if (!identical(compression, "uncompressed")) {
       file <- CompressedInputStream$create(file, compression)
     }
   } else if (inherits(file, c("raw", "Buffer"))) {
     file <- BufferReader$create(file)
+  } else if (inherits(file, "connection")) {
+    if (!isOpen(file)) {
+      open(file, "rb")
+    }
+
+    # isSeekable() is not sufficient to check for seekability
+    # because we rely on seek(whence = "end") to get the size
+    # of the stream and a gzfile() is "seekable".
+    file <- tryCatch(
+      MakeRConnectionRandomAccessFile(file),
+      error = function(e) MakeRConnectionInputStream(file)
+    )
   }
   assert_is(file, "InputStream")
   file
 }
 
 make_output_stream <- function(x, filesystem = NULL) {
+  if (inherits(x, "connection")) {
+    if (!isOpen(x)) {
+      open(x, "wb")
+    }
+
+    return(MakeRConnectionOutputStream(x))
+  }
+
   if (inherits(x, "SubTreeFileSystem")) {
     filesystem <- x$base_fs
     x <- x$base_path
@@ -287,7 +315,10 @@ make_output_stream <- function(x, filesystem = NULL) {
 }
 
 detect_compression <- function(path) {
-  assert_that(is.string(path))
+  if (!is.string(path)) {
+    return("uncompressed")
+  }
+
   switch(tools::file_ext(path),
     bz2 = "bz2",
     gz = "gzip",

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -38,7 +38,7 @@ read_parquet <- function(file,
                          as_data_frame = TRUE,
                          props = ParquetArrowReaderProperties$create(),
                          ...) {
-  if (is.string(file)) {
+  if (!inherits(file, "RandomAccessFile")) {
     file <- make_readable_file(file)
     on.exit(file$close())
   }
@@ -541,6 +541,7 @@ ParquetFileReader$create <- function(file,
                                      ...) {
   file <- make_readable_file(file, mmap)
   assert_is(props, "ParquetArrowReaderProperties")
+  assert_is(file, "RandomAccessFile")
 
   parquet___arrow___FileReader__OpenFile(file, props)
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3442,6 +3442,30 @@ BEGIN_CPP11
 END_CPP11
 }
 // io.cpp
+std::shared_ptr<arrow::io::InputStream> MakeRConnectionInputStream(cpp11::sexp con);
+extern "C" SEXP _arrow_MakeRConnectionInputStream(SEXP con_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::sexp>::type con(con_sexp);
+	return cpp11::as_sexp(MakeRConnectionInputStream(con));
+END_CPP11
+}
+// io.cpp
+std::shared_ptr<arrow::io::OutputStream> MakeRConnectionOutputStream(cpp11::sexp con);
+extern "C" SEXP _arrow_MakeRConnectionOutputStream(SEXP con_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::sexp>::type con(con_sexp);
+	return cpp11::as_sexp(MakeRConnectionOutputStream(con));
+END_CPP11
+}
+// io.cpp
+std::shared_ptr<arrow::io::RandomAccessFile> MakeRConnectionRandomAccessFile(cpp11::sexp con);
+extern "C" SEXP _arrow_MakeRConnectionRandomAccessFile(SEXP con_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::sexp>::type con(con_sexp);
+	return cpp11::as_sexp(MakeRConnectionRandomAccessFile(con));
+END_CPP11
+}
+// io.cpp
 std::shared_ptr<arrow::io::InputStream> MakeReencodeInputStream(const std::shared_ptr<arrow::io::InputStream>& wrapped, std::string from);
 extern "C" SEXP _arrow_MakeReencodeInputStream(SEXP wrapped_sexp, SEXP from_sexp){
 BEGIN_CPP11
@@ -5440,6 +5464,9 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_io___BufferOutputStream__Finish", (DL_FUNC) &_arrow_io___BufferOutputStream__Finish, 1}, 
 		{ "_arrow_io___BufferOutputStream__Tell", (DL_FUNC) &_arrow_io___BufferOutputStream__Tell, 1}, 
 		{ "_arrow_io___BufferOutputStream__Write", (DL_FUNC) &_arrow_io___BufferOutputStream__Write, 2}, 
+		{ "_arrow_MakeRConnectionInputStream", (DL_FUNC) &_arrow_MakeRConnectionInputStream, 1}, 
+		{ "_arrow_MakeRConnectionOutputStream", (DL_FUNC) &_arrow_MakeRConnectionOutputStream, 1}, 
+		{ "_arrow_MakeRConnectionRandomAccessFile", (DL_FUNC) &_arrow_MakeRConnectionRandomAccessFile, 1}, 
 		{ "_arrow_MakeReencodeInputStream", (DL_FUNC) &_arrow_MakeReencodeInputStream, 2}, 
 		{ "_arrow_json___ReadOptions__initialize", (DL_FUNC) &_arrow_json___ReadOptions__initialize, 2}, 
 		{ "_arrow_json___ParseOptions__initialize1", (DL_FUNC) &_arrow_json___ParseOptions__initialize1, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2814,11 +2814,11 @@ BEGIN_CPP11
 END_CPP11
 }
 // feather.cpp
-std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(const std::shared_ptr<arrow::ipc::feather::Reader>& reader, SEXP columns);
+std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(const std::shared_ptr<arrow::ipc::feather::Reader>& reader, cpp11::sexp columns);
 extern "C" SEXP _arrow_ipc___feather___Reader__Read(SEXP reader_sexp, SEXP columns_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ipc::feather::Reader>&>::type reader(reader_sexp);
-	arrow::r::Input<SEXP>::type columns(columns_sexp);
+	arrow::r::Input<cpp11::sexp>::type columns(columns_sexp);
 	return cpp11::as_sexp(ipc___feather___Reader__Read(reader, columns));
 END_CPP11
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2814,20 +2814,22 @@ BEGIN_CPP11
 END_CPP11
 }
 // feather.cpp
-std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(const std::shared_ptr<arrow::ipc::feather::Reader>& reader, cpp11::sexp columns);
-extern "C" SEXP _arrow_ipc___feather___Reader__Read(SEXP reader_sexp, SEXP columns_sexp){
+std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(const std::shared_ptr<arrow::ipc::feather::Reader>& reader, cpp11::sexp columns, bool on_old_windows);
+extern "C" SEXP _arrow_ipc___feather___Reader__Read(SEXP reader_sexp, SEXP columns_sexp, SEXP on_old_windows_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ipc::feather::Reader>&>::type reader(reader_sexp);
 	arrow::r::Input<cpp11::sexp>::type columns(columns_sexp);
-	return cpp11::as_sexp(ipc___feather___Reader__Read(reader, columns));
+	arrow::r::Input<bool>::type on_old_windows(on_old_windows_sexp);
+	return cpp11::as_sexp(ipc___feather___Reader__Read(reader, columns, on_old_windows));
 END_CPP11
 }
 // feather.cpp
-std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(const std::shared_ptr<arrow::io::RandomAccessFile>& stream);
-extern "C" SEXP _arrow_ipc___feather___Reader__Open(SEXP stream_sexp){
+std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(const std::shared_ptr<arrow::io::RandomAccessFile>& stream, bool on_old_windows);
+extern "C" SEXP _arrow_ipc___feather___Reader__Open(SEXP stream_sexp, SEXP on_old_windows_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::io::RandomAccessFile>&>::type stream(stream_sexp);
-	return cpp11::as_sexp(ipc___feather___Reader__Open(stream));
+	arrow::r::Input<bool>::type on_old_windows(on_old_windows_sexp);
+	return cpp11::as_sexp(ipc___feather___Reader__Open(stream, on_old_windows));
 END_CPP11
 }
 // feather.cpp
@@ -5396,8 +5398,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_arrow__UnregisterRExtensionType", (DL_FUNC) &_arrow_arrow__UnregisterRExtensionType, 1}, 
 		{ "_arrow_ipc___WriteFeather__Table", (DL_FUNC) &_arrow_ipc___WriteFeather__Table, 6}, 
 		{ "_arrow_ipc___feather___Reader__version", (DL_FUNC) &_arrow_ipc___feather___Reader__version, 1}, 
-		{ "_arrow_ipc___feather___Reader__Read", (DL_FUNC) &_arrow_ipc___feather___Reader__Read, 2}, 
-		{ "_arrow_ipc___feather___Reader__Open", (DL_FUNC) &_arrow_ipc___feather___Reader__Open, 1}, 
+		{ "_arrow_ipc___feather___Reader__Read", (DL_FUNC) &_arrow_ipc___feather___Reader__Read, 3}, 
+		{ "_arrow_ipc___feather___Reader__Open", (DL_FUNC) &_arrow_ipc___feather___Reader__Open, 2}, 
 		{ "_arrow_ipc___feather___Reader__schema", (DL_FUNC) &_arrow_ipc___feather___Reader__schema, 1}, 
 		{ "_arrow_Field__initialize", (DL_FUNC) &_arrow_Field__initialize, 3}, 
 		{ "_arrow_Field__ToString", (DL_FUNC) &_arrow_Field__ToString, 1}, 

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -164,9 +164,11 @@ std::shared_ptr<arrow::csv::TableReader> csv___TableReader__Make(
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> csv___TableReader__Read(
     const std::shared_ptr<arrow::csv::TableReader>& table_reader) {
-  auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>(
-      [&]() { return table_reader->ReadAsync(); });
-
+  const auto& io_context = arrow::io::default_io_context();
+  auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
+    return DeferNotOk(
+        io_context.executor()->Submit([&]() { return table_reader->Read(); }));
+  });
   return ValueOrStop(result);
 }
 

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -164,17 +164,9 @@ std::shared_ptr<arrow::csv::TableReader> csv___TableReader__Make(
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> csv___TableReader__Read(
     const std::shared_ptr<arrow::csv::TableReader>& table_reader) {
-  std::thread* thread_ptr;
   auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
-    auto fut = arrow::Future<std::shared_ptr<arrow::Table>>::Make();
-
-    thread_ptr = new std::thread([&] { fut.MarkFinished(table_reader->Read()); });
-
-    return fut;
+    return table_reader->ReadAsync();
   });
-
-  thread_ptr->join();
-  delete thread_ptr;
 
   return ValueOrStop(result);
 }

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -164,9 +164,8 @@ std::shared_ptr<arrow::csv::TableReader> csv___TableReader__Make(
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> csv___TableReader__Read(
     const std::shared_ptr<arrow::csv::TableReader>& table_reader) {
-  auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
-    return table_reader->ReadAsync();
-  });
+  auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>(
+      [&]() { return table_reader->ReadAsync(); });
 
   return ValueOrStop(result);
 }

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -165,7 +165,7 @@ std::shared_ptr<arrow::csv::TableReader> csv___TableReader__Make(
 std::shared_ptr<arrow::Table> csv___TableReader__Read(
     const std::shared_ptr<arrow::csv::TableReader>& table_reader) {
 #if !defined(HAS_SAFE_CALL_INTO_R)
-  return table_reader->Read();
+  return ValueOrStop(table_reader->Read());
 #else
   const auto& io_context = arrow::io::default_io_context();
   auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -164,12 +164,16 @@ std::shared_ptr<arrow::csv::TableReader> csv___TableReader__Make(
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> csv___TableReader__Read(
     const std::shared_ptr<arrow::csv::TableReader>& table_reader) {
+#if !defined(HAS_SAFE_CALL_INTO_R)
+  return table_reader->Read();
+#else
   const auto& io_context = arrow::io::default_io_context();
   auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
     return DeferNotOk(
         io_context.executor()->Submit([&]() { return table_reader->Read(); }));
   });
   return ValueOrStop(result);
+#endif
 }
 
 // [[arrow::export]]

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -90,9 +90,8 @@ std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& stream) {
   const auto& io_context = arrow::io::default_io_context();
   auto result = RunWithCapturedR<std::shared_ptr<arrow::ipc::feather::Reader>>([&]() {
-    return DeferNotOk(io_context.executor()->Submit([&]() {
-      return arrow::ipc::feather::Reader::Open(stream);
-    }));
+    return DeferNotOk(io_context.executor()->Submit(
+        [&]() { return arrow::ipc::feather::Reader::Open(stream); }));
   });
   return ValueOrStop(result);
 }

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -18,6 +18,9 @@
 #include "./arrow_types.h"
 
 #if defined(ARROW_R_WITH_ARROW)
+
+#include "./safe-call-into-r.h"
+
 #include <arrow/ipc/feather.h>
 #include <arrow/type.h>
 
@@ -48,34 +51,63 @@ int ipc___feather___Reader__version(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
-    const std::shared_ptr<arrow::ipc::feather::Reader>& reader, SEXP columns) {
-  std::shared_ptr<arrow::Table> table;
-
-  switch (TYPEOF(columns)) {
-    case STRSXP: {
-      R_xlen_t n = XLENGTH(columns);
-      std::vector<std::string> names(n);
-      for (R_xlen_t i = 0; i < n; i++) {
-        names[i] = CHAR(STRING_ELT(columns, i));
-      }
-      StopIfNotOk(reader->Read(names, &table));
-      break;
+    const std::shared_ptr<arrow::ipc::feather::Reader>& reader, cpp11::sexp columns) {
+  bool use_names = columns != R_NilValue;
+  std::vector<std::string> names;
+  if (use_names) {
+    cpp11::strings columns_chr(columns);
+    names.reserve(columns_chr.size());
+    for (const auto& name : columns_chr) {
+      names.push_back(name);
     }
-    case NILSXP:
-      StopIfNotOk(reader->Read(&table));
-      break;
-    default:
-      cpp11::stop("incompatible column specification");
-      break;
   }
 
-  return table;
+  std::thread* thread_ptr;
+  auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
+    auto fut = arrow::Future<std::shared_ptr<arrow::Table>>::Make();
+
+    thread_ptr = new std::thread([&] {
+      std::shared_ptr<arrow::Table> table;
+      arrow::Status read_result;
+      if (use_names) {
+        read_result = reader->Read(names, &table);
+      } else {
+        read_result = reader->Read(&table);
+      }
+
+      if (read_result.ok()) {
+        fut.MarkFinished(table);
+      } else {
+        fut.MarkFinished(read_result);
+      }
+    });
+
+    return fut;
+  });
+
+  thread_ptr->join();
+  delete thread_ptr;
+
+  return ValueOrStop(result);
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& stream) {
-  return ValueOrStop(arrow::ipc::feather::Reader::Open(stream));
+  std::thread* thread_ptr;
+  auto result = RunWithCapturedR<std::shared_ptr<arrow::ipc::feather::Reader>>([&]() {
+    auto fut = arrow::Future<std::shared_ptr<arrow::ipc::feather::Reader>>::Make();
+
+    thread_ptr = new std::thread(
+        [&] { fut.MarkFinished(arrow::ipc::feather::Reader::Open(stream)); });
+
+    return fut;
+  });
+
+  thread_ptr->join();
+  delete thread_ptr;
+
+  return ValueOrStop(result);
 }
 
 // [[arrow::export]]

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -81,10 +81,9 @@ std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
 
   if (!on_old_windows) {
     const auto& io_context = arrow::io::default_io_context();
-    auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>([&]() {
-      return DeferNotOk(io_context.executor()->Submit(read_table));
-    });
-  return ValueOrStop(result);
+    auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>(
+        [&]() { return DeferNotOk(io_context.executor()->Submit(read_table)); });
+    return ValueOrStop(result);
   } else {
     return ValueOrStop(read_table());
   }

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -79,6 +79,9 @@ std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
     }
   };
 
+#if !defined(HAS_SAFE_CALL_INTO_R)
+  return ValueOrStop(read_table());
+#else
   if (!on_old_windows) {
     const auto& io_context = arrow::io::default_io_context();
     auto result = RunWithCapturedR<std::shared_ptr<arrow::Table>>(
@@ -87,11 +90,15 @@ std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
   } else {
     return ValueOrStop(read_table());
   }
+#endif
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& stream, bool on_old_windows) {
+#if !defined(HAS_SAFE_CALL_INTO_R)
+  return ValueOrStop(arrow::ipc::feather::Reader::Open(stream));
+#else
   if (!on_old_windows) {
     const auto& io_context = arrow::io::default_io_context();
     auto result = RunWithCapturedR<std::shared_ptr<arrow::ipc::feather::Reader>>([&]() {
@@ -102,6 +109,7 @@ std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
   } else {
     return ValueOrStop(arrow::ipc::feather::Reader::Open(stream));
   }
+#endif
 }
 
 // [[arrow::export]]

--- a/r/src/io.cpp
+++ b/r/src/io.cpp
@@ -272,10 +272,8 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
     arrow::BufferBuilder builder;
     RETURN_NOT_OK(builder.Reserve(nbytes));
 
-    arrow::Result<int64_t> result;
-    RETURN_NOT_OK(result = ReadBase(nbytes, builder.mutable_data()));
-
-    builder.UnsafeAdvance(result.ValueOrDie());
+    ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadBase(nbytes, builder.mutable_data()));
+    builder.UnsafeAdvance(bytes_read);
     return builder.Finish();
   }
 

--- a/r/src/io.cpp
+++ b/r/src/io.cpp
@@ -223,14 +223,11 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
       return arrow::Status::OK();
     }
 
-    auto result = SafeCallIntoR<bool>([&]() {
-      cpp11::package("base")["close"](connection_sexp_);
-      return true;
-    });
+    auto result =
+        SafeCallIntoRVoid([&]() { cpp11::package("base")["close"](connection_sexp_); });
 
-    RETURN_NOT_OK(result);
     closed_ = true;
-    return arrow::Status::OK();
+    return result;
   }
 
   arrow::Result<int64_t> Tell() const {
@@ -282,16 +279,13 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
       return arrow::Status::IOError("R connection is closed");
     }
 
-    auto result = SafeCallIntoR<bool>([&]() {
+    return SafeCallIntoRVoid([&]() {
       cpp11::writable::raws data_raw(nbytes);
       memcpy(cpp11::safe[RAW](data_raw), data, nbytes);
 
       cpp11::function write_bin = cpp11::package("base")["writeBin"];
       write_bin(data_raw, connection_sexp_);
-      return true;
     });
-
-    return result.status();
   }
 
   arrow::Status SeekBase(int64_t pos) {
@@ -299,12 +293,9 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
       return arrow::Status::IOError("R connection is closed");
     }
 
-    auto result = SafeCallIntoR<bool>([&]() {
+    return SafeCallIntoRVoid([&]() {
       cpp11::package("base")["seek"](connection_sexp_, cpp11::as_sexp<double>(pos));
-      return true;
     });
-
-    return result.status();
   }
 
  private:

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -86,7 +86,7 @@ MainRThread& GetMainRThread();
 // a SEXP (use cpp11::as_cpp<T> to convert it to a C++ type inside
 // `fun`).
 template <typename T>
-arrow::Future<T> SafeCallIntoRAsync(std::function<T(void)> fun) {
+arrow::Future<T> SafeCallIntoRAsync(std::function<arrow::Result<T>(void)> fun) {
   MainRThread& main_r_thread = GetMainRThread();
   if (main_r_thread.IsMainThread()) {
     // If we're on the main thread, run the task immediately and let
@@ -104,7 +104,7 @@ arrow::Future<T> SafeCallIntoRAsync(std::function<T(void)> fun) {
       }
 
       try {
-        return arrow::Result<T>(fun());
+        return fun();
       } catch (cpp11::unwind_exception& e) {
         GetMainRThread().SetError(e.token);
         return arrow::Result<T>(arrow::Status::UnknownError("R code execution error"));

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -122,6 +122,14 @@ arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
   return future.result();
 }
 
+static inline arrow::Status SafeCallIntoRVoid(std::function<void(void)> fun) {
+  arrow::Future<bool> future = SafeCallIntoRAsync<bool>([&fun]() {
+    fun();
+    return true;
+  });
+  return future.status();
+}
+
 template <typename T>
 arrow::Result<T> RunWithCapturedR(std::function<arrow::Future<T>()> make_arrow_call) {
   if (GetMainRThread().Executor() != nullptr) {

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -292,6 +292,17 @@ test_that("more informative error when reading a CSV with headers and schema", {
   )
 })
 
+test_that("read_csv_arrow() and write_csv_arrow() accept connection objects", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write_csv_arrow(tibble::tibble(x = 1:5), file(tf))
+  expect_identical(read_csv_arrow(tf), tibble::tibble(x = 1:5))
+
+  # read_csv_arrow() on a connection may error because it can call
+  # the stream's Read() method from another thread
+  # expect_identical(read_csv_arrow(file(tf)), read_csv_arrow(tf))
+})
+
 test_that("CSV reader works on files with non-UTF-8 encoding", {
   strings <- c("a", "\u00e9", "\U0001f4a9")
   file_string <- paste0(

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -295,11 +295,17 @@ test_that("more informative error when reading a CSV with headers and schema", {
 test_that("read_csv_arrow() and write_csv_arrow() accept connection objects", {
   tf <- tempfile()
   on.exit(unlink(tf))
-  write_csv_arrow(tibble::tibble(x = 1:5), file(tf))
-  expect_identical(read_csv_arrow(tf), tibble::tibble(x = 1:5))
 
-  # read_csv_arrow() on a connection may error because it can call
-  # the stream's Read() method from another thread
+  # make this big enough that we might expose concurrency problems,
+  # but not so big that it slows down the tests
+  test_tbl <- tibble::tibble(
+    x = 1:1e4,
+    y = vapply(x, rlang::hash, character(1), USE.NAMES = FALSE),
+    z = vapply(y, rlang::hash, character(1), USE.NAMES = FALSE)
+  )
+
+  write_csv_arrow(test_tbl, file(tf))
+  expect_identical(read_csv_arrow(tf), test_tbl)
   expect_identical(read_csv_arrow(file(tf)), read_csv_arrow(tf))
 })
 

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -293,6 +293,10 @@ test_that("more informative error when reading a CSV with headers and schema", {
 })
 
 test_that("read_csv_arrow() and write_csv_arrow() accept connection objects", {
+  # connections with csv need RunWithCapturedR, which is not available
+  # in R <= 3.4.4
+  skip_if_r_version("3.4.4")
+
   tf <- tempfile()
   on.exit(unlink(tf))
 

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -300,7 +300,7 @@ test_that("read_csv_arrow() and write_csv_arrow() accept connection objects", {
 
   # read_csv_arrow() on a connection may error because it can call
   # the stream's Read() method from another thread
-  # expect_identical(read_csv_arrow(file(tf)), read_csv_arrow(tf))
+  expect_identical(read_csv_arrow(file(tf)), read_csv_arrow(tf))
 })
 
 test_that("CSV reader works on files with non-UTF-8 encoding", {

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -184,6 +184,9 @@ test_that("read_feather requires RandomAccessFile and errors nicely otherwise (A
 test_that("read_feather() and write_feather() accept connection objects", {
   # connection object don't work on Windows i386 before R 4.0
   skip_if(on_old_windows())
+  # connections with feather need RunWithCapturedR, which is not available
+  # in R <= 3.4.4
+  skip_if_r_version("3.4.4")
 
   tf <- tempfile()
   on.exit(unlink(tf))

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -189,7 +189,7 @@ test_that("read_feather() and write_feather() accept connection objects", {
 
   # read_feather() on a connection may error because it can call
   # the stream's Read() method from another thread
-  # expect_identical(read_feather(file(feather_file)), read_feather(feather_file))
+  expect_identical(read_feather(file(feather_file)), read_feather(feather_file))
 })
 
 test_that("read_feather closes connection to file", {

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -182,6 +182,9 @@ test_that("read_feather requires RandomAccessFile and errors nicely otherwise (A
 })
 
 test_that("read_feather() and write_feather() accept connection objects", {
+  # connection object don't work on Windows i386 before R 4.0
+  skip_if(on_old_windows())
+
   tf <- tempfile()
   on.exit(unlink(tf))
 

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -181,6 +181,17 @@ test_that("read_feather requires RandomAccessFile and errors nicely otherwise (A
   )
 })
 
+test_that("read_feather() and write_feather() accept connection objects", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write_feather(tibble::tibble(x = 1:5), file(tf))
+  expect_identical(read_feather(tf), tibble::tibble(x = 1:5))
+
+  # read_feather() on a connection may error because it can call
+  # the stream's Read() method from another thread
+  # expect_identical(read_feather(file(feather_file)), read_feather(feather_file))
+})
+
 test_that("read_feather closes connection to file", {
   tf <- tempfile()
   on.exit(unlink(tf))

--- a/r/tests/testthat/test-ipc_stream.R
+++ b/r/tests/testthat/test-ipc_stream.R
@@ -19,8 +19,14 @@
 test_that("read_ipc_stream() and write_ipc_stream() accept connection objects", {
   tf <- tempfile()
   on.exit(unlink(tf))
-  write_ipc_stream(tibble::tibble(x = 1:5), file(tf))
-  expect_identical(read_ipc_stream(tf), tibble::tibble(x = 1:5))
 
+  test_tbl <- tibble::tibble(
+    x = 1:1e4,
+    y = vapply(x, rlang::hash, character(1), USE.NAMES = FALSE),
+    z = vapply(y, rlang::hash, character(1), USE.NAMES = FALSE)
+  )
+
+  write_ipc_stream(test_tbl, file(tf))
+  expect_identical(read_ipc_stream(tf), test_tbl)
   expect_identical(read_ipc_stream(file(tf)), read_ipc_stream(tf))
 })

--- a/r/tests/testthat/test-ipc_stream.R
+++ b/r/tests/testthat/test-ipc_stream.R
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+test_that("read_ipc_stream() and write_ipc_stream() accept connection objects", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write_ipc_stream(tibble::tibble(x = 1:5), file(tf))
+  expect_identical(read_ipc_stream(tf), tibble::tibble(x = 1:5))
+
+  expect_identical(read_ipc_stream(file(tf)), read_ipc_stream(tf))
+})

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -199,6 +199,15 @@ test_that("Maps are preserved when writing/reading from Parquet", {
   expect_equal(df, df_read, ignore_attr = TRUE)
 })
 
+test_that("read_parquet() and write_parquet() accept connection objects", {
+  expect_identical(read_parquet(file(pq_file)), read_parquet(pq_file))
+
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write_parquet(tibble::tibble(x = 1:5), file(tf))
+  expect_identical(read_parquet(tf), tibble::tibble(x = 1:5))
+})
+
 test_that("write_parquet() to stream", {
   df <- tibble::tibble(x = 1:5)
   tf <- tempfile()
@@ -229,6 +238,14 @@ test_that("write_parquet() handles version argument", {
   purrr::walk(list("3.0", 3.0, 3L, "A"), ~ {
     expect_error(write_parquet(df, tf, version = .x))
   })
+})
+
+test_that("ParquetFileReader raises an error for non-RandomAccessFile source", {
+  skip_if_not_available("gzip")
+  expect_error(
+    ParquetFileReader$create(CompressedInputStream$create(pq_file)),
+    'file must be a "RandomAccessFile"'
+  )
 })
 
 test_that("ParquetFileWriter raises an error for non-OutputStream sink", {

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -32,6 +32,7 @@ test_that("SafeCallIntoR works from the main R thread", {
 })
 
 test_that("SafeCallIntoR works within RunWithCapturedR", {
+  skip_if_r_version("3.4.4")
   skip_on_cran()
 
   expect_identical(


### PR DESCRIPTION
This is a PR to support arbitrary R "connection" objects as Input and Output streams. In particular, this adds support for sockets (ARROW-4512), URLs, and some other IO operations that are implemented as R connections (e.g., in the [archive](https://github.com/r-lib/archive#archive) package). The gist of it is that you should be able to do this:

``` r
# remotes::install_github("paleolimbot/arrow/r@r-connections")
library(arrow, warn.conflicts = FALSE)

addr <- "https://github.com/apache/arrow/raw/master/r/inst/v0.7.1.parquet"

stream <- arrow:::make_readable_file(addr)
rawToChar(as.raw(stream$Read(4)))
#> [1] "PAR1"
stream$close()

stream <- arrow:::make_readable_file(url(addr, open = "rb"))
rawToChar(as.raw(stream$Read(4)))
#> [1] "PAR1"
stream$close()
```

There are two serious issues that prevent this PR from being useful yet. First, it uses functions that R considers "non-API" functions from the C API.

    > checking compiled code ... NOTE
      File ‘arrow/libs/arrow.so’:
        Found non-API calls to R: ‘R_GetConnection’, ‘R_ReadConnection’,
          ‘R_WriteConnection’
      
      Compiled code should not call non-API entry points in R.

We can get around this by calling back into R (in the same way this PR implements `Tell()` and `Close()`). We could also go all out and implement the other half (exposing `InputStream`/`OutputStream`s as R connections) and ask for an exemption (at least one R package, curl, does this). The archive package seems to expose connections without a NOTE on the CRAN check page, so perhaps there is also a workaround.

Second, we get a crash when passing the input stream to most functions. I think this is because the `Read()` method is getting called from another thread but it also could be an error in my implementation. If the issue is threading, we would have to arrange a way to queue jobs for the R main thread (e.g., how the [later](https://github.com/r-lib/later#background-tasks) package does it) and a way to ping it occasionally to fetch the results. This is complicated but might be useful for other reasons (supporting evaluation of R functions in more places). It also might be more work than it's worth.

``` r
# remotes::install_github("paleolimbot/arrow/r@r-connections")
library(arrow, warn.conflicts = FALSE)

addr <- "https://github.com/apache/arrow/raw/master/r/inst/v0.7.1.parquet"
read_parquet(addr)
```

```
*** caught segfault ***
address 0x28, cause 'invalid permissions'

Traceback:
 1: parquet___arrow___FileReader__OpenFile(file, props)
```