### PR TITLE
ARROW-15701 [R] month() should allow integer inputs

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -20,17 +20,10 @@
 # arrow 7.0.0.9000
 
 * `read_csv_arrow()`'s readr-style type `T` is now mapped to `timestamp(unit = "ns")` instead of `timestamp(unit = "s")`.
-* `lubridate`: 
-  * `tz()` to extract/get timezone
-  * `semester()` to extract/get semester
-  * `dst()` to get daylight savings time indicator.
-  * `date()` to extract date
-  * `epiyear()` to get epiyear
+* `lubridate`:
+  * component extraction functions: `tz()` (timezone), `semester()` (semester), `dst()` (daylight savings time indicator), `date()` (extract date), `epiyear()` (epiyear), improvements to `month()`, which now works with integer inputs.
 * date-time functionality:
   * `as.Date()` to convert to date
-* `lubridate`:
-  * component extraction functions: `tz()` (timezone), `semester()` (semester), `dst()` (daylight savings time indicator)
-  * improvements to `month()`, which now works with integer inputs 
 
 # arrow 7.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -28,6 +28,9 @@
   * `epiyear()` to get epiyear
 * date-time functionality:
   * `as.Date()` to convert to date
+* `lubridate`:
+  * component extraction functions: `tz()` (timezone), `semester()` (semester), `dst()` (daylight savings time indicator)
+  * improvements to `month()`, which now works with integer inputs 
 
 # arrow 7.0.0
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -127,8 +127,7 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-      return(Expression$create("strftime", x,
-                               options = list(format = format, locale = locale)))
+      return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
     }
 
     Expression$create("month", x)

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -106,6 +106,23 @@ register_bindings_datetime <- function() {
   })
 
   register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {
+    if (call_binding("is.integer", x)) {
+      if (inherits(x, "Expression")) {
+        x <- call_binding(
+          "if_else",
+          call_binding_agg("all", call_binding("between", x, 1, 12)),
+          x,
+          abort("bla1: Values are not in 1:12")
+        )
+      } else {
+        if (all(1 <= x & x <= 12)) {
+          x <- x
+        } else {
+          abort("bla2: Values are not in 1:12")
+        }
+      }
+    }
+
     if (label) {
       if (abbr) {
         format <- "%b"

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -105,25 +105,20 @@ register_bindings_datetime <- function() {
     (call_binding("yday", x) - 1) %/% 7 + 1
   })
 
-  register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {
-    browser()
+  register_binding("month", function(x,
+                                     label = FALSE,
+                                     abbr = TRUE,
+                                     locale = Sys.getlocale("LC_TIME")) {
+
     if (call_binding("is.integer", x)) {
-      if (inherits(x, "Expression")) {
-        x <- call_binding(
-          "if_else",
-          call_binding_agg("all", call_binding("between", x, 1, 12)),
-          x,
-          abort("bla1: Values are not in 1:12")
-        )
-        return(x)
-      } else {
-        if (all(1 <= x & x <= 12)) {
-          # x needs to be an Expression
-          x <- x
-        } else {
-          abort("bla2: Values are not in 1:12")
-        }
+      if (is.integer(x)) {
+        x <- build_expr("cast", x, options = cast_options(to_type = int32()))
       }
+      x <- call_binding("if_else",
+                        call_binding("between", x, 1, 12),
+                        x,
+                        NA_integer_)
+      x <- build_expr("cast", x * 28L, options = cast_options(to_type = date32()))
     }
 
     if (label) {
@@ -132,7 +127,8 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-      return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
+      return(Expression$create("strftime", x,
+                               options = list(format = format, locale = locale)))
     }
 
     Expression$create("month", x)

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -106,6 +106,7 @@ register_bindings_datetime <- function() {
   })
 
   register_binding("month", function(x, label = FALSE, abbr = TRUE, locale = Sys.getlocale("LC_TIME")) {
+    browser()
     if (call_binding("is.integer", x)) {
       if (inherits(x, "Expression")) {
         x <- call_binding(
@@ -114,8 +115,10 @@ register_bindings_datetime <- function() {
           x,
           abort("bla1: Values are not in 1:12")
         )
+        return(x)
       } else {
         if (all(1 <= x & x <= 12)) {
+          # x needs to be an Expression
           x <- x
         } else {
           abort("bla2: Values are not in 1:12")

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -111,14 +111,21 @@ register_bindings_datetime <- function() {
                                      locale = Sys.getlocale("LC_TIME")) {
 
     if (call_binding("is.integer", x)) {
-      if (is.integer(x)) {
-        x <- build_expr("cast", x, options = cast_options(to_type = int32()))
-      }
       x <- call_binding("if_else",
                         call_binding("between", x, 1, 12),
                         x,
                         NA_integer_)
-      x <- build_expr("cast", x * 28L, options = cast_options(to_type = date32()))
+      if (!label) {
+        # if we don't need a label we can return the integer itself (constrained
+        # to 1:12)
+        return(x)
+      } else {
+        # make the integer into a date32() - which interprets integers as
+        # days from epoch (we multiply by 28 to be able to later extract the
+        # month with label) - NB this builds a false date (to be used by strftime)
+        # since we only know and care about the month
+        x <- build_expr("cast", x * 28L, options = cast_options(to_type = date32()))
+      }
     }
 
     if (label) {
@@ -127,10 +134,10 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-      return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
+      return(build_expr("strftime", x, options = list(format = format, locale = locale)))
     }
 
-    Expression$create("month", x)
+    build_expr("month", x)
   })
 
   register_binding("is.Date", function(x) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -116,16 +116,15 @@ register_bindings_datetime <- function() {
                         x,
                         NA_integer_)
       if (!label) {
-        # if we don't need a label we can return the integer itself (constrained
-        # to 1:12)
+        # if we don't need a label we can return the integer itself (already
+        # constrained to 1:12)
         return(x)
-      } else {
+      }
         # make the integer into a date32() - which interprets integers as
         # days from epoch (we multiply by 28 to be able to later extract the
         # month with label) - NB this builds a false date (to be used by strftime)
         # since we only know and care about the month
         x <- build_expr("cast", x * 28L, options = cast_options(to_type = date32()))
-      }
     }
 
     if (label) {

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -78,7 +78,3 @@ process_is_running <- function(x) {
   cmd <- sprintf("ps aux | grep '%s' | grep -v grep", x)
   tryCatch(system(cmd, ignore.stdout = TRUE) == 0, error = function(e) FALSE)
 }
-
-on_windows <- function() {
-  ifelse(tolower(Sys.info()[["sysname"]]) == "windows", TRUE, FALSE)
-}

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -78,3 +78,7 @@ process_is_running <- function(x) {
   cmd <- sprintf("ps aux | grep '%s' | grep -v grep", x)
   tryCatch(system(cmd, ignore.stdout = TRUE) == 0, error = function(e) FALSE)
 }
+
+on_windows <- function() {
+  ifelse(tolower(Sys.info()[["sysname"]]) == "windows", TRUE, FALSE)
+}

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -859,6 +859,18 @@ test_that("month() errors with double input and returns NA with int outside 1:12
     month_as_double = month_as_int + 0.1
   )
 
+  expect_equal(
+    test_df_month %>%
+      arrow_table() %>%
+      select(month_as_int) %>%
+      mutate(month_int_input = month(month_as_int)) %>%
+      collect(),
+    tibble(
+      month_as_int = c(-1L, 1L, 13L, NA),
+      month_int_input = c(NA, 1L, NA, NA)
+    )
+  )
+
   expect_error(
     test_df_month %>%
       arrow_table() %>%
@@ -877,17 +889,6 @@ test_that("month() errors with double input and returns NA with int outside 1:12
     fixed = TRUE
   )
 
-  expect_equal(
-    test_df_month %>%
-      arrow_table() %>%
-      select(month_as_int) %>%
-      mutate(month_int_input = month(month_as_int)) %>%
-      collect(),
-    tibble(
-      month_as_int = c(-1L, 1L, 13L, NA),
-      month_int_input = c(NA, 1L, NA, NA)
-    )
-  )
 })
 
 test_that("date works in arrow", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -356,11 +356,6 @@ test_that("extract month from timestamp", {
     test_df
   )
 
-  test_df %>%
-    arrow_table() %>%
-    mutate(x = month(datetime, label = TRUE)) %>%
-    collect()
-
   skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
 
   compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -798,7 +798,7 @@ test_that("semester works with temporal types and integers", {
       collect(),
     regexp = "NotImplemented: Function 'month' has no kernel matching input types (array[string])",
     fixed = TRUE
-    )
+  )
 })
 
 test_that("dst extracts daylight savings time correctly", {
@@ -852,40 +852,39 @@ test_that("month() supports integer input", {
     )
   })
 
-  test_that("month() errors with double input and returns NA with int outside 1:12", {
-    test_df_month <- tibble(
+test_that("month() errors with double input and returns NA with int outside 1:12", {
+  test_df_month <- tibble(
+    month_as_int = c(-1L, 1L, 13L, NA),
+    month_as_double = month_as_int + 0.1
+  )
+
+  expect_error(
+    test_df_month %>%
+      arrow_table() %>%
+      mutate(month_dbl_input = month(month_as_double)) %>%
+      collect(),
+    regexp = "Function 'month' has no kernel matching input types (array[double])",
+    fixed = TRUE
+  )
+
+  expect_error(
+    test_df_month %>%
+      record_batch() %>%
+      mutate(month_dbl_input = month(month_as_double)) %>%
+      collect(),
+    regexp = "Function 'month' has no kernel matching input types (array[double])",
+    fixed = TRUE
+  )
+
+  expect_equal(
+    test_df_month %>%
+      arrow_table() %>%
+      select(month_as_int) %>%
+      mutate(month_int_input = month(month_as_int)) %>%
+      collect(),
+    tibble(
       month_as_int = c(-1L, 1L, 13L, NA),
-      month_as_double = month_as_int + 0.1
-    )
-
-    expect_error(
-      test_df_month %>%
-        arrow_table() %>%
-        mutate(month_dbl_input = month(month_as_double)) %>%
-        collect(),
-      regexp = "Function 'month' has no kernel matching input types (array[double])",
-      fixed = TRUE
-    )
-
-    expect_error(
-      test_df_month %>%
-        record_batch() %>%
-        mutate(month_dbl_input = month(month_as_double)) %>%
-        collect(),
-      regexp = "Function 'month' has no kernel matching input types (array[double])",
-      fixed = TRUE
-    )
-
-    expect_equal(
-      test_df_month %>%
-        arrow_table() %>%
-        select(month_as_int) %>%
-        mutate(month_int_input = month(month_as_int)) %>%
-        collect(),
-      tibble(
-        month_as_int = c(-1L, 1L, 13L, NA),
-        month_int_input = c(NA, 1L, NA, NA)
-      )
+      month_int_input = c(NA, 1L, NA, NA)
     )
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -356,6 +356,11 @@ test_that("extract month from timestamp", {
     test_df
   )
 
+  test_df %>%
+    arrow_table() %>%
+    mutate(x = month(datetime, label = TRUE)) %>%
+    collect()
+
   skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
 
   compare_dplyr_binding(
@@ -770,7 +775,7 @@ test_that("extract tz", {
 
 test_that("semester works with temporal types and integers", {
 test_that("month() supports integer input",{
-  test_df <- tibble(
+  test_df_month <- tibble(
     month_as_int = c(1:12, NA),
     month_as_char_pad = sprintf("%02i", month_as_int),
     dates = as.Date(paste0("2021-", month_as_char_pad, "-15"))
@@ -819,9 +824,15 @@ test_that("dst extracts daylight savings time correctly", {
       collect(),
     test_df
   test_df %>%
+  test_df_month %>%
     arrow_table() %>%
     mutate(month_int_input = month(month_as_int)) %>%
     collect()
+
+  at <- arrow_table(example_with_times)
+  at$posixlt$as_vector()
+  at$posixlt$as_vector()$mon
+
 
   # we need to support both integer and integer + label, similar to below
   lubridate::month(1)

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -828,6 +828,8 @@ test_that("month() supports integer input",{
       test_df_month
     )
 
+    skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
+
     compare_dplyr_binding(
       .input %>%
         # R returns ordered factor whereas Arrow returns character
@@ -835,8 +837,7 @@ test_that("month() supports integer input",{
           month_int_input = as.character(month(month_as_int, label = TRUE))
         ) %>%
         collect(),
-      test_df_month,
-      ignore_attr = on_windows()
+      test_df_month
     )
 
     compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -888,7 +888,6 @@ test_that("month() errors with double input and returns NA with int outside 1:12
     regexp = "Function 'month' has no kernel matching input types (array[double])",
     fixed = TRUE
   )
-
 })
 
 test_that("date works in arrow", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -816,7 +816,7 @@ test_that("dst extracts daylight savings time correctly", {
   )
 })
 
-test_that("month() supports integer input",{
+test_that("month() supports integer input", {
     test_df_month <- tibble(
       month_as_int = c(1:12, NA)
     )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -835,7 +835,8 @@ test_that("month() supports integer input",{
           month_int_input = as.character(month(month_as_int, label = TRUE))
         ) %>%
         collect(),
-      test_df_month
+      test_df_month,
+      ignore_attr = on_windows()
     )
 
     compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -769,6 +769,7 @@ test_that("extract tz", {
 })
 
 test_that("semester works with temporal types and integers", {
+test_that("month() supports integer input",{
   test_df <- tibble(
     month_as_int = c(1:12, NA),
     month_as_char_pad = sprintf("%02i", month_as_int),
@@ -817,6 +818,29 @@ test_that("dst extracts daylight savings time correctly", {
       mutate(dst = dst(dates)) %>%
       collect(),
     test_df
+  test_df %>%
+    arrow_table() %>%
+    mutate(month_int_input = month(month_as_int)) %>%
+    collect()
+
+  # we need to support both integer and integer + label, similar to below
+  lubridate::month(1)
+  lubridate::month(1.1)
+  lubridate::month(4L)
+  lubridate::month(4L, label = TRUE)
+
+
+  expect_error(
+    call_binding("month", "not a month")
+  )
+  expect_error(
+    call_binding("month", 22L)
+  )
+  expect_error(
+    call_binding("month", -4)
+  )
+  expect_error(
+    call_binding("month", NA)
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -846,7 +846,8 @@ test_that("month() supports integer input", {
         mutate(
           month_int_input = as.character(
             month(month_as_int, label = TRUE, abbr = FALSE)
-          )) %>%
+          )
+        ) %>%
         collect(),
       test_df_month
     )


### PR DESCRIPTION
Once this PR is merge the {arrow} binding for `month()` will be able to accept integer inputs. This also impact the `semester()` which now will be able to extract semesters from integer inputs.
``` r
library(lubridate)
library(dplyr)
library(arrow)

df <- tibble(
  month_as_int = 1:12
)

df %>% 
  mutate(m = month(month_as_int),
         s = semester(month_as_int))
#> # A tibble: 12 × 3
#>    month_as_int     m     s
#>           <int> <int> <int>
#>  1            1     1     1
#>  2            2     2     1
#>  3            3     3     1
#>  4            4     4     1
#>  5            5     5     1
#>  6            6     6     1
#>  7            7     7     2
#>  8            8     8     2
#>  9            9     9     2
#> 10           10    10     2
#> 11           11    11     2
#> 12           12    12     2

df %>% 
  arrow_table() %>% 
  mutate(m = month(month_as_int),
         s = semester(month_as_int)) %>% 
  collect()
#> # A tibble: 12 × 3
#>    month_as_int     m     s
#>           <int> <int> <int>
#>  1            1     1     1
#>  2            2     2     1
#>  3            3     3     1
#>  4            4     4     1
#>  5            5     5     1
#>  6            6     6     1
#>  7            7     7     2
#>  8            8     8     2
#>  9            9     9     2
#> 10           10    10     2
#> 11           11    11     2
#> 12           12    12     2
```

<sup>Created on 2022-03-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>  