### PR TITLE
ARROW-15598: [C++][Gandiva] Avoid using hardcoded raw pointer addresses in generated code

### DIFF
--- a/cpp/src/gandiva/annotator.cc
+++ b/cpp/src/gandiva/annotator.cc
@@ -57,6 +57,12 @@ FieldDescriptorPtr Annotator::MakeDesc(FieldPtr field, bool is_output) {
                                            data_buffer_ptr_idx);
 }
 
+int Annotator::AddHolderPointer(void* holder) {
+  int size = static_cast<int>(holder_pointers_.size());
+  holder_pointers_.push_back(holder);
+  return size;
+}
+
 void Annotator::PrepareBuffersForField(const FieldDescriptor& desc,
                                        const arrow::ArrayData& array_data,
                                        EvalBatch* eval_batch, bool is_output) {

--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -47,6 +47,13 @@ class GANDIVA_EXPORT Annotator {
   /// Returns the index of the bitmap in the list of local bitmaps.
   int AddLocalBitMap() { return local_bitmap_count_++; }
 
+  /// Add a pointer to function holder or in holder
+  /// Returns the index of the holder in the holder_pointers vector
+  int AddHolderPointer(void* holder);
+
+  /// Return a pointer to the underlying array containing the holder pointers
+  void** GetHolderPointersArray() { return holder_pointers_.data(); }
+
   /// Prepare an eval batch for the incoming record batch.
   EvalBatchPtr PrepareEvalBatch(const arrow::RecordBatch& record_batch,
                                 const ArrayDataVector& out_vector);
@@ -76,6 +83,9 @@ class GANDIVA_EXPORT Annotator {
 
   /// vector of annotated output field descriptors.
   std::vector<FieldDescriptorPtr> out_descs_;
+
+  /// vector of pointers to function holders and in holders
+  std::vector<void*> holder_pointers_;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -52,6 +52,8 @@ class GANDIVA_EXPORT Annotator {
   int AddHolderPointer(void* holder);
 
   /// Return a pointer to the underlying array containing the holder pointers
+  /// This should only be called after expr decomposition when all the holder
+  /// pointers are added
   void** GetHolderPointersArray() { return holder_pointers_.data(); }
 
   /// Prepare an eval batch for the incoming record batch.

--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -25,8 +25,8 @@
 namespace gandiva {
 
 using EvalFunc = int (*)(uint8_t** buffers, int64_t* offsets, uint8_t** local_bitmaps,
-                         const uint8_t* selection_buffer, int64_t execution_ctx_ptr,
-                         int64_t record_count);
+                         void** holder_ptrs, const uint8_t* selection_buffer,
+                         int64_t execution_ctx_ptr, int64_t record_count);
 
 /// \brief Tracks the compiled state for one expression.
 class CompiledExpr {

--- a/cpp/src/gandiva/dex.h
+++ b/cpp/src/gandiva/dex.h
@@ -111,17 +111,19 @@ class GANDIVA_EXPORT LocalBitMapValidityDex : public Dex {
 class GANDIVA_EXPORT FuncDex : public Dex {
  public:
   FuncDex(FuncDescriptorPtr func_descriptor, const NativeFunction* native_function,
-          FunctionHolderPtr function_holder, const ValueValidityPairVector& args)
+          FunctionHolderPtr function_holder, int function_holder_idx,
+          const ValueValidityPairVector& args)
       : func_descriptor_(func_descriptor),
         native_function_(native_function),
         function_holder_(function_holder),
+        function_holder_idx_(function_holder_idx),
         args_(args) {}
 
   FuncDescriptorPtr func_descriptor() const { return func_descriptor_; }
 
   const NativeFunction* native_function() const { return native_function_; }
 
-  FunctionHolderPtr function_holder() const { return function_holder_; }
+  int get_holder_idx() const { return function_holder_idx_; }
 
   const ValueValidityPairVector& args() const { return args_; }
 
@@ -129,6 +131,7 @@ class GANDIVA_EXPORT FuncDex : public Dex {
   FuncDescriptorPtr func_descriptor_;
   const NativeFunction* native_function_;
   FunctionHolderPtr function_holder_;
+  int function_holder_idx_;
   ValueValidityPairVector args_;
 };
 
@@ -138,9 +141,10 @@ class GANDIVA_EXPORT NonNullableFuncDex : public FuncDex {
  public:
   NonNullableFuncDex(FuncDescriptorPtr func_descriptor,
                      const NativeFunction* native_function,
-                     FunctionHolderPtr function_holder,
+                     FunctionHolderPtr function_holder, int function_holder_idx,
                      const ValueValidityPairVector& args)
-      : FuncDex(func_descriptor, native_function, function_holder, args) {}
+      : FuncDex(func_descriptor, native_function, function_holder, function_holder_idx,
+                args) {}
 
   void Accept(DexVisitor& visitor) override { visitor.Visit(*this); }
 };
@@ -151,9 +155,10 @@ class GANDIVA_EXPORT NullableNeverFuncDex : public FuncDex {
  public:
   NullableNeverFuncDex(FuncDescriptorPtr func_descriptor,
                        const NativeFunction* native_function,
-                       FunctionHolderPtr function_holder,
+                       FunctionHolderPtr function_holder, int function_holder_idx,
                        const ValueValidityPairVector& args)
-      : FuncDex(func_descriptor, native_function, function_holder, args) {}
+      : FuncDex(func_descriptor, native_function, function_holder, function_holder_idx,
+                args) {}
 
   void Accept(DexVisitor& visitor) override { visitor.Visit(*this); }
 };
@@ -164,9 +169,10 @@ class GANDIVA_EXPORT NullableInternalFuncDex : public FuncDex {
  public:
   NullableInternalFuncDex(FuncDescriptorPtr func_descriptor,
                           const NativeFunction* native_function,
-                          FunctionHolderPtr function_holder,
+                          FunctionHolderPtr function_holder, int function_holder_idx,
                           const ValueValidityPairVector& args, int local_bitmap_idx)
-      : FuncDex(func_descriptor, native_function, function_holder, args),
+      : FuncDex(func_descriptor, native_function, function_holder, function_holder_idx,
+                args),
         local_bitmap_idx_(local_bitmap_idx) {}
 
   void Accept(DexVisitor& visitor) override { visitor.Visit(*this); }
@@ -296,10 +302,15 @@ class InExprDexBase : public Dex {
 
   const std::shared_ptr<InHolder<Type>>& in_holder() const { return in_holder_; }
 
+  void set_holder_idx(int holder_idx) { holder_idx_ = holder_idx; }
+
+  int get_holder_idx() const { return holder_idx_; }
+
  protected:
   ValueValidityPairVector args_;
   std::string runtime_function_;
   std::shared_ptr<InHolder<Type>> in_holder_;
+  int holder_idx_;
 };
 
 template <>
@@ -326,11 +337,16 @@ class InExprDexBase<gandiva::DecimalScalar128> : public Dex {
     return in_holder_;
   }
 
+  void set_holder_idx(int holder_idx) { holder_idx_ = holder_idx; }
+
+  int get_holder_idx() const { return holder_idx_; }
+
  protected:
   ValueValidityPairVector args_;
   std::string runtime_function_;
   std::shared_ptr<InHolder<gandiva::DecimalScalar128>> in_holder_;
   int32_t precision_, scale_;
+  int holder_idx_;
 };
 
 template <>

--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -183,6 +183,7 @@ Status ExprDecomposer::Visit(const BooleanNode& node) {
   result_ = std::make_shared<ValueValidityPair>(validity_dex, value_dex);
   return Status::OK();
 }
+
 Status ExprDecomposer::Visit(const InExpressionNode<gandiva::DecimalScalar128>& node) {
   /* decompose the children. */
   std::vector<ValueValidityPairPtr> args;
@@ -198,26 +199,40 @@ Status ExprDecomposer::Visit(const InExpressionNode<gandiva::DecimalScalar128>& 
   return Status::OK();
 }
 
-#define MAKE_VISIT_IN(ctype)                                                    \
-  Status ExprDecomposer::Visit(const InExpressionNode<ctype>& node) {           \
-    /* decompose the children. */                                               \
-    std::vector<ValueValidityPairPtr> args;                                     \
-    auto status = node.eval_expr()->Accept(*this);                              \
-    ARROW_RETURN_NOT_OK(status);                                                \
-    args.push_back(result());                                                   \
-    /* In always outputs valid results, so no validity dex */                   \
-    auto value_dex = std::make_shared<InExprDex<ctype>>(args, node.values());   \
-    int holder_idx = annotator_.AddHolderPointer(value_dex->in_holder().get()); \
-    value_dex->set_holder_idx(holder_idx);                                      \
-    result_ = std::make_shared<ValueValidityPair>(value_dex);                   \
-    return Status::OK();                                                        \
-  }
+template <typename ctype>
+Status ExprDecomposer::VisitInGeneric(const InExpressionNode<ctype>& node) {
+  /* decompose the children. */
+  std::vector<ValueValidityPairPtr> args;
+  auto status = node.eval_expr()->Accept(*this);
+  ARROW_RETURN_NOT_OK(status);
+  args.push_back(result());
+  /* In always outputs valid results, so no validity dex */
+  auto value_dex = std::make_shared<InExprDex<ctype>>(args, node.values());
+  int holder_idx = annotator_.AddHolderPointer(value_dex->in_holder().get());
+  value_dex->set_holder_idx(holder_idx);
+  result_ = std::make_shared<ValueValidityPair>(value_dex);
+  return Status::OK();
+}
 
-MAKE_VISIT_IN(int32_t);
-MAKE_VISIT_IN(int64_t);
-MAKE_VISIT_IN(float);
-MAKE_VISIT_IN(double);
-MAKE_VISIT_IN(std::string);
+Status ExprDecomposer::Visit(const InExpressionNode<int32_t>& node) {
+  return VisitInGeneric<int32_t>(node);
+}
+
+Status ExprDecomposer::Visit(const InExpressionNode<int64_t>& node) {
+  return VisitInGeneric<int64_t>(node);
+}
+
+Status ExprDecomposer::Visit(const InExpressionNode<float>& node) {
+  return VisitInGeneric<float>(node);
+}
+
+Status ExprDecomposer::Visit(const InExpressionNode<double>& node) {
+  return VisitInGeneric<double>(node);
+}
+
+Status ExprDecomposer::Visit(const InExpressionNode<std::string>& node) {
+  return VisitInGeneric<std::string>(node);
+}
 
 Status ExprDecomposer::Visit(const LiteralNode& node) {
   auto value_dex = std::make_shared<LiteralDex>(node.return_type(), node.holder());

--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -79,8 +79,10 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
 
   // Make a function holder, if required.
   std::shared_ptr<FunctionHolder> holder;
+  int holder_idx = -1;
   if (native_function->NeedsFunctionHolder()) {
     auto status = FunctionHolderRegistry::Make(desc->name(), node, &holder);
+    holder_idx = annotator_.AddHolderPointer(holder.get());
     ARROW_RETURN_NOT_OK(status);
   }
 
@@ -95,13 +97,13 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
                              decomposed->validity_exprs().end());
     }
 
-    auto value_dex =
-        std::make_shared<NonNullableFuncDex>(desc, native_function, holder, args);
+    auto value_dex = std::make_shared<NonNullableFuncDex>(desc, native_function, holder,
+                                                          holder_idx, args);
     result_ = std::make_shared<ValueValidityPair>(merged_validity, value_dex);
   } else if (native_function->result_nullable_type() == kResultNullNever) {
     // These functions always output valid results. So, no validity dex.
-    auto value_dex =
-        std::make_shared<NullableNeverFuncDex>(desc, native_function, holder, args);
+    auto value_dex = std::make_shared<NullableNeverFuncDex>(desc, native_function, holder,
+                                                            holder_idx, args);
     result_ = std::make_shared<ValueValidityPair>(value_dex);
   } else {
     DCHECK(native_function->result_nullable_type() == kResultNullInternal);
@@ -111,7 +113,7 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
     auto validity_dex = std::make_shared<LocalBitMapValidityDex>(local_bitmap_idx);
 
     auto value_dex = std::make_shared<NullableInternalFuncDex>(
-        desc, native_function, holder, args, local_bitmap_idx);
+        desc, native_function, holder, holder_idx, args, local_bitmap_idx);
     result_ = std::make_shared<ValueValidityPair>(validity_dex, value_dex);
   }
   return Status::OK();
@@ -190,21 +192,25 @@ Status ExprDecomposer::Visit(const InExpressionNode<gandiva::DecimalScalar128>& 
   /* In always outputs valid results, so no validity dex */
   auto value_dex = std::make_shared<InExprDex<gandiva::DecimalScalar128>>(
       args, node.values(), node.get_precision(), node.get_scale());
+  int holder_idx = annotator_.AddHolderPointer(value_dex->in_holder().get());
+  value_dex->set_holder_idx(holder_idx);
   result_ = std::make_shared<ValueValidityPair>(value_dex);
   return Status::OK();
 }
 
-#define MAKE_VISIT_IN(ctype)                                                  \
-  Status ExprDecomposer::Visit(const InExpressionNode<ctype>& node) {         \
-    /* decompose the children. */                                             \
-    std::vector<ValueValidityPairPtr> args;                                   \
-    auto status = node.eval_expr()->Accept(*this);                            \
-    ARROW_RETURN_NOT_OK(status);                                              \
-    args.push_back(result());                                                 \
-    /* In always outputs valid results, so no validity dex */                 \
-    auto value_dex = std::make_shared<InExprDex<ctype>>(args, node.values()); \
-    result_ = std::make_shared<ValueValidityPair>(value_dex);                 \
-    return Status::OK();                                                      \
+#define MAKE_VISIT_IN(ctype)                                                    \
+  Status ExprDecomposer::Visit(const InExpressionNode<ctype>& node) {           \
+    /* decompose the children. */                                               \
+    std::vector<ValueValidityPairPtr> args;                                     \
+    auto status = node.eval_expr()->Accept(*this);                              \
+    ARROW_RETURN_NOT_OK(status);                                                \
+    args.push_back(result());                                                   \
+    /* In always outputs valid results, so no validity dex */                   \
+    auto value_dex = std::make_shared<InExprDex<ctype>>(args, node.values());   \
+    int holder_idx = annotator_.AddHolderPointer(value_dex->in_holder().get()); \
+    value_dex->set_holder_idx(holder_idx);                                      \
+    result_ = std::make_shared<ValueValidityPair>(value_dex);                   \
+    return Status::OK();                                                        \
   }
 
 MAKE_VISIT_IN(int32_t);

--- a/cpp/src/gandiva/expr_decomposer.h
+++ b/cpp/src/gandiva/expr_decomposer.h
@@ -72,6 +72,9 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   Status Visit(const InExpressionNode<gandiva::DecimalScalar128>& node) override;
   Status Visit(const InExpressionNode<std::string>& node) override;
 
+  template <typename ctype>
+  Status VisitInGeneric(const InExpressionNode<ctype>& node);
+
   // Optimize a function node, if possible.
   const FunctionNode TryOptimize(const FunctionNode& node);
 

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -98,8 +98,9 @@ class GANDIVA_EXPORT LLVMGenerator {
    public:
     Visitor(LLVMGenerator* generator, llvm::Function* function,
             llvm::BasicBlock* entry_block, llvm::Value* arg_addrs,
-            llvm::Value* arg_local_bitmaps, std::vector<llvm::Value*> slice_offsets,
-            llvm::Value* arg_context_ptr, llvm::Value* loop_var);
+            llvm::Value* arg_local_bitmaps, llvm::Value* arg_holder_ptrs,
+            std::vector<llvm::Value*> slice_offsets, llvm::Value* arg_context_ptr,
+            llvm::Value* loop_var);
 
     void Visit(const VectorReadValidityDex& dex) override;
     void Visit(const VectorReadFixedLenValueDex& dex) override;
@@ -141,7 +142,7 @@ class GANDIVA_EXPORT LLVMGenerator {
     LValuePtr BuildValueAndValidity(const ValueValidityPair& pair);
 
     // Generate code to build the params.
-    std::vector<llvm::Value*> BuildParams(FunctionHolder* holder,
+    std::vector<llvm::Value*> BuildParams(int holder_idx,
                                           const ValueValidityPairVector& args,
                                           bool with_validity, bool with_context);
 
@@ -172,6 +173,7 @@ class GANDIVA_EXPORT LLVMGenerator {
     llvm::BasicBlock* entry_block_;
     llvm::Value* arg_addrs_;
     llvm::Value* arg_local_bitmaps_;
+    llvm::Value* arg_holder_ptrs_;
     std::vector<llvm::Value*> slice_offsets_;
     llvm::Value* arg_context_ptr_;
     llvm::Value* loop_var_;

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -75,8 +75,8 @@ TEST_F(TestLLVMGenerator, TestAdd) {
       generator->function_registry_.LookupSignature(signature);
 
   std::vector<ValueValidityPairPtr> pairs{pair0, pair1};
-  auto func_dex = std::make_shared<NonNullableFuncDex>(func_desc, native_func,
-                                                       FunctionHolderPtr(nullptr), pairs);
+  auto func_dex = std::make_shared<NonNullableFuncDex>(
+      func_desc, native_func, FunctionHolderPtr(nullptr), -1, pairs);
 
   auto field_sum = std::make_shared<arrow::Field>("out", arrow::int32());
   auto desc_sum = annotator.CheckAndAddInputFieldDescriptor(field_sum);
@@ -106,7 +106,7 @@ TEST_F(TestLLVMGenerator, TestAdd) {
       reinterpret_cast<uint8_t*>(out.data()), reinterpret_cast<uint8_t*>(&out_bitmap),
   };
   std::array<int64_t, 6> addr_offsets{0, 0, 0, 0, 0, 0};
-  eval_func(addrs.data(), addr_offsets.data(), nullptr, nullptr,
+  eval_func(addrs.data(), addr_offsets.data(), nullptr, nullptr, nullptr,
             0 /* dummy context ptr */, kNumRecords);
 
   EXPECT_THAT(out, testing::ElementsAre(6, 8, 10, 12));


### PR DESCRIPTION
This change fixes sporadic crashes that happened with certain expression when caching only the generated object code. The crash was happening because the generated code contained raw hardcoded pointer addresses during building certain expressions, and when using this cache entry during subsequent times these addresses point to then invalid memory.

This change :
* introduces an array of pointers that holds the pointers to function holders and in holders, that is filled up during the annotate stage and passed to the generated function during execution. The generated IR contains indices to this array instead of hardcoded addresses. 
* includes string literal in the generated IR as a global variable instead of a raw pointer address to the process memory.