### PR TITLE
ARROW-15550: [C++] Add optional debug memory checks

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -26,6 +26,8 @@ git submodule update --init || exit /B
 set ARROW_TEST_DATA=%CD%\testing\data
 set PARQUET_TEST_DATA=%CD%\cpp\submodules\parquet-testing\data
 
+set ARROW_DEBUG_MEMORY_POOL=trap
+
 @rem
 @rem In the configurations below we disable building the Arrow static library
 @rem to save some time.  Unfortunately this will still build the Parquet static

--- a/ci/scripts/c_glib_test.sh
+++ b/ci/scripts/c_glib_test.sh
@@ -26,6 +26,9 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 export PKG_CONFIG_PATH=${ARROW_HOME}/lib/pkgconfig
 export GI_TYPELIB_PATH=${ARROW_HOME}/lib/girepository-1.0
 
+# Enable memory debug checks.
+export ARROW_DEBUG_MEMORY_POOL=trap
+
 pushd ${source_dir}
 
 ruby test/run-test.rb

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -37,6 +37,9 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}:${LD_LIBRARY_P
 # to retrieve metadata. Disable this so that S3FileSystem tests run faster.
 export AWS_EC2_METADATA_DISABLED=TRUE
 
+# Enable memory debug checks.
+export ARROW_DEBUG_MEMORY_POOL=trap
+
 ctest_options=()
 case "$(uname)" in
   Linux)

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -30,6 +30,9 @@ export ARROW_GDB_SCRIPT=${arrow_dir}/cpp/gdb_arrow.py
 # Enable some checks inside Python itself
 export PYTHONDEVMODE=1
 
+# Enable memory debug checks.
+export ARROW_DEBUG_MEMORY_POOL=trap
+
 # By default, force-test all optional components
 : ${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}
 : ${PYARROW_TEST_DATASET:=${ARROW_DATASET:-ON}}

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -56,6 +56,9 @@ export _R_CHECK_TESTS_NLINES_=0
 # to retrieve metadata. Disable this so that S3FileSystem tests run faster.
 export AWS_EC2_METADATA_DISABLED=TRUE
 
+# Enable memory debug checks.
+export ARROW_DEBUG_MEMORY_POOL=trap
+
 # Hack so that texlive2020 doesn't pollute the home dir
 export TEXMFCONFIG=/tmp/texmf-config
 export TEXMFVAR=/tmp/texmf-var

--- a/ci/scripts/ruby_test.sh
+++ b/ci/scripts/ruby_test.sh
@@ -26,4 +26,7 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 export PKG_CONFIG_PATH=${ARROW_HOME}/lib/pkgconfig
 export GI_TYPELIB_PATH=${ARROW_HOME}/lib/girepository-1.0
 
+# Enable memory debug checks.
+export ARROW_DEBUG_MEMORY_POOL=trap
+
 rake -f ${source_dir}/Rakefile BUILD_DIR=${build_dir} USE_BUNDLER=yes

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1636,6 +1636,10 @@ if(ARROW_JEMALLOC)
        # See https://github.com/jemalloc/jemalloc/issues/1237
        "--disable-initial-exec-tls"
        ${EP_LOG_OPTIONS})
+  if(${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
+    # Enable jemalloc debug checks when Arrow itself has debugging enabled
+    list(APPEND JEMALLOC_CONFIGURE_COMMAND "--enable-debug")
+  endif()
   set(JEMALLOC_BUILD_COMMAND ${MAKE} ${MAKE_BUILD_ARGS})
   if(CMAKE_OSX_SYSROOT)
     list(APPEND JEMALLOC_BUILD_COMMAND "SDKROOT=${CMAKE_OSX_SYSROOT}")

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -204,6 +204,7 @@ set(ARROW_SRCS
     util/compression.cc
     util/counting_semaphore.cc
     util/cpu_info.cc
+    util/debug.cc
     util/decimal.cc
     util/delimiting.cc
     util/formatting.cc

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -24,6 +24,7 @@
 #include <iostream>  // IWYU pragma: keep
 #include <limits>
 #include <memory>
+#include <mutex>
 
 #if defined(sun) || defined(__sun)
 #include <stdlib.h>
@@ -34,11 +35,14 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/debug.h"
+#include "arrow/util/int_util_internal.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"  // IWYU pragma: keep
 #include "arrow/util/optional.h"
 #include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"
+#include "arrow/util/ubsan.h"
 
 #ifdef __GLIBC__
 #include <malloc.h>
@@ -106,6 +110,7 @@ namespace {
 constexpr size_t kAlignment = 64;
 
 constexpr char kDefaultBackendEnvVar[] = "ARROW_DEFAULT_MEMORY_POOL";
+constexpr char kDebugMemoryEnvVar[] = "ARROW_DEBUG_MEMORY_POOL";
 
 enum class MemoryPoolBackend : uint8_t { System, Jemalloc, Mimalloc };
 
@@ -183,9 +188,142 @@ MemoryPoolBackend DefaultBackend() {
   return default_backend.backend;
 }
 
+static constexpr int64_t kDebugXorSuffix = -0x181fe80e0b464188LL;
+
 // A static piece of memory for 0-size allocations, so as to return
-// an aligned non-null pointer.
-alignas(kAlignment) static uint8_t zero_size_area[1];
+// an aligned non-null pointer.  Note the correct value for DebugAllocator
+// checks is hardcoded.
+alignas(kAlignment) static int64_t zero_size_area[1] = {kDebugXorSuffix};
+static uint8_t* const kZeroSizeArea = reinterpret_cast<uint8_t*>(&zero_size_area);
+
+using MemoryDebugHandler = std::function<void(uint8_t* ptr, int64_t size, const Status&)>;
+
+struct DebugState {
+  void Invoke(uint8_t* ptr, int64_t size, const Status& st) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    handler_(ptr, size, st);
+  }
+
+  void SetHandler(MemoryDebugHandler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    handler_ = std::move(handler);
+  }
+
+ private:
+  std::mutex mutex_;
+  MemoryDebugHandler handler_;
+} debug_state;
+
+void DebugAbort(uint8_t* ptr, int64_t size, const Status& st) { st.Abort(); }
+
+void DebugTrap(uint8_t* ptr, int64_t size, const Status& st) {
+  ARROW_LOG(ERROR) << st.ToString();
+  arrow::internal::DebugTrap();
+}
+
+void DebugWarn(uint8_t* ptr, int64_t size, const Status& st) {
+  ARROW_LOG(WARNING) << st.ToString();
+}
+
+bool IsDebugEnabled() {
+  static const bool is_enabled = []() {
+    auto maybe_env_value = internal::GetEnvVar(kDebugMemoryEnvVar);
+    if (!maybe_env_value.ok()) {
+      return false;
+    }
+    auto env_value = *std::move(maybe_env_value);
+    if (env_value.empty()) {
+      return false;
+    }
+    if (env_value == "abort") {
+      debug_state.SetHandler(DebugAbort);
+      return true;
+    }
+    if (env_value == "trap") {
+      debug_state.SetHandler(DebugTrap);
+      return true;
+    }
+    if (env_value == "warn") {
+      debug_state.SetHandler(DebugWarn);
+      return true;
+    }
+    ARROW_LOG(WARNING) << "Invalid value for " << kDebugMemoryEnvVar << ": '" << env_value
+                       << "'. Valid values are 'abort', 'trap', 'warn'.";
+    return false;
+  }();
+
+  return is_enabled;
+}
+
+// An allocator wrapper that adds a suffix at the end of allocation to check
+// for writes beyond the allocated area.
+template <typename WrappedAllocator>
+class DebugAllocator {
+ public:
+  static Status AllocateAligned(int64_t size, uint8_t** out) {
+    if (size == 0) {
+      *out = kZeroSizeArea;
+    } else {
+      ARROW_ASSIGN_OR_RAISE(int64_t raw_size, RawSize(size));
+      RETURN_NOT_OK(WrappedAllocator::AllocateAligned(raw_size, out));
+      InitAllocatedArea(*out, size);
+    }
+    return Status::OK();
+  }
+
+  static void ReleaseUnused() { WrappedAllocator::ReleaseUnused(); }
+
+  static Status ReallocateAligned(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+    CheckAllocatedArea(*ptr, old_size, "reallocation");
+    if (*ptr == kZeroSizeArea) {
+      return AllocateAligned(new_size, ptr);
+    }
+    if (new_size == 0) {
+      // Note that an overflow check isn't needed as `old_size` is supposed to have
+      // been successfully passed to AllocateAligned() before.
+      WrappedAllocator::DeallocateAligned(*ptr, old_size + kOverhead);
+      *ptr = kZeroSizeArea;
+      return Status::OK();
+    }
+    ARROW_ASSIGN_OR_RAISE(int64_t raw_new_size, RawSize(new_size));
+    RETURN_NOT_OK(
+        WrappedAllocator::ReallocateAligned(old_size + kOverhead, raw_new_size, ptr));
+    InitAllocatedArea(*ptr, new_size);
+    return Status::OK();
+  }
+
+  static void DeallocateAligned(uint8_t* ptr, int64_t size) {
+    CheckAllocatedArea(ptr, size, "deallocation");
+    if (ptr != kZeroSizeArea) {
+      WrappedAllocator::DeallocateAligned(ptr, size + kOverhead);
+    }
+  }
+
+ private:
+  static Result<int64_t> RawSize(int64_t size) {
+    if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(size, kOverhead, &size))) {
+      return Status::OutOfMemory("Memory allocation size too large");
+    }
+    return size;
+  }
+
+  static void InitAllocatedArea(uint8_t* ptr, int64_t size) {
+    DCHECK_NE(size, 0);
+    util::SafeStore(ptr + size, size ^ kDebugXorSuffix);
+  }
+
+  static void CheckAllocatedArea(uint8_t* ptr, int64_t size, const char* context) {
+    // Check that memory wasn't clobbered at the end of the allocated area.
+    int64_t stored_size = kDebugXorSuffix ^ util::SafeLoadAs<int64_t>(ptr + size);
+    if (ARROW_PREDICT_FALSE(stored_size != size)) {
+      auto st = Status::Invalid("Wrong size on ", context, ": given size = ", size,
+                                ", actual size = ", stored_size);
+      debug_state.Invoke(ptr, size, st);
+    }
+  }
+
+  static constexpr int64_t kOverhead = sizeof(int64_t);
+};
 
 // Helper class directing allocations to the standard system allocator.
 class SystemAllocator {
@@ -194,7 +332,7 @@ class SystemAllocator {
   // (as of May 2016 64 bytes)
   static Status AllocateAligned(int64_t size, uint8_t** out) {
     if (size == 0) {
-      *out = zero_size_area;
+      *out = kZeroSizeArea;
       return Status::OK();
     }
 #ifdef _WIN32
@@ -225,13 +363,13 @@ class SystemAllocator {
 
   static Status ReallocateAligned(int64_t old_size, int64_t new_size, uint8_t** ptr) {
     uint8_t* previous_ptr = *ptr;
-    if (previous_ptr == zero_size_area) {
+    if (previous_ptr == kZeroSizeArea) {
       DCHECK_EQ(old_size, 0);
       return AllocateAligned(new_size, ptr);
     }
     if (new_size == 0) {
       DeallocateAligned(previous_ptr, old_size);
-      *ptr = zero_size_area;
+      *ptr = kZeroSizeArea;
       return Status::OK();
     }
     // Note: We cannot use realloc() here as it doesn't guarantee alignment.
@@ -252,7 +390,7 @@ class SystemAllocator {
   }
 
   static void DeallocateAligned(uint8_t* ptr, int64_t size) {
-    if (ptr == zero_size_area) {
+    if (ptr == kZeroSizeArea) {
       DCHECK_EQ(size, 0);
     } else {
 #ifdef _WIN32
@@ -279,7 +417,7 @@ class JemallocAllocator {
  public:
   static Status AllocateAligned(int64_t size, uint8_t** out) {
     if (size == 0) {
-      *out = zero_size_area;
+      *out = kZeroSizeArea;
       return Status::OK();
     }
     *out = reinterpret_cast<uint8_t*>(
@@ -292,13 +430,13 @@ class JemallocAllocator {
 
   static Status ReallocateAligned(int64_t old_size, int64_t new_size, uint8_t** ptr) {
     uint8_t* previous_ptr = *ptr;
-    if (previous_ptr == zero_size_area) {
+    if (previous_ptr == kZeroSizeArea) {
       DCHECK_EQ(old_size, 0);
       return AllocateAligned(new_size, ptr);
     }
     if (new_size == 0) {
       DeallocateAligned(previous_ptr, old_size);
-      *ptr = zero_size_area;
+      *ptr = kZeroSizeArea;
       return Status::OK();
     }
     *ptr = reinterpret_cast<uint8_t*>(
@@ -311,7 +449,7 @@ class JemallocAllocator {
   }
 
   static void DeallocateAligned(uint8_t* ptr, int64_t size) {
-    if (ptr == zero_size_area) {
+    if (ptr == kZeroSizeArea) {
       DCHECK_EQ(size, 0);
     } else {
       dallocx(ptr, MALLOCX_ALIGN(kAlignment));
@@ -332,7 +470,7 @@ class MimallocAllocator {
  public:
   static Status AllocateAligned(int64_t size, uint8_t** out) {
     if (size == 0) {
-      *out = zero_size_area;
+      *out = kZeroSizeArea;
       return Status::OK();
     }
     *out = reinterpret_cast<uint8_t*>(
@@ -347,13 +485,13 @@ class MimallocAllocator {
 
   static Status ReallocateAligned(int64_t old_size, int64_t new_size, uint8_t** ptr) {
     uint8_t* previous_ptr = *ptr;
-    if (previous_ptr == zero_size_area) {
+    if (previous_ptr == kZeroSizeArea) {
       DCHECK_EQ(old_size, 0);
       return AllocateAligned(new_size, ptr);
     }
     if (new_size == 0) {
       DeallocateAligned(previous_ptr, old_size);
-      *ptr = zero_size_area;
+      *ptr = kZeroSizeArea;
       return Status::OK();
     }
     *ptr = reinterpret_cast<uint8_t*>(
@@ -366,7 +504,7 @@ class MimallocAllocator {
   }
 
   static void DeallocateAligned(uint8_t* ptr, int64_t size) {
-    if (ptr == zero_size_area) {
+    if (ptr == kZeroSizeArea) {
       DCHECK_EQ(size, 0);
     } else {
       mi_free(ptr);
@@ -466,8 +604,19 @@ class SystemMemoryPool : public BaseMemoryPoolImpl<SystemAllocator> {
   std::string backend_name() const override { return "system"; }
 };
 
+class SystemDebugMemoryPool : public BaseMemoryPoolImpl<DebugAllocator<SystemAllocator>> {
+ public:
+  std::string backend_name() const override { return "system"; }
+};
+
 #ifdef ARROW_JEMALLOC
 class JemallocMemoryPool : public BaseMemoryPoolImpl<JemallocAllocator> {
+ public:
+  std::string backend_name() const override { return "jemalloc"; }
+};
+
+class JemallocDebugMemoryPool
+    : public BaseMemoryPoolImpl<DebugAllocator<JemallocAllocator>> {
  public:
   std::string backend_name() const override { return "jemalloc"; }
 };
@@ -478,20 +627,29 @@ class MimallocMemoryPool : public BaseMemoryPoolImpl<MimallocAllocator> {
  public:
   std::string backend_name() const override { return "mimalloc"; }
 };
+
+class MimallocDebugMemoryPool
+    : public BaseMemoryPoolImpl<DebugAllocator<MimallocAllocator>> {
+ public:
+  std::string backend_name() const override { return "mimalloc"; }
+};
 #endif
 
 std::unique_ptr<MemoryPool> MemoryPool::CreateDefault() {
   auto backend = DefaultBackend();
   switch (backend) {
     case MemoryPoolBackend::System:
-      return std::unique_ptr<MemoryPool>(new SystemMemoryPool);
+      return IsDebugEnabled() ? std::unique_ptr<MemoryPool>(new SystemDebugMemoryPool)
+                              : std::unique_ptr<MemoryPool>(new SystemMemoryPool);
 #ifdef ARROW_JEMALLOC
     case MemoryPoolBackend::Jemalloc:
-      return std::unique_ptr<MemoryPool>(new JemallocMemoryPool);
+      return IsDebugEnabled() ? std::unique_ptr<MemoryPool>(new JemallocDebugMemoryPool)
+                              : std::unique_ptr<MemoryPool>(new JemallocMemoryPool);
 #endif
 #ifdef ARROW_MIMALLOC
     case MemoryPoolBackend::Mimalloc:
-      return std::unique_ptr<MemoryPool>(new MimallocMemoryPool);
+      return IsDebugEnabled() ? std::unique_ptr<MemoryPool>(new MimallocDebugMemoryPool)
+                              : std::unique_ptr<MemoryPool>(new MimallocMemoryPool);
 #endif
     default:
       ARROW_LOG(FATAL) << "Internal error: cannot create default memory pool";
@@ -500,26 +658,58 @@ std::unique_ptr<MemoryPool> MemoryPool::CreateDefault() {
 }
 
 static struct GlobalState {
-  ~GlobalState() { finalizing.store(true, std::memory_order_relaxed); }
+  ~GlobalState() { finalizing_.store(true, std::memory_order_relaxed); }
 
-  bool is_finalizing() const { return finalizing.load(std::memory_order_relaxed); }
+  bool is_finalizing() const { return finalizing_.load(std::memory_order_relaxed); }
 
-  std::atomic<bool> finalizing{false};  // constructed first, destroyed last
+  MemoryPool* system_memory_pool() {
+    if (IsDebugEnabled()) {
+      return &system_debug_pool_;
+    } else {
+      return &system_pool_;
+    }
+  }
 
-  SystemMemoryPool system_pool;
 #ifdef ARROW_JEMALLOC
-  JemallocMemoryPool jemalloc_pool;
+  MemoryPool* jemalloc_memory_pool() {
+    if (IsDebugEnabled()) {
+      return &jemalloc_debug_pool_;
+    } else {
+      return &jemalloc_pool_;
+    }
+  }
+#endif
+
+#ifdef ARROW_MIMALLOC
+  MemoryPool* mimalloc_memory_pool() {
+    if (IsDebugEnabled()) {
+      return &mimalloc_debug_pool_;
+    } else {
+      return &mimalloc_pool_;
+    }
+  }
+#endif
+
+ private:
+  std::atomic<bool> finalizing_{false};  // constructed first, destroyed last
+
+  SystemMemoryPool system_pool_;
+  SystemDebugMemoryPool system_debug_pool_;
+#ifdef ARROW_JEMALLOC
+  JemallocMemoryPool jemalloc_pool_;
+  JemallocDebugMemoryPool jemalloc_debug_pool_;
 #endif
 #ifdef ARROW_MIMALLOC
-  MimallocMemoryPool mimalloc_pool;
+  MimallocMemoryPool mimalloc_pool_;
+  MimallocDebugMemoryPool mimalloc_debug_pool_;
 #endif
 } global_state;
 
-MemoryPool* system_memory_pool() { return &global_state.system_pool; }
+MemoryPool* system_memory_pool() { return global_state.system_memory_pool(); }
 
 Status jemalloc_memory_pool(MemoryPool** out) {
 #ifdef ARROW_JEMALLOC
-  *out = &global_state.jemalloc_pool;
+  *out = global_state.jemalloc_memory_pool();
   return Status::OK();
 #else
   return Status::NotImplemented("This Arrow build does not enable jemalloc");
@@ -528,7 +718,7 @@ Status jemalloc_memory_pool(MemoryPool** out) {
 
 Status mimalloc_memory_pool(MemoryPool** out) {
 #ifdef ARROW_MIMALLOC
-  *out = &global_state.mimalloc_pool;
+  *out = global_state.mimalloc_memory_pool();
   return Status::OK();
 #else
   return Status::NotImplemented("This Arrow build does not enable mimalloc");
@@ -539,14 +729,14 @@ MemoryPool* default_memory_pool() {
   auto backend = DefaultBackend();
   switch (backend) {
     case MemoryPoolBackend::System:
-      return &global_state.system_pool;
+      return global_state.system_memory_pool();
 #ifdef ARROW_JEMALLOC
     case MemoryPoolBackend::Jemalloc:
-      return &global_state.jemalloc_pool;
+      return global_state.jemalloc_memory_pool();
 #endif
 #ifdef ARROW_MIMALLOC
     case MemoryPoolBackend::Mimalloc:
-      return &global_state.mimalloc_pool;
+      return global_state.mimalloc_memory_pool();
 #endif
     default:
       ARROW_LOG(FATAL) << "Internal error: cannot create default memory pool";

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -552,7 +552,7 @@ class BaseMemoryPoolImpl : public MemoryPool {
       return Status::Invalid("negative malloc size");
     }
     if (static_cast<uint64_t>(size) >= std::numeric_limits<size_t>::max()) {
-      return Status::CapacityError("malloc size overflows size_t");
+      return Status::OutOfMemory("malloc size overflows size_t");
     }
     RETURN_NOT_OK(Allocator::AllocateAligned(size, out));
 #ifndef NDEBUG
@@ -573,7 +573,7 @@ class BaseMemoryPoolImpl : public MemoryPool {
       return Status::Invalid("negative realloc size");
     }
     if (static_cast<uint64_t>(new_size) >= std::numeric_limits<size_t>::max()) {
-      return Status::CapacityError("realloc overflows size_t");
+      return Status::OutOfMemory("realloc overflows size_t");
     }
     RETURN_NOT_OK(Allocator::ReallocateAligned(old_size, new_size, ptr));
 #ifndef NDEBUG

--- a/cpp/src/arrow/memory_pool_test.h
+++ b/cpp/src/arrow/memory_pool_test.h
@@ -57,11 +57,12 @@ class TestMemoryPoolBase : public ::testing::Test {
     auto pool = memory_pool();
 
     uint8_t* data;
-    int64_t to_alloc = std::min<uint64_t>(std::numeric_limits<int64_t>::max(),
-                                          std::numeric_limits<size_t>::max());
+    int64_t max_alloc = std::min<uint64_t>(std::numeric_limits<int64_t>::max(),
+                                           std::numeric_limits<size_t>::max());
     // subtract 63 to prevent overflow after the size is aligned
-    to_alloc -= 63;
-    ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+    for (int64_t to_alloc : {max_alloc, max_alloc - 63, max_alloc - 127}) {
+      ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+    }
   }
 
   void TestReallocate() {

--- a/cpp/src/arrow/python/gdb.cc
+++ b/cpp/src/arrow/python/gdb.cc
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cerrno>
-#include <csignal>
 #include <cstdlib>
 #include <memory>
 #include <utility>
@@ -31,6 +29,7 @@
 #include "arrow/scalar.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
+#include "arrow/util/debug.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
@@ -47,18 +46,6 @@ using ipc::internal::json::ScalarFromJSON;
 
 namespace gdb {
 namespace {
-
-void Trap() {
-  // XXX Perhaps vendor
-  // https://github.com/nemequ/portable-snippets/blob/master/debug-trap/debug-trap.h ?
-#if defined(_MSC_VER)
-  __debugbreak();
-#elif defined(SIGTRAP)
-  raise(SIGTRAP);
-#else
-  std::abort();
-#endif
-}
 
 class CustomStatusDetail : public StatusDetail {
  public:
@@ -442,7 +429,7 @@ void TestSession() {
 #endif
 
   // Hook into debugger
-  Trap();
+  arrow::internal::DebugTrap();
 }
 
 }  // namespace gdb

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -522,9 +522,10 @@ TEST(allocator, MemoryTracking) {
 #if !(defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER) || defined(ARROW_JEMALLOC))
 
 TEST(allocator, TestOOM) {
-  allocator<uint64_t> alloc;
-  uint64_t to_alloc = std::numeric_limits<uint64_t>::max() / 2;
-  ASSERT_THROW(alloc.allocate(to_alloc), std::bad_alloc);
+  allocator<uint8_t> alloc;
+  size_t max_alloc = std::min<uint64_t>(std::numeric_limits<int64_t>::max(),
+                                        std::numeric_limits<size_t>::max());
+  ASSERT_THROW(alloc.allocate(max_alloc), std::bad_alloc);
 }
 
 TEST(stl_allocator, MaxMemory) {
@@ -544,5 +545,4 @@ TEST(stl_allocator, MaxMemory) {
         // || defined(ARROW_JEMALLOC))
 
 }  // namespace stl
-
 }  // namespace arrow

--- a/cpp/src/arrow/util/debug.cc
+++ b/cpp/src/arrow/util/debug.cc
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/debug.h"
+
+#include <csignal>
+#include <cstdlib>
+
+#include "arrow/vendored/portable-snippets/debug-trap.h"
+
+namespace arrow {
+namespace internal {
+
+void DebugTrap() { psnip_trap(); }
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/debug.h
+++ b/cpp/src/arrow/util/debug.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace internal {
+
+ARROW_EXPORT
+void DebugTrap();
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/vendored/portable-snippets/debug-trap.h
+++ b/cpp/src/arrow/vendored/portable-snippets/debug-trap.h
@@ -1,0 +1,83 @@
+/* Debugging assertions and traps
+ * Portable Snippets - https://github.com/nemequ/portable-snippets
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ *   To the extent possible under law, the authors have waived all
+ *   copyright and related or neighboring rights to this code.  For
+ *   details, see the Creative Commons Zero 1.0 Universal license at
+ *   https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+#if !defined(PSNIP_DEBUG_TRAP_H)
+#define PSNIP_DEBUG_TRAP_H
+
+#if !defined(PSNIP_NDEBUG) && defined(NDEBUG) && !defined(PSNIP_DEBUG)
+#  define PSNIP_NDEBUG 1
+#endif
+
+#if defined(__has_builtin) && !defined(__ibmxl__)
+#  if __has_builtin(__builtin_debugtrap)
+#    define psnip_trap() __builtin_debugtrap()
+#  elif __has_builtin(__debugbreak)
+#    define psnip_trap() __debugbreak()
+#  endif
+#endif
+#if !defined(psnip_trap)
+#  if defined(_MSC_VER) || defined(__INTEL_COMPILER)
+#    define psnip_trap() __debugbreak()
+#  elif defined(__ARMCC_VERSION)
+#    define psnip_trap() __breakpoint(42)
+#  elif defined(__ibmxl__) || defined(__xlC__)
+#    include <builtins.h>
+#    define psnip_trap() __trap(42)
+#  elif defined(__DMC__) && defined(_M_IX86)
+     static inline void psnip_trap(void) { __asm int 3h; }
+#  elif defined(__i386__) || defined(__x86_64__)
+     static inline void psnip_trap(void) { __asm__ __volatile__("int $03"); }
+#  elif defined(__thumb__)
+     static inline void psnip_trap(void) { __asm__ __volatile__(".inst 0xde01"); }
+#  elif defined(__aarch64__)
+     static inline void psnip_trap(void) { __asm__ __volatile__(".inst 0xd4200000"); }
+#  elif defined(__arm__)
+     static inline void psnip_trap(void) { __asm__ __volatile__(".inst 0xe7f001f0"); }
+#  elif defined (__alpha__) && !defined(__osf__)
+     static inline void psnip_trap(void) { __asm__ __volatile__("bpt"); }
+#  elif defined(_54_)
+     static inline void psnip_trap(void) { __asm__ __volatile__("ESTOP"); }
+#  elif defined(_55_)
+     static inline void psnip_trap(void) { __asm__ __volatile__(";\n .if (.MNEMONIC)\n ESTOP_1\n .else\n ESTOP_1()\n .endif\n NOP"); }
+#  elif defined(_64P_)
+     static inline void psnip_trap(void) { __asm__ __volatile__("SWBP 0"); }
+#  elif defined(_6x_)
+     static inline void psnip_trap(void) { __asm__ __volatile__("NOP\n .word 0x10000000"); }
+#  elif defined(__STDC_HOSTED__) && (__STDC_HOSTED__ == 0) && defined(__GNUC__)
+#    define psnip_trap() __builtin_trap()
+#  else
+#    include <signal.h>
+#    if defined(SIGTRAP)
+#      define psnip_trap() raise(SIGTRAP)
+#    else
+#      define psnip_trap() raise(SIGABRT)
+#    endif
+#  endif
+#endif
+
+#if defined(HEDLEY_LIKELY)
+#  define PSNIP_DBG_LIKELY(expr) HEDLEY_LIKELY(expr)
+#elif defined(__GNUC__) && (__GNUC__ >= 3)
+#  define PSNIP_DBG_LIKELY(expr) __builtin_expect(!!(expr), 1)
+#else
+#  define PSNIP_DBG_LIKELY(expr) (!!(expr))
+#endif
+
+#if !defined(PSNIP_NDEBUG) || (PSNIP_NDEBUG == 0)
+#  define psnip_dbg_assert(expr) do { \
+    if (!PSNIP_DBG_LIKELY(expr)) { \
+      psnip_trap(); \
+    } \
+  } while (0)
+#else
+#  define psnip_dbg_assert(expr)
+#endif
+
+#endif /* !defined(PSNIP_DEBUG_TRAP_H) */

--- a/cpp/src/parquet/level_conversion_inc.h
+++ b/cpp/src/parquet/level_conversion_inc.h
@@ -333,7 +333,7 @@ void DefLevelsToBitmapSimd(const int16_t* def_levels, int64_t num_def_levels,
   ::arrow::internal::FirstTimeBitmapWriter writer(
       output->valid_bits,
       /*start_offset=*/output->valid_bits_offset,
-      /*length=*/num_def_levels);
+      /*length=*/output->values_read_upper_bound);
   int64_t set_count = 0;
   output->values_read = 0;
   int64_t values_read_remaining = output->values_read_upper_bound;

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -19,6 +19,7 @@
 
 from pyarrow.includes.common cimport *
 
+
 cdef extern from "arrow/util/key_value_metadata.h" namespace "arrow" nogil:
     cdef cppclass CKeyValueMetadata" arrow::KeyValueMetadata":
         CKeyValueMetadata()

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -17,17 +17,26 @@
 
 import contextlib
 import os
+import signal
 import subprocess
 import sys
 import weakref
 
 import pyarrow as pa
 
+import pytest
+
 
 possible_backends = ["system", "jemalloc", "mimalloc"]
 
 should_have_jemalloc = sys.platform == "linux"
 should_have_mimalloc = sys.platform == "win32"
+
+
+def supported_factories():
+    yield pa.default_memory_pool
+    for backend in pa.supported_memory_backends():
+        yield getattr(pa, f"{backend}_memory_pool")
 
 
 @contextlib.contextmanager
@@ -169,3 +178,63 @@ def test_supported_memory_backends():
         assert "jemalloc" in backends
     if should_have_mimalloc:
         assert "mimalloc" in backends
+
+
+def run_debug_memory_pool(pool_factory, env_value):
+    """
+    Run a piece of code making an invalid memory write with the
+    ARROW_DEBUG_MEMORY_POOL environment variable set to a specific value.
+    """
+    code = f"""if 1:
+        import ctypes
+        import pyarrow as pa
+
+        pool = pa.{pool_factory}()
+        buf = pa.allocate_buffer(64, memory_pool=pool)
+
+        # Write memory out of bounds
+        ptr = ctypes.cast(buf.address, ctypes.POINTER(ctypes.c_ubyte))
+        ptr[64] = 0
+
+        del buf
+        """
+    env = dict(os.environ)
+    env['ARROW_DEBUG_MEMORY_POOL'] = env_value
+    res = subprocess.run([sys.executable, "-c", code], env=env,
+                         universal_newlines=True, stderr=subprocess.PIPE)
+    print(res.stderr, file=sys.stderr)
+    return res
+
+
+@pytest.mark.parametrize('pool_factory', supported_factories())
+def test_debug_memory_pool_abort(pool_factory):
+    res = run_debug_memory_pool(pool_factory.__name__, "abort")
+    if os.name == "posix":
+        assert res.returncode == -signal.SIGABRT
+    else:
+        assert res.returncode != 0
+    assert "Wrong size on deallocation" in res.stderr
+
+
+@pytest.mark.parametrize('pool_factory', supported_factories())
+def test_debug_memory_pool_trap(pool_factory):
+    res = run_debug_memory_pool(pool_factory.__name__, "trap")
+    if os.name == "posix":
+        assert res.returncode == -signal.SIGTRAP
+    else:
+        assert res.returncode != 0
+    assert "Wrong size on deallocation" in res.stderr
+
+
+@pytest.mark.parametrize('pool_factory', supported_factories())
+def test_debug_memory_pool_warn(pool_factory):
+    res = run_debug_memory_pool(pool_factory.__name__, "warn")
+    res.check_returncode()
+    assert "Wrong size on deallocation" in res.stderr
+
+
+@pytest.mark.parametrize('pool_factory', supported_factories())
+def test_debug_memory_pool_disabled(pool_factory):
+    res = run_debug_memory_pool(pool_factory.__name__, "")
+    res.check_returncode()
+    assert res.stderr == ""


### PR DESCRIPTION
Debug memory checks can be enabled by setting the environment variable ARROW_DEBUG_MEMORY_POOL
to one of the recognized values "abort", "trap" or "warn" (regardless of whether Arrow
was compiled in debug or release mode).

The only implemented check adds a suffix past the allocation and checks that it isn't clobbered on deallocation.
Adding a prefix would be more expensive because of alignment constraints.

Also add a fix by Will Jones for ARROW-14047 (Parquet Arrow reader sets null values in buffer overflow), since otherwise CI would fail.