### PR TITLE
ARROW-13204: [MATLAB] Update documentation for the MATLAB Interface to reflect latest CMake build system changes

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -76,8 +76,32 @@ Run the `test` function to execute the unit tests:
 >> test
 ```
 
-## Try it out
+### Install MATLAB Interface to Arrow using CMake
+After building the MATLAB Interface to Arrow, install the library by running the following command:
+``` CMake
+cmake --build build --config Release --target install
+```
+The installation process includes 
 
+Once installed, the interface's source files and libraries are relocatable, on all platforms. If the interface is relocated, then the user must manually add the new location to the [MATLAB Search Path](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+
+The following flags can be passed to the CMake generation command to configure the installation step:
+| CMake Flag                               | Default Value       | Values accepted     | Description   |
+| ---------------------------------------- | ------------------- | ---------------------------------------------- | ------------- |
+| `CMAKE_INSTALL_PREFIX`                   | platform dependent  | A path to any directory with write permissions | The location that the MATLAB Interface to Arrow will be installed.
+| `MATLAB_ADD_INSTALL_DIR_TO_SEARCH_PATH`  | `ON`        | `ON` or `OFF` | Whether the path to the install directory should be added directly added to the MATLAB Search Path.
+| `MATLAB_ADD_INSTALL_DIR_TO_STARTUP_FILE` | `ON`        | `ON` or `OFF` | Whether a command to add the path to the install directory should be added to the `startup.m` file located at the MATLAB `userpath`.
+
+###### `CMAKE_INSTALL_PREFIX`   
+The install command will install the interface to the location pointed to by `CMAKE_INSTALL_PREFIX`. The default value for this CMake variable is platform dependent. Default values for the location on different platforms can be found here: [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html). 
+
+###### `MATLAB_ADD_INSTALL_DIR_TO_SEARCH_PATH`   
+Call `addpath` and `savepath` to modify the default `pathdef.m` file that MATLAB uses on startup. This option is on by default. However, it can only be used if CMake has the appropriate permissions to modify `pathdef.m`.
+
+###### `MATLAB_ADD_INSTALL_DIR_TO_STARTUP_FILE`   
+Add an `addpath` command to the `startup.m` file located at the [`userpath`](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html#:~:text=on%20Search%20Path.-,userpath%20Folder%20on%20the%20Search%20Path,-The%20userpath%20folder). This option can be used if a user does not have the permissions to modify the default `pathdef.m` file. 
+
+## Try it out
 ### Add the src and build directories to your MATLAB path
 
 ``` matlab

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -17,29 +17,58 @@
   under the License.
 -->
 
-## MATLAB Library for Apache Arrow
+# MATLAB Interface to Apache Arrow
 
 ## Status
 
 This is a very early stage MATLAB interface to the Apache Arrow C++ libraries.
 
-The current code only supports reading/writing numeric types from/to Feather files.
+The current code only supports reading/writing numeric types from/to Feather v1 files.
 
-## Building from source
+## Build
 
-### Get Arrow and build Arrow CPP
+## Install
 
-See: [Arrow CPP README](../cpp/README.md)
+After building the MATLAB Interface to Arrow, install the library by running the following command:
 
-### Build MATLAB interface to Apache Arrow using MATLAB R2018a:
+``` CMake
+cmake --build build --config Release --target install
+```
 
-    cd arrow/matlab
-    mkdir build
-    cd build
-    cmake ..
-    make
+The installation process includes 
 
-#### Non-standard MATLAB and Arrow installations
+Once installed, the interface's source files and libraries are relocatable, on all platforms. If the interface is relocated, then the user must manually add the new location to the [MATLAB Search Path](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+
+## Test
+
+### C++
+
+### MATLAB
+
+``` matlab
+>> runtests test;
+```
+
+## Usage
+
+### Write a MATLAB table to a Feather v1 file
+
+``` matlab
+>> t = array2table(rand(10, 10));
+>> filename = 'table.feather';
+>> featherwrite(filename,t);
+```
+
+### Read a Feather v1 file into a MATLAB table
+
+``` matlab
+>> filename = 'table.feather';
+>> t = featherread(filename);
+```
+
+## Troubleshooting
+
+### Non-standard MATLAB and Arrow installations
 
 To specify a non-standard MATLAB install location, use the Matlab_ROOT_DIR CMake flag:
 
@@ -49,72 +78,4 @@ To specify a non-standard Arrow install location, use the ARROW_HOME CMake flag:
 
     cmake .. -DARROW_HOME=/<PATH_TO_ARROW_INSTALL>
 
-### Build MATLAB interface to Arrow using MATLAB R2018b or later:
 
-This may be preferred if you are using MATLAB R2018b or later and have encountered [linker errors](https://gitlab.kitware.com/cmake/cmake/issues/18391) when using CMake.
-
-Prerequisite: Ensure that the Arrow C++ library is already installed and the `ARROW_HOME` environment variable is set to the installation root.
-
-To verify this, you can run:
-
-``` matlab
->> getenv ARROW_HOME
-```
-
-This should print a path that contains `include` and `lib` directories with Arrow C++ headers and libraries.
-
-Navigate to the `build_support` subfolder and run the `compile` function to build the necessary MEX files:
-
-``` matlab
->> cd build_support
->> compile
-```
-
-Run the `test` function to execute the unit tests:
-
-``` matlab
->> test
-```
-
-### Install MATLAB Interface to Arrow using CMake
-After building the MATLAB Interface to Arrow, install the library by running the following command:
-``` CMake
-cmake --build build --config Release --target install
-```
-The installation process includes 
-
-Once installed, the interface's source files and libraries are relocatable, on all platforms. If the interface is relocated, then the user must manually add the new location to the [MATLAB Search Path](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
-
-## Try it out
-### Add the src and build directories to your MATLAB path
-
-``` matlab
->> cd(fullfile('arrow', 'matlab'));
->> addpath src;
->> addpath build;
-```
-
-### Write a MATLAB table to a Feather file
-
-``` matlab
->> t = array2table(rand(10, 10));
->> filename = 'table.feather';
->> featherwrite(filename,t);
-```
-
-### Read a Feather file into a MATLAB table
-
-``` matlab
->> filename = 'table.feather';
->> t = featherread(filename);
-```
-
-## Running the tests
-
-``` matlab
->> cd(fullfile('arrow', 'matlab'));
->> addpath src;
->> addpath build;
->> cd test;
->> runtests .;
-```

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -25,31 +25,59 @@ This is a very early stage MATLAB interface to the Apache Arrow C++ libraries.
 
 The current code only supports reading/writing numeric types from/to Feather v1 files.
 
-## Build
+## Prerequisites
 
-## Install
-
-After building the MATLAB Interface to Arrow, install the library by running the following command:
-
-``` CMake
-cmake --build build --config Release --target install
+## Setup
+To set up a local working copy of the source code, start by cloning the repository:
+```bash
+$ git clone https://github.com/apache/arrow.git
 ```
 
-The installation process includes 
+Change the working directory to the `matlab` subdirectory:
+```bash
+$ cd arrow/matlab
+```
 
-Once installed, the interface's source files and libraries are relocatable, on all platforms. If the interface is relocated, then the user must manually add the new location to the [MATLAB Search Path](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+## Build
+To build the project:
+```bash
+$ cmake -S . -B build 
+$ cmake --build build --config Release
+```
+
+## Install
+To install the MATLAB interface to the default software location (e.g. `/usr/local` or `C:\Program Files`):
+```bash
+$ cmake --build build --config Release --target install
+```
+
+As part of the install step, the install directory is added to the [MATLAB Search Path](https://mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+
+Note: this step may fail if the current user is lacking the necessary filesystem permissions. Please see Troubleshooting for more information.
 
 ## Test
+There are two kinds of tests for the MATLAB Interface to Arrow: C++ and MATLAB. 
 
 ### C++
+To enable the C++ tests, the `MATLAB_BUILD_TESTS` flag must enabled at build time: 
+```bash
+$ cmake -S . -B build -D MATLAB_BUILD_TESTS=ON
+$ cmake --build build --config Release
+```
+
+After building with the `MATLAB_BUILD_TESTS` flag enabled, the C++ tests can be run using [`ctest`](https://cmake.org/cmake/help/v3.22/manual/ctest.1.html):
+```bash
+$ ctest --test-dir build
+```
 
 ### MATLAB
-
+To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call the [`runtests`](https://mathworks.com/help/matlab/ref/runtests.html) command on the `test` directory:
 ``` matlab
 >> runtests test;
 ```
 
 ## Usage
+Included below are some example code snippets that illustrate how to use the MATLAB Interface To Arrow.
 
 ### Write a MATLAB table to a Feather v1 file
 
@@ -65,17 +93,4 @@ Once installed, the interface's source files and libraries are relocatable, on a
 >> filename = 'table.feather';
 >> t = featherread(filename);
 ```
-
-## Troubleshooting
-
-### Non-standard MATLAB and Arrow installations
-
-To specify a non-standard MATLAB install location, use the Matlab_ROOT_DIR CMake flag:
-
-    cmake .. -DMatlab_ROOT_DIR=/<PATH_TO_MATLAB_INSTALL>
-
-To specify a non-standard Arrow install location, use the ARROW_HOME CMake flag:
-
-    cmake .. -DARROW_HOME=/<PATH_TO_ARROW_INSTALL>
-
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -38,13 +38,13 @@ To build the MATLAB Interface to Apache Arrow from source, the following softwar
 
 To set up a local working copy of the source code, start by cloning the [`apache/arrow`](https://github.com/apache/arrow) GitHub repository using [Git](https://git-scm.com/):
 
-```bash
+```console
 $ git clone https://github.com/apache/arrow.git
 ```
 
 After cloning, change the working directory to the `matlab` subdirectory:
 
-```bash
+```console
 $ cd arrow/matlab
 ```
 
@@ -52,7 +52,7 @@ $ cd arrow/matlab
 
 To build the MATLAB interface, use [CMake](https://cmake.org/cmake/help/latest/):
 
-```bash
+```console
 $ cmake -S . -B build 
 $ cmake --build build --config Release
 ```
@@ -61,7 +61,7 @@ $ cmake --build build --config Release
 
 To install the MATLAB interface to the default software installation location for the target machine (e.g. `/usr/local` on Linux or `C:\Program Files` on Windows), pass the `--taget install` flag to CMake.
 
-```bash
+```console
 $ cmake --build build --config Release --target install
 ```
 
@@ -85,14 +85,14 @@ To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call t
 
 To enable the C++ tests, set the `MATLAB_BUILD_TESTS` to `ON` at build time: 
 
-```bash
+```console
 $ cmake -S . -B build -D MATLAB_BUILD_TESTS=ON
 $ cmake --build build --config Release
 ```
 
 After building with the `MATLAB_BUILD_TESTS` flag enabled, the C++ tests can be run using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html):
 
-```bash
+```console
 $ ctest --test-dir build
 ```
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -85,22 +85,6 @@ The installation process includes
 
 Once installed, the interface's source files and libraries are relocatable, on all platforms. If the interface is relocated, then the user must manually add the new location to the [MATLAB Search Path](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
 
-The following flags can be passed to the CMake generation command to configure the installation step:
-| CMake Flag                               | Default Value       | Values accepted     | Description   |
-| ---------------------------------------- | ------------------- | ---------------------------------------------- | ------------- |
-| `CMAKE_INSTALL_PREFIX`                   | platform dependent  | A path to any directory with write permissions | The location that the MATLAB Interface to Arrow will be installed.
-| `MATLAB_ADD_INSTALL_DIR_TO_SEARCH_PATH`  | `ON`        | `ON` or `OFF` | Whether the path to the install directory should be added directly added to the MATLAB Search Path.
-| `MATLAB_ADD_INSTALL_DIR_TO_STARTUP_FILE` | `ON`        | `ON` or `OFF` | Whether a command to add the path to the install directory should be added to the `startup.m` file located at the MATLAB `userpath`.
-
-###### `CMAKE_INSTALL_PREFIX`   
-The install command will install the interface to the location pointed to by `CMAKE_INSTALL_PREFIX`. The default value for this CMake variable is platform dependent. Default values for the location on different platforms can be found here: [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html). 
-
-###### `MATLAB_ADD_INSTALL_DIR_TO_SEARCH_PATH`   
-Call `addpath` and `savepath` to modify the default `pathdef.m` file that MATLAB uses on startup. This option is on by default. However, it can only be used if CMake has the appropriate permissions to modify `pathdef.m`.
-
-###### `MATLAB_ADD_INSTALL_DIR_TO_STARTUP_FILE`   
-Add an `addpath` command to the `startup.m` file located at the [`userpath`](https://uk.mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html#:~:text=on%20Search%20Path.-,userpath%20Folder%20on%20the%20Search%20Path,-The%20userpath%20folder). This option can be used if a user does not have the permissions to modify the default `pathdef.m` file. 
-
 ## Try it out
 ### Add the src and build directories to your MATLAB path
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -27,57 +27,78 @@ The current code only supports reading/writing numeric types from/to Feather v1 
 
 ## Prerequisites
 
+To build the MATLAB Interface to Apache Arrow from source, the following software must be installed on the target machine:
+
+1. [MATLAB](https://www.mathworks.com/products/get-matlab.html)
+2. [CMake](https://cmake.org/cmake/help/latest/)
+3. C++ compiler which supports C++11 (e.g. [`gcc`](https://gcc.gnu.org/) on Linux, [`Xcode`](https://developer.apple.com/xcode/) on macOS, or [`Visual Studio`](https://visualstudio.microsoft.com/) on Windows)
+4. [Git](https://git-scm.com/)
+
 ## Setup
-To set up a local working copy of the source code, start by cloning the repository:
+
+To set up a local working copy of the source code, start by cloning the [`apache/arrow`](https://github.com/apache/arrow) GitHub repository using [Git](https://git-scm.com/):
+
 ```bash
 $ git clone https://github.com/apache/arrow.git
 ```
 
-Change the working directory to the `matlab` subdirectory:
+After cloning, change the working directory to the `matlab` subdirectory:
+
 ```bash
 $ cd arrow/matlab
 ```
 
 ## Build
-To build the project:
+
+To build the MATLAB interface, use [CMake](https://cmake.org/cmake/help/latest/):
+
 ```bash
 $ cmake -S . -B build 
 $ cmake --build build --config Release
 ```
 
 ## Install
-To install the MATLAB interface to the default software location (e.g. `/usr/local` or `C:\Program Files`):
+
+To install the MATLAB interface to the default software installation location for the target machine (e.g. `/usr/local` on Linux or `C:\Program Files` on Windows), pass the `--taget install` flag to CMake.
+
 ```bash
 $ cmake --build build --config Release --target install
 ```
 
-As part of the install step, the install directory is added to the [MATLAB Search Path](https://mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
+As part of the install step, the installation directory is added to the [MATLAB Search Path](https://mathworks.com/help/matlab/matlab_env/what-is-the-matlab-search-path.html).
 
-Note: this step may fail if the current user is lacking the necessary filesystem permissions. Please see Troubleshooting for more information.
+**Note**: This step may fail if the current user is lacking necessary filesystem permissions. If the install step fails, the installation directory can be manually added to the MATLAB Search Path using the [`addpath`](https://www.mathworks.com/help/matlab/ref/addpath.html) command. 
 
 ## Test
-There are two kinds of tests for the MATLAB Interface to Arrow: C++ and MATLAB. 
+
+There are two kinds of tests for the MATLAB Interface: MATLAB and C++. 
+
+### MATLAB
+
+To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call the [`runtests`](https://mathworks.com/help/matlab/ref/runtests.html) command on the `test` directory:
+
+``` matlab
+>> runtests test;
+```
 
 ### C++
-To enable the C++ tests, the `MATLAB_BUILD_TESTS` flag must enabled at build time: 
+
+To enable the C++ tests, set the `MATLAB_BUILD_TESTS` to `ON` at build time: 
+
 ```bash
 $ cmake -S . -B build -D MATLAB_BUILD_TESTS=ON
 $ cmake --build build --config Release
 ```
 
-After building with the `MATLAB_BUILD_TESTS` flag enabled, the C++ tests can be run using [`ctest`](https://cmake.org/cmake/help/v3.22/manual/ctest.1.html):
+After building with the `MATLAB_BUILD_TESTS` flag enabled, the C++ tests can be run using [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html):
+
 ```bash
 $ ctest --test-dir build
 ```
 
-### MATLAB
-To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call the [`runtests`](https://mathworks.com/help/matlab/ref/runtests.html) command on the `test` directory:
-``` matlab
->> runtests test;
-```
-
 ## Usage
-Included below are some example code snippets that illustrate how to use the MATLAB Interface To Arrow.
+
+Included below are some example code snippets that illustrate how to use the MATLAB interface.
 
 ### Write a MATLAB table to a Feather v1 file
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -83,7 +83,7 @@ To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call t
 
 ### C++
 
-To enable the C++ tests, set the `MATLAB_BUILD_TESTS` to `ON` at build time: 
+To enable the C++ tests, set the `MATLAB_BUILD_TESTS` flag to `ON` at build time: 
 
 ```console
 $ cmake -S . -B build -D MATLAB_BUILD_TESTS=ON

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -59,7 +59,7 @@ $ cmake --build build --config Release
 
 ## Install
 
-To install the MATLAB interface to the default software installation location for the target machine (e.g. `/usr/local` on Linux or `C:\Program Files` on Windows), pass the `--taget install` flag to CMake.
+To install the MATLAB interface to the default software installation location for the target machine (e.g. `/usr/local` on Linux or `C:\Program Files` on Windows), pass the `--target install` flag to CMake.
 
 ```console
 $ cmake --build build --config Release --target install


### PR DESCRIPTION
# Overview

This pull request:

1. Updates the high level documentation for the MATLAB interface in `arrow/matlab/README.md` to reflect the latest CMake build system changes that were merged upstream as part of [#12004](https://github.com/apache/arrow/pull/12004).

# Implementation

1. Restructured the `README.md` to focus on the most common build and test workflows for the MATLAB interface.

# Testing

N/A

# Future Directions

1. To be consistent and in-model with the other language bindings (e.g. Python, R, C++, etc.) - we plan to author in-depth technical documentation over time under [`arrow/docs/source/matlab`](https://github.com/apache/arrow/tree/master/docs/source) using the [reStructedText (.rst) format](https://docutils.sourceforge.io/rst.html). The thought behind this `README.md` documentation is to provide a convenient "landing page" for the MATLAB interface which allows end users to quickly get a sense of where the project is at and to get started immediately with building and running the interface. However, every user and developer will have different use cases and needs for working with the MATLAB interface, so we will also want include in-depth documentation for major topics like building, installing, testing, contributing, usage, etc. As the MATLAB interface continues to develop, we will do our best to keep the documentation in sync with the source code.

# Notes

1. Thank you to @lafiona for her help writing this updated documentation!