### PR TITLE
ARROW-15820: [C++][Doc] Add table_source to streaming_execution.rst & clarify parameter name

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -367,10 +367,10 @@ arrow::Status SourceSinkExample(cp::ExecContext& exec_context) {
 /**
  * \brief
  * TableSource-Sink Example
- * This example shows how a tabl_source and sink can be used
- * in an execution plan. This includes table source node
- * receiving data as a table and the sink node emits
- * the data as an output represented in a table.
+ * This example shows how a table_source and sink can be used
+ * in an execution plan. This includes a table source node
+ * receiving data from a table and the sink node emits
+ * the data to a generator which we collect into a table.
  * \param exec_context : execution context
  * \return arrow::Status
  */

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -99,8 +99,8 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
 }
 
 /**
- * \brief Get the Dataset object
- *  Creating Dataset
+ * \brief Get a Table object
+ *  Creating Table
  *  a, b
     1,null
     2,true
@@ -112,9 +112,9 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetSampleRecordBatch(
     6,false
     7,false
     8,true
- * \return arrow::Result<std::shared_ptr<arrow::dataset::Dataset>>
+ * \return arrow::Result<std::shared_ptr<arrow::Table>>
  */
-arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> GetDataset() {
+arrow::Result<std::shared_ptr<arrow::Table>> GetTable() {
   auto null_long = std::numeric_limits<int64_t>::quiet_NaN();
   ARROW_ASSIGN_OR_RAISE(auto int64_array,
                         GetArrayDataSample<arrow::Int64Type>(
@@ -139,6 +139,16 @@ arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> GetDataset() {
                                               arrow::field("b", arrow::boolean())}),
                                10, {int64_array, bool_array});
   ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches({record_batch}));
+  return table;
+}
+
+/**
+ * \brief Get the Dataset object
+ * Create Dataset from Table
+ * \return arrow::Result<std::shared_ptr<arrow::dataset::Dataset>>
+ */
+arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> GetDataset() {
+  ARROW_ASSIGN_OR_RAISE(auto table, GetTable());
   auto ds = std::make_shared<arrow::dataset::InMemoryDataset>(table);
   return ds;
 }
@@ -352,6 +362,38 @@ arrow::Status SourceSinkExample(cp::ExecContext& exec_context) {
   return ExecutePlanAndCollectAsTable(exec_context, plan, basic_data.schema, sink_gen);
 }
 // (Doc section: Source Example)
+
+// (Doc section: Table Source Example)
+/**
+ * \brief
+ * TableSource-Sink Example
+ * This example shows how a tabl_source and sink can be used
+ * in an execution plan. This includes table source node
+ * receiving data as a table and the sink node emits
+ * the data as an output represented in a table.
+ * \param exec_context : execution context
+ * \return arrow::Status
+ */
+arrow::Status TableSourceSinkExample(cp::ExecContext& exec_context) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
+                        cp::ExecPlan::Make(&exec_context));
+
+  ARROW_ASSIGN_OR_RAISE(auto table, GetTable());
+
+  arrow::AsyncGenerator<arrow::util::optional<cp::ExecBatch>> sink_gen;
+  int max_batch_size = 2;
+  auto table_source_options = cp::TableSourceNodeOptions{table, max_batch_size};
+
+  ARROW_ASSIGN_OR_RAISE(
+      cp::ExecNode * source,
+      cp::MakeExecNode("table_source", plan.get(), {}, table_source_options));
+
+  ARROW_RETURN_NOT_OK(
+      cp::MakeExecNode("sink", plan.get(), {source}, cp::SinkNodeOptions{&sink_gen}));
+
+  return ExecutePlanAndCollectAsTable(exec_context, plan, table->schema(), sink_gen);
+}
+// (Doc section: Table Source Example)
 
 // (Doc section: Filter Example)
 /**
@@ -832,17 +874,18 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
 
 enum ExampleMode {
   SOURCE_SINK = 0,
-  SCAN = 1,
-  FILTER = 2,
-  PROJECT = 3,
-  SCALAR_AGGREGATION = 4,
-  GROUP_AGGREGATION = 5,
-  CONSUMING_SINK = 6,
-  ORDER_BY_SINK = 7,
-  HASHJOIN = 8,
-  KSELECT = 9,
-  WRITE = 10,
-  UNION = 11,
+  TABLE_SOURCE_SINK = 1,
+  SCAN = 2,
+  FILTER = 3,
+  PROJECT = 4,
+  SCALAR_AGGREGATION = 5,
+  GROUP_AGGREGATION = 6,
+  CONSUMING_SINK = 7,
+  ORDER_BY_SINK = 8,
+  HASHJOIN = 9,
+  KSELECT = 10,
+  WRITE = 11,
+  UNION = 12,
 };
 
 int main(int argc, char** argv) {
@@ -863,6 +906,10 @@ int main(int argc, char** argv) {
     case SOURCE_SINK:
       PrintBlock("Source Sink Example");
       status = SourceSinkExample(exec_context);
+      break;
+    case TABLE_SOURCE_SINK:
+      PrintBlock("Table Source Sink Example");
+      status = TableSourceSinkExample(exec_context);
       break;
     case SCAN:
       PrintBlock("Scan Example");

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -58,15 +58,15 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 /// \brief An extended Source node which accepts a table
 class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:
-  TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t batch_size)
-      : table(table), batch_size(batch_size) {}
+  TableSourceNodeOptions(std::shared_ptr<Table> table, int64_t max_batch_size)
+      : table(table), max_batch_size(max_batch_size) {}
 
   // arrow table which acts as the data source
   std::shared_ptr<Table> table;
   // Size of batches to emit from this node
   // If the table is larger the node will emit multiple batches from the
   // the table to be processed in parallel.
-  int64_t batch_size;
+  int64_t max_batch_size;
 };
 
 /// \brief Make a node which excludes some rows from batches passed through it

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -186,7 +186,7 @@ struct TableSourceNode : public SourceNode {
     RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 0, "TableSourceNode"));
     const auto& table_options = checked_cast<const TableSourceNodeOptions&>(options);
     const auto& table = table_options.table;
-    const int64_t batch_size = table_options.batch_size;
+    const int64_t batch_size = table_options.max_batch_size;
 
     RETURN_NOT_OK(ValidateTableSourceNodeInput(table, batch_size));
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -403,15 +403,12 @@ Example of using ``source`` (usage of sink is explained in detail in :ref:`sink<
 .. _stream_execution_table_source_docs:
 
 In the previous example, :ref:`source node <stream_execution_source_docs>`, a source node
-was used to input the data and the node expected data to be fed using a generator. But in 
-developing application much easier and to enable performance optimization, the 
-:class:`arrow::compute::TableSourceNodeOptions` can be used. Here the input data can be 
-passed as a ``std::shared_ptr<arrow::Table>`` along with a ``max_batch_size``. The objetive
-of the ``max_batch_size`` is to enable the user to tune the performance given the nature of 
-vivid workloads. Another important fact is that the streaming execution engine will use
-the ``max_batch_size`` as execution batch size. And it is important to note that the output
-batches from an execution plan doesn't get merged to form larger batches when an inserted 
-table has smaller batch size. 
+was used to input the data.  But when developing an application, if the data is already in memory
+as a table, it is much easier, and more performant to use :class:`arrow::compute::TableSourceNodeOptions`.
+Here the input data can be passed as a ``std::shared_ptr<arrow::Table>`` along with a ``max_batch_size``. 
+The ``max_batch_size`` is to break up large record batches so that they can be processed in parallel.
+It is important to note that the table batches will not get merged to form larger batches when the source
+table has a smaller batch size. 
 
 Example of using ``table_source``
 

--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -322,6 +322,8 @@ This is the list of operations associated with the execution plan:
      - Options
    * - ``source``
      - :class:`arrow::compute::SourceNodeOptions`
+   * - ``table_source``
+     - :class:`arrow::compute::TableSourceNodeOptions`
    * - ``filter``
      - :class:`arrow::compute::FilterNodeOptions`
    * - ``project``
@@ -344,7 +346,6 @@ This is the list of operations associated with the execution plan:
      - :class:`arrow::dataset::WriteNodeOptions`
    * - ``union``
      - N/A
-
 
 .. _stream_execution_source_docs:
 
@@ -393,6 +394,31 @@ Example of using ``source`` (usage of sink is explained in detail in :ref:`sink<
   :language: cpp
   :start-after: (Doc section: Source Example)
   :end-before: (Doc section: Source Example)
+  :linenos:
+  :lineno-match:
+
+``table_source``
+----------------
+
+.. _stream_execution_table_source_docs:
+
+In the previous example, :ref:`source node <stream_execution_source_docs>`, a source node
+was used to input the data and the node expected data to be fed using a generator. But in 
+developing application much easier and to enable performance optimization, the 
+:class:`arrow::compute::TableSourceNodeOptions` can be used. Here the input data can be 
+passed as a ``std::shared_ptr<arrow::Table>`` along with a ``max_batch_size``. The objetive
+of the ``max_batch_size`` is to enable the user to tune the performance given the nature of 
+vivid workloads. Another important fact is that the streaming execution engine will use
+the ``max_batch_size`` as execution batch size. And it is important to note that the output
+batches from an execution plan doesn't get merged to form larger batches when an inserted 
+table has smaller batch size. 
+
+Example of using ``table_source``
+
+.. literalinclude:: ../../../cpp/examples/arrow/execution_plan_documentation_examples.cc
+  :language: cpp
+  :start-after: (Doc section: Table Source Example)
+  :end-before: (Doc section: Table Source Example)
   :linenos:
   :lineno-match:
 


### PR DESCRIPTION
This PR includes the following modifications;

- Adding an example of using `TableSourceNodeOptions` for `table_source` 
- Updating documentation on streaming execution engine
- Minor refactoring to redefine definition of `batch_size` to `max_batch_size`