### PR TITLE
ARROW-15817: [R] Use TableSourceNode instead of InMemoryDataset

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -128,7 +128,7 @@ arrow_with_dataset <- function() {
   is_32bit <- .Machine$sizeof.pointer < 8
   is_old_r <- getRversion() < "4.0.0"
   is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
-  if (is_32bit && is_old_r && is_windows) {
+  if (on_old_windows()) {
     # 32-bit rtools 3.5 does not properly implement the std::thread expectations
     # but we can't just disable ARROW_DATASET in that build,
     # so report it as "off" here.
@@ -137,6 +137,14 @@ arrow_with_dataset <- function() {
   tryCatch(.Call(`_dataset_available`), error = function(e) {
     return(FALSE)
   })
+}
+
+on_old_windows <- function() {
+  is_32bit <- .Machine$sizeof.pointer < 8
+  is_old_r <- getRversion() < "4.0.0"
+  is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
+
+  is_32bit && is_old_r && is_windows
 }
 
 #' @rdname arrow_available

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -125,9 +125,6 @@ arrow_available <- function() {
 #' @rdname arrow_available
 #' @export
 arrow_with_dataset <- function() {
-  is_32bit <- .Machine$sizeof.pointer < 8
-  is_old_r <- getRversion() < "4.0.0"
-  is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
   if (on_old_windows()) {
     # 32-bit rtools 3.5 does not properly implement the std::thread expectations
     # but we can't just disable ARROW_DATASET in that build,

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -440,6 +440,10 @@ ExecNode_ReadFromRecordBatchReader <- function(plan, reader) {
   .Call(`_arrow_ExecNode_ReadFromRecordBatchReader`, plan, reader)
 }
 
+ExecNode_TableSourceNode <- function(plan, table) {
+  .Call(`_arrow_ExecNode_TableSourceNode`, plan, table)
+}
+
 RecordBatch__cast <- function(batch, schema, options) {
   .Call(`_arrow_RecordBatch__cast`, batch, schema, options)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -436,8 +436,8 @@ ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_o
   .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output)
 }
 
-ExecNode_ReadFromRecordBatchReader <- function(plan, reader) {
-  .Call(`_arrow_ExecNode_ReadFromRecordBatchReader`, plan, reader)
+ExecNode_SourceNode <- function(plan, reader) {
+  .Call(`_arrow_ExecNode_SourceNode`, plan, reader)
 }
 
 ExecNode_TableSourceNode <- function(plan, table) {
@@ -1654,6 +1654,10 @@ RecordBatchReader__batches <- function(reader) {
 
 Table__from_RecordBatchReader <- function(reader) {
   .Call(`_arrow_Table__from_RecordBatchReader`, reader)
+}
+
+RecordBatchReader__Head <- function(reader, num_rows) {
+  .Call(`_arrow_RecordBatchReader__Head`, reader, num_rows)
 }
 
 ipc___RecordBatchStreamReader__Open <- function(stream) {

--- a/r/R/dataset-scan.R
+++ b/r/R/dataset-scan.R
@@ -146,21 +146,29 @@ names.Scanner <- function(x) names(x$schema)
 
 #' @export
 head.Scanner <- function(x, n = 6L, ...) {
-  assert_that(n > 0) # For now
+  # Negative n requires knowing nrow(x), which requires a scan itself
+  assert_that(n >= 0)
   dataset___Scanner__head(x, n)
 }
 
 #' @export
 tail.Scanner <- function(x, n = 6L, ...) {
-  assert_that(n > 0) # For now
+  tail_from_batches(dataset___Scanner__ScanBatches(x), n)
+}
+
+tail_from_batches <- function(batches, n) {
+  # Negative n requires knowing nrow(x), which requires a scan itself
+  assert_that(n >= 0) # For now
   result <- list()
   batch_num <- 0
-  for (batch in rev(dataset___Scanner__ScanBatches(x))) {
+  # Given a list of batches, iterate from the back
+  for (batch in rev(batches)) {
     batch_num <- batch_num + 1
     result[[batch_num]] <- tail(batch, n)
     n <- n - nrow(batch)
     if (n <= 0) break
   }
+  # rev() the result to put the batches back in the right order
   Table$create(!!!rev(result))
 }
 

--- a/r/R/dataset-scan.R
+++ b/r/R/dataset-scan.R
@@ -77,6 +77,8 @@ Scanner$create <- function(dataset,
                            batch_size = NULL,
                            fragment_scan_options = NULL,
                            ...) {
+  stop_if_no_datasets()
+
   if (!is.null(use_async)) {
     .Deprecated(msg = paste(
       "The parameter 'use_async' is deprecated",

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -179,9 +179,8 @@ open_dataset <- function(sources,
                          unify_schemas = NULL,
                          format = c("parquet", "arrow", "ipc", "feather", "csv", "tsv", "text"),
                          ...) {
-  if (!arrow_with_dataset()) {
-    stop("This build of the arrow package does not support Datasets", call. = FALSE)
-  }
+  stop_if_no_datasets()
+
   if (is_list_of(sources, "Dataset")) {
     if (is.null(schema)) {
       if (is.null(unify_schemas) || isTRUE(unify_schemas)) {
@@ -370,9 +369,7 @@ UnionDataset <- R6Class("UnionDataset",
 #' @export
 InMemoryDataset <- R6Class("InMemoryDataset", inherit = Dataset)
 InMemoryDataset$create <- function(x) {
-  if (!arrow_with_dataset()) {
-    stop("This build of the arrow package does not support Datasets", call. = FALSE)
-  }
+  stop_if_no_datasets()
   if (!inherits(x, "Table")) {
     x <- Table$create(x)
   }
@@ -422,4 +419,10 @@ take_dataset_rows <- function(x, i) {
   scanner <- Scanner$create(x)
   i <- Array$create(i - 1)
   dataset___Scanner__TakeRows(scanner, i)
+}
+
+stop_if_no_datasets <- function() {
+  if (!arrow_with_dataset()) {
+    stop("This build of the arrow package does not support Datasets", call. = FALSE)
+  }
 }

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -26,8 +26,8 @@ arrow_dplyr_query <- function(.data) {
   # An arrow_dplyr_query can contain another arrow_dplyr_query in .data
   gv <- dplyr::group_vars(.data) %||% character()
 
-  if (!inherits(.data, c("Dataset", "arrow_dplyr_query", "RecordBatchReader"))) {
-    .data <- InMemoryDataset$create(.data)
+  if (inherits(.data, "data.frame")) {
+    .data <- Table$create(.data)
   }
   # Evaluating expressions on a dataset with duplicated fieldnames will error
   dupes <- duplicated(names(.data))
@@ -237,7 +237,7 @@ abandon_ship <- function(call, .data, msg) {
   eval.parent(call, 2)
 }
 
-query_on_dataset <- function(x) !inherits(source_data(x), "InMemoryDataset")
+query_on_dataset <- function(x) inherits(source_data(x), c("Dataset", "RecordBatchReader"))
 
 source_data <- function(x) {
   if (is_collapsed(x)) {

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -151,8 +151,14 @@ dim.arrow_dplyr_query <- function(x) {
     rows <- NA_integer_
   } else if (isTRUE(x$filtered_rows)) {
     rows <- x$.data$num_rows
-  } else {
+  } else if (query_on_dataset(x)) {
+    # TODO: do this with an ExecPlan instead of Scanner?
     rows <- Scanner$create(x)$CountRows()
+  } else {
+    # Query on in-memory Table, so evaluate the filter
+    # Don't need any columns
+    x <- select.arrow_dplyr_query(x, NULL)
+    rows <- nrow(compute.arrow_dplyr_query(x))
   }
   c(rows, cols)
 }

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -152,7 +152,8 @@ dim.arrow_dplyr_query <- function(x) {
   } else if (isTRUE(x$filtered_rows)) {
     rows <- x$.data$num_rows
   } else if (query_on_dataset(x)) {
-    # TODO: do this with an ExecPlan instead of Scanner?
+    # TODO: do this with an ExecPlan instead of Scanner (after ARROW-12311)?
+    # See also https://github.com/apache/arrow/pull/12533/files#r818129459
     rows <- Scanner$create(x)$CountRows()
   } else {
     # Query on in-memory Table, so evaluate the filter

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -65,6 +65,11 @@ ExecPlan <- R6Class("ExecPlan",
       if (inherits(dataset, "arrow_dplyr_query")) {
         if (inherits(dataset$.data, "RecordBatchReader")) {
           return(ExecNode_ReadFromRecordBatchReader(self, dataset$.data))
+        } else if (inherits(dataset$.data, "ArrowTabular")) {
+          if (inherits(dataset$.data, "RecordBatch")) {
+            dataset$.data <- Table$create(dataset$.data)
+          }
+          return(ExecNode_TableSourceNode(self, dataset$.data))
         }
 
         filter <- dataset$filtered_rows

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -64,7 +64,7 @@ ExecPlan <- R6Class("ExecPlan",
       # Handle arrow_dplyr_query
       if (inherits(dataset, "arrow_dplyr_query")) {
         if (inherits(dataset$.data, "RecordBatchReader")) {
-          return(ExecNode_ReadFromRecordBatchReader(self, dataset$.data))
+          return(ExecNode_SourceNode(self, dataset$.data))
         } else if (inherits(dataset$.data, "ArrowTabular")) {
           if (inherits(dataset$.data, "RecordBatch")) {
             dataset$.data <- Table$create(dataset$.data)

--- a/r/R/record-batch-reader.R
+++ b/r/R/record-batch-reader.R
@@ -106,11 +106,13 @@ RecordBatchReader <- R6Class("RecordBatchReader",
 
 #' @export
 head.RecordBatchReader <- function(x, n = 6L, ...) {
-  head(Scanner$create(x), n)
+  assert_that(n >= 0) # For now
+  RecordBatchReader__Head(x, n)
 }
 
 #' @export
 tail.RecordBatchReader <- function(x, n = 6L, ...) {
+  # TODO: implement without Scanner so that ARROW_DATASET is not required
   tail(Scanner$create(x), n)
 }
 

--- a/r/R/record-batch-reader.R
+++ b/r/R/record-batch-reader.R
@@ -106,14 +106,14 @@ RecordBatchReader <- R6Class("RecordBatchReader",
 
 #' @export
 head.RecordBatchReader <- function(x, n = 6L, ...) {
-  assert_that(n >= 0) # For now
+  # Negative n requires knowing nrow(x), which requires consuming the whole RBR
+  assert_that(n >= 0)
   RecordBatchReader__Head(x, n)
 }
 
 #' @export
 tail.RecordBatchReader <- function(x, n = 6L, ...) {
-  # TODO: implement without Scanner so that ARROW_DATASET is not required
-  tail(Scanner$create(x), n)
+  tail_from_batches(x$batches(), n)
 }
 
 #' @rdname RecordBatchReader

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1717,17 +1717,17 @@ extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right
 
 // compute-exec.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<compute::ExecNode> ExecNode_ReadFromRecordBatchReader(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<arrow::RecordBatchReader>& reader);
-extern "C" SEXP _arrow_ExecNode_ReadFromRecordBatchReader(SEXP plan_sexp, SEXP reader_sexp){
+std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<arrow::RecordBatchReader>& reader);
+extern "C" SEXP _arrow_ExecNode_SourceNode(SEXP plan_sexp, SEXP reader_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::ExecPlan>&>::type plan(plan_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatchReader>&>::type reader(reader_sexp);
-	return cpp11::as_sexp(ExecNode_ReadFromRecordBatchReader(plan, reader));
+	return cpp11::as_sexp(ExecNode_SourceNode(plan, reader));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_ExecNode_ReadFromRecordBatchReader(SEXP plan_sexp, SEXP reader_sexp){
-	Rf_error("Cannot call ExecNode_ReadFromRecordBatchReader(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+extern "C" SEXP _arrow_ExecNode_SourceNode(SEXP plan_sexp, SEXP reader_sexp){
+	Rf_error("Cannot call ExecNode_SourceNode(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
@@ -6519,6 +6519,22 @@ extern "C" SEXP _arrow_Table__from_RecordBatchReader(SEXP reader_sexp){
 
 // recordbatchreader.cpp
 #if defined(ARROW_R_WITH_ARROW)
+std::shared_ptr<arrow::Table> RecordBatchReader__Head(const std::shared_ptr<arrow::RecordBatchReader>& reader, int64_t num_rows);
+extern "C" SEXP _arrow_RecordBatchReader__Head(SEXP reader_sexp, SEXP num_rows_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::RecordBatchReader>&>::type reader(reader_sexp);
+	arrow::r::Input<int64_t>::type num_rows(num_rows_sexp);
+	return cpp11::as_sexp(RecordBatchReader__Head(reader, num_rows));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_RecordBatchReader__Head(SEXP reader_sexp, SEXP num_rows_sexp){
+	Rf_error("Cannot call RecordBatchReader__Head(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// recordbatchreader.cpp
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::ipc::RecordBatchStreamReader> ipc___RecordBatchStreamReader__Open(const std::shared_ptr<arrow::io::InputStream>& stream);
 extern "C" SEXP _arrow_ipc___RecordBatchStreamReader__Open(SEXP stream_sexp){
 BEGIN_CPP11
@@ -7699,7 +7715,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ExecNode_Project", (DL_FUNC) &_arrow_ExecNode_Project, 3}, 
 		{ "_arrow_ExecNode_Aggregate", (DL_FUNC) &_arrow_ExecNode_Aggregate, 5}, 
 		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 7}, 
-		{ "_arrow_ExecNode_ReadFromRecordBatchReader", (DL_FUNC) &_arrow_ExecNode_ReadFromRecordBatchReader, 2}, 
+		{ "_arrow_ExecNode_SourceNode", (DL_FUNC) &_arrow_ExecNode_SourceNode, 2}, 
 		{ "_arrow_ExecNode_TableSourceNode", (DL_FUNC) &_arrow_ExecNode_TableSourceNode, 2}, 
 		{ "_arrow_RecordBatch__cast", (DL_FUNC) &_arrow_RecordBatch__cast, 3}, 
 		{ "_arrow_Table__cast", (DL_FUNC) &_arrow_Table__cast, 3}, 
@@ -8004,6 +8020,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_RecordBatchReader__ReadNext", (DL_FUNC) &_arrow_RecordBatchReader__ReadNext, 1}, 
 		{ "_arrow_RecordBatchReader__batches", (DL_FUNC) &_arrow_RecordBatchReader__batches, 1}, 
 		{ "_arrow_Table__from_RecordBatchReader", (DL_FUNC) &_arrow_Table__from_RecordBatchReader, 1}, 
+		{ "_arrow_RecordBatchReader__Head", (DL_FUNC) &_arrow_RecordBatchReader__Head, 2}, 
 		{ "_arrow_ipc___RecordBatchStreamReader__Open", (DL_FUNC) &_arrow_ipc___RecordBatchStreamReader__Open, 1}, 
 		{ "_arrow_ipc___RecordBatchFileReader__schema", (DL_FUNC) &_arrow_ipc___RecordBatchFileReader__schema, 1}, 
 		{ "_arrow_ipc___RecordBatchFileReader__num_record_batches", (DL_FUNC) &_arrow_ipc___RecordBatchFileReader__num_record_batches, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1610,7 +1610,7 @@ extern "C" SEXP _arrow_ExecPlan_StopProducing(SEXP plan_sexp){
 #endif
 
 // compute-exec.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::Schema> ExecNode_output_schema(const std::shared_ptr<compute::ExecNode>& node);
 extern "C" SEXP _arrow_ExecNode_output_schema(SEXP node_sexp){
 BEGIN_CPP11
@@ -1643,7 +1643,7 @@ extern "C" SEXP _arrow_ExecNode_Scan(SEXP plan_sexp, SEXP dataset_sexp, SEXP fil
 #endif
 
 // compute-exec.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<compute::ExecNode> ExecNode_Filter(const std::shared_ptr<compute::ExecNode>& input, const std::shared_ptr<compute::Expression>& filter);
 extern "C" SEXP _arrow_ExecNode_Filter(SEXP input_sexp, SEXP filter_sexp){
 BEGIN_CPP11
@@ -1659,7 +1659,7 @@ extern "C" SEXP _arrow_ExecNode_Filter(SEXP input_sexp, SEXP filter_sexp){
 #endif
 
 // compute-exec.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<compute::ExecNode> ExecNode_Project(const std::shared_ptr<compute::ExecNode>& input, const std::vector<std::shared_ptr<compute::Expression>>& exprs, std::vector<std::string> names);
 extern "C" SEXP _arrow_ExecNode_Project(SEXP input_sexp, SEXP exprs_sexp, SEXP names_sexp){
 BEGIN_CPP11
@@ -1676,7 +1676,7 @@ extern "C" SEXP _arrow_ExecNode_Project(SEXP input_sexp, SEXP exprs_sexp, SEXP n
 #endif
 
 // compute-exec.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(const std::shared_ptr<compute::ExecNode>& input, cpp11::list options, std::vector<std::string> target_names, std::vector<std::string> out_field_names, std::vector<std::string> key_names);
 extern "C" SEXP _arrow_ExecNode_Aggregate(SEXP input_sexp, SEXP options_sexp, SEXP target_names_sexp, SEXP out_field_names_sexp, SEXP key_names_sexp){
 BEGIN_CPP11
@@ -1695,7 +1695,7 @@ extern "C" SEXP _arrow_ExecNode_Aggregate(SEXP input_sexp, SEXP options_sexp, SE
 #endif
 
 // compute-exec.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<compute::ExecNode> ExecNode_Join(const std::shared_ptr<compute::ExecNode>& input, int type, const std::shared_ptr<compute::ExecNode>& right_data, std::vector<std::string> left_keys, std::vector<std::string> right_keys, std::vector<std::string> left_output, std::vector<std::string> right_output);
 extern "C" SEXP _arrow_ExecNode_Join(SEXP input_sexp, SEXP type_sexp, SEXP right_data_sexp, SEXP left_keys_sexp, SEXP right_keys_sexp, SEXP left_output_sexp, SEXP right_output_sexp){
 BEGIN_CPP11
@@ -1728,6 +1728,22 @@ END_CPP11
 #else
 extern "C" SEXP _arrow_ExecNode_ReadFromRecordBatchReader(SEXP plan_sexp, SEXP reader_sexp){
 	Rf_error("Cannot call ExecNode_ReadFromRecordBatchReader(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// compute-exec.cpp
+#if defined(ARROW_R_WITH_ARROW)
+std::shared_ptr<compute::ExecNode> ExecNode_TableSourceNode(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<arrow::Table>& table);
+extern "C" SEXP _arrow_ExecNode_TableSourceNode(SEXP plan_sexp, SEXP table_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<compute::ExecPlan>&>::type plan(plan_sexp);
+	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
+	return cpp11::as_sexp(ExecNode_TableSourceNode(plan, table));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_ExecNode_TableSourceNode(SEXP plan_sexp, SEXP table_sexp){
+	Rf_error("Cannot call ExecNode_TableSourceNode(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
@@ -7523,32 +7539,6 @@ extern "C" SEXP _arrow_Array__infer_type(SEXP x_sexp){
 }
 #endif
 
-#if defined(ARROW_R_WITH_ARROW)
-extern "C" SEXP _arrow_Table__Reset(SEXP r6) {
-BEGIN_CPP11
-arrow::r::r6_reset_pointer<arrow::Table>(r6);
-END_CPP11
-return R_NilValue;
-}
-#else
-extern "C" SEXP _arrow_Table__Reset(SEXP r6){
-	Rf_error("Cannot call Table(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
-#if defined(ARROW_R_WITH_ARROW)
-extern "C" SEXP _arrow_RecordBatch__Reset(SEXP r6) {
-BEGIN_CPP11
-arrow::r::r6_reset_pointer<arrow::RecordBatch>(r6);
-END_CPP11
-return R_NilValue;
-}
-#else
-extern "C" SEXP _arrow_RecordBatch__Reset(SEXP r6){
-	Rf_error("Cannot call RecordBatch(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
 extern "C" SEXP _arrow_available() {
 return Rf_ScalarLogical(
 #if defined(ARROW_R_WITH_ARROW)
@@ -7595,11 +7585,11 @@ return Rf_ScalarLogical(
 );
 }
 static const R_CallMethodDef CallEntries[] = {
-		{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
-		{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
-		{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
-		{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
-		{ "_json_available", (DL_FUNC)& _json_available, 0 },
+{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
+{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
+{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
+{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
+{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
 		{ "_arrow_is_arrow_altrep", (DL_FUNC) &_arrow_is_arrow_altrep, 1}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 
@@ -7710,6 +7700,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ExecNode_Aggregate", (DL_FUNC) &_arrow_ExecNode_Aggregate, 5}, 
 		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 7}, 
 		{ "_arrow_ExecNode_ReadFromRecordBatchReader", (DL_FUNC) &_arrow_ExecNode_ReadFromRecordBatchReader, 2}, 
+		{ "_arrow_ExecNode_TableSourceNode", (DL_FUNC) &_arrow_ExecNode_TableSourceNode, 2}, 
 		{ "_arrow_RecordBatch__cast", (DL_FUNC) &_arrow_RecordBatch__cast, 3}, 
 		{ "_arrow_Table__cast", (DL_FUNC) &_arrow_Table__cast, 3}, 
 		{ "_arrow_compute__CallFunction", (DL_FUNC) &_arrow_compute__CallFunction, 3}, 
@@ -8078,8 +8069,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_GetIOThreadPoolCapacity", (DL_FUNC) &_arrow_GetIOThreadPoolCapacity, 0}, 
 		{ "_arrow_SetIOThreadPoolCapacity", (DL_FUNC) &_arrow_SetIOThreadPoolCapacity, 1}, 
 		{ "_arrow_Array__infer_type", (DL_FUNC) &_arrow_Array__infer_type, 1}, 
-		{ "_arrow_Table__Reset", (DL_FUNC) &_arrow_Table__Reset, 1}, 
-		{ "_arrow_RecordBatch__Reset", (DL_FUNC) &_arrow_RecordBatch__Reset, 1}, 
 		{NULL, NULL, 0}
 };
 extern "C" void R_init_arrow(DllInfo* dll){

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -281,14 +281,11 @@ std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(
 std::shared_ptr<compute::ExecNode> ExecNode_TableSourceNode(
     const std::shared_ptr<compute::ExecPlan>& plan,
     const std::shared_ptr<arrow::Table>& table) {
-  arrow::compute::TableSourceNodeOptions options{
-      /*table=*/table,
-      // TODO: make batch_size configurable
-      /*batch_size=*/1048576
-      };
+  arrow::compute::TableSourceNodeOptions options{/*table=*/table,
+                                                 // TODO: make batch_size configurable
+                                                 /*batch_size=*/1048576};
 
   return MakeExecNodeOrStop("table_source", plan.get(), {}, options);
 }
-
 
 #endif

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
 }
 
 // [[arrow::export]]
-std::shared_ptr<compute::ExecNode> ExecNode_ReadFromRecordBatchReader(
+std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(
     const std::shared_ptr<compute::ExecPlan>& plan,
     const std::shared_ptr<arrow::RecordBatchReader>& reader) {
   arrow::compute::SourceNodeOptions options{

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -113,16 +113,16 @@ void ExecPlan_StopProducing(const std::shared_ptr<compute::ExecPlan>& plan) {
   plan->StopProducing();
 }
 
-#if defined(ARROW_R_WITH_DATASET)
-
-#include <arrow/dataset/plan.h>
-#include <arrow/dataset/scanner.h>
-
-// [[dataset::export]]
+// [[arrow::export]]
 std::shared_ptr<arrow::Schema> ExecNode_output_schema(
     const std::shared_ptr<compute::ExecNode>& node) {
   return node->output_schema();
 }
+
+#if defined(ARROW_R_WITH_DATASET)
+
+#include <arrow/dataset/plan.h>
+#include <arrow/dataset/scanner.h>
 
 // [[dataset::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Scan(
@@ -159,7 +159,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Scan(
 
 #endif
 
-// [[dataset::export]]
+// [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Filter(
     const std::shared_ptr<compute::ExecNode>& input,
     const std::shared_ptr<compute::Expression>& filter) {
@@ -167,7 +167,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Filter(
                             compute::FilterNodeOptions{*filter});
 }
 
-// [[dataset::export]]
+// [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Project(
     const std::shared_ptr<compute::ExecNode>& input,
     const std::vector<std::shared_ptr<compute::Expression>>& exprs,
@@ -182,7 +182,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Project(
       compute::ProjectNodeOptions{std::move(expressions), std::move(names)});
 }
 
-// [[dataset::export]]
+// [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(
     const std::shared_ptr<compute::ExecNode>& input, cpp11::list options,
     std::vector<std::string> target_names, std::vector<std::string> out_field_names,
@@ -212,7 +212,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(
                                     std::move(out_field_names), std::move(keys)});
 }
 
-// [[dataset::export]]
+// [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Join(
     const std::shared_ptr<compute::ExecNode>& input, int type,
     const std::shared_ptr<compute::ExecNode>& right_data,
@@ -276,5 +276,19 @@ std::shared_ptr<compute::ExecNode> ExecNode_ReadFromRecordBatchReader(
 
   return MakeExecNodeOrStop("source", plan.get(), {}, options);
 }
+
+// [[arrow::export]]
+std::shared_ptr<compute::ExecNode> ExecNode_TableSourceNode(
+    const std::shared_ptr<compute::ExecPlan>& plan,
+    const std::shared_ptr<arrow::Table>& table) {
+  arrow::compute::TableSourceNodeOptions options{
+      /*table=*/table,
+      // TODO: make batch_size configurable
+      /*batch_size=*/1048576
+      };
+
+  return MakeExecNodeOrStop("table_source", plan.get(), {}, options);
+}
+
 
 #endif

--- a/r/src/recordbatchreader.cpp
+++ b/r/src/recordbatchreader.cpp
@@ -51,6 +51,20 @@ std::shared_ptr<arrow::Table> Table__from_RecordBatchReader(
   return table;
 }
 
+// [[arrow::export]]
+std::shared_ptr<arrow::Table> RecordBatchReader__Head(
+    const std::shared_ptr<arrow::RecordBatchReader>& reader, int64_t num_rows) {
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+  std::shared_ptr<arrow::RecordBatch> this_batch;
+  while (num_rows > 0) {
+    this_batch = ValueOrStop(reader->Next());
+    if (this_batch == nullptr) break;
+    batches.push_back(this_batch->Slice(0, num_rows));
+    num_rows -= this_batch->num_rows();
+  }
+  return ValueOrStop(arrow::Table::FromRecordBatches(reader->schema(), batches));
+}
+
 // -------- RecordBatchStreamReader
 
 // [[arrow::export]]

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -281,8 +281,8 @@ test_that("compute()/collect(as_data_frame=FALSE)", {
   # the group_by() prevents compute() from returning a Table...
   expect_s3_class(tab5, "arrow_dplyr_query")
 
-  # ... but $.data is a Table (InMemoryDataset)...
-  expect_r6_class(tab5$.data, "InMemoryDataset")
+  # ... but $.data is a Table...
+  expect_r6_class(tab5$.data, "Table")
   # ... and the mutate() was evaluated
   expect_true("negint" %in% names(tab5$.data))
 })

--- a/r/tests/testthat/test-dplyr-arrange.R
+++ b/r/tests/testthat/test-dplyr-arrange.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -30,9 +30,10 @@ tbl$verses <- verses[[1]]
 tbl$padded_strings <- stringr::str_pad(letters[1:10], width = 2 * (1:10) + 1, side = "both")
 tbl$some_grouping <- rep(c(1, 2), 5)
 
-tab <- Table$create(tbl)
 
 test_that("implicit_schema with select", {
+  tab <- Table$create(tbl)
+
   expect_equal(
     tab %>%
       select(int, lgl) %>%

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -161,7 +161,7 @@ test_that("Properties of collapsed query", {
 
   expect_output(
     print(q),
-    "InMemoryDataset (query)
+    "Table (query)
 lgl: bool
 total: int32
 extra: double (multiply_checked(total, 5))
@@ -171,7 +171,7 @@ See $.data for the source Arrow object",
   )
   expect_output(
     print(q$.data),
-    "InMemoryDataset (query)
+    "Table (query)
 int: int32
 lgl: bool
 

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 withr::local_options(list(arrow.summarise.sort = TRUE))
 
@@ -215,6 +215,8 @@ test_that("query_on_dataset handles collapse()", {
       collapse() %>%
       select(int)
   ))
+
+  skip_if_not_available("dataset")
 
   ds_dir <- tempfile()
   dir.create(ds_dir)

--- a/r/tests/testthat/test-dplyr-count.R
+++ b/r/tests/testthat/test-dplyr-count.R
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 

--- a/r/tests/testthat/test-dplyr-distinct.R
+++ b/r/tests/testthat/test-dplyr-distinct.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(lubridate, warn.conflicts = FALSE)
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 skip_if_not_available("utf8proc")
 
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 
@@ -257,6 +257,7 @@ test_that("arrow dplyr query can join with tibble", {
   # By default, snappy encoding will be used, and
   # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
   skip_on_linux_devel()
+  skip_if_not_available("dataset")
 
   dir_out <- tempdir()
   write_dataset(iris, file.path(dir_out, "iris"))

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -22,14 +22,11 @@ library(dplyr, warn.conflicts = FALSE)
 left <- example_data
 left$some_grouping <- rep(c(1, 2), 5)
 
-left_tab <- Table$create(left)
-
 to_join <- tibble::tibble(
   some_grouping = c(1, 2),
   capital_letters = c("A", "B"),
   another_column = TRUE
 )
-to_join_tab <- Table$create(to_join)
 
 
 test_that("left_join", {
@@ -76,8 +73,8 @@ test_that("left_join `by` args", {
 
 test_that("join two tables", {
   expect_identical(
-    left_tab %>%
-      left_join(to_join_tab, by = "some_grouping") %>%
+    arrow_table(left) %>%
+      left_join(arrow_table(to_join), by = "some_grouping") %>%
       collect(),
     left %>%
       left_join(to_join, by = "some_grouping") %>%
@@ -87,7 +84,7 @@ test_that("join two tables", {
 
 test_that("Error handling", {
   expect_error(
-    left_tab %>%
+    arrow_table(left) %>%
       left_join(to_join, by = "not_a_col") %>%
       collect(),
     "Join columns must be present in data"
@@ -207,7 +204,8 @@ test_that("arrow dplyr query correctly mutates then joins", {
   expect_equal(
     left %>%
       rename(dos = two) %>%
-      mutate(one = toupper(one)) %>%
+      # Use the ASCII version so we don't need utf8proc for this test
+      mutate(one = arrow_ascii_upper(one)) %>%
       left_join(
         right %>%
           mutate(three = !three)

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -432,7 +432,7 @@ test_that("print a mutated table", {
       select(int) %>%
       mutate(twice = int * 2) %>%
       print(),
-    "InMemoryDataset (query)
+    "Table (query)
 int: int32
 twice: double (multiply_checked(int, 2))
 

--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)

--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -60,7 +60,7 @@ test_that("Print method", {
       filter(int < 5) %>%
       select(int, chr) %>%
       print(),
-    'InMemoryDataset (query)
+    'RecordBatch (query)
 int: int32
 chr: string
 

--- a/r/tests/testthat/test-dplyr-select.R
+++ b/r/tests/testthat/test-dplyr-select.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
@@ -25,8 +25,7 @@ tbl <- example_data
 test_that("Empty select returns no columns", {
   compare_dplyr_binding(
     .input %>% select() %>% collect(),
-    tbl,
-    skip_table = "Table with 0 cols doesn't know how many rows it should have"
+    tbl
   )
 })
 test_that("Empty select still includes the group_by columns", {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not_available("dataset")
+skip_if(on_old_windows())
 
 withr::local_options(list(arrow.summarise.sort = TRUE))
 
@@ -721,7 +721,6 @@ test_that("Expressions on aggregations", {
       "Aggregate within aggregate expression",
       "any\\(any\\(!lgl\\)\\) not supported in Arrow"
     )
-
   )
   expect_warning(
     record_batch(tbl) %>% summarise(!any(any(lgl))),
@@ -954,7 +953,7 @@ test_that("summarise() can handle scalars and literal values", {
   )
 
   compare_dplyr_binding(
-    .input %>% summarise(y = !! some_scalar_value) %>% collect(),
+    .input %>% summarise(y = !!some_scalar_value) %>% collect(),
     tbl
   )
 
@@ -979,7 +978,7 @@ test_that("summarise() can handle scalars and literal values", {
   )
 
   expect_identical(
-    record_batch(tbl) %>% summarise(y = !! some_scalar_value) %>% collect(),
+    record_batch(tbl) %>% summarise(y = !!some_scalar_value) %>% collect(),
     tibble(y = 2L)
   )
 })

--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -111,7 +111,8 @@ test_that("Field roundtrip", {
 })
 
 test_that("RecordBatchReader to python", {
-  library(dplyr)
+  skip_if_not_available("dataset")
+  library(dplyr, warn.conflicts = FALSE)
 
   tab <- Table$create(example_data)
   scan <- tab %>%
@@ -134,6 +135,8 @@ test_that("RecordBatchReader to python", {
 })
 
 test_that("RecordBatchReader from python", {
+  skip_if_not_available("dataset")
+
   tab <- Table$create(example_data)
   scan <- Scanner$create(tab)
   reader <- scan$ToRecordBatchReader()

--- a/r/tests/testthat/test-record-batch-reader.R
+++ b/r/tests/testthat/test-record-batch-reader.R
@@ -139,3 +139,21 @@ test_that("reader with 0 batches", {
   expect_r6_class(tab, "Table")
   expect_identical(dim(tab), c(0L, 1L))
 })
+
+test_that("reader head method edge cases", {
+  batch <- record_batch(
+    x = 1:10,
+    y = letters[1:10]
+  )
+  sink <- BufferOutputStream$create()
+  writer <- RecordBatchStreamWriter$create(sink, batch$schema)
+  writer$write(batch)
+  writer$write(batch)
+  writer$close()
+  buf <- sink$finish()
+
+  reader <- RecordBatchStreamReader$create(buf)
+  expect_error(head(reader, -1)) # Not (yet) supported
+  expect_equal(head(reader, 0), Table$create(x = integer(0), y = character(0)))
+  expect_equal(head(reader, 100), Table$create(batch, batch))
+})


### PR DESCRIPTION
This allows us to use the query engine without `ARROW_DATASET=ON`, and it's nice to just keep around the object that was provided instead of transforming it, which makes printing query objects a little more intuitive. There may be other optimizations or cleanups we could do as well.

Other changes: added head/tail methods for RecordBatchReader and fixed an edge case (`head(x, 0)` works but was previously rejected as invalid input).