### PR TITLE
ARROW-5248: [Python] support zoneinfo / dateutil timezones

### DIFF
--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -427,8 +427,6 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
 Result<std::string> TzinfoToString(PyObject* tzinfo) {
   OwnedRef module_pytz;        // import pytz
   OwnedRef module_datetime;    // import datetime
-  OwnedRef module_zoneinfo;    // import zoneinfo
-  OwnedRef module_dateutil;    // import dateutil
   OwnedRef class_timezone;     // from datetime import timezone
   OwnedRef class_fixedoffset;  // from pytz import _FixedOffset
 

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -492,7 +492,7 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     // _filename returns a full path in general ('/usr/share/zoneinfo/Europe/Paris')
     // or POSIX name on Windows ('Europe/Paris') - we need a substring in first case
     std::size_t pos = result.find("zoneinfo/");
-    if (pos > 0) {
+    if (pos != std::string::npos) {
       return result.substr(pos + 9);
     }
     return result;

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -490,7 +490,9 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     std::string result;
     RETURN_NOT_OK(internal::PyUnicode_AsStdString(_filename.obj(), &result));
     std::size_t pos = result.find("zoneinfo/");
-    if (pos > 0) {return result.substr (pos+9);}
+    if (pos > 0) {
+      return result.substr(pos + 9);
+    }
     return result;
   }
 

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -435,8 +435,6 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
   // import necessary modules
   RETURN_NOT_OK(internal::ImportModule("pytz", &module_pytz));
   RETURN_NOT_OK(internal::ImportModule("datetime", &module_datetime));
-  RETURN_NOT_OK(internal::ImportModule("zoneinfo", &module_zoneinfo));
-  RETURN_NOT_OK(internal::ImportModule("dateutil", &module_dateutil));
   // import necessary classes
   RETURN_NOT_OK(
       internal::ImportFromModule(module_pytz.obj(), "_FixedOffset", &class_fixedoffset));

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -473,6 +473,7 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
   }
 
   // try to look up key attribute
+  // in case of zoneinfo object
   if (PyObject_HasAttrString(tzinfo, "key")) {
     OwnedRef key(PyObject_GetAttrString(tzinfo, "key"));
     RETURN_IF_PYERROR();
@@ -482,11 +483,14 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
   }
 
   // try to look up _filename attribute
+  // in case of dateutil.tz object
   if (PyObject_HasAttrString(tzinfo, "_filename")) {
     OwnedRef _filename(PyObject_GetAttrString(tzinfo, "_filename"));
     RETURN_IF_PYERROR();
     std::string result;
     RETURN_NOT_OK(internal::PyUnicode_AsStdString(_filename.obj(), &result));
+    // _filename returns a full path in general ('/usr/share/zoneinfo/Europe/Paris')
+    // or POSIX name on Windows ('Europe/Paris') - we need a substring in first case
     std::size_t pos = result.find("zoneinfo/");
     if (pos > 0) {
       return result.substr(pos + 9);

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -24,7 +24,6 @@ import sys
 import pickle
 import pytest
 import pytz
-import dateutil.tz
 import hypothesis as h
 import hypothesis.strategies as st
 import hypothesis.extra.pytz as tzst
@@ -298,12 +297,19 @@ def test_is_primitive():
     (pytz.timezone('Etc/GMT-9'), 'Etc/GMT-9'),
     (pytz.FixedOffset(180), '+03:00'),
     (datetime.timezone.utc, 'UTC'),
-    (datetime.timezone(datetime.timedelta(hours=1, minutes=30)), '+01:30'),
-    (dateutil.tz.gettz('Europe/Brussels'), 'Europe/Brussels'),
-    (dateutil.tz.UTC, 'UTC')
+    (datetime.timezone(datetime.timedelta(hours=1, minutes=30)), '+01:30')
 ])
 def test_tzinfo_to_string(tz, expected):
     assert pa.lib.tzinfo_to_string(tz) == expected
+
+
+def test_dateutil_tzinfo_to_string():
+    import dateutil.tz
+
+    tz = dateutil.tz.UTC
+    assert pa.lib.tzinfo_to_string(tz) == 'UTC'
+    tz = dateutil.tz.gettz('Europe/Paris')
+    assert pa.lib.tzinfo_to_string(tz) == 'Europe/Paris'
 
 
 def test_zoneinfo_tzinfo_to_string():

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -24,7 +24,6 @@ import sys
 import pickle
 import pytest
 import pytz
-import zoneinfo
 import dateutil.tz
 import hypothesis as h
 import hypothesis.strategies as st
@@ -300,13 +299,20 @@ def test_is_primitive():
     (pytz.FixedOffset(180), '+03:00'),
     (datetime.timezone.utc, 'UTC'),
     (datetime.timezone(datetime.timedelta(hours=1, minutes=30)), '+01:30'),
-    (zoneinfo.ZoneInfo('Europe/Paris'), 'Europe/Paris'),
-    (zoneinfo.ZoneInfo('UTC'), 'UTC'),
     (dateutil.tz.gettz('Europe/Brussels'), 'Europe/Brussels'),
     (dateutil.tz.UTC, 'UTC')
 ])
 def test_tzinfo_to_string(tz, expected):
     assert pa.lib.tzinfo_to_string(tz) == expected
+
+
+def test_zoneinfo_tzinfo_to_string():
+    zoneinfo = pytest.importorskip('zoneinfo')
+
+    tz = zoneinfo.ZoneInfo('UTC')
+    assert pa.lib.tzinfo_to_string(tz) == 'UTC'
+    tz = zoneinfo.ZoneInfo('Europe/Paris')
+    assert pa.lib.tzinfo_to_string(tz) == 'Europe/Paris'
 
 
 def test_tzinfo_to_string_errors():

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -24,6 +24,8 @@ import sys
 import pickle
 import pytest
 import pytz
+import zoneinfo
+import dateutil.tz
 import hypothesis as h
 import hypothesis.strategies as st
 import hypothesis.extra.pytz as tzst
@@ -297,7 +299,11 @@ def test_is_primitive():
     (pytz.timezone('Etc/GMT-9'), 'Etc/GMT-9'),
     (pytz.FixedOffset(180), '+03:00'),
     (datetime.timezone.utc, 'UTC'),
-    (datetime.timezone(datetime.timedelta(hours=1, minutes=30)), '+01:30')
+    (datetime.timezone(datetime.timedelta(hours=1, minutes=30)), '+01:30'),
+    (zoneinfo.ZoneInfo('Europe/Paris'), 'Europe/Paris'),
+    (zoneinfo.ZoneInfo('UTC'), 'UTC'),
+    (dateutil.tz.gettz('Europe/Brussels'), 'Europe/Brussels'),
+    (dateutil.tz.UTC, 'UTC')
 ])
 def test_tzinfo_to_string(tz, expected):
     assert pa.lib.tzinfo_to_string(tz) == expected

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -304,6 +304,7 @@ def test_tzinfo_to_string(tz, expected):
 
 
 def test_dateutil_tzinfo_to_string():
+    pytest.importorskip("dateutil")
     import dateutil.tz
 
     tz = dateutil.tz.UTC


### PR DESCRIPTION
This PR tries to add support for `zoneinfo` and `dateutil` timezones. 

- [x] Add support for the `zoneinfo`
- [x] Add tests for `zoneinfo` support
- [x] Add support for `dateutil`
- [x] Add tests for `dateutil` support