### PR TITLE
ARROW-15552: [Doc][Format] Remove erroneous mention of base64

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -511,8 +511,7 @@ For extension arrays, the :c:member:`ArrowSchema.format` string encodes the
 metadata key ``ARROW:extension:name``  encodes the extension type name,
 and the metadata key ``ARROW:extension:metadata`` encodes the
 implementation-specific serialization of the extension type (for
-parameterized extension types).  The base64 encoding of metadata values
-ensures that any possible serialization is representable.
+parameterized extension types).
 
 The ``ArrowArray`` structure exported from an extension array simply points
 to the storage data of the extension array.


### PR DESCRIPTION
This is probably a leftover of a draft version of the C data interface which involved base64 encoding of metadata values.