### PR TITLE
ARROW-15844: [Release][Packaging] Use ASCII format for detached sign

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -887,7 +887,8 @@ class BinaryTask
       rm(destination_path, verbose: false)
     end
     sh("gpg",
-       "--detach-sig",
+       "--armor",
+       "--detach-sign",
        "--local-user", gpg_key_id,
        "--output", destination_path,
        source_path,


### PR DESCRIPTION
We use .asc for extension. Generally, .asc is used for ASCII format.