### PR TITLE
ARROW-15744: [Gandiva][C++] Add NEGATIVE function for interval types

### DIFF
--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -180,12 +180,12 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
                      kResultNullIfNull, "negative_decimal",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
-      NativeFunction("negative", {}, DataTypeVector{month_interval()}, month_interval(), kResultNullIfNull,
-                     "negative_monthinterval",
+      NativeFunction("negative", {}, DataTypeVector{month_interval()}, month_interval(),
+                     kResultNullIfNull, "negative_month_interval",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
-      NativeFunction("negative", {}, DataTypeVector{day_time_interval()}, day_time_interval(), kResultNullIfNull,
-                     "negative_daytimeinterval",
+      NativeFunction("negative", {}, DataTypeVector{day_time_interval()},
+                     day_time_interval(), kResultNullIfNull, "negative_daytimeinterval",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       // compare functions

--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -180,6 +180,14 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
                      kResultNullIfNull, "negative_decimal",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
+      NativeFunction("negative", {}, DataTypeVector{month_interval()}, month_interval(), kResultNullIfNull,
+                     "negative_monthinterval",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
+
+      NativeFunction("negative", {}, DataTypeVector{day_time_interval()}, day_time_interval(), kResultNullIfNull,
+                     "negative_daytimeinterval",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
+
       // compare functions
       BINARY_RELATIONAL_BOOL_FN(equal, ({"eq", "same"})),
       BINARY_RELATIONAL_BOOL_FN(not_equal, {}),

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -25,7 +25,7 @@ extern "C" {
 
 #include "./types.h"
 
-//using arrow::DayTimeIntervalType;
+// using arrow::DayTimeIntervalType;
 
 // Expand inner macro for all numeric types.
 #define NUMERIC_TYPES(INNER, NAME, OP) \
@@ -394,27 +394,15 @@ NEGATIVE_INTEGER(month_interval, 32)
 
 const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
 
-gdv_int64 negative_daytimeinterval(gdv_int64 context,
-                                   gdv_day_time_interval interval) {
-
+gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval interval) {
   if (interval > INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME) {
     gdv_fn_context_set_error_msg(
         context, "Interval is more than max allowed in negative execution");
     return 0;
   }
 
-  int64_t qty_days;
-  int64_t qty_millis;
-  if (interval < 0) {
-    qty_days = interval >> 32;
-    qty_millis = (interval << 32) >> 32;
-  }
-  else {
-    // The interval is a 64-bit integer where the lower half of the bytes represents the
-    // number of the days and the other half represents the number of milliseconds.
-    qty_days = (interval & 0xFFFFFFFF00000000) >> 32;
-    qty_millis = (interval & 0x00000000FFFFFFFF);
-  }
+  int64_t qty_days = interval >> 32;
+  int64_t qty_millis = (interval << 32) >> 32;
 
   qty_days = -1 * qty_days;
   qty_millis = -1 * qty_millis;

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -403,14 +403,14 @@ gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval inte
     return 0;
   }
 
-  int64_t qty_days = interval >> 32;
-  int64_t qty_millis = interval & 0x00000000FFFFFFFF;
+  int64_t left = interval >> 32;
+  int64_t right = interval & 0x00000000FFFFFFFF;
 
-  qty_days = -1 * qty_days;
-  qty_millis = -1 * qty_millis;
+  left = -1 * left;
+  right = -1 * right;
 
-  gdv_int64 out = (qty_days & 0x00000000FFFFFFFF) << 32;
-  out |= (qty_millis & 0x00000000FFFFFFFF);
+  gdv_int64 out = (left & 0x00000000FFFFFFFF) << 32;
+  out |= (right & 0x00000000FFFFFFFF);
 
   return out;
 }

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -17,15 +17,11 @@
 
 #include <cmath>
 #include <cstdint>
-#include "./epoch_time_point.h"
 #include "arrow/util/basic_decimal.h"
-//#include "../../arrow/type.h"
 
 extern "C" {
 
 #include "./types.h"
-
-// using arrow::DayTimeIntervalType;
 
 // Expand inner macro for all numeric types.
 #define NUMERIC_TYPES(INNER, NAME, OP) \

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -389,11 +389,18 @@ NEGATIVE_INTEGER(int32, 32)
 NEGATIVE_INTEGER(int64, 64)
 NEGATIVE_INTEGER(month_interval, 32)
 
-gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interval interval) {
+const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
 
-  if (interval < 0)
-  {
+gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
+                                         gdv_day_time_interval interval) {
+  if (interval < 0) {
     return interval;
+  }
+
+  if (interval > INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME) {
+    gdv_fn_context_set_error_msg(
+        context, "Interval is more than max allowed in negative execution");
+    return 0;
   }
 
   // The interval is a 64-bit integer where the lower half of the bytes represents the

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -393,11 +393,13 @@ NEGATIVE_INTEGER(int64, 64)
 NEGATIVE_INTEGER(month_interval, 32)
 
 const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
+const int64_t INT_MIN_TO_NEGATIVE_INTERVAL_DAY_TIME = -9223372030412324863;
 
 gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval interval) {
-  if (interval > INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME) {
+  if (interval > INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME ||
+      interval < INT_MIN_TO_NEGATIVE_INTERVAL_DAY_TIME) {
     gdv_fn_context_set_error_msg(
-        context, "Interval is more than max allowed in negative execution");
+        context, "Interval day time is out of boundaries for the negative function");
     return 0;
   }
 

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -19,10 +19,13 @@
 #include <cstdint>
 #include "./epoch_time_point.h"
 #include "arrow/util/basic_decimal.h"
+//#include "../../arrow/type.h"
 
 extern "C" {
 
 #include "./types.h"
+
+//using arrow::DayTimeIntervalType;
 
 // Expand inner macro for all numeric types.
 #define NUMERIC_TYPES(INNER, NAME, OP) \
@@ -391,11 +394,8 @@ NEGATIVE_INTEGER(month_interval, 32)
 
 const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
 
-gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
-                                         gdv_day_time_interval interval) {
-  if (interval < 0) {
-    return interval;
-  }
+gdv_int64 negative_daytimeinterval(gdv_int64 context,
+                                   gdv_day_time_interval interval) {
 
   if (interval > INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME) {
     gdv_fn_context_set_error_msg(
@@ -403,10 +403,18 @@ gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
     return 0;
   }
 
-  // The interval is a 64-bit integer where the lower half of the bytes represents the
-  // number of the days and the other half represents the number of milliseconds.
-  int64_t qty_days = (interval & 0xFFFFFFFF00000000) >> 32;
-  int64_t qty_millis = (interval & 0x00000000FFFFFFFF);
+  int64_t qty_days;
+  int64_t qty_millis;
+  if (interval < 0) {
+    qty_days = interval >> 32;
+    qty_millis = (interval << 32) >> 32;
+  }
+  else {
+    // The interval is a 64-bit integer where the lower half of the bytes represents the
+    // number of the days and the other half represents the number of milliseconds.
+    qty_days = (interval & 0xFFFFFFFF00000000) >> 32;
+    qty_millis = (interval & 0x00000000FFFFFFFF);
+  }
 
   qty_days = -1 * qty_days;
   qty_millis = -1 * qty_millis;

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include "./epoch_time_point.h"
 #include "arrow/util/basic_decimal.h"
 
 extern "C" {
@@ -386,6 +387,28 @@ NUMERIC_FUNCTION_FOR_REAL(NEGATIVE)
 
 NEGATIVE_INTEGER(int32, 32)
 NEGATIVE_INTEGER(int64, 64)
+NEGATIVE_INTEGER(month_interval, 32)
+
+gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interval interval) {
+
+  if (interval < 0)
+  {
+    return interval;
+  }
+
+  // The interval is a 64-bit integer where the lower half of the bytes represents the
+  // number of the days and the other half represents the number of milliseconds.
+  int64_t qty_days = (interval & 0xFFFFFFFF00000000) >> 32;
+  int64_t qty_millis = (interval & 0x00000000FFFFFFFF);
+
+  qty_days = -1 * qty_days;
+  qty_millis = -1 * qty_millis;
+
+  gdv_int64 out = (qty_days & 0x00000000FFFFFFFF) << 32;
+  out |= (qty_millis & 0x00000000FFFFFFFF);
+
+  return out;
+}
 
 #undef NEGATIVE
 #undef NEGATIVE_INTEGER

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -404,7 +404,7 @@ gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval inte
   }
 
   int64_t qty_days = interval >> 32;
-  int64_t qty_millis = ((interval & 0x00000000FFFFFFFF) << 32) >> 32;
+  int64_t qty_millis = interval & 0x00000000FFFFFFFF;
 
   qty_days = -1 * qty_days;
   qty_millis = -1 * qty_millis;

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -402,7 +402,7 @@ gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval inte
   }
 
   int64_t qty_days = interval >> 32;
-  int64_t qty_millis = (interval << 32) >> 32;
+  int64_t qty_millis = ((interval & 0x00000000FFFFFFFF) << 32) >> 32;
 
   qty_days = -1 * qty_days;
   qty_millis = -1 * qty_millis;

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -216,8 +216,7 @@ TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
   EXPECT_EQ(ctx.get_error(), "Interval is more than max allowed in negative execution");
   ctx.Reset();
 
-
-  //Month interval
+  // Month interval
   gdv_month_interval result2 = negative_month_interval(ctx_ptr, 2);
   EXPECT_EQ(result2, -2);
 
@@ -229,7 +228,6 @@ TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
 
   result2 = negative_month_interval(ctx_ptr, INT32_MAX);
   EXPECT_EQ(result2, -INT32_MAX);
-
 }
 
 TEST(TestArithmeticOps, TestDivide) {

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -213,7 +213,18 @@ TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
 
   result = negative_daytimeinterval(ctx_ptr, INT64_MAX);
   EXPECT_EQ(ctx.has_error(), true);
-  EXPECT_EQ(ctx.get_error(), "Interval is more than max allowed in negative execution");
+  EXPECT_EQ(ctx.get_error(),
+            "Interval day time is out of boundaries for the negative function");
+  ctx.Reset();
+
+  const int64_t INT_MIN_TO_NEGATIVE_INTERVAL_DAY_TIME = -9223372030412324863;
+  result = negative_daytimeinterval(ctx_ptr, INT_MIN_TO_NEGATIVE_INTERVAL_DAY_TIME);
+  EXPECT_EQ(result, INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME);
+
+  result = negative_daytimeinterval(ctx_ptr, INT64_MIN);
+  EXPECT_EQ(ctx.has_error(), true);
+  EXPECT_EQ(ctx.get_error(),
+            "Interval day time is out of boundaries for the negative function");
   ctx.Reset();
 
   // Month interval

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -183,28 +183,28 @@ TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
   gandiva::ExecutionContext ctx;
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  // Input: 8589934594;         Mean:  2 days &  2 time
-  // Response: -4294967298;     Mean: -2 days & -2 time
+  // Input: 8589934594;         Mean:  2 time &  2 days
+  // Response: -4294967298;     Mean: -2 time & -2 days
   gdv_int64 result = negative_daytimeinterval(ctx_ptr, 8589934594);
   EXPECT_EQ(result, -4294967298);
 
-  // Input: -4294967298;      Mean: -2 days & -2 time
-  // Response: 8589934594;    Mean:  2 days &  2 time
+  // Input: -4294967298;      Mean: -2 time & -2 days
+  // Response: 8589934594;    Mean:  2 time &  2 days
   result = negative_daytimeinterval(ctx_ptr, -4294967298);
   EXPECT_EQ(result, 8589934594);
 
-  // Input: -12884903388;      Mean: -4 days & -1500 time
-  // Response: 17179870684;    Mean:  4 days &  1500 time
+  // Input: -12884903388;      Mean: -4 time & -1500 days
+  // Response: 17179870684;    Mean:  4 time &  1500 days
   result = negative_daytimeinterval(ctx_ptr, -12884903388);
   EXPECT_EQ(result, 17179870684);
 
-  // Input: 44023418384000;      Mean:  10250 days &  3600000 time
-  // Response: -44019123416704;  Mean: -10250 days & -3600000 time
+  // Input: 44023418384000;      Mean:  10250 time &  3600000 days
+  // Response: -44019123416704;  Mean: -10250 time & -3600000 days
   result = negative_daytimeinterval(ctx_ptr, 44023418384000);
   EXPECT_EQ(result, -44019123416704);
 
-  // Input: 9223372034707292159;      Mean:  2147483647 days &  2147483647 time
-  // Response: -9223372030412324863;  Mean: -2147483647 days & -2147483647 time
+  // Input: 9223372034707292159;      Mean:  2147483647 time &  2147483647 days
+  // Response: -9223372030412324863;  Mean: -2147483647 time & -2147483647 days
   const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
   result = negative_daytimeinterval(ctx_ptr, INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME);
   EXPECT_EQ(result, -9223372030412324863);

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -179,6 +179,24 @@ TEST(TestArithmeticOps, TestPositiveNegative) {
   ctx.Reset();
 }
 
+TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
+
+  gandiva::ExecutionContext ctx;
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  gdv_int64 result = negative_daytimeinterval_int64(ctx_ptr, 8589934594);
+  EXPECT_EQ(result, -4294967298);
+
+  result = negative_daytimeinterval_int64(ctx_ptr, -4294967298);
+  EXPECT_EQ(result, -4294967298);
+
+  //Input: 44023418384000;      Mean:  10250 days &  3600000 time
+  //Response: -44019123416704;  Mean: -10250 days & -3600000 time
+  result = negative_daytimeinterval_int64(ctx_ptr, 44023418384000);
+  EXPECT_EQ(result, -44019123416704);
+
+}
+
 TEST(TestArithmeticOps, TestDivide) {
   gandiva::ExecutionContext context;
   EXPECT_EQ(divide_int64_int64(reinterpret_cast<gdv_int64>(&context), 10, 0), 0);

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -180,7 +180,6 @@ TEST(TestArithmeticOps, TestPositiveNegative) {
 }
 
 TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
-
   gandiva::ExecutionContext ctx;
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
@@ -190,11 +189,21 @@ TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
   result = negative_daytimeinterval_int64(ctx_ptr, -4294967298);
   EXPECT_EQ(result, -4294967298);
 
-  //Input: 44023418384000;      Mean:  10250 days &  3600000 time
-  //Response: -44019123416704;  Mean: -10250 days & -3600000 time
+  // Input: 44023418384000;      Mean:  10250 days &  3600000 time
+  // Response: -44019123416704;  Mean: -10250 days & -3600000 time
   result = negative_daytimeinterval_int64(ctx_ptr, 44023418384000);
   EXPECT_EQ(result, -44019123416704);
 
+  // Input: 9223372034707292159;      Mean:  2147483647 days &  2147483647 time
+  // Response: -9223372030412324863;  Mean: -2147483647 days & -2147483647 time
+  const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
+  result = negative_daytimeinterval_int64(ctx_ptr, INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME);
+  EXPECT_EQ(result, -9223372030412324863);
+
+  result = negative_daytimeinterval_int64(ctx_ptr, INT64_MAX);
+  EXPECT_EQ(ctx.has_error(), true);
+  EXPECT_EQ(ctx.get_error(), "Interval is more than max allowed in negative execution");
+  ctx.Reset();
 }
 
 TEST(TestArithmeticOps, TestDivide) {

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -179,31 +179,57 @@ TEST(TestArithmeticOps, TestPositiveNegative) {
   ctx.Reset();
 }
 
+//
+
 TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
   gandiva::ExecutionContext ctx;
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  gdv_int64 result = negative_daytimeinterval_int64(ctx_ptr, 8589934594);
+  // Input: 8589934594;         Mean:  2 days &  2 time
+  // Response: -4294967298;     Mean: -2 days & -2 time
+  gdv_int64 result = negative_daytimeinterval(ctx_ptr, 8589934594);
   EXPECT_EQ(result, -4294967298);
 
-  result = negative_daytimeinterval_int64(ctx_ptr, -4294967298);
-  EXPECT_EQ(result, -4294967298);
+  // Input: -4294967298;      Mean: -2 days & -2 time
+  // Response: 8589934594;    Mean:  2 days &  2 time
+  result = negative_daytimeinterval(ctx_ptr, -4294967298);
+  EXPECT_EQ(result, 8589934594);
+
+  // Input: -12884903388;      Mean: -4 days & -1500 time
+  // Response: 17179870684;    Mean:  4 days &  1500 time
+  result = negative_daytimeinterval(ctx_ptr, -12884903388);
+  EXPECT_EQ(result, 17179870684);
 
   // Input: 44023418384000;      Mean:  10250 days &  3600000 time
   // Response: -44019123416704;  Mean: -10250 days & -3600000 time
-  result = negative_daytimeinterval_int64(ctx_ptr, 44023418384000);
+  result = negative_daytimeinterval(ctx_ptr, 44023418384000);
   EXPECT_EQ(result, -44019123416704);
 
   // Input: 9223372034707292159;      Mean:  2147483647 days &  2147483647 time
   // Response: -9223372030412324863;  Mean: -2147483647 days & -2147483647 time
   const int64_t INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME = 9223372034707292159;
-  result = negative_daytimeinterval_int64(ctx_ptr, INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME);
+  result = negative_daytimeinterval(ctx_ptr, INT_MAX_TO_NEGATIVE_INTERVAL_DAY_TIME);
   EXPECT_EQ(result, -9223372030412324863);
 
-  result = negative_daytimeinterval_int64(ctx_ptr, INT64_MAX);
+  result = negative_daytimeinterval(ctx_ptr, INT64_MAX);
   EXPECT_EQ(ctx.has_error(), true);
   EXPECT_EQ(ctx.get_error(), "Interval is more than max allowed in negative execution");
   ctx.Reset();
+
+
+  //Month interval
+  gdv_month_interval result2 = negative_month_interval(ctx_ptr, 2);
+  EXPECT_EQ(result2, -2);
+
+  result2 = negative_month_interval(ctx_ptr, -2);
+  EXPECT_EQ(result2, 2);
+
+  result2 = negative_month_interval(ctx_ptr, 510);
+  EXPECT_EQ(result2, -510);
+
+  result2 = negative_month_interval(ctx_ptr, INT32_MAX);
+  EXPECT_EQ(result2, -INT32_MAX);
+
 }
 
 TEST(TestArithmeticOps, TestDivide) {

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -179,8 +179,6 @@ TEST(TestArithmeticOps, TestPositiveNegative) {
   ctx.Reset();
 }
 
-//
-
 TEST(TestArithmeticOps, TestNegativeIntervalTypes) {
   gandiva::ExecutionContext ctx;
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -216,9 +216,8 @@ gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
                                          gdv_day_time_interval interval);
 
 gdv_month_interval negative_month_interval(gdv_int64 context,
-                                  gdv_month_interval interval);
-gdv_int64 negative_daytimeinterval(gdv_int64 context,
-                                   gdv_day_time_interval interval);
+                                           gdv_month_interval interval);
+gdv_int64 negative_daytimeinterval(gdv_int64 context, gdv_day_time_interval interval);
 
 gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -212,6 +212,8 @@ void negative_decimal(gdv_int64 context, int64_t high_bits, uint64_t low_bits,
                       int32_t /*out_scale*/, int64_t* out_high_bits,
                       uint64_t* out_low_bits);
 gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interval interval);
+gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
+                                         gdv_day_time_interval interval);
 
 gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -215,6 +215,11 @@ gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interva
 gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
                                          gdv_day_time_interval interval);
 
+gdv_month_interval negative_month_interval(gdv_int64 context,
+                                  gdv_month_interval interval);
+gdv_int64 negative_daytimeinterval(gdv_int64 context,
+                                   gdv_day_time_interval interval);
+
 gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
 
 gdv_int64 div_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -211,6 +211,7 @@ void negative_decimal(gdv_int64 context, int64_t high_bits, uint64_t low_bits,
                       int32_t /*precision*/, int32_t /*scale*/, int32_t /*out_precision*/,
                       int32_t /*out_scale*/, int64_t* out_high_bits,
                       uint64_t* out_low_bits);
+gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interval interval);
 
 gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -207,14 +207,11 @@ gdv_float32 positive_float32(gdv_float32 in);
 gdv_float64 positive_float64(gdv_float64 in);
 gdv_float32 negative_float32(gdv_float32 in);
 gdv_float64 negative_float64(gdv_float64 in);
+
 void negative_decimal(gdv_int64 context, int64_t high_bits, uint64_t low_bits,
                       int32_t /*precision*/, int32_t /*scale*/, int32_t /*out_precision*/,
                       int32_t /*out_scale*/, int64_t* out_high_bits,
                       uint64_t* out_low_bits);
-gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
-                                         gdv_day_time_interval interval);
-gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
-                                         gdv_day_time_interval interval);
 
 gdv_month_interval negative_month_interval(gdv_int64 context,
                                            gdv_month_interval interval);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -211,7 +211,8 @@ void negative_decimal(gdv_int64 context, int64_t high_bits, uint64_t low_bits,
                       int32_t /*precision*/, int32_t /*scale*/, int32_t /*out_precision*/,
                       int32_t /*out_scale*/, int64_t* out_high_bits,
                       uint64_t* out_low_bits);
-gdv_int64 negative_daytimeinterval_int64(gdv_int64 context, gdv_day_time_interval interval);
+gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
+                                         gdv_day_time_interval interval);
 gdv_int64 negative_daytimeinterval_int64(gdv_int64 context,
                                          gdv_day_time_interval interval);
 

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1038,8 +1038,47 @@ TEST_F(TestProjector, TestPositiveNegative) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_neg2, outputs.at(1));
 }
 
-TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
+TEST_F(TestProjector, TestNegativeMonthInterval) {
+  // schema for input fields
+  auto field0 = field("f0", arrow::month_interval());
+  auto schema = arrow::schema({field0});
 
+  // output fields
+  auto field_pos = field("result", arrow::month_interval());
+
+  // Build expression for NEGATIVE function
+  auto pos_expr = TreeExprBuilder::MakeExpression("negative", {field0}, field_pos);
+
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {pos_expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 6;
+
+  std::shared_ptr<arrow::Array> array0, exp_pos;
+  arrow::ArrayFromVector<arrow::MonthIntervalType>(
+      arrow::month_interval(), {true, true, true, true, true, true},
+      {2, -2, 10250, 2147483647, 4, -4}, &array0);
+
+  // expected output
+  arrow::ArrayFromVector<arrow::MonthIntervalType>(
+      arrow::month_interval(), {true, true, true, true, true, true},
+      {-2, 2, -10250, -2147483647, -4, 4}, &exp_pos);
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_pos, outputs.at(0));
+}
+
+TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
   // schema for input fields
   auto field0 = field("f1", arrow::day_time_interval());
   auto schema = arrow::schema({field0});
@@ -1051,35 +1090,35 @@ TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
   auto pos_expr = TreeExprBuilder::MakeExpression("negative", {field0}, output_negative);
 
   std::shared_ptr<Projector> projector;
-  auto status =
-      Projector::Make(schema, {pos_expr}, TestConfiguration(), &projector);
+  auto status = Projector::Make(schema, {pos_expr}, TestConfiguration(), &projector);
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
   int num_records = 6;
 
-
   std::shared_ptr<arrow::Array> array_day_interval, array_day_interval_output;
-  arrow::ArrayFromVector<arrow::DayTimeIntervalType, arrow::DayTimeIntervalType::DayMilliseconds>(
-      arrow::day_time_interval(),
-      {true, true, true, true, true, true},
+  arrow::ArrayFromVector<arrow::DayTimeIntervalType,
+                         arrow::DayTimeIntervalType::DayMilliseconds>(
+      arrow::day_time_interval(), {true, true, true, true, true, true},
       {{2, 2},
        {-2, -2},
        {10250, 3600000},
        {2147483647, 2147483647},
        {4, 1500},
-       {-4, -1500}}, &array_day_interval);
+       {-4, -1500}},
+      &array_day_interval);
 
   // expected output
-  arrow::ArrayFromVector<arrow::DayTimeIntervalType, arrow::DayTimeIntervalType::DayMilliseconds>(
-      arrow::day_time_interval(),
-      {true, true, true, true, true, true},
+  arrow::ArrayFromVector<arrow::DayTimeIntervalType,
+                         arrow::DayTimeIntervalType::DayMilliseconds>(
+      arrow::day_time_interval(), {true, true, true, true, true, true},
       {{-2, -2},
        {-2, -2},
        {-10250, -3600000},
        {-2147483647, -2147483647},
        {-4, -1500},
-       {4, 1500}}, &array_day_interval_output);
+       {4, 1500}},
+      &array_day_interval_output);
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_day_interval});
@@ -1091,7 +1130,6 @@ TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
 
   // Validate results
   EXPECT_ARROW_ARRAY_EQUALS(array_day_interval_output, outputs.at(0));
-
 }
 
 TEST_F(TestProjector, TestConcat) {

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1094,30 +1094,32 @@ TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 6;
+  int num_records = 7;
 
   std::shared_ptr<arrow::Array> array_day_interval, array_day_interval_output;
   arrow::ArrayFromVector<arrow::DayTimeIntervalType,
                          arrow::DayTimeIntervalType::DayMilliseconds>(
-      arrow::day_time_interval(), {true, true, true, true, true, true},
+      arrow::day_time_interval(), {true, true, true, true, true, true, true},
       {{2, 2},
        {-2, -2},
        {10250, 3600000},
        {2147483647, 2147483647},
        {4, 1500},
-       {-4, -1500}},
+       {-4, -1500},
+       {-2147483647, -2147483647}},
       &array_day_interval);
 
   // expected output
   arrow::ArrayFromVector<arrow::DayTimeIntervalType,
                          arrow::DayTimeIntervalType::DayMilliseconds>(
-      arrow::day_time_interval(), {true, true, true, true, true, true},
+      arrow::day_time_interval(), {true, true, true, true, true, true, true},
       {{-2, -2},
        {2, 2},
        {-10250, -3600000},
        {-2147483647, -2147483647},
        {-4, -1500},
-       {4, 1500}},
+       {4, 1500},
+       {2147483647, 2147483647}},
       &array_day_interval_output);
 
   // prepare input record batch

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1113,7 +1113,7 @@ TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
                          arrow::DayTimeIntervalType::DayMilliseconds>(
       arrow::day_time_interval(), {true, true, true, true, true, true},
       {{-2, -2},
-       {-2, -2},
+       {2, 2},
        {-10250, -3600000},
        {-2147483647, -2147483647},
        {-4, -1500},

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1038,6 +1038,62 @@ TEST_F(TestProjector, TestPositiveNegative) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_neg2, outputs.at(1));
 }
 
+TEST_F(TestProjector, TestNegativeIntervalTypeDayTime) {
+
+  // schema for input fields
+  auto field0 = field("f1", arrow::day_time_interval());
+  auto schema = arrow::schema({field0});
+
+  // output fields
+  auto output_negative = field("result", arrow::day_time_interval());
+
+  // Build expression for POSITIVE function
+  auto pos_expr = TreeExprBuilder::MakeExpression("negative", {field0}, output_negative);
+
+  std::shared_ptr<Projector> projector;
+  auto status =
+      Projector::Make(schema, {pos_expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 6;
+
+
+  std::shared_ptr<arrow::Array> array_day_interval, array_day_interval_output;
+  arrow::ArrayFromVector<arrow::DayTimeIntervalType, arrow::DayTimeIntervalType::DayMilliseconds>(
+      arrow::day_time_interval(),
+      {true, true, true, true, true, true},
+      {{2, 2},
+       {-2, -2},
+       {10250, 3600000},
+       {2147483647, 2147483647},
+       {4, 1500},
+       {-4, -1500}}, &array_day_interval);
+
+  // expected output
+  arrow::ArrayFromVector<arrow::DayTimeIntervalType, arrow::DayTimeIntervalType::DayMilliseconds>(
+      arrow::day_time_interval(),
+      {true, true, true, true, true, true},
+      {{-2, -2},
+       {-2, -2},
+       {-10250, -3600000},
+       {-2147483647, -2147483647},
+       {-4, -1500},
+       {4, 1500}}, &array_day_interval_output);
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_day_interval});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(array_day_interval_output, outputs.at(0));
+
+}
+
 TEST_F(TestProjector, TestConcat) {
   // schema for input fields
   auto field0 = field("f0", arrow::utf8());


### PR DESCRIPTION
There are two interval types:

YEAR_MONTH
DAY_TIME

This implementation is based on java implementation.