### PR TITLE
MINOR: [C++][CI] Pin CMake to fix builds failing due to aws-sdk-cpp

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -21,7 +21,8 @@ boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares
-cmake
+# Required due to the AWS SDK C++ pin
+cmake<3.22
 gflags
 glog
 gmock>=1.10.0


### PR DESCRIPTION
See: https://gitlab.kitware.com/cmake/cmake/-/issues/22524