### PR TITLE
ARROW-15652: [C++] Fix GDB pretty-printing from inside parquet namespace

### DIFF
--- a/cpp/gdb_arrow.py
+++ b/cpp/gdb_arrow.py
@@ -118,12 +118,20 @@ def for_evaluation(val, ty=None):
     """
     if ty is None:
         ty = get_basic_type(val.type)
+    typename = str(ty)  # (`ty.name` sometimes returns None...)
+    if '::' in typename and not typename.startswith('::'):
+        # ARROW-15652: expressions evaluated by GDB are evaluated in the
+        # scope of the C++ namespace of the currently selected frame.
+        # When inside a Parquet frame, `arrow::<some type>` would be looked
+        # up as `parquet::arrow::<some type>` and fail.
+        # Therefore, force the lookup to happen in the global namespace scope.
+        typename = f"::{typename}"
     if ty.code == gdb.TYPE_CODE_PTR:
         # It's already a pointer, can represent it directly
-        return f"(({ty}) ({val}))"
+        return f"(({typename}) ({val}))"
     if val.address is None:
         raise ValueError(f"Cannot further evaluate rvalue: {val}")
-    return f"(* ({ty}*) ({val.address}))"
+    return f"(* ({typename}*) ({val.address}))"
 
 
 def is_char_star(ty):

--- a/cpp/gdb_arrow.py
+++ b/cpp/gdb_arrow.py
@@ -118,7 +118,7 @@ def for_evaluation(val, ty=None):
     """
     if ty is None:
         ty = get_basic_type(val.type)
-    typename = str(ty)  # (`ty.name` sometimes returns None...)
+    typename = str(ty)  # `ty.name` is sometimes None...
     if '::' in typename and not typename.startswith('::'):
         # ARROW-15652: expressions evaluated by GDB are evaluated in the
         # scope of the C++ namespace of the currently selected frame.

--- a/cpp/src/arrow/python/gdb.cc
+++ b/cpp/src/arrow/python/gdb.cc
@@ -45,6 +45,12 @@ using ipc::internal::json::ChunkedArrayFromJSON;
 using ipc::internal::json::ScalarFromJSON;
 
 namespace gdb {
+
+// Add a nested `arrow` namespace to exercise type lookup from GDB (ARROW-15652)
+namespace arrow {
+const int dummy = 42;
+}  // namespace arrow
+
 namespace {
 
 class CustomStatusDetail : public StatusDetail {
@@ -152,20 +158,20 @@ void TestSession() {
       {"key_text", "key_binary"}, {"some value", std::string("z") + '\x00' + "\x1f\xff"});
 
   // Decimals
-  arrow::Decimal128 decimal128_zero{};
-  arrow::Decimal128 decimal128_pos{"98765432109876543210987654321098765432"};
-  arrow::Decimal128 decimal128_neg{"-98765432109876543210987654321098765432"};
-  arrow::BasicDecimal128 basic_decimal128_zero{};
-  arrow::BasicDecimal128 basic_decimal128_pos{decimal128_pos.native_endian_array()};
-  arrow::BasicDecimal128 basic_decimal128_neg{decimal128_neg.native_endian_array()};
-  arrow::Decimal256 decimal256_zero{};
-  arrow::Decimal256 decimal256_pos{
+  Decimal128 decimal128_zero{};
+  Decimal128 decimal128_pos{"98765432109876543210987654321098765432"};
+  Decimal128 decimal128_neg{"-98765432109876543210987654321098765432"};
+  BasicDecimal128 basic_decimal128_zero{};
+  BasicDecimal128 basic_decimal128_pos{decimal128_pos.native_endian_array()};
+  BasicDecimal128 basic_decimal128_neg{decimal128_neg.native_endian_array()};
+  Decimal256 decimal256_zero{};
+  Decimal256 decimal256_pos{
       "9876543210987654321098765432109876543210987654321098765432109876543210987654"};
-  arrow::Decimal256 decimal256_neg{
+  Decimal256 decimal256_neg{
       "-9876543210987654321098765432109876543210987654321098765432109876543210987654"};
-  arrow::BasicDecimal256 basic_decimal256_zero{};
-  arrow::BasicDecimal256 basic_decimal256_pos{decimal256_pos.native_endian_array()};
-  arrow::BasicDecimal256 basic_decimal256_neg{decimal256_neg.native_endian_array()};
+  BasicDecimal256 basic_decimal256_zero{};
+  BasicDecimal256 basic_decimal256_pos{decimal256_pos.native_endian_array()};
+  BasicDecimal256 basic_decimal256_neg{decimal256_neg.native_endian_array()};
 
   // Data types
   NullType null_type;
@@ -528,7 +534,7 @@ void TestSession() {
 #endif
 
   // Hook into debugger
-  arrow::internal::DebugTrap();
+  ::arrow::internal::DebugTrap();
 }
 
 }  // namespace gdb

--- a/cpp/src/arrow/python/gdb.cc
+++ b/cpp/src/arrow/python/gdb.cc
@@ -48,7 +48,7 @@ namespace gdb {
 
 // Add a nested `arrow` namespace to exercise type lookup from GDB (ARROW-15652)
 namespace arrow {
-const int dummy = 42;
+void DummyFunction() {}
 }  // namespace arrow
 
 namespace {
@@ -113,6 +113,8 @@ void TestSession() {
   _Pragma("GCC diagnostic push");
   _Pragma("GCC diagnostic ignored \"-Wunused-variable\"");
 #endif
+
+  arrow::DummyFunction();
 
   // Status & Result
   auto ok_status = Status::OK();


### PR DESCRIPTION
Expressions evaluated by GDB are evaluated in the scope of the C++ namespace of the currently selected frame.
Therefore, when inside a Parquet frame, `arrow::<some type>` would be looked up as `parquet::arrow::<some type>` and fail.