### PR TITLE
ARROW-15700: [C++] Compilation error on Ubuntu 18.04

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1523,8 +1523,9 @@ macro(build_protobuf)
 endmacro()
 
 if(ARROW_WITH_PROTOBUF)
-  if(ARROW_WITH_GRPC)
+  if(ARROW_WITH_GRPC OR ARROW_ENGINE)
     # FlightSQL uses proto3 optionals, which require 3.15 or later.
+    # Substrait (via ARROW_ENGINE) also relies on these optionals
     set(ARROW_PROTOBUF_REQUIRED_VERSION "3.15.0")
   elseif(ARROW_GANDIVA_JAVA)
     # google::protobuf::MessageLite::ByteSize() is deprecated since

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1049,6 +1049,9 @@ tasks:
     params:
       env:
         UBUNTU: "{{ ubuntu_version }}"
+      {% if ubuntu_version == "18.04" %}
+      flags: -e ARROW_ENGINE=OFF
+      {% endif %}
       image: ubuntu-cpp
 {% endfor %}
 


### PR DESCRIPTION
Ubuntu 18.04 does not have a new enough version of protobuf to use the engine module.