### PR TITLE
ARROW-15672: [C++] Enable CSV writer to control the field delimiter

### DIFF
--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,7 +73,7 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
-    if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r')) {
+  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r')) {
     return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n");
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -75,7 +75,9 @@ WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 Status WriteOptions::Validate() const {
   if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '"' ||
                           std::string(1, delimiter) == eol)) {
-    return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n or \" or EOL");
+    return Status::Invalid(
+        "WriteOptions: delimiter cannot be \\r or \\n or \" or EOL. Invalid value: ",
+        delimiter);
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {
     return Status::Invalid("WriteOptions: batch_size must be at least 1: ", batch_size);

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -74,7 +74,7 @@ WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
   if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '"' ||
-                          std::string(1, delimiter) == eol)) {
+                          eol.find(delimiter) != std::string::npos)) {
     return Status::Invalid(
         "WriteOptions: delimiter cannot be \\r or \\n or \" or EOL. Invalid value: ",
         delimiter);

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,7 +73,7 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
-  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r')) {
+  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '\"')) {
     return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n");
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,7 +73,7 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
-  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '\"')) {
+  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '"')) {
     return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n");
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,6 +73,9 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
+    if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r')) {
+    return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n");
+  }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {
     return Status::Invalid("WriteOptions: batch_size must be at least 1: ", batch_size);
   }

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,8 +73,8 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
-  if (ARROW_PREDICT_FALSE(delimiter.compare("\n") == 0 || delimiter.compare("\r") == 0 ||
-                          delimiter.compare("\"") == 0 || delimiter.compare(eol) == 0)) {
+  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '"' ||
+                          std::string(1, delimiter) == eol)) {
     return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n or \" or EOL");
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -73,8 +73,9 @@ Status ReadOptions::Validate() const {
 WriteOptions WriteOptions::Defaults() { return WriteOptions(); }
 
 Status WriteOptions::Validate() const {
-  if (ARROW_PREDICT_FALSE(delimiter == '\n' || delimiter == '\r' || delimiter == '"')) {
-    return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n");
+  if (ARROW_PREDICT_FALSE(delimiter.compare("\n") == 0 || delimiter.compare("\r") == 0 ||
+                          delimiter.compare("\"") == 0 || delimiter.compare(eol) == 0)) {
+    return Status::Invalid("WriteOptions: delimiter cannot be \\r or \\n or \" or EOL");
   }
   if (ARROW_PREDICT_FALSE(batch_size < 1)) {
     return Status::Invalid("WriteOptions: batch_size must be at least 1: ", batch_size);

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -194,6 +194,9 @@ struct ARROW_EXPORT WriteOptions {
   /// This number can impact performance.
   int32_t batch_size = 1024;
 
+  /// Field delimiter
+  char delimiter = ',';
+
   /// \brief The string to write for null values. Quotes are not allowed in this string.
   std::string null_string;
 

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -195,7 +195,7 @@ struct ARROW_EXPORT WriteOptions {
   int32_t batch_size = 1024;
 
   /// Field delimiter
-  char delimiter = ',';
+  std::string delimiter = ",";
 
   /// \brief The string to write for null values. Quotes are not allowed in this string.
   std::string null_string;

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -195,7 +195,7 @@ struct ARROW_EXPORT WriteOptions {
   int32_t batch_size = 1024;
 
   /// Field delimiter
-  std::string delimiter = ",";
+  char delimiter = ',';
 
   /// \brief The string to write for null values. Quotes are not allowed in this string.
   std::string null_string;

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -428,9 +428,10 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
            options.null_string.length());
 
     std::vector<std::unique_ptr<ColumnPopulator>> populators(schema->num_fields());
+    std::string delimiter(1, options.delimiter);
     for (int col = 0; col < schema->num_fields(); col++) {
       const std::string& end_chars =
-          col < schema->num_fields() - 1 ? std::string(1,options.delimiter) : options.eol;
+          col < schema->num_fields() - 1 ? delimiter : options.eol;
       ASSIGN_OR_RAISE(populators[col],
                       MakePopulator(*schema->field(col), end_chars, null_string,
                                     options.quoting_style, options.io_context.pool()));

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -157,16 +157,18 @@ char* EscapeReverse(arrow::util::string_view s, char* out_end) {
 class UnquotedColumnPopulator : public ColumnPopulator {
  public:
   explicit UnquotedColumnPopulator(MemoryPool* memory_pool, std::string end_chars,
+                                   std::string delimiter,
                                    std::shared_ptr<Buffer> null_string_,
                                    bool reject_values_with_quotes)
       : ColumnPopulator(memory_pool, std::move(end_chars), std::move(null_string_)),
+        delimiter_(delimiter),
         reject_values_with_quotes_(reject_values_with_quotes) {}
 
   Status UpdateRowLengths(int32_t* row_lengths) override {
     if (reject_values_with_quotes_) {
       // When working on values that, after casting, could produce quotes,
       // we need to return an error in accord with RFC4180.
-      RETURN_NOT_OK(CheckStringArrayHasNoStructuralChars(*casted_array_));
+      RETURN_NOT_OK(CheckStringArrayHasNoStructuralChars(*casted_array_, delimiter_));
     }
 
     for (int x = 0; x < casted_array_->length(); x++) {
@@ -209,7 +211,8 @@ class UnquotedColumnPopulator : public ColumnPopulator {
 
  private:
   // Returns an error status if string array has any structural characters.
-  static Status CheckStringArrayHasNoStructuralChars(const StringArray& array) {
+  static Status CheckStringArrayHasNoStructuralChars(const StringArray& array,
+                                                     const std::string delimiter) {
     // scan the underlying string array buffer as a single big string
     const uint8_t* const data = array.raw_data() + array.value_offset(0);
     const int64_t buffer_size = array.total_values_length();
@@ -224,7 +227,7 @@ class UnquotedColumnPopulator : public ColumnPopulator {
 #endif
     while ((offset + 16) <= buffer_size) {
       const auto v = simd_batch::load_unaligned(data + offset);
-      if (xsimd::any((v == '\n') | (v == '\r') | (v == ',') | (v == '"'))) {
+      if (xsimd::any((v == '\n') | (v == '\r') | (v == '"') | (v == delimiter))) {
         break;
       }
       offset += 16;
@@ -251,6 +254,7 @@ class UnquotedColumnPopulator : public ColumnPopulator {
   }
 
   // Whether to reject values with quotes when populating.
+  const std::string delimiter_;
   const bool reject_values_with_quotes_;
 };
 
@@ -347,7 +351,7 @@ struct PopulatorFactory {
         // In unquoted output we must reject values with quotes. Since these types can
         // produce quotes in their output rendering, we must check them and reject if
         // quotes appear, hence reject_values_with_quotes is set to true.
-        populator = new UnquotedColumnPopulator(pool, end_chars, null_string,
+        populator = new UnquotedColumnPopulator(pool, end_chars, delimiter, null_string,
                                                 /*reject_values_with_quotes=*/true);
         break;
         // Quoting is needed for strings/binary, or when all valid values need to be
@@ -384,7 +388,7 @@ struct PopulatorFactory {
         // is None.
       case QuotingStyle::None:
       case QuotingStyle::Needed:
-        populator = new UnquotedColumnPopulator(pool, end_chars, null_string,
+        populator = new UnquotedColumnPopulator(pool, end_chars, delimiter, null_string,
                                                 /*reject_values_with_quotes=*/false);
         break;
       case QuotingStyle::AllValid:
@@ -395,6 +399,7 @@ struct PopulatorFactory {
   }
 
   const std::string end_chars;
+  const std::string delimiter;
   std::shared_ptr<Buffer> null_string;
   const QuotingStyle quoting_style;
   MemoryPool* pool;
@@ -402,10 +407,10 @@ struct PopulatorFactory {
 };
 
 Result<std::unique_ptr<ColumnPopulator>> MakePopulator(
-    const Field& field, std::string end_chars, std::shared_ptr<Buffer> null_string,
-    QuotingStyle quoting_style, MemoryPool* pool) {
-  PopulatorFactory factory{std::move(end_chars), std::move(null_string), quoting_style,
-                           pool, nullptr};
+    const Field& field, std::string end_chars, std::string delimiter,
+    std::shared_ptr<Buffer> null_string, QuotingStyle quoting_style, MemoryPool* pool) {
+  PopulatorFactory factory{std::move(end_chars), delimiter, std::move(null_string),
+                           quoting_style,        pool,      nullptr};
 
   RETURN_NOT_OK(VisitTypeInline(*field.type(), &factory));
   return std::unique_ptr<ColumnPopulator>(factory.populator);
@@ -431,9 +436,10 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     for (int col = 0; col < schema->num_fields(); col++) {
       const std::string& end_chars =
           col < schema->num_fields() - 1 ? options.delimiter : options.eol;
-      ASSIGN_OR_RAISE(populators[col],
-                      MakePopulator(*schema->field(col), end_chars, null_string,
-                                    options.quoting_style, options.io_context.pool()));
+      ASSIGN_OR_RAISE(
+          populators[col],
+          MakePopulator(*schema->field(col), end_chars, options.delimiter, null_string,
+                        options.quoting_style, options.io_context.pool()));
     }
     auto writer = std::make_shared<CSVWriterImpl>(
         sink, std::move(owned_sink), std::move(schema), std::move(populators), options);

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -235,7 +235,7 @@ class UnquotedColumnPopulator : public ColumnPopulator {
     while (offset < buffer_size) {
       // error happened or remaining bytes to check
       const char c = static_cast<char>(data[offset]);
-      if (c == '\n' || c == '\r' || c == ',' || c == '"' || c == delimiter) {
+      if (c == '\n' || c == '\r' || c == '"' || c == delimiter) {
         // extract the offending string from array per offset
         const auto* offsets = array.raw_value_offsets();
         const auto index =

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -87,7 +87,6 @@ int64_t CountQuotes(arrow::util::string_view s) {
 // Matching quote pair character length.
 constexpr int64_t kQuoteCount = 2;
 constexpr int64_t kQuoteDelimiterCount = kQuoteCount + /*end_char*/ 1;
-constexpr const char* kStrComma = ",";
 
 // Interface for generating CSV data per column.
 // The intended usage is to iteratively call UpdateRowLengths for a column and
@@ -431,7 +430,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     std::vector<std::unique_ptr<ColumnPopulator>> populators(schema->num_fields());
     for (int col = 0; col < schema->num_fields(); col++) {
       const std::string& end_chars =
-          col < schema->num_fields() - 1 ? kStrComma : options.eol;
+          col < schema->num_fields() - 1 ? std::string(1,options.delimiter) : options.eol;
       ASSIGN_OR_RAISE(populators[col],
                       MakePopulator(*schema->field(col), end_chars, null_string,
                                     options.quoting_style, options.io_context.pool()));

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -428,10 +428,9 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
            options.null_string.length());
 
     std::vector<std::unique_ptr<ColumnPopulator>> populators(schema->num_fields());
-    std::string delimiter(1, options.delimiter);
     for (int col = 0; col < schema->num_fields(); col++) {
       const std::string& end_chars =
-          col < schema->num_fields() - 1 ? delimiter : options.eol;
+          col < schema->num_fields() - 1 ? options.delimiter : options.eol;
       ASSIGN_OR_RAISE(populators[col],
                       MakePopulator(*schema->field(col), end_chars, null_string,
                                     options.quoting_style, options.io_context.pool()));

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -521,7 +521,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     char* next = reinterpret_cast<char*>(data_buffer_->mutable_data() +
                                          data_buffer_->size() - options_.eol.size());
     for (int col = schema_->num_fields() - 1; col >= 0; col--) {
-      *next-- = ',';
+      *next-- = options_.delimiter;
       *next-- = '"';
       next = EscapeReverse(schema_->field(col)->name(), next);
       *next-- = '"';

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -242,6 +242,7 @@ std::vector<WriterTestParams> GenerateTestCases() {
       reject_structural_params({"0123456789", nullptr, "abcdef,", nullptr}, "abcdef,"),
       reject_structural_params({nullptr, nullptr, ",0123456789", "abcde"}, ",0123456789"),
       reject_structural_params({"0123456", nullptr, "7\\\"89", ",abcdef"}, "7\"89"),
+      // exercise custom delimiter
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, "\n", /*delimiter=*/'\t'),

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -61,7 +61,7 @@ WriteOptions DefaultTestOptions(bool include_header = false,
                                 const std::string& null_string = "",
                                 QuotingStyle quoting_style = QuotingStyle::Needed,
                                 const std::string& eol = "\n",
-                                const std::string& delimiter = ",") {
+                                const char& delimiter = ',') {
   WriteOptions options;
   options.batch_size = 5;
   options.include_header = include_header;
@@ -173,7 +173,7 @@ std::vector<WriterTestParams> GenerateTestCases() {
         "style is \"None\". See RFC4180. Invalid value: ",
         value);
   };
-  auto expected_status_custom_delimiter = [](const char* value) {
+  auto expected_status_custom_delimiter = [](const char value) {
     return Status::Invalid(value, " Delimiter is not valid with the provided data. ");
   };
 
@@ -250,20 +250,20 @@ std::vector<WriterTestParams> GenerateTestCases() {
       // exercise custom delimiter
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
-                          QuotingStyle::Needed, "\n", /*delimiter=*/"\t"),
+                          QuotingStyle::Needed, "\n", /*delimiter=*/'\t'),
        expected_output_delimiter_tabs},
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
-                          QuotingStyle::Needed, "\n", /*delimiter=*/"|"),
+                          QuotingStyle::Needed, "\n", /*delimiter=*/'|'),
        expected_output_delimiter_pipe},
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, "\n"),
-       expected_output_delimiter_pipe, expected_status_custom_delimiter("|")},
+       expected_output_delimiter_pipe, expected_status_custom_delimiter('|')},
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
-                          QuotingStyle::Needed, "\n", /*delimiter=*/"|"),
-       expected_output_delimiter_comma, expected_status_custom_delimiter(",")}};
+                          QuotingStyle::Needed, "\n", /*delimiter=*/'|'),
+       expected_output_delimiter_comma, expected_status_custom_delimiter(',')}};
 }
 
 class TestWriteCSV : public ::testing::TestWithParam<WriterTestParams> {

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -60,8 +60,7 @@ void PrintTo(const WriterTestParams& p, std::ostream* os) {
 WriteOptions DefaultTestOptions(bool include_header = false,
                                 const std::string& null_string = "",
                                 QuotingStyle quoting_style = QuotingStyle::Needed,
-                                const std::string& eol = "\n",
-                                const char& delimiter = ',') {
+                                const std::string& eol = "\n", char delimiter = ',') {
   WriteOptions options;
   options.batch_size = 5;
   options.include_header = include_header;
@@ -174,12 +173,6 @@ std::vector<WriterTestParams> GenerateTestCases() {
         value);
   };
 
-  auto expected_status_illegal_delimiter = [](const char value) {
-    return Status::Invalid(
-        "WriteOptions: delimiter cannot be \\r or \\n or \" or EOL. Invalid value: ",
-        value);
-  };
-
   auto reject_structural_params = [&](std::vector<const char*> rows,
                                       const char* error_val) -> WriterTestParams {
     std::string json_rows = "[";
@@ -202,7 +195,11 @@ std::vector<WriterTestParams> GenerateTestCases() {
   auto schema_custom_delimiter = schema({field("a", int64()), field("b", int64())});
   auto batch_custom_delimiter = R"([{"a": 42, "b": -12}])";
   auto expected_output_delimiter_tabs = "42\t-12\n";
-  auto expected_output_delimiter_pipe = "42|-12\n";
+  auto expected_status_illegal_delimiter = [](const char value) {
+    return Status::Invalid(
+        "WriteOptions: delimiter cannot be \\r or \\n or \" or EOL. Invalid value: ",
+        value);
+  };
 
   return std::vector<WriterTestParams>{
       {abc_schema, "[]", DefaultTestOptions(), ""},
@@ -254,10 +251,6 @@ std::vector<WriterTestParams> GenerateTestCases() {
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, "\n", /*delimiter=*/'\t'),
        expected_output_delimiter_tabs},
-      {schema_custom_delimiter, batch_custom_delimiter,
-       DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
-                          QuotingStyle::Needed, "\n", /*delimiter=*/'|'),
-       expected_output_delimiter_pipe},
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/"\n", /*delimiter=*/'\r'),

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1025,7 +1025,7 @@ cdef class WriteOptions(_Weakrefable):
     batch_size : int, optional (default 1024)
         How many rows to process together when converting and writing
         CSV data
-    delimiter : 1-character string, optional (default ',')
+    delimiter : 1-character string, optional (default ",")
         The character delimiting individual cells in the CSV data.
     """
 
@@ -1070,11 +1070,11 @@ cdef class WriteOptions(_Weakrefable):
         """
         The character delimiting individual cells in the CSV data.
         """
-        return chr(deref(self.options).delimiter)
+        return deref(self.options).delimiter.decode()
 
     @delimiter.setter
     def delimiter(self, value):
-        deref(self.options).delimiter = _single_char(value)
+        deref(self.options).delimiter = tobytes(value)
 
     @staticmethod
     cdef WriteOptions wrap(CCSVWriteOptions options):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1025,17 +1025,21 @@ cdef class WriteOptions(_Weakrefable):
     batch_size : int, optional (default 1024)
         How many rows to process together when converting and writing
         CSV data
+    delimiter : char, optional (default `'`)
+        The character delimiting individual cells in the CSV data.
     """
 
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
-    def __init__(self, *, include_header=None, batch_size=None):
+    def __init__(self, *, include_header=None, batch_size=None, delimiter=None):
         self.options.reset(new CCSVWriteOptions(CCSVWriteOptions.Defaults()))
         if include_header is not None:
             self.include_header = include_header
         if batch_size is not None:
             self.batch_size = batch_size
+        if delimiter is not None:
+            self.delimiter = delimiter
 
     @property
     def include_header(self):
@@ -1059,6 +1063,17 @@ cdef class WriteOptions(_Weakrefable):
     @batch_size.setter
     def batch_size(self, value):
         deref(self.options).batch_size = value
+
+    @property
+    def delimiter(self):
+        """
+        The character delimiting individual cells in the CSV data.
+        """
+        return deref(self.options).delimiter
+
+    @delimiter.setter
+    def delimiter(self, value):
+        deref(self.options).delimiter = value
 
     @staticmethod
     cdef WriteOptions wrap(CCSVWriteOptions options):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1032,7 +1032,8 @@ cdef class WriteOptions(_Weakrefable):
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
-    def __init__(self, *, include_header=None, batch_size=None, delimiter=None):
+    def __init__(self, *, include_header=None, batch_size=None,
+                 delimiter=None):
         self.options.reset(new CCSVWriteOptions(CCSVWriteOptions.Defaults()))
         if include_header is not None:
             self.include_header = include_header

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1070,11 +1070,11 @@ cdef class WriteOptions(_Weakrefable):
         """
         The character delimiting individual cells in the CSV data.
         """
-        return deref(self.options).delimiter.decode()
+        return chr(deref(self.options).delimiter)
 
     @delimiter.setter
     def delimiter(self, value):
-        deref(self.options).delimiter = tobytes(value)
+        deref(self.options).delimiter = _single_char(value)
 
     @staticmethod
     cdef WriteOptions wrap(CCSVWriteOptions options):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1025,7 +1025,7 @@ cdef class WriteOptions(_Weakrefable):
     batch_size : int, optional (default 1024)
         How many rows to process together when converting and writing
         CSV data
-    delimiter : char, optional (default `'`)
+    delimiter : 1-character string, optional (default ',')
         The character delimiting individual cells in the CSV data.
     """
 
@@ -1069,11 +1069,11 @@ cdef class WriteOptions(_Weakrefable):
         """
         The character delimiting individual cells in the CSV data.
         """
-        return deref(self.options).delimiter
+        return chr(deref(self.options).delimiter)
 
     @delimiter.setter
     def delimiter(self, value):
-        deref(self.options).delimiter = value
+        deref(self.options).delimiter = _single_char(value)
 
     @staticmethod
     cdef WriteOptions wrap(CCSVWriteOptions options):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1713,6 +1713,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVWriteOptions" arrow::csv::WriteOptions":
         c_bool include_header
         int32_t batch_size
+        unsigned char delimiter
         CIOContext io_context
 
         CCSVWriteOptions()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1713,7 +1713,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVWriteOptions" arrow::csv::WriteOptions":
         c_bool include_header
         int32_t batch_size
-        c_string delimiter
+        char delimiter
         CIOContext io_context
 
         CCSVWriteOptions()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1651,7 +1651,7 @@ cdef extern from "arrow/python/csv.h" namespace "arrow::py::csv":
 cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
 
     cdef cppclass CCSVParseOptions" arrow::csv::ParseOptions":
-        char delimiter
+        unsigned char delimiter
         c_bool quoting
         unsigned char quote_char
         c_bool double_quote
@@ -1713,7 +1713,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVWriteOptions" arrow::csv::WriteOptions":
         c_bool include_header
         int32_t batch_size
-        char delimiter
+        unsigned char delimiter
         CIOContext io_context
 
         CCSVWriteOptions()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1651,7 +1651,7 @@ cdef extern from "arrow/python/csv.h" namespace "arrow::py::csv":
 cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
 
     cdef cppclass CCSVParseOptions" arrow::csv::ParseOptions":
-        unsigned char delimiter
+        char delimiter
         c_bool quoting
         unsigned char quote_char
         c_bool double_quote
@@ -1713,7 +1713,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVWriteOptions" arrow::csv::WriteOptions":
         c_bool include_header
         int32_t batch_size
-        unsigned char delimiter
+        char delimiter
         CIOContext io_context
 
         CCSVWriteOptions()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1713,7 +1713,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVWriteOptions" arrow::csv::WriteOptions":
         c_bool include_header
         int32_t batch_size
-        char delimiter
+        c_string delimiter
         CIOContext io_context
 
         CCSVWriteOptions()

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -326,7 +326,7 @@ def test_write_options():
     opts = cls()
 
     check_options_class(
-        cls, include_header=[True, False], delimiter=[",", "\t", "|"])
+        cls, include_header=[True, False], delimiter=[',', '\t', '|'])
 
     assert opts.batch_size > 0
     opts.batch_size = 12345
@@ -1873,10 +1873,15 @@ def test_write_read_round_trip():
         assert t == read_csv(buf, read_options=read_options)
 
     # Test with writer
-    for read_options, write_options in [
-        (None, WriteOptions(include_header=True)),
-        (ReadOptions(column_names=t.column_names),
+    for read_options, parse_options, write_options in [
+        (None, None, WriteOptions(include_header=True)),
+        (ReadOptions(column_names=t.column_names), None,
          WriteOptions(include_header=False)),
+        (None, ParseOptions(delimiter='|'),
+         WriteOptions(include_header=True, delimiter='|')),
+        (ReadOptions(column_names=t.column_names),
+         ParseOptions(delimiter='\t'),
+         WriteOptions(include_header=False, delimiter='\t')),
     ]:
         buf = io.BytesIO()
         with CSVWriter(buf, t.schema, write_options=write_options) as writer:
@@ -1889,7 +1894,8 @@ def test_write_read_round_trip():
             for batch in t.to_batches(max_chunksize=1):
                 writer.write_batch(batch)
         buf.seek(0)
-        assert t == read_csv(buf, read_options=read_options)
+        assert t == read_csv(buf, read_options=read_options,
+                             parse_options=parse_options)
 
 
 def test_read_csv_reference_cycle():

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -326,7 +326,7 @@ def test_write_options():
     opts = cls()
 
     check_options_class(
-        cls, include_header=[True, False])
+        cls, include_header=[True, False], delimiter=[",", "\t", "|"])
 
     assert opts.batch_size > 0
     opts.batch_size = 12345

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -1887,8 +1887,8 @@ def test_write_read_round_trip():
         with CSVWriter(buf, t.schema, write_options=write_options) as writer:
             writer.write_table(t)
         buf.seek(0)
-        assert t == read_csv(buf, read_options=read_options)
-
+        assert t == read_csv(buf, read_options=read_options,
+                             parse_options=parse_options)
         buf = io.BytesIO()
         with CSVWriter(buf, t.schema, write_options=write_options) as writer:
             for batch in t.to_batches(max_chunksize=1):


### PR DESCRIPTION
This PR modifies the WriteOptions for CSV to allow changing the default delimiter.