### PR TITLE
ARROW-15579: [C++] Add MemoryManager::CopyBuffer(const Buffer&)

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -126,6 +126,11 @@ Result<std::shared_ptr<Buffer>> Buffer::Copy(std::shared_ptr<Buffer> source,
   return MemoryManager::CopyBuffer(source, to);
 }
 
+Result<std::unique_ptr<Buffer>> Buffer::Copy(const Buffer& source,
+                                             const std::shared_ptr<MemoryManager>& to) {
+  return MemoryManager::CopyBuffer(source, to);
+}
+
 Result<std::shared_ptr<Buffer>> Buffer::View(std::shared_ptr<Buffer> source,
                                              const std::shared_ptr<MemoryManager>& to) {
   return MemoryManager::ViewBuffer(source, to);

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -128,7 +128,7 @@ Result<std::shared_ptr<Buffer>> Buffer::Copy(std::shared_ptr<Buffer> source,
 
 Result<std::unique_ptr<Buffer>> Buffer::Copy(const Buffer& source,
                                              const std::shared_ptr<MemoryManager>& to) {
-  return MemoryManager::CopyMemory(source, to);
+  return MemoryManager::CopyBufferRef(source, to);
 }
 
 Result<std::shared_ptr<Buffer>> Buffer::View(std::shared_ptr<Buffer> source,

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -128,7 +128,7 @@ Result<std::shared_ptr<Buffer>> Buffer::Copy(std::shared_ptr<Buffer> source,
 
 Result<std::unique_ptr<Buffer>> Buffer::Copy(const Buffer& source,
                                              const std::shared_ptr<MemoryManager>& to) {
-  return MemoryManager::CopyBuffer(source, to);
+  return MemoryManager::CopyMemory(source, to);
 }
 
 Result<std::shared_ptr<Buffer>> Buffer::View(std::shared_ptr<Buffer> source,

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -126,9 +126,9 @@ Result<std::shared_ptr<Buffer>> Buffer::Copy(std::shared_ptr<Buffer> source,
   return MemoryManager::CopyBuffer(source, to);
 }
 
-Result<std::unique_ptr<Buffer>> Buffer::Copy(const Buffer& source,
-                                             const std::shared_ptr<MemoryManager>& to) {
-  return MemoryManager::CopyBufferRef(source, to);
+Result<std::unique_ptr<Buffer>> Buffer::CopyNonOwned(
+    const Buffer& source, const std::shared_ptr<MemoryManager>& to) {
+  return MemoryManager::CopyNonOwned(source, to);
 }
 
 Result<std::shared_ptr<Buffer>> Buffer::View(std::shared_ptr<Buffer> source,

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -256,8 +256,11 @@ class ARROW_EXPORT Buffer {
                                               const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Copy a non-owned buffer
-  static Result<std::unique_ptr<Buffer>> Copy(const Buffer& source,
-                                              const std::shared_ptr<MemoryManager>& to);
+  ///
+  /// This is useful for cases where the source memory area is externally managed
+  /// (its lifetime not tied to the source Buffer), otherwise please use Copy().
+  static Result<std::unique_ptr<Buffer>> CopyNonOwned(
+      const Buffer& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief View buffer
   ///

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -255,6 +255,10 @@ class ARROW_EXPORT Buffer {
   static Result<std::shared_ptr<Buffer>> Copy(std::shared_ptr<Buffer> source,
                                               const std::shared_ptr<MemoryManager>& to);
 
+  /// \brief Copy buffer
+  static Result<std::unique_ptr<Buffer>> Copy(const Buffer& source,
+                                              const std::shared_ptr<MemoryManager>& to);
+
   /// \brief View buffer
   ///
   /// Return a Buffer that reflects this buffer, seen potentially from another

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -255,7 +255,7 @@ class ARROW_EXPORT Buffer {
   static Result<std::shared_ptr<Buffer>> Copy(std::shared_ptr<Buffer> source,
                                               const std::shared_ptr<MemoryManager>& to);
 
-  /// \brief Copy buffer
+  /// \brief Copy a non-owned buffer
   static Result<std::unique_ptr<Buffer>> Copy(const Buffer& source,
                                               const std::shared_ptr<MemoryManager>& to);
 

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -159,8 +159,8 @@ Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferFrom(
   if (from->is_cpu()) {
     // CPU to MyDevice:
     // 1. CPU to CPU
-    ARROW_ASSIGN_OR_RAISE(auto dest,
-                          MemoryManager::CopyMemory(buf, default_cpu_memory_manager()));
+    ARROW_ASSIGN_OR_RAISE(
+        auto dest, MemoryManager::CopyBufferRef(buf, default_cpu_memory_manager()));
     // 2. Wrap CPU buffer result
     return internal::make_unique<MyBuffer>(shared_from_this(), std::move(dest));
   }
@@ -174,7 +174,7 @@ Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferTo(
   }
   if (to->is_cpu() && buf.parent()) {
     // MyDevice to CPU
-    return MemoryManager::CopyMemory(*buf.parent(), to);
+    return MemoryManager::CopyBufferRef(*buf.parent(), to);
   }
   return nullptr;
 }
@@ -260,7 +260,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*cpu_src_, cpu_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBufferRef(*cpu_src_, cpu_mm_));
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
@@ -277,7 +277,7 @@ TEST_F(TestDevice, Copy) {
 #endif
   AssertMyBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*cpu_src_, my_copy_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBufferRef(*cpu_src_, my_copy_mm_));
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
@@ -294,7 +294,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*my_copy_src_, cpu_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBufferRef(*my_copy_src_, cpu_mm_));
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -34,6 +34,7 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/make_unique.h"
 
 namespace arrow {
 
@@ -115,6 +116,10 @@ class MyMemoryManager : public MemoryManager {
   Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& to) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferTo(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& to) override;
   Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& from) override;
@@ -138,6 +143,16 @@ std::shared_ptr<MemoryManager> MyDevice::default_memory_manager() {
 
 Result<std::shared_ptr<Buffer>> MyMemoryManager::CopyBufferFrom(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from) {
+  return CopyBufferFrom(*buf, from);
+}
+
+Result<std::shared_ptr<Buffer>> MyMemoryManager::CopyBufferTo(
+    const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to) {
+  return CopyBufferTo(*buf, to);
+}
+
+Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferFrom(
+    const Buffer& buf, const std::shared_ptr<MemoryManager>& from) {
   if (!allow_copy()) {
     return nullptr;
   }
@@ -147,19 +162,19 @@ Result<std::shared_ptr<Buffer>> MyMemoryManager::CopyBufferFrom(
     ARROW_ASSIGN_OR_RAISE(auto dest,
                           MemoryManager::CopyBuffer(buf, default_cpu_memory_manager()));
     // 2. Wrap CPU buffer result
-    return std::make_shared<MyBuffer>(shared_from_this(), dest);
+    return internal::make_unique<MyBuffer>(shared_from_this(), std::move(dest));
   }
   return nullptr;
 }
 
-Result<std::shared_ptr<Buffer>> MyMemoryManager::CopyBufferTo(
-    const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to) {
+Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferTo(
+    const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   if (!allow_copy()) {
     return nullptr;
   }
-  if (to->is_cpu() && buf->parent()) {
+  if (to->is_cpu() && buf.parent()) {
     // MyDevice to CPU
-    return MemoryManager::CopyBuffer(buf->parent(), to);
+    return MemoryManager::CopyBuffer(*buf.parent(), to);
   }
   return nullptr;
 }
@@ -245,6 +260,13 @@ TEST_F(TestDevice, Copy) {
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*cpu_src_, cpu_mm_));
+  ASSERT_EQ(buffer->device(), cpu_device_);
+  ASSERT_TRUE(buffer->is_cpu());
+  ASSERT_NE(buffer->address(), cpu_src_->address());
+  ASSERT_NE(buffer->data(), nullptr);
+  AssertBufferEqual(*buffer, "some data");
+
   // CPU-to-device
   ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(cpu_src_, my_copy_mm_));
   ASSERT_EQ(buffer->device(), my_copy_device_);
@@ -255,8 +277,24 @@ TEST_F(TestDevice, Copy) {
 #endif
   AssertMyBufferEqual(*buffer, "some data");
 
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*cpu_src_, my_copy_mm_));
+  ASSERT_EQ(buffer->device(), my_copy_device_);
+  ASSERT_FALSE(buffer->is_cpu());
+  ASSERT_NE(buffer->address(), cpu_src_->address());
+#ifdef NDEBUG
+  ASSERT_EQ(buffer->data(), nullptr);
+#endif
+  AssertMyBufferEqual(*buffer, "some data");
+
   // Device-to-CPU
   ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(my_copy_src_, cpu_mm_));
+  ASSERT_EQ(buffer->device(), cpu_device_);
+  ASSERT_TRUE(buffer->is_cpu());
+  ASSERT_NE(buffer->address(), my_copy_src_->address());
+  ASSERT_NE(buffer->data(), nullptr);
+  AssertBufferEqual(*buffer, "some data");
+
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*my_copy_src_, cpu_mm_));
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -160,7 +160,7 @@ Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferFrom(
     // CPU to MyDevice:
     // 1. CPU to CPU
     ARROW_ASSIGN_OR_RAISE(auto dest,
-                          MemoryManager::CopyBuffer(buf, default_cpu_memory_manager()));
+                          MemoryManager::CopyMemory(buf, default_cpu_memory_manager()));
     // 2. Wrap CPU buffer result
     return internal::make_unique<MyBuffer>(shared_from_this(), std::move(dest));
   }
@@ -174,7 +174,7 @@ Result<std::unique_ptr<Buffer>> MyMemoryManager::CopyBufferTo(
   }
   if (to->is_cpu() && buf.parent()) {
     // MyDevice to CPU
-    return MemoryManager::CopyBuffer(*buf.parent(), to);
+    return MemoryManager::CopyMemory(*buf.parent(), to);
   }
   return nullptr;
 }
@@ -260,7 +260,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*cpu_src_, cpu_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*cpu_src_, cpu_mm_));
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
@@ -277,7 +277,7 @@ TEST_F(TestDevice, Copy) {
 #endif
   AssertMyBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*cpu_src_, my_copy_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*cpu_src_, my_copy_mm_));
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
@@ -294,7 +294,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
-  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyBuffer(*my_copy_src_, cpu_mm_));
+  ASSERT_OK_AND_ASSIGN(buffer, MemoryManager::CopyMemory(*my_copy_src_, cpu_mm_));
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -74,7 +74,7 @@ Result<std::shared_ptr<Buffer>> MemoryManager::CopyBuffer(
                                 " to ", to->device()->ToString(), " not supported");
 }
 
-Result<std::unique_ptr<Buffer>> MemoryManager::CopyMemory(
+Result<std::unique_ptr<Buffer>> MemoryManager::CopyBufferRef(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   const auto& from = buf.memory_manager();
   auto maybe_buffer = to->CopyBufferFrom(buf, from);

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -74,7 +74,7 @@ Result<std::shared_ptr<Buffer>> MemoryManager::CopyBuffer(
                                 " to ", to->device()->ToString(), " not supported");
 }
 
-Result<std::unique_ptr<Buffer>> MemoryManager::CopyBuffer(
+Result<std::unique_ptr<Buffer>> MemoryManager::CopyMemory(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   const auto& from = buf.memory_manager();
   auto maybe_buffer = to->CopyBufferFrom(buf, from);

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -74,13 +74,13 @@ Result<std::shared_ptr<Buffer>> MemoryManager::CopyBuffer(
                                 " to ", to->device()->ToString(), " not supported");
 }
 
-Result<std::unique_ptr<Buffer>> MemoryManager::CopyBufferRef(
+Result<std::unique_ptr<Buffer>> MemoryManager::CopyNonOwned(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   const auto& from = buf.memory_manager();
-  auto maybe_buffer = to->CopyBufferFrom(buf, from);
+  auto maybe_buffer = to->CopyNonOwnedFrom(buf, from);
   COPY_BUFFER_RETURN(maybe_buffer, to);
   // `to` doesn't support copying from `from`, try the other way
-  maybe_buffer = from->CopyBufferTo(buf, to);
+  maybe_buffer = from->CopyNonOwnedTo(buf, to);
   COPY_BUFFER_RETURN(maybe_buffer, to);
 
   return Status::NotImplemented("Copying buffer from ", from->device()->ToString(),
@@ -116,12 +116,12 @@ Result<std::shared_ptr<Buffer>> MemoryManager::CopyBufferTo(
   return nullptr;
 }
 
-Result<std::unique_ptr<Buffer>> MemoryManager::CopyBufferFrom(
+Result<std::unique_ptr<Buffer>> MemoryManager::CopyNonOwnedFrom(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& from) {
   return nullptr;
 }
 
-Result<std::unique_ptr<Buffer>> MemoryManager::CopyBufferTo(
+Result<std::unique_ptr<Buffer>> MemoryManager::CopyNonOwnedTo(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   return nullptr;
 }
@@ -164,10 +164,10 @@ Result<std::unique_ptr<Buffer>> CPUMemoryManager::AllocateBuffer(int64_t size) {
 
 Result<std::shared_ptr<Buffer>> CPUMemoryManager::CopyBufferFrom(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from) {
-  return CopyBufferFrom(*buf, from);
+  return CopyNonOwnedFrom(*buf, from);
 }
 
-Result<std::unique_ptr<Buffer>> CPUMemoryManager::CopyBufferFrom(
+Result<std::unique_ptr<Buffer>> CPUMemoryManager::CopyNonOwnedFrom(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& from) {
   if (!from->is_cpu()) {
     return nullptr;
@@ -189,10 +189,10 @@ Result<std::shared_ptr<Buffer>> CPUMemoryManager::ViewBufferFrom(
 
 Result<std::shared_ptr<Buffer>> CPUMemoryManager::CopyBufferTo(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to) {
-  return CopyBufferTo(*buf, to);
+  return CopyNonOwnedTo(*buf, to);
 }
 
-Result<std::unique_ptr<Buffer>> CPUMemoryManager::CopyBufferTo(
+Result<std::unique_ptr<Buffer>> CPUMemoryManager::CopyNonOwnedTo(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   if (!to->is_cpu()) {
     return nullptr;

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -126,7 +126,10 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Copy a non-owned Buffer to a destination MemoryManager
-  static Result<std::unique_ptr<Buffer>> CopyBufferRef(
+  ///
+  /// This is useful for cases where the source memory area is externally managed
+  /// (its lifetime not tied to the source Buffer), otherwise please use CopyBuffer().
+  static Result<std::unique_ptr<Buffer>> CopyNonOwned(
       const Buffer& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Make a no-copy Buffer view in a destination MemoryManager
@@ -149,9 +152,9 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from);
   virtual Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to);
-  virtual Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+  virtual Result<std::unique_ptr<Buffer>> CopyNonOwnedFrom(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& from);
-  virtual Result<std::unique_ptr<Buffer>> CopyBufferTo(
+  virtual Result<std::unique_ptr<Buffer>> CopyNonOwnedTo(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& to);
   virtual Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from);
@@ -209,9 +212,9 @@ class ARROW_EXPORT CPUMemoryManager : public MemoryManager {
   Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& to) override;
-  Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+  Result<std::unique_ptr<Buffer>> CopyNonOwnedFrom(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override;
-  Result<std::unique_ptr<Buffer>> CopyBufferTo(
+  Result<std::unique_ptr<Buffer>> CopyNonOwnedTo(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& to) override;
   Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf,

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -125,8 +125,8 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   static Result<std::shared_ptr<Buffer>> CopyBuffer(
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
-  /// \brief Copy a Buffer to a destination MemoryManager
-  static Result<std::unique_ptr<Buffer>> CopyBuffer(
+  /// \brief Copy a non-owned Buffer to a destination MemoryManager
+  static Result<std::unique_ptr<Buffer>> CopyMemory(
       const Buffer& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Make a no-copy Buffer view in a destination MemoryManager

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -126,7 +126,7 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Copy a non-owned Buffer to a destination MemoryManager
-  static Result<std::unique_ptr<Buffer>> CopyMemory(
+  static Result<std::unique_ptr<Buffer>> CopyBufferRef(
       const Buffer& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Make a no-copy Buffer view in a destination MemoryManager

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -119,12 +119,15 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   /// The buffer will be allocated in the device's memory.
   virtual Result<std::unique_ptr<Buffer>> AllocateBuffer(int64_t size) = 0;
 
-  // XXX Should this take a `const Buffer&` instead
   /// \brief Copy a Buffer to a destination MemoryManager
   ///
   /// See also the Buffer::Copy shorthand.
   static Result<std::shared_ptr<Buffer>> CopyBuffer(
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
+
+  /// \brief Copy a Buffer to a destination MemoryManager
+  static Result<std::unique_ptr<Buffer>> CopyBuffer(
+      const Buffer& source, const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Make a no-copy Buffer view in a destination MemoryManager
   ///
@@ -146,6 +149,10 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from);
   virtual Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to);
+  virtual Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& from);
+  virtual Result<std::unique_ptr<Buffer>> CopyBufferTo(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& to);
   virtual Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from);
   virtual Result<std::shared_ptr<Buffer>> ViewBufferTo(
@@ -202,6 +209,10 @@ class ARROW_EXPORT CPUMemoryManager : public MemoryManager {
   Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& to) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferTo(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& to) override;
   Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& from) override;

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -302,14 +302,14 @@ Result<std::shared_ptr<io::RandomAccessFile>> CudaMemoryManager::GetBufferReader
         "for device ",
         buf->device()->ToString());
   }
-  return std::make_shared<CudaBufferReader>(checked_pointer_cast<CudaBuffer>(buf));
+  return std::make_shared<CudaBufferReader>(buf);
 }
 
 Result<std::shared_ptr<io::OutputStream>> CudaMemoryManager::GetBufferWriter(
     std::shared_ptr<Buffer> buf) {
   if (*buf->device() != *device_) {
     return Status::Invalid(
-        "CudaMemoryManager::GetBufferReader called on foreign buffer "
+        "CudaMemoryManager::GetBufferWriter called on foreign buffer "
         "for device ",
         buf->device()->ToString());
   }
@@ -327,13 +327,18 @@ Result<std::unique_ptr<Buffer>> CudaMemoryManager::AllocateBuffer(int64_t size) 
 
 Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to) {
+  return CopyBufferTo(*buf, to);
+}
+
+Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
+    const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   if (to->is_cpu()) {
     // Device-to-CPU copy
-    std::shared_ptr<Buffer> dest;
+    std::unique_ptr<Buffer> dest;
     ARROW_ASSIGN_OR_RAISE(auto from_context, cuda_device()->GetContext());
-    ARROW_ASSIGN_OR_RAISE(dest, to->AllocateBuffer(buf->size()));
-    RETURN_NOT_OK(from_context->CopyDeviceToHost(dest->mutable_data(), buf->address(),
-                                                 buf->size()));
+    ARROW_ASSIGN_OR_RAISE(dest, to->AllocateBuffer(buf.size()));
+    RETURN_NOT_OK(
+        from_context->CopyDeviceToHost(dest->mutable_data(), buf.address(), buf.size()));
     return dest;
   }
   return nullptr;
@@ -341,13 +346,17 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
 
 Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from) {
+  // TODO: remove these or just make them base class
+  return CopyBufferFrom(*buf, from);
+}
+
+Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
+    const Buffer& buf, const std::shared_ptr<MemoryManager>& from) {
   if (from->is_cpu()) {
     // CPU-to-device copy
     ARROW_ASSIGN_OR_RAISE(auto to_context, cuda_device()->GetContext());
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> dest,
-                          to_context->Allocate(buf->size()));
-    RETURN_NOT_OK(
-        to_context->CopyHostToDevice(dest->address(), buf->data(), buf->size()));
+    ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> dest, to_context->Allocate(buf.size()));
+    RETURN_NOT_OK(to_context->CopyHostToDevice(dest->address(), buf.data(), buf.size()));
     return dest;
   }
   if (IsCudaMemoryManager(*from)) {
@@ -356,16 +365,15 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
     ARROW_ASSIGN_OR_RAISE(
         auto from_context,
         checked_cast<const CudaMemoryManager&>(*from).cuda_device()->GetContext());
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> dest,
-                          to_context->Allocate(buf->size()));
+    ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> dest, to_context->Allocate(buf.size()));
     if (to_context->handle() == from_context->handle()) {
       // Same context
       RETURN_NOT_OK(
-          to_context->CopyDeviceToDevice(dest->address(), buf->address(), buf->size()));
+          to_context->CopyDeviceToDevice(dest->address(), buf.address(), buf.size()));
     } else {
       // Other context
       RETURN_NOT_OK(from_context->CopyDeviceToAnotherDevice(to_context, dest->address(),
-                                                            buf->address(), buf->size()));
+                                                            buf.address(), buf.size()));
     }
     return dest;
   }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -327,10 +327,10 @@ Result<std::unique_ptr<Buffer>> CudaMemoryManager::AllocateBuffer(int64_t size) 
 
 Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& to) {
-  return CopyBufferTo(*buf, to);
+  return CopyNonOwnedTo(*buf, to);
 }
 
-Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
+Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyNonOwnedTo(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& to) {
   if (to->is_cpu()) {
     // Device-to-CPU copy
@@ -347,10 +347,10 @@ Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyBufferTo(
 Result<std::shared_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
     const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from) {
   // TODO: remove these or just make them base class
-  return CopyBufferFrom(*buf, from);
+  return CopyNonOwnedFrom(*buf, from);
 }
 
-Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyBufferFrom(
+Result<std::unique_ptr<Buffer>> CudaMemoryManager::CopyNonOwnedFrom(
     const Buffer& buf, const std::shared_ptr<MemoryManager>& from) {
   if (from->is_cpu()) {
     // CPU-to-device copy

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -185,6 +185,10 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& to) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override;
+  Result<std::unique_ptr<Buffer>> CopyBufferTo(
+      const Buffer& buf, const std::shared_ptr<MemoryManager>& to) override;
   Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& from) override;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -185,9 +185,9 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   Result<std::shared_ptr<Buffer>> CopyBufferTo(
       const std::shared_ptr<Buffer>& buf,
       const std::shared_ptr<MemoryManager>& to) override;
-  Result<std::unique_ptr<Buffer>> CopyBufferFrom(
+  Result<std::unique_ptr<Buffer>> CopyNonOwnedFrom(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override;
-  Result<std::unique_ptr<Buffer>> CopyBufferTo(
+  Result<std::unique_ptr<Buffer>> CopyNonOwnedTo(
       const Buffer& buf, const std::shared_ptr<MemoryManager>& to) override;
   Result<std::shared_ptr<Buffer>> ViewBufferFrom(
       const std::shared_ptr<Buffer>& buf,

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -162,8 +162,8 @@ TEST_F(TestCudaDevice, Copy) {
   ASSERT_EQ(other_buffer->device(), device_);
   AssertCudaBufferEquals(*other_buffer, "some data");
 
-  // Copy const Buffer&
-  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::Copy(*cpu_buffer, mm_));
+  // Copy non-owned
+  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::CopyNonOwned(*cpu_buffer, mm_));
   ASSERT_EQ(other_buffer->device(), device_);
   AssertCudaBufferEquals(*other_buffer, "some data");
 
@@ -172,8 +172,8 @@ TEST_F(TestCudaDevice, Copy) {
   ASSERT_TRUE(cpu_buffer->device()->is_cpu());
   AssertBufferEqual(*cpu_buffer, "some data");
 
-  // Copy const Buffer&
-  ASSERT_OK_AND_ASSIGN(cpu_buffer, Buffer::Copy(*other_buffer, cpu_mm_));
+  // Copy non-owned
+  ASSERT_OK_AND_ASSIGN(cpu_buffer, Buffer::CopyNonOwned(*other_buffer, cpu_mm_));
   ASSERT_TRUE(cpu_buffer->device()->is_cpu());
   AssertBufferEqual(*cpu_buffer, "some data");
 
@@ -184,9 +184,9 @@ TEST_F(TestCudaDevice, Copy) {
   ASSERT_NE(other_buffer->address(), old_address);
   AssertCudaBufferEquals(*other_buffer, "some data");
 
-  // Copy const Buffer&
+  // Copy non-owned
   old_address = other_buffer->address();
-  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::Copy(*other_buffer, mm_));
+  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::CopyNonOwned(*other_buffer, mm_));
   ASSERT_EQ(other_buffer->device(), device_);
   ASSERT_NE(other_buffer->address(), old_address);
   AssertCudaBufferEquals(*other_buffer, "some data");

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -162,14 +162,31 @@ TEST_F(TestCudaDevice, Copy) {
   ASSERT_EQ(other_buffer->device(), device_);
   AssertCudaBufferEquals(*other_buffer, "some data");
 
+  // Copy const Buffer&
+  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::Copy(*cpu_buffer, mm_));
+  ASSERT_EQ(other_buffer->device(), device_);
+  AssertCudaBufferEquals(*other_buffer, "some data");
+
   // device -> CPU
   ASSERT_OK_AND_ASSIGN(cpu_buffer, Buffer::Copy(other_buffer, cpu_mm_));
   ASSERT_TRUE(cpu_buffer->device()->is_cpu());
   AssertBufferEqual(*cpu_buffer, "some data");
 
+  // Copy const Buffer&
+  ASSERT_OK_AND_ASSIGN(cpu_buffer, Buffer::Copy(*other_buffer, cpu_mm_));
+  ASSERT_TRUE(cpu_buffer->device()->is_cpu());
+  AssertBufferEqual(*cpu_buffer, "some data");
+
   // device -> device
-  const auto old_address = other_buffer->address();
+  auto old_address = other_buffer->address();
   ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::Copy(other_buffer, mm_));
+  ASSERT_EQ(other_buffer->device(), device_);
+  ASSERT_NE(other_buffer->address(), old_address);
+  AssertCudaBufferEquals(*other_buffer, "some data");
+
+  // Copy const Buffer&
+  old_address = other_buffer->address();
+  ASSERT_OK_AND_ASSIGN(other_buffer, Buffer::Copy(*other_buffer, mm_));
   ASSERT_EQ(other_buffer->device(), device_);
   ASSERT_NE(other_buffer->address(), old_address);
   AssertCudaBufferEquals(*other_buffer, "some data");


### PR DESCRIPTION
This is useful to implement, for instance, a copy from a void* (from an external API) to a buffer on a different device (the current API would require allocating a shared_ptr, and provides no way to get back a unique_ptr). Note that while we have the BufferWriter API, that also fails (because it needs ownership of the buffer to write to, and there isn't a good way to express "a temporary writer that does not have ownership of the target buffer").