### PR TITLE
ARROW-15709: [C++] Revert change

### DIFF
--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -34,7 +34,7 @@ set(ARROW_ENGINE_SRCS
     substrait/relation_internal.cc
     substrait/type_internal.cc)
 
-set(SUBSTRAIT_LOCAL_DIR "${CMAKE_CURRENT_BINARY_DIR}/substrait_clone")
+set(SUBSTRAIT_LOCAL_DIR "${CMAKE_CURRENT_BINARY_DIR}/substrait")
 set(SUBSTRAIT_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(SUBSTRAIT_PROTOS
     capabilities


### PR DESCRIPTION
This reverts commit afaa92e7e4289d6e4f302cc91810368794e8092b, as it seems it can have adverse effects on contributors' checkouts.