### PR TITLE
ARROW-15829: [C++] Support SetNull in NumericalBuilder

### DIFF
--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -146,6 +146,11 @@ class NumericBuilder : public ArrayBuilder {
     return reinterpret_cast<value_type*>(data_builder_.mutable_data())[index];
   }
 
+  void UnsafeSetIsNull(int64_t index, bool is_null) {
+    this->operator[](index) = value_type{};
+    null_count_ += null_bitmap_builder_.UnsafeUpdate(index, !is_null);
+  }
+
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values a contiguous C array of values
   /// \param[in] length the number of values to append

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -383,6 +383,24 @@ class TypedBufferBuilder<bool> {
     bit_length_ += num_elements;
   }
 
+  /// \brief Update a bit based on the given index and returns the change of
+  /// total number of false bits
+  int UnsafeUpdate(int64_t index, bool value) {
+    auto old_value = bit_util::GetBit(data(), index);
+    if (old_value == value) {
+      return 0;
+    }
+
+    bit_util::SetBitTo(mutable_data(), index, value);
+    if (value) {
+      --false_count_;
+      return -1;
+    } else {
+      ++false_count_;
+      return 1;
+    }
+  }
+
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
     const int64_t old_byte_capacity = bytes_builder_.capacity();
     ARROW_RETURN_NOT_OK(

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -863,6 +863,27 @@ TEST(TestBoolBufferBuilder, AppendCopies) {
   ASSERT_EQ(built->size(), bit_util::BytesForBits(13 + 17));
 }
 
+TEST(TestBoolBufferBuilder, Update) {
+  TypedBufferBuilder<bool> builder;
+
+  ASSERT_OK(builder.Append(10, true));
+  ASSERT_EQ(builder.false_count(), 0);
+  builder.UnsafeUpdate(0, false);
+  ASSERT_EQ(builder.false_count(), 1);
+  builder.UnsafeUpdate(0, true);
+  ASSERT_EQ(builder.false_count(), 0);
+  builder.UnsafeUpdate(6, false);
+  ASSERT_EQ(builder.false_count(), 1);
+
+  std::shared_ptr<Buffer> built;
+  ASSERT_OK(builder.Finish(&built));
+  AssertIsCPUBuffer(*built);
+
+  for (int i = 0; i < 10; ++i) {
+    ASSERT_EQ(bit_util::GetBit(built->data(), i), i == 6 ? false : true);
+  }
+}
+
 TEST(TestBoolBufferBuilder, Reserve) {
   TypedBufferBuilder<bool> builder;
 


### PR DESCRIPTION
Support `SetNull` in NumericalBuilder