### PR TITLE
ARROW-15760: [C++] Avoid hard dependency on git in cmake (download tarballs from github instead)

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -478,10 +478,11 @@ advised that if this is enabled 'install' will fail silently on components;\
 that have not been built"
                 OFF)
 
-  set(ARROW_SUBSTRAIT_REPO_DEFAULT "https://github.com/substrait-io/substrait")
+  set(ARROW_SUBSTRAIT_REPO_DEFAULT "substrait-io/substrait")
   define_option_string(ARROW_SUBSTRAIT_REPO
-                       "Custom git repository URL for downloading Substrait sources.;\
-See also ARROW_SUBSTRAIT_TAG" "${ARROW_SUBSTRAIT_REPO_DEFAULT}")
+                       "Custom GitHub user/repository pair for downloading Substrait sources.;\
+See also ARROW_SUBSTRAIT_TAG"
+                       "${ARROW_SUBSTRAIT_REPO_DEFAULT}")
 
   set(ARROW_SUBSTRAIT_TAG_DEFAULT "e1b4c04a1b518912f4c4065b16a1b2c0ac8e14cf")
   define_option_string(ARROW_SUBSTRAIT_TAG

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -48,7 +48,7 @@ set(SUBSTRAIT_PROTOS
     type_expressions)
 
 externalproject_add(substrait_ep
-                    URL "${ARROW_SUBSTRAIT_REPO}/archive/${ARROW_SUBSTRAIT_TAG}.tar.gz"
+                    URL "https://github.com/${ARROW_SUBSTRAIT_REPO}/archive/${ARROW_SUBSTRAIT_TAG}.tar.gz"
                     SOURCE_DIR "${SUBSTRAIT_LOCAL_DIR}"
                     CONFIGURE_COMMAND ""
                     BUILD_COMMAND ""

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -48,8 +48,7 @@ set(SUBSTRAIT_PROTOS
     type_expressions)
 
 externalproject_add(substrait_ep
-                    GIT_REPOSITORY "${ARROW_SUBSTRAIT_REPO}"
-                    GIT_TAG "${ARROW_SUBSTRAIT_TAG}"
+                    URL "https://github.com/${ARROW_SUBSTRAIT_REPO}/archive/${ARROW_SUBSTRAIT_TAG}.tar.gz"
                     SOURCE_DIR "${SUBSTRAIT_LOCAL_DIR}"
                     CONFIGURE_COMMAND ""
                     BUILD_COMMAND ""

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -48,7 +48,7 @@ set(SUBSTRAIT_PROTOS
     type_expressions)
 
 externalproject_add(substrait_ep
-                    URL "https://github.com/${ARROW_SUBSTRAIT_REPO}/archive/${ARROW_SUBSTRAIT_TAG}.tar.gz"
+                    URL "${ARROW_SUBSTRAIT_REPO}/archive/${ARROW_SUBSTRAIT_TAG}.tar.gz"
                     SOURCE_DIR "${SUBSTRAIT_LOCAL_DIR}"
                     CONFIGURE_COMMAND ""
                     BUILD_COMMAND ""


### PR DESCRIPTION
As suggested in https://github.com/apache/arrow/pull/12322#issuecomment-1048527114.