### PR TITLE
ARROW-15772: [Go][Flight] Server Basic Auth Middleware/Interceptor wrongly base64 decode

### DIFF
--- a/go/arrow/flight/server_auth.go
+++ b/go/arrow/flight/server_auth.go
@@ -187,7 +187,10 @@ func createServerBearerTokenStreamInterceptor(validator BasicAuthValidator) grpc
 			if auth[0] == basicAuthPrefix {
 				val, err := base64.RawStdEncoding.DecodeString(auth[1])
 				if err != nil {
-					return status.Errorf(codes.Unauthenticated, "invalid basic auth encoding: %s", err)
+					val, err = base64.StdEncoding.DecodeString(auth[1])
+					if err != nil {
+						return status.Errorf(codes.Unauthenticated, "invalid basic auth encoding: %s", err)
+					}
 				}
 
 				creds := strings.SplitN(string(val), ":", 2)


### PR DESCRIPTION
The proposed fixed made the server auth works for both actual go implementation and other. I am not sure if the base64 padding should be used but in all cases having the server being able to read both seems better (being liberal with the inputs, strict with the output).

An other fix would be to change the Go implementation of the client to use the padded base64 (in `client.go` l.299). But I think making the server more robust is better.