### PR TITLE
ARROW-15634: [C++][Packaging] Improve compilation speed for java-jars nighlty build for MacOS

### DIFF
--- a/ci/scripts/java_jni_macos_build.sh
+++ b/ci/scripts/java_jni_macos_build.sh
@@ -50,6 +50,7 @@ mkdir -p "${build_dir}"
 pushd "${build_dir}"
 
 cmake \
+  -GNinja \
   -DARROW_BOOST_USE_SHARED=OFF \
   -DARROW_BROTLI_USE_SHARED=OFF \
   -DARROW_BUILD_TESTS=${ARROW_BUILD_TESTS} \


### PR DESCRIPTION
Currently, the [script](https://github.com/apache/arrow/blob/master/ci/scripts/java_jni_macos_build.sh) that builds the C++ Arrow modules in MacOS for the java-jars nightly build uses Unix Makefiles as the CMake generator.

Changing the generator to ninja helps to speed up the compile process as it is parallel by default and has better dependency management.