### PR TITLE
PARQUET-2123: [C++] Fix invalid memory access in ScanFileContents

### DIFF
--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -826,6 +826,11 @@ int64_t ScanFileContents(std::vector<int> columns, const int32_t column_batch_si
       columns[i] = i;
     }
   }
+  if (num_columns == 0) {
+    // If we still have no columns(none in file), return early. The remainder of function
+    // expects there to be at least one column.
+    return 0;
+  }
 
   std::vector<int64_t> total_rows(num_columns, 0);
 


### PR DESCRIPTION
ScanFileContents assumes that there is at least one column and returns
the number of rows in total_rows[0], which is technically invalid when
there are zero columns. Fix by returning early if there are zero
columns.