### PR TITLE
ARROW-14612: [C++] Support for filename-based partitioning

### DIFF
--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -249,14 +249,15 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
         write_options_(write_options),
         writer_state_(writer_state) {}
 
-  DatasetWriterDirectoryQueue(std::string directory, std::string prefix, std::shared_ptr<Schema> schema,
+  DatasetWriterDirectoryQueue(std::string directory, std::string prefix,
+                              std::shared_ptr<Schema> schema,
                               const FileSystemDatasetWriteOptions& write_options,
                               DatasetWriterState* writer_state)
       : directory_(std::move(directory)),
         prefix_(std::move(prefix)),
         schema_(std::move(schema)),
         write_options_(write_options),
-        writer_state_(writer_state) {}      
+        writer_state_(writer_state) {}
 
   Result<std::shared_ptr<RecordBatch>> NextWritableChunk(
       std::shared_ptr<RecordBatch> batch, std::shared_ptr<RecordBatch>* remainder,
@@ -350,13 +351,13 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
                                 util::DestroyingDeleter<DatasetWriterDirectoryQueue>>>
   Make(util::AsyncTaskGroup* task_group,
        const FileSystemDatasetWriteOptions& write_options,
-       DatasetWriterState* writer_state, std::shared_ptr<Schema> schema,
-       std::string dir, std::string prefix) {
+       DatasetWriterState* writer_state, std::shared_ptr<Schema> schema, std::string dir,
+       std::string prefix) {
     auto dir_queue = util::MakeUniqueAsync<DatasetWriterDirectoryQueue>(
-        std::move(dir), std::move(prefix), std::move(schema), write_options, writer_state);
-
+        std::move(dir), std::move(prefix), std::move(schema), write_options,
+        writer_state);
     RETURN_NOT_OK(task_group->AddTask(dir_queue->on_closed()));
-    if(prefix.empty()){
+    if (prefix.empty()) {
       dir_queue->PrepareDirectory();
     }
     ARROW_ASSIGN_OR_RAISE(dir_queue->current_filename_, dir_queue->GetNextFilename());

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -286,7 +286,7 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
     if (!basename) {
       return Status::Invalid("string interpolation of basename template failed");
     }
-    return fs::internal::ConcatAbstractPaths({directory_, prefix_, *basename});
+    return fs::internal::ConcatAbstractPath(directory_, prefix_ + *basename);
   }
 
   Status FinishCurrentFile() {

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -286,8 +286,7 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
     if (!basename) {
       return Status::Invalid("string interpolation of basename template failed");
     }
-
-    return fs::internal::ConcatAbstractPath(directory_, prefix_, *basename);
+    return fs::internal::ConcatAbstractPaths({directory_, prefix_, *basename});
   }
 
   Status FinishCurrentFile() {

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -452,8 +452,6 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
       auto full_path =
           fs::internal::ConcatAbstractPath(write_options_.base_dir, directory);
       return DoWriteRecordBatch(std::move(batch), full_path, prefix);
-    } else if (!prefix.empty()) {
-      return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix);
     } else {
       return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix);
     }

--- a/cpp/src/arrow/dataset/dataset_writer.h
+++ b/cpp/src/arrow/dataset/dataset_writer.h
@@ -79,7 +79,7 @@ class ARROW_DS_EXPORT DatasetWriter {
   /// directory.  The only way to get two parallel writes immediately would be to queue
   /// all 1000 pending writes to the first directory.
   Future<> WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                            const std::string& directory, const std::string& prefix="");
+                            const std::string& directory, const std::string& prefix = "");
 
   /// Finish all pending writes and close any open files
   Future<> Finish();

--- a/cpp/src/arrow/dataset/dataset_writer.h
+++ b/cpp/src/arrow/dataset/dataset_writer.h
@@ -79,7 +79,7 @@ class ARROW_DS_EXPORT DatasetWriter {
   /// directory.  The only way to get two parallel writes immediately would be to queue
   /// all 1000 pending writes to the first directory.
   Future<> WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                            const std::string& directory);
+                            const std::string& directory, const std::string& prefix="");
 
   /// Finish all pending writes and close any open files
   Future<> Finish();

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -211,7 +211,7 @@ TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "", "1_");
   AssertFinished(queue_fut);
   ASSERT_FINISHES_OK(dataset_writer->Finish());
-  AssertFilesCreated({"testdir/1_/1_chunk-0.arrow"});
+  AssertFilesCreated({"testdir/1_chunk-0.arrow"});
 }
 
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -206,6 +206,14 @@ TEST_F(DatasetWriterTestFixture, Basic) {
   AssertCreatedData({{"testdir/chunk-0.arrow", 0, 100}});
 }
 
+TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "", "1_");
+  AssertFinished(queue_fut);
+  ASSERT_FINISHES_OK(dataset_writer->Finish());
+  AssertFilesCreated({"testdir1_/1_chunk-0.arrow"});
+}
+
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {
   write_options_.max_rows_per_file = 10;
   write_options_.max_rows_per_group = 10;

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -211,7 +211,7 @@ TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "", "1_");
   AssertFinished(queue_fut);
   ASSERT_FINISHES_OK(dataset_writer->Finish());
-  AssertFilesCreated({"testdir1_/1_chunk-0.arrow"});
+  AssertFilesCreated({"testdir/1_/1_chunk-0.arrow"});
 }
 
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -214,6 +214,14 @@ TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
   AssertFilesCreated({"testdir/1_chunk-0.arrow"});
 }
 
+TEST_F(DatasetWriterTestFixture, BasicFileDirectoryPrefix) {
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "a", "1_");
+  AssertFinished(queue_fut);
+  ASSERT_FINISHES_OK(dataset_writer->Finish());
+  AssertFilesCreated({"testdir/a/1_chunk-0.arrow"});
+}
+
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {
   write_options_.max_rows_per_file = 10;
   write_options_.max_rows_per_group = 10;

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -311,11 +311,12 @@ class DatasetWritingSinkNodeConsumer : public compute::SinkNodeConsumer {
     for (std::size_t index = 0; index < groups.batches.size(); index++) {
       auto partition_expression = and_(groups.expressions[index], guarantee);
       auto next_batch = groups.batches[index];
-      std::pair<std::string,std::string> destination;
+      std::pair<std::string, std::string> destination;
       ARROW_ASSIGN_OR_RAISE(destination,
                             write_options_.partitioning->Format(partition_expression));
       RETURN_NOT_OK(task_group_.AddTask([this, next_batch, destination] {
-        Future<> has_room = dataset_writer_->WriteRecordBatch(next_batch, destination.first, destination.second);
+        Future<> has_room = dataset_writer_->WriteRecordBatch(
+            next_batch, destination.first, destination.second);
         if (!has_room.is_finished() && backpressure_toggle_) {
           backpressure_toggle_->Close();
           return has_room.Then([this] { backpressure_toggle_->Open(); });

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -311,12 +311,12 @@ class DatasetWritingSinkNodeConsumer : public compute::SinkNodeConsumer {
     for (std::size_t index = 0; index < groups.batches.size(); index++) {
       auto partition_expression = and_(groups.expressions[index], guarantee);
       auto next_batch = groups.batches[index];
-      std::pair<std::string, std::string> destination;
+      Partitioning::PartitionPathFormat destination;
       ARROW_ASSIGN_OR_RAISE(destination,
                             write_options_.partitioning->Format(partition_expression));
       RETURN_NOT_OK(task_group_.AddTask([this, next_batch, destination] {
         Future<> has_room = dataset_writer_->WriteRecordBatch(
-            next_batch, destination.first, destination.second);
+            next_batch, destination.directory, destination.prefix);
         if (!has_room.is_finished() && backpressure_toggle_) {
           backpressure_toggle_->Close();
           return has_room.Then([this] { backpressure_toggle_->Open(); });

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -62,11 +62,11 @@ Result<std::string> SafeUriUnescape(util::string_view encoded) {
   return decoded;
 }
 
-arrow::util::string_view StripNonPrefix(const std::string& path) {
-  auto v = util::string_view(path);
-  auto non_prefix_index = v.rfind(arrow::fs::internal::kFilenameSep);
-  if (v.length() > 0 && non_prefix_index != std::string::npos) {
-    v = v.substr(0, non_prefix_index + 1);
+std::string StripNonPrefix(const std::string& path) {
+  std::string v;
+  auto non_prefix_index = path.rfind(kFilenamePartitionSep);
+  if (path.length() > 0 && non_prefix_index != std::string::npos) {
+    v = path.substr(0, non_prefix_index + 1);
   }
   return v;
 }
@@ -353,8 +353,8 @@ Result<std::vector<KeyValuePartitioning::Key>> FilenamePartitioning::ParseKeys(
   std::vector<Key> keys;
 
   int i = 0;
-  for (auto&& segment : fs::internal::SplitAbstractPath(
-           StripNonPrefix(path), arrow::fs::internal::kFilenameSep)) {
+  for (auto&& segment :
+       fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep)) {
     if (i >= schema_->num_fields()) break;
 
     switch (options_.segment_encoding) {
@@ -434,9 +434,9 @@ Result<std::pair<std::string, std::string>> FilenamePartitioning::FormatValues(
     // if all subsequent keys are absent we'll just print the available keys
     break;
   }
-  return std::make_pair("", fs::internal::JoinAbstractPath(
-                                std::move(segments), arrow::fs::internal::kFilenameSep) +
-                                arrow::fs::internal::kFilenameSep);
+  return std::make_pair(
+      "", fs::internal::JoinAbstractPath(std::move(segments), kFilenamePartitionSep) +
+              kFilenamePartitionSep);
 }
 
 KeyValuePartitioningOptions PartitioningFactoryOptions::AsPartitioningOptions() const {
@@ -651,8 +651,8 @@ class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
       const std::vector<std::string>& paths) override {
     for (const auto& path : paths) {
       size_t field_index = 0;
-      for (auto&& segment : fs::internal::SplitAbstractPath(
-               StripNonPrefix(path), arrow::fs::internal::kFilenameSep)) {
+      for (auto&& segment :
+           fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep)) {
         if (field_index == field_names_.size()) break;
 
         switch (options_.segment_encoding) {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -65,7 +65,7 @@ Result<std::string> SafeUriUnescape(util::string_view encoded) {
 std::string StripNonPrefix(const std::string& path) {
   std::string v;
   auto non_prefix_index = path.rfind(kFilenamePartitionSep);
-  if (path.length() > 0 && non_prefix_index != std::string::npos) {
+  if (non_prefix_index != std::string::npos) {
     v = path.substr(0, non_prefix_index + 1);
   }
   return v;

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -352,7 +352,7 @@ FilenamePartitioning::FilenamePartitioning(std::shared_ptr<Schema> schema,
 Result<std::vector<KeyValuePartitioning::Key>> FilenamePartitioning::ParseKeys(
     const std::string& path) const {
   std::vector<Key> keys;
-
+  keys.reserve(schema_->num_fields());
   int i = 0;
   for (auto&& segment :
        fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep)) {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -423,8 +423,7 @@ Result<std::pair<std::string, std::string>> FilenamePartitioning::FormatValues(
     // if all subsequent keys are absent we'll just print the available keys
     break;
   }
-
-  return std::make_pair("", fs::internal::JoinFilenamePartitions(std::move(segments)));
+  return std::make_pair("", fs::internal::JoinAbstractPath(std::move(segments),"_")+"_");
 }
 
 KeyValuePartitioningOptions PartitioningFactoryOptions::AsPartitioningOptions() const {
@@ -637,7 +636,7 @@ class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
 
   Result<std::shared_ptr<Schema>> Inspect(
       const std::vector<std::string>& paths) override {
-    for (auto path : paths) {
+    for (const auto& path : paths) {
       size_t field_index = 0;
       for (auto&& segment : fs::internal::SplitFilename(path)) {
         if (field_index == field_names_.size()) break;

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -400,7 +400,7 @@ Result<std::pair<std::string, std::string>> DirectoryPartitioning::FormatValues(
     break;
   }
 
-  return make_pair(fs::internal::JoinAbstractPath(std::move(segments)), "");
+  return std::make_pair(fs::internal::JoinAbstractPath(std::move(segments)), "");
 }
 
 Result<std::pair<std::string, std::string>> FilenamePartitioning::FormatValues(

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -74,7 +74,8 @@ std::shared_ptr<Partitioning> Partitioning::Default() {
       return compute::literal(true);
     }
 
-    Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const override {
+    Result<std::pair<std::string, std::string>> Format(
+        const compute::Expression& expr) const override {
       return Status::NotImplemented("formatting paths from ", type_name(),
                                     " Partitioning");
     }
@@ -251,7 +252,8 @@ Result<compute::Expression> KeyValuePartitioning::Parse(const std::string& path)
   return and_(std::move(expressions));
 }
 
-Result<std::pair<std::string,std::string>> KeyValuePartitioning::Format(const compute::Expression& expr) const {
+Result<std::pair<std::string, std::string>> KeyValuePartitioning::Format(
+    const compute::Expression& expr) const {
   ScalarVector values{static_cast<size_t>(schema_->num_fields()), nullptr};
 
   ARROW_ASSIGN_OR_RAISE(auto known_values, ExtractKnownFieldValues(expr));
@@ -330,8 +332,8 @@ Result<std::vector<KeyValuePartitioning::Key>> DirectoryPartitioning::ParseKeys(
 }
 
 FilenamePartitioning::FilenamePartitioning(std::shared_ptr<Schema> schema,
-                                             ArrayVector dictionaries,
-                                             KeyValuePartitioningOptions options)
+                                           ArrayVector dictionaries,
+                                           KeyValuePartitioningOptions options)
     : KeyValuePartitioning(std::move(schema), std::move(dictionaries), options) {
   util::InitializeUTF8();
 }
@@ -377,7 +379,7 @@ inline util::optional<int> NextValid(const ScalarVector& values, int first_null)
   return static_cast<int>(it - values.begin());
 }
 
-Result<std::pair<std::string,std::string>> DirectoryPartitioning::FormatValues(
+Result<std::pair<std::string, std::string>> DirectoryPartitioning::FormatValues(
     const ScalarVector& values) const {
   std::vector<std::string> segments(static_cast<size_t>(schema_->num_fields()));
 
@@ -398,10 +400,10 @@ Result<std::pair<std::string,std::string>> DirectoryPartitioning::FormatValues(
     break;
   }
 
-  return make_pair(fs::internal::JoinAbstractPath(std::move(segments)),"");
+  return make_pair(fs::internal::JoinAbstractPath(std::move(segments)), "");
 }
 
-Result<std::pair<std::string,std::string>> FilenamePartitioning::FormatValues(
+Result<std::pair<std::string, std::string>> FilenamePartitioning::FormatValues(
     const ScalarVector& values) const {
   std::vector<std::string> segments(static_cast<size_t>(schema_->num_fields()));
 
@@ -422,7 +424,7 @@ Result<std::pair<std::string,std::string>> FilenamePartitioning::FormatValues(
     break;
   }
 
-  return make_pair("",fs::internal::JoinFilenamePartitions(std::move(segments)));
+  return std::make_pair("", fs::internal::JoinFilenamePartitions(std::move(segments)));
 }
 
 KeyValuePartitioningOptions PartitioningFactoryOptions::AsPartitioningOptions() const {
@@ -625,7 +627,7 @@ class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {
 class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
  public:
   FilenamePartitioningFactory(std::vector<std::string> field_names,
-                               PartitioningFactoryOptions options)
+                              PartitioningFactoryOptions options)
       : KeyValuePartitioningFactory(options), field_names_(std::move(field_names)) {
     Reset();
     util::InitializeUTF8();
@@ -674,7 +676,7 @@ class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
     auto out_schema = SchemaFromColumnNames(schema, field_names_);
 
     return std::make_shared<FilenamePartitioning>(std::move(out_schema), dictionaries_,
-                                                   options_.AsPartitioningOptions());
+                                                  options_.AsPartitioningOptions());
   }
 
  private:
@@ -757,7 +759,8 @@ Result<std::vector<KeyValuePartitioning::Key>> HivePartitioning::ParseKeys(
   return keys;
 }
 
-Result<std::pair<std::string,std::string>> HivePartitioning::FormatValues(const ScalarVector& values) const {
+Result<std::pair<std::string, std::string>> HivePartitioning::FormatValues(
+    const ScalarVector& values) const {
   std::vector<std::string> segments(static_cast<size_t>(schema_->num_fields()));
 
   for (int i = 0; i < schema_->num_fields(); ++i) {
@@ -774,7 +777,7 @@ Result<std::pair<std::string,std::string>> HivePartitioning::FormatValues(const 
     }
   }
 
-  return make_pair(fs::internal::JoinAbstractPath(std::move(segments)),"");
+  return std::make_pair(fs::internal::JoinAbstractPath(std::move(segments)), "");
 }
 
 class HivePartitioningFactory : public KeyValuePartitioningFactory {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -434,8 +434,9 @@ Result<std::pair<std::string, std::string>> FilenamePartitioning::FormatValues(
     // if all subsequent keys are absent we'll just print the available keys
     break;
   }
-  return std::make_pair("",
-                        fs::internal::JoinAbstractPath(std::move(segments), '_') + '_');
+  return std::make_pair("", fs::internal::JoinAbstractPath(
+                                std::move(segments), arrow::fs::internal::kFilenameSep) +
+                                arrow::fs::internal::kFilenameSep);
 }
 
 KeyValuePartitioningOptions PartitioningFactoryOptions::AsPartitioningOptions() const {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -316,10 +316,11 @@ inline util::optional<int> NextValid(const ScalarVector& values, int first_null)
   return static_cast<int>(it - values.begin());
 }
 
-Result<std::vector<std::string>> KeyValuePartitioning::FormatPartitionSegments(const ScalarVector& values) const{
-    std::vector<std::string> segments(static_cast<size_t>(schema_->num_fields()));
+Result<std::vector<std::string>> KeyValuePartitioning::FormatPartitionSegments(
+    const ScalarVector& values) const {
+  std::vector<std::string> segments(static_cast<size_t>(schema_->num_fields()));
 
-    for (int i = 0; i < schema_->num_fields(); ++i) {
+  for (int i = 0; i < schema_->num_fields(); ++i) {
     if (values[i] != nullptr && values[i]->is_valid) {
       segments[i] = values[i]->ToString();
       continue;
@@ -338,10 +339,12 @@ Result<std::vector<std::string>> KeyValuePartitioning::FormatPartitionSegments(c
   return segments;
 }
 
-Result<std::vector<KeyValuePartitioning::Key>> KeyValuePartitioning::ParsePartitionSegments(const std::vector<std::string>& segments) const{
-    int i = 0;
-    std::vector<Key> keys;
-    for (auto&& segment : segments) {
+Result<std::vector<KeyValuePartitioning::Key>>
+KeyValuePartitioning::ParsePartitionSegments(
+    const std::vector<std::string>& segments) const {
+  int i = 0;
+  std::vector<Key> keys;
+  for (auto&& segment : segments) {
     if (i >= schema_->num_fields()) break;
 
     switch (options_.segment_encoding) {
@@ -387,21 +390,22 @@ FilenamePartitioning::FilenamePartitioning(std::shared_ptr<Schema> schema,
 
 Result<std::vector<KeyValuePartitioning::Key>> FilenamePartitioning::ParseKeys(
     const std::string& path) const {
-  std::vector<std::string> segments = fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep);
+  std::vector<std::string> segments =
+      fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep);
   return ParsePartitionSegments(segments);
 }
 
 Result<Partitioning::PartitionPathFormat> DirectoryPartitioning::FormatValues(
     const ScalarVector& values) const {
   std::vector<std::string> segments;
-  ARROW_ASSIGN_OR_RAISE(segments,FormatPartitionSegments(values));
+  ARROW_ASSIGN_OR_RAISE(segments, FormatPartitionSegments(values));
   return PartitionPathFormat{fs::internal::JoinAbstractPath(std::move(segments)), ""};
 }
 
 Result<Partitioning::PartitionPathFormat> FilenamePartitioning::FormatValues(
     const ScalarVector& values) const {
   std::vector<std::string> segments;
-  ARROW_ASSIGN_OR_RAISE(segments,FormatPartitionSegments(values));
+  ARROW_ASSIGN_OR_RAISE(segments, FormatPartitionSegments(values));
   return Partitioning::PartitionPathFormat{
       "", fs::internal::JoinAbstractPath(std::move(segments), kFilenamePartitionSep) +
               kFilenamePartitionSep};
@@ -531,10 +535,11 @@ class KeyValuePartitioningFactory : public PartitioningFactory {
                                                                utf8());
   }
 
-Status InspectPartitionSegments(std::vector<std::string> segments, const std::vector<std::string>& field_names){
+  Status InspectPartitionSegments(std::vector<std::string> segments,
+                                  const std::vector<std::string>& field_names) {
     size_t field_index = 0;
-    for(auto&& segment:segments){
-    if (field_index == field_names.size()) break;
+    for (auto&& segment : segments) {
+      if (field_index == field_names.size()) break;
 
       switch (options_.segment_encoding) {
         case SegmentEncoding::None: {
@@ -555,7 +560,7 @@ Status InspectPartitionSegments(std::vector<std::string> segments, const std::ve
       }
     }
     return Status::OK();
-}
+  }
 
   PartitioningFactoryOptions options_;
   ArrayVector dictionaries_;
@@ -579,7 +584,7 @@ class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {
     for (auto path : paths) {
       std::vector<std::string> segments;
       segments = fs::internal::SplitAbstractPath(path);
-      RETURN_NOT_OK(InspectPartitionSegments(segments,field_names_));
+      RETURN_NOT_OK(InspectPartitionSegments(segments, field_names_));
     }
     return DoInspect();
   }
@@ -625,8 +630,9 @@ class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
       const std::vector<std::string>& paths) override {
     for (const auto& path : paths) {
       std::vector<std::string> segments;
-      segments = fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep);
-      RETURN_NOT_OK(InspectPartitionSegments(segments,field_names_));
+      segments =
+          fs::internal::SplitAbstractPath(StripNonPrefix(path), kFilenamePartitionSep);
+      RETURN_NOT_OK(InspectPartitionSegments(segments, field_names_));
     }
     return DoInspect();
   }

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -62,14 +62,6 @@ Result<std::string> SafeUriUnescape(util::string_view encoded) {
   return decoded;
 }
 
-arrow::util::string_view StripTrailingSlash(const std::string& path) {
-  auto v = util::string_view(path);
-  if (v.length() > 0 && v.back() == arrow::fs::internal::kSep) {
-    v = v.substr(0, v.length() - 1);
-  }
-  return v;
-}
-
 arrow::util::string_view StripNonPrefix(const std::string& path) {
   auto v = util::string_view(path);
   auto non_prefix_index = v.rfind(arrow::fs::internal::kFilenameSep);
@@ -324,7 +316,7 @@ Result<std::vector<KeyValuePartitioning::Key>> DirectoryPartitioning::ParseKeys(
   std::vector<Key> keys;
 
   int i = 0;
-  for (auto&& segment : fs::internal::SplitAbstractPath(StripTrailingSlash(path))) {
+  for (auto&& segment : fs::internal::SplitAbstractPath(path)) {
     if (i >= schema_->num_fields()) break;
 
     switch (options_.segment_encoding) {
@@ -591,7 +583,7 @@ class DirectoryPartitioningFactory : public KeyValuePartitioningFactory {
       const std::vector<std::string>& paths) override {
     for (auto path : paths) {
       size_t field_index = 0;
-      for (auto&& segment : fs::internal::SplitAbstractPath(StripTrailingSlash(path))) {
+      for (auto&& segment : fs::internal::SplitAbstractPath(path)) {
         if (field_index == field_names_.size()) break;
 
         switch (options_.segment_encoding) {
@@ -769,7 +761,7 @@ Result<std::vector<KeyValuePartitioning::Key>> HivePartitioning::ParseKeys(
     const std::string& path) const {
   std::vector<Key> keys;
 
-  for (const auto& segment : fs::internal::SplitAbstractPath(StripTrailingSlash(path))) {
+  for (const auto& segment : fs::internal::SplitAbstractPath(path)) {
     ARROW_ASSIGN_OR_RAISE(auto maybe_key, ParseKey(segment, hive_options_));
     if (auto key = maybe_key) {
       keys.push_back(std::move(*key));
@@ -811,7 +803,7 @@ class HivePartitioningFactory : public KeyValuePartitioningFactory {
       const std::vector<std::string>& paths) override {
     auto options = options_.AsHivePartitioningOptions();
     for (auto path : paths) {
-      for (auto&& segment : fs::internal::SplitAbstractPath(StripTrailingSlash(path))) {
+      for (auto&& segment : fs::internal::SplitAbstractPath(path)) {
         ARROW_ASSIGN_OR_RAISE(auto maybe_key,
                               HivePartitioning::ParseKey(segment, options));
         if (auto key = maybe_key) {

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -198,8 +198,10 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   /// Convert a Key to a full expression.
   Result<compute::Expression> ConvertKey(const Key& key) const;
 
-  Result<std::vector<std::string>> FormatPartitionSegments(const ScalarVector& values) const;
-  Result<std::vector<Key>> ParsePartitionSegments(const std::vector<std::string>& segments) const;
+  Result<std::vector<std::string>> FormatPartitionSegments(
+      const ScalarVector& values) const;
+  Result<std::vector<Key>> ParsePartitionSegments(
+      const std::vector<std::string>& segments) const;
 
   ArrayVector dictionaries_;
   KeyValuePartitioningOptions options_;

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -330,6 +330,8 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
 
 class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
  public:
+  /// \brief Construct a FilenamePartitioning from its components.
+  ///
   /// If a field in schema is of dictionary type, the corresponding element of
   /// dictionaries must be contain the dictionary of values for that field.
   explicit FilenamePartitioning(std::shared_ptr<Schema> schema,

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -36,6 +36,8 @@ namespace arrow {
 
 namespace dataset {
 
+constexpr char kFilenamePartitionSep = '_';
+
 // ----------------------------------------------------------------------
 // Partitioning
 

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -76,7 +76,8 @@ class ARROW_DS_EXPORT Partitioning {
   /// \brief Parse a path into a partition expression
   virtual Result<compute::Expression> Parse(const std::string& path) const = 0;
 
-  virtual Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const = 0;
+  virtual Result<std::pair<std::string, std::string>> Format(
+      const compute::Expression& expr) const = 0;
 
   /// \brief A default Partitioning which always yields scalar(true)
   static std::shared_ptr<Partitioning> Default();
@@ -170,7 +171,8 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   Result<compute::Expression> Parse(const std::string& path) const override;
 
-  Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const override;
+  Result<std::pair<std::string, std::string>> Format(
+      const compute::Expression& expr) const override;
 
   const ArrayVector& dictionaries() const { return dictionaries_; }
 
@@ -187,7 +189,8 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   virtual Result<std::vector<Key>> ParseKeys(const std::string& path) const = 0;
 
-  virtual Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const = 0;
+  virtual Result<std::pair<std::string, std::string>> FormatValues(
+      const ScalarVector& values) const = 0;
 
   /// Convert a Key to a full expression.
   Result<compute::Expression> ConvertKey(const Key& key) const;
@@ -222,7 +225,8 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
+  Result<std::pair<std::string, std::string>> FormatValues(
+      const ScalarVector& values) const override;
 };
 
 /// \brief The default fallback used for null values in a Hive-style partitioning.
@@ -279,7 +283,8 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   const HivePartitioningOptions hive_options_;
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
+  Result<std::pair<std::string, std::string>> FormatValues(
+      const ScalarVector& values) const override;
 };
 
 /// \brief Implementation provided by lambda or other callable
@@ -287,7 +292,8 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
  public:
   using ParseImpl = std::function<Result<compute::Expression>(const std::string&)>;
 
-  using FormatImpl = std::function<Result<std::pair<std::string,std::string>>(const compute::Expression&)>;
+  using FormatImpl = std::function<Result<std::pair<std::string, std::string>>(
+      const compute::Expression&)>;
 
   FunctionPartitioning(std::shared_ptr<Schema> schema, ParseImpl parse_impl,
                        FormatImpl format_impl = NULLPTR, std::string name = "function")
@@ -302,7 +308,8 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
     return parse_impl_(path);
   }
 
-  Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const override {
+  Result<std::pair<std::string, std::string>> Format(
+      const compute::Expression& expr) const override {
     if (format_impl_) {
       return format_impl_(expr);
     }
@@ -326,8 +333,8 @@ class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
   /// If a field in schema is of dictionary type, the corresponding element of
   /// dictionaries must be contain the dictionary of values for that field.
   explicit FilenamePartitioning(std::shared_ptr<Schema> schema,
-                                 ArrayVector dictionaries = {},
-                                 KeyValuePartitioningOptions options = {});
+                                ArrayVector dictionaries = {},
+                                KeyValuePartitioningOptions options = {});
 
   std::string type_name() const override { return "filename"; }
 
@@ -341,9 +348,9 @@ class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
+  Result<std::pair<std::string, std::string>> FormatValues(
+      const ScalarVector& values) const override;
 };
-
 
 /// \brief Remove a prefix and the filename of a path.
 ///

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -76,7 +76,7 @@ class ARROW_DS_EXPORT Partitioning {
   /// \brief Parse a path into a partition expression
   virtual Result<compute::Expression> Parse(const std::string& path) const = 0;
 
-  virtual Result<std::string> Format(const compute::Expression& expr) const = 0;
+  virtual Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const = 0;
 
   /// \brief A default Partitioning which always yields scalar(true)
   static std::shared_ptr<Partitioning> Default();
@@ -170,7 +170,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   Result<compute::Expression> Parse(const std::string& path) const override;
 
-  Result<std::string> Format(const compute::Expression& expr) const override;
+  Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const override;
 
   const ArrayVector& dictionaries() const { return dictionaries_; }
 
@@ -187,7 +187,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   virtual Result<std::vector<Key>> ParseKeys(const std::string& path) const = 0;
 
-  virtual Result<std::string> FormatValues(const ScalarVector& values) const = 0;
+  virtual Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const = 0;
 
   /// Convert a Key to a full expression.
   Result<compute::Expression> ConvertKey(const Key& key) const;
@@ -222,7 +222,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::string> FormatValues(const ScalarVector& values) const override;
+  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
 };
 
 /// \brief The default fallback used for null values in a Hive-style partitioning.
@@ -279,7 +279,7 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   const HivePartitioningOptions hive_options_;
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::string> FormatValues(const ScalarVector& values) const override;
+  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
 };
 
 /// \brief Implementation provided by lambda or other callable
@@ -287,7 +287,7 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
  public:
   using ParseImpl = std::function<Result<compute::Expression>(const std::string&)>;
 
-  using FormatImpl = std::function<Result<std::string>(const compute::Expression&)>;
+  using FormatImpl = std::function<Result<std::pair<std::string,std::string>>(const compute::Expression&)>;
 
   FunctionPartitioning(std::shared_ptr<Schema> schema, ParseImpl parse_impl,
                        FormatImpl format_impl = NULLPTR, std::string name = "function")
@@ -302,7 +302,7 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
     return parse_impl_(path);
   }
 
-  Result<std::string> Format(const compute::Expression& expr) const override {
+  Result<std::pair<std::string,std::string>> Format(const compute::Expression& expr) const override {
     if (format_impl_) {
       return format_impl_(expr);
     }
@@ -320,6 +320,30 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
   FormatImpl format_impl_;
   std::string name_;
 };
+
+class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
+ public:
+  /// If a field in schema is of dictionary type, the corresponding element of
+  /// dictionaries must be contain the dictionary of values for that field.
+  explicit FilenamePartitioning(std::shared_ptr<Schema> schema,
+                                 ArrayVector dictionaries = {},
+                                 KeyValuePartitioningOptions options = {});
+
+  std::string type_name() const override { return "filename"; }
+
+  /// \brief Create a factory for a filename partitioning.
+  ///
+  /// \param[in] field_names The names for the partition fields. Types will be
+  ///     inferred.
+  static std::shared_ptr<PartitioningFactory> MakeFactory(
+      std::vector<std::string> field_names, PartitioningFactoryOptions = {});
+
+ private:
+  Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
+
+  Result<std::pair<std::string,std::string>> FormatValues(const ScalarVector& values) const override;
+};
+
 
 /// \brief Remove a prefix and the filename of a path.
 ///

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -199,6 +199,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   Result<compute::Expression> ConvertKey(const Key& key) const;
 
   Result<std::vector<std::string>> FormatPartitionSegments(const ScalarVector& values) const;
+  Result<std::vector<Key>> ParsePartitionSegments(const std::vector<std::string>& segments) const;
 
   ArrayVector dictionaries_;
   KeyValuePartitioningOptions options_;

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -198,6 +198,8 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   /// Convert a Key to a full expression.
   Result<compute::Expression> ConvertKey(const Key& key) const;
 
+  Result<std::vector<std::string>> FormatPartitionSegments(const ScalarVector& values) const;
+
   ArrayVector dictionaries_;
   KeyValuePartitioningOptions options_;
 };

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -78,8 +78,11 @@ class ARROW_DS_EXPORT Partitioning {
   /// \brief Parse a path into a partition expression
   virtual Result<compute::Expression> Parse(const std::string& path) const = 0;
 
-  virtual Result<std::pair<std::string, std::string>> Format(
-      const compute::Expression& expr) const = 0;
+  struct PartitionPathFormat {
+    std::string directory, prefix;
+  };
+
+  virtual Result<PartitionPathFormat> Format(const compute::Expression& expr) const = 0;
 
   /// \brief A default Partitioning which always yields scalar(true)
   static std::shared_ptr<Partitioning> Default();
@@ -173,8 +176,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   Result<compute::Expression> Parse(const std::string& path) const override;
 
-  Result<std::pair<std::string, std::string>> Format(
-      const compute::Expression& expr) const override;
+  Result<PartitionPathFormat> Format(const compute::Expression& expr) const override;
 
   const ArrayVector& dictionaries() const { return dictionaries_; }
 
@@ -191,8 +193,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   virtual Result<std::vector<Key>> ParseKeys(const std::string& path) const = 0;
 
-  virtual Result<std::pair<std::string, std::string>> FormatValues(
-      const ScalarVector& values) const = 0;
+  virtual Result<PartitionPathFormat> FormatValues(const ScalarVector& values) const = 0;
 
   /// Convert a Key to a full expression.
   Result<compute::Expression> ConvertKey(const Key& key) const;
@@ -227,8 +228,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string, std::string>> FormatValues(
-      const ScalarVector& values) const override;
+  Result<PartitionPathFormat> FormatValues(const ScalarVector& values) const override;
 };
 
 /// \brief The default fallback used for null values in a Hive-style partitioning.
@@ -285,8 +285,7 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   const HivePartitioningOptions hive_options_;
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string, std::string>> FormatValues(
-      const ScalarVector& values) const override;
+  Result<PartitionPathFormat> FormatValues(const ScalarVector& values) const override;
 };
 
 /// \brief Implementation provided by lambda or other callable
@@ -294,8 +293,8 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
  public:
   using ParseImpl = std::function<Result<compute::Expression>(const std::string&)>;
 
-  using FormatImpl = std::function<Result<std::pair<std::string, std::string>>(
-      const compute::Expression&)>;
+  using FormatImpl =
+      std::function<Result<PartitionPathFormat>(const compute::Expression&)>;
 
   FunctionPartitioning(std::shared_ptr<Schema> schema, ParseImpl parse_impl,
                        FormatImpl format_impl = NULLPTR, std::string name = "function")
@@ -310,8 +309,7 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
     return parse_impl_(path);
   }
 
-  Result<std::pair<std::string, std::string>> Format(
-      const compute::Expression& expr) const override {
+  Result<PartitionPathFormat> Format(const compute::Expression& expr) const override {
     if (format_impl_) {
       return format_impl_(expr);
     }
@@ -350,8 +348,7 @@ class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;
 
-  Result<std::pair<std::string, std::string>> FormatValues(
-      const ScalarVector& values) const override;
+  Result<PartitionPathFormat> FormatValues(const ScalarVector& values) const override;
 };
 
 /// \brief Remove a prefix and the filename of a path.

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -61,12 +61,12 @@ class TestPartitioning : public ::testing::Test {
     // formatted partition expressions are bound to the schema of the dataset being
     // written
     ASSERT_OK_AND_ASSIGN(auto formatted, partitioning_->Format(expr));
-    ASSERT_EQ(formatted, expected);
+    ASSERT_EQ(formatted.first, expected);
 
     // ensure the formatted path round trips the relevant components of the partition
     // expression: roundtripped should be a subset of expr
     ASSERT_OK_AND_ASSIGN(compute::Expression roundtripped,
-                         partitioning_->Parse(formatted));
+                         partitioning_->Parse(formatted.first));
 
     ASSERT_OK_AND_ASSIGN(roundtripped, roundtripped.Bind(*written_schema_));
     ASSERT_OK_AND_ASSIGN(auto simplified, SimplifyWithGuarantee(roundtripped, expr));
@@ -843,7 +843,7 @@ class RangePartitioning : public Partitioning {
     return Status::OK();
   }
 
-  Result<std::string> Format(const compute::Expression&) const override { return ""; }
+  Result<std::pair<std::string,std::string>> Format(const compute::Expression&) const override { return std::make_pair("",""); }
   Result<PartitionedBatches> Partition(
       const std::shared_ptr<RecordBatch>&) const override {
     return Status::OK();

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -843,7 +843,10 @@ class RangePartitioning : public Partitioning {
     return Status::OK();
   }
 
-  Result<std::pair<std::string,std::string>> Format(const compute::Expression&) const override { return std::make_pair("",""); }
+  Result<std::pair<std::string, std::string>> Format(
+      const compute::Expression&) const override {
+    return std::make_pair("", "");
+  }
   Result<PartitionedBatches> Partition(
       const std::shared_ptr<RecordBatch>&) const override {
     return Status::OK();

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -369,8 +369,6 @@ TEST_F(TestPartitioning, HivePartitioning) {
   AssertParseError("/alpha=0.0/beta=3.25");  // conversion of "0.0" to int32 fails
 }
 
-
-
 TEST_F(TestPartitioning, HivePartitioningFormat) {
   partitioning_ = std::make_shared<HivePartitioning>(
       schema({field("alpha", int32()), field("beta", float32())}), ArrayVector(), "xyz");
@@ -577,7 +575,7 @@ TEST_F(TestPartitioning, ExistingSchemaFilename) {
   factory_ = FilenamePartitioning::MakeFactory({"alpha", "beta"}, options);
 
   // Now we don't fail since our type is large enough
-  AssertInspect({"3760212050_1"}, options.schema->fields());
+  AssertInspect({"3760212050_1_"}, options.schema->fields());
   // If there are still too many digits, fail
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("Failed to parse string"),
                                   factory_->Inspect({"1038581385102940193760212050_1_"}));
@@ -585,7 +583,6 @@ TEST_F(TestPartitioning, ExistingSchemaFilename) {
 
   AssertInspect({"0_1_", "2_"}, options.schema->fields());
 }
-
 
 TEST_F(TestPartitioning, UrlEncodedDirectory) {
   PartitioningFactoryOptions options;

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -450,6 +450,7 @@ TEST_F(TestPartitioning, FilenamePartitioningFormat) {
   AssertFormat(and_(equal(field_ref("alpha"), literal(0)),
                     equal(field_ref("beta"), literal("hello"))),
                "", "0_hello_");
+  AssertFormat(equal(field_ref("alpha"), literal(0)), "", "0_");
 }
 
 TEST_F(TestPartitioning, DiscoverHiveSchema) {

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -57,7 +57,8 @@ class TestPartitioning : public ::testing::Test {
     ASSERT_EQ(partitioning_->Format(expr).status().code(), code);
   }
 
-  void AssertFormat(compute::Expression expr, const std::string& expected_directory, const std::string& expected_prefix="") {
+  void AssertFormat(compute::Expression expr, const std::string& expected_directory,
+                    const std::string& expected_prefix = "") {
     // formatted partition expressions are bound to the schema of the dataset being
     // written
     ASSERT_OK_AND_ASSIGN(auto formatted, partitioning_->Format(expr));
@@ -306,9 +307,6 @@ TEST_F(TestPartitioning, DiscoverSchemaFilename) {
 
   // If there are too many digits fall back to string
   AssertInspect({"3760212050_1_"}, {Str("alpha"), Int("beta")});
-
-  // missing segment for beta doesn't cause an error or fallback
-  AssertInspect({"0_1_", "hello_"}, {Str("alpha"), Int("beta")});
 }
 
 TEST_F(TestPartitioning, DirectoryDictionaryInference) {
@@ -345,8 +343,6 @@ TEST_F(TestPartitioning, FilenameDictionaryInference) {
   // successful dictionary inference
   AssertInspect({"a_0_"}, {DictStr("alpha"), DictInt("beta")});
   AssertInspect({"a_0_", "a_1_"}, {DictStr("alpha"), DictInt("beta")});
-  AssertInspect({"a_0_", "a_"}, {DictStr("alpha"), DictInt("beta")});
-  AssertInspect({"0_a_", "1_"}, {DictInt("alpha"), DictStr("beta")});
   AssertInspect({"a_0_", "b_0_", "a_1_", "b_1_"}, {DictStr("alpha"), DictInt("beta")});
 }
 

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -89,6 +89,8 @@ struct KeyValuePartitioningOptions;
 class DirectoryPartitioning;
 class HivePartitioning;
 struct HivePartitioningOptions;
+class FilenamePartitioning;
+struct FilenamePartitioningOptions;
 
 struct ScanOptions;
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -109,14 +109,6 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& stem)
   return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
 }
 
-std::string ConcatAbstractPaths(const std::vector<std::string>& parts) {
-  auto result = EnsureTrailingSlash(*parts.begin());
-  std::for_each(parts.begin() + 1, parts.end() - 1,
-                [&result](const std::string& s) { result += s; });
-  result = result + std::string(RemoveLeadingSlash(*(parts.end() - 1)));
-  return result;
-}
-
 std::string EnsureTrailingSlash(util::string_view v) {
   if (v.length() > 0 && v.back() != kSep) {
     // XXX How about "C:" on Windows?  We probably don't want to turn it into "C:/"...

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -30,62 +30,23 @@ namespace internal {
 
 // XXX How does this encode Windows UNC paths?
 
-std::vector<std::string> SplitAbstractPath(const std::string& path) {
+std::vector<std::string> SplitAbstractPath(util::string_view path, const char& sep) {
   std::vector<std::string> parts;
-  auto v = util::string_view(path);
-  // Strip trailing slash
-  if (v.length() > 0 && v.back() == kSep) {
-    v = v.substr(0, v.length() - 1);
-  }
   // Strip leading slash
-  if (v.length() > 0 && v.front() == kSep) {
-    v = v.substr(1);
+  if (path.length() > 0 && path.front() == kSep) {
+    path = path.substr(1);
   }
-  if (v.length() == 0) {
+  if (path.length() == 0) {
     return parts;
   }
 
-  auto append_part = [&parts, &v](size_t start, size_t end) {
-    parts.push_back(std::string(v.substr(start, end - start)));
+  auto append_part = [&parts, &path](size_t start, size_t end) {
+    parts.push_back(std::string(path.substr(start, end - start)));
   };
 
   size_t start = 0;
   while (true) {
-    size_t end = v.find_first_of(kSep, start);
-    append_part(start, end);
-    if (end == std::string::npos) {
-      break;
-    }
-    start = end + 1;
-  }
-  return parts;
-}
-
-std::vector<std::string> SplitFilename(const std::string& path) {
-  std::vector<std::string> parts;
-  auto v = util::string_view(path);
-
-  // Strip non-prefix segment
-  auto non_prefix_index = v.rfind(kFilenameSep);
-  if (v.length() > 0 && non_prefix_index != std::string::npos) {
-    v = v.substr(0, non_prefix_index);
-  }
-
-  // Strip leading slash
-  if (v.length() > 0 && v.front() == kSep) {
-    v = v.substr(1);
-  }
-  if (v.length() == 0) {
-    return parts;
-  }
-
-  auto append_part = [&parts, &v](size_t start, size_t end) {
-    parts.push_back(std::string(v.substr(start, end - start)));
-  };
-
-  size_t start = 0;
-  while (true) {
-    size_t end = v.find_first_of(kFilenameSep, start);
+    size_t end = path.find_first_of(sep, start);
     append_part(start, end);
     if (end == std::string::npos) {
       break;
@@ -151,7 +112,8 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& prefi
 
 std::string ConcatAbstractPath(const std::vector<std::string>& parts) {
   auto result = EnsureTrailingSlash(*parts.begin());
-  std::for_each(parts.begin(), parts.end()-1, [&result] (const std::string& s) { result+=s; });
+  std::for_each(parts.begin(), parts.end() - 1,
+                [&result](const std::string& s) { result += s; });
   return result + std::string(RemoveLeadingSlash(*parts.end()));
 }
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -70,7 +70,7 @@ std::vector<std::string> SplitFilename(const std::string& path) {
   auto non_prefix_index = v.rfind(kFilenameSep);
   if (v.length() > 0 && non_prefix_index != std::string::npos) {
     v = v.substr(0, non_prefix_index);
-   }
+  }
 
   // Strip leading slash
   if (v.length() > 0 && v.front() == kSep) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -133,13 +133,21 @@ Status ValidateAbstractPathParts(const std::vector<std::string>& parts) {
   return Status::OK();
 }
 
+std::string ConcatAbstractPath(const std::string& base, const std::string& stem) {
+  DCHECK(!stem.empty());
+  if (base.empty()) {
+    return stem;
+  }
+  return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
+}
+
 std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
                                const std::string& stem) {
   DCHECK(!stem.empty());
   if (base.empty()) {
     return stem;
   }
-  return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
+  return EnsureTrailingSlash(base) + prefix + std::string(RemoveLeadingSlash(stem));
 }
 
 std::string EnsureTrailingSlash(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -69,7 +69,7 @@ std::vector<std::string> SplitFilename(const std::string& path) {
   // Strip non-prefix segment
   auto non_prefix_index = v.rfind(kFilenameSep);
   if (v.length() > 0 && non_prefix_index!=std::string::npos){
-    v = v.substr(non_prefix_index);
+    v = v.substr(0,non_prefix_index);
   }
 
   // Strip leading slash

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -68,9 +68,9 @@ std::vector<std::string> SplitFilename(const std::string& path) {
 
   // Strip non-prefix segment
   auto non_prefix_index = v.rfind(kFilenameSep);
-  if (v.length() > 0 && non_prefix_index!=std::string::npos){
-    v = v.substr(0,non_prefix_index);
-  }
+  if (v.length() > 0 && non_prefix_index != std::string::npos) {
+    v = v.substr(0, non_prefix_index);
+   }
 
   // Strip leading slash
   if (v.length() > 0 && v.front() == kSep) {
@@ -133,20 +133,13 @@ Status ValidateAbstractPathParts(const std::vector<std::string>& parts) {
   return Status::OK();
 }
 
-std::string ConcatAbstractPath(const std::string& base, const std::string& stem) {
+std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
+                               const std::string& stem) {
   DCHECK(!stem.empty());
   if (base.empty()) {
     return stem;
   }
   return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
-}
-
-std::string ConcatAbstractPath(const std::string& base, const std::string& prefix, const std::string& stem) {
-  DCHECK(!stem.empty());
-  if (base.empty()) {
-    return stem;
-  }
-  return EnsureTrailingSlash(base) + prefix + std::string(RemoveLeadingSlash(stem));
 }
 
 std::string EnsureTrailingSlash(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -30,23 +30,28 @@ namespace internal {
 
 // XXX How does this encode Windows UNC paths?
 
-std::vector<std::string> SplitAbstractPath(util::string_view path, const char& sep) {
+std::vector<std::string> SplitAbstractPath(const std::string& path, char sep) {
   std::vector<std::string> parts;
-  // Strip leading slash
-  if (path.length() > 0 && path.front() == kSep) {
-    path = path.substr(1);
+  auto v = util::string_view(path);
+  // Strip trailing slash
+  if (v.length() > 0 && v.back() == kSep) {
+    v = v.substr(0, v.length() - 1);
   }
-  if (path.length() == 0) {
+  // Strip leading slash
+  if (v.length() > 0 && v.front() == kSep) {
+    v = v.substr(1);
+  }
+  if (v.length() == 0) {
     return parts;
   }
 
-  auto append_part = [&parts, &path](size_t start, size_t end) {
-    parts.push_back(std::string(path.substr(start, end - start)));
+  auto append_part = [&parts, &v](size_t start, size_t end) {
+    parts.push_back(std::string(v.substr(start, end - start)));
   };
 
   size_t start = 0;
   while (true) {
-    size_t end = path.find_first_of(sep, start);
+    size_t end = v.find_first_of(sep, start);
     append_part(start, end);
     if (end == std::string::npos) {
       break;
@@ -54,14 +59,6 @@ std::vector<std::string> SplitAbstractPath(util::string_view path, const char& s
     start = end + 1;
   }
   return parts;
-}
-
-std::vector<std::string> SplitAbstractPath(const std::string& path) {
-  auto v = util::string_view(path);
-  if (v.length() > 0 && v.back() == arrow::fs::internal::kSep) {
-    v = v.substr(0, v.length() - 1);
-  }
-  return SplitAbstractPath(v, kSep);
 }
 
 std::pair<std::string, std::string> GetAbstractPathParent(const std::string& s) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -109,11 +109,12 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& stem)
   return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
 }
 
-std::string ConcatAbstractPath(const std::vector<std::string>& parts) {
+std::string ConcatAbstractPaths(const std::vector<std::string>& parts) {
   auto result = EnsureTrailingSlash(*parts.begin());
-  std::for_each(parts.begin(), parts.end() - 1,
+  std::for_each(parts.begin() + 1, parts.end() - 1,
                 [&result](const std::string& s) { result += s; });
-  return result + std::string(RemoveLeadingSlash(*parts.end()));
+  result = result + std::string(RemoveLeadingSlash(*(parts.end() - 1)));
+  return result;
 }
 
 std::string EnsureTrailingSlash(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -33,7 +33,6 @@ namespace internal {
 std::vector<std::string> SplitAbstractPath(const std::string& path) {
   std::vector<std::string> parts;
   auto v = util::string_view(path);
-
   // Strip trailing slash
   if (v.length() > 0 && v.back() == kSep) {
     v = v.substr(0, v.length() - 1);
@@ -148,6 +147,12 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& prefi
     return stem;
   }
   return EnsureTrailingSlash(base) + prefix + std::string(RemoveLeadingSlash(stem));
+}
+
+std::string ConcatAbstractPath(const std::vector<std::string>& parts) {
+  auto result = EnsureTrailingSlash(*parts.begin());
+  std::for_each(parts.begin(), parts.end()-1, [&result] (const std::string& s) { result+=s; });
+  return result + std::string(RemoveLeadingSlash(*parts.end()));
 }
 
 std::string EnsureTrailingSlash(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -56,6 +56,14 @@ std::vector<std::string> SplitAbstractPath(util::string_view path, const char& s
   return parts;
 }
 
+std::vector<std::string> SplitAbstractPath(const std::string& path) {
+  auto v = util::string_view(path);
+  if (v.length() > 0 && v.back() == arrow::fs::internal::kSep) {
+    v = v.substr(0, v.length() - 1);
+  }
+  return SplitAbstractPath(v, kSep);
+}
+
 std::pair<std::string, std::string> GetAbstractPathParent(const std::string& s) {
   // XXX should strip trailing slash?
 
@@ -99,15 +107,6 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& stem)
     return stem;
   }
   return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
-}
-
-std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
-                               const std::string& stem) {
-  DCHECK(!stem.empty());
-  if (base.empty()) {
-    return stem;
-  }
-  return EnsureTrailingSlash(base) + prefix + std::string(RemoveLeadingSlash(stem));
 }
 
 std::string ConcatAbstractPath(const std::vector<std::string>& parts) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -33,6 +33,7 @@ namespace internal {
 std::vector<std::string> SplitAbstractPath(const std::string& path) {
   std::vector<std::string> parts;
   auto v = util::string_view(path);
+
   // Strip trailing slash
   if (v.length() > 0 && v.back() == kSep) {
     v = v.substr(0, v.length() - 1);
@@ -52,6 +53,40 @@ std::vector<std::string> SplitAbstractPath(const std::string& path) {
   size_t start = 0;
   while (true) {
     size_t end = v.find_first_of(kSep, start);
+    append_part(start, end);
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return parts;
+}
+
+std::vector<std::string> SplitFilename(const std::string& path) {
+  std::vector<std::string> parts;
+  auto v = util::string_view(path);
+
+  // Strip non-prefix segment
+  auto non_prefix_index = v.rfind(kFilenameSep);
+  if (v.length() > 0 && non_prefix_index!=std::string::npos){
+    v = v.substr(non_prefix_index);
+  }
+
+  // Strip leading slash
+  if (v.length() > 0 && v.front() == kSep) {
+    v = v.substr(1);
+  }
+  if (v.length() == 0) {
+    return parts;
+  }
+
+  auto append_part = [&parts, &v](size_t start, size_t end) {
+    parts.push_back(std::string(v.substr(start, end - start)));
+  };
+
+  size_t start = 0;
+  while (true) {
+    size_t end = v.find_first_of(kFilenameSep, start);
     append_part(start, end);
     if (end == std::string::npos) {
       break;
@@ -104,6 +139,14 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& stem)
     return stem;
   }
   return EnsureTrailingSlash(base) + std::string(RemoveLeadingSlash(stem));
+}
+
+std::string ConcatAbstractPath(const std::string& base, const std::string& prefix, const std::string& stem) {
+  DCHECK(!stem.empty());
+  if (base.empty()) {
+    return stem;
+  }
+  return EnsureTrailingSlash(base) + prefix + std::string(RemoveLeadingSlash(stem));
 }
 
 std::string EnsureTrailingSlash(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -58,9 +58,6 @@ Status ValidateAbstractPathParts(const std::vector<std::string>& parts);
 ARROW_EXPORT
 std::string ConcatAbstractPath(const std::string& base, const std::string& stem);
 
-ARROW_EXPORT
-std::string ConcatAbstractPaths(const std::vector<std::string>& parts);
-
 // Make path relative to base, if it starts with base.  Otherwise error out.
 ARROW_EXPORT
 Result<std::string> MakeAbstractPathRelative(const std::string& base,

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -108,13 +108,13 @@ std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs);
 
 // Join the components of an abstract path.
 template <class StringIt>
-std::string JoinAbstractPath(StringIt it, StringIt end) {
+std::string JoinAbstractPath(StringIt it, StringIt end, const std::string& sep) {
   std::string path;
   for (; it != end; ++it) {
     if (it->empty()) continue;
 
     if (!path.empty()) {
-      path += kSep;
+      path += sep;
     }
     path += *it;
   }
@@ -122,29 +122,8 @@ std::string JoinAbstractPath(StringIt it, StringIt end) {
 }
 
 template <class StringRange>
-std::string JoinAbstractPath(const StringRange& range) {
-  return JoinAbstractPath(range.begin(), range.end());
-}
-
-// Join the components of filename partitions
-template <class StringIt>
-std::string JoinFilenamePartitions(StringIt it, StringIt end) {
-  std::string path;
-  for (; it != end; ++it) {
-    if (it->empty()) continue;
-
-    if (!path.empty()) {
-      path += kFilenameSep;
-    }
-    path += *it;
-  }
-  path += kFilenameSep;
-  return path;
-}
-
-template <class StringRange>
-std::string JoinFilenamePartitions(const StringRange& range) {
-  return JoinFilenamePartitions(range.begin(), range.end());
+std::string JoinAbstractPath(const StringRange& range, const std::string& sep = kSep) {
+  return JoinAbstractPath(range.begin(), range.end(), sep);
 }
 
 /// Convert slashes to backslashes, on all platforms.  Mostly useful for testing.

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -37,12 +37,8 @@ constexpr char kFilenameSep = '_';
 
 // Split an abstract path into its individual components.
 ARROW_EXPORT
-std::vector<std::string> SplitAbstractPath(const std::string& s);
-
-// Split a filename into its individual partitions.
-ARROW_EXPORT
-std::vector<std::string> SplitFilename(const std::string& s);
-
+std::vector<std::string> SplitAbstractPath(util::string_view path,
+                                           const char& sep = kSep);
 // Return the extension of the file
 ARROW_EXPORT
 std::string GetAbstractPathExtension(const std::string& s);
@@ -108,7 +104,7 @@ std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs);
 
 // Join the components of an abstract path.
 template <class StringIt>
-std::string JoinAbstractPath(StringIt it, StringIt end, const std::string& sep) {
+std::string JoinAbstractPath(StringIt it, StringIt end, const char& sep = kSep) {
   std::string path;
   for (; it != end; ++it) {
     if (it->empty()) continue;
@@ -122,7 +118,7 @@ std::string JoinAbstractPath(StringIt it, StringIt end, const std::string& sep) 
 }
 
 template <class StringRange>
-std::string JoinAbstractPath(const StringRange& range, const std::string& sep = kSep) {
+std::string JoinAbstractPath(const StringRange& range, const char& sep = kSep) {
   return JoinAbstractPath(range.begin(), range.end(), sep);
 }
 

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -30,6 +30,7 @@ namespace fs {
 namespace internal {
 
 constexpr char kSep = '/';
+constexpr char kFilenameSep = '_';
 
 // Computations on abstract paths (not local paths with system-dependent behaviour).
 // Abstract paths are typically used in URIs.
@@ -37,6 +38,10 @@ constexpr char kSep = '/';
 // Split an abstract path into its individual components.
 ARROW_EXPORT
 std::vector<std::string> SplitAbstractPath(const std::string& s);
+
+// Split a filename into its individual partitions.
+ARROW_EXPORT
+std::vector<std::string> SplitFilename(const std::string& s);
 
 // Return the extension of the file
 ARROW_EXPORT
@@ -54,6 +59,10 @@ Status ValidateAbstractPathParts(const std::vector<std::string>& parts);
 // Append a non-empty stem to an abstract path.
 ARROW_EXPORT
 std::string ConcatAbstractPath(const std::string& base, const std::string& stem);
+
+// Append a non-empty stem to an abstract path with a filename prefix.
+ARROW_EXPORT
+std::string ConcatAbstractPath(const std::string& base, const std::string& prefix, const std::string& stem);
 
 // Make path relative to base, if it starts with base.  Otherwise error out.
 ARROW_EXPORT
@@ -111,6 +120,26 @@ std::string JoinAbstractPath(StringIt it, StringIt end) {
 template <class StringRange>
 std::string JoinAbstractPath(const StringRange& range) {
   return JoinAbstractPath(range.begin(), range.end());
+}
+
+// Join the components of filename partitions
+template <class StringIt>
+std::string JoinFilenamePartitions(StringIt it, StringIt end) {
+  std::string path;
+  for (; it != end; ++it) {
+    if (it->empty()) continue;
+
+    if (!path.empty()) {
+      path += kFilenameSep;
+    }
+    path += *it;
+  }
+  return path;
+}
+
+template <class StringRange>
+std::string JoinFilenamePartitions(const StringRange& range) {
+  return JoinFilenamePartitions(range.begin(), range.end());
 }
 
 /// Convert slashes to backslashes, on all platforms.  Mostly useful for testing.

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -37,8 +37,10 @@ constexpr char kFilenameSep = '_';
 
 // Split an abstract path into its individual components.
 ARROW_EXPORT
-std::vector<std::string> SplitAbstractPath(util::string_view path,
-                                           const char& sep = kSep);
+std::vector<std::string> SplitAbstractPath(util::string_view path, const char& sep);
+ARROW_EXPORT
+std::vector<std::string> SplitAbstractPath(const std::string& path);
+
 // Return the extension of the file
 ARROW_EXPORT
 std::string GetAbstractPathExtension(const std::string& s);
@@ -55,11 +57,6 @@ Status ValidateAbstractPathParts(const std::vector<std::string>& parts);
 // Append a non-empty stem to an abstract path.
 ARROW_EXPORT
 std::string ConcatAbstractPath(const std::string& base, const std::string& stem);
-
-// Append a non-empty stem to an abstract path with a filename prefix.
-ARROW_EXPORT
-std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
-                               const std::string& stem);
 
 ARROW_EXPORT
 std::string ConcatAbstractPaths(const std::vector<std::string>& parts);

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -65,6 +65,9 @@ ARROW_EXPORT
 std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
                                const std::string& stem);
 
+ARROW_EXPORT
+std::string ConcatAbstractPaths(const std::vector<std::string>& parts);
+
 // Make path relative to base, if it starts with base.  Otherwise error out.
 ARROW_EXPORT
 Result<std::string> MakeAbstractPathRelative(const std::string& base,

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -62,7 +62,8 @@ std::string ConcatAbstractPath(const std::string& base, const std::string& stem)
 
 // Append a non-empty stem to an abstract path with a filename prefix.
 ARROW_EXPORT
-std::string ConcatAbstractPath(const std::string& base, const std::string& prefix, const std::string& stem);
+std::string ConcatAbstractPath(const std::string& base, const std::string& prefix,
+                               const std::string& stem);
 
 // Make path relative to base, if it starts with base.  Otherwise error out.
 ARROW_EXPORT

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -30,16 +30,13 @@ namespace fs {
 namespace internal {
 
 constexpr char kSep = '/';
-constexpr char kFilenameSep = '_';
 
 // Computations on abstract paths (not local paths with system-dependent behaviour).
 // Abstract paths are typically used in URIs.
 
 // Split an abstract path into its individual components.
 ARROW_EXPORT
-std::vector<std::string> SplitAbstractPath(util::string_view path, const char& sep);
-ARROW_EXPORT
-std::vector<std::string> SplitAbstractPath(const std::string& path);
+std::vector<std::string> SplitAbstractPath(const std::string& path, char sep = kSep);
 
 // Return the extension of the file
 ARROW_EXPORT
@@ -98,7 +95,7 @@ std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs);
 
 // Join the components of an abstract path.
 template <class StringIt>
-std::string JoinAbstractPath(StringIt it, StringIt end, const char& sep = kSep) {
+std::string JoinAbstractPath(StringIt it, StringIt end, char sep = kSep) {
   std::string path;
   for (; it != end; ++it) {
     if (it->empty()) continue;
@@ -112,7 +109,7 @@ std::string JoinAbstractPath(StringIt it, StringIt end, const char& sep = kSep) 
 }
 
 template <class StringRange>
-std::string JoinAbstractPath(const StringRange& range, const char& sep = kSep) {
+std::string JoinAbstractPath(const StringRange& range, char sep = kSep) {
   return JoinAbstractPath(range.begin(), range.end(), sep);
 }
 

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -135,6 +135,7 @@ std::string JoinFilenamePartitions(StringIt it, StringIt end) {
     }
     path += *it;
   }
+  path += kFilenameSep;
   return path;
 }
 

--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -58,6 +58,7 @@ Classes
    PartitioningFactory
    DirectoryPartitioning
    HivePartitioning
+   FilenamePartitioning
    Dataset
    FileSystemDataset
    FileSystemFactoryOptions

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1388,7 +1388,7 @@ cdef class DirectoryPartitioning(KeyValuePartitioning):
     Examples
     --------
     >>> from pyarrow.dataset import DirectoryPartitioning
-    >>> partition = DirectoryPartitioning(
+    >>> partitioning = DirectoryPartitioning(
     ...     pa.schema([("year", pa.int16()), ("month", pa.int8())]))
     >>> print(partitioning.parse("/2009/11"))
     ((year == 2009:int16) and (month == 11:int8))
@@ -1639,7 +1639,7 @@ cdef class FilenamePartitioning(KeyValuePartitioning):
     Examples
     --------
     >>> from pyarrow.dataset import FilenamePartitioning
-    >>> partition = FilenamePartitioning(
+    >>> partitioning = FilenamePartitioning(
     ...     pa.schema([("year", pa.int16()), ("month", pa.int8())]))
     >>> print(partitioning.parse("2009_11"))
     ((year == 2009:int16) and (month == 11:int8))

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1617,7 +1617,7 @@ cdef class FilenamePartitioning(KeyValuePartitioning):
     The FilenamePartitioning expects one segment in the file name for each
     field in the schema (all fields are required to be present) separated
     by '_'. For example given schema<year:int16, month:int8> the name
-    "2009_11" would be parsed to ("year"_ == 2009 and "month"_ == 11).
+    "2009_11_" would be parsed to ("year"_ == 2009 and "month"_ == 11).
 
     Parameters
     ----------
@@ -1641,7 +1641,7 @@ cdef class FilenamePartitioning(KeyValuePartitioning):
     >>> from pyarrow.dataset import FilenamePartitioning
     >>> partitioning = FilenamePartitioning(
     ...     pa.schema([("year", pa.int16()), ("month", pa.int8())]))
-    >>> print(partitioning.parse("2009_11"))
+    >>> print(partitioning.parse("2009_11_"))
     ((year == 2009:int16) and (month == 11:int8))
     """
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1255,6 +1255,7 @@ cdef class Partitioning(_Weakrefable):
         classes = {
             'directory': DirectoryPartitioning,
             'hive': HivePartitioning,
+            'filename': HivePartitioning,
         }
 
         class_ = classes.get(type_name, None)
@@ -1615,6 +1616,145 @@ cdef class HivePartitioning(Partitioning):
             res.append(pyarrow_wrap_array(arr))
         return res
 
+cdef class FilenamePartitioning(Partitioning):
+    """
+    A Partitioning based on a specified Schema.
+
+    The FilenamePartitioning expects one segment in the file name for each
+    field in the schema (all fields are required to be present) separated by '_'
+    For example given schema<year:int16, month:int8> the name "2009_11" would
+    be parsed to ("year"_ == 2009 and "month"_ == 11).
+
+    Parameters
+    ----------
+    schema : Schema
+        The schema that describes the partitions present in the file path.
+    dictionaries : dict[str, Array]
+        If the type of any field of `schema` is a dictionary type, the
+        corresponding entry of `dictionaries` must be an array containing
+        every value which may be taken by the corresponding column or an
+        error will be raised in parsing.
+    segment_encoding : str, default "uri"
+        After splitting paths into segments, decode the segments. Valid
+        values are "uri" (URI-decode segments) and "none" (leave as-is).
+
+    Returns
+    -------
+    FilenamePartitioning
+
+    Examples
+    --------
+    >>> from pyarrow.dataset import FilenamePartitioning
+    >>> partition = FilenamePartitioning(
+    ...     pa.schema([("year", pa.int16()), ("month", pa.int8())]))
+    >>> print(partitioning.parse("2009_11"))
+    ((year == 2009:int16) and (month == 11:int8))
+    """
+
+    cdef:
+        CFilenamePartitioning* filename_partitioning
+
+    def __init__(self, Schema schema not None, dictionaries=None,
+                 segment_encoding="uri"):
+        cdef:
+            shared_ptr[CFilenamePartitioning] c_partitioning
+            CKeyValuePartitioningOptions c_options
+
+        c_options.segment_encoding = _get_segment_encoding(segment_encoding)
+        c_partitioning = make_shared[CFilenamePartitioning](
+            pyarrow_unwrap_schema(schema),
+            _partitioning_dictionaries(schema, dictionaries),
+            c_options,
+        )
+        self.init(<shared_ptr[CPartitioning]> c_partitioning)
+
+    cdef init(self, const shared_ptr[CPartitioning]& sp):
+        Partitioning.init(self, sp)
+        self.filename_partitioning = <CFilenamePartitioning*> sp.get()
+
+    @staticmethod
+    def discover(field_names=None, infer_dictionary=False,
+                 max_partition_dictionary_size=0,
+                 schema=None, segment_encoding="uri"):
+        """
+        Discover a FilenamePartitioning.
+
+        Parameters
+        ----------
+        field_names : list of str
+            The names to associate with the values from the subdirectory names.
+            If schema is given, will be populated from the schema.
+        infer_dictionary : bool, default False
+            When inferring a schema for partition fields, yield dictionary
+            encoded types instead of plain types. This can be more efficient
+            when materializing virtual columns, and Expressions parsed by the
+            finished Partitioning will include dictionaries of all unique
+            inspected values for each field.
+        max_partition_dictionary_size : int, default 0
+            Synonymous with infer_dictionary for backwards compatibility with
+            1.0: setting this to -1 or None is equivalent to passing
+            infer_dictionary=True.
+        schema : Schema, default None
+            Use this schema instead of inferring a schema from partition
+            values. Partition values will be validated against this schema
+            before accumulation into the Partitioning's dictionary.
+        segment_encoding : str, default "uri"
+            After splitting paths into segments, decode the segments. Valid
+            values are "uri" (URI-decode segments) and "none" (leave as-is).
+
+        Returns
+        -------
+        PartitioningFactory
+            To be used in the FileSystemFactoryOptions.
+        """
+        cdef:
+            CPartitioningFactoryOptions c_options
+            vector[c_string] c_field_names
+
+        if max_partition_dictionary_size in {-1, None}:
+            infer_dictionary = True
+        elif max_partition_dictionary_size != 0:
+            raise NotImplementedError("max_partition_dictionary_size must be "
+                                      "0, -1, or None")
+
+        if infer_dictionary:
+            c_options.infer_dictionary = True
+
+        if schema:
+            c_options.schema = pyarrow_unwrap_schema(schema)
+            c_field_names = [tobytes(f.name) for f in schema]
+        elif not field_names:
+            raise ValueError(
+                "Neither field_names nor schema was passed; "
+                "cannot infer field_names")
+        else:
+            c_field_names = [tobytes(s) for s in field_names]
+
+        c_options.segment_encoding = _get_segment_encoding(segment_encoding)
+
+        return PartitioningFactory.wrap(
+            CFilenamePartitioning.MakeFactory(c_field_names, c_options))
+
+    @property
+    def dictionaries(self):
+        """
+        The unique values for each partition field, if available.
+
+        Those values are only available if the Partitioning object was
+        created through dataset discovery from a PartitioningFactory, or
+        if the dictionaries were manually specified in the constructor.
+        If not available, this returns None.
+        """
+        cdef vector[shared_ptr[CArray]] c_arrays
+        c_arrays = self.filename_partitioning.dictionaries()
+        res = []
+        for arr in c_arrays:
+            if arr.get() == nullptr:
+                # Partitioning object has not been created through
+                # inspected Factory
+                return None
+            res.append(pyarrow_wrap_array(arr))
+        return res
 
 cdef class DatasetFactory(_Weakrefable):
     """

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1345,7 +1345,7 @@ cdef class KeyValuePartitioning(Partitioning):
         Those values are only available if the Partitioning object was
         created through dataset discovery from a PartitioningFactory, or
         if the dictionaries were manually specified in the constructor.
-        If not available, this returns None.
+        If no dictionary field is available, this returns an empty list.
         """
         cdef vector[shared_ptr[CArray]] c_arrays
         c_arrays = self.keyvalue_partitioning.dictionaries()

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1464,6 +1464,7 @@ cdef class DirectoryPartitioning(Partitioning):
             res.append(pyarrow_wrap_array(arr))
         return res
 
+
 cdef class HivePartitioning(Partitioning):
     """
     A Partitioning for "/$key=$value/" nested directories as found in

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1255,7 +1255,7 @@ cdef class Partitioning(_Weakrefable):
         classes = {
             'directory': DirectoryPartitioning,
             'hive': HivePartitioning,
-            'filename': HivePartitioning,
+            'filename': FilenamePartitioning,
         }
 
         class_ = classes.get(type_name, None)
@@ -1621,9 +1621,9 @@ cdef class FilenamePartitioning(Partitioning):
     A Partitioning based on a specified Schema.
 
     The FilenamePartitioning expects one segment in the file name for each
-    field in the schema (all fields are required to be present) separated by '_'
-    For example given schema<year:int16, month:int8> the name "2009_11" would
-    be parsed to ("year"_ == 2009 and "month"_ == 11).
+    field in the schema (all fields are required to be present) separated
+    by '_'. For example given schema<year:int16, month:int8> the name
+    "2009_11" would be parsed to ("year"_ == 2009 and "month"_ == 11).
 
     Parameters
     ----------

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1354,7 +1354,7 @@ cdef class KeyValuePartitioning(Partitioning):
             if arr.get() == nullptr:
                 # Partitioning object has not been created through
                 # inspected Factory
-                return None
+                continue
             res.append(pyarrow_wrap_array(arr))
         return res
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1673,7 +1673,6 @@ cdef class FilenamePartitioning(Partitioning):
 
     @staticmethod
     def discover(field_names=None, infer_dictionary=False,
-                 max_partition_dictionary_size=0,
                  schema=None, segment_encoding="uri"):
         """
         Discover a FilenamePartitioning.
@@ -1705,12 +1704,6 @@ cdef class FilenamePartitioning(Partitioning):
         cdef:
             CPartitioningFactoryOptions c_options
             vector[c_string] c_field_names
-
-        if max_partition_dictionary_size in {-1, None}:
-            infer_dictionary = True
-        elif max_partition_dictionary_size != 0:
-            raise NotImplementedError("max_partition_dictionary_size must be "
-                                      "0, -1, or None")
 
         if infer_dictionary:
             c_options.infer_dictionary = True

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1464,7 +1464,6 @@ cdef class DirectoryPartitioning(Partitioning):
             res.append(pyarrow_wrap_array(arr))
         return res
 
-
 cdef class HivePartitioning(Partitioning):
     """
     A Partitioning for "/$key=$value/" nested directories as found in
@@ -1690,10 +1689,6 @@ cdef class FilenamePartitioning(Partitioning):
             when materializing virtual columns, and Expressions parsed by the
             finished Partitioning will include dictionaries of all unique
             inspected values for each field.
-        max_partition_dictionary_size : int, default 0
-            Synonymous with infer_dictionary for backwards compatibility with
-            1.0: setting this to -1 or None is equivalent to passing
-            infer_dictionary=True.
         schema : Schema, default None
             Use this schema instead of inferring a schema from partition
             values. Partition values will be validated against this schema
@@ -1724,7 +1719,7 @@ cdef class FilenamePartitioning(Partitioning):
             c_options.schema = pyarrow_unwrap_schema(schema)
             c_field_names = [tobytes(f.name) for f in schema]
         elif not field_names:
-            raise ValueError(
+            raise TypeError(
                 "Neither field_names nor schema was passed; "
                 "cannot infer field_names")
         else:

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -26,6 +26,7 @@ from pyarrow._dataset import (  # noqa
     Dataset,
     DatasetFactory,
     DirectoryPartitioning,
+    FilenamePartitioning,
     FileFormat,
     FileFragment,
     FileSystemDataset,
@@ -209,6 +210,26 @@ def partitioning(schema=None, field_names=None, flavor=None,
         else:
             raise ValueError(
                 "For the default directory flavor, need to specify "
+                "a Schema or a list of field names")
+    if flavor == "filename":
+        # default flavor
+        if schema is not None:
+            if field_names is not None:
+                raise ValueError(
+                    "Cannot specify both 'schema' and 'field_names'")
+            if dictionaries == 'infer':
+                return FilenamePartitioning.discover(schema=schema)
+            return FilenamePartitioning(schema, dictionaries)
+        elif field_names is not None:
+            if isinstance(field_names, list):
+                return FilenamePartitioning.discover(field_names)
+            else:
+                raise ValueError(
+                    "Expected list of field names, got {}".format(
+                        type(field_names)))
+        else:
+            raise ValueError(
+                "For the default filename flavor, need to specify "
                 "a Schema or a list of field names")
     elif flavor == 'hive':
         if field_names is not None:

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -136,7 +136,7 @@ def partitioning(schema=None, field_names=None, flavor=None,
         inferred from the file paths (only valid for DirectoryPartitioning).
     flavor : str, default None
         The default is DirectoryPartitioning. Specify ``flavor="hive"`` for
-        a HivePartitioning.
+        a HivePartitioning, and ``flavor="filename"`` for a FilenamePartitioning.
     dictionaries : dict[str, Array]
         If the type of any field of `schema` is a dictionary type, the
         corresponding entry of `dictionaries` must be an array containing

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -136,7 +136,8 @@ def partitioning(schema=None, field_names=None, flavor=None,
         inferred from the file paths (only valid for DirectoryPartitioning).
     flavor : str, default None
         The default is DirectoryPartitioning. Specify ``flavor="hive"`` for
-        a HivePartitioning, and ``flavor="filename"`` for a FilenamePartitioning.
+        a HivePartitioning, and ``flavor="filename"`` for a
+        FilenamePartitioning.
     dictionaries : dict[str, Array]
         If the type of any field of `schema` is a dictionary type, the
         corresponding entry of `dictionaries` must be an array containing

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -118,6 +118,11 @@ def partitioning(schema=None, field_names=None, flavor=None,
       For example, given schema<year:int16, month:int8, day:int8>, a possible
       path would be "/year=2009/month=11/day=15" (but the field order does not
       need to match).
+    - "FilenamePartitioning": this scheme expects the partitions will have
+      filenames containing the field values separated by "_".
+      For example, given schema<year:int16, month:int8, day:int8>, a possible
+      partition filename "2009_11_part-0.parquet" would be parsed
+      to ("year"_ == 2009 and "month"_ == 11).
 
     Parameters
     ----------
@@ -229,7 +234,7 @@ def partitioning(schema=None, field_names=None, flavor=None,
                         type(field_names)))
         else:
             raise ValueError(
-                "For the default filename flavor, need to specify "
+                "For the filename flavor, need to specify "
                 "a Schema or a list of field names")
     elif flavor == 'hive':
         if field_names is not None:

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -321,8 +321,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             vector[c_string] field_names, CPartitioningFactoryOptions)
-
+        
         vector[shared_ptr[CArray]] dictionaries() const
+
 
     cdef cppclass CHivePartitioning \
             "arrow::dataset::HivePartitioning"(CPartitioning):
@@ -333,8 +334,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             CHivePartitioningFactoryOptions)
-
+        
         vector[shared_ptr[CArray]] dictionaries() const
+
 
     cdef cppclass CFilenamePartitioning \
             "arrow::dataset::FilenamePartitioning"(CPartitioning):
@@ -344,8 +346,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             vector[c_string] field_names, CPartitioningFactoryOptions)
-
+        
         vector[shared_ptr[CArray]] dictionaries() const
+
 
     cdef cppclass CPartitioningOrFactory \
             "arrow::dataset::PartitioningOrFactory":

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -305,6 +305,14 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CPartitioningFactory "arrow::dataset::PartitioningFactory":
         c_string type_name() const
 
+    cdef cppclass CKeyValuePartitioning \
+            "arrow::dataset::KeyValuePartitioning"(CPartitioning):
+        CKeyValuePartitioning(shared_ptr[CSchema] schema,
+                              vector[shared_ptr[CArray]] dictionaries,
+                              CKeyValuePartitioningOptions options)
+
+        vector[shared_ptr[CArray]] dictionaries() const
+
     cdef cppclass CDirectoryPartitioning \
             "arrow::dataset::DirectoryPartitioning"(CPartitioning):
         CDirectoryPartitioning(shared_ptr[CSchema] schema,

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -331,7 +331,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CFilenamePartitioning \
             "arrow::dataset::FilenamePartitioning"(CPartitioning):
         CFilenamePartitioning(shared_ptr[CSchema] schema,
-                               vector[shared_ptr[CArray]] dictionaries)
+                              vector[shared_ptr[CArray]] dictionaries)
 
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -328,6 +328,17 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
         vector[shared_ptr[CArray]] dictionaries() const
 
+    cdef cppclass CFilenamePartitioning \
+            "arrow::dataset::FilenamePartitioning"(CPartitioning):
+        CFilenamePartitioning(shared_ptr[CSchema] schema,
+                               vector[shared_ptr[CArray]] dictionaries)
+
+        @staticmethod
+        shared_ptr[CPartitioningFactory] MakeFactory(
+            vector[c_string] field_names, CPartitioningFactoryOptions)
+
+        vector[shared_ptr[CArray]] dictionaries() const
+
     cdef cppclass CPartitioningOrFactory \
             "arrow::dataset::PartitioningOrFactory":
         CPartitioningOrFactory(shared_ptr[CPartitioning])

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -321,9 +321,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             vector[c_string] field_names, CPartitioningFactoryOptions)
-        
-        vector[shared_ptr[CArray]] dictionaries() const
 
+        vector[shared_ptr[CArray]] dictionaries() const
 
     cdef cppclass CHivePartitioning \
             "arrow::dataset::HivePartitioning"(CPartitioning):
@@ -334,9 +333,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             CHivePartitioningFactoryOptions)
-        
-        vector[shared_ptr[CArray]] dictionaries() const
 
+        vector[shared_ptr[CArray]] dictionaries() const
 
     cdef cppclass CFilenamePartitioning \
             "arrow::dataset::FilenamePartitioning"(CPartitioning):
@@ -346,9 +344,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
             vector[c_string] field_names, CPartitioningFactoryOptions)
-        
-        vector[shared_ptr[CArray]] dictionaries() const
 
+        vector[shared_ptr[CArray]] dictionaries() const
 
     cdef cppclass CPartitioningOrFactory \
             "arrow::dataset::PartitioningOrFactory":

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -586,6 +586,12 @@ def test_partitioning():
     with pytest.raises(pa.ArrowInvalid):
         partitioning.parse('prefix_3_aaa_')
 
+# @pytest.mark.parquet
+# def test_partitioning_dictionaries(tempdir):
+#     directory = tempdir / "partitioned-dataset"
+#     directory.mkdir()
+
+
 
 def test_expression_arithmetic_operators():
     dataset = ds.dataset(pa.table({'a': [1, 2, 3], 'b': [2, 2, 2]}))

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -520,7 +520,8 @@ def test_partitioning():
         pa.field('i64', pa.int64()),
         pa.field('f64', pa.float64())
     ])
-    for klass in [ds.DirectoryPartitioning, ds.HivePartitioning, ds.FilenamePartitioning]:
+    for klass in [ds.DirectoryPartitioning, ds.HivePartitioning,
+                  ds.FilenamePartitioning]:
         partitioning = klass(schema)
         assert isinstance(partitioning, ds.Partitioning)
 
@@ -568,7 +569,7 @@ def test_partitioning():
     for shouldfail in ['/alpha=one/beta=2', '/alpha=one', '/beta=two']:
         with pytest.raises(pa.ArrowInvalid):
             partitioning.parse(shouldfail)
-    
+
     partitioning = ds.FilenamePartitioning(
         pa.schema([
             pa.field('group', pa.int64()),
@@ -584,6 +585,7 @@ def test_partitioning():
 
     with pytest.raises(pa.ArrowInvalid):
         partitioning.parse('prefix_3_aaa_')
+
 
 def test_expression_arithmetic_operators():
     dataset = ds.dataset(pa.table({'a': [1, 2, 3], 'b': [2, 2, 2]}))


### PR DESCRIPTION
This PR adds support for Filename-based partitioning. With this change, dataset partitions will be formed by the filenames separated by `_`

Filename-based partitioning is done very similarly to DirectoryPartitioning, where instead of creating a new directory, the partitions use the values within their names. With this, the `Format()` and `FormatValues()` will now return a pair that will have Directory as the first element and File prefix as the second element. File prefix contains the required string representing the partitioning values.