### PR TITLE
ARROW-14908: [C++][R] Dataset hash join segfaults on Windows

### DIFF
--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -103,7 +103,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
     filter_ = std::move(filter);
     output_batch_callback_ = std::move(output_batch_callback);
     finished_callback_ = std::move(finished_callback);
-    local_states_.resize(num_threads);
+    local_states_.resize(num_threads + 1);  // +1 for calling thread + worker thread
     for (size_t i = 0; i < local_states_.size(); ++i) {
       local_states_[i].is_initialized = false;
       local_states_[i].is_has_match_initialized = false;

--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -151,6 +151,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
   }
 
   void InitLocalStateIfNeeded(size_t thread_index) {
+    DCHECK_LT(thread_index, local_states_.size());
     ThreadLocalState& local_state = local_states_[thread_index];
     if (!local_state.is_initialized) {
       InitEncoder(0, HashJoinProjection::KEY, &local_state.exec_batch_keys);

--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -103,7 +103,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
     filter_ = std::move(filter);
     output_batch_callback_ = std::move(output_batch_callback);
     finished_callback_ = std::move(finished_callback);
-    local_states_.resize(num_threads + 1);  // +1 for calling thread + worker thread
+    local_states_.resize(num_threads + 1);  // +1 for calling thread + worker threads
     for (size_t i = 0; i < local_states_.size(); ++i) {
       local_states_[i].is_initialized = false;
       local_states_[i].is_has_match_initialized = false;

--- a/cpp/src/arrow/compute/exec/hash_join_dict.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_dict.cc
@@ -566,7 +566,7 @@ Status HashJoinDictBuildMulti::PostDecode(
 }
 
 void HashJoinDictProbeMulti::Init(size_t num_threads) {
-  local_states_.resize(num_threads + 1); // +1 for calling thread + worker thread
+  local_states_.resize(num_threads + 1);  // +1 for calling thread + worker thread
   for (size_t i = 0; i < local_states_.size(); ++i) {
     local_states_[i].is_initialized = false;
   }

--- a/cpp/src/arrow/compute/exec/hash_join_dict.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_dict.cc
@@ -566,7 +566,7 @@ Status HashJoinDictBuildMulti::PostDecode(
 }
 
 void HashJoinDictProbeMulti::Init(size_t num_threads) {
-  local_states_.resize(num_threads);
+  local_states_.resize(num_threads + 1); // +1 for calling thread + worker thread
   for (size_t i = 0; i < local_states_.size(); ++i) {
     local_states_[i].is_initialized = false;
   }

--- a/cpp/src/arrow/compute/exec/hash_join_dict.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_dict.cc
@@ -566,7 +566,7 @@ Status HashJoinDictBuildMulti::PostDecode(
 }
 
 void HashJoinDictProbeMulti::Init(size_t num_threads) {
-  local_states_.resize(num_threads + 1);  // +1 for calling thread + worker thread
+  local_states_.resize(num_threads + 1);  // +1 for calling thread + worker threads
   for (size_t i = 0; i < local_states_.size(); ++i) {
     local_states_[i].is_initialized = false;
   }

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -253,20 +253,19 @@ test_that("arrow dplyr query correctly filters then joins", {
 
 test_that("arrow dplyr query can join with tibble", {
   # ARROW-14908
-  existing_use_threads <- getOption("arrow.use_threads")
-  options(arrow.use_threads = FALSE)
   dir_out <- tempdir()
-
-  # Note: Species is a DictionaryArray, but this still fails even if we convert to StringArray.
   write_dataset(iris, file.path(dir_out, "iris"))
-  species_codes <- data.frame(Species = c("setosa", "versicolor", "virginica"),
-                              code = c("SET", "VER", "VIR"))
+  species_codes <- data.frame(
+    Species = c("setosa", "versicolor", "virginica"),
+    code = c("SET", "VER", "VIR")
+  )
 
-  iris <- open_dataset(file.path(dir_out, "iris"))
-
-  res <- left_join(iris, species_codes) %>% collect() # We should not segfault here.
-  expect_equal(nrow(res), 150)
-
-  # Reset
-  options(arrow.use_threads = existing_use_threads)
+  withr::with_options(
+    list(arrow.use_threads = FALSE),
+    {
+      iris <- open_dataset(file.path(dir_out, "iris"))
+      res <- left_join(iris, species_codes) %>% collect() # We should not segfault here.
+      expect_equal(nrow(res), 150)
+    }
+  )
 })

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -249,3 +249,17 @@ test_that("arrow dplyr query correctly filters then joins", {
     )
   )
 })
+
+
+test_that("arrow dplyr query can join with tibble", {
+  # ARROW-14908
+  dir_out <- tempdir()
+
+  write_dataset(iris, file.path(dir_out, "iris"))
+  species_codes <- data.frame(Species = c("setosa", "versicolor", "virginica"),
+                              code = c("SET", "VER", "VIR"))
+
+  iris <- open_dataset(file.path(dir_out, "iris"))
+
+  left_join(iris, species_codes) %>% collect()
+})

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -265,7 +265,7 @@ test_that("arrow dplyr query can join with tibble", {
   iris <- open_dataset(file.path(dir_out, "iris"))
 
   res <- left_join(iris, species_codes) %>% collect() # We should not segfault here.
-  expect_equal(nrow(res), 150) 
+  expect_equal(nrow(res), 150)
 
   # Reset
   options(arrow.use_threads = existing_use_threads)

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -264,7 +264,8 @@ test_that("arrow dplyr query can join with tibble", {
 
   iris <- open_dataset(file.path(dir_out, "iris"))
 
-  left_join(iris, species_codes) %>% collect()
+  res <- left_join(iris, species_codes) %>% collect() # We should not segfault here.
+  expect_equal(nrow(res), 150) 
 
   # Reset
   options(arrow.use_threads = existing_use_threads)

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -253,8 +253,11 @@ test_that("arrow dplyr query correctly filters then joins", {
 
 test_that("arrow dplyr query can join with tibble", {
   # ARROW-14908
+  existing_use_threads <- getOption("arrow.use_threads")
+  options(arrow.use_threads = FALSE)
   dir_out <- tempdir()
 
+  # Note: Species is a DictionaryArray, but this still fails even if we convert to StringArray.
   write_dataset(iris, file.path(dir_out, "iris"))
   species_codes <- data.frame(Species = c("setosa", "versicolor", "virginica"),
                               code = c("SET", "VER", "VIR"))
@@ -262,4 +265,7 @@ test_that("arrow dplyr query can join with tibble", {
   iris <- open_dataset(file.path(dir_out, "iris"))
 
   left_join(iris, species_codes) %>% collect()
+
+  # Reset
+  options(arrow.use_threads = existing_use_threads)
 })


### PR DESCRIPTION
Test failure on my branch: https://github.com/wjones127/arrow/runs/5068285944?check_suite_focus=true#step:18:27831

~This only fails on Windows~. On any platform, when `USE_THREADS = FALSE` we cannot execute an exec plan that joins after scanning from a dataset.

The source node executes the `InputRecieved()` callback in the IO thread, while the HashJoin wasn't anticipating another thread if executor is null (which `USE_THREADS=FALSE` sets). This PR adds one to the thread local state vector size to anticipate this case of 1 main thread + 1 IO thread.