### PR TITLE
ARROW-14815 [R] bindings for `lubridate::semester()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,8 +21,7 @@
 
 * `lubridate`: 
   * `tz()` to extract/get timezone
-* `lubridate` features: `semester()`
-* Additional `lubridate` features: `semester()`.
+  * `semester()` to extract/get semester
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,6 +21,7 @@
 
 * `lubridate`: 
   * `tz()` to extract/get timezone
+* `lubridate` features: `semester()`
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -22,6 +22,7 @@
 * `lubridate`: 
   * `tz()` to extract/get timezone
 * `lubridate` features: `semester()`
+* Additional `lubridate` features: `semester()`.
 
 # arrow 7.0.0
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -115,23 +115,6 @@ register_bindings_datetime <- function() {
       return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
     }
 
-    if (call_binding("is.integer", x)) {
-      if (inherits(x, "Expression")) {
-        call_binding(
-          "if_else",
-          call_binding_agg("all", call_binding("between", x, 1, 12))$data,
-          x,
-          abort("bla: Values are not in 1:12")
-        )
-      } else {
-        if (all(1 <= x & x <= 12)) {
-          return(x)
-        } else {
-          abort("bla2: Values are not in 1:12")
-        }
-      }
-    }
-
     Expression$create("month", x)
   })
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -115,6 +115,14 @@ register_bindings_datetime <- function() {
       return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
     }
 
+    if (call_binding("is.integer", x)) {
+      if (call_binding_agg("all", call_binding("between", x, 1, 12))) {
+        return(x)
+      } else {
+        abort("Values are not in 1:12")
+      }
+    }
+
     Expression$create("month", x)
   })
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -153,5 +153,14 @@ register_bindings_datetime <- function() {
     }
 
     x$type()$timezone()
+  register_binding("semester", function(x, with_year = FALSE) {
+    month <- call_binding("month", x)
+    semester <- call_binding("if_else", month <= 6, 1L, 2L)
+    if (with_year) {
+      year <- call_binding("year", x)
+      return(year + semester / 10)
+    } else {
+      return(semester)
+    }
   })
 }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -153,6 +153,7 @@ register_bindings_datetime <- function() {
     }
 
     x$type()$timezone()
+  })
   register_binding("semester", function(x, with_year = FALSE) {
     month <- call_binding("month", x)
     semester <- call_binding("if_else", month <= 6, 1L, 2L)

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -116,10 +116,19 @@ register_bindings_datetime <- function() {
     }
 
     if (call_binding("is.integer", x)) {
-      if (call_binding_agg("all", call_binding("between", x, 1, 12))) {
-        return(x)
+      if (inherits(x, "Expression")) {
+        call_binding(
+          "if_else",
+          call_binding_agg("all", call_binding("between", x, 1, 12))$data,
+          x,
+          abort("bla: Values are not in 1:12")
+        )
       } else {
-        abort("Values are not in 1:12")
+        if (all(1 <= x & x <= 12)) {
+          return(x)
+        } else {
+          abort("bla2: Values are not in 1:12")
+        }
       }
     }
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -781,7 +781,8 @@ test_that("semester errors with integers and characters", {
       arrow_table() %>%
       mutate(sem_month_as_int = semester(month_as_int)) %>%
       collect(),
-    regexp = "no kernel matching input types"
+    regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[int32])",
+    fixed = TRUE
   )
 
   expect_error(
@@ -789,6 +790,7 @@ test_that("semester errors with integers and characters", {
       arrow_table() %>%
       mutate(sem_month_as_char_pad = semester(month_as_char_pad)) %>%
       collect(),
-    regexp = "no kernel matching input types"
+    regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[string])",
+    fixed = TRUE
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -749,13 +749,14 @@ test_that("extract tz", {
     "timezone extraction for objects of class `string` not supported in Arrow"
 test_that("semester", {
 test_that("semester works with temporal types", {
+test_that("semester works with temporal types and integers", {
   test_df <- tibble(
     month_as_int = c(1:12, NA),
     month_as_char_pad = sprintf("%02i", month_as_int),
     dates = as.Date(paste0("2021-", month_as_char_pad, "-15"))
   )
 
-  # test extraction from dates
+  # semester extraction from dates
   compare_dplyr_binding(
      .input %>%
       mutate(sem_wo_year = semester(dates),
@@ -763,26 +764,16 @@ test_that("semester works with temporal types", {
       collect(),
      test_df
   )
-})
-
-test_that("semester errors with integers and characters", {
-  test_df <- tibble(
-    month_as_int = c(1:12, NA),
-    month_as_char_pad = sprintf("%02i", month_as_int),
-    dates = as.Date(paste0("2021-", month_as_char_pad, "-15"))
-  )
-
-  # extraction from integers should error as we currently do not support setting
-  # month components with month, but this is supported by `lubridate::month()`
-  # TODO this should no longer fail once https://issues.apache.org/jira/browse/ARROW-15701
-  # is addressed
-  expect_error(
-    test_df %>%
-      arrow_table() %>%
+  # semester extraction from months as integers
+  compare_dplyr_binding(
+    .input %>%
       mutate(sem_month_as_int = semester(month_as_int)) %>%
       collect(),
-    regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[int32])",
-    fixed = TRUE
+    test_df
+  )
+
+  expect_error(
+    call_binding("semester", Expression$scalar(1:13))
   )
 
   expect_error(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -764,16 +764,16 @@ test_that("semester works with temporal types and integers", {
       collect(),
      test_df
   )
-  # semester extraction from months as integers
-  compare_dplyr_binding(
-    .input %>%
+  # semester extraction from months as integers is not supported yet
+  # it will be once https://issues.apache.org/jira/browse/ARROW-15701 is done
+  # TODO change from expect_error to compare_dplyr_bindings
+  expect_error(
+    test_df %>%
+      arrow_table() %>%
       mutate(sem_month_as_int = semester(month_as_int)) %>%
       collect(),
-    test_df
-  )
-
-  expect_error(
-    call_binding("semester", Expression$scalar(1:13))
+    regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[int32])",
+    fixed = TRUE
   )
 
   expect_error(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -747,5 +747,18 @@ test_that("extract tz", {
   expect_error(
     call_binding("tz", Expression$scalar("2020-10-01")),
     "timezone extraction for objects of class `string` not supported in Arrow"
+test_that("semester", {
+  test_df <- tibble(
+    month = c(1:12, NA),
+    month_char_pad = ifelse(month < 10, paste0("0", month), month),
+    dates = as.Date(paste0("2021-", month_char_pad, "-15"))
+  )
+
+  compare_dplyr_binding(
+     .input %>%
+      mutate(sem_wo_year = semester(dates),
+             sem_w_year = semester(dates, with_year = TRUE)) %>%
+      collect(),
+     test_df
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -744,11 +744,12 @@ test_that("extract tz", {
   )
 
   # Test one expression
-  expect_error(
-    call_binding("tz", Expression$scalar("2020-10-01")),
-    "timezone extraction for objects of class `string` not supported in Arrow"
-test_that("semester", {
-test_that("semester works with temporal types", {
+   expect_error(
+     call_binding("tz", Expression$scalar("2020-10-01")),
+     "timezone extraction for objects of class `string` not supported in Arrow"
+   )
+})
+
 test_that("semester works with temporal types and integers", {
   test_df <- tibble(
     month_as_int = c(1:12, NA),

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -751,7 +751,7 @@ test_that("semester", {
 test_that("semester works with temporal types", {
   test_df <- tibble(
     month_as_int = c(1:12, NA),
-    month_as_char_pad = ifelse(month_as_int < 10, paste0("0", month_as_int), month_as_int),
+    month_as_char_pad = sprintf("%02i", month_as_int),
     dates = as.Date(paste0("2021-", month_as_char_pad, "-15"))
   )
 
@@ -768,13 +768,13 @@ test_that("semester works with temporal types", {
 test_that("semester errors with integers and characters", {
   test_df <- tibble(
     month_as_int = c(1:12, NA),
-    month_as_char_pad = ifelse(month_as_int < 10, paste0("0", month_as_int), month_as_int),
+    month_as_char_pad = sprintf("%02i", month_as_int),
     dates = as.Date(paste0("2021-", month_as_char_pad, "-15"))
   )
 
   # extraction from integers should error as we currently do not support setting
   # month components with month, but this is supported by `lubridate::month()`
-  # this should no longer fail once https://issues.apache.org/jira/browse/ARROW-15701
+  # TODO this should no longer fail once https://issues.apache.org/jira/browse/ARROW-15701
   # is addressed
   expect_error(
     test_df %>%


### PR DESCRIPTION
Once this PR is merged the following code snippet will be valid

``` r
suppressPackageStartupMessages(library(dplyr))
suppressPackageStartupMessages(library(lubridate))
suppressPackageStartupMessages(library(arrow))

df <- tibble(
  dates = as.Date(c("2021-04-30", "2021-07-31", "2021-10-31", "2021-01-31"))
  )
df %>% 
  record_batch() %>% 
  mutate(
    semester_without_year = semester(dates),
    semester_with_year = semester(dates, with_year = TRUE)) %>% 
  collect()
#> # A tibble: 4 × 3
#>   dates      semester_without_year semester_with_year
#>   <date>                     <int>              <dbl>
#> 1 2021-04-30                     1              2021.1
#> 2 2021-07-31                     2              2021.2
#> 3 2021-10-31                     2              2021.2
#> 4 2021-01-31                     1              2021.1
```

and identical with the `lubridate` result:
``` r
suppressPackageStartupMessages(library(dplyr))
suppressPackageStartupMessages(library(lubridate))

df <- tibble(
  dates = as.Date(c("2021-04-30", "2021-07-31", "2021-10-31", "2021-01-31"))
  )
df %>% 
  mutate(
    semester_without_year = semester(dates),
    semester_with_year = semester(dates, with_year = TRUE))
#> # A tibble: 4 × 3
#>   dates      semester_without_year semester_with_year
#>   <date>                     <int>              <dbl>
#> 1 2021-04-30                     1              2021.1
#> 2 2021-07-31                     2              2021.2
#> 3 2021-10-31                     2              2021.2
#> 4 2021-01-31                     1              2021.1
```

<sup>Created on 2022-02-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>