### PR TITLE
MINOR: [PYTHON] Fix typo in open_input_file docs

### DIFF
--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -579,7 +579,7 @@ cdef class FileSystem(_Weakrefable):
 
         Returns
         -------
-        stram : NativeFile
+        stream : NativeFile
         """
         cdef:
             c_string pathstr = _path_as_bytes(path)


### PR DESCRIPTION
The other open methods return stream, but open_input_file returns stram. This fixes the typo.