### PR TITLE
ARROW-15748: [Python] Round temporal options default unit is `day` but documented as `second`

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -882,14 +882,14 @@ class RoundTemporalOptions(_RoundTemporalOptions):
     ----------
     multiple : int, default 1
         Number of units to round to.
-    unit : str, default "second"
+    unit : str, default "day"
         The unit in which `multiple` is expressed.
         Accepted values are "year", "quarter", "month", "week", "day",
         "hour", "minute", "second", "millisecond", "microsecond",
         "nanosecond".
     """
 
-    def __init__(self, multiple=1, unit="second"):
+    def __init__(self, multiple=1, unit="day"):
         self._set_options(multiple, unit)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2032,6 +2032,11 @@ def _check_temporal_rounding(ts, values, unit):
         expected = ts.dt.round(frequency)
         np.testing.assert_array_equal(result, expected)
 
+    # Check RoundTemporalOptions defaults
+    result = pc.round_temporal(ta).to_pandas()
+    expected = ts.dt.round("1D")
+    np.testing.assert_array_equal(result, expected)
+
 
 # TODO: We should test on windows once ARROW-13168 is resolved.
 @pytest.mark.skipif(sys.platform == 'win32',


### PR DESCRIPTION
This is to resolve [ARROW-15748](https://issues.apache.org/jira/browse/ARROW-15748).