### PR TITLE
ARROW-15648: [C++][Gandiva] Fix the size of the Gandiva cache

### DIFF
--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -20,7 +20,7 @@
 
 namespace gandiva {
 
-static const size_t DEFAULT_CACHE_SIZE = 500000;
+static const size_t DEFAULT_CACHE_SIZE = 500;
 
 int GetCapacity() {
   size_t capacity;

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -20,7 +20,11 @@
 
 namespace gandiva {
 
+#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
+static const size_t DEFAULT_CACHE_SIZE = 500000;
+#else
 static const size_t DEFAULT_CACHE_SIZE = 500;
+#endif
 
 int GetCapacity() {
   size_t capacity;


### PR DESCRIPTION
Add a flag that was missing in that PR to [add a flag related to the Object Code cache](https://github.com/apache/arrow/pull/12308)

Caching the entire projector/filter instead of object cache has a higher memory overhead so need to lower the size when not using object code caching.