### PR TITLE
MINOR: [Docs][Archery] Correct the links in the README.md

### DIFF
--- a/dev/archery/README.md
+++ b/dev/archery/README.md
@@ -21,9 +21,9 @@
 
 Archery is documented on the Arrow website:
 
-* [Daily development using Archery](https://arrow.apache.org/docs/developers/archery.html)
-* [Using Archery and Crossbow](https://arrow.apache.org/docs/developers/crossbow.html)
-* [Using Archer and Docker](https://arrow.apache.org/docs/developers/docker.html)
+* [Daily development using Archery](https://arrow.apache.org/docs/developers/continuous_integration/archery.html)
+* [Using Archery and Crossbow](https://arrow.apache.org/docs/developers/continuous_integration/crossbow.html)
+* [Using Archer and Docker](https://arrow.apache.org/docs/developers/continuous_integration/docker.html)
 
 # Installing Archery
 


### PR DESCRIPTION
This PR corrects the links in the `archery/README.md` due to the change in the structure of the developers docs.