### PR TITLE
ARROW-14826 [R] Implement bindings for `lubridate::dst()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -23,6 +23,7 @@
   * `tz()` to extract/get timezone
   * `semester()` to extract/get semester
 * Additional `lubridate` features: `dst()`.
+  * `dst()` to get daylight savings time indicator.
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -22,6 +22,7 @@
 * `lubridate`: 
   * `tz()` to extract/get timezone
   * `semester()` to extract/get semester
+* Additional `lubridate` features: `dst()`.
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -22,7 +22,6 @@
 * `lubridate`: 
   * `tz()` to extract/get timezone
   * `semester()` to extract/get semester
-* Additional `lubridate` features: `dst()`.
   * `dst()` to get daylight savings time indicator.
 
 # arrow 7.0.0

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -62,6 +62,7 @@
 
   # date and time functions
   "day" = "day",
+  "dst" = "is_dst",
   "hour" = "hour",
   "isoweek" = "iso_week",
   "epiweek" = "us_week",

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -784,5 +784,20 @@ test_that("semester works with temporal types and integers", {
       collect(),
     regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[string])",
     fixed = TRUE
+    )
+  })
+
+test_that("dst extracts daylight savings time correctly", {
+  test_df <- tibble(
+    dates = as.POSIXct(c("2021-02-20", "2021-07-31", "2021-10-31", "2021-01-31"), tz = "Europe/London")
+  )
+  # https://issues.apache.org/jira/browse/ARROW-13168
+  skip_on_os("windows")
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(dst = dst(dates)) %>%
+      collect(),
+    test_df
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -801,3 +801,26 @@ test_that("dst extracts daylight savings time correctly", {
     test_df
   )
 })
+
+test_that("dst errors with unsupported input", {
+  expect_error(
+    call_function("is_dst", Scalar$create("this is a string, not a timestamp")),
+    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[string])",
+    fixed = TRUE
+  )
+  expect_error(
+    call_function("is_dst", Scalar$create(1L)),
+    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[int32])",
+    fixed = TRUE
+  )
+  expect_error(
+    call_function("is_dst", Scalar$create(2.2)),
+    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[double])",
+    fixed = TRUE
+  )
+  expect_error(
+    call_function("is_dst", Scalar$create(TRUE)),
+    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[bool])",
+    fixed = TRUE
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -801,26 +801,3 @@ test_that("dst extracts daylight savings time correctly", {
     test_df
   )
 })
-
-test_that("dst errors with unsupported input", {
-  expect_error(
-    call_function("is_dst", Scalar$create("this is a string, not a timestamp")),
-    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[string])",
-    fixed = TRUE
-  )
-  expect_error(
-    call_function("is_dst", Scalar$create(1L)),
-    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[int32])",
-    fixed = TRUE
-  )
-  expect_error(
-    call_function("is_dst", Scalar$create(2.2)),
-    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[double])",
-    fixed = TRUE
-  )
-  expect_error(
-    call_function("is_dst", Scalar$create(TRUE)),
-    "NotImplemented: Function 'is_dst' has no kernel matching input types (scalar[bool])",
-    fixed = TRUE
-  )
-})


### PR DESCRIPTION
This PR adds support for `lubridate::dst()`:
``` r
suppressPackageStartupMessages(library(dplyr))
suppressPackageStartupMessages(library(lubridate))
suppressPackageStartupMessages(library(arrow))

df <- tibble(
  dates = as.POSIXct(c("2021-02-20", "2021-07-31", "2021-10-31", "2021-01-31"), tz = "Europe/London")
)

df %>% 
  record_batch() %>% 
  mutate(is_dst = dst(dates)) %>% 
  collect()
#> # A tibble: 4 × 2
#>   dates               is_dst
#>   <dttm>              <lgl> 
#> 1 2021-02-20 00:00:00 FALSE 
#> 2 2021-07-31 00:00:00 TRUE  
#> 3 2021-10-31 00:00:00 TRUE  
#> 4 2021-01-31 00:00:00 FALSE
```

will be equivalent to:

``` r
suppressPackageStartupMessages(library(dplyr))
suppressPackageStartupMessages(library(lubridate))

df <- tibble(
  dates = as.POSIXct(c("2021-02-20", "2021-07-31", "2021-10-31", "2021-01-31"), tz = "Europe/London")
)

df %>% 
  mutate(is_dst = dst(dates))
#> # A tibble: 4 × 2
#>   dates               is_dst
#>   <dttm>              <lgl> 
#> 1 2021-02-20 00:00:00 FALSE 
#> 2 2021-07-31 00:00:00 TRUE  
#> 3 2021-10-31 00:00:00 TRUE  
#> 4 2021-01-31 00:00:00 FALSE
```

<sup>Created on 2022-02-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>