### PR TITLE
ARROW-15659 [R] strptime should return NA (not error) with format mismatch

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1846,6 +1846,7 @@ TYPED_TEST(TestStringKernels, Strptime) {
   std::string input4 = R"(["5/1/2020", "AA/BB/CCCC", "AA/BB/CCCC", "AA/BB/CCCC", null])";
   std::string input5 = R"(["5/1/2020 %z", null, null, "12/13/1900 %z", null])";
   std::string input6 = R"(["2022-02-07", "2012/03-28", "1975/01-02", "1981/01-07"])";
+  std::string input7 = R"(["02-07-2022", "03/28/2012", "01/02/1975", "01/07/1981"])";
   std::string output1 = R"(["2020-05-01", null, null, "1900-12-13", null])";
   std::string output2 = R"([null, "1900-12-13"])";
   std::string output3 = R"(["2020-05-01", null])";
@@ -1866,6 +1867,9 @@ TYPED_TEST(TestStringKernels, Strptime) {
 
   options.format = "%Y/%m-%d";
   this->CheckUnary("strptime", input6, unit, output6, &options);
+
+  options.format = "%m/%d/%Y %%z";
+  this->CheckUnary("strptime", input7, unit, output6, &options);
 
   options.error_is_null = false;
   this->CheckUnary("strptime", input5, unit, output1, &options);

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1845,13 +1845,10 @@ TYPED_TEST(TestStringKernels, Strptime) {
   std::string input3 = R"(["5/1/2020", "AA/BB/CCCC"])";
   std::string input4 = R"(["5/1/2020", "AA/BB/CCCC", "AA/BB/CCCC", "AA/BB/CCCC", null])";
   std::string input5 = R"(["5/1/2020 %z", null, null, "12/13/1900 %z", null])";
-  std::string input6 = R"(["2022-02-07", "2012/03-28", "1975/01-02", "1981/01-07"])";
-  std::string input7 = R"(["02-07-2022", "03/28/2012", "01/02/1975", "01/07/1981"])";
   std::string output1 = R"(["2020-05-01", null, null, "1900-12-13", null])";
   std::string output2 = R"([null, "1900-12-13"])";
   std::string output3 = R"(["2020-05-01", null])";
   std::string output4 = R"(["2020-01-05", null, null, null, null])";
-  std::string output6 = R"([null, "2012-03-28", "1975-01-02", "1981-01-07"])";
 
   StrptimeOptions options("%m/%d/%Y", TimeUnit::MICRO, /*error_is_null=*/true);
   auto unit = timestamp(TimeUnit::MICRO);
@@ -1864,12 +1861,6 @@ TYPED_TEST(TestStringKernels, Strptime) {
 
   options.format = "%m/%d/%Y %%z";
   this->CheckUnary("strptime", input5, unit, output1, &options);
-
-  options.format = "%Y/%m-%d";
-  this->CheckUnary("strptime", input6, unit, output6, &options);
-
-  options.format = "%m/%d/%Y %%z";
-  this->CheckUnary("strptime", input7, unit, output6, &options);
 
   options.error_is_null = false;
   this->CheckUnary("strptime", input5, unit, output1, &options);

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1845,12 +1845,12 @@ TYPED_TEST(TestStringKernels, Strptime) {
   std::string input3 = R"(["5/1/2020", "AA/BB/CCCC"])";
   std::string input4 = R"(["5/1/2020", "AA/BB/CCCC", "AA/BB/CCCC", "AA/BB/CCCC", null])";
   std::string input5 = R"(["5/1/2020 %z", null, null, "12/13/1900 %z", null])";
-  std::string input6 = R"(["2022-02-07", "1989 12-22"])";
+  std::string input6 = R"(["2022-02-07", "2012/03-28", "1975/01-02", "1981/01-07"])";
   std::string output1 = R"(["2020-05-01", null, null, "1900-12-13", null])";
   std::string output2 = R"([null, "1900-12-13"])";
   std::string output3 = R"(["2020-05-01", null])";
   std::string output4 = R"(["2020-01-05", null, null, null, null])";
-  std::string output6 = R"([null, "1989-12-22"])";
+  std::string output6 = R"([null, "2012-03-28", "1975-01-02", "1981-01-07"])";
 
   StrptimeOptions options("%m/%d/%Y", TimeUnit::MICRO, /*error_is_null=*/true);
   auto unit = timestamp(TimeUnit::MICRO);
@@ -1864,7 +1864,7 @@ TYPED_TEST(TestStringKernels, Strptime) {
   options.format = "%m/%d/%Y %%z";
   this->CheckUnary("strptime", input5, unit, output1, &options);
 
-  options.format = "%Y %m-%d";
+  options.format = "%Y/%m-%d";
   this->CheckUnary("strptime", input6, unit, output6, &options);
 
   options.error_is_null = false;

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1845,10 +1845,12 @@ TYPED_TEST(TestStringKernels, Strptime) {
   std::string input3 = R"(["5/1/2020", "AA/BB/CCCC"])";
   std::string input4 = R"(["5/1/2020", "AA/BB/CCCC", "AA/BB/CCCC", "AA/BB/CCCC", null])";
   std::string input5 = R"(["5/1/2020 %z", null, null, "12/13/1900 %z", null])";
+  std::string input6 = R"(["2022-02-07", "1989 12-22"])";
   std::string output1 = R"(["2020-05-01", null, null, "1900-12-13", null])";
   std::string output2 = R"([null, "1900-12-13"])";
   std::string output3 = R"(["2020-05-01", null])";
   std::string output4 = R"(["2020-01-05", null, null, null, null])";
+  std::string output6 = R"([null, "1989-12-22"])";
 
   StrptimeOptions options("%m/%d/%Y", TimeUnit::MICRO, /*error_is_null=*/true);
   auto unit = timestamp(TimeUnit::MICRO);
@@ -1861,6 +1863,9 @@ TYPED_TEST(TestStringKernels, Strptime) {
 
   options.format = "%m/%d/%Y %%z";
   this->CheckUnary("strptime", input5, unit, output1, &options);
+
+  options.format = "%Y %m-%d";
+  this->CheckUnary("strptime", input6, unit, output6, &options);
 
   options.error_is_null = false;
   this->CheckUnary("strptime", input5, unit, output1, &options);

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -40,7 +40,7 @@ register_bindings_datetime <- function() {
 
     unit <- make_valid_time_unit(unit, c(valid_time64_units, valid_time32_units))
 
-    Expression$create("strptime", x, options = list(format = format, unit = unit))
+    Expression$create("strptime", x, options = list(format = format, unit = unit, error_is_null = TRUE))
   })
 
   register_binding("strftime", function(x, format = "", tz = "", usetz = FALSE) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -40,7 +40,7 @@ register_bindings_datetime <- function() {
 
     unit <- make_valid_time_unit(unit, c(valid_time64_units, valid_time32_units))
 
-    Expression$create("strptime", x, options = list(format = format, unit = unit, error_is_null = TRUE))
+    build_expr("strptime", x, options = list(format = format, unit = unit, error_is_null = TRUE))
   })
 
   register_binding("strftime", function(x, format = "", tz = "", usetz = FALSE) {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -121,8 +121,6 @@ test_that("errors in strptime", {
 test_that("strptime returns NA when format doesn't match the data", {
   df <- tibble(str_date = c("2022-02-07", "2022 02-07"))
 
-  # "2022 02-07 10:12:14"
-
   expect_equal(
     df %>%
       arrow_table() %>%
@@ -136,7 +134,7 @@ test_that("strptime returns NA when format doesn't match the data", {
   )
 
 
-  # something is weird when the Ym separator is something else than a hyphen
+  # something is weird when the first element fails to parse
   expect_equal(
     df %>%
       arrow_table() %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -119,9 +119,23 @@ test_that("errors in strptime", {
 })
 
 test_that("strptime returns NA when format doesn't match the data", {
-  df <- tibble(str_date = c("2022-02-07", "2022 02-07"))
   df <- tibble(
     str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07")
+  )
+
+  expect_equal(
+    df %>%
+      arrow_table() %>%
+      mutate(
+        r_obj_parsed_date = strptime("03-27/2022", format = "%m-%d/%Y"),
+        r_obj_parsed_na = strptime("03-27/2022", format = "Y%-%m-%d")) %>%
+      collect(),
+    tibble(
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
+      r_obj_parsed_date = as.POSIXct(rep("2022-03-27", 4)),
+      r_obj_parsed_na = as.POSIXct(rep(NA, 4))
+    ),
+    ignore_attr = "tzone"
   )
 
   expect_equal(
@@ -131,9 +145,9 @@ test_that("strptime returns NA when format doesn't match the data", {
       collect(),
     tibble(
       str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
-      parsed_date = as.POSIXct(c("2022-02-07 00:00:00", NA, NA, NA))
+      parsed_date = as.POSIXct(c("2022-02-07", NA, NA, NA))
     ),
-    ignore_attr = TRUE
+    ignore_attr = "tzone"
   )
 
   expect_equal(
@@ -145,7 +159,7 @@ test_that("strptime returns NA when format doesn't match the data", {
       str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
       parsed_date = as.POSIXct(c(NA, "2012-02-07", "1975-01-02", "1981-01-07"))
     ),
-    ignore_attr = TRUE
+    ignore_attr = "tzone"
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -119,14 +119,42 @@ test_that("errors in strptime", {
 })
 
 test_that("strptime returns NA when format doesn't match the data", {
-  df <- tibble(a = "2022-02-07")
+  df <- tibble(str_date = c("2022-02-07", "2022 02-07"))
 
-  compare_dplyr_binding(
-    .input %>%
-      mutate(b = strptime(a, format = "%Y %m-%d")) %>%
+  # "2022 02-07 10:12:14"
+
+  expect_equal(
+    df %>%
+      arrow_table() %>%
+      mutate(parsed_date = strptime(str_date, format = "%Y-%m-%d")) %>%
       collect(),
-    df
+    tibble(
+      str_date = c("2022-02-07", "2022 02-07"),
+      parsed_date = as.POSIXct(c("2022-02-07 00:00:00", NA))
+    ),
+    ignore_attr = TRUE
   )
+
+
+  # something is weird when the Ym separator is something else than a hyphen
+  expect_equal(
+    df %>%
+      arrow_table() %>%
+      mutate(parsed_date = strptime(str_date, format = "%Y %m-%d")) %>%
+      collect(),
+    tibble(
+      str_date = c("2022-02-07", "2022 02-07"),
+      parsed_date = as.POSIXct(c(NA, "2022-02-07 00:00:00"))
+    ),
+    ignore_attr = TRUE
+  )
+
+  # compare_dplyr_binding(
+  #   .input %>%
+  #     mutate(b = strptime(str_date, format = "%Y %m-%d")) %>%
+  #     collect(),
+  #   df
+  # )
 })
 
 test_that("strftime", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -120,7 +120,7 @@ test_that("errors in strptime", {
 
 test_that("strptime returns NA when format doesn't match the data", {
   df <- tibble(
-    str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07")
+    str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07", NA)
   )
 
   expect_equal(
@@ -131,9 +131,9 @@ test_that("strptime returns NA when format doesn't match the data", {
         r_obj_parsed_na = strptime("03-27/2022", format = "Y%-%m-%d")) %>%
       collect(),
     tibble(
-      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
-      r_obj_parsed_date = as.POSIXct(rep("2022-03-27", 4)),
-      r_obj_parsed_na = as.POSIXct(rep(NA, 4))
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07", NA),
+      r_obj_parsed_date = as.POSIXct(rep("2022-03-27", 5)),
+      r_obj_parsed_na = as.POSIXct(rep(NA, 5))
     ),
     ignore_attr = "tzone"
   )
@@ -144,8 +144,8 @@ test_that("strptime returns NA when format doesn't match the data", {
       mutate(parsed_date = strptime(str_date, format = "%Y-%m-%d")) %>%
       collect(),
     tibble(
-      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
-      parsed_date = as.POSIXct(c("2022-02-07", NA, NA, NA))
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07", NA),
+      parsed_date = as.POSIXct(c("2022-02-07", NA, NA, NA, NA))
     ),
     ignore_attr = "tzone"
   )
@@ -156,8 +156,8 @@ test_that("strptime returns NA when format doesn't match the data", {
       mutate(parsed_date = strptime(str_date, format = "%Y/%m-%d")) %>%
       collect(),
     tibble(
-      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
-      parsed_date = as.POSIXct(c(NA, "2012-02-07", "1975-01-02", "1981-01-07"))
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07", NA),
+      parsed_date = as.POSIXct(c(NA, "2012-02-07", "1975-01-02", "1981-01-07", NA))
     ),
     ignore_attr = "tzone"
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -120,6 +120,9 @@ test_that("errors in strptime", {
 
 test_that("strptime returns NA when format doesn't match the data", {
   df <- tibble(str_date = c("2022-02-07", "2022 02-07"))
+  df <- tibble(
+    str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07")
+  )
 
   expect_equal(
     df %>%
@@ -127,32 +130,23 @@ test_that("strptime returns NA when format doesn't match the data", {
       mutate(parsed_date = strptime(str_date, format = "%Y-%m-%d")) %>%
       collect(),
     tibble(
-      str_date = c("2022-02-07", "2022 02-07"),
-      parsed_date = as.POSIXct(c("2022-02-07 00:00:00", NA))
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
+      parsed_date = as.POSIXct(c("2022-02-07 00:00:00", NA, NA, NA))
     ),
     ignore_attr = TRUE
   )
 
-
-  # something is weird when the first element fails to parse
   expect_equal(
     df %>%
       arrow_table() %>%
-      mutate(parsed_date = strptime(str_date, format = "%Y %m-%d")) %>%
+      mutate(parsed_date = strptime(str_date, format = "%Y/%m-%d")) %>%
       collect(),
     tibble(
-      str_date = c("2022-02-07", "2022 02-07"),
-      parsed_date = as.POSIXct(c(NA, "2022-02-07 00:00:00"))
+      str_date = c("2022-02-07", "2012/02-07", "1975/01-02", "1981/01-07"),
+      parsed_date = as.POSIXct(c(NA, "2012-02-07", "1975-01-02", "1981-01-07"))
     ),
     ignore_attr = TRUE
   )
-
-  # compare_dplyr_binding(
-  #   .input %>%
-  #     mutate(b = strptime(str_date, format = "%Y %m-%d")) %>%
-  #     collect(),
-  #   df
-  # )
 })
 
 test_that("strftime", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -118,6 +118,17 @@ test_that("errors in strptime", {
   )
 })
 
+test_that("strptime returns NA when format doesn't match the data", {
+  df <- tibble(a = "2022-02-07")
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(b = strptime(a, format = "%Y %m-%d")) %>%
+      collect(),
+    df
+  )
+})
+
 test_that("strftime", {
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA),


### PR DESCRIPTION
This PR aligns arrow's binding to `strptime()` to `base::strptime()` when the value passed to the `format` argument does not match the data. Currently arrow errors, when it should return `NA`. 

``` r
library(lubridate)
library(arrow)
library(dplyr)

df <- tibble(x = "2022-02-11")

df %>% 
  mutate(z = strptime(x, format = "%Y-%m %d"))
#> # A tibble: 1 × 2
#>   x          z     
#>   <chr>      <dttm>
#> 1 2022-02-11 NA

df %>% 
  record_batch() %>% 
  mutate(z = strptime(x, format = "%Y-%m %d")) %>% 
  collect()
#> Error: Invalid: Failed to parse string: '2022-02-11' as a scalar of type timestamp[ms]
```

<sup>Created on 2022-02-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>