### PR TITLE
PARQUET-2119: [C++] Fix DeltaBitPackDecoder fuzzer found issue

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2181,9 +2181,7 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
   }
 
   int GetInternal(T* buffer, int max_values) {
-    int total_value_count = static_cast<int>(std::min(
-        total_value_count_, static_cast<uint32_t>(std::numeric_limits<int>::max())));
-    max_values = std::min(max_values, total_value_count);
+    max_values = static_cast<int>(std::min<int64_t>(max_values, total_value_count_));
     DCHECK_GE(max_values, 0);
     if (max_values == 0) {
       return 0;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2427,7 +2427,7 @@ class DeltaByteArrayDecoder : public DecoderImpl,
     int suffix_read = suffix_decoder_.Decode(buffer, max_values);
     if (ARROW_PREDICT_FALSE(suffix_read != max_values)) {
       ParquetException::EofException("Read " + std::to_string(suffix_read) +
-                                     "Expecting " + std::to_string(max_values) +
+                                     ", expecting " + std::to_string(max_values) +
                                      " from suffix decoder");
     }
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2182,7 +2182,6 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
 
   int GetInternal(T* buffer, int max_values) {
     max_values = static_cast<int>(std::min<int64_t>(max_values, total_value_count_));
-    DCHECK_GE(max_values, 0);
     if (max_values == 0) {
       return 0;
     }


### PR DESCRIPTION
DeltaBitPackDecoder was using num_values_(which includes) null to compute batch size instead of total_value_count_. This lead to a failed check when comparing those counts. Changed to just use total_value_count_ and get rid of the check. Alternatively, we could throw an exception instead of the check; I think we only enter this state if the file is malformed (assuming no bugs elsewhere). 

Also modified decode arrow to check the return value of DecodeInternal; this might be pointless as its callers only compare the returned value count as a DCHECK. It might be a good idea to standardize at what stage of decoding values should be compared to expected values and the behavior when they are not equal (preferably an exception and not a check).