### PR TITLE
PARQUET-2124: [C++] Remove Parquet Dictionary DCHECK

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -752,9 +752,6 @@ class ColumnReaderImplBase {
     auto it = decoders_.find(static_cast<int>(encoding));
     if (it != decoders_.end()) {
       DCHECK(it->second.get() != nullptr);
-      if (encoding == Encoding::RLE_DICTIONARY) {
-        DCHECK(current_decoder_->encoding() == Encoding::RLE_DICTIONARY);
-      }
       current_decoder_ = it->second.get();
     } else {
       switch (encoding) {


### PR DESCRIPTION
DCHECK doesn't make sense here as we can hit this condition due to
Parquet file with a non-dictionary encoded data page followed by a
dictionary encoded data page(dictionary page before both data pages).
Nothing in Parquet spec seems to preclude this and this should work with
decoding logic. See JIRA for more evidence in support of this.