### PR TITLE
ARROW-15546: [FlightRPC][C++] Remove quotes from cookie header

### DIFF
--- a/cpp/src/arrow/flight/client_header_internal.cc
+++ b/cpp/src/arrow/flight/client_header_internal.cc
@@ -235,8 +235,7 @@ bool Cookie::IsExpired() const {
 
 std::string Cookie::AsCookieString() const {
   // Return the string for the cookie as it would appear in a Cookie header.
-  // Keys must be wrapped in quotes depending on if this is a v1 or v2 cookie.
-  return cookie_name_ + "=\"" + cookie_value_ + "\"";
+  return cookie_name_ + "=" + cookie_value_;
 }
 
 std::string Cookie::GetName() const { return cookie_name_; }

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -2669,11 +2669,11 @@ TEST_F(TestCookieParsing, GetName) {
 }
 
 TEST_F(TestCookieParsing, ToString) {
-  VerifyCookieString("id1=1; foo=bar;", "id1=\"1\"");
-  VerifyCookieString("id1=1; foo=bar", "id1=\"1\"");
-  VerifyCookieString("id2=2;", "id2=\"2\"");
-  VerifyCookieString("id4=\"4\"", "id4=\"4\"");
-  VerifyCookieString("id5=5; foo=bar; baz=buz;", "id5=\"5\"");
+  VerifyCookieString("id1=1; foo=bar;", "id1=1");
+  VerifyCookieString("id1=1; foo=bar", "id1=1");
+  VerifyCookieString("id2=2;", "id2=2");
+  VerifyCookieString("id4=\"4\"", "id4=4");
+  VerifyCookieString("id5=5; foo=bar; baz=buz;", "id5=5");
 }
 
 TEST_F(TestCookieParsing, DateConversion) {
@@ -2718,9 +2718,9 @@ TEST_F(TestCookieParsing, ParseCookieAttribute) {
 
 TEST_F(TestCookieParsing, CookieCache) {
   AddCookieVerifyCache({"id0=0;"}, "");
-  AddCookieVerifyCache({"id0=0;", "id0=1;"}, "id0=\"1\"");
-  AddCookieVerifyCache({"id0=0;", "id1=1;"}, "id0=\"0\"; id1=\"1\"");
-  AddCookieVerifyCache({"id0=0;", "id1=1;", "id2=2"}, "id0=\"0\"; id1=\"1\"; id2=\"2\"");
+  AddCookieVerifyCache({"id0=0;", "id0=1;"}, "id0=1");
+  AddCookieVerifyCache({"id0=0;", "id1=1;"}, "id0=0; id1=1");
+  AddCookieVerifyCache({"id0=0;", "id1=1;", "id2=2"}, "id0=0; id1=1; id2=2");
 }
 
 class ForeverFlightListing : public FlightListing {


### PR DESCRIPTION
The client cookie middleware should not wrap values in quotes when
emitting the Cookie header.