### PR TITLE
ARROW-13168: [C++][R] Enable runtime timezone database for Windows

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -239,6 +239,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Download Timezone Database
+        shell: bash
+        run: ci/scripts/download_tz_database.sh
       - name: Build
         shell: bash
         run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
@@ -319,6 +322,9 @@ jobs:
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
           ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
+      - name: Download Timezone Database
+        shell: bash
+        run: ci/scripts/download_tz_database.sh
       - name: Download MinIO
         shell: msys2 {0}
         run: |

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -121,9 +121,10 @@ if "%ARROW_S3%" == "ON" (
 @rem Download IANA Timezone Database for unit tests
 @rem
 @rem (Doc section: Download timezone database)
-curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output %USERPROFILE%\Downloads\tzdata2021e.tar.gz
-mkdir %USERPROFILE%\Downloads\tzdata
-tar --extract --file %USERPROFILE%\Downloads\tzdata2021e.tar.gz --directory %USERPROFILE%\Downloads\tzdata
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
+mkdir tzdata
+tar --extract --file tzdata.tar.gz --directory tzdata
+move tzdata %USERPROFILE%\Downloads\tzdata
 @rem Also need Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\tzdata\windowsZones.xml

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -120,9 +120,11 @@ if "%ARROW_S3%" == "ON" (
 @rem
 @rem Download IANA Timezone Database for unit tests
 @rem
+@rem (Doc section: Download timezone database)
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output %USERPROFILE%\Downloads\tzdata2021e.tar.gz
 mkdir %USERPROFILE%\Downloads\tzdata
 tar --extract --file %USERPROFILE%\Downloads\tzdata2021e.tar.gz --directory %USERPROFILE%\Downloads\tzdata
 @rem Also need Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\tzdata\windowsZones.xml
+@rem (Doc section: Download timezone database)

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -115,3 +115,14 @@ powershell.exe -Command "Start-Process clcache-server" || exit /B
 if "%ARROW_S3%" == "ON" (
     appveyor DownloadFile https://dl.min.io/server/minio/release/windows-amd64/minio.exe -FileName C:\Windows\Minio.exe || exit /B
 )
+
+
+@rem
+@rem Download IANA Timezone Database for unit tests
+@rem
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output %USERPROFILE%\Downloads\tzdata2021e.tar.gz
+mkdir %USERPROFILE%\Downloads\tzdata
+tar --extract --file %USERPROFILE%\Downloads\tzdata2021e.tar.gz --directory %USERPROFILE%\Downloads\tzdata
+@rem Also need Windows timezone mapping
+curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
+  --output %USERPROFILE%\Downloads\tzdata\windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+# Download database
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output ~/Downloads/tzdata2021e.tar.gz
+
+# Extract
+mkdir -p ~/Downloads/tzdata
+tar --extract --file ~/Downloads/tzdata2021e.tar.gz --directory ~/Downloads/tzdata
+
+# Download windows
+curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -26,5 +26,5 @@ curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output ~/Dow
 mkdir -p ~/Downloads/tzdata
 tar --extract --file ~/Downloads/tzdata2021e.tar.gz --directory ~/Downloads/tzdata
 
-# Download windows
+# Download Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -150,12 +150,6 @@ struct TemporalToStringCastFunctor<O, TimestampType> {
             return Status::OK();
           }));
     } else {
-#ifdef _WIN32
-      // TODO(ARROW-13168):
-      return Status::NotImplemented(
-          "Casting a timestamp with time zone to string is not yet supported on "
-          "Windows.");
-#else
       switch (ty.unit()) {
         case TimeUnit::SECOND:
           RETURN_NOT_OK(ConvertZoned<std::chrono::seconds>(input, timezone, &builder));
@@ -176,7 +170,6 @@ struct TemporalToStringCastFunctor<O, TimestampType> {
           DCHECK(false);
           return Status::NotImplemented("Unimplemented time unit");
       }
-#endif
     }
     std::shared_ptr<Array> output_array;
     RETURN_NOT_OK(builder.Finish(&output_array));

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1182,11 +1182,6 @@ TEST(Cast, TimestampToDate) {
 }
 
 TEST(Cast, ZonedTimestampToDate) {
-#ifdef _WIN32
-  // TODO(ARROW-13168): we lack tzdb on Windows
-  GTEST_SKIP() << "ARROW-13168: no access to timezone database on Windows";
-#endif
-
   {
     // See TestZoned in scalar_temporal_test.cc
     auto timestamps =
@@ -1378,11 +1373,6 @@ TEST(Cast, TimestampToTime) {
 }
 
 TEST(Cast, ZonedTimestampToTime) {
-#ifdef _WIN32
-  // TODO(ARROW-13168): we lack tzdb on Windows
-  GTEST_SKIP() << "ARROW-13168: no access to timezone database on Windows";
-#endif
-
   CheckCast(ArrayFromJSON(timestamp(TimeUnit::NANO, "Pacific/Marquesas"), kTimestampJson),
             ArrayFromJSON(time64(TimeUnit::NANO), R"([
           52259123456789, 50003999999999, 56480001001001, 65000000000000,
@@ -1573,7 +1563,6 @@ TEST(Cast, TimestampToString) {
   }
 }
 
-#ifndef _WIN32
 TEST(Cast, TimestampWithZoneToString) {
   for (auto string_type : {utf8(), large_utf8()}) {
     CheckCast(
@@ -1608,21 +1597,6 @@ TEST(Cast, TimestampWithZoneToString) {
             R"(["1968-11-30 13:30:44.123456789-0700", "2016-02-29 10:42:23.456789246-0700"])"));
   }
 }
-#else
-// TODO(ARROW-13168): we lack tzdb on Windows
-TEST(Cast, TimestampWithZoneToString) {
-  for (auto string_type : {utf8(), large_utf8()}) {
-    ASSERT_RAISES(NotImplemented, Cast(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"),
-                                                     "[-34226955, 1456767743]"),
-                                       CastOptions::Safe(string_type)));
-
-    ASSERT_RAISES(NotImplemented,
-                  Cast(ArrayFromJSON(timestamp(TimeUnit::SECOND, "America/Phoenix"),
-                                     "[-34226955, 1456767743]"),
-                       CastOptions::Safe(string_type)));
-  }
-}
-#endif
 
 TEST(Cast, DateToDate) {
   auto day_32 = ArrayFromJSON(date32(), "[0, null, 100, 1, 10]");

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
+#include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
@@ -407,6 +408,14 @@ class ScalarTemporalTest : public ::testing::Test {
   RoundTemporalOptions round_to_15_quarters =
       RoundTemporalOptions(15, CalendarUnit::QUARTER);
   RoundTemporalOptions round_to_15_years = RoundTemporalOptions(15, CalendarUnit::YEAR);
+
+ protected:
+  void SetUp() override {
+#ifdef _WIN32
+    // Initialize timezone database on Windows
+    ASSERT_OK(InitTestTimezoneDatabase());
+#endif
+  }
 };
 
 TEST_F(ScalarTemporalTest, TestTemporalComponentExtractionAllTemporalTypes) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1887,13 +1887,17 @@ TEST_F(ScalarTemporalTest, PlatformLocale) {
   if (!LocaleExists("fr_FR.UTF-8")) {
     GTEST_SKIP() << "locale 'fr_FR.UTF-8' doesn't exist on this system";
   }
-  auto locale = std::locale("fr_FR.UTF-8");
-  std::stringstream ss;
-  ss.imbue(locale);
-  auto dt = ScalarFromJSON(timestamp(TimeUnit::MILLI, "UTC"), "2021-08-18T15:11:50.456");
-  ss << dt;
-  auto result = ss.str();
-  EXPECT_EQ(result, "01 janvier 1970 00:00:59,123");
+  using namespace std::chrono;
+  using namespace arrow_vendored::date;
+  zoned_time<std::chrono::seconds> d{"America/New_York", local_days{August/18/2021}};
+  auto locale_str = "fr_FR.UTF-8";
+  std::locale loc(locale_str);
+  std::ostringstream oss;
+  oss.imbue(loc);
+  oss << format("%d %B %Y", d);
+  oss.clear();
+  const auto s = oss.str();
+  EXPECT_EQ(s, "18 août 2021");
 }
 
 TEST_F(ScalarTemporalTest, StrftimeInvalidLocale) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1870,6 +1870,9 @@ TEST_F(ScalarTemporalTest, StrftimeCLocale) {
 }
 
 TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
+#ifdef WIN32
+  GTEST_SKIP() << "There is a known bug in strftime for locales on Windows (ARROW-15922)";
+#endif
   if (!LocaleExists("fr_FR.UTF-8")) {
     GTEST_SKIP() << "locale 'fr_FR.UTF-8' doesn't exist on this system";
   }
@@ -1881,23 +1884,6 @@ TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
       ["01 janvier 1970 00:00:59,123", "18 août 2021 15:11:50,456", null])";
   CheckScalarUnary("strftime", timestamp(TimeUnit::MILLI, "UTC"), milliseconds, utf8(),
                    expected, &options);
-}
-
-TEST_F(ScalarTemporalTest, PlatformLocale) {
-  if (!LocaleExists("fr_FR.UTF-8")) {
-    GTEST_SKIP() << "locale 'fr_FR.UTF-8' doesn't exist on this system";
-  }
-  using namespace std::chrono;
-  using namespace arrow_vendored::date;
-  zoned_time<std::chrono::seconds> d{"America/New_York", local_days{August / 18 / 2021}};
-  auto locale_str = "fr_FR.UTF-8";
-  std::locale loc(locale_str);
-  std::ostringstream oss;
-  oss.imbue(loc);
-  to_stream(oss, "%d %B %Y", d);
-  oss.clear();
-  const auto s = oss.str();
-  EXPECT_EQ(s, "18 août 2021");
 }
 
 TEST_F(ScalarTemporalTest, StrftimeInvalidLocale) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -564,8 +564,6 @@ TEST_F(ScalarTemporalTest, TestOutsideNanosecondRange) {
   CheckScalarUnary("subsecond", unit, times, float64(), subsecond);
 }
 
-#ifndef _WIN32
-// TODO: We should test on windows once ARROW-13168 is resolved.
 TEST_F(ScalarTemporalTest, TestIsLeapYear) {
   auto is_leap_year_marquesas =
       "[false, true, false, false, false, false, false, false, false, false, false, "
@@ -792,7 +790,6 @@ TEST_F(ScalarTemporalTest, TestNonexistentTimezone) {
     ASSERT_RAISES(Invalid, Subsecond(timestamp_array));
   }
 }
-#endif
 
 TEST_F(ScalarTemporalTest, Week) {
   auto unit = timestamp(TimeUnit::NANO);
@@ -1607,8 +1604,6 @@ TEST_F(ScalarTemporalTest, TestTemporalDifferenceErrors) {
       CallFunction("weeks_between", {arr1, arr1}, &options));
 }
 
-// TODO: We should test on windows once ARROW-13168 is resolved.
-#ifndef _WIN32
 TEST_F(ScalarTemporalTest, TestAssumeTimezone) {
   std::string timezone_utc = "UTC";
   std::string timezone_kolkata = "Asia/Kolkata";
@@ -2579,7 +2574,6 @@ TEST_F(ScalarTemporalTest, TestCeilFloorRoundTemporalKolkata) {
   CheckScalarUnary("round_temporal", unit, times, unit, round_1_hours, &round_to_1_hours);
   CheckScalarUnary("round_temporal", unit, times, unit, round_2_hours, &round_to_2_hours);
 }
-#endif  // !_WIN32
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1883,6 +1883,19 @@ TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
                    expected, &options);
 }
 
+TEST_F(ScalarTemporalTest, PlatformLocale) {
+  if (!LocaleExists("fr_FR.UTF-8")) {
+    GTEST_SKIP() << "locale 'fr_FR.UTF-8' doesn't exist on this system";
+  }
+  auto locale = std::locale("fr_FR.UTF-8");
+  std::stringstream ss;
+  ss.imbue(locale);
+  auto dt = ScalarFromJSON(timestamp(TimeUnit::MILLI, "UTC"), "2021-08-18T15:11:50.456");
+  ss << dt;
+  auto result = ss.str();
+  EXPECT_EQ(result, "01 janvier 1970 00:00:59,123");
+}
+
 TEST_F(ScalarTemporalTest, StrftimeInvalidLocale) {
   auto options = StrftimeOptions("%d %B %Y %H:%M:%S", "non-existent");
   const char* seconds = R"(["1970-01-01T00:00:59", null])";

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1889,12 +1889,12 @@ TEST_F(ScalarTemporalTest, PlatformLocale) {
   }
   using namespace std::chrono;
   using namespace arrow_vendored::date;
-  zoned_time<std::chrono::seconds> d{"America/New_York", local_days{August/18/2021}};
+  zoned_time<std::chrono::seconds> d{"America/New_York", local_days{August / 18 / 2021}};
   auto locale_str = "fr_FR.UTF-8";
   std::locale loc(locale_str);
   std::ostringstream oss;
   oss.imbue(loc);
-  oss << format("%d %B %Y", d);
+  to_stream(oss, "%d %B %Y", d);
   oss.clear();
   const auto s = oss.str();
   EXPECT_EQ(s, "18 août 2021");

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1872,7 +1872,7 @@ TEST_F(ScalarTemporalTest, StrftimeCLocale) {
 TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
 #ifdef WIN32
   GTEST_SKIP() << "There is a known bug in strftime for locales on Windows (ARROW-15922)";
-#endif
+#else
   if (!LocaleExists("fr_FR.UTF-8")) {
     GTEST_SKIP() << "locale 'fr_FR.UTF-8' doesn't exist on this system";
   }
@@ -1884,6 +1884,7 @@ TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
       ["01 janvier 1970 00:00:59,123", "18 août 2021 15:11:50,456", null])";
   CheckScalarUnary("strftime", timestamp(TimeUnit::MILLI, "UTC"), milliseconds, utf8(),
                    expected, &options);
+#endif
 }
 
 TEST_F(ScalarTemporalTest, StrftimeInvalidLocale) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1870,7 +1870,7 @@ TEST_F(ScalarTemporalTest, StrftimeCLocale) {
 }
 
 TEST_F(ScalarTemporalTest, StrftimeOtherLocale) {
-#ifdef WIN32
+#ifdef _WIN32
   GTEST_SKIP() << "There is a known bug in strftime for locales on Windows (ARROW-15922)";
 #else
   if (!LocaleExists("fr_FR.UTF-8")) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -1046,7 +1046,6 @@ struct RoundTemporal {
 // ----------------------------------------------------------------------
 // Convert timestamps to a string representation with an arbitrary format
 
-#ifndef _WIN32
 Result<std::locale> GetLocale(const std::string& locale) {
   try {
     return std::locale(locale.c_str());
@@ -1130,18 +1129,6 @@ struct Strftime {
     return Status::OK();
   }
 };
-#else
-// TODO(ARROW-13168)
-template <typename Duration, typename InType>
-struct Strftime {
-  static Status Call(KernelContext* ctx, const Scalar& in, Scalar* out) {
-    return Status::NotImplemented("Strftime not yet implemented on windows.");
-  }
-  static Status Call(KernelContext* ctx, const ArrayData& in, ArrayData* out) {
-    return Status::NotImplemented("Strftime not yet implemented on windows.");
-  }
-};
-#endif
 
 // ----------------------------------------------------------------------
 // Convert timestamps from local timestamp without a timezone to timestamps with a

--- a/cpp/src/arrow/config.cc
+++ b/cpp/src/arrow/config.cc
@@ -77,16 +77,14 @@ RuntimeInfo GetRuntimeInfo() {
   return info;
 }
 
-Status Initialize(const ArrowGlobalOptions& options) {
+Status Initialize(const ArrowGlobalOptions& options) noexcept {
   if (options.tz_db_path != nullptr) {
     #if !USE_OS_TZDB
     try {
       arrow_vendored::date::set_install(*options.tz_db_path);
       arrow_vendored::date::reload_tzdb();
     } catch(const std::runtime_error& e) {
-      return Status::ExecutionError(e.msg);
-    } catch(const std::system_error& e) {
-      return Status::ExecutionError(e.msg);
+      return Status::ExecutionError(e.what());
     }
     #else
       return Status::Invalid("Arrow was set to use OS timezone database at compile time, so it cannot be set at runtime.");

--- a/cpp/src/arrow/config.cc
+++ b/cpp/src/arrow/config.cc
@@ -97,8 +97,8 @@ Status Initialize(const GlobalOptions& options) noexcept {
     timezone_db_path = options.timezone_db_path.value();
 #else
     return Status::Invalid(
-        "Arrow was set to use OS timezone database at compile time, so a downloaded database "
-        "cannot be provided at runtime.");
+        "Arrow was set to use OS timezone database at compile time, "
+        "so a downloaded database cannot be provided at runtime.");
 #endif  // !USE_OS_TZDB
   }
   return Status::OK();

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -88,7 +88,6 @@ RuntimeInfo GetRuntimeInfo();
 struct ArrowGlobalOptions {
   /// Path to text timezone database. This is only configurable on Windows,
   /// which does not have a compatible OS timezone database.
-<<<<<<< HEAD
   util::optional<std::string> tz_db_path;
 };
 
@@ -96,11 +95,5 @@ struct ArrowGlobalOptions {
 // TODO: We need to run this before C++ unit tests on Windows
 ARROW_EXPORT
 Status Initialize(const ArrowGlobalOptions& options) noexcept;
-== == == = std::string * tz_db_path;
-};
-
-ARROW_EXPORT
-Status Initialize(const ArrowGlobalOptions& options);
->>>>>>> 1f1750ae6 (First pass at R bindings)
 
 }  // namespace arrow

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -85,6 +85,6 @@ struct ArrowGlobalOptions {
 };
 
 ARROW_EXPORT
-Status Initialize(const ArrowGlobalOptions& options);
+Status Initialize(const ArrowGlobalOptions& options) noexcept;
 
 }  // namespace arrow

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -86,13 +86,13 @@ const BuildInfo& GetBuildInfo();
 ARROW_EXPORT
 RuntimeInfo GetRuntimeInfo();
 
-struct ArrowGlobalOptions {
+struct GlobalOptions {
   /// Path to text timezone database. This is only configurable on Windows,
   /// which does not have a compatible OS timezone database.
-  util::optional<std::string> tz_db_path;
+  util::optional<std::string> timezone_db_path;
 };
 
 ARROW_EXPORT
-Status Initialize(const ArrowGlobalOptions& options) noexcept;
+Status Initialize(const GlobalOptions& options) noexcept;
 
 }  // namespace arrow

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -88,6 +88,7 @@ RuntimeInfo GetRuntimeInfo();
 struct ArrowGlobalOptions {
   /// Path to text timezone database. This is only configurable on Windows,
   /// which does not have a compatible OS timezone database.
+<<<<<<< HEAD
   util::optional<std::string> tz_db_path;
 };
 
@@ -95,5 +96,11 @@ struct ArrowGlobalOptions {
 // TODO: We need to run this before C++ unit tests on Windows
 ARROW_EXPORT
 Status Initialize(const ArrowGlobalOptions& options) noexcept;
+== == == = std::string * tz_db_path;
+};
+
+ARROW_EXPORT
+Status Initialize(const ArrowGlobalOptions& options);
+>>>>>>> 1f1750ae6 (First pass at R bindings)
 
 }  // namespace arrow

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -66,9 +66,10 @@ struct RuntimeInfo {
   std::string detected_simd_level;
 
   /// Whether using the OS-based timezone database
+  /// This is set at compile-time.
   bool using_os_timezone_db;
 
-  /// The path to the timezone database; is None
+  /// The path to the timezone database; by default None.
   util::optional<std::string> timezone_db_path;
 };
 
@@ -91,8 +92,6 @@ struct ArrowGlobalOptions {
   util::optional<std::string> tz_db_path;
 };
 
-// TODO: We need to tell users to run this before using timezones on Windows
-// TODO: We need to run this before C++ unit tests on Windows
 ARROW_EXPORT
 Status Initialize(const ArrowGlobalOptions& options) noexcept;
 

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -19,8 +19,9 @@
 
 #include <string>
 
-#include "arrow/util/config.h"  // IWYU pragma: export
 #include "arrow/status.h"
+#include "arrow/util/config.h"  // IWYU pragma: export
+#include "arrow/util/optional.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -63,6 +64,12 @@ struct RuntimeInfo {
 
   /// The SIMD level available on the OS and CPU
   std::string detected_simd_level;
+
+  /// Whether using the OS-based timezone database
+  bool using_os_timezone_db;
+
+  /// The path to the timezone database; is None
+  util::optional<std::string> timezone_db_path;
 };
 
 /// \brief Get runtime build info.
@@ -81,9 +88,11 @@ RuntimeInfo GetRuntimeInfo();
 struct ArrowGlobalOptions {
   /// Path to text timezone database. This is only configurable on Windows,
   /// which does not have a compatible OS timezone database.
-  std::string* tz_db_path;
+  util::optional<std::string> tz_db_path;
 };
 
+// TODO: We need to tell users to run this before using timezones on Windows
+// TODO: We need to run this before C++ unit tests on Windows
 ARROW_EXPORT
 Status Initialize(const ArrowGlobalOptions& options) noexcept;
 

--- a/cpp/src/arrow/config.h
+++ b/cpp/src/arrow/config.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "arrow/util/config.h"  // IWYU pragma: export
+#include "arrow/status.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -76,5 +77,14 @@ const BuildInfo& GetBuildInfo();
 ///
 ARROW_EXPORT
 RuntimeInfo GetRuntimeInfo();
+
+struct ArrowGlobalOptions {
+  /// Path to text timezone database. This is only configurable on Windows,
+  /// which does not have a compatible OS timezone database.
+  std::string* tz_db_path;
+};
+
+ARROW_EXPORT
+Status Initialize(const ArrowGlobalOptions& options);
 
 }  // namespace arrow

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -105,16 +105,6 @@ TEST(Misc, BuildInfo) {
   ASSERT_THAT(info.full_so_version, ::testing::HasSubstr(info.so_version));
 }
 
-// class ConfigTest : public ::testing::Test {
-//  protected:
-//   void TearDown() override {
-//     // Reset global options to defaults
-//     arrow::GlobalOptions default_options;
-//     default_options.timezone_db_path = util::optional<std::string>();
-//     ASSERT_OK(arrow::Initialize(default_options));
-//   }
-// };
-
 TEST(Misc, SetTimezoneConfig) {
 #ifndef _WIN32
   GTEST_SKIP() << "Can only set the Timezone database on Windows";

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -85,6 +85,7 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include "arrow/testing/gtest_util.h"
 
 namespace arrow {
 
@@ -101,6 +102,29 @@ TEST(Misc, BuildInfo) {
   ss << info.version_major << "." << info.version_minor << "." << info.version_patch;
   ASSERT_THAT(info.version_string, ::testing::HasSubstr(ss.str()));
   ASSERT_THAT(info.full_so_version, ::testing::HasSubstr(info.so_version));
+}
+
+TEST(Misc, SetTimzoneConfig) {
+#ifndef _WIN32
+  GTEST_SKIP() << "Can only set the Timezone database on Windows";
+#else
+  // Create a tmp directory
+  ASSERT_OK_AND_ASSIGN(auto tempdir, arrow::internal::TemporaryDir::Make("tzdata"));
+
+  // Validate that setting tzdb to that dir fails
+  arrow::ArrowGlobalOptions options = {util::make_optional(tempdir->path().ToString())};
+  ASSERT_NOT_OK(arrow::Initialize(options));
+
+  // Copy tzdb data from ~/Downloads
+  auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+  auto selector = arrow::fs::FileSelector();
+  selector.base_dir = "~/Downloads/tzdata";
+  selector.recursive = true;
+  ASSERT_OK(arrow::fs::CopyFiles(fs, selector, fs, tempdir->path().ToString()));
+
+  // Validate that tzdb is working
+  ASSERT_OK(arrow::Initialize(options));
+#endif  // _WIN32
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -104,7 +104,17 @@ TEST(Misc, BuildInfo) {
   ASSERT_THAT(info.full_so_version, ::testing::HasSubstr(info.so_version));
 }
 
-TEST(Misc, SetTimzoneConfig) {
+class ConfigTest : public ::testing::Test {
+  protected:
+    void TearDown() override {
+      // Reset global options to defaults
+      arrow::GlobalOptions default_options;
+      default_options.timezone_db_path = util::optional<std::string>();
+      ASSERT_OK(arrow::Initialize(default_options));
+    }
+};
+
+TEST_F(ConfigTest, SetTimezoneConfig) {
 #ifndef _WIN32
   GTEST_SKIP() << "Can only set the Timezone database on Windows";
 #elif !defined(ARROW_FILESYSTEM)
@@ -124,7 +134,7 @@ TEST(Misc, SetTimzoneConfig) {
   ASSERT_OK_AND_ASSIGN(auto tempdir, arrow::internal::TemporaryDir::Make("tzdata"));
 
   // Validate that setting tzdb to that dir fails
-  arrow::ArrowGlobalOptions options = {util::make_optional(tempdir->path().ToString())};
+  arrow::GlobalOptions options = {util::make_optional(tempdir->path().ToString())};
   ASSERT_NOT_OK(arrow::Initialize(options));
 
   // Copy tzdb data from ~/Downloads

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -107,8 +107,7 @@ TEST(Misc, BuildInfo) {
 TEST(Misc, SetTimzoneConfig) {
 #ifndef _WIN32
   GTEST_SKIP() << "Can only set the Timezone database on Windows";
-#else
-#ifndef ARROW_FILESYSTEM
+#elif !defined(ARROW_FILESYSTEM)
   GTEST_SKIP() << "Need filesystem support to test timezone config.";
 #else
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -108,6 +108,9 @@ TEST(Misc, SetTimzoneConfig) {
 #ifndef _WIN32
   GTEST_SKIP() << "Can only set the Timezone database on Windows";
 #else
+#ifndef ARROW_FILESYSTEM
+  GTEST_SKIP() << "Need filesystem support to test timezone config.";
+#else
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
   auto home_raw = std::getenv("USERPROFILE");
   std::string home = home_raw == nullptr ? "~" : std::string(home_raw);
@@ -133,6 +136,7 @@ TEST(Misc, SetTimzoneConfig) {
 
   // Validate that tzdb is working
   ASSERT_OK(arrow::Initialize(options));
+#endif  // ARROW_FILESYSTEM
 #endif  // _WIN32
 }
 

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -123,10 +123,10 @@ TEST(Misc, SetTimezoneConfig) {
 #else
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
 
-  Result<std::string> tzdata_result = GetTestTimezoneDatabaseRoot();
+  util::optional<std::string> tzdata_result = GetTestTimezoneDatabaseRoot();
   std::string tzdata_dir;
-  if (tzdata_result.ok()) {
-    tzdata_dir = tzdata_result.ValueUnsafe();
+  if (tzdata_result.has_value()) {
+    tzdata_dir = tzdata_result.value();
   } else {
     auto home_raw = std::getenv("USERPROFILE");
     std::string home = home_raw == nullptr ? "~" : std::string(home_raw);
@@ -135,7 +135,6 @@ TEST(Misc, SetTimezoneConfig) {
   ASSERT_OK_AND_ASSIGN(tzdata_dir, fs->NormalizePath(tzdata_dir));
   ASSERT_OK_AND_ASSIGN(auto tzdata_path,
                        arrow::internal::PlatformFilename::FromString(tzdata_dir));
-  
 
   if (!arrow::internal::FileExists(tzdata_path).ValueOr(false)) {
     GTEST_SKIP() << "Couldn't find timezone database in expected dir: " << tzdata_dir;

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -112,7 +112,7 @@ Status GetTestResourceRoot(std::string* out) {
 util::optional<std::string> GetTestTimezoneDatabaseRoot() {
   const char* c_root = std::getenv("ARROW_TIMEZONE_DATABASE");
   if (!c_root) {
-    return util::make_optional<std::string>();
+    return util::optional<std::string>();
   }
   return util::make_optional(std::string(c_root));
 }

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -117,7 +117,6 @@ util::optional<std::string> GetTestTimezoneDatabaseRoot() {
   return util::make_optional(std::string(c_root));
 }
 
-// This is only relevant on Windows, since other OSs have compatible databases built-in
 Status InitTestTimezoneDatabase() {
   auto maybe_tzdata = GetTestTimezoneDatabaseRoot();
   // If missing, timezone database will default to %USERPROFILE%\Downloads\tzdata
@@ -125,7 +124,6 @@ Status InitTestTimezoneDatabase() {
 
   auto tzdata_path = std::string(maybe_tzdata.value());
   arrow::GlobalOptions options = {util::make_optional(tzdata_path)};
-  std::cout << "timezone db path set to: " << tzdata_path;  // TODO: remove
   ARROW_RETURN_NOT_OK(arrow::Initialize(options));
   return Status::OK();
 }

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -108,6 +108,15 @@ Status GetTestResourceRoot(std::string* out) {
   return Status::OK();
 }
 
+Result<std::string> GetTestTimezoneDatabaseRoot() {
+  const char* c_root = std::getenv("ARROW_TIMEZONE_DATABASE");
+  if (!c_root) {
+    return Status::IOError(
+        "Test resources not found, set ARROW_TIMEZONE_DATABASE");
+  }
+  return std::string(c_root);
+}
+
 int GetListenPort() {
   // Get a new available port number by binding a socket to an ephemeral port
   // and then closing it.  Since ephemeral port allocation tends to avoid

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -114,7 +114,8 @@ ARROW_TESTING_EXPORT Status GetTestResourceRoot(std::string*);
 // Return the value of the ARROW_TIMEZONE_DATABASE environment variable
 ARROW_TESTING_EXPORT util::optional<std::string> GetTestTimezoneDatabaseRoot();
 
-//
+// Set the Timezone database based on the ARROW_TIMEZONE_DATABASE env variable
+// This is only relevant on Windows, since other OSs have compatible databases built-in
 ARROW_TESTING_EXPORT Status InitTestTimezoneDatabase();
 
 // Get a TCP port number to listen on.  This is a different number every time,

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -34,6 +34,7 @@
 #include "arrow/testing/visibility.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/optional.h"
 
 namespace arrow {
 
@@ -110,9 +111,11 @@ UnionTypeFactories() {
 // Status
 ARROW_TESTING_EXPORT Status GetTestResourceRoot(std::string*);
 
-// Return the value of the ARROW_TIMEZONE_DATABASE environment variable or return error
-// Status
-ARROW_TESTING_EXPORT Result<std::string> GetTestTimezoneDatabaseRoot();
+// Return the value of the ARROW_TIMEZONE_DATABASE environment variable
+ARROW_TESTING_EXPORT util::optional<std::string> GetTestTimezoneDatabaseRoot();
+
+//
+ARROW_TESTING_EXPORT Status InitTestTimezoneDatabase();
 
 // Get a TCP port number to listen on.  This is a different number every time,
 // as reusing the same port across tests can produce spurious bind errors on

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -110,6 +110,10 @@ UnionTypeFactories() {
 // Status
 ARROW_TESTING_EXPORT Status GetTestResourceRoot(std::string*);
 
+// Return the value of the ARROW_TIMEZONE_DATABASE environment variable or return error
+// Status
+ARROW_TESTING_EXPORT Result<std::string> GetTestTimezoneDatabaseRoot();
+
 // Get a TCP port number to listen on.  This is a different number every time,
 // as reusing the same port across tests can produce spurious bind errors on
 // Windows.

--- a/docs/source/cpp/api/support.rst
+++ b/docs/source/cpp/api/support.rst
@@ -73,6 +73,16 @@ introduced API).
    ``"7.0.1"``.
 
 
+Runtime Configuration
+=====================
+
+.. doxygenstruct:: arrow::ArrowGlobalOptions
+   :members:
+
+
+.. doxygenfunction:: arrow::Initialize
+
+
 Error return and reporting
 ==========================
 

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -165,6 +165,8 @@ alternatively, use Arrow from a package manager such as Conda or vcpkg which
 will manage consistent versions of Arrow and its dependencies.
 
 
+.. _download-timezone-database:
+
 Runtime Dependencies
 ====================
 

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -163,3 +163,24 @@ can control the source of each dependency and whether it is statically or
 dynamically linked. See :doc:`/developers/cpp/building` for instructions. Or
 alternatively, use Arrow from a package manager such as Conda or vcpkg which
 will manage consistent versions of Arrow and its dependencies.
+
+
+Runtime Dependencies
+====================
+
+While Arrow uses the OS-provided timezone database on Linux and Mac OS, it
+requires a user-provided database on Windows. You must download and extract the
+text version of the IANA timezone database and add the Windows timezone mapping
+XML. To download, you can use the following batch script:
+
+.. literalinclude:: ../../../ci/appveyor-cpp-setup.bat
+   :language: cmd
+   :start-after: @rem (Doc section: Download timezone database)
+   :end-before: @rem (Doc section: Download timezone database)
+
+By default, the timezone database will be detected at ``%USERPROFILE%\Downloads\tzdata``,
+but you can set a custom path at runtime in :struct:`arrow::ArrowGlobalOptions`::
+
+   arrow::ArrowGlobalOptions options;
+   options.tz_db_path = "path/to/tzdata";
+   ARROW_RETURN_NOT_OK(arrow::Initialize(options));

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -168,7 +168,7 @@ will manage consistent versions of Arrow and its dependencies.
 Runtime Dependencies
 ====================
 
-While Arrow uses the OS-provided timezone database on Linux and Mac OS, it
+While Arrow uses the OS-provided timezone database on Linux and macOS, it
 requires a user-provided database on Windows. You must download and extract the
 text version of the IANA timezone database and add the Windows timezone mapping
 XML. To download, you can use the following batch script:

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -367,7 +367,9 @@ Downloading the Timezone Database
 
 To run some of the compute unit tests on Windows, the IANA timezone database
 and the Windows timezone mapping need to be downloaded first. See 
-:ref:`download-timezone-database`.
+:ref:`download-timezone-database` for download instructions. To set a non-default
+path for the timezone database while running the unit tests, set the 
+``ARROW_TIMEZONE_DATABASE`` environment variable.
 
 Replicating Appveyor Builds
 ===========================

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -362,6 +362,22 @@ suppress dllimport/dllexport marking of symbols. Projects that statically link
 against Arrow on Windows additionally need this definition. The Unix builds do
 not use the macro.
 
+Downloading the Timezone Database
+=================================
+
+To run some of the compute unit tests on Windows, the IANA timezone database
+and the Windows timezone mapping need to be downloaded first. To download
+them to the default search directory (in the user Downloads directory), use 
+the following section of the `ci/appveyor-setup.bat
+<https://github.com/apache/arrow/blob/master/ci/appveyor-cpp-setup.bat>`_
+script:
+
+.. literalinclude:: ../../../ci/appveyor-cpp-setup.bat
+   :language: cpp
+   :start-after: @rem (Doc section: Download timezone database)
+   :end-before: @rem (Doc section: Download timezone database)
+   :linenos:
+
 Replicating Appveyor Builds
 ===========================
 

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -366,16 +366,8 @@ Downloading the Timezone Database
 =================================
 
 To run some of the compute unit tests on Windows, the IANA timezone database
-and the Windows timezone mapping need to be downloaded first. To download
-them to the default search directory (in the user Downloads directory), use 
-the following section of the `ci/appveyor-setup.bat
-<https://github.com/apache/arrow/blob/master/ci/appveyor-cpp-setup.bat>`_
-script:
-
-.. literalinclude:: ../../../../ci/appveyor-cpp-setup.bat
-   :language: cmd
-   :start-after: @rem (Doc section: Download timezone database)
-   :end-before: @rem (Doc section: Download timezone database)
+and the Windows timezone mapping need to be downloaded first. See 
+:ref:`download-timezone-database`.
 
 Replicating Appveyor Builds
 ===========================

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -372,11 +372,10 @@ the following section of the `ci/appveyor-setup.bat
 <https://github.com/apache/arrow/blob/master/ci/appveyor-cpp-setup.bat>`_
 script:
 
-.. literalinclude:: ../../../ci/appveyor-cpp-setup.bat
-   :language: cpp
+.. literalinclude:: ../../../../ci/appveyor-cpp-setup.bat
+   :language: cmd
    :start-after: @rem (Doc section: Download timezone database)
    :end-before: @rem (Doc section: Download timezone database)
-   :linenos:
 
 Replicating Appveyor Builds
 ===========================

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -58,6 +58,7 @@ Suggests:
     stringr,
     testthat (>= 3.1.0),
     tibble,
+    tzdb,
     withr
 LinkingTo: cpp11 (>= 0.4.2)
 Collate:

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -69,7 +69,7 @@
     # Try to set timezone database
     if ("tzdb" %in% rownames(installed.packages())) {
       tzdb::tzdb_initialize()
-      set_timezone_database(tzdb::tzdb_path())
+      set_timezone_database(tzdb::tzdb_path("text"))
     } else {
       warning("tzdb not installed. Timezones will not be available.")
     }

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -67,7 +67,7 @@
     options(arrow.use_threads = FALSE)
 
     # Try to set timezone database
-    if ("tzdb" %in% rownames(installed.packages())) {
+    if (length(find.package("tzdb", quiet=TRUE))) {
       tzdb::tzdb_initialize()
       set_timezone_database(tzdb::tzdb_path("text"))
     } else {

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -71,7 +71,7 @@
       tzdb::tzdb_initialize()
       set_timezone_database(tzdb::tzdb_path("text"))
     } else {
-      warning("tzdb not installed. Timezones will not be available.")
+      warning("The tzdb package is not installed. Timezones will not be available.")
     }
   }
 

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -65,6 +65,14 @@
     # Disable multithreading on Windows
     # See https://issues.apache.org/jira/browse/ARROW-8379
     options(arrow.use_threads = FALSE)
+
+    # Try to set timezone database
+    if ("tzdb" %in% rownames(installed.packages())) {
+      tzdb::tzdb_initialize()
+      set_timezone_database(tzdb::tzdb_path())
+    } else {
+      warning("tzdb not installed. Timezones will not be available.")
+    }
   }
 
   invisible()

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -67,7 +67,7 @@
     options(arrow.use_threads = FALSE)
 
     # Try to set timezone database
-    if (length(find.package("tzdb", quiet=TRUE))) {
+    if (requireNamespace("tzdb", quietly = TRUE)) {
       tzdb::tzdb_initialize()
       set_timezone_database(tzdb::tzdb_path("text"))
     } else {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -468,6 +468,10 @@ runtime_info <- function() {
   .Call(`_arrow_runtime_info`)
 }
 
+set_timezone_database <- function(path) {
+  invisible(.Call(`_arrow_set_timezone_database`, path))
+}
+
 csv___WriteOptions__initialize <- function(options) {
   .Call(`_arrow_csv___WriteOptions__initialize`, options)
 }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+check_locale <- function(locale = Sys.getlocale("LC_TIME")) {
+  if (tolower(Sys.info()[["sysname"]]) == "windows" & locale != "C") {
+    # MingW C++ std::locale only supports "C" and "POSIX"
+    stop(paste0("On Windows, locales other than 'C' are not supported in Arrow. ",
+                "Consider setting `Sys.setlocale('LC_TIME', 'C')`"))
+  }
+  locale
+}
+
 register_bindings_datetime <- function() {
   register_binding("strptime", function(x, format = "%Y-%m-%d %H:%M:%S", tz = NULL,
                                             unit = "ms") {
@@ -48,7 +57,7 @@ register_bindings_datetime <- function() {
     } else {
       ts <- x
     }
-    Expression$create("strftime", ts, options = list(format = format, locale = Sys.getlocale("LC_TIME")))
+    Expression$create("strftime", ts, options = list(format = format, locale = check_locale()))
   })
 
   register_binding("format_ISO8601", function(x, usetz = FALSE, precision = NULL, ...) {
@@ -95,7 +104,7 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%A"
       }
-      return(Expression$create("strftime", x, options = list(format = format, locale = locale)))
+      return(Expression$create("strftime", x, options = list(format = format, locale = check_locale(locale))))
     }
 
     Expression$create("day_of_week", x, options = list(count_from_zero = FALSE, week_start = week_start))
@@ -133,7 +142,7 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-      return(build_expr("strftime", x, options = list(format = format, locale = locale)))
+      return(build_expr("strftime", x, options = list(format = format, locale = check_locale(locale))))
     }
 
     build_expr("month", x)

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-check_locale <- function(locale = Sys.getlocale("LC_TIME")) {
+check_time_locale <- function(locale = Sys.getlocale("LC_TIME")) {
   if (tolower(Sys.info()[["sysname"]]) == "windows" & locale != "C") {
     # MingW C++ std::locale only supports "C" and "POSIX"
-    stop(paste0("On Windows, locales other than 'C' are not supported in Arrow. ",
+    stop(paste0("On Windows, time locales other than 'C' are not supported in Arrow. ",
                 "Consider setting `Sys.setlocale('LC_TIME', 'C')`"))
   }
   locale
@@ -57,7 +57,7 @@ register_bindings_datetime <- function() {
     } else {
       ts <- x
     }
-    Expression$create("strftime", ts, options = list(format = format, locale = check_locale()))
+    Expression$create("strftime", ts, options = list(format = format, locale = check_time_locale()))
   })
 
   register_binding("format_ISO8601", function(x, usetz = FALSE, precision = NULL, ...) {
@@ -104,7 +104,7 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%A"
       }
-      return(Expression$create("strftime", x, options = list(format = format, locale = check_locale(locale))))
+      return(Expression$create("strftime", x, options = list(format = format, locale = check_time_locale(locale))))
     }
 
     Expression$create("day_of_week", x, options = list(count_from_zero = FALSE, week_start = week_start))
@@ -142,7 +142,8 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-      return(build_expr("strftime", x, options = list(format = format, locale = check_locale(locale))))
+<<<<<<< HEAD
+      return(build_expr("strftime", x, options = list(format = format, locale = check_time_locale(locale))))
     }
 
     build_expr("month", x)

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -142,7 +142,6 @@ register_bindings_datetime <- function() {
       } else {
         format <- "%B"
       }
-<<<<<<< HEAD
       return(build_expr("strftime", x, options = list(format = format, locale = check_time_locale(locale))))
     }
 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1840,6 +1840,22 @@ extern "C" SEXP _arrow_runtime_info(){
 }
 #endif
 
+// config.cpp
+#if defined(ARROW_R_WITH_ARROW)
+void set_timezone_database(std::string& path);
+extern "C" SEXP _arrow_set_timezone_database(SEXP path_sexp){
+BEGIN_CPP11
+	arrow::r::Input<std::string&>::type path(path_sexp);
+	set_timezone_database(path);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_set_timezone_database(SEXP path_sexp){
+	Rf_error("Cannot call set_timezone_database(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // csv.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::csv::WriteOptions> csv___WriteOptions__initialize(cpp11::list options);
@@ -7741,6 +7757,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_compute__GetFunctionNames", (DL_FUNC) &_arrow_compute__GetFunctionNames, 0}, 
 		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0}, 
 		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0}, 
+		{ "_arrow_set_timezone_database", (DL_FUNC) &_arrow_set_timezone_database, 1}, 
 		{ "_arrow_csv___WriteOptions__initialize", (DL_FUNC) &_arrow_csv___WriteOptions__initialize, 1}, 
 		{ "_arrow_csv___ReadOptions__initialize", (DL_FUNC) &_arrow_csv___ReadOptions__initialize, 1}, 
 		{ "_arrow_csv___ParseOptions__initialize", (DL_FUNC) &_arrow_csv___ParseOptions__initialize, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1842,10 +1842,10 @@ extern "C" SEXP _arrow_runtime_info(){
 
 // config.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void set_timezone_database(std::string& path);
+void set_timezone_database(cpp11::strings path);
 extern "C" SEXP _arrow_set_timezone_database(SEXP path_sexp){
 BEGIN_CPP11
-	arrow::r::Input<std::string&>::type path(path_sexp);
+	arrow::r::Input<cpp11::strings>::type path(path_sexp);
 	set_timezone_database(path);
 	return R_NilValue;
 END_CPP11
@@ -7635,11 +7635,11 @@ return Rf_ScalarLogical(
 );
 }
 static const R_CallMethodDef CallEntries[] = {
-{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
-{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
-{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
-{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
-{ "_json_available", (DL_FUNC)& _json_available, 0 },
+		{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
+		{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
+		{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
+		{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
+		{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
 		{ "_arrow_is_arrow_altrep", (DL_FUNC) &_arrow_is_arrow_altrep, 1}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -20,6 +20,7 @@
 #if defined(ARROW_R_WITH_ARROW)
 
 #include <arrow/config.h>
+#include <arrow/util/optional.h>
 
 // [[arrow::export]]
 std::vector<std::string> build_info() {
@@ -40,9 +41,9 @@ void set_timezone_database(cpp11::strings path) {
   if (path.size() != 1) {
     cpp11::stop("Must provide a single path to the timezone database.");
   }
-  
+
   arrow::ArrowGlobalOptions options;
-  options.tz_db_path = &paths[0];
+  options.tz_db_path = arrow::util::make_optional(paths[0]);
   arrow::StopIfNotOk(arrow::Initialize(options));
 }
 

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -35,10 +35,15 @@ std::vector<std::string> runtime_info() {
 }
 
 // [[arrow::export]]
-void set_timezone_database(std::string& path) {
-  ArrowGlobalOptions options;
-  options.tz_db_path = &path;
-  StopIfNotOk(arrow::Initialize(options))
+void set_timezone_database(cpp11::strings path) {
+  auto paths = cpp11::as_cpp<std::vector<std::string>>(path);
+  if (path.size() != 1) {
+    cpp11::stop("Must provide a single path to the timezone database.");
+  }
+  
+  arrow::ArrowGlobalOptions options;
+  options.tz_db_path = &paths[0];
+  arrow::StopIfNotOk(arrow::Initialize(options));
 }
 
 #endif

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -42,7 +42,7 @@ void set_timezone_database(cpp11::strings path) {
     cpp11::stop("Must provide a single path to the timezone database.");
   }
 
-  arrow::ArrowGlobalOptions options;
+  arrow::GlobalOptions options;
   options.timezone_db_path = arrow::util::make_optional(paths[0]);
   arrow::StopIfNotOk(arrow::Initialize(options));
 }

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -43,7 +43,7 @@ void set_timezone_database(cpp11::strings path) {
   }
 
   arrow::ArrowGlobalOptions options;
-  options.tz_db_path = arrow::util::make_optional(paths[0]);
+  options.timezone_db_path = arrow::util::make_optional(paths[0]);
   arrow::StopIfNotOk(arrow::Initialize(options));
 }
 

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -34,4 +34,11 @@ std::vector<std::string> runtime_info() {
   return {info.simd_level, info.detected_simd_level};
 }
 
+// [[arrow::export]]
+void set_timezone_database(std::string& path) {
+  ArrowGlobalOptions options;
+  options.tz_db_path = &path;
+  StopIfNotOk(arrow::Initialize(options))
+}
+
 #endif

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -181,8 +181,7 @@ test_that("strftime", {
 
   # This check is due to differences in the way %c currently works in Arrow and R's strftime.
   # We can revisit after https://github.com/HowardHinnant/date/issues/704 is resolved.
-  # Skip on Windows because it must use C locale.
-  if (tolower(Sys.info()[["sysname"]]) != "windows") {
+  if (Sys.getlocale("LC_TIME") != "C") {
     expect_error(
       times %>%
         Table$create() %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -26,12 +26,7 @@ library(dplyr, warn.conflicts = FALSE)
 # TODO: consider reevaluating this workaround after ARROW-12980
 withr::local_timezone("UTC")
 
-# TODO: We should test on windows once ARROW-13168 is resolved.
-if (tolower(Sys.info()[["sysname"]]) == "windows") {
-  test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "")
-} else {
-  test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "Pacific/Marquesas")
-}
+test_date <- as.POSIXct("2017-01-01 00:00:11.3456789", tz = "Pacific/Marquesas")
 
 
 test_df <- tibble::tibble(
@@ -120,8 +115,6 @@ test_that("errors in strptime", {
 })
 
 test_that("strftime", {
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
-
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA),
     date = c(as.Date("2021-01-01"), NA)
@@ -209,8 +202,6 @@ test_that("strftime", {
 test_that("format_ISO8601", {
   # https://issues.apache.org/jira/projects/ARROW/issues/ARROW-15266
   skip_if_not_available("re2")
-  # https://issues.apache.org/jira/browse/ARROW-13168
-  skip_on_os("windows")
   times <- tibble(x = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA))
 
   compare_dplyr_binding(
@@ -356,8 +347,6 @@ test_that("extract month from timestamp", {
     test_df
   )
 
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
-
   compare_dplyr_binding(
     .input %>%
       # R returns ordered factor whereas Arrow returns character
@@ -433,8 +422,6 @@ test_that("extract wday from timestamp", {
       collect(),
     test_df
   )
-
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
 
   compare_dplyr_binding(
     .input %>%
@@ -582,8 +569,6 @@ test_that("extract month from date", {
     test_df
   )
 
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
-
   compare_dplyr_binding(
     .input %>%
       # R returns ordered factor whereas Arrow returns character
@@ -633,8 +618,6 @@ test_that("extract wday from date", {
       collect(),
     test_df
   )
-
-  skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
 
   compare_dplyr_binding(
     .input %>%
@@ -704,10 +687,6 @@ test_that("leap_year mirror lubridate", {
 })
 
 test_that("am/pm mirror lubridate", {
-
-  # https://issues.apache.org/jira/browse/ARROW-13168
-  skip_on_os("windows")
-
   compare_dplyr_binding(
     .input %>%
       mutate(
@@ -805,8 +784,6 @@ test_that("dst extracts daylight savings time correctly", {
   test_df <- tibble(
     dates = as.POSIXct(c("2021-02-20", "2021-07-31", "2021-10-31", "2021-01-31"), tz = "Europe/London")
   )
-  # https://issues.apache.org/jira/browse/ARROW-13168
-  skip_on_os("windows")
 
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -119,6 +119,8 @@ test_that("errors in strptime", {
 })
 
 test_that("strftime", {
+  skip_on_os("windows") # TODO: Fix Windows locales
+  # Error on Windows: Cannot find locale 'English_United States.1252'
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA),
     date = c(as.Date("2021-01-01"), NA)
@@ -347,6 +349,7 @@ test_that("extract quarter from timestamp", {
 })
 
 test_that("extract month from timestamp", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(datetime)) %>%
@@ -409,6 +412,7 @@ test_that("extract day from timestamp", {
 })
 
 test_that("extract wday from timestamp", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(datetime)) %>%
@@ -561,6 +565,7 @@ test_that("extract week from date", {
 
 # Duplicate?
 test_that("extract month from date", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(date)) %>%
@@ -597,6 +602,7 @@ test_that("extract day from date", {
 })
 
 test_that("extract wday from date", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(date)) %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -115,6 +115,8 @@ test_that("errors in strptime", {
 })
 
 test_that("strftime", {
+  skip_on_os("windows") # TODO: Fix Windows locales
+  # Error on Windows: Cannot find locale 'English_United States.1252'
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA),
     date = c(as.Date("2021-01-01"), NA)
@@ -340,6 +342,7 @@ test_that("extract quarter from timestamp", {
 })
 
 test_that("extract month from timestamp", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(datetime)) %>%
@@ -402,6 +405,7 @@ test_that("extract day from timestamp", {
 })
 
 test_that("extract wday from timestamp", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(datetime)) %>%
@@ -525,15 +529,6 @@ test_that("extract quarter from date", {
   )
 })
 
-test_that("extract month from date", {
-  compare_dplyr_binding(
-    .input %>%
-      mutate(x = month(date)) %>%
-      collect(),
-    test_df
-  )
-})
-
 test_that("extract isoweek from date", {
   compare_dplyr_binding(
     .input %>%
@@ -561,7 +556,9 @@ test_that("extract week from date", {
   )
 })
 
+# Duplicate?
 test_that("extract month from date", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(date)) %>%
@@ -598,6 +595,7 @@ test_that("extract day from date", {
 })
 
 test_that("extract wday from date", {
+  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(date)) %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -119,8 +119,6 @@ test_that("errors in strptime", {
 })
 
 test_that("strftime", {
-  skip_on_os("windows") # TODO: Fix Windows locales
-  # Error on Windows: Cannot find locale 'English_United States.1252'
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Etc/GMT+6"), NA),
     date = c(as.Date("2021-01-01"), NA)
@@ -349,7 +347,6 @@ test_that("extract quarter from timestamp", {
 })
 
 test_that("extract month from timestamp", {
-  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(datetime)) %>%
@@ -412,7 +409,6 @@ test_that("extract day from timestamp", {
 })
 
 test_that("extract wday from timestamp", {
-  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(datetime)) %>%
@@ -565,7 +561,6 @@ test_that("extract week from date", {
 
 # Duplicate?
 test_that("extract month from date", {
-  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = month(date)) %>%
@@ -602,7 +597,6 @@ test_that("extract day from date", {
 })
 
 test_that("extract wday from date", {
-  skip_on_os("windows") # TODO: Fix Windows locales
   compare_dplyr_binding(
     .input %>%
       mutate(x = wday(date)) %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -558,7 +558,6 @@ test_that("extract week from date", {
   )
 })
 
-# Duplicate?
 test_that("extract month from date", {
   compare_dplyr_binding(
     .input %>%
@@ -584,7 +583,6 @@ test_that("extract month from date", {
     ignore_attr = TRUE
   )
 })
-
 
 test_that("extract day from date", {
   compare_dplyr_binding(


### PR DESCRIPTION
This allows for runtime configuration of the timezone database on Windows for C++ and R. Python will be handled later because it's available timezone libraries use the binary rather than text format, which is not yet supported the vendored date library.

For R, Windows will only support the "C" locale, since (as far as I can tell) that's the only locale supported by the MingW std::locale implementation. I think R itself gets around this by implementing a completely custom version of `strftime()` and friends.