### PR TITLE
ARROW-15688: [C++] add_checked doesn't error out on duration overflow

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -2630,7 +2630,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // Add add(duration, duration) -> duration
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::DurationTypeUnit(unit));
-    auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Add>(Type::DURATION);
+    auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, AddChecked>(Type::DURATION);
     DCHECK_OK(
         add_checked->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
   }

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -28,24 +28,12 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/logging.h"
-#include "arrow/util/string.h"
 
 namespace arrow {
 
 using internal::StringFormatter;
 
 namespace compute {
-
-template <typename... Elements>
-std::string MakeArray(Elements... elements) {
-  std::vector<std::string> elements_as_strings = {std::to_string(elements)...};
-
-  std::vector<util::string_view> elements_as_views(sizeof...(Elements));
-  std::copy(elements_as_strings.begin(), elements_as_strings.end(),
-            elements_as_views.begin());
-
-  return "[" + ::arrow::internal::JoinStrings(elements_as_views, ",") + "]";
-}
 
 class ScalarTemporalTest : public ::testing::Test {
  public:
@@ -1094,14 +1082,11 @@ TEST_F(ScalarTemporalTest, TestTemporalAddDuration) {
     CheckScalarBinary(op, seconds_1, milliseconds_2k, milliseconds_3k);
   }
 
-  auto min = std::numeric_limits<int64_t>::lowest();
-  auto max = std::numeric_limits<int64_t>::max();
-
   for (auto unit : TimeUnit::values()) {
     auto duration_ty = duration(unit);
-    auto arr1 = ArrayFromJSON(duration_ty, MakeArray(max));
-    auto arr2 = ArrayFromJSON(duration_ty, MakeArray(1));
-    auto arr3 = ArrayFromJSON(duration_ty, MakeArray(min));
+    auto arr1 = ArrayFromJSON(duration_ty, R"([9223372036854775807, null])");
+    auto arr2 = ArrayFromJSON(duration_ty, R"([1, null])");
+    auto arr3 = ArrayFromJSON(duration_ty, R"([-9223372036854775808, null])");
 
     CheckScalarBinary("add", arr1, arr2, arr3);
     EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("overflow"),

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -28,12 +28,24 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 
 using internal::StringFormatter;
 
 namespace compute {
+
+template <typename... Elements>
+std::string MakeArray(Elements... elements) {
+  std::vector<std::string> elements_as_strings = {std::to_string(elements)...};
+
+  std::vector<util::string_view> elements_as_views(sizeof...(Elements));
+  std::copy(elements_as_strings.begin(), elements_as_strings.end(),
+            elements_as_views.begin());
+
+  return "[" + ::arrow::internal::JoinStrings(elements_as_views, ",") + "]";
+}
 
 class ScalarTemporalTest : public ::testing::Test {
  public:
@@ -1080,6 +1092,20 @@ TEST_F(ScalarTemporalTest, TestTemporalAddDuration) {
     auto milliseconds_2k = ArrayFromJSON(duration(TimeUnit::MILLI), R"([2000, null])");
     auto milliseconds_3k = ArrayFromJSON(duration(TimeUnit::MILLI), R"([3000, null])");
     CheckScalarBinary(op, seconds_1, milliseconds_2k, milliseconds_3k);
+  }
+
+  auto min = std::numeric_limits<int64_t>::lowest();
+  auto max = std::numeric_limits<int64_t>::max();
+
+  for (auto unit : TimeUnit::values()) {
+    auto duration_ty = duration(unit);
+    auto arr1 = ArrayFromJSON(duration_ty, MakeArray(max));
+    auto arr2 = ArrayFromJSON(duration_ty, MakeArray(1));
+    auto arr3 = ArrayFromJSON(duration_ty, MakeArray(min));
+
+    CheckScalarBinary("add", arr1, arr2, arr3);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("overflow"),
+                                    CallFunction("add_checked", {arr1, arr2}));
   }
 }
 


### PR DESCRIPTION
This is to resolve [ARROW-15688](https://issues.apache.org/jira/browse/ARROW-15688).