### PR TITLE
MINOR: [Python] Add GitHub URL for PyPi

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -642,5 +642,9 @@ setup(
     maintainer='Apache Arrow Developers',
     maintainer_email='dev@arrow.apache.org',
     test_suite='pyarrow.tests',
-    url='https://arrow.apache.org/'
+    url='https://arrow.apache.org/',
+    project_urls={
+        'Documentation': 'https://arrow.apache.org/docs/python',
+        'Source': 'https://github.com/apache/arrow',
+    },
 )


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)