### PR TITLE
PARQUET-2130:  Fix crash in debug with non-standard key names.

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -366,9 +366,14 @@ TEST_F(TestConvertParquetSchema, ParquetMaps) {
     auto list = GroupNode::Make("key_value", Repetition::REPEATED, {key, value});
     parquet_fields.push_back(
         GroupNode::Make("my_map", Repetition::REQUIRED, {list}, LogicalType::Map()));
-    auto arrow_value = ::arrow::field("string", UTF8, /*nullable=*/true);
-    auto arrow_map = ::arrow::map(/*key=*/UTF8, arrow_value);
-    arrow_fields.push_back(::arrow::field("my_map", arrow_map, false));
+    auto arrow_key = ::arrow::field("key", UTF8, /*nullable=*/false);
+    auto arrow_value = ::arrow::field("value", UTF8, /*nullable=*/true);
+    auto arrow_map = std::make_shared<::arrow::MapType>(
+        ::arrow::field("my_map", ::arrow::struct_({arrow_key, arrow_value}),
+                       /*nullable=*/false),
+        /*nullable=*/false);
+
+    arrow_fields.push_back(::arrow::field("my_map", arrow_map, /*nullable=*/false));
   }
   // Single column map (i.e. set) gets converted to list of struct.
   {
@@ -381,11 +386,40 @@ TEST_F(TestConvertParquetSchema, ParquetMaps) {
     auto arrow_list = ::arrow::list({::arrow::field("key", UTF8, /*nullable=*/false)});
     arrow_fields.push_back(::arrow::field("my_set", arrow_list, false));
   }
+  // Two column map with non-standard field names.
+  {
+    auto key = PrimitiveNode::Make("int_key", Repetition::REQUIRED, ParquetType::INT32,
+                                   ConvertedType::INT_32);
+    auto value = PrimitiveNode::Make("str_value", Repetition::OPTIONAL,
+                                     ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+
+    auto list = GroupNode::Make("items", Repetition::REPEATED, {key, value});
+    parquet_fields.push_back(
+        GroupNode::Make("items", Repetition::REQUIRED, {list}, LogicalType::Map()));
+    auto arrow_value = ::arrow::field("str_value", UTF8, /*nullable=*/true);
+    auto arrow_key = ::arrow::field("int_key", INT32, /*nullable=*/false);
+    auto arrow_map = std::make_shared<::arrow::MapType>(
+        ::arrow::field("items", ::arrow::struct_({arrow_key, arrow_value}), false),
+        false);
+
+    arrow_fields.push_back(::arrow::field("items", arrow_map, false));
+  }
 
   auto arrow_schema = ::arrow::schema(arrow_fields);
   ASSERT_OK(ConvertSchema(parquet_fields));
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(arrow_schema));
+  for (int i = 0; i < arrow_schema->num_fields(); ++i) {
+    auto result_field = result_schema_->field(i);
+    auto expected_field = arrow_schema->field(i);
+    if (expected_field->type()->id() == ::arrow::Type::MAP) {
+      EXPECT_TRUE(
+          expected_field->type()->field(0)->Equals(result_field->type()->field(0)))
+          << "Map's struct in field " << i
+          << "\n result: " << result_field->type()->field(0)->ToString() << " "
+          << "\n expected: " << expected_field->type()->field(0)->ToString() << "\n";
+    }
+  }
 }
 
 TEST_F(TestConvertParquetSchema, ParquetLists) {

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -596,7 +596,7 @@ Status MapToSchemaField(const GroupNode& group, LevelInfo current_levels,
   key_value_field->level_info = current_levels;
 
   out->field = ::arrow::field(group.name(),
-                              ::arrow::map(key_field->field->type(), value_field->field),
+                              std::make_shared<::arrow::MapType>(key_value_field->field),
                               group.is_optional(), FieldIdMetadata(group.field_id()));
   out->level_info = current_levels;
   // At this point current levels contains the def level for this list,


### PR DESCRIPTION
SetListData in array_nested.cc has a DCHECK that the map type matches
the type of the child struct. When a Parquet file has a non-standard
field name for a map key(not "key"), the struct would have the alternate
name whereas the maptype would not, triggering the DCHECK. The fix is to
call the appropriate MapType constructor so the key field name is
preserved. This is very similar to ARROW-13735.