### PR TITLE
ARROW-15398: [Integration-tests] Made integration tests be built in parallel and increase cache hit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,6 +65,7 @@
 # include explicitly
 !go/*
 !js/*
+!rust/*
 !csharp/*
 !format/*
 !java/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -61,3 +61,17 @@
 !rust/datafusion/Cargo.toml
 !rust/datafusion/benches
 !rust/integration-testing/Cargo.toml
+
+# include explicitly
+!go/*
+!js/*
+!csharp/*
+!format/*
+!java/*
+!cpp/*
+# files needed by cpp
+!.env
+!LICENSE.txt
+!NOTICE.txt
+# archery is needed to run integration tests
+!dev/archery

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ cpp/Brewfile.lock.json
 
 # docker volumes used for caching
 .docker
+
+# Python
+venv/

--- a/ci/conda_env_archery.txt
+++ b/ci/conda_env_archery.txt
@@ -27,6 +27,7 @@ pygithub
 ruamel.yaml
 setuptools_scm
 toolz
+pydantic
 
 # benchmark
 pandas

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -17,32 +17,11 @@
 
 ARG repo
 ARG arch=amd64
-FROM ${repo}:${arch}-conda-cpp
+##################### GO #####################
+FROM ${repo}:${arch}-conda-cpp AS builder-go
 
 ARG arch=amd64
-ARG maven=3.5
-ARG node=16
-ARG jdk=8
 ARG go=1.15
-
-# Install Archery and integration dependencies
-COPY ci/conda_env_archery.txt /arrow/ci/
-RUN mamba install -q \
-        --file arrow/ci/conda_env_archery.txt \
-        "python>=3.7" \
-        numpy \
-        compilers \
-        maven=${maven} \
-        nodejs=${node} \
-        yarn \
-        openjdk=${jdk} && \
-    mamba clean --all --force-pkgs-dirs
-
-# Install Rust with only the needed components
-# (rustfmt is needed for tonic-build to compile the protobuf definitions)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y && \
-    $HOME/.cargo/bin/rustup toolchain install stable && \
-    $HOME/.cargo/bin/rustup component add rustfmt
 
 ENV GOROOT=/opt/go \
     GOBIN=/opt/go/bin \
@@ -50,9 +29,28 @@ ENV GOROOT=/opt/go \
     PATH=/opt/go/bin:$PATH
 RUN wget -nv -O - https://dl.google.com/go/go${go}.linux-${arch}.tar.gz | tar -xzf - -C /opt
 
-ENV DOTNET_ROOT=/opt/dotnet \
-    PATH=/opt/dotnet:$PATH
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 3.1 -InstallDir /opt/dotnet
+COPY ./go /arrow/go
+COPY ./ci/scripts/go_build.sh /arrow/ci/scripts/go_build.sh
+
+RUN /arrow/ci/scripts/go_build.sh /arrow
+
+##################### C++ #####################
+FROM ${repo}:${arch}-conda-cpp AS builder-cpp
+
+# Install Archery and integration dependencies
+COPY ci/conda_env_archery.txt /arrow/ci/
+RUN mamba install -q \
+        --file arrow/ci/conda_env_archery.txt \
+        compilers && \
+    mamba clean --all --force-pkgs-dirs
+
+COPY ./.env /arrow/.env
+COPY ./cpp /arrow/cpp
+COPY ./format /arrow/format
+COPY ./ci/scripts/cpp_build.sh /arrow/ci/scripts/cpp_build.sh
+RUN git init && git checkout -b master && git -c "user.name=no one" -c "user.email=no_one@example.com" commit --allow-empty -m "bla"
+COPY ./LICENSE.txt /arrow/LICENSE.txt
+COPY ./NOTICE.txt /arrow/NOTICE.txt
 
 ENV ARROW_BUILD_INTEGRATION=ON \
     ARROW_BUILD_STATIC=OFF \
@@ -72,3 +70,69 @@ ENV ARROW_BUILD_INTEGRATION=ON \
     ARROW_S3=OFF \
     ARROW_USE_GLOG=OFF \
     CMAKE_UNITY_BUILD=ON
+
+RUN /arrow/ci/scripts/cpp_build.sh /arrow /build
+
+##################### C# #####################
+FROM ${repo}:${arch}-conda-cpp AS builder-csharp
+
+ENV DOTNET_ROOT=/opt/dotnet \
+    PATH=/opt/dotnet:$PATH
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 3.1 -InstallDir /opt/dotnet
+
+COPY ./csharp /arrow/csharp
+COPY ./format /arrow/format
+COPY ./ci/scripts/csharp_build.sh /arrow/ci/scripts/csharp_build.sh
+
+RUN /arrow/ci/scripts/csharp_build.sh /arrow /build
+
+##################### Java #####################
+FROM ${repo}:${arch}-conda-cpp AS builder-java
+
+ARG maven=3.5
+ARG jdk=8
+RUN mamba install -q \
+        maven=${maven} \
+        openjdk=${jdk} && \
+    mamba clean --all --force-pkgs-dirs
+
+COPY ./java /arrow/java
+COPY ./format /arrow/format
+COPY ./ci/scripts/java_build.sh /arrow/ci/scripts/java_build.sh
+
+RUN /arrow/ci/scripts/java_build.sh /arrow /build
+
+##################### TESTS #####################
+FROM ${repo}:${arch}-conda-cpp
+
+# Install Archery and integration dependencies
+COPY ci/conda_env_archery.txt /arrow/ci/
+RUN mamba install -q \
+        --file arrow/ci/conda_env_archery.txt \
+        "python>=3.7" \
+        numpy \
+        nodejs=${node} \
+        openjdk=${jdk} && \
+    mamba clean --all --force-pkgs-dirs
+
+# install cpp
+COPY --from=builder-cpp /build/cpp /build/cpp
+
+# install js
+COPY ./js /arrow/js
+
+# install java
+COPY --from=builder-java /arrow/java/tools/target /arrow/java/tools/target
+COPY --from=builder-java /arrow/java/flight/flight-integration-tests/target /arrow/java/flight/flight-integration-tests/target
+COPY --from=builder-java /arrow/java/pom.xml /arrow/java/pom.xml
+
+# install csharp
+COPY --from=builder-csharp /arrow/csharp/artifacts/Apache.Arrow.IntegrationTest/ /arrow/csharp/artifacts/Apache.Arrow.IntegrationTest/
+COPY --from=builder-csharp /opt/dotnet /opt/dotnet
+ENV DOTNET_ROOT=/opt/dotnet
+
+# install go
+COPY --from=builder-go /opt/go/bin/arrow-* /root/go/bin/
+
+COPY ./dev/archery /arrow/dev/archery
+COPY ./ci/scripts/integration_arrow.sh /arrow/ci/scripts/integration_arrow.sh

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -24,9 +24,20 @@ from .reports import EmailReport, ConsoleReport
 from ..utils.source import ArrowSources
 
 
-_default_arrow_path = ArrowSources.find().path
-_default_queue_path = _default_arrow_path.parent / "crossbow"
-_default_config_path = _default_arrow_path / "dev" / "tasks" / "tasks.yml"
+def _default_arrow_path():
+    return ArrowSources.find().path
+
+
+def _default_queue_path():
+    return _default_arrow_path().parent / "crossbow"
+
+
+def _default_config_path():
+    return _default_arrow_path().parent / "dev" / "tasks" / "tasks.yml"
+
+
+def _default_packages_path():
+    return _default_arrow_path() / 'packages'
 
 
 @click.group()
@@ -304,7 +315,7 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
 @crossbow.command()
 @click.argument('job-name', required=True)
 @click.option('-t', '--target-dir',
-              default=_default_arrow_path / 'packages',
+              default=_default_packages_path,
               type=click.Path(file_okay=False, dir_okay=True),
               help='Directory to download the build artifacts')
 @click.option('--dry-run/--execute', default=False,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1493,20 +1493,15 @@ services:
         maven: 3.5
         node: ${NODE}
         go: ${GO}
-    volumes: *conda-volumes
+    volumes:
+      - ./testing:/arrow/testing:delegated
     environment:
       <<: *ccache
       # tell archery where the arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
       ARCHERY_INTEGRATION_WITH_RUST: 0
     command:
-      ["/arrow/ci/scripts/rust_build.sh /arrow /build &&
-        /arrow/ci/scripts/cpp_build.sh /arrow /build &&
-        /arrow/ci/scripts/csharp_build.sh /arrow /build &&
-        /arrow/ci/scripts/go_build.sh /arrow &&
-        /arrow/ci/scripts/java_build.sh /arrow /build &&
-        /arrow/ci/scripts/js_build.sh /arrow /build &&
-        /arrow/ci/scripts/integration_arrow.sh /arrow /build"]
+      ["/arrow/ci/scripts/integration_arrow.sh /arrow /build"]
 
   ################################ Docs #######################################
 


### PR DESCRIPTION
This is a draft PR to gauge interest in splitting the build of integration tests into separate stages, so that a change in a language does not trigger a rebuild in all of them.

The idea is to use docker multi-stage builds to build the integration test binaries for each language, which are then packed in the same docker image prior to running all the tests. This has 2 main consequences:

1. the build of each of the languages is done in parallel, since docker parallelizes independent stages
2. the build of a language is only done when something changed on it

Overall, the hope is to significantly reduce the time it takes to build and run the tests, as we only need to build the language that changed in a given PR, as opposed to all of them. It also makes it easier to understand what dependencies each language depends on.

There are some rough edges in the crossbow, but before handling them, I would like to gauge whether this is something that others would be interested in.