### PR TITLE
ARROW-15080: [Python][C++] Enable tuples conversion to interval

### DIFF
--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -417,21 +417,21 @@ class PyValue {
     RETURN_NOT_OK(PopulateMonthDayNano<MonthDayNanoField::kNanoseconds>::Field(
         obj, &output.nanoseconds, &found_attrs));
 
-    // date_offset can have zero fields.    
-    if (ARROW_PREDICT_FALSE(!found_attrs) && !is_date_offset) {
-      if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
-        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months,
-                                               "Months (tuple item #0) too large"));
-        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days,
-                                               "Days (tuple item #1) too large"));
-        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2),
-                                               &output.nanoseconds,
-                                               "Nanoseconds (tuple item #2) too large"));
-        return output;
-      }  
-      return Status::TypeError("No temporal attributes found on object.");
+    // date_offset can have zero fields.
+    if (found_attrs || is_date_offset) {
+      return output;
     }
-    return output;
+    if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
+      RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months,
+                                             "Months (tuple item #0) too large"));
+      RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days,
+                                             "Days (tuple item #1) too large"));
+      RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2),
+                                             &output.nanoseconds,
+                                             "Nanoseconds (tuple item #2) too large"));
+      return output;
+    }
+    return Status::TypeError("No temporal attributes found on object.");
   }
 
   static Result<int64_t> Convert(const DurationType* type, const O&, I obj) {

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -416,8 +416,14 @@ class PyValue {
     }
     RETURN_NOT_OK(PopulateMonthDayNano<MonthDayNanoField::kNanoseconds>::Field(
         obj, &output.nanoseconds, &found_attrs));
-
     if (ARROW_PREDICT_FALSE(!found_attrs) && !is_date_offset) {
+       if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
+         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months, "Months (Index 0) index to large"));
+         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days, "Days (Index 1) index to large"));
+         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2), &output.nanoseconds, "Nanoseconds (Index 2) index to large"));
+         return output;
+       }
+
       // date_offset can have zero fields.
       return Status::TypeError("No temporal attributes found on object.");
     }

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -419,12 +419,12 @@ class PyValue {
     if (ARROW_PREDICT_FALSE(!found_attrs) && !is_date_offset) {
       if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months,
-                                               "Months (Index 0) index to large"));
+                                               "Months (tuple item #0) too large"));
         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days,
-                                               "Days (Index 1) index to large"));
+                                               "Days (tuple item #1) too large"));
         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2),
                                                &output.nanoseconds,
-                                               "Nanoseconds (Index 2) index to large"));
+                                               "Nanoseconds (tuple item #2) too large"));
         return output;
       }
 

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -417,12 +417,16 @@ class PyValue {
     RETURN_NOT_OK(PopulateMonthDayNano<MonthDayNanoField::kNanoseconds>::Field(
         obj, &output.nanoseconds, &found_attrs));
     if (ARROW_PREDICT_FALSE(!found_attrs) && !is_date_offset) {
-       if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
-         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months, "Months (Index 0) index to large"));
-         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days, "Days (Index 1) index to large"));
-         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2), &output.nanoseconds, "Nanoseconds (Index 2) index to large"));
-         return output;
-       }
+      if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
+        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months,
+                                               "Months (Index 0) index to large"));
+        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 1), &output.days,
+                                               "Days (Index 1) index to large"));
+        RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 2),
+                                               &output.nanoseconds,
+                                               "Nanoseconds (Index 2) index to large"));
+        return output;
+      }
 
       // date_offset can have zero fields.
       return Status::TypeError("No temporal attributes found on object.");

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -416,6 +416,8 @@ class PyValue {
     }
     RETURN_NOT_OK(PopulateMonthDayNano<MonthDayNanoField::kNanoseconds>::Field(
         obj, &output.nanoseconds, &found_attrs));
+
+    // date_offset can have zero fields.    
     if (ARROW_PREDICT_FALSE(!found_attrs) && !is_date_offset) {
       if (PyTuple_Check(obj) && PyTuple_Size(obj) == 3) {
         RETURN_NOT_OK(internal::CIntFromPython(PyTuple_GET_ITEM(obj, 0), &output.months,
@@ -426,9 +428,7 @@ class PyValue {
                                                &output.nanoseconds,
                                                "Nanoseconds (tuple item #2) too large"));
         return output;
-      }
-
-      // date_offset can have zero fields.
+      }  
       return Status::TypeError("No temporal attributes found on object.");
     }
     return output;

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -274,6 +274,8 @@ def arrays(draw, type, size=None, nullable=True):
                              max_value=max_datetime)
     elif pa.types.is_duration(ty):
         value = st.timedeltas()
+    elif pa.types.is_interval(ty):
+        value = st.timedeltas()
     elif pa.types.is_binary(ty) or pa.types.is_large_binary(ty):
         value = st.binary()
     elif pa.types.is_string(ty) or pa.types.is_large_string(ty):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2286,6 +2286,21 @@ def test_interval_array_from_relativedelta():
         pa.array([DateOffset(microseconds=((1 << 64) // 100))])
 
 
+def test_interval_array_from_tuple():
+    data = [None, (1, 2, -3)]
+
+    # From timedelta (explicit type required)
+    arr = pa.array(data, pa.month_day_nano_interval())
+    assert isinstance(arr, pa.MonthDayNanoIntervalArray)
+    assert arr.type == pa.month_day_nano_interval()
+    expected_list = [
+        None,
+        pa.MonthDayNano([1, 2, -3])]
+    expected = pa.array(expected_list)
+    assert arr.equals(expected)
+    assert arr.to_pylist() == expected_list
+
+
 @pytest.mark.pandas
 def test_interval_array_from_dateoffset():
     from pandas.tseries.offsets import DateOffset


### PR DESCRIPTION
Allows tuples to be converted to MonthDayNanoInterval
when type is explicitly specified.

Also, add missing branch for intervals to strategy.py