### PR TITLE
ARROW-15749: [Ruby] Add support for #values of Month Interval Type

### DIFF
--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -202,6 +202,13 @@ namespace red_arrow {
     //                      const int64_t i) {
     // };
 
+
+    inline VALUE convert(const arrow::MonthIntervalArray& array,
+                         const int64_t i) {
+      return INT2NUM(array.Value(i));
+    }
+
+
     VALUE convert(const arrow::ListArray& array,
                   const int64_t i);
 
@@ -300,6 +307,7 @@ namespace red_arrow {
     VISIT(Timestamp)
     // TODO
     // VISIT(Interval)
+    VISIT(MonthInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -406,6 +414,7 @@ namespace red_arrow {
     VISIT(Timestamp)
     // TODO
     // VISIT(Interval)
+    VISIT(MonthInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -508,6 +517,7 @@ namespace red_arrow {
     VISIT(Timestamp)
     // TODO
     // VISIT(Interval)
+    VISIT(MonthInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -611,6 +621,7 @@ namespace red_arrow {
     VISIT(Timestamp)
     // TODO
     // VISIT(Interval)
+    VISIT(MonthInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -202,7 +202,6 @@ namespace red_arrow {
     //                      const int64_t i) {
     // };
 
-
     inline VALUE convert(const arrow::MonthIntervalArray& array,
                          const int64_t i) {
       return INT2NUM(array.Value(i));

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -207,7 +207,6 @@ namespace red_arrow {
       return INT2NUM(array.Value(i));
     }
 
-
     VALUE convert(const arrow::ListArray& array,
                   const int64_t i);
 

--- a/ruby/red-arrow/ext/arrow/values.cpp
+++ b/ruby/red-arrow/ext/arrow/values.cpp
@@ -79,6 +79,7 @@ namespace red_arrow {
       VISIT(Timestamp)
       // TODO
       // VISIT(Interval)
+      VISIT(MonthInterval)
       VISIT(List)
       VISIT(Struct)
       VISIT(Map)

--- a/ruby/red-arrow/test/values/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/values/test-basic-arrays.rb
@@ -276,6 +276,16 @@ module ValuesBasicArraysTests
     target = build(Arrow::Decimal256Array.new(data_type, values))
     assert_equal(values, target.values)
   end
+
+  def test_month_interval
+    values = [
+      1,
+      nil,
+      12,
+    ]
+    target = build(Arrow::MonthIntervalArray.new(values))
+    assert_equal(values, target.values)
+  end
 end
 
 class ValuesArrayBasicArraysTest < Test::Unit::TestCase

--- a/ruby/red-arrow/test/values/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/values/test-dense-union-array.rb
@@ -347,6 +347,15 @@ module ValuesDenseUnionArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_month_interval
+    values = [
+      {"0" => 1},
+      {"1" => nil},
+    ]
+    target = build(:month_interval, values)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"0" => [true, nil, false]},

--- a/ruby/red-arrow/test/values/test-list-array.rb
+++ b/ruby/red-arrow/test/values/test-list-array.rb
@@ -372,6 +372,19 @@ module ValuesListArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_month_interval
+    values = [
+      [
+        1,
+        nil,
+        12,
+      ],
+      nil,
+    ]
+    target = build(:month_interval, values)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       [

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -302,6 +302,15 @@ module ValuesMapArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_month_interval
+    values = [
+      {"key1" => 1, "key2" => nil},
+      nil,
+    ]
+    target = build(:month_interval, values)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"key1" => [true, nil, false], "key2" => nil},

--- a/ruby/red-arrow/test/values/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/values/test-sparse-union-array.rb
@@ -324,6 +324,15 @@ module ValuesSparseUnionArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_month_interval
+    values = [
+      {"0" => 1},
+      {"1" => nil},
+    ]
+    target = build(:month_interval, values)
+    assert_equal(values, target.values)
+  end
+
   def test_decimal256
     values = [
       {"0" => BigDecimal("92.92")},

--- a/ruby/red-arrow/test/values/test-struct-array.rb
+++ b/ruby/red-arrow/test/values/test-struct-array.rb
@@ -341,6 +341,16 @@ module ValuesStructArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_month_interval
+    values = [
+      {"field" => 1},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:month_interval, values)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"field" => [true, nil, false]},


### PR DESCRIPTION
Implement #values method of month interval type to red arrow.