### PR TITLE
ARROW-14183: [C++] Improve select_k_unstable performance

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -170,10 +170,12 @@ PartitionNthOptions::PartitionNthOptions(int64_t pivot, NullPlacement null_place
       null_placement(null_placement) {}
 constexpr char PartitionNthOptions::kTypeName[];
 
-SelectKOptions::SelectKOptions(int64_t k, std::vector<SortKey> sort_keys)
+SelectKOptions::SelectKOptions(int64_t k, std::vector<SortKey> sort_keys,
+                               NullPlacement null_placement)
     : FunctionOptions(internal::kSelectKOptionsType),
       k(k),
-      sort_keys(std::move(sort_keys)) {}
+      sort_keys(std::move(sort_keys)),
+      null_placement(null_placement) {}
 constexpr char SelectKOptions::kTypeName[];
 
 namespace internal {

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -142,7 +142,8 @@ class ARROW_EXPORT SortOptions : public FunctionOptions {
 /// \brief SelectK options
 class ARROW_EXPORT SelectKOptions : public FunctionOptions {
  public:
-  explicit SelectKOptions(int64_t k = -1, std::vector<SortKey> sort_keys = {});
+  explicit SelectKOptions(int64_t k = -1, std::vector<SortKey> sort_keys = {},
+                          NullPlacement null_placement = NullPlacement::AtEnd);
   static constexpr char const kTypeName[] = "SelectKOptions";
   static SelectKOptions Defaults() { return SelectKOptions(); }
 
@@ -172,6 +173,8 @@ class ARROW_EXPORT SelectKOptions : public FunctionOptions {
   int64_t k;
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys;
+  /// Whether nulls and NaNs are placed at the start or at the end
+  NullPlacement null_placement;
 };
 
 /// \brief Partitioning options for NthToIndices

--- a/cpp/src/arrow/compute/kernels/chunked_internal.h
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.h
@@ -144,6 +144,19 @@ struct ChunkedArrayResolver : protected ChunkResolver {
         checked_cast<const ArrayType*>(chunks_[loc.chunk_index]), loc.index_in_chunk);
   }
 
+  template <typename ArrayType>
+  ResolvedChunk<ArrayType> Resolve(ChunkLocation loc) const {
+    return ResolvedChunk<ArrayType>(
+        checked_cast<const ArrayType*>(chunks_[loc.chunk_index]), loc.index_in_chunk);
+  }
+
+  template <typename ArrayType>
+  ChunkLocation ResolveChunkLocation(int64_t index) const {
+    const auto loc = ChunkResolver::Resolve(index);
+    return ResolvedChunk<ArrayType>(
+        checked_cast<const ArrayType*>(chunks_[loc.chunk_index]), loc.index_in_chunk);
+  }
+
  protected:
   static std::vector<int64_t> MakeLengths(const std::vector<const Array*>& chunks) {
     std::vector<int64_t> lengths(chunks.size());


### PR DESCRIPTION
Improve select_k_unstable performance, for tables using radix sort for sort individual batches, and a merge sort with K first elements.