### PR TITLE
ARROW-15195: [MATLAB] Enable GitHub Actions CI for MATLAB Interface on macOS

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
 
-  matlab:
+  matlab-ubuntu:
     name: AMD64 Ubuntu 20.04 MATLAB
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
@@ -49,7 +49,7 @@ jobs:
       - name: Install ninja-build
         run: sudo apt-get install ninja-build
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v0
+        uses: matlab-actions/setup-matlab@v1
       - name: Build MATLAB Interface
         run: ci/scripts/matlab_build.sh $(pwd)
       - name: Run MATLAB Tests
@@ -68,3 +68,25 @@ jobs:
         uses: matlab-actions/run-tests@v1
         with:
           select-by-folder: matlab/test
+  macos:
+    name: AMD64 MacOS 10.15 MATLAB
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository        
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install ninja-build
+        run: brew install ninja
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+      - name: Build MATLAB Interface
+        run: ci/scripts/matlab_build.sh $(pwd)
+      - name: Run MATLAB Tests
+        env:
+          # Add the installation directory to the MATLAB Search Path by
+          # setting the MATLABPATH environment variable.
+          MATLABPATH: matlab/install/arrow_matlab
+        uses: matlab-actions/run-tests@v1
+        with:
+          select-by-folder: matlab/test 

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -68,7 +68,7 @@ jobs:
         uses: matlab-actions/run-tests@v1
         with:
           select-by-folder: matlab/test
-  matlab-macos:
+  macos:
     name: AMD64 MacOS 10.15 MATLAB
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -68,7 +68,7 @@ jobs:
         uses: matlab-actions/run-tests@v1
         with:
           select-by-folder: matlab/test
-  macos:
+  matlab-macos:
     name: AMD64 MacOS 10.15 MATLAB
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
 
-  matlab-ubuntu:
+  ubuntu:
     name: AMD64 Ubuntu 20.04 MATLAB
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -71,6 +71,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 MATLAB
     runs-on: macos-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Check out repository        
         uses: actions/checkout@v2


### PR DESCRIPTION
## Overview
This Pull Request:

- Enables building of the MATLAB Interface C++ code, running of the C++ tests, and running of the MATLAB tests using GitHub Actions on a `macos-latest` VM.
- This is also updating the old version `v0` of [`matlab-actions/setup-matlab`](https://github.com/matlab-actions/setup-matlab) enabled for `ubuntu-latest` VM to the lastest `v1` [`matlab-actions/setup-matlab`](https://github.com/matlab-actions/setup-matlab).

## Implementation
This implementation uses [`matlab-actions`](https://github.com/matlab-actions) to automatically install MATLAB into a GitHub Actions Linux and Mac VM. 

We are using the most updated version: `v1` [`matlab-actions/setup-matlab`](https://github.com/matlab-actions/setup-matlab) to enable the CI for Mac. 

Here are the steps we require to build and run tests on Mac:
- Check out the repository
- Install ninja using the `brew` command
- Install MATLAB using [`matlab-actions/setup-matlab@v1`](https://github.com/matlab-actions/setup-matlab)
- Build MATLAB using the existing `matlab_build.sh` script in `ci/scripts`
- Set the `MATLABPATH` environment variable to the MATLAB Interface to Apache Arrow installation directory
- Run MATLAB tests in the folder `matlab/test` using [`matlab-actions/run-tests@v1`](https://github.com/matlab-actions/run-tests)

## Testing
1. The GitHub Actions workflows passed successfully with no errors in this [Job](https://github.com/mathworks/arrow/actions/runs/1796808254).
2. All C++ test results and MATLAB test results can be viewed in the workflow logs.

## Future Directions
Enable support for Windows: [`matlab-actions/setup-matlab@v1`](https://github.com/matlab-actions/setup-matlab) supports Windows now. We are working on enabling this for the MATLAB Arrow interface. 

## Notes

Thank you, Fiona @lafiona, for helping me with this pull request to submit the changes for `matlab.yml`.