### PR TITLE
ARROW-15580: [Python] Make pytz an actual optional dependency of PyArrow

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -26,7 +26,6 @@ numpy>=1.16.6
 pytest
 pytest-faulthandler
 pytest-lazy-fixture
-pytz
 s3fs>=2021.8.0
 setuptools
 setuptools_scm

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -546,16 +546,8 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
   // HH:MM offset string representation
   if (module_pytz.obj() != nullptr &&
       PyObject_IsInstance(tzinfo, class_fixedoffset.obj())) {
-    // still recognize datetime.timezone.utc as UTC (instead of +00:00)
     OwnedRef tzname_object(PyObject_CallMethod(tzinfo, "tzname", "O", Py_None));
     RETURN_IF_PYERROR();
-    if (PyUnicode_Check(tzname_object.obj())) {
-      std::string result;
-      RETURN_NOT_OK(internal::PyUnicode_AsStdString(tzname_object.obj(), &result));
-      if (result == "UTC") {
-        return result;
-      }
-    }
     return PyTZInfo_utcoffset_hhmm(tzinfo);
   }
 

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -481,7 +481,7 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
   }
 
   return Status::Invalid(
-    "Pytz package or Python>=3.8 for zoneinfo module must be installed.");
+      "Pytz package or Python>=3.8 for zoneinfo module must be installed.");
 }
 
 Result<std::string> TzinfoToString(PyObject* tzinfo) {

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -395,7 +395,6 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
   OwnedRef datetime;
 
   if (internal::ImportModule("pytz", &pytz).ok()) {
-    RETURN_NOT_OK(internal::ImportModule("pytz", &pytz));
 
     if (MatchFixedOffset(tz, &sign_str, &hour_str, &minute_str)) {
       int sign = -1;
@@ -471,7 +470,6 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
 
   // fallback on zoneinfo if tz is string and pytz is not present
   if (internal::ImportModule("zoneinfo", &zoneinfo).ok()) {
-    RETURN_NOT_OK(internal::ImportModule("zoneinfo", &zoneinfo));
 
     OwnedRef class_zoneinfo;
     RETURN_NOT_OK(
@@ -506,7 +504,6 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
 
   // Try to import pytz if it is available
   if (internal::ImportModule("pytz", &module_pytz).ok()) {
-    RETURN_NOT_OK(internal::ImportModule("pytz", &module_pytz));
     RETURN_NOT_OK(internal::ImportFromModule(module_pytz.obj(), "_FixedOffset",
                                              &class_fixedoffset));
     RETURN_NOT_OK(
@@ -515,13 +512,11 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
 
   // Try to import zoneinfo if it is available
   if (internal::ImportModule("zoneinfo", &module_zoneinfo).ok()) {
-    RETURN_NOT_OK(internal::ImportModule("zoneinfo", &module_zoneinfo));
     RETURN_NOT_OK(
         internal::ImportFromModule(module_zoneinfo.obj(), "ZoneInfo", &class_zoneinfo));
   }
   // Try to import dateutil if it is available
   if (internal::ImportModule("dateutil.tz", &module_dateutil).ok()) {
-    RETURN_NOT_OK(internal::ImportModule("dateutil.tz", &module_dateutil));
     RETURN_NOT_OK(
         internal::ImportFromModule(module_dateutil.obj(), "tzfile", &class_tzfile));
   }

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -395,7 +395,6 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
   OwnedRef datetime;
 
   if (internal::ImportModule("pytz", &pytz).ok()) {
-
     if (MatchFixedOffset(tz, &sign_str, &hour_str, &minute_str)) {
       int sign = -1;
       if (sign_str == "+") {
@@ -470,7 +469,6 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
 
   // fallback on zoneinfo if tz is string and pytz is not present
   if (internal::ImportModule("zoneinfo", &zoneinfo).ok()) {
-
     OwnedRef class_zoneinfo;
     RETURN_NOT_OK(
         internal::ImportFromModule(zoneinfo.obj(), "ZoneInfo", &class_zoneinfo));
@@ -482,7 +480,8 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
     return tzinfo;
   }
 
-  return Status::Invalid("Pytz package or Python>=3.8 for zoneinfo module must be installed.");
+  return Status::Invalid(
+    "Pytz package or Python>=3.8 for zoneinfo module must be installed.");
 }
 
 Result<std::string> TzinfoToString(PyObject* tzinfo) {

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -391,62 +391,163 @@ Result<std::string> PyTZInfo_utcoffset_hhmm(PyObject* pytzinfo) {
 Result<PyObject*> StringToTzinfo(const std::string& tz) {
   util::string_view sign_str, hour_str, minute_str;
   OwnedRef pytz;
-  RETURN_NOT_OK(internal::ImportModule("pytz", &pytz));
+  OwnedRef zoneinfo;
+  OwnedRef datetime;
 
+  if (internal::ImportModule("pytz", &pytz).ok()) {
+    RETURN_NOT_OK(internal::ImportModule("pytz", &pytz));
+
+    if (MatchFixedOffset(tz, &sign_str, &hour_str, &minute_str)) {
+      int sign = -1;
+      if (sign_str == "+") {
+        sign = 1;
+      }
+      OwnedRef fixed_offset;
+      RETURN_NOT_OK(internal::ImportFromModule(pytz.obj(), "FixedOffset", &fixed_offset));
+      uint32_t minutes, hours;
+      if (!::arrow::internal::ParseUnsigned(hour_str.data(), hour_str.size(), &hours) ||
+          !::arrow::internal::ParseUnsigned(minute_str.data(), minute_str.size(),
+                                            &minutes)) {
+        return Status::Invalid("Invalid timezone: ", tz);
+      }
+      OwnedRef total_minutes(PyLong_FromLong(
+          sign * ((static_cast<int>(hours) * 60) + static_cast<int>(minutes))));
+      RETURN_IF_PYERROR();
+      auto tzinfo =
+          PyObject_CallFunctionObjArgs(fixed_offset.obj(), total_minutes.obj(), NULL);
+      RETURN_IF_PYERROR();
+      return tzinfo;
+    }
+
+    OwnedRef timezone;
+    RETURN_NOT_OK(internal::ImportFromModule(pytz.obj(), "timezone", &timezone));
+    OwnedRef py_tz_string(
+        PyUnicode_FromStringAndSize(tz.c_str(), static_cast<Py_ssize_t>(tz.size())));
+    auto tzinfo = PyObject_CallFunctionObjArgs(timezone.obj(), py_tz_string.obj(), NULL);
+    RETURN_IF_PYERROR();
+    return tzinfo;
+  }
+
+  // catch fixed offset if pytz is not present
   if (MatchFixedOffset(tz, &sign_str, &hour_str, &minute_str)) {
+    RETURN_NOT_OK(internal::ImportModule("datetime", &datetime));
     int sign = -1;
     if (sign_str == "+") {
       sign = 1;
     }
-    OwnedRef fixed_offset;
-    RETURN_NOT_OK(internal::ImportFromModule(pytz.obj(), "FixedOffset", &fixed_offset));
+
+    // import timezone and timedelta module to create a tzinfo object
+    OwnedRef class_timezone;
+    OwnedRef class_timedelta;
+    RETURN_NOT_OK(internal::ImportFromModule(datetime.obj(), "timezone", &class_timezone));
+    RETURN_NOT_OK(internal::ImportFromModule(datetime.obj(), "timedelta", &class_timedelta));
+
+    // check input
     uint32_t minutes, hours;
     if (!::arrow::internal::ParseUnsigned(hour_str.data(), hour_str.size(), &hours) ||
         !::arrow::internal::ParseUnsigned(minute_str.data(), minute_str.size(),
                                           &minutes)) {
       return Status::Invalid("Invalid timezone: ", tz);
     }
+
+    // save offset as a signed integer
     OwnedRef total_minutes(PyLong_FromLong(
         sign * ((static_cast<int>(hours) * 60) + static_cast<int>(minutes))));
+    // create zero integers for empty arguments in datetime.timedelta
+    OwnedRef zero(PyLong_FromLong(static_cast<int>(0)));
+
+    // call datetime.timedelta to get correct offset object for datetime.timezone
+    auto offset =
+        PyObject_CallFunctionObjArgs(class_timedelta.obj(), zero.obj(), zero.obj(), zero.obj(), zero.obj(), total_minutes.obj(), NULL);
     RETURN_IF_PYERROR();
+    // call datetime.timezone
     auto tzinfo =
-        PyObject_CallFunctionObjArgs(fixed_offset.obj(), total_minutes.obj(), NULL);
+        PyObject_CallFunctionObjArgs(class_timezone.obj(), offset, NULL);
     RETURN_IF_PYERROR();
     return tzinfo;
   }
 
-  OwnedRef timezone;
-  RETURN_NOT_OK(internal::ImportFromModule(pytz.obj(), "timezone", &timezone));
-  OwnedRef py_tz_string(
-      PyUnicode_FromStringAndSize(tz.c_str(), static_cast<Py_ssize_t>(tz.size())));
-  auto tzinfo = PyObject_CallFunctionObjArgs(timezone.obj(), py_tz_string.obj(), NULL);
-  RETURN_IF_PYERROR();
-  return tzinfo;
+  // fallback on zoneinfo if tz is string and pytz is not present
+  if (internal::ImportModule("zoneinfo", &zoneinfo).ok()) {
+    RETURN_NOT_OK(internal::ImportModule("zoneinfo", &zoneinfo));
+
+    OwnedRef class_zoneinfo;
+    RETURN_NOT_OK(
+        internal::ImportFromModule(zoneinfo.obj(), "ZoneInfo", &class_zoneinfo));
+    OwnedRef py_tz_string(
+        PyUnicode_FromStringAndSize(tz.c_str(), static_cast<Py_ssize_t>(tz.size())));
+    auto tzinfo =
+        PyObject_CallFunctionObjArgs(class_zoneinfo.obj(), py_tz_string.obj(), NULL);
+    RETURN_IF_PYERROR();
+    return tzinfo;
+  }
+
+  return Status::Invalid("Pytz package must be installed.");
 }
 
 Result<std::string> TzinfoToString(PyObject* tzinfo) {
   OwnedRef module_pytz;        // import pytz
   OwnedRef module_datetime;    // import datetime
+  OwnedRef module_zoneinfo;    // import zoneinfo
+  OwnedRef module_dateutil;    // import dateutil
   OwnedRef class_timezone;     // from datetime import timezone
   OwnedRef class_fixedoffset;  // from pytz import _FixedOffset
+  OwnedRef class_basetzinfo;   // from pytz import BaseTzInfo
+  OwnedRef class_zoneinfo;     // from zoneinfo import ZoneInfo
+  OwnedRef class_tzfile;       // from zoneinfo import tzfile
 
   // import necessary modules
-  RETURN_NOT_OK(internal::ImportModule("pytz", &module_pytz));
   RETURN_NOT_OK(internal::ImportModule("datetime", &module_datetime));
   // import necessary classes
   RETURN_NOT_OK(
-      internal::ImportFromModule(module_pytz.obj(), "_FixedOffset", &class_fixedoffset));
-  RETURN_NOT_OK(
       internal::ImportFromModule(module_datetime.obj(), "timezone", &class_timezone));
+
+  // Try to import pytz if it is available
+  if (internal::ImportModule("pytz", &module_pytz).ok()) {
+    RETURN_NOT_OK(internal::ImportModule("pytz", &module_pytz));
+    RETURN_NOT_OK(internal::ImportFromModule(module_pytz.obj(), "_FixedOffset",
+                                             &class_fixedoffset));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(module_pytz.obj(), "BaseTzInfo", &class_basetzinfo));
+  }
+
+  // Try to import zoneinfo if it is available
+  if (internal::ImportModule("zoneinfo", &module_zoneinfo).ok()) {
+    RETURN_NOT_OK(internal::ImportModule("zoneinfo", &module_zoneinfo));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(module_zoneinfo.obj(), "ZoneInfo", &class_zoneinfo));
+  }
+  // Try to import dateutil if it is available
+  if (internal::ImportModule("dateutil.tz", &module_dateutil).ok()) {
+    RETURN_NOT_OK(internal::ImportModule("dateutil.tz", &module_dateutil));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(module_dateutil.obj(), "tzfile", &class_tzfile));
+  }
 
   // check that it's a valid tzinfo object
   if (!PyTZInfo_Check(tzinfo)) {
     return Status::TypeError("Not an instance of datetime.tzinfo");
   }
 
-  // if tzinfo is an instance of pytz._FixedOffset or datetime.timezone return the
+  // if tzinfo is an instance of datetime.timezone return the
   // HH:MM offset string representation
-  if (PyObject_IsInstance(tzinfo, class_timezone.obj()) ||
+  if (PyObject_IsInstance(tzinfo, class_timezone.obj())) {
+    // still recognize datetime.timezone.utc as UTC (instead of +00:00)
+    OwnedRef tzname_object(PyObject_CallMethod(tzinfo, "tzname", "O", Py_None));
+    RETURN_IF_PYERROR();
+    if (PyUnicode_Check(tzname_object.obj())) {
+      std::string result;
+      RETURN_NOT_OK(internal::PyUnicode_AsStdString(tzname_object.obj(), &result));
+      if (result == "UTC") {
+        return result;
+      }
+    }
+    return PyTZInfo_utcoffset_hhmm(tzinfo);
+  }
+
+  // if tzinfo is an instance of pytz._FixedOffset return the
+  // HH:MM offset string representation
+  if (module_pytz.obj() != nullptr &&
       PyObject_IsInstance(tzinfo, class_fixedoffset.obj())) {
     // still recognize datetime.timezone.utc as UTC (instead of +00:00)
     OwnedRef tzname_object(PyObject_CallMethod(tzinfo, "tzname", "O", Py_None));
@@ -461,8 +562,9 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     return PyTZInfo_utcoffset_hhmm(tzinfo);
   }
 
-  // try to look up zone attribute
-  if (PyObject_HasAttrString(tzinfo, "zone")) {
+  // if pytz is installed and tzinfo is and instance of pytz.BaseTzInfo
+  if (module_pytz.obj() != nullptr &&
+      PyObject_IsInstance(tzinfo, class_basetzinfo.obj())) {
     OwnedRef zone(PyObject_GetAttrString(tzinfo, "zone"));
     RETURN_IF_PYERROR();
     std::string result;
@@ -470,9 +572,9 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     return result;
   }
 
-  // try to look up key attribute
-  // in case of zoneinfo object
-  if (PyObject_HasAttrString(tzinfo, "key")) {
+  // if zoneinfo is installed and tzinfo is and instance of zoneinfo.ZoneInfo
+  if (module_zoneinfo.obj() != nullptr &&
+      PyObject_IsInstance(tzinfo, class_zoneinfo.obj())) {
     OwnedRef key(PyObject_GetAttrString(tzinfo, "key"));
     RETURN_IF_PYERROR();
     std::string result;
@@ -482,7 +584,9 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
 
   // try to look up _filename attribute
   // in case of dateutil.tz object
-  if (PyObject_HasAttrString(tzinfo, "_filename")) {
+  // if dateutil is installed and tzinfo is and instance of dateutil.tz.tzfile
+  if (module_dateutil.obj() != nullptr &&
+      PyObject_IsInstance(tzinfo, class_tzfile.obj())) {
     OwnedRef _filename(PyObject_GetAttrString(tzinfo, "_filename"));
     RETURN_IF_PYERROR();
     std::string result;

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -439,8 +439,10 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
     // import timezone and timedelta module to create a tzinfo object
     OwnedRef class_timezone;
     OwnedRef class_timedelta;
-    RETURN_NOT_OK(internal::ImportFromModule(datetime.obj(), "timezone", &class_timezone));
-    RETURN_NOT_OK(internal::ImportFromModule(datetime.obj(), "timedelta", &class_timedelta));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(datetime.obj(), "timezone", &class_timezone));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(datetime.obj(), "timedelta", &class_timedelta));
 
     // check input
     uint32_t minutes, hours;
@@ -458,11 +460,11 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
 
     // call datetime.timedelta to get correct offset object for datetime.timezone
     auto offset =
-        PyObject_CallFunctionObjArgs(class_timedelta.obj(), zero.obj(), zero.obj(), zero.obj(), zero.obj(), total_minutes.obj(), NULL);
+        PyObject_CallFunctionObjArgs(class_timedelta.obj(), zero.obj(), zero.obj(),
+                                     zero.obj(), zero.obj(), total_minutes.obj(), NULL);
     RETURN_IF_PYERROR();
     // call datetime.timezone
-    auto tzinfo =
-        PyObject_CallFunctionObjArgs(class_timezone.obj(), offset, NULL);
+    auto tzinfo = PyObject_CallFunctionObjArgs(class_timezone.obj(), offset, NULL);
     RETURN_IF_PYERROR();
     return tzinfo;
   }

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -482,7 +482,7 @@ Result<PyObject*> StringToTzinfo(const std::string& tz) {
     return tzinfo;
   }
 
-  return Status::Invalid("Pytz package must be installed.");
+  return Status::Invalid("Pytz package or Python>=3.8 for zoneinfo module must be installed.");
 }
 
 Result<std::string> TzinfoToString(PyObject* tzinfo) {

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -561,7 +561,7 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     return result;
   }
 
-  // if zoneinfo is installed and tzinfo is and instance of zoneinfo.ZoneInfo
+  // if zoneinfo is installed and tzinfo is an instance of zoneinfo.ZoneInfo
   if (module_zoneinfo.obj() != nullptr &&
       PyObject_IsInstance(tzinfo, class_zoneinfo.obj())) {
     OwnedRef key(PyObject_GetAttrString(tzinfo, "key"));
@@ -571,9 +571,7 @@ Result<std::string> TzinfoToString(PyObject* tzinfo) {
     return result;
   }
 
-  // try to look up _filename attribute
-  // in case of dateutil.tz object
-  // if dateutil is installed and tzinfo is and instance of dateutil.tz.tzfile
+  // if dateutil is installed and tzinfo is an instance of dateutil.tz.tzfile
   if (module_dateutil.obj() != nullptr &&
       PyObject_IsInstance(tzinfo, class_tzfile.obj())) {
     OwnedRef _filename(PyObject_GetAttrString(tzinfo, "_filename"));

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -17,11 +17,18 @@
 
 import datetime
 
-import pytz
+import pytest
 import hypothesis as h
 import hypothesis.strategies as st
 import hypothesis.extra.numpy as npst
-import hypothesis.extra.pytz as tzst
+try:
+    import hypothesis.extra.pytz as tzst
+except ImportError:
+    tzst = None
+try:
+    import zoneinfo
+except ImportError:
+    zoneinfo = None
 import numpy as np
 
 import pyarrow as pa
@@ -96,10 +103,16 @@ time_types = st.sampled_from([
     pa.time64('us'),
     pa.time64('ns')
 ])
+if tzst:
+    timezones = st.one_of(st.none(), tzst.timezones())
+elif zoneinfo:
+    timezones = st.one_of(st.none(), st.timezones())
+else:
+    timezones = st.none()
 timestamp_types = st.builds(
     pa.timestamp,
     unit=st.sampled_from(['s', 'ms', 'us', 'ns']),
-    tz=tzst.timezones()
+    tz=timezones
 )
 duration_types = st.builds(
     pa.duration,
@@ -261,6 +274,10 @@ def arrays(draw, type, size=None, nullable=True):
     elif pa.types.is_date(ty):
         value = st.dates()
     elif pa.types.is_timestamp(ty):
+        if zoneinfo is None:
+            pytest.skip('no module named zoneinfo')
+        if ty.tz is None:
+            pytest.skip('requires timezone not None')
         min_int64 = -(2**63)
         max_int64 = 2**63 - 1
         min_datetime = datetime.datetime.fromtimestamp(
@@ -268,10 +285,12 @@ def arrays(draw, type, size=None, nullable=True):
         max_datetime = datetime.datetime.fromtimestamp(
             max_int64 // 10**9) - datetime.timedelta(hours=12)
         try:
-            offset_hours = int(ty.tz)
-            tz = pytz.FixedOffset(offset_hours * 60)
+            offset = ty.tz.split(":")
+            offset_hours = int(offset[0])
+            offset_min = int(offset[1])
+            tz = datetime.timedelta(hours=offset_hours, minutes=offset_min)
         except ValueError:
-            tz = pytz.timezone(ty.tz)
+            tz = zoneinfo.ZoneInfo(ty.tz)
         value = st.datetimes(timezones=st.just(tz), min_value=min_datetime,
                              max_value=max_datetime)
     elif pa.types.is_duration(ty):

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -103,10 +103,8 @@ time_types = st.sampled_from([
     pa.time64('us'),
     pa.time64('ns')
 ])
-if tzst:
-    timezones = st.one_of(st.none(), tzst.timezones())
-elif zoneinfo:
-    timezones = st.one_of(st.none(), st.timezones())
+if tzst and zoneinfo:
+    timezones = st.one_of(st.none(), tzst.timezones(), st.timezones())
 else:
     timezones = st.none()
 timestamp_types = st.builds(

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -105,6 +105,10 @@ time_types = st.sampled_from([
 ])
 if tzst and zoneinfo:
     timezones = st.one_of(st.none(), tzst.timezones(), st.timezones())
+elif tzst:
+    timezones = st.one_of(st.none(), tzst.timezones())
+elif zoneinfo:
+    timezones = st.one_of(st.none(), st.timezones())
 else:
     timezones = st.none()
 timestamp_types = st.builds(

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -32,7 +32,6 @@ try:
     import pickle5
 except ImportError:
     pickle5 = None
-import pytz
 
 import pyarrow as pa
 import pyarrow.tests.strategies as past
@@ -324,6 +323,8 @@ def test_nulls(ty):
 
 
 def test_array_from_scalar():
+    pytz = pytest.importorskip("pytz")
+
     today = datetime.date.today()
     now = datetime.datetime.now()
     now_utc = now.replace(tzinfo=pytz.utc)

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -24,7 +24,6 @@ import re
 
 import hypothesis as h
 import numpy as np
-import pytz
 import pytest
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
@@ -995,6 +994,9 @@ def test_sequence_timestamp():
     'ns'
 ])
 def test_sequence_timestamp_with_timezone(timezone, unit):
+    pytest.importorskip("pytz")
+    import pytz
+
     def expected_integer_value(dt):
         units = ['s', 'ms', 'us', 'ns']
         multiplier = 10**(units.index(unit) * 3)
@@ -1067,6 +1069,9 @@ def test_sequence_timestamp_with_timezone(timezone, unit):
 ])
 def test_pyarrow_ignore_timezone_environment_variable(monkeypatch, timezone):
     # note that any non-empty value will evaluate to true
+    pytest.importorskip("pytz")
+    import pytz
+
     monkeypatch.setenv("PYARROW_IGNORE_TIMEZONE", "1")
     data = [
         datetime.datetime(2007, 7, 13, 8, 23, 34, 123456),  # naive
@@ -1092,6 +1097,9 @@ def test_pyarrow_ignore_timezone_environment_variable(monkeypatch, timezone):
 
 
 def test_sequence_timestamp_with_timezone_inference():
+    pytest.importorskip("pytz")
+    import pytz
+
     data = [
         datetime.datetime(2007, 7, 13, 8, 23, 34, 123456),  # naive
         pytz.utc.localize(
@@ -1120,6 +1128,8 @@ def test_sequence_timestamp_with_timezone_inference():
 
 @pytest.mark.pandas
 def test_sequence_timestamp_from_mixed_builtin_and_pandas_datetimes():
+    pytest.importorskip("pytz")
+    import pytz
     import pandas as pd
 
     data = [

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -994,8 +994,7 @@ def test_sequence_timestamp():
     'ns'
 ])
 def test_sequence_timestamp_with_timezone(timezone, unit):
-    pytest.importorskip("pytz")
-    import pytz
+    pytz = pytest.importorskip("pytz")
 
     def expected_integer_value(dt):
         units = ['s', 'ms', 'us', 'ns']

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -25,12 +25,10 @@ from collections import OrderedDict
 from datetime import date, datetime, time, timedelta, timezone
 
 import hypothesis as h
-import hypothesis.extra.pytz as tzst
 import hypothesis.strategies as st
 import numpy as np
 import numpy.testing as npt
 import pytest
-import pytz
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
 from pyarrow.tests.util import invoke_script, random_ascii, rands
@@ -1039,6 +1037,8 @@ class TestConvertDateTimeLikeTypes:
         tm.assert_frame_equal(expected_df, result)
 
     def test_python_datetime_with_pytz_tzinfo(self):
+        pytz = pytest.importorskip("pytz")
+
         for tz in [pytz.utc, pytz.timezone('US/Eastern'), pytz.FixedOffset(1)]:
             values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]
             df = pd.DataFrame({'datetime': values})
@@ -1052,6 +1052,7 @@ class TestConvertDateTimeLikeTypes:
         _check_pandas_roundtrip(df)
 
     def test_python_datetime_with_timezone_tzinfo(self):
+        pytz = pytest.importorskip("pytz")
         from datetime import timezone
 
         if Version(pd.__version__) > Version("0.25.0"):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1044,7 +1044,7 @@ class TestConvertDateTimeLikeTypes:
             df = pd.DataFrame({'datetime': values})
             _check_pandas_roundtrip(df)
 
-    @h.given(st.none() | st.timezones())
+    @h.given(st.none() | past.timezones())
     @h.settings(deadline=None)
     def test_python_datetime_with_pytz_timezone(self, tz):
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1049,7 +1049,7 @@ class TestConvertDateTimeLikeTypes:
     def test_python_datetime_with_pytz_timezone(self, tz):
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]
         df = pd.DataFrame({'datetime': values})
-        _check_pandas_roundtrip(df)
+        _check_pandas_roundtrip(df, check_dtype=False)
 
     def test_python_datetime_with_timezone_tzinfo(self):
         pytz = pytest.importorskip("pytz")

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1044,7 +1044,7 @@ class TestConvertDateTimeLikeTypes:
             df = pd.DataFrame({'datetime': values})
             _check_pandas_roundtrip(df)
 
-    @h.given(st.none() | tzst.timezones())
+    @h.given(st.none() | st.timezones())
     @h.settings(deadline=None)
     def test_python_datetime_with_pytz_timezone(self, tz):
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1044,7 +1044,7 @@ class TestConvertDateTimeLikeTypes:
             df = pd.DataFrame({'datetime': values})
             _check_pandas_roundtrip(df)
 
-    @h.given(st.none() | past.timezones())
+    @h.given(st.none() | past.timezones)
     @h.settings(deadline=None)
     def test_python_datetime_with_pytz_timezone(self, tz):
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -289,6 +289,7 @@ def test_timestamp():
 @pytest.mark.nopandas
 def test_timestamp_nanos_nopandas():
     # ARROW-5450
+    pytest.importorskip("pytz")
     import pytz
     tz = 'America/New_York'
     ty = pa.timestamp('ns', tz=tz)
@@ -312,6 +313,7 @@ def test_timestamp_nanos_nopandas():
 
 def test_timestamp_no_overflow():
     # ARROW-5450
+    pytest.importorskip("pytz")
     import pytz
 
     timestamps = [
@@ -326,6 +328,7 @@ def test_timestamp_no_overflow():
 
 def test_timestamp_fixed_offset_print():
     # ARROW-13896
+    pytest.importorskip("pytz")
     arr = pa.array([0], pa.timestamp('s', tz='+02:00'))
     assert str(arr[0]) == "1970-01-01 02:00:00+02:00"
 


### PR DESCRIPTION
This PR tries to change `pytz` module to be an optional dependency.

The tests that install/use `pytz` had to be changed. 

I ran all `pyarrow` tests locally with and without `pytz` installed. We could update the build without Pandas to not include `pytz` either so the code could be checked on the CI also.

- [x] Change `pytz` to an optional dependency
- [x] Change the use of `PyObject_HasAttrString` to use `PyObject_IsInstance`