### PR TITLE
ARROW-15841: [R] Implement SafeCallIntoR to safely call the R API from another thread

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -31,8 +31,10 @@
 
 #' @importFrom vctrs s3_register vec_size vec_cast vec_unique
 .onLoad <- function(...) {
-  # Make sure C++ knows on which thread it is safe to call the R API
-  InitializeMainRThread()
+  if (arrow_available()) {
+    # Make sure C++ knows on which thread it is safe to call the R API
+    InitializeMainRThread()
+  }
 
   dplyr_methods <- paste0(
     "dplyr::",

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -31,6 +31,9 @@
 
 #' @importFrom vctrs s3_register vec_size vec_cast vec_unique
 .onLoad <- function(...) {
+  # Make sure C++ knows on which thread it is safe to call the R API
+  InitializeMainRThread()
+
   dplyr_methods <- paste0(
     "dplyr::",
     c(

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1704,6 +1704,10 @@ ipc___RecordBatchStreamWriter__Open <- function(stream, schema, use_legacy_forma
   .Call(`_arrow_ipc___RecordBatchStreamWriter__Open`, stream, schema, use_legacy_format, metadata_version)
 }
 
+TestSafeCallIntoR <- function(funs_that_return_a_string) {
+  .Call(`_arrow_TestSafeCallIntoR`, funs_that_return_a_string)
+}
+
 Array__GetScalar <- function(x, i) {
   .Call(`_arrow_Array__GetScalar`, x, i)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1708,8 +1708,8 @@ InitializeMainRThread <- function() {
   invisible(.Call(`_arrow_InitializeMainRThread`))
 }
 
-TestSafeCallIntoR <- function(fun_that_returns_a_string, opt) {
-  .Call(`_arrow_TestSafeCallIntoR`, fun_that_returns_a_string, opt)
+TestSafeCallIntoR <- function(r_fun_that_returns_a_string, opt) {
+  .Call(`_arrow_TestSafeCallIntoR`, r_fun_that_returns_a_string, opt)
 }
 
 Array__GetScalar <- function(x, i) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1708,8 +1708,8 @@ InitializeMainRThread <- function() {
   invisible(.Call(`_arrow_InitializeMainRThread`))
 }
 
-TestSafeCallIntoR <- function(funs_that_return_a_string, async) {
-  .Call(`_arrow_TestSafeCallIntoR`, funs_that_return_a_string, async)
+TestSafeCallIntoR <- function(fun_that_returns_a_string, opt) {
+  .Call(`_arrow_TestSafeCallIntoR`, fun_that_returns_a_string, opt)
 }
 
 Array__GetScalar <- function(x, i) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1704,8 +1704,12 @@ ipc___RecordBatchStreamWriter__Open <- function(stream, schema, use_legacy_forma
   .Call(`_arrow_ipc___RecordBatchStreamWriter__Open`, stream, schema, use_legacy_format, metadata_version)
 }
 
-TestSafeCallIntoR <- function(funs_that_return_a_string) {
-  .Call(`_arrow_TestSafeCallIntoR`, funs_that_return_a_string)
+InitializeMainRThread <- function() {
+  invisible(.Call(`_arrow_InitializeMainRThread`))
+}
+
+TestSafeCallIntoR <- function(funs_that_return_a_string, async) {
+  .Call(`_arrow_TestSafeCallIntoR`, funs_that_return_a_string, async)
 }
 
 Array__GetScalar <- function(x, i) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6711,6 +6711,21 @@ extern "C" SEXP _arrow_ipc___RecordBatchStreamWriter__Open(SEXP stream_sexp, SEX
 }
 #endif
 
+// safe-call-into-r.cpp
+#if defined(ARROW_R_WITH_ARROW)
+cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string);
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::list>::type funs_that_return_a_string(funs_that_return_a_string_sexp);
+	return cpp11::as_sexp(TestSafeCallIntoR(funs_that_return_a_string));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp){
+	Rf_error("Cannot call TestSafeCallIntoR(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // scalar.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::Scalar> Array__GetScalar(const std::shared_ptr<arrow::Array>& x, int64_t i);
@@ -7541,32 +7556,6 @@ extern "C" SEXP _arrow_Array__infer_type(SEXP x_sexp){
 }
 #endif
 
-#if defined(ARROW_R_WITH_ARROW)
-extern "C" SEXP _arrow_Table__Reset(SEXP r6) {
-BEGIN_CPP11
-arrow::r::r6_reset_pointer<arrow::Table>(r6);
-END_CPP11
-return R_NilValue;
-}
-#else
-extern "C" SEXP _arrow_Table__Reset(SEXP r6){
-	Rf_error("Cannot call Table(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
-#if defined(ARROW_R_WITH_ARROW)
-extern "C" SEXP _arrow_RecordBatch__Reset(SEXP r6) {
-BEGIN_CPP11
-arrow::r::r6_reset_pointer<arrow::RecordBatch>(r6);
-END_CPP11
-return R_NilValue;
-}
-#else
-extern "C" SEXP _arrow_RecordBatch__Reset(SEXP r6){
-	Rf_error("Cannot call RecordBatch(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
 extern "C" SEXP _arrow_available() {
 return Rf_ScalarLogical(
 #if defined(ARROW_R_WITH_ARROW)
@@ -8044,6 +8033,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ipc___RecordBatchWriter__Close", (DL_FUNC) &_arrow_ipc___RecordBatchWriter__Close, 1}, 
 		{ "_arrow_ipc___RecordBatchFileWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchFileWriter__Open, 4}, 
 		{ "_arrow_ipc___RecordBatchStreamWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchStreamWriter__Open, 4}, 
+		{ "_arrow_TestSafeCallIntoR", (DL_FUNC) &_arrow_TestSafeCallIntoR, 1}, 
 		{ "_arrow_Array__GetScalar", (DL_FUNC) &_arrow_Array__GetScalar, 2}, 
 		{ "_arrow_Scalar__ToString", (DL_FUNC) &_arrow_Scalar__ToString, 1}, 
 		{ "_arrow_StructScalar__field", (DL_FUNC) &_arrow_StructScalar__field, 2}, 
@@ -8097,8 +8087,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_GetIOThreadPoolCapacity", (DL_FUNC) &_arrow_GetIOThreadPoolCapacity, 0}, 
 		{ "_arrow_SetIOThreadPoolCapacity", (DL_FUNC) &_arrow_SetIOThreadPoolCapacity, 1}, 
 		{ "_arrow_Array__infer_type", (DL_FUNC) &_arrow_Array__infer_type, 1}, 
-		{ "_arrow_Table__Reset", (DL_FUNC) &_arrow_Table__Reset, 1}, 
-		{ "_arrow_RecordBatch__Reset", (DL_FUNC) &_arrow_RecordBatch__Reset, 1}, 
 		{NULL, NULL, 0}
 };
 extern "C" void R_init_arrow(DllInfo* dll){

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6728,16 +6728,16 @@ extern "C" SEXP _arrow_InitializeMainRThread(){
 
 // safe-call-into-r.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::string TestSafeCallIntoR(cpp11::sexp fun_that_returns_a_string, std::string opt);
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP fun_that_returns_a_string_sexp, SEXP opt_sexp){
+std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string, std::string opt);
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP r_fun_that_returns_a_string_sexp, SEXP opt_sexp){
 BEGIN_CPP11
-	arrow::r::Input<cpp11::sexp>::type fun_that_returns_a_string(fun_that_returns_a_string_sexp);
+	arrow::r::Input<cpp11::function>::type r_fun_that_returns_a_string(r_fun_that_returns_a_string_sexp);
 	arrow::r::Input<std::string>::type opt(opt_sexp);
-	return cpp11::as_sexp(TestSafeCallIntoR(fun_that_returns_a_string, opt));
+	return cpp11::as_sexp(TestSafeCallIntoR(r_fun_that_returns_a_string, opt));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP fun_that_returns_a_string_sexp, SEXP opt_sexp){
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP r_fun_that_returns_a_string_sexp, SEXP opt_sexp){
 	Rf_error("Cannot call TestSafeCallIntoR(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6711,7 +6711,7 @@ extern "C" SEXP _arrow_ipc___RecordBatchStreamWriter__Open(SEXP stream_sexp, SEX
 }
 #endif
 
-// safe-call-into-r.cpp
+// safe-call-into-r-impl.cpp
 #if defined(ARROW_R_WITH_ARROW)
 void InitializeMainRThread();
 extern "C" SEXP _arrow_InitializeMainRThread(){
@@ -6726,7 +6726,7 @@ extern "C" SEXP _arrow_InitializeMainRThread(){
 }
 #endif
 
-// safe-call-into-r.cpp
+// safe-call-into-r-impl.cpp
 #if defined(ARROW_R_WITH_ARROW)
 std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string, std::string opt);
 extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP r_fun_that_returns_a_string_sexp, SEXP opt_sexp){

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6713,15 +6713,31 @@ extern "C" SEXP _arrow_ipc___RecordBatchStreamWriter__Open(SEXP stream_sexp, SEX
 
 // safe-call-into-r.cpp
 #if defined(ARROW_R_WITH_ARROW)
-cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string);
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp){
+void InitializeMainRThread();
+extern "C" SEXP _arrow_InitializeMainRThread(){
 BEGIN_CPP11
-	arrow::r::Input<cpp11::list>::type funs_that_return_a_string(funs_that_return_a_string_sexp);
-	return cpp11::as_sexp(TestSafeCallIntoR(funs_that_return_a_string));
+	InitializeMainRThread();
+	return R_NilValue;
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp){
+extern "C" SEXP _arrow_InitializeMainRThread(){
+	Rf_error("Cannot call InitializeMainRThread(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// safe-call-into-r.cpp
+#if defined(ARROW_R_WITH_ARROW)
+cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string, bool async);
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp, SEXP async_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::list>::type funs_that_return_a_string(funs_that_return_a_string_sexp);
+	arrow::r::Input<bool>::type async(async_sexp);
+	return cpp11::as_sexp(TestSafeCallIntoR(funs_that_return_a_string, async));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp, SEXP async_sexp){
 	Rf_error("Cannot call TestSafeCallIntoR(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -8033,7 +8049,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ipc___RecordBatchWriter__Close", (DL_FUNC) &_arrow_ipc___RecordBatchWriter__Close, 1}, 
 		{ "_arrow_ipc___RecordBatchFileWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchFileWriter__Open, 4}, 
 		{ "_arrow_ipc___RecordBatchStreamWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchStreamWriter__Open, 4}, 
-		{ "_arrow_TestSafeCallIntoR", (DL_FUNC) &_arrow_TestSafeCallIntoR, 1}, 
+		{ "_arrow_InitializeMainRThread", (DL_FUNC) &_arrow_InitializeMainRThread, 0}, 
+		{ "_arrow_TestSafeCallIntoR", (DL_FUNC) &_arrow_TestSafeCallIntoR, 2}, 
 		{ "_arrow_Array__GetScalar", (DL_FUNC) &_arrow_Array__GetScalar, 2}, 
 		{ "_arrow_Scalar__ToString", (DL_FUNC) &_arrow_Scalar__ToString, 1}, 
 		{ "_arrow_StructScalar__field", (DL_FUNC) &_arrow_StructScalar__field, 2}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6728,16 +6728,16 @@ extern "C" SEXP _arrow_InitializeMainRThread(){
 
 // safe-call-into-r.cpp
 #if defined(ARROW_R_WITH_ARROW)
-cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string, bool async);
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp, SEXP async_sexp){
+std::string TestSafeCallIntoR(cpp11::sexp fun_that_returns_a_string, std::string opt);
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP fun_that_returns_a_string_sexp, SEXP opt_sexp){
 BEGIN_CPP11
-	arrow::r::Input<cpp11::list>::type funs_that_return_a_string(funs_that_return_a_string_sexp);
-	arrow::r::Input<bool>::type async(async_sexp);
-	return cpp11::as_sexp(TestSafeCallIntoR(funs_that_return_a_string, async));
+	arrow::r::Input<cpp11::sexp>::type fun_that_returns_a_string(fun_that_returns_a_string_sexp);
+	arrow::r::Input<std::string>::type opt(opt_sexp);
+	return cpp11::as_sexp(TestSafeCallIntoR(fun_that_returns_a_string, opt));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP funs_that_return_a_string_sexp, SEXP async_sexp){
+extern "C" SEXP _arrow_TestSafeCallIntoR(SEXP fun_that_returns_a_string_sexp, SEXP opt_sexp){
 	Rf_error("Cannot call TestSafeCallIntoR(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -53,9 +53,6 @@ std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string,
     thread_ptr->join();
     delete thread_ptr;
 
-    // Stop for any R execution errors that may have occurred
-    GetMainRThread().ClearError();
-
     return arrow::ValueOrStop(result);
   } else if (opt == "async_without_executor") {
     std::thread* thread_ptr;
@@ -75,10 +72,6 @@ std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string,
     thread_ptr->join();
     delete thread_ptr;
 
-    // We didn't evaluate any R code because it wasn't safe, but
-    // if we did and there was an error, we need to stop() here
-    GetMainRThread().ClearError();
-
     // We should be able to get this far, but fut will contain an error
     // because it tried to evaluate R code from another thread
     return arrow::ValueOrStop(fut.result());
@@ -86,7 +79,6 @@ std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string,
   } else if (opt == "on_main_thread") {
     auto result = SafeCallIntoR<std::string>(
         [&]() { return cpp11::as_cpp<std::string>(r_fun_that_returns_a_string()); });
-    GetMainRThread().ClearError();
     arrow::StopIfNotOk(result.status());
     return result.ValueUnsafe();
   } else {

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -27,7 +27,7 @@ MainRThread& GetMainRThread() {
   return main_r_thread;
 }
 
-arrow::Status MainRThread::RunTask(Task* task) {
+arrow::Result<MainRThread::Task*> MainRThread::RunTask(Task* task) {
   if (IsMainThread()) {
     // If we're on the main thread, run the task immediately
     try {
@@ -40,7 +40,7 @@ arrow::Status MainRThread::RunTask(Task* task) {
     // If we are not on the main thread and have an Executor
     // use it to run the task on the main R thread.
     auto fut = DeferNotOk(executor_->Submit([task]() { return task->run(); }));
-    return fut.status();
+    return fut.result();
   } else {
     return arrow::Status::NotImplemented(
         "Call to R from a non-R thread without calling RunWithCapturedR");

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -46,7 +46,7 @@ arrow::Status MainRThread::RunTask(Task* task) {
     return arrow::Status::OK();
   } else {
     return arrow::Status::NotImplemented(
-        "Call to R from a non-R thread without an event loop");
+        "Call to R from a non-R thread without calling RunWithCapturedR");
   }
 }
 

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -27,25 +27,6 @@ MainRThread& GetMainRThread() {
   return main_r_thread;
 }
 
-arrow::Future<MainRThread::Task*> MainRThread::RunTask(Task* task) {
-  if (IsMainThread()) {
-    // If we're on the main thread, run the task immediately
-    try {
-      return arrow::Future<Task*>::MakeFinished(task->run());
-    } catch (cpp11::unwind_exception& e) {
-      SetError(e.token);
-      return arrow::Future<Task*>::MakeFinished(arrow::Status::UnknownError("R code execution error"));
-    }
-  } else if (executor_ != nullptr) {
-    // If we are not on the main thread and have an Executor
-    // use it to run the task on the main R thread.
-    return DeferNotOk(executor_->Submit([task]() { return task->run(); }));
-  } else {
-    return arrow::Future<Task*>::MakeFinished(arrow::Status::NotImplemented(
-        "Call to R from a non-R thread without calling RunWithCapturedR"));
-  }
-}
-
 // [[arrow::export]]
 void InitializeMainRThread() { GetMainRThread().Initialize(); }
 

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -82,7 +82,7 @@ std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string,
     arrow::StopIfNotOk(result.status());
     return result.ValueUnsafe();
   } else {
-    return "";
+    cpp11::stop("Unknown `opt`");
   }
 }
 

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -27,23 +27,22 @@ MainRThread& GetMainRThread() {
   return main_r_thread;
 }
 
-arrow::Result<MainRThread::Task*> MainRThread::RunTask(Task* task) {
+arrow::Future<MainRThread::Task*> MainRThread::RunTask(Task* task) {
   if (IsMainThread()) {
     // If we're on the main thread, run the task immediately
     try {
-      return task->run();
+      return arrow::Future<Task*>::MakeFinished(task->run());
     } catch (cpp11::unwind_exception& e) {
       SetError(e.token);
-      return arrow::Status::UnknownError("R code execution error");
+      return arrow::Future<Task*>::MakeFinished(arrow::Status::UnknownError("R code execution error"));
     }
   } else if (executor_ != nullptr) {
     // If we are not on the main thread and have an Executor
     // use it to run the task on the main R thread.
-    auto fut = DeferNotOk(executor_->Submit([task]() { return task->run(); }));
-    return fut.result();
+    return DeferNotOk(executor_->Submit([task]() { return task->run(); }));
   } else {
-    return arrow::Status::NotImplemented(
-        "Call to R from a non-R thread without calling RunWithCapturedR");
+    return arrow::Future<Task*>::MakeFinished(arrow::Status::NotImplemented(
+        "Call to R from a non-R thread without calling RunWithCapturedR"));
   }
 }
 

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "./arrow_types.h"
+#if defined(ARROW_R_WITH_ARROW)
+
 #include <functional>
 #include <thread>
 #include "./safe-call-into-r.h"
@@ -116,3 +119,5 @@ std::string TestSafeCallIntoR(cpp11::function r_fun_that_returns_a_string,
     return "";
   }
 }
+
+#endif

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "safe-call-into-r.h"
 #include <functional>
 #include <thread>
+#include "./safe-call-into-r.h"
 
 static MainRThread main_r_thread;
 

--- a/r/src/safe-call-into-r.cpp
+++ b/r/src/safe-call-into-r.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "safe-call-into-r.h"
+#include "./safe-call-into-r.h"
 #include <functional>
 #include <thread>
 

--- a/r/src/safe-call-into-r.cpp
+++ b/r/src/safe-call-into-r.cpp
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "safe-call-into-r.h"
 #include <functional>

--- a/r/src/safe-call-into-r.cpp
+++ b/r/src/safe-call-into-r.cpp
@@ -1,0 +1,67 @@
+
+#include "safe-call-into-r.h"
+#include <thread>
+#include <functional>
+
+static MainRThreadTasks main_r_thread_tasks;
+
+void SafeCallIntoRBase(MainRThreadTasks::Task* task) {
+    main_r_thread_tasks.Add(task);
+    while (!main_r_thread_tasks.is_finished(task)) {
+        std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::nanoseconds(1000));
+    }
+}
+
+MainRThreadTasks::EventLoop::EventLoop(): keep_looping_(false) {
+    thread_ = std::this_thread::get_id();
+    main_r_thread_tasks.Register(this);
+}
+
+MainRThreadTasks::EventLoop::~EventLoop() {
+    main_r_thread_tasks.Unregister();
+}
+
+void MainRThreadTasks::EventLoop::start_looping() {
+    // must be called from another thread but needs to evaluate this next
+    // part on the main thread?
+     while (keep_looping_) {
+        try {
+            main_r_thread_tasks.EvaluatePending();
+        } catch (cpp11::unwind_exception& e) {
+            // important that this this error makes its way back to the top
+            // level and is caught in the auto-generated glue code
+            throw e;
+        }
+        std::this_thread::sleep_for(std::chrono::nanoseconds(10000));
+    }
+}
+
+void MainRThreadTasks::EventLoop::stop_looping() {
+    keep_looping_ = false;
+}
+
+// [[arrow::export]]
+cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string) {
+
+    // pretending that this could be called from another thread
+    std::vector<std::string> results;
+    for (R_xlen_t i = 0; i < funs_that_return_a_string.size(); i++) {
+        std::function<cpp11::sexp()> f = [&]() {
+            cpp11::function fun (funs_that_return_a_string[i]);
+            return fun();
+        };
+
+        std::string result = SafeCallIntoR<std::string>(f);
+        results.push_back(result);
+    }
+
+    // and then this would be back on the main thread just to make
+    // sure the results are correct
+    cpp11::writable::strings results_sexp;
+    for (std::string& result: results) {
+        results_sexp.push_back(result);
+    }
+
+    return results_sexp;
+}

--- a/r/src/safe-call-into-r.cpp
+++ b/r/src/safe-call-into-r.cpp
@@ -19,44 +19,90 @@
 #include <functional>
 #include <thread>
 
-static MainRThreadTasks main_r_thread_tasks;
+static MainRThread main_r_thread;
 
-void SafeCallIntoRBase(MainRThreadTasks::Task* task) {
-  if (main_r_thread_tasks.Loop() == nullptr) {
-    throw std::runtime_error("Global R executor not registered");
-  }
+MainRThread* GetMainRThread() { return &main_r_thread; }
 
-  if (main_r_thread_tasks.Loop()->thread() == std::this_thread::get_id()) {
-    task->run();
+arrow::Status MainRThread::RunTask(Task* task) {
+  if (IsMainThread()) {
+    try {
+      ARROW_RETURN_NOT_OK(task->run());
+      return arrow::Status::OK();
+    } catch (cpp11::unwind_exception& e) {
+      SetError(e.token);
+      return arrow::Status::UnknownError("R code execution error");
+    }
   } else {
-    throw std::runtime_error("Attempt to evaluate task on the non-R thread");
+    return arrow::Status::NotImplemented("Call to R from a non-R thread");
   }
 }
-
-MainRThreadTasks::EventLoop::EventLoop() {
-  thread_ = std::this_thread::get_id();
-  main_r_thread_tasks.Register(this);
-}
-
-MainRThreadTasks::EventLoop::~EventLoop() { main_r_thread_tasks.Unregister(); }
 
 // [[arrow::export]]
-cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string) {
-  MainRThreadTasks::EventLoop loop;
+void InitializeMainRThread() { main_r_thread.Initialize(); }
 
-  // pretending that this could be called from another thread
+// [[arrow::export]]
+cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string, bool async) {
   std::vector<std::string> results;
-  for (R_xlen_t i = 0; i < funs_that_return_a_string.size(); i++) {
-    std::string result = SafeCallIntoR<std::string>([&]() {
-        cpp11::function fun(funs_that_return_a_string[i]);
-        return fun();
+
+  if (async) {
+    // Probably a better test would be to submit all the jobs at once and
+    // wait for them all to finish, but I'm not sure how to do that yet!
+
+    // This simulates the Arrow thread pool. Just imagine it is static and lives forever.
+    std::thread* thread_ptr;
+
+    SEXP funs_sexp = funs_that_return_a_string;
+    R_xlen_t n_funs = funs_that_return_a_string.size();
+
+    auto fut = arrow::Future<std::vector<std::string>>::Make();
+
+    thread_ptr = new std::thread([fut, funs_sexp, n_funs]() mutable {
+      std::vector<std::string> results_local;
+
+      for (R_xlen_t i = 0; i < n_funs; i++) {
+        auto result = SafeCallIntoR<std::string>([&] {
+          cpp11::function fun(VECTOR_ELT(funs_sexp, i));
+          return cpp11::as_cpp<std::string>(fun());
+        });
+
+        if (result.ok()) {
+          results_local.push_back(result.ValueUnsafe());
+        } else {
+          fut.MarkFinished(result.status());
+          return;
+        }
+      }
+
+      fut.MarkFinished(results_local);
     });
-    results.push_back(result);
+
+    // Simulated thread pool
+    thread_ptr->join();
+    delete thread_ptr;
+
+    // We didn't evaluate any R code because it wasn't safe, but
+    // if we did and there was an error, we need to stop() here
+    GetMainRThread()->ClearError();
+
+    // We should be able to get this far, but fut will contain an error
+    // because it tried to evaluate R code from another thread
+    results = arrow::ValueOrStop(fut.result());
+
+  } else {
+    for (R_xlen_t i = 0; i < funs_that_return_a_string.size(); i++) {
+      auto result = SafeCallIntoR<std::string>([&]() {
+        cpp11::function fun(funs_that_return_a_string[i]);
+        return cpp11::as_cpp<std::string>(fun());
+      });
+      GetMainRThread()->ClearError();
+      arrow::StopIfNotOk(result.status());
+      results.push_back(result.ValueUnsafe());
+    }
   }
 
-  // and then this would be back on the main thread just to make
-  // sure the results are correct
+  // To make sure the results are correct
   cpp11::writable::strings results_sexp;
+
   for (std::string& result : results) {
     results_sexp.push_back(result);
   }

--- a/r/src/safe-call-into-r.cpp
+++ b/r/src/safe-call-into-r.cpp
@@ -1,67 +1,49 @@
 
 #include "safe-call-into-r.h"
-#include <thread>
 #include <functional>
+#include <thread>
 
 static MainRThreadTasks main_r_thread_tasks;
 
 void SafeCallIntoRBase(MainRThreadTasks::Task* task) {
-    main_r_thread_tasks.Add(task);
-    while (!main_r_thread_tasks.is_finished(task)) {
-        std::this_thread::yield();
-        std::this_thread::sleep_for(std::chrono::nanoseconds(1000));
-    }
+  if (main_r_thread_tasks.Loop() == nullptr) {
+    throw std::runtime_error("Global R executor not registered");
+  }
+
+  if (main_r_thread_tasks.Loop()->thread() == std::this_thread::get_id()) {
+    task->run();
+  } else {
+    throw std::runtime_error("Attempt to evaluate task on the non-R thread");
+  }
 }
 
-MainRThreadTasks::EventLoop::EventLoop(): keep_looping_(false) {
-    thread_ = std::this_thread::get_id();
-    main_r_thread_tasks.Register(this);
+MainRThreadTasks::EventLoop::EventLoop() {
+  thread_ = std::this_thread::get_id();
+  main_r_thread_tasks.Register(this);
 }
 
-MainRThreadTasks::EventLoop::~EventLoop() {
-    main_r_thread_tasks.Unregister();
-}
-
-void MainRThreadTasks::EventLoop::start_looping() {
-    // must be called from another thread but needs to evaluate this next
-    // part on the main thread?
-     while (keep_looping_) {
-        try {
-            main_r_thread_tasks.EvaluatePending();
-        } catch (cpp11::unwind_exception& e) {
-            // important that this this error makes its way back to the top
-            // level and is caught in the auto-generated glue code
-            throw e;
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(10000));
-    }
-}
-
-void MainRThreadTasks::EventLoop::stop_looping() {
-    keep_looping_ = false;
-}
+MainRThreadTasks::EventLoop::~EventLoop() { main_r_thread_tasks.Unregister(); }
 
 // [[arrow::export]]
 cpp11::strings TestSafeCallIntoR(cpp11::list funs_that_return_a_string) {
+  MainRThreadTasks::EventLoop loop;
 
-    // pretending that this could be called from another thread
-    std::vector<std::string> results;
-    for (R_xlen_t i = 0; i < funs_that_return_a_string.size(); i++) {
-        std::function<cpp11::sexp()> f = [&]() {
-            cpp11::function fun (funs_that_return_a_string[i]);
-            return fun();
-        };
+  // pretending that this could be called from another thread
+  std::vector<std::string> results;
+  for (R_xlen_t i = 0; i < funs_that_return_a_string.size(); i++) {
+    std::string result = SafeCallIntoR<std::string>([&]() {
+        cpp11::function fun(funs_that_return_a_string[i]);
+        return fun();
+    });
+    results.push_back(result);
+  }
 
-        std::string result = SafeCallIntoR<std::string>(f);
-        results.push_back(result);
-    }
+  // and then this would be back on the main thread just to make
+  // sure the results are correct
+  cpp11::writable::strings results_sexp;
+  for (std::string& result : results) {
+    results_sexp.push_back(result);
+  }
 
-    // and then this would be back on the main thread just to make
-    // sure the results are correct
-    cpp11::writable::strings results_sexp;
-    for (std::string& result: results) {
-        results_sexp.push_back(result);
-    }
-
-    return results_sexp;
+  return results_sexp;
 }

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -93,7 +93,7 @@ class MainRThread {
 MainRThread& GetMainRThread();
 
 // Call into R and return a C++ object. Note that you can't return
-// a SEXP (use cpp11::as_sexp<T> to convert it to a C++ type inside
+// a SEXP (use cpp11::as_cpp<T> to convert it to a C++ type inside
 // `fun`).
 template <typename T>
 arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -55,11 +55,11 @@ class MainRThread {
   class Task {
    public:
     virtual ~Task() {}
-    virtual arrow::Status run() = 0;
+    virtual arrow::Result<Task*> run() = 0;
   };
 
   // Run `task` if it is safe to do so or return an error otherwise.
-  arrow::Status RunTask(Task* task);
+  arrow::Result<Task*> RunTask(Task* task);
 
   // The Executor that is running on the main R thread, if it exists
   arrow::internal::Executor*& Executor() { return executor_; }
@@ -101,9 +101,9 @@ arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
    public:
     explicit TypedTask(std::function<T(void)> fun) : fun_(fun) {}
 
-    arrow::Status run() {
+    arrow::Result<Task*> run() {
       result = fun_();
-      return arrow::Status::OK();
+      return this;
     }
 
     T result;

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -112,7 +112,7 @@ arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
     std::function<T(void)> fun_;
   };
 
-  TypedTask task(fun);
+  TypedTask task(std::move(fun));
   ARROW_RETURN_NOT_OK(GetMainRThread().RunTask(&task));
   return task.result;
 }

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -59,7 +59,7 @@ class MainRThread {
   };
 
   // Run `task` if it is safe to do so or return an error otherwise.
-  arrow::Result<Task*> RunTask(Task* task);
+  arrow::Future<Task*> RunTask(Task* task);
 
   // The Executor that is running on the main R thread, if it exists
   arrow::internal::Executor*& Executor() { return executor_; }
@@ -113,7 +113,8 @@ arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
   };
 
   TypedTask task(std::move(fun));
-  ARROW_RETURN_NOT_OK(GetMainRThread().RunTask(&task));
+  arrow::Future<MainRThread::Task*> task_result = GetMainRThread().RunTask(&task);
+  ARROW_RETURN_NOT_OK(task_result.result());
   return task.result;
 }
 

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -31,7 +31,7 @@
 // if it is not safe). The MainRThread singleton can be accessed from
 // any thread using GetMainRThread(); the preferred way to call
 // the R API where it may not be safe to do so is to use
-// SafeCallIntoR<cpp_type>([&]() { some_expression_returning_sexp; }).
+// SafeCallIntoR<cpp_type>([&]() { ... }).
 class MainRThread {
  public:
   MainRThread() : initialized_(false), executor_(nullptr) {}

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -118,15 +118,15 @@ arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
 }
 
 template <typename T>
-arrow::Result<T> RunWithCapturedR(std::function<arrow::Future<T>()> task) {
+arrow::Result<T> RunWithCapturedR(std::function<arrow::Future<T>()> make_arrow_call) {
   if (GetMainRThread().Executor() != nullptr) {
     return arrow::Status::AlreadyExists("Attempt to use more than one R Executor()");
   }
 
   arrow::Result<T> result = arrow::internal::SerialExecutor::RunInSerialExecutor<T>(
-      [task](arrow::internal::Executor* executor) {
+      [make_arrow_call](arrow::internal::Executor* executor) {
         GetMainRThread().Executor() = executor;
-        arrow::Future<T> result = task();
+        arrow::Future<T> result = make_arrow_call();
         return result;
       });
 

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -67,21 +67,10 @@ class MainRThread {
   void ClearError() {
     if (HasError()) {
       cpp11::unwind_exception e(error_token_);
-      SetError(R_NilValue);
+      ResetError();
       throw e;
     }
   }
-
-  class UnwindStatusDetail : public arrow::StatusDetail {
-   public:
-    UnwindStatusDetail(SEXP token) : token_(token) {}
-    const char* type_id() const { return "MainRThread::UnwindStatusDetail"; };
-    std::string ToString() const { return type_id(); }
-    SEXP token() { return token_; }
-
-   private:
-    SEXP token_;
-  };
 
  private:
   bool initialized_;

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -61,6 +61,7 @@ class MainRThread {
   // Run `task` if it is safe to do so or return an error otherwise.
   arrow::Status RunTask(Task* task);
 
+  // The Executor that is running on the main R thread, if it exists
   arrow::internal::Executor*& Executor() { return executor_; }
 
   // Save an error token generated from a cpp11::unwind_exception

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -1,0 +1,98 @@
+
+#ifndef SAFE_CALL_INTO_R_INCLUDED
+#define SAFE_CALL_INTO_R_INCLUDED
+
+#include "./arrow_types.h"
+
+#include <deque>
+#include <unordered_set>
+#include <mutex>
+#include <thread>
+#include <functional>
+
+class MainRThreadTasks {
+public:
+    class Task {
+    public:
+        virtual ~Task() {}
+        virtual void run() {}
+    };
+
+    class EventLoop {
+    public:
+        EventLoop();
+        ~EventLoop();
+        void start_looping();
+        void stop_looping();
+    private:
+        std::thread::id thread_;
+        bool keep_looping_;
+    };
+
+    void EvaluatePending() {
+        lock_.lock();
+        while (!tasks_.empty()) {
+            Task* task = tasks_.back();
+            tasks_.pop_back();
+            task->run();
+        }
+        lock_.unlock();
+    }
+
+    void Add(Task* task) {
+        lock_.lock();
+        tasks_.push_front(task);
+        lock_.unlock();
+    }
+
+    bool is_finished(Task* task) {
+        lock_.lock();
+        bool result = results_.find(task) != results_.end();
+        lock_.unlock();
+        return result;
+    }
+
+    void Register(EventLoop* loop) {
+        if (loop_ == nullptr) {
+            throw std::runtime_error("Event loop already registered");
+        }
+        loop_ = loop;
+    }
+
+    void Unregister() {
+        loop_ = nullptr;
+    }
+
+private:
+    std::deque<Task*> tasks_;
+    std::unordered_set<Task*> results_;
+    std::mutex lock_;
+    EventLoop* loop_;
+};
+
+
+void SafeCallIntoRBase(MainRThreadTasks::Task* task);
+
+template <typename T>
+T SafeCallIntoR(std::function<cpp11::sexp(void)> fun) {
+    class TypedTask: public MainRThreadTasks::Task {
+    public:
+        TypedTask(std::function<cpp11::sexp(void)> fun): fun_(fun) {};
+
+        void run() {
+            result = cpp11::as_cpp<T>(fun_());
+        }
+
+        T result;
+
+    private:
+        std::function<cpp11::sexp(void)> fun_;
+    };
+
+    TypedTask task(fun);
+    // SafeCallIntoRBase(&task);
+    task.run();
+    return task.result;
+}
+
+#endif

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -95,7 +95,7 @@ template <typename T>
 arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
   class TypedTask : public MainRThread::Task {
    public:
-    TypedTask(std::function<T(void)> fun) : fun_(fun){};
+    explicit TypedTask(std::function<T(void)> fun) : fun_(fun) {}
 
     arrow::Status run() {
       result = fun_();

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -20,58 +20,96 @@
 
 #include "./arrow_types.h"
 
-#include <deque>
-#include <functional>
-#include <mutex>
-#include <thread>
-#include <unordered_set>
+#include <arrow/util/future.h>
 
-class MainRThreadTasks {
+#include <functional>
+#include <thread>
+
+// The MainRThread class keeps track of the thread on which it is safe
+// to call the R API to facilitate its safe use (or erroring
+// if it is not safe). The MainRThread singleton can be accessed from
+// any thread using GetMainRThread(); the preferred way to call
+// the R API where it may not be safe to do so is to use
+// SafeCallIntoR<cpp_type>([&]() { some_expression_returning_sexp; }).
+class MainRThread {
  public:
+  MainRThread() : initialized_(false) {}
+
+  // Call this method from the R thread (e.g., on package load)
+  // to save an internal copy of the thread id.
+  void Initialize() {
+    thread_id_ = std::this_thread::get_id();
+    initialized_ = true;
+    SetError(R_NilValue);
+  }
+
+  bool IsInitialized() { return initialized_; }
+
+  // Check if the current thread is the main R thread
+  bool IsMainThread() { return initialized_ && std::this_thread::get_id() == thread_id_; }
+
+  // Class whose run() method will be called from the main R thread
+  // but whose results may be accessed (as class fields) from
+  // potentially another thread.
   class Task {
    public:
     virtual ~Task() {}
-    virtual void run() {}
+    virtual arrow::Status run() = 0;
   };
 
-  class EventLoop {
-   public:
-    EventLoop();
-    ~EventLoop();
-    std::thread::id thread() { return thread_; }
+  // Synchronously run `task` if it is safe to do so or return an
+  // error otherwise.
+  arrow::Status RunTask(Task* task);
 
-   private:
-    std::thread::id thread_;
-  };
+  // Save an error token generated from a cpp11::unwind_exception
+  // so that it can be properly handled after some cleanup code
+  // has run (e.g., cancelling some futures or waiting for them
+  // to finish).
+  void SetError(cpp11::sexp token) { error_token_ = token; }
 
-  void Register(EventLoop* loop) { loop_ = loop; }
+  // Check if there is a saved error
+  bool HasError() { return error_token_ != R_NilValue; }
 
-  void Unregister() { loop_ = nullptr; }
-
-  EventLoop* Loop() { return loop_; }
+  // Throw a cpp11::unwind_exception() with the saved token if it exists
+  void ClearError() {
+    if (HasError()) {
+      cpp11::unwind_exception e(error_token_);
+      SetError(R_NilValue);
+      throw e;
+    }
+  }
 
  private:
-  EventLoop* loop_;
+  bool initialized_;
+  std::thread::id thread_id_;
+  cpp11::sexp error_token_;
 };
 
-void SafeCallIntoRBase(MainRThreadTasks::Task* task);
+// Retrieve the MainRThread singleton
+MainRThread* GetMainRThread();
 
+// Call into R and return a C++ object. Note that you can't return
+// a SEXP (use cpp11::as_sexp<T> to convert it to a C++ type inside
+// `fun`).
 template <typename T>
-T SafeCallIntoR(std::function<cpp11::sexp(void)> fun) {
-  class TypedTask : public MainRThreadTasks::Task {
+arrow::Result<T> SafeCallIntoR(std::function<T(void)> fun) {
+  class TypedTask : public MainRThread::Task {
    public:
-    TypedTask(std::function<cpp11::sexp(void)> fun) : fun_(fun){};
+    TypedTask(std::function<T(void)> fun) : fun_(fun){};
 
-    void run() { result = cpp11::as_cpp<T>(fun_()); }
+    arrow::Status run() {
+      result = fun_();
+      return arrow::Status::OK();
+    }
 
     T result;
 
    private:
-    std::function<cpp11::sexp(void)> fun_;
+    std::function<T(void)> fun_;
   };
 
   TypedTask task(fun);
-  SafeCallIntoRBase(&task);
+  ARROW_RETURN_NOT_OK(GetMainRThread()->RunTask(&task));
   return task.result;
 }
 

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef SAFE_CALL_INTO_R_INCLUDED
 #define SAFE_CALL_INTO_R_INCLUDED

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -5,94 +5,58 @@
 #include "./arrow_types.h"
 
 #include <deque>
-#include <unordered_set>
+#include <functional>
 #include <mutex>
 #include <thread>
-#include <functional>
+#include <unordered_set>
 
 class MainRThreadTasks {
-public:
-    class Task {
-    public:
-        virtual ~Task() {}
-        virtual void run() {}
-    };
+ public:
+  class Task {
+   public:
+    virtual ~Task() {}
+    virtual void run() {}
+  };
 
-    class EventLoop {
-    public:
-        EventLoop();
-        ~EventLoop();
-        void start_looping();
-        void stop_looping();
-    private:
-        std::thread::id thread_;
-        bool keep_looping_;
-    };
+  class EventLoop {
+   public:
+    EventLoop();
+    ~EventLoop();
+    std::thread::id thread() { return thread_; }
 
-    void EvaluatePending() {
-        lock_.lock();
-        while (!tasks_.empty()) {
-            Task* task = tasks_.back();
-            tasks_.pop_back();
-            task->run();
-        }
-        lock_.unlock();
-    }
+   private:
+    std::thread::id thread_;
+  };
 
-    void Add(Task* task) {
-        lock_.lock();
-        tasks_.push_front(task);
-        lock_.unlock();
-    }
+  void Register(EventLoop* loop) { loop_ = loop; }
 
-    bool is_finished(Task* task) {
-        lock_.lock();
-        bool result = results_.find(task) != results_.end();
-        lock_.unlock();
-        return result;
-    }
+  void Unregister() { loop_ = nullptr; }
 
-    void Register(EventLoop* loop) {
-        if (loop_ == nullptr) {
-            throw std::runtime_error("Event loop already registered");
-        }
-        loop_ = loop;
-    }
+  EventLoop* Loop() { return loop_; }
 
-    void Unregister() {
-        loop_ = nullptr;
-    }
-
-private:
-    std::deque<Task*> tasks_;
-    std::unordered_set<Task*> results_;
-    std::mutex lock_;
-    EventLoop* loop_;
+ private:
+  EventLoop* loop_;
 };
-
 
 void SafeCallIntoRBase(MainRThreadTasks::Task* task);
 
 template <typename T>
 T SafeCallIntoR(std::function<cpp11::sexp(void)> fun) {
-    class TypedTask: public MainRThreadTasks::Task {
-    public:
-        TypedTask(std::function<cpp11::sexp(void)> fun): fun_(fun) {};
+  class TypedTask : public MainRThreadTasks::Task {
+   public:
+    TypedTask(std::function<cpp11::sexp(void)> fun) : fun_(fun){};
 
-        void run() {
-            result = cpp11::as_cpp<T>(fun_());
-        }
+    void run() { result = cpp11::as_cpp<T>(fun_()); }
 
-        T result;
+    T result;
 
-    private:
-        std::function<cpp11::sexp(void)> fun_;
-    };
+   private:
+    std::function<cpp11::sexp(void)> fun_;
+  };
 
-    TypedTask task(fun);
-    // SafeCallIntoRBase(&task);
-    task.run();
-    return task.result;
+  TypedTask task(fun);
+  SafeCallIntoRBase(&task);
+  return task.result;
 }
 
 #endif

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -49,8 +49,6 @@ class MainRThread {
   // Check if the current thread is the main R thread
   bool IsMainThread() { return initialized_ && std::this_thread::get_id() == thread_id_; }
 
-
-
   // Class whose run() method will be called from the main R thread
   // but whose results may be accessed (as class fields) from
   // potentially another thread.
@@ -63,9 +61,7 @@ class MainRThread {
   // Run `task` if it is safe to do so or return an error otherwise.
   arrow::Status RunTask(Task* task);
 
-  arrow::internal::Executor*& Executor() {
-    return executor_;
-  }
+  arrow::internal::Executor*& Executor() { return executor_; }
 
   // Save an error token generated from a cpp11::unwind_exception
   // so that it can be properly handled after some cleanup code

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -39,7 +39,6 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
   )
 })
 
-
 test_that("SafeCallIntoR errors from the non-R thread", {
   expect_error(
     TestSafeCallIntoR(function() "string one!", opt = "async_without_executor"),

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -35,10 +35,10 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
 
   # This runs with the expected error, but causes subsequent segfaults, probably related
   # to the error_token_ (maybe having to do with the copy-constructor?)
-  # expect_error(
-  #   TestSafeCallIntoR(function() stop("an error!"), opt = "async_with_executor"),
-  #   "an error!"
-  # )
+  expect_error(
+    TestSafeCallIntoR(function() stop("an error!"), opt = "async_with_executor"),
+    "an error!"
+  )
 })
 
 

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -33,8 +33,6 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
     "string one!"
   )
 
-  # This runs with the expected error, but causes subsequent segfaults, probably related
-  # to the error_token_ (maybe having to do with the copy-constructor?)
   expect_error(
     TestSafeCallIntoR(function() stop("an error!"), opt = "async_with_executor"),
     "an error!"

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Note that TestSafeCallIntoR is defined in safe-call-into-r-impl.cpp
+
 test_that("SafeCallIntoR works from the main R thread", {
   expect_identical(
     TestSafeCallIntoR(function() "string one!", opt = "on_main_thread"),

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -45,11 +45,11 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
 test_that("SafeCallIntoR errors from the non-R thread", {
   expect_error(
     TestSafeCallIntoR(function() "string one!", opt = "async_without_executor"),
-    "Call to R from a non-R thread without an event loop"
+    "Call to R from a non-R thread"
   )
 
   expect_error(
     TestSafeCallIntoR(function() stop("an error!"), opt = "async_without_executor"),
-    "Call to R from a non-R thread without an event loop"
+    "Call to R from a non-R thread"
   )
 })

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -18,6 +18,8 @@
 # Note that TestSafeCallIntoR is defined in safe-call-into-r-impl.cpp
 
 test_that("SafeCallIntoR works from the main R thread", {
+  skip_on_cran()
+
   expect_identical(
     TestSafeCallIntoR(function() "string one!", opt = "on_main_thread"),
     "string one!"
@@ -30,6 +32,8 @@ test_that("SafeCallIntoR works from the main R thread", {
 })
 
 test_that("SafeCallIntoR works within RunWithCapturedR", {
+  skip_on_cran()
+
   expect_identical(
     TestSafeCallIntoR(function() "string one!", opt = "async_with_executor"),
     "string one!"
@@ -42,6 +46,8 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
 })
 
 test_that("SafeCallIntoR errors from the non-R thread", {
+  skip_on_cran()
+
   expect_error(
     TestSafeCallIntoR(function() "string one!", opt = "async_without_executor"),
     "Call to R from a non-R thread"

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+test_that("SafeCallIntoR works from the main R thread", {
+  expect_identical(
+    TestSafeCallIntoR(function() "string one!", opt = "on_main_thread"),
+    "string one!"
+  )
+
+  expect_error(
+    TestSafeCallIntoR(function() stop("an error!"), opt = "on_main_thread"),
+    "an error!"
+  )
+})
+
+test_that("SafeCallIntoR works within RunWithCapturedR", {
+  expect_identical(
+    TestSafeCallIntoR(function() "string one!", opt = "async_with_executor"),
+    "string one!"
+  )
+
+  # This runs with the expected error, but causes subsequent segfaults, probably related
+  # to the error_token_ (maybe having to do with the copy-constructor?)
+  # expect_error(
+  #   TestSafeCallIntoR(function() stop("an error!"), opt = "async_with_executor"),
+  #   "an error!"
+  # )
+})
+
+
+test_that("SafeCallIntoR errors from the non-R thread", {
+  expect_error(
+    TestSafeCallIntoR(function() "string one!", opt = "async_without_executor"),
+    "Call to R from a non-R thread without an event loop"
+  )
+
+  expect_error(
+    TestSafeCallIntoR(function() stop("an error!"), opt = "async_without_executor"),
+    "Call to R from a non-R thread without an event loop"
+  )
+})


### PR DESCRIPTION
This is a very WIP draft that currently just sketches a few things related to calling into R from other threads. Some code to get started:

``` r
arrow:::TestSafeCallIntoR(
  list(
    function() "string one",
    function() "string two"
  )
)
#> [1] "string one" "string two"

arrow:::TestSafeCallIntoR(
  list(
    function() stop("This is an error!")
  )
)
#> Error in (function () : This is an error!
```
