### PR TITLE
ARROW-15709: [C++] Compilation of ARROW_ENGINE fails if doing an "inline" build

### DIFF
--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -34,7 +34,7 @@ set(ARROW_ENGINE_SRCS
     substrait/relation_internal.cc
     substrait/type_internal.cc)
 
-set(SUBSTRAIT_LOCAL_DIR "${CMAKE_CURRENT_BINARY_DIR}/substrait")
+set(SUBSTRAIT_LOCAL_DIR "${CMAKE_CURRENT_BINARY_DIR}/substrait_clone")
 set(SUBSTRAIT_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(SUBSTRAIT_PROTOS
     capabilities


### PR DESCRIPTION
This change modifies the destination directory of the clone so it is unique.