### PR TITLE
MINOR: [C++] Fix Valgrind failures

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -366,6 +366,8 @@ std::string Field::ToString(bool show_metadata) const {
   return ss.str();
 }
 
+void PrintTo(const Field& field, std::ostream* os) { *os << field.ToString(); }
+
 DataType::~DataType() {}
 
 bool DataType::Equals(const DataType& other, bool check_metadata) const {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -365,6 +365,8 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   std::string ComputeFingerprint() const override;
   std::string ComputeMetadataFingerprint() const override;
 
+  ARROW_EXPORT friend void PrintTo(const Field& field, std::ostream* os);
+
   // Field name
   std::string name_;
 


### PR DESCRIPTION
Fix a "Conditional jump or move depends on uninitialised value" error when GTest tries to print a Field object.