### PR TITLE
ARROW-14808 [R] Implement bindings for `lubridate::date()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -25,8 +25,9 @@
   * `semester()` to extract/get semester
   * `dst()` to get daylight savings time indicator.
   * `date()` to extract date
-  * * `epiyear()` to get epiyear
-* `as.Date()` to convert to date
+  * `epiyear()` to get epiyear
+* date-time functionality:
+  * `as.Date()` to convert to date
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,7 @@
   * `tz()` to extract/get timezone
   * `semester()` to extract/get semester
   * `dst()` to get daylight savings time indicator.
+* Additional `lubridate` features: `date()`
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,7 +24,8 @@
   * `tz()` to extract/get timezone
   * `semester()` to extract/get semester
   * `dst()` to get daylight savings time indicator.
-* Additional `lubridate` features: `date()`
+  * `date()` to extract date
+* `as.Date()` to convert to date
 
 # arrow 7.0.0
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -164,4 +164,7 @@ register_bindings_datetime <- function() {
       return(semester)
     }
   })
+  register_binding("date", function(x) {
+    x$cast(date32())
+  })
 }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -165,9 +165,6 @@ register_bindings_datetime <- function() {
     }
   })
   register_binding("date", function(x) {
-    if (inherits(x, "POSIXct")) {
-      x <- vec_to_Array(x, date32())
-    }
-    x$cast(date32())
+    build_expr("cast", x, options = list(to_type = date32()))
   })
 }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -165,6 +165,9 @@ register_bindings_datetime <- function() {
     }
   })
   register_binding("date", function(x) {
+    if (inherits(x, "POSIXct")) {
+      x <- vec_to_Array(x, date32())
+    }
     x$cast(date32())
   })
 }

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -80,8 +80,8 @@ register_bindings_type_cast <- function() {
     # base::as.Date() first converts to UTC and then extracts the date, which is
     # why we need to go through timestamp() first - see unit tests for the real
     # life impact of the difference between lubridate::date() and base::as.Date()
-    y <- build_expr("cast", x, options = list(to_type = timestamp()))
-    build_expr("cast", y, options = list(to_type = date32()))
+    y <- build_expr("cast", x, options = cast_options(to_type = timestamp()))
+    build_expr("cast", y, options = cast_options(to_type = date32()))
   })
 
   register_binding("is", function(object, class2) {

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -79,7 +79,7 @@ register_bindings_type_cast <- function() {
   register_binding("as.Date", function(x) {
     # base::as.Date() first converts to UTC and then extracts the date, which is
     # why we need to go through timestamp() first - see unit tests for the real
-    # life impact of the difference between lubridate::date() and base::as.Date
+    # life impact of the difference between lubridate::date() and base::as.Date()
     y <- build_expr("cast", x, options = list(to_type = timestamp()))
     build_expr("cast", y, options = list(to_type = date32()))
   })

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -76,6 +76,13 @@ register_bindings_type_cast <- function() {
   register_binding("as.numeric", function(x) {
     Expression$create("cast", x, options = cast_options(to_type = float64()))
   })
+  register_binding("as.Date", function(x) {
+    # base::as.Date() first converts to UTC and then extracts the date, which is
+    # why we need to go through timestamp() first - see unit tests for the real
+    # life impact of the difference between lubridate::date() and base::as.Date
+    y <- build_expr("cast", x, options = list(to_type = timestamp()))
+    build_expr("cast", y, options = list(to_type = date32()))
+  })
 
   register_binding("is", function(object, class2) {
     if (is.string(class2)) {

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -90,7 +90,7 @@ register_bindings_type_cast <- function() {
     # cast from POSIXct
     } else if (call_binding("is.POSIXct", x)) {
       if (tz == "UTC") {
-        interim_x <- build_expr("cast", x, options = cast_options(to_type = timestamp(timezone = tz)))
+        x <- build_expr("cast", x, options = cast_options(to_type = timestamp(timezone = tz)))
       } else {
         abort("`as.Date()` with a timezone different to 'UTC' is not supported in Arrow")
       }
@@ -111,7 +111,7 @@ register_bindings_type_cast <- function() {
       if (!inherits(x, "Expression")) {
         x <- build_expr("cast", x, options = cast_options(to_type = type(x)))
       }
-      interim_x <- call_binding("strptime", x, format, unit = "s")
+      x <- call_binding("strptime", x, format, unit = "s")
 
     # cast from numeric
     } else if (call_binding("is.numeric", x)) {
@@ -124,15 +124,13 @@ register_bindings_type_cast <- function() {
         # need to use round before casting
         # TODO revisit if arrow decides to support double -> date casting
         x <- call_binding("floor", x)
-        interim_x <- build_expr("cast", x, options = (cast_options(to_type = int32())))
-      } else {
-        interim_x <- x
+        x <- build_expr("cast", x, options = (cast_options(to_type = int32())))
       }
       if (origin != "1970-01-01") {
         abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")
       }
     }
-    build_expr("cast", interim_x, options = cast_options(to_type = date32()))
+    build_expr("cast", x, options = cast_options(to_type = date32()))
   })
 
   register_binding("is", function(object, class2) {

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -101,7 +101,7 @@ register_bindings_type_cast <- function() {
         if (length(tryFormats) == 1) {
           format <- tryFormats[1]
         } else {
-          abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
+          abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow yet")
         }
       }
       # if x is not an expression (e.g. passed as filter), convert it to one

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -89,9 +89,6 @@ register_bindings_type_cast <- function() {
       abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")
     }
 
-    if (tz != "UTC") {
-      abort("`as.Date()` with a timezone different to 'UTC' is not supported in Arrow")
-    }
     # this could be improved with tryFormats once strptime returns NA and we
     # can use coalesce - https://issues.apache.org/jira/browse/ARROW-15659
     # TODO revisit once https://issues.apache.org/jira/browse/ARROW-15659 is done
@@ -106,7 +103,7 @@ register_bindings_type_cast <- function() {
     } else if (call_binding("is.POSIXct", x)) {
       # base::as.Date() first converts to the desired timezone and then extracts
       # the date, which is why we need to go through timestamp() first
-      x <- build_expr("cast", x, options = cast_options(to_type = timestamp(timezone = "UTC")))
+      x <- build_expr("cast", x, options = cast_options(to_type = timestamp(timezone = tz)))
 
     # cast from character
     } else if (call_binding("is.character", x)) {

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -107,8 +107,7 @@ register_bindings_type_cast <- function() {
           abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow yet")
         }
       }
-      unit <- make_valid_time_unit("s", c(valid_time64_units, valid_time32_units))
-      x <- build_expr("strptime", x, options = list(format = format, unit = unit))
+      x <- build_expr("strptime", x, options = list(format = format, unit = 0L))
 
     # cast from numeric
     } else if (call_binding("is.numeric", x)) {

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -121,9 +121,13 @@ register_bindings_type_cast <- function() {
       # TODO revisit once the above has been sorted
       if (!call_binding("is.integer", x)) {
         # Arrow does not support direct casting from double to date so we have
-        # to convert to integers first
+        # to convert to integers first - casting to int32() would error so we
+        # need to use `floor` before casting. `floor` is also a bit safer than
+        # int32() with `safe = FALSE` since it doesn't switch to `ceiling` for
+        # negative numbers
         # TODO revisit if arrow decides to support double -> date casting
-        x <- build_expr("cast", x, options = (cast_options(to_type = int32(), safe = FALSE)))
+        x <- call_binding("floor", x)
+        x <- build_expr("cast", x, options = (cast_options(to_type = int32())))
       }
       if (origin != "1970-01-01") {
         abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -108,11 +108,13 @@ register_bindings_type_cast <- function() {
     # cast from character
     } else if (call_binding("is.character", x)) {
       format <- format %||% tryFormats[[1]]
+      # unit = 0L is the identifier for seconds in valid_time32_units
       x <- build_expr("strptime", x, options = list(format = format, unit = 0L))
 
     # cast from numeric
     } else if (call_binding("is.numeric", x) & !call_binding("is.integer", x)) {
       # Arrow does not support direct casting from double to date32()
+      # https://issues.apache.org/jira/browse/ARROW-15798
       # TODO revisit if arrow decides to support double -> date casting
       abort("`as.Date()` with double/float is not supported in Arrow")
     }

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -120,11 +120,9 @@ register_bindings_type_cast <- function() {
       # TODO revisit once the above has been sorted
       if (!call_binding("is.integer", x)) {
         # Arrow does not support direct casting from double to date so we have
-        # to convert to integers first - casting to int32() would error so we
-        # need to use round before casting
+        # to convert to integers first
         # TODO revisit if arrow decides to support double -> date casting
-        x <- call_binding("floor", x)
-        x <- build_expr("cast", x, options = (cast_options(to_type = int32())))
+        x <- build_expr("cast", x, options = (cast_options(to_type = int32(), safe = FALSE)))
       }
       if (origin != "1970-01-01") {
         abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -107,7 +107,8 @@ register_bindings_type_cast <- function() {
           abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow yet")
         }
       }
-      # if x is not an expression (e.g. passed as filter), convert it to one
+      # if x is a character, but not an Expression (such as in some instances
+      # when passed via `filter.arrow_dplyr_query()`), convert it to one
       if (!inherits(x, "Expression")) {
         x <- build_expr("cast", x, options = cast_options(to_type = type(x)))
       }

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -107,12 +107,8 @@ register_bindings_type_cast <- function() {
           abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow yet")
         }
       }
-      # if x is a character, but not an Expression (such as in some instances
-      # when passed via `filter.arrow_dplyr_query()`), convert it to one
-      if (!inherits(x, "Expression")) {
-        x <- build_expr("cast", x, options = cast_options(to_type = type(x)))
-      }
-      x <- call_binding("strptime", x, format, unit = "s")
+      unit <- make_valid_time_unit("s", c(valid_time64_units, valid_time32_units))
+      x <- build_expr("strptime", x, options = list(format = format, unit = unit))
 
     # cast from numeric
     } else if (call_binding("is.numeric", x)) {
@@ -127,7 +123,7 @@ register_bindings_type_cast <- function() {
         # negative numbers
         # TODO revisit if arrow decides to support double -> date casting
         x <- call_binding("floor", x)
-        x <- build_expr("cast", x, options = (cast_options(to_type = int32())))
+        x <- build_expr("cast", x, options = cast_options(to_type = int32()))
       }
       if (origin != "1970-01-01") {
         abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -85,7 +85,7 @@ register_bindings_type_cast <- function() {
     # the origin argument will be better supported once we implement temporal
     # arithmetic (https://issues.apache.org/jira/browse/ARROW-14947)
     # TODO revisit once the above has been sorted
-    if (origin != "1970-01-01") {
+    if (call_binding("is.numeric", x) & origin != "1970-01-01") {
       abort("`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow")
     }
 
@@ -93,7 +93,7 @@ register_bindings_type_cast <- function() {
     # can use coalesce - https://issues.apache.org/jira/browse/ARROW-15659
     # TODO revisit once https://issues.apache.org/jira/browse/ARROW-15659 is done
     if (is.null(format) && length(tryFormats) > 1) {
-      abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow yet")
+      abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
     }
 
     if (call_binding("is.Date", x)) {
@@ -112,13 +112,9 @@ register_bindings_type_cast <- function() {
 
     # cast from numeric
     } else if (call_binding("is.numeric", x) & !call_binding("is.integer", x)) {
-      # Arrow does not support direct casting from double to date so we have to
-      # convert to integers first - casting to int32() would error so we need to
-      # use `floor` before casting. `floor` is also a bit safer than int32() with
-      # `safe = FALSE` since it doesn't switch to `ceiling` for negative numbers
+      # Arrow does not support direct casting from double to date32()
       # TODO revisit if arrow decides to support double -> date casting
-      x <- call_binding("floor", x)
-      x <- build_expr("cast", x, options = cast_options(to_type = int32()))
+      abort("`as.Date()` with double/float is not supported in Arrow")
     }
     build_expr("cast", x, options = cast_options(to_type = date32()))
   })

--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -80,12 +80,10 @@ register_bindings_type_cast <- function() {
                                        format = NULL,
                                        origin = "1970-01-01",
                                        tz = "UTC") {
-    # base::as.Date() first converts to UTC and then extracts the date, which is
-    # why we need to go through timestamp() first - see unit tests for the real
-    # life impact of the difference between lubridate::date() and base::as.Date()
-    # browser()
+
     if (call_binding("is.Date", x)) {
-      # arrow_date <- build_expr("cast", x, options = cast_options(to_type = date32()))
+      # base::as.Date() first converts to the desired timestamp and then extracts
+      # the date, which is why we need to go through timestamp() first
       return(x)
     } else if (call_binding("is.POSIXct", x)) {
       if (tz == "UTC") {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -824,6 +824,12 @@ test_that("date works in arrow", {
     call_binding("date", Array$create(as.POSIXct("2022-02-21"))),
     Array$create(as.POSIXct("2022-02-21"), type = date32())
   )
+
+  # date() supports R objects
+  expect_equal(
+    call_binding("date", as.POSIXct("2022-02-21")),
+    Array$create(as.POSIXct("2022-02-21"), type = date32())
+  )
 })
 
 test_that("date() errors with unsupported inputs", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -808,39 +808,56 @@ test_that("date works in arrow", {
   # this date is specific since lubridate::date() is different from base::as.Date()
   # since as.Date returns the UTC date and date() doesn't
   test_df <- tibble(
-    a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
+    posixct_date = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"),
+    integer_var = c(32L, NA))
+
   r_date_object <- lubridate::ymd_hms("2012-03-26 23:12:13")
 
   # we can't (for now) use namespacing, so we need to make sure lubridate::date()
-  # and not base::date() is being used
+  # and not base::date() is being used. This is due to the way testthat runs and
+  # normal use of arrow would not have to do this explicitly.
   # TODO remove once https://issues.apache.org/jira/browse/ARROW-14575 is done
   date <- lubridate::date
+
   compare_dplyr_binding(
     .input %>%
-      mutate(a_date = date(a)) %>%
+      mutate(a_date = date(posixct_date)) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(a_date_base = as.Date(a)) %>%
+      mutate(a_date_base = as.Date(posixct_date)) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(b = date(r_date_object)) %>%
+      mutate(date_from_r_object = date(r_date_object)) %>%
       collect(),
     test_df
   )
 
   compare_dplyr_binding(
     .input %>%
-      mutate(b_base = as.Date(r_date_object)) %>%
+      mutate(as_date_from_r_object = as.Date(r_date_object)) %>%
       collect(),
     test_df
+  )
+
+  # date from integer supported in arrow (similar to base::as.Date()), but in
+  # Arrow it assumes a fixed origin "1970-01-01". However this is not supported
+  # by lubridate. lubridate::date(integer_var) errors without an `origin`
+  expect_equal(
+    test_df %>%
+      arrow_table() %>%
+      select(integer_var) %>%
+      mutate(date_int = date(integer_var)) %>%
+      collect(),
+    tibble(integer_var = c(32L, NA),
+           date_int = as.Date(c("1970-02-02", NA)))
   )
 })
 
@@ -853,18 +870,6 @@ test_that("date() errors with unsupported inputs", {
     integer_var = 32L,
     double_var = 34.56,
     boolean_var = TRUE
-  )
-
-  # date from integer supported in arrow (similar to base::as.Date()), but in
-  # Arrow it assumes a fixed origin "1970-01-01"
-  expect_equal(
-    test_df %>%
-      arrow_table() %>%
-      select(integer_var) %>%
-      mutate(date_int = date(integer_var)) %>%
-      collect(),
-    tibble(integer_var = 32L,
-           date_int = as.Date("1970-02-02"))
   )
 
   expect_error(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -806,6 +806,8 @@ test_that("date works in arrow", {
   test_df <- tibble(
     a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
 
+  # we can't (for now) use namespacing, so we need to make sure lubridate::date()
+  # and not base::date() is being used
   date <- lubridate::date
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -839,11 +839,6 @@ test_that("date() errors with unsupported inputs", {
   )
 
   expect_error(
-    call_binding("date", Scalar$create(32L)),
-    "NotImplemented: Unsupported cast from integer to date32 using function cast_date32"
-  )
-
-  expect_error(
     call_binding("date", Scalar$create(32.2)),
     "NotImplemented: Unsupported cast from double to date32 using function cast_date32"
   )
@@ -851,5 +846,14 @@ test_that("date() errors with unsupported inputs", {
   expect_error(
     call_binding("date", Scalar$create(TRUE)),
     "NotImplemented: Unsupported cast from bool to date32 using function cast_date32"
+  )
+
+  # if we are aiming for equivalent behaviour to lubridate this should fail, but
+  # it doesn't as it is supported in arrow, where integer casting to date returns
+  # the date x days away from epoch
+  skip("supported in arrow, but not in lubridate")
+  expect_error(
+    call_binding("date", Scalar$create(32L)),
+    "NotImplemented: Unsupported cast from integer to date32 using function cast_date32"
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -821,6 +821,29 @@ test_that("date works in arrow", {
     test_df
   )
 
+  compare_dplyr_binding(
+    .input %>%
+      mutate(a_date_base = as.Date(a)) %>%
+      collect(),
+    test_df
+  )
+
+  r_date_object <- lubridate::ymd_hms("2012-03-26 23:12:13")
+  compare_dplyr_binding(
+    .input %>%
+      mutate(b = date(r_date_object)) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(b_base = as.Date(r_date_object)) %>%
+      collect(),
+    test_df
+  )
+
+  skip("All these will fail as we're not actually forcing evaluation")
   # a timestamp is cast correctly to date
   expect_equal(
     call_binding("date", Array$create(as.POSIXct("2022-02-21"))),
@@ -835,6 +858,7 @@ test_that("date works in arrow", {
 })
 
 test_that("date() errors with unsupported inputs", {
+  skip("All these will fail as we're not actually forcing evaluation")
   expect_error(
     call_binding("date", Scalar$create("a string")),
     "NotImplemented: Unsupported cast from string to date32 using function cast_date32"
@@ -846,7 +870,7 @@ test_that("date() errors with unsupported inputs", {
   )
 
   expect_error(
-    call_binding("date", Scalar$create(TRUE)),
+    arrow_eval(call_binding("date", Scalar$create(TRUE)), mask = arrow_mask(list())),
     "NotImplemented: Unsupported cast from bool to date32 using function cast_date32"
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -801,6 +801,8 @@ test_that("dst extracts daylight savings time correctly", {
 })
 
 test_that("date works in arrow", {
+  # https://issues.apache.org/jira/browse/ARROW-13168
+  skip_on_os("windows")
   # this date is specific since lubridate::date() is different from base::as.Date()
   # since as.Date returns the UTC date and date() doesn't
   test_df <- tibble(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -895,5 +895,4 @@ test_that("date() errors with unsupported inputs", {
       collect(),
     regexp = "Unsupported cast from double to date32 using function cast_date32"
   )
-
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -806,7 +806,7 @@ test_that("date works in arrow", {
   test_df <- tibble(
     a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
 
-  date <- base:date
+  date <- lubridate::date
   compare_dplyr_binding(
     .input %>%
       mutate(a_date = date(a)) %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -862,36 +862,26 @@ test_that("date works in arrow", {
 })
 
 test_that("date() errors with unsupported inputs", {
-  test_df <- tibble::tibble(
-    posixct_var = as.POSIXct("2022-02-25 00:00:01", tz = "Europe/London"),
-    date_var = as.Date("2022-02-25"),
-    character_ymd_var = "2022-02-25 00:00:01",
-    character_ydm_var = "2022/25/02 00:00:01",
-    integer_var = 32L,
-    double_var = 34.56,
-    boolean_var = TRUE
-  )
-
   expect_error(
-    test_df %>%
+    example_data %>%
       arrow_table() %>%
-      mutate(date_char = date(character_ymd_var)) %>%
+      mutate(date_char = date("2022-02-25 00:00:01")) %>%
       collect(),
     regexp = "Unsupported cast from string to date32 using function cast_date32"
   )
 
   expect_error(
-    test_df %>%
+    example_data %>%
       arrow_table() %>%
-      mutate(date_bool = date(boolean_var)) %>%
+      mutate(date_bool = date(TRUE)) %>%
       collect(),
     regexp = "Unsupported cast from bool to date32 using function cast_date32"
   )
 
   expect_error(
-    test_df %>%
+    example_data %>%
       arrow_table() %>%
-      mutate(date_double = date(double_var)) %>%
+      mutate(date_double = date(34.56)) %>%
       collect(),
     regexp = "Unsupported cast from double to date32 using function cast_date32"
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -797,6 +797,18 @@ test_that("dst extracts daylight savings time correctly", {
   compare_dplyr_binding(
     .input %>%
       mutate(dst = dst(dates)) %>%
+  )
+})
+
+test_that("date works in arrow", {
+  # this date is specific since lubridate::date() is different from base::as.Date()
+  # since as.Date returns the UTC date and date() doesn't
+  test_df <- tibble(
+    a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(a_date = date(a)) %>%
       collect(),
     test_df
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -808,7 +808,7 @@ test_that("date works in arrow", {
 
   compare_dplyr_binding(
     .input %>%
-      mutate(a_date = lubridate::date(a)) %>%
+      mutate(a_date = date(a)) %>%
       collect(),
     test_df
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -797,6 +797,8 @@ test_that("dst extracts daylight savings time correctly", {
   compare_dplyr_binding(
     .input %>%
       mutate(dst = dst(dates)) %>%
+      collect(),
+    test_df
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -818,4 +818,32 @@ test_that("date works in arrow", {
       collect(),
     test_df
   )
+
+  # a timestamp is cast correctly to date
+  expect_equal(
+    call_binding("date", Array$create(as.POSIXct("2022-02-21"))),
+    Array$create(as.POSIXct("2022-02-21"), type = date32())
+  )
+})
+
+test_that("date() errors with unsupported inputs", {
+  expect_error(
+    call_binding("date", Scalar$create("a string")),
+    "NotImplemented: Unsupported cast from string to date32 using function cast_date32"
+  )
+
+  expect_error(
+    call_binding("date", Scalar$create(32L)),
+    "NotImplemented: Unsupported cast from integer to date32 using function cast_date32"
+  )
+
+  expect_error(
+    call_binding("date", Scalar$create(32.2)),
+    "NotImplemented: Unsupported cast from double to date32 using function cast_date32"
+  )
+
+  expect_error(
+    call_binding("date", Scalar$create(TRUE)),
+    "NotImplemented: Unsupported cast from bool to date32 using function cast_date32"
+  )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -808,7 +808,7 @@ test_that("date works in arrow", {
 
   compare_dplyr_binding(
     .input %>%
-      mutate(a_date = date(a)) %>%
+      mutate(a_date = lubridate::date(a)) %>%
       collect(),
     test_df
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -810,6 +810,7 @@ test_that("date works in arrow", {
 
   # we can't (for now) use namespacing, so we need to make sure lubridate::date()
   # and not base::date() is being used
+  # TODO remove once https://issues.apache.org/jira/browse/ARROW-14575 is done
   date <- lubridate::date
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -803,6 +803,7 @@ test_that("dst extracts daylight savings time correctly", {
 test_that("date works in arrow", {
   # this date is specific since lubridate::date() is different from base::as.Date()
   # since as.Date returns the UTC date and date() doesn't
+  library(lubridate)
   test_df <- tibble(
     a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -803,10 +803,10 @@ test_that("dst extracts daylight savings time correctly", {
 test_that("date works in arrow", {
   # this date is specific since lubridate::date() is different from base::as.Date()
   # since as.Date returns the UTC date and date() doesn't
-  library(lubridate)
   test_df <- tibble(
     a = as.POSIXct(c("2012-03-26 23:12:13", NA), tz = "America/New_York"))
 
+  date <- base:date
   compare_dplyr_binding(
     .input %>%
       mutate(a_date = date(a)) %>%

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -768,7 +768,8 @@ test_that("nested structs can be created from scalars and existing data frames",
       collect(),
     tibble(a = 1:2)
   )
-})
+
+  })
 
 test_that("as.Date() converts successfully from date, timestamp, integer, char and double", {
   test_df <- tibble::tibble(
@@ -841,16 +842,6 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
       collect(),
     regexp = "`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow",
     fixed = TRUE
-
-  )
-
-  expect_warning(
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_pv = as.Date(posixct_var, tz = "Pacific/Marquesas")) %>%
-      collect(),
-    regexp = "`as.Date()` with a timezone different to 'UTC' is not supported in Arrow",
-    fixed = TRUE
   )
 
   expect_warning(
@@ -875,7 +866,10 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
   skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
   compare_dplyr_binding(
     .input %>%
-      mutate(date_pv = as.Date(posixct_var)) %>%
+      mutate(
+        date_pv = as.Date(posixct_var),
+        date_pv_tz = as.Date(posixct_var, tz = "Pacific/Marquesas")
+      ) %>%
       collect(),
     test_df
   )

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -819,7 +819,7 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
   )
 
   # actual and expected differ due to doubles are accounted for (floored in
-  # arrow and rouded to the next decimal in R)
+  # arrow and rounded to the next decimal in R)
   expect_error(
     compare_dplyr_binding(
       .input %>%
@@ -827,6 +827,34 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
         collect(),
       test_df
     )
+  )
+
+  expect_equal(
+    test_df %>%
+      arrow_table() %>%
+      mutate(date_double = as.Date(double_var, origin = "1970-01-01")) %>%
+      collect(),
+    test_df %>%
+      mutate(date_double = as.Date(double_var, origin = "1970-01-01")),
+    # the absolute value for date_double is different due to arrow casting from
+    # integer and r from double => testing with a tolerance of 0.6
+    # `actual$date_double`: 34.0
+    # `expected$date_double`: 34.6
+    tolerance = 0.6
+  )
+
+  expect_equal(
+    test_df %>%
+      record_batch() %>%
+      mutate(date_double = as.Date(double_var, origin = "1970-01-01")) %>%
+      collect(),
+    test_df %>%
+      mutate(date_double = as.Date(double_var, origin = "1970-01-01")),
+    # the absolute value for date_double is different due to arrow casting from
+    # integer and r from double => testing with a tolerance of 0.6
+    # `actual$date_double`: 34.0
+    # `expected$date_double`: 34.6
+    tolerance = 0.6
   )
 
   # currently we do not support an origin different to "1970-01-01"

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -851,9 +851,19 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
   expect_warning(
     test_df %>%
       arrow_table() %>%
+      mutate(date_char_ymd = as.Date(character_ymd_var,
+                                     tryFormats = c("%Y-%m-%d", "%Y/%m/%d"))) %>%
+      collect(),
+    regexp = "`as.Date()` with multiple `tryFormats` is not supported in Arrow",
+    fixed = TRUE
+  )
+
+  expect_error(
+    test_df %>%
+      arrow_table() %>%
       mutate(date_char_ymd = as.Date(character_ymd_var)) %>%
       collect(),
-    regexp = "`as.Date()` without `format` is not supported in Arrow",
+    regexp = "Failed to parse string: '2022-02-25 00:00:01' as a scalar of type timestamp[s]",
     fixed = TRUE
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -796,24 +796,22 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
   )
 
   # currently we do not support an origin different to "1970-01-01"
-  expect_warning(
-    test_df %>%
-      arrow_table() %>%
+  compare_dplyr_binding(
+    .input %>%
       mutate(date_int = as.Date(integer_var, origin = "1970-01-03")) %>%
       collect(),
-    regexp = "`as.Date()` with an `origin` different than '1970-01-01' is not supported in Arrow",
-    fixed = TRUE
+    test_df,
+    warning = TRUE
   )
 
   # we do not support multiple tryFormats
-  expect_warning(
-    test_df %>%
-      arrow_table() %>%
+  compare_dplyr_binding(
+    .input %>%
       mutate(date_char_ymd = as.Date(character_ymd_var,
                                      tryFormats = c("%Y-%m-%d", "%Y/%m/%d"))) %>%
       collect(),
-    regexp = "`as.Date()` with multiple `tryFormats` is not supported in Arrow",
-    fixed = TRUE
+    test_df,
+    warning = TRUE
   )
 
   expect_error(
@@ -826,13 +824,12 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
   )
 
   # we do not support as.Date() with double/ float
-  expect_warning(
-    test_df %>%
-      arrow_table() %>%
+  compare_dplyr_binding(
+     .input %>%
       mutate(date_double = as.Date(double_var, origin = "1970-01-01")) %>%
       collect(),
-    regexp = "`as.Date()` with double/float is not supported in Arrow",
-    fixed = TRUE
+     test_df,
+     warning = TRUE
   )
 
   skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -883,7 +883,7 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
       mutate(date_char_ymd = as.Date(character_ymd_var,
                                      tryFormats = c("%Y-%m-%d", "%Y/%m/%d"))) %>%
       collect(),
-    regexp = "`as.Date()` with multiple `tryFormats` is not supported in Arrow",
+    regexp = "`as.Date()` with multiple `tryFormats` is not supported in Arrow yet",
     fixed = TRUE
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -794,30 +794,6 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
     test_df
   )
 
-  # the way we go about it is a bit different, but the result is the same =>
-  # testing without compare_dplyr_binding()
-  expect_equal(
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_double = as.Date(double_var)) %>%
-      collect(),
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_double = as.Date(double_var, origin = "1970-01-01")) %>%
-      collect()
-  )
-
-  expect_equal(
-    test_df %>%
-      record_batch() %>%
-      mutate(date_double = as.Date(double_var)) %>%
-      collect(),
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_double = as.Date(double_var, origin = "1970-01-01")) %>%
-      collect()
-  )
-
   # actual and expected differ due to doubles are accounted for (floored in
   # arrow and rounded to the next decimal in R)
   expect_error(

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -780,51 +780,14 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
     double_var = 34.56
   )
 
-  # compare_dplyr_binding(
-  #   .input %>%
-  #     mutate(
-  #       date_pv = as.Date(posixct_var),
-  #       date_dv = as.Date(date_var),
-  #       date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
-  #       date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
-  #       date_int = as.Date(integer_var, origin = "1970-01-01")
-  #     ) %>%
-  #     collect(),
-  #   test_df
-  # )
-
-  compare_dplyr_binding(
-    .input %>%
-      mutate(date_pv = as.Date(posixct_var)) %>%
-      collect(),
-    test_df
-  )
-
-  compare_dplyr_binding(
-    .input %>%
-      mutate(date_dv = as.Date(date_var)) %>%
-      collect(),
-    test_df
-  )
+  # casting from POSIXct treated separately so we can skip on Windows
+  # TODO move the test for casting from POSIXct below once ARROW-13168 is done
   compare_dplyr_binding(
     .input %>%
       mutate(
-        date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S")
-      ) %>%
-      collect(),
-    test_df
-  )
-  compare_dplyr_binding(
-    .input %>%
-      mutate(
-        date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S")
-      ) %>%
-      collect(),
-    test_df
-  )
-  compare_dplyr_binding(
-    .input %>%
-      mutate(
+        date_dv = as.Date(date_var),
+        date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
+        date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
         date_int = as.Date(integer_var, origin = "1970-01-01")
       ) %>%
       collect(),
@@ -903,5 +866,13 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
       collect(),
     regexp = "Failed to parse string: '2022-02-25 00:00:01' as a scalar of type timestamp[s]",
     fixed = TRUE
+  )
+
+  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_pv = as.Date(posixct_var)) %>%
+      collect(),
+    test_df
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -780,13 +780,51 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
     double_var = 34.56
   )
 
+  # compare_dplyr_binding(
+  #   .input %>%
+  #     mutate(
+  #       date_pv = as.Date(posixct_var),
+  #       date_dv = as.Date(date_var),
+  #       date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
+  #       date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
+  #       date_int = as.Date(integer_var, origin = "1970-01-01")
+  #     ) %>%
+  #     collect(),
+  #   test_df
+  # )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_pv = as.Date(posixct_var)) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_dv = as.Date(date_var)) %>%
+      collect(),
+    test_df
+  )
   compare_dplyr_binding(
     .input %>%
       mutate(
-        date_pv = as.Date(posixct_var),
-        date_dv = as.Date(date_var),
-        date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
-        date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
+        date_char_ymd = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S")
+      ) %>%
+      collect(),
+    test_df
+  )
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        date_char_ydm = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S")
+      ) %>%
+      collect(),
+    test_df
+  )
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
         date_int = as.Date(integer_var, origin = "1970-01-01")
       ) %>%
       collect(),


### PR DESCRIPTION
The following will be supported in arrow (`base::as.Date()` included to show the difference to `date()`, but not supported):
``` r
library(dplyr)
library(lubridate)

df <- tibble(a = as.POSIXct("2012-03-26 23:12:13", tz = "America/New_York"))

df %>%
  mutate(
    a_date = date(a),
    a_date_base = as.Date(a))
#> # A tibble: 1 × 3
#>   a                   a_date     a_date_base
#>   <dttm>              <date>     <date>     
#> 1 2012-03-26 23:12:13 2012-03-26 2012-03-27
```

``` r
library(arrow)
library(dplyr)
library(lubridate)

df <- tibble(a = as.POSIXct("2012-03-26 23:12:13", tz = "America/New_York"))
df %>% 
  arrow_table() %>% 
  mutate(
    a_date = date(a)
  ) %>% 
  collect()
#> # A tibble: 1 × 2
#>   a                   a_date    
#>   <dttm>              <date>    
#> 1 2012-03-26 23:12:13 2012-03-26
```

<sup>Created on 2022-02-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>