### PR TITLE
ARROW-15682: [CI] Github starting to migrate "windows-latest" tag from windows 2019 to windows 2022

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -186,9 +186,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-latest
+          - windows-2019
         include:
-          - os: windows-latest
+          - os: windows-2019
             name: Windows 2019
             generator: Visual Studio 16 2019
     env:
@@ -248,7 +248,7 @@ jobs:
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -65,7 +65,7 @@ jobs:
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -134,7 +134,7 @@ jobs:
 
   windows:
     name: AMD64 Windows 2019 Go ${{ matrix.go }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:
@@ -217,7 +217,7 @@ jobs:
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} CGO
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -93,8 +93,8 @@ jobs:
         run: ci/scripts/js_test.sh $(pwd)
 
   windows:
-    name: AMD64 Windows 2019 NodeJS ${{ matrix.node }}
-    runs-on: windows-2019
+    name: AMD64 Windows NodeJS ${{ matrix.node }}
+    runs-on: windows-latest
     if: github.event_name == 'push'
     strategy:
       fail-fast: false

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -94,7 +94,7 @@ jobs:
 
   windows:
     name: AMD64 Windows 2019 NodeJS ${{ matrix.node }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: github.event_name == 'push'
     strategy:
       fail-fast: false

--- a/.github/workflows/julia.yml
+++ b/.github/workflows/julia.yml
@@ -46,7 +46,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -164,7 +164,7 @@ jobs:
 
   windows-cpp:
     name: AMD64 Windows C++ RTools ${{ matrix.config.rtools }} ${{ matrix.config.arch }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:
@@ -234,7 +234,7 @@ jobs:
   windows-r:
     needs: [windows-cpp]
     name: AMD64 Windows R RTools ${{ matrix.rtools }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -171,7 +171,7 @@ jobs:
 
   windows:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} GLib & Ruby
-    runs-on: windows-latest
+    runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 40
     strategy:


### PR DESCRIPTION
Announcement: https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/

It will be rolling out over the next 8 weeks.  I noticed because they changed one of the runners for my local fork.

Some of our builds assume windows-latest means 2019.
