### PR TITLE
ARROW-15864: [Java][Docs] Update Arrow nightly Maven releases documentation

### DIFF
--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -83,7 +83,8 @@ Installing Nightly Packages
 
 Arrow nightly builds are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
 
-Follow the steps and get your nightly packages installed to local maven repository:
+Maven cannot directly use the artifacts from GitHub.
+Instead, install them to the local Maven repository:
 
 1. Decide nightly packages repository to use, for example: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-03-0-github-java-jars
 2. Define nightly packages to use, for example: `arrow-vector` and `arrow-format`
@@ -121,7 +122,7 @@ Follow the steps and get your nightly packages installed to local maven reposito
     |__ arrow-format-8.0.0.dev165.jar
     |__ arrow-vector-8.0.0.dev165.jar
 
-4. Install nightly java version to local maven repository with `mvn install:install-file`
+4. Install the artifacts to the local Maven repository with ``mvn install:install-file``
 
 .. code-block:: shell
 
@@ -144,7 +145,7 @@ Follow the steps and get your nightly packages installed to local maven reposito
         -Dgenerate.pom=true
     [INFO] Installing /nightly-2022-03-03-0-github-java-jars/arrow-vector-8.0.0.dev165.jar to /Users/arrow/.m2/repository/org/apache/arrow/arrow-vector/8.0.0.dev165/arrow-vector-8.0.0.dev165.jar
 
-6. Validate packages installed locally on maven repository:
+6. Validate that the packages were installed:
 
 .. code-block:: shell
 

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -83,35 +83,93 @@ Installing Nightly Packages
 
 Arrow nightly builds are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
 
-To test your code with these artifacts, then configure Maven with:
+There is not a recipe to configure maven settings.xml/pom.xml to integrate local project with github nightly packages
+in a easily/transparent way. For that reason if you need to test nightly packages one way is:
 
-.. code-block:: xml
+* Define what nightly directory are you needed, example: nightly-2022-03-03-0-github-java-jars
+* Then, define packages needed: ALL or only needed (memory)
+* Then, run a shell that download ALL or only needed (memory) jar|pom files to a temporary directory
+* Then, the same shell install packages downloaded locally using maven command `mvn install:install-file`
+* Then, go to your project add nightly packages needed
+* Then, compile your project with `mvn clean install`
 
-    $ cat ~/.m2/settings.xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <profiles>
-        <profile>
-          <repositories>
-            <repository>
-               <id>staged</id>
-               <name>staged-releases</name>
-               <url>https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-01-0-github-java-jars/</url>
-               <releases>
-                 <enabled>true</enabled>
-               </releases>
-               <snapshots>
-                 <enabled>true</enabled>
-               </snapshots>
-             </repository>
-          </repositories>
-          <id>arrownightly</id>
-        </profile>
-      </profiles>
-    </settings>
-    $ mvn -Parrownightly clean install -X
-    Downloading from staged: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-01-0-github-java-jars/org/apache/arrow/arrow-vector/8.0.0.dev143/arrow-vector-8.0.0.dev143.pom
+These are detailed steps:
+
+Create a filename `arrow_java_nightly.sh` that contains the following lines ofcode:
+
+.. code-block:: shell
+
+    $ cat arrow_java_nightly.sh
+    #!/bin/bash
+
+    # Shell variables
+    ARROW_JAVA_NIGHTLY_VERSION=${1:-'nightly-2022-03-03-0-github-java-jars'}
+    DEPENDENCY_TO_INSTALL=${2:-'arrow'}
+
+    # Local Variables
+    TMP_FOLDER=arrow_java_$(date +"%d-%m-%Y")
+    PATTERN_TO_GET_LIB_AND_VERSION='([a-z].+)-([0-9].[0-9].[0-9].dev[0-9]+).([a-z]+)'
+
+    # Aplication logic
+    echo $DEPENDENCY_TO_INSTALL
+    mkdir -p $TMP_FOLDER
+    pushd $TMP_FOLDER
+    echo "**************** 1 - Download arrow-java $1 dependencies ****************"
+    wget $( \
+        wget \
+            -qO- https://api.github.com/repos/ursacomputing/crossbow/releases/tags/$ARROW_JAVA_NIGHTLY_VERSION \
+            | jq -r '.assets[] | select((.name | endswith(".pom")) or (.name | endswith(".jar"))) | .browser_download_url' \
+            | grep $DEPENDENCY_TO_INSTALL )
+
+
+    echo "**************** 2 - Install arrow java libraries to local repository ****************"
+    for LIBRARY in $(ls | grep -E '.jar' | grep dev); do
+        [[ $LIBRARY =~ $PATTERN_TO_GET_LIB_AND_VERSION ]]
+        FILE=$PWD/${BASH_REMATCH[0]}
+        if [[ ( ${BASH_REMATCH[0]} == *"$DEPENDENCY_TO_INSTALL"* ) ]];then
+            if [ -f "$FILE" ]; then
+                FILE=$FILE
+            else
+                if [ -f "$FILE.jar" ]; then # Out of regex: -javadoc.jar / -sources.jar
+                    FILE=$FILE.jar
+                else
+                    if [ -f "$FILE-with-dependencies.jar" ]; then # Out of regex: -with-dependencies.jar
+                        FILE=$FILE-with-dependencies.jar
+                    else
+                        echo "Please! Review $FILE, it was not intalled on m2 locally."
+                    fi
+                fi
+            fi
+            echo "$FILE"
+            mvn install:install-file \
+                -Dfile="$FILE" \
+                -DgroupId=org.apache.arrow \
+                -DartifactId=${BASH_REMATCH[1]} \
+                -Dversion=${BASH_REMATCH[2]} \
+                -Dpackaging=${BASH_REMATCH[3]} \
+                -DcreateChecksum=true \
+                -Dgenerate.pom=true
+        fi
+    done
+    popd
+    # rm -rf $TMP_FOLDER
+    echo "Go to your project and execute: mvn clean install"
+
+Run the shell file just created with the following parameters:
+
+.. code-block:: shell
+
+    # Download all dependencies
+    sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars
+
+    # Download needed library, for example: memory
+    sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars memory
+
+Run maven project and execute:
+
+.. code-block:: shell
+
+    mvn clean install
 
 Arrow nightly builds are posted on the mailing list at `builds@arrow.apache.org`_.
 

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -146,7 +146,7 @@ Instead, install them to the local Maven repository:
         -Dgenerate.pom=true
     [INFO] Installing /nightly-2022-03-03-0-github-java-jars/arrow-vector-8.0.0.dev165.jar to /Users/arrow/.m2/repository/org/apache/arrow/arrow-vector/8.0.0.dev165/arrow-vector-8.0.0.dev165.jar
 
-6. Validate that the packages were installed:
+5. Validate that the packages were installed:
 
 .. code-block:: shell
 
@@ -160,12 +160,7 @@ Instead, install them to the local Maven repository:
             |__ arrow-vector-8.0.0.dev165.jar
             |__ arrow-vector-8.0.0.dev165.pom
 
-5. Compile your project with `mvn clean install`.
-
-.. code-block:: shell
-
-    $ mvn clean install
-    [INFO] BUILD SUCCESS
+6. Compile your project like usual with ``mvn install``.
 
 .. _builds@arrow.apache.org: https://lists.apache.org/list.html?builds@arrow.apache.org
 .. _Github Nightly: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-01-0-github-java-jars

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -81,7 +81,8 @@ Installing Nightly Packages
 .. warning::
     These packages are not official releases. Use them at your own risk.
 
-Arrow nightly builds are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
+Arrow nightly builds are posted on the mailing list at `builds@arrow.apache.org`_.
+The artifacts are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
 
 Maven cannot directly use the artifacts from GitHub.
 Instead, install them to the local Maven repository:
@@ -165,9 +166,6 @@ Instead, install them to the local Maven repository:
 
     $ mvn clean install
     [INFO] BUILD SUCCESS
-
-Arrow nightly builds are posted on the mailing list at `builds@arrow.apache.org`_.
-The artifacts are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
 
 .. _builds@arrow.apache.org: https://lists.apache.org/list.html?builds@arrow.apache.org
 .. _Github Nightly: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-01-0-github-java-jars

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -160,16 +160,16 @@ Run the shell file just created with the following parameters:
 .. code-block:: shell
 
     # Download all dependencies
-    sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars
+    $ sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars
 
     # Download needed library, for example: memory
-    sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars memory
+    $ sh arrow_java_nightly.sh nightly-2022-03-03-0-github-java-jars memory
 
 Run maven project and execute:
 
 .. code-block:: shell
 
-    mvn clean install
+    $ mvn clean install
 
 Arrow nightly builds are posted on the mailing list at `builds@arrow.apache.org`_.
 

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -167,6 +167,7 @@ Instead, install them to the local Maven repository:
     [INFO] BUILD SUCCESS
 
 Arrow nightly builds are posted on the mailing list at `builds@arrow.apache.org`_.
+The artifacts are uploaded to GitHub. For example, for 2022/03/01, they can be found at `Github Nightly`_.
 
 .. _builds@arrow.apache.org: https://lists.apache.org/list.html?builds@arrow.apache.org
 .. _Github Nightly: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-01-0-github-java-jars

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -88,7 +88,7 @@ Maven cannot directly use the artifacts from GitHub.
 Instead, install them to the local Maven repository:
 
 1. Decide nightly packages repository to use, for example: https://github.com/ursacomputing/crossbow/releases/tag/nightly-2022-03-03-0-github-java-jars
-2. Define nightly packages to use, for example: `arrow-vector` and `arrow-format`
+2. Add packages to your pom.xml, for example: ``arrow-vector`` and ``arrow-format``:
 
 .. code-block:: xml
 
@@ -111,7 +111,7 @@ Instead, install them to the local Maven repository:
         </dependency>
     </dependencies>
 
-3. Download packages needed to a temporary directory
+3. Download packages needed to a temporary directory:
 
 .. code-block:: shell
 
@@ -123,7 +123,7 @@ Instead, install them to the local Maven repository:
     |__ arrow-format-8.0.0.dev165.jar
     |__ arrow-vector-8.0.0.dev165.jar
 
-4. Install the artifacts to the local Maven repository with ``mvn install:install-file``
+4. Install the artifacts to the local Maven repository with ``mvn install:install-file``:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Current java artifacts nightly build are uploaded to github as an assets.

Update current [documentation](https://github.com/apache/arrow/blob/650f111b524fb1c5bfbfa6f533d15929c90ddc40/docs/source/java/install.rst#installing-nightly-packages) related to how to install java artifacts nightly.

The artifacts are downloaded without problems but .pom and .jar are downloaded as an invalid file format.

Add detail about how to upload jar to maven locally.