### PR TITLE
ARROW-15708: [R] [CI] skip snappy encoded parquets on clang sanitizer

### DIFF
--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -40,7 +40,10 @@ ${R_BIN} CMD build .
 ${R_BIN} CMD INSTALL ${INSTALL_ARGS} arrow*.tar.gz
 
 # But unset the env var so that it doesn't cause us to run extra dev tests
-# unset ARROW_R_DEV
+unset ARROW_R_DEV
+
+# Set the testthat output to be verbose for easier debugging
+export ARROW_R_VERBOSE_TEST=TRUE
 
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=/arrow/r/tools/ubsan.supp"
 

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -40,7 +40,7 @@ ${R_BIN} CMD build .
 ${R_BIN} CMD INSTALL ${INSTALL_ARGS} arrow*.tar.gz
 
 # But unset the env var so that it doesn't cause us to run extra dev tests
-unset ARROW_R_DEV
+# unset ARROW_R_DEV
 
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=/arrow/r/tools/ubsan.supp"
 

--- a/r/tests/testthat.R
+++ b/r/tests/testthat.R
@@ -19,7 +19,10 @@ library(testthat)
 library(arrow)
 library(tibble)
 
-if (identical(tolower(Sys.getenv("ARROW_R_DEV", "false")), "true")) {
+verbose_test_output <- identical(tolower(Sys.getenv("ARROW_R_DEV", "false")), "true") ||
+  identical(tolower(Sys.getenv("ARROW_R_VERBOSE_TEST", "false")), "true")
+
+if (verbose_test_output) {
   arrow_reporter <- MultiReporter$new(list(CheckReporter$new(), LocationReporter$new()))
 } else {
   arrow_reporter <- check_reporter()

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -829,6 +829,10 @@ test_that("Assembling multiple DatasetFactories with DatasetFactory", {
   expect_scan_result(ds, schm)
 })
 
+# By default, snappy encoding will be used, and
+# Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
+skip_on_linux_devel()
+
 # see https://issues.apache.org/jira/browse/ARROW-11328
 test_that("Collecting zero columns from a dataset doesn't return entire dataset", {
   tmp <- tempfile()
@@ -838,7 +842,6 @@ test_that("Collecting zero columns from a dataset doesn't return entire dataset"
     c(32, 0)
   )
 })
-
 
 test_that("dataset RecordBatchReader to C-interface to arrow_dplyr_query", {
   ds <- open_dataset(hive_dir)
@@ -867,9 +870,6 @@ test_that("dataset RecordBatchReader to C-interface to arrow_dplyr_query", {
 })
 
 test_that("dataset to C-interface to arrow_dplyr_query with proj/filter", {
-  # By default, snappy encoding will be used, and
-  # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
-  skip_on_linux_devel()
   ds <- open_dataset(hive_dir)
 
   # filter the dataset

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -867,6 +867,9 @@ test_that("dataset RecordBatchReader to C-interface to arrow_dplyr_query", {
 })
 
 test_that("dataset to C-interface to arrow_dplyr_query with proj/filter", {
+  # By default, snappy encoding will be used, and
+  # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
+  skip_on_linux_devel()
   ds <- open_dataset(hive_dir)
 
   # filter the dataset

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -253,6 +253,11 @@ test_that("arrow dplyr query correctly filters then joins", {
 
 test_that("arrow dplyr query can join with tibble", {
   # ARROW-14908
+
+  # By default, snappy encoding will be used, and
+  # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
+  skip_on_linux_devel()
+
   dir_out <- tempdir()
   write_dataset(iris, file.path(dir_out, "iris"))
   species_codes <- data.frame(


### PR DESCRIPTION
This adds a few skips for some new tests that involved snappy, which has a known sanitizer bug.

I also added a `ARROW_R_VERBOSE_TEST` env var to enable verbosity without relying on `ARROW_R_DEV` which helps show exactly where these kinds of issues are without needing to run locally.