### PR TITLE
ARROW-14893: [C++] Allow creating GCS filesystem from URI

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -689,7 +689,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const Uri& uri,
     }
     return std::make_shared<LocalFileSystem>(options, io_context);
   }
-  if (scheme == "gs") {
+  if (scheme == "gs" || scheme == "gcs") {
 #ifdef ARROW_GCS
     ARROW_ASSIGN_OR_RAISE(auto options, GcsOptions::FromUri(uri, out_path));
     ARROW_ASSIGN_OR_RAISE(auto gcsfs, GcsFileSystem::Make(options, io_context));

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -24,6 +24,9 @@
 #ifdef ARROW_HDFS
 #include "arrow/filesystem/hdfs.h"
 #endif
+#ifdef ARROW_GCS
+#include "arrow/filesystem/gcsfs.h"
+#endif
 #ifdef ARROW_S3
 #include "arrow/filesystem/s3fs.h"
 #endif
@@ -686,6 +689,16 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const Uri& uri,
     }
     return std::make_shared<LocalFileSystem>(options, io_context);
   }
+  if (scheme == "gs") {
+#ifdef ARROW_GCS
+    ARROW_ASSIGN_OR_RAISE(auto options, GcsOptions::FromUri(uri, out_path));
+    ARROW_ASSIGN_OR_RAISE(auto gcsfs, GcsFileSystem::Make(options, io_context));
+    return gcsfs;
+#else
+    return Status::NotImplemented("Got GCS URI but Arrow compiled without GCS support");
+#endif
+  }
+
   if (scheme == "hdfs" || scheme == "viewfs") {
 #ifdef ARROW_HDFS
     ARROW_ASSIGN_OR_RAISE(auto options, HdfsOptions::FromUri(uri));

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -624,42 +624,46 @@ bool GcsOptions::Equals(const GcsOptions& other) const {
 }
 
 GcsOptions GcsOptions::Defaults() {
-  return GcsOptions{
-      std::make_shared<GcsCredentials>(google::cloud::MakeGoogleDefaultCredentials()),
-      {},
-      "https"};
+  GcsOptions options{};
+  options.credentials =
+      std::make_shared<GcsCredentials>(google::cloud::MakeGoogleDefaultCredentials());
+  options.scheme = "https";
+  return options;
 }
 
 GcsOptions GcsOptions::Anonymous() {
-  return GcsOptions{
-      std::make_shared<GcsCredentials>(google::cloud::MakeInsecureCredentials()),
-      {},
-      "http"};
+  GcsOptions options{};
+  options.credentials =
+      std::make_shared<GcsCredentials>(google::cloud::MakeInsecureCredentials());
+  options.scheme = "http";
+  return options;
 }
 
 GcsOptions GcsOptions::FromAccessToken(const std::string& access_token,
                                        std::chrono::system_clock::time_point expiration) {
-  return GcsOptions{
-      std::make_shared<GcsCredentials>(
-          google::cloud::MakeAccessTokenCredentials(access_token, expiration)),
-      {},
-      "https"};
+  GcsOptions options{};
+  options.credentials = std::make_shared<GcsCredentials>(
+      google::cloud::MakeAccessTokenCredentials(access_token, expiration));
+  options.scheme = "https";
+  return options;
 }
 
 GcsOptions GcsOptions::FromImpersonatedServiceAccount(
     const GcsCredentials& base_credentials, const std::string& target_service_account) {
-  return GcsOptions{std::make_shared<GcsCredentials>(
-                        google::cloud::MakeImpersonateServiceAccountCredentials(
-                            base_credentials.credentials, target_service_account)),
-                    {},
-                    "https"};
+  GcsOptions options{};
+  options.credentials = std::make_shared<GcsCredentials>(
+      google::cloud::MakeImpersonateServiceAccountCredentials(
+          base_credentials.credentials, target_service_account));
+  options.scheme = "https";
+  return options;
 }
 
 GcsOptions GcsOptions::FromServiceAccountCredentials(const std::string& json_object) {
-  return GcsOptions{std::make_shared<GcsCredentials>(
-                        google::cloud::MakeServiceAccountCredentials(json_object)),
-                    {},
-                    "https"};
+  GcsOptions options{};
+  options.credentials = std::make_shared<GcsCredentials>(
+      google::cloud::MakeServiceAccountCredentials(json_object));
+  options.scheme = "https";
+  return options;
 }
 
 Result<GcsOptions> GcsOptions::FromUri(const arrow::internal::Uri& uri,

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -410,7 +410,8 @@ class GcsFileSystem::Impl {
       google::cloud::StatusOr<gcs::BucketMetadata> b = client_.GetBucketMetadata(bucket);
       if (!b) {
         if (b.status().code() == GcsCode::kNotFound) {
-          b = client_.CreateBucket(bucket, gcs::BucketMetadata());
+          b = client_.CreateBucket(bucket, gcs::BucketMetadata().set_location(
+                                               options_.default_bucket_location));
         }
         if (!b) return internal::ToArrowStatus(b.status());
       }
@@ -433,7 +434,10 @@ class GcsFileSystem::Impl {
   Status CreateDir(const GcsPath& p) {
     if (p.object.empty()) {
       return internal::ToArrowStatus(
-          client_.CreateBucket(p.bucket, gcs::BucketMetadata()).status());
+          client_
+              .CreateBucket(p.bucket, gcs::BucketMetadata().set_location(
+                                          options_.default_bucket_location))
+              .status());
     }
     auto parent = p.parent();
     if (!parent.object.empty()) {
@@ -542,14 +546,19 @@ class GcsFileSystem::Impl {
 
   Result<std::shared_ptr<io::OutputStream>> OpenOutputStream(
       const GcsPath& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
+    std::shared_ptr<const KeyValueMetadata> resolved_metadata = metadata;
+    if (resolved_metadata == nullptr && options_.default_metadata != nullptr) {
+      resolved_metadata = options_.default_metadata;
+    }
     gcs::EncryptionKey encryption_key;
-    ARROW_ASSIGN_OR_RAISE(encryption_key, internal::ToEncryptionKey(metadata));
+    ARROW_ASSIGN_OR_RAISE(encryption_key, internal::ToEncryptionKey(resolved_metadata));
     gcs::PredefinedAcl predefined_acl;
-    ARROW_ASSIGN_OR_RAISE(predefined_acl, internal::ToPredefinedAcl(metadata));
+    ARROW_ASSIGN_OR_RAISE(predefined_acl, internal::ToPredefinedAcl(resolved_metadata));
     gcs::KmsKeyName kms_key_name;
-    ARROW_ASSIGN_OR_RAISE(kms_key_name, internal::ToKmsKeyName(metadata));
+    ARROW_ASSIGN_OR_RAISE(kms_key_name, internal::ToKmsKeyName(resolved_metadata));
     gcs::WithObjectMetadata with_object_metadata;
-    ARROW_ASSIGN_OR_RAISE(with_object_metadata, internal::ToObjectMetadata(metadata));
+    ARROW_ASSIGN_OR_RAISE(with_object_metadata,
+                          internal::ToObjectMetadata(resolved_metadata));
 
     auto stream = client_.WriteObject(path.bucket, path.object, encryption_key,
                                       predefined_acl, kms_key_name, with_object_metadata);
@@ -610,7 +619,8 @@ class GcsFileSystem::Impl {
 
 bool GcsOptions::Equals(const GcsOptions& other) const {
   return credentials == other.credentials &&
-         endpoint_override == other.endpoint_override && scheme == other.scheme;
+         endpoint_override == other.endpoint_override && scheme == other.scheme &&
+         default_bucket_location == other.default_bucket_location;
 }
 
 GcsOptions GcsOptions::Defaults() {
@@ -650,6 +660,61 @@ GcsOptions GcsOptions::FromServiceAccountCredentials(const std::string& json_obj
                         google::cloud::MakeServiceAccountCredentials(json_object)),
                     {},
                     "https"};
+}
+
+Result<GcsOptions> GcsOptions::FromUri(const arrow::internal::Uri& uri,
+                                       std::string* out_path) {
+  const auto bucket = uri.host();
+  auto path = uri.path();
+  if (bucket.empty()) {
+    if (!path.empty()) {
+      return Status::Invalid("Missing bucket name in GCS URI");
+    }
+  } else {
+    if (path.empty()) {
+      path = bucket;
+    } else {
+      if (path[0] != '/') {
+        return Status::Invalid("GCS URI should be absolute, not relative");
+      }
+      path = bucket + path;
+    }
+  }
+  if (out_path != nullptr) {
+    *out_path = std::string(internal::RemoveTrailingSlash(path));
+  }
+
+  std::unordered_map<std::string, std::string> options_map;
+  ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
+  for (const auto& kv : options_items) {
+    options_map.emplace(kv.first, kv.second);
+  }
+
+  if (!uri.password().empty() || !uri.username().empty()) {
+    return Status::Invalid("GCS does not accept username or password.");
+  }
+
+  auto options = GcsOptions::Defaults();
+  for (const auto& kv : options_map) {
+    if (kv.first == "location") {
+      options.default_bucket_location = kv.second;
+    } else if (kv.first == "scheme") {
+      options.scheme = kv.second;
+    } else if (kv.first == "endpoint_override") {
+      options.endpoint_override = kv.second;
+    } else {
+      return Status::Invalid("Unexpected query parameter in GCS URI: '", kv.first, "'");
+    }
+  }
+
+  return options;
+}
+
+Result<GcsOptions> GcsOptions::FromUri(const std::string& uri_string,
+                                       std::string* out_path) {
+  arrow::internal::Uri uri;
+  RETURN_NOT_OK(uri.Parse(uri_string));
+  return FromUri(uri, out_path);
 }
 
 std::string GcsFileSystem::type_name() const { return "gcs"; }

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -627,18 +627,14 @@ GcsOptions GcsOptions::Defaults() {
   return GcsOptions{
       std::make_shared<GcsCredentials>(google::cloud::MakeGoogleDefaultCredentials()),
       {},
-      "https",
-      /*default_bucket_location=*/{},
-      /*default_metadata=*/nullptr};
+      "https"};
 }
 
 GcsOptions GcsOptions::Anonymous() {
   return GcsOptions{
       std::make_shared<GcsCredentials>(google::cloud::MakeInsecureCredentials()),
       {},
-      "http",
-      /*default_bucket_location=*/{},
-      /*default_metadata=*/nullptr};
+      "http"};
 }
 
 GcsOptions GcsOptions::FromAccessToken(const std::string& access_token,
@@ -647,9 +643,7 @@ GcsOptions GcsOptions::FromAccessToken(const std::string& access_token,
       std::make_shared<GcsCredentials>(
           google::cloud::MakeAccessTokenCredentials(access_token, expiration)),
       {},
-      "https",
-      /*default_bucket_location=*/{},
-      /*default_metadata=*/nullptr};
+      "https"};
 }
 
 GcsOptions GcsOptions::FromImpersonatedServiceAccount(
@@ -658,18 +652,14 @@ GcsOptions GcsOptions::FromImpersonatedServiceAccount(
                         google::cloud::MakeImpersonateServiceAccountCredentials(
                             base_credentials.credentials, target_service_account)),
                     {},
-                    "https",
-                    /*default_bucket_location=*/{},
-                    /*default_metadata=*/nullptr};
+                    "https"};
 }
 
 GcsOptions GcsOptions::FromServiceAccountCredentials(const std::string& json_object) {
   return GcsOptions{std::make_shared<GcsCredentials>(
                         google::cloud::MakeServiceAccountCredentials(json_object)),
                     {},
-                    "https",
-                    /*default_bucket_location=*/{},
-                    /*default_metadata=*/nullptr};
+                    "https"};
 }
 
 Result<GcsOptions> GcsOptions::FromUri(const arrow::internal::Uri& uri,

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -627,14 +627,18 @@ GcsOptions GcsOptions::Defaults() {
   return GcsOptions{
       std::make_shared<GcsCredentials>(google::cloud::MakeGoogleDefaultCredentials()),
       {},
-      "https"};
+      "https",
+      /*default_bucket_location=*/{},
+      /*default_metadata=*/nullptr};
 }
 
 GcsOptions GcsOptions::Anonymous() {
   return GcsOptions{
       std::make_shared<GcsCredentials>(google::cloud::MakeInsecureCredentials()),
       {},
-      "http"};
+      "http",
+      /*default_bucket_location=*/{},
+      /*default_metadata=*/nullptr};
 }
 
 GcsOptions GcsOptions::FromAccessToken(const std::string& access_token,
@@ -643,7 +647,9 @@ GcsOptions GcsOptions::FromAccessToken(const std::string& access_token,
       std::make_shared<GcsCredentials>(
           google::cloud::MakeAccessTokenCredentials(access_token, expiration)),
       {},
-      "https"};
+      "https",
+      /*default_bucket_location=*/{},
+      /*default_metadata=*/nullptr};
 }
 
 GcsOptions GcsOptions::FromImpersonatedServiceAccount(
@@ -652,14 +658,18 @@ GcsOptions GcsOptions::FromImpersonatedServiceAccount(
                         google::cloud::MakeImpersonateServiceAccountCredentials(
                             base_credentials.credentials, target_service_account)),
                     {},
-                    "https"};
+                    "https",
+                    /*default_bucket_location=*/{},
+                    /*default_metadata=*/nullptr};
 }
 
 GcsOptions GcsOptions::FromServiceAccountCredentials(const std::string& json_object) {
   return GcsOptions{std::make_shared<GcsCredentials>(
                         google::cloud::MakeServiceAccountCredentials(json_object)),
                     {},
-                    "https"};
+                    "https",
+                    /*default_bucket_location=*/{},
+                    /*default_metadata=*/nullptr};
 }
 
 Result<GcsOptions> GcsOptions::FromUri(const arrow::internal::Uri& uri,

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -98,7 +98,7 @@ struct ARROW_EXPORT GcsOptions {
   /// [aip/4112]: https://google.aip.dev/auth/4112
   static GcsOptions FromServiceAccountCredentials(const std::string& json_object);
 
-  // Initialize from URIs such as (gs://bucket/object).
+  /// Initialize from URIs such as "gs://bucket/object".
   static Result<GcsOptions> FromUri(const arrow::internal::Uri& uri,
                                     std::string* out_path);
   static Result<GcsOptions> FromUri(const std::string& uri, std::string* out_path);

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "arrow/filesystem/filesystem.h"
+#include "arrow/util/uri.h"
 
 namespace arrow {
 namespace fs {
@@ -34,6 +35,13 @@ struct ARROW_EXPORT GcsOptions {
 
   std::string endpoint_override;
   std::string scheme;
+  // Location to use or creating buckets.
+  std::string default_bucket_location;
+
+  /// \brief Default metadata for OpenOutputStream.
+  ///
+  /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
+  std::shared_ptr<const KeyValueMetadata> default_metadata;
 
   bool Equals(const GcsOptions& other) const;
 
@@ -89,6 +97,11 @@ struct ARROW_EXPORT GcsOptions {
   ///
   /// [aip/4112]: https://google.aip.dev/auth/4112
   static GcsOptions FromServiceAccountCredentials(const std::string& json_object);
+
+  // Initialize from URIs such as (gs://bucket/object).
+  static Result<GcsOptions> FromUri(const arrow::internal::Uri& uri,
+                                    std::string* out_path);
+  static Result<GcsOptions> FromUri(const std::string& uri, std::string* out_path);
 };
 
 /// \brief GCS-backed FileSystem implementation.

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -35,7 +35,7 @@ struct ARROW_EXPORT GcsOptions {
 
   std::string endpoint_override;
   std::string scheme;
-  // \brief Location to use for creating buckets.
+  /// \brief Location to use for creating buckets.
   std::string default_bucket_location;
 
   /// \brief Default metadata for OpenOutputStream.

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -36,12 +36,12 @@ struct ARROW_EXPORT GcsOptions {
   std::string endpoint_override;
   std::string scheme;
   // \brief Location to use for creating buckets.
-  std::string default_bucket_location = "";
+  std::string default_bucket_location;
 
   /// \brief Default metadata for OpenOutputStream.
   ///
   /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
-  std::shared_ptr<const KeyValueMetadata> default_metadata = nullptr;
+  std::shared_ptr<const KeyValueMetadata> default_metadata;
 
   bool Equals(const GcsOptions& other) const;
 

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -36,12 +36,12 @@ struct ARROW_EXPORT GcsOptions {
   std::string endpoint_override;
   std::string scheme;
   // Location to use or creating buckets.
-  std::string default_bucket_location;
+  std::string default_bucket_location = "";
 
   /// \brief Default metadata for OpenOutputStream.
   ///
   /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
-  std::shared_ptr<const KeyValueMetadata> default_metadata;
+  std::shared_ptr<const KeyValueMetadata> default_metadata = nullptr;
 
   bool Equals(const GcsOptions& other) const;
 

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -35,7 +35,7 @@ struct ARROW_EXPORT GcsOptions {
 
   std::string endpoint_override;
   std::string scheme;
-  // Location to use or creating buckets.
+  // \brief Location to use for creating buckets.
   std::string default_bucket_location = "";
 
   /// \brief Default metadata for OpenOutputStream.

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -321,7 +321,7 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
       path = bucket;
     } else {
       if (path[0] != '/') {
-        return Status::Invalid("S3 URI should absolute, not relative");
+        return Status::Invalid("S3 URI should be absolute, not relative");
       }
       path = bucket + path;
     }


### PR DESCRIPTION
This is mostly adapted from s3. One place that it differs
is it doesn't allow for username and password. The only thing
that I could see supporting in the future is taking username as
user to impersonate, but we can see if there is demand for that feature.

I also added in two useful features in s3:
- Option for setting a default location to create a bucket in.
- Default key-value metadata to use for object creation if none
  is specified.

Also fixed a typo in s3fs error message.