### PR TITLE
ARROW-15569: [Packaging][deb] Use gem instead of apt to install gobject-introspection gem

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -158,7 +158,7 @@ echo "::group::Test Apache Arrow GLib"
 ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
-${APT_INSTALL} ruby-rubygems
+${APT_INSTALL} ruby-dev ruby-rubygems
 gem install gobject-introspection
 ruby -r gi -e "p GI.load('Arrow')"
 echo "::endgroup::"

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -158,6 +158,7 @@ echo "::group::Test Apache Arrow GLib"
 ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
+${APT_INSTALL} ruby-rubygems
 gem install gobject-introspection
 ruby -r gi -e "p GI.load('Arrow')"
 echo "::endgroup::"

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -158,8 +158,8 @@ echo "::group::Test Apache Arrow GLib"
 ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
-${APT_INSTALL} ruby-gobject-introspection
-ruby -r gobject-introspection -e "p GObjectIntrospection.load('Arrow')"
+gem install gobject-introspection
+ruby -r gi -e "p GI.load('Arrow')"
 echo "::endgroup::"
 
 
@@ -167,7 +167,7 @@ if [ "${have_flight}" = "yes" ]; then
   echo "::group::Test Apache Arrow Flight"
   ${APT_INSTALL} libarrow-flight-glib-dev=${package_version}
   ${APT_INSTALL} libarrow-flight-glib-doc=${package_version}
-  ruby -r gobject-introspection -e "p GObjectIntrospection.load('ArrowFlight')"
+  ruby -r gi -e "p GI.load('ArrowFlight')"
   echo "::endgroup::"
 fi
 
@@ -182,7 +182,7 @@ if [ "${have_plasma}" = "yes" ]; then
   ${APT_INSTALL} libplasma-glib-dev=${package_version}
   ${APT_INSTALL} libplasma-glib-doc=${package_version}
   ${APT_INSTALL} plasma-store-server=${package_version}
-  ruby -r gobject-introspection -e "p GObjectIntrospection.load('Plasma')"
+  ruby -r gi -e "p GI.load('Plasma')"
   echo "::endgroup::"
 fi
 
@@ -190,19 +190,19 @@ fi
 echo "::group::Test Gandiva"
 ${APT_INSTALL} libgandiva-glib-dev=${package_version}
 ${APT_INSTALL} libgandiva-glib-doc=${package_version}
-ruby -r gobject-introspection -e "p GObjectIntrospection.load('Gandiva')"
+ruby -r gi -e "p GI.load('Gandiva')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Parquet"
 ${APT_INSTALL} libparquet-glib-dev=${package_version}
 ${APT_INSTALL} libparquet-glib-doc=${package_version}
-ruby -r gobject-introspection -e "p GObjectIntrospection.load('Parquet')"
+ruby -r gi -e "p GI.load('Parquet')"
 echo "::endgroup::"
 
 
 echo "::group::Test Apache Arrow Dataset"
 ${APT_INSTALL} libarrow-dataset-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-dataset-glib-doc=${package_version}
-ruby -r gobject-introspection -e "p GObjectIntrospection.load('ArrowDataset')"
+ruby -r gi -e "p GI.load('ArrowDataset')"
 echo "::endgroup::"

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -158,7 +158,7 @@ echo "::group::Test Apache Arrow GLib"
 ${APT_INSTALL} libarrow-glib-dev=${package_version}
 ${APT_INSTALL} libarrow-glib-doc=${package_version}
 
-${APT_INSTALL} ruby-dev ruby-rubygems
+${APT_INSTALL} ruby-dev rubygems-integration
 gem install gobject-introspection
 ruby -r gi -e "p GI.load('Arrow')"
 echo "::endgroup::"


### PR DESCRIPTION
It seems that ruby-gobject-introspection package was removed from
Debian GNU/Linux bookwarm:

https://github.com/ursacomputing/crossbow/runs/5062773703?check_suite_focus=true#step:10:1910

    + apt install -y -V --no-install-recommends ruby-gobject-introspection

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

    Reading package lists...
    Building dependency tree...
    Reading state information...
    Package ruby-gobject-introspection is not available, but is referred to by another package.
    This may mean that the package is missing, has been obsoleted, or
    is only available from another source

    E: Package 'ruby-gobject-introspection' has no installation candidate