### PR TITLE
ARROW-15291: [C++][Python] Segfault in StructArray.to_numpy and to_pandas if it contains an ExtensionArray

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -655,20 +655,14 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
     auto arr = checked_cast<const StructArray*>(data.chunk(c).get());
     // Convert the struct arrays first
     for (int32_t i = 0; i < num_fields; i++) {
-      const auto field = arr->field(static_cast<int>(i));
+      auto field = arr->field(static_cast<int>(i));
       // In case the field is an extension array, use .storage() to convert to Pandas
       if (field->type()->id() == Type::EXTENSION){
-        // Save the field object as an Extension Array
         const ExtensionArray& arr_ext = checked_cast<const ExtensionArray&>(*field);
-        // Save the storage Array and use it to convert to Pandas
-        const std::shared_ptr<Array> field_ext = arr_ext.storage();
-        RETURN_NOT_OK(ConvertArrayToPandas(options, field_ext, nullptr,
-                                           fields_data[i + fields_data_offset].ref()));
+        field = arr_ext.storage();
       }
-      else{
-        RETURN_NOT_OK(ConvertArrayToPandas(options, field, nullptr,
-                                           fields_data[i + fields_data_offset].ref()));
-      }
+      RETURN_NOT_OK(ConvertArrayToPandas(options, field, nullptr,
+                                         fields_data[i + fields_data_offset].ref()));
       DCHECK(PyArray_Check(fields_data[i + fields_data_offset].obj()));
     }
 

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -657,7 +657,7 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
     for (int32_t i = 0; i < num_fields; i++) {
       auto field = arr->field(static_cast<int>(i));
       // In case the field is an extension array, use .storage() to convert to Pandas
-      if (field->type()->id() == Type::EXTENSION){
+      if (field->type()->id() == Type::EXTENSION) {
         const ExtensionArray& arr_ext = checked_cast<const ExtensionArray&>(*field);
         field = arr_ext.storage();
       }

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -360,12 +360,8 @@ def test_ext_array_conversion_to_pandas():
     pd.testing.assert_series_equal(result, expected)
 
 
-def test_struct_w_ext_array_to_numpy():
-    # ARROW-15291
-    # Check that we don't segfault when trying to build
-    # a numpy array from a StructArray with a field being
-    # an ExtensionArray
-
+@pytest.fixture
+def struct_w_ext_data():
     storage1 = pa.array([1, 2, 3], type=pa.int64())
     storage2 = pa.array([b"123", b"456", b"789"], type=pa.binary(3))
     ty1 = IntegerType()
@@ -377,42 +373,40 @@ def test_struct_w_ext_array_to_numpy():
     sarr1 = pa.StructArray.from_arrays([arr1], ["f0"])
     sarr2 = pa.StructArray.from_arrays([arr2], ["f1"])
 
-    result = sarr1.to_numpy(zero_copy_only=False)
+    return [sarr1, sarr2]
+
+
+def test_struct_w_ext_array_to_numpy(struct_w_ext_data):
+    # ARROW-15291
+    # Check that we don't segfault when trying to build
+    # a numpy array from a StructArray with a field being
+    # an ExtensionArray
+
+    result = struct_w_ext_data[0].to_numpy(zero_copy_only=False)
     expected = np.array([{'f0': 1}, {'f0': 2},
                          {'f0': 3}], dtype=object)
     np.testing.assert_array_equal(result, expected)
 
-    result = sarr2.to_numpy(zero_copy_only=False)
+    result = struct_w_ext_data[1].to_numpy(zero_copy_only=False)
     expected = np.array([{'f1': b'123'}, {'f1': b'456'},
                          {'f1': b'789'}], dtype=object)
     np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.pandas
-def test_struct_w_ext_array_to_pandas():
+def test_struct_w_ext_array_to_pandas(struct_w_ext_data):
     # ARROW-15291
     # Check that we don't segfault when trying to build
     # a Pandas dataframe from a StructArray with a field
     # being an ExtensionArray
     import pandas as pd
 
-    storage1 = pa.array([1, 2, 3], type=pa.int64())
-    storage2 = pa.array([b"123", b"456", b"789"], type=pa.binary(3))
-    ty1 = IntegerType()
-    ty2 = ParamExtType(3)
-
-    arr1 = pa.ExtensionArray.from_storage(ty1, storage1)
-    arr2 = pa.ExtensionArray.from_storage(ty2, storage2)
-
-    sarr1 = pa.StructArray.from_arrays([arr1], ["f0"])
-    sarr2 = pa.StructArray.from_arrays([arr2], ["f1"])
-
-    result = sarr1.to_pandas()
+    result = struct_w_ext_data[0].to_pandas()
     expected = pd.Series([{'f0': 1}, {'f0': 2},
                          {'f0': 3}], dtype=object)
     pd.testing.assert_series_equal(result, expected)
 
-    result = sarr2.to_pandas()
+    result = struct_w_ext_data[1].to_pandas()
     expected = pd.Series([{'f1': b'123'}, {'f1': b'456'},
                          {'f1': b'789'}], dtype=object)
     pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
This PR tries to solve [ARROW-15291](https://issues.apache.org/jira/browse/ARROW-15291).

Not sure about `if/else` in the `arrow_to_pandas.cc`. Maybe there is a way to redefine a field `shared_ptr` and optimize a bit? @pitrou what do you think?

cc @jorisvandenbossche 