### PR TITLE
ARROW-14997: [Python][Doc] Add thread_count functions to API docs

### DIFF
--- a/docs/source/python/api/misc.rst
+++ b/docs/source/python/api/misc.rst
@@ -28,6 +28,8 @@ Multi-Threading
 
    cpu_count
    set_cpu_count
+   io_thread_count
+   set_io_thread_count
 
 Using with C extensions
 -----------------------


### PR DESCRIPTION
This PR adds the `thread_count` functions into the API docs.