### PR TITLE
ARROW-15750: [Ruby] Add support for #raw_records of Month Interval Type

### DIFF
--- a/ruby/red-arrow/ext/arrow/raw-records.cpp
+++ b/ruby/red-arrow/ext/arrow/raw-records.cpp
@@ -98,6 +98,7 @@ namespace red_arrow {
       VISIT(Timestamp)
       // TODO
       // VISIT(Interval)
+      VISIT(MonthInterval)
       VISIT(List)
       VISIT(Struct)
       VISIT(Map)

--- a/ruby/red-arrow/test/raw-records/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/raw-records/test-basic-arrays.rb
@@ -330,6 +330,16 @@ module RawRecordsBasicArraysTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [1],
+      [nil],
+      [12],
+    ]
+    target = build({column: :month_interval}, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_decimal256
     records = [
       [BigDecimal("92.92")],

--- a/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
@@ -359,6 +359,15 @@ module RawRecordsDenseUnionArrayTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [{"0" => 1}],
+      [{"1" => nil}],
+    ]
+    target = build(:month_interval, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_list
     records = [
       [{"0" => [true, nil, false]}],

--- a/ruby/red-arrow/test/raw-records/test-list-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-list-array.rb
@@ -399,6 +399,15 @@ module RawRecordsListArrayTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [[1, nil, 12]],
+      [nil],
+    ]
+    target = build(:month_interval, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_list
     records = [
       [

--- a/ruby/red-arrow/test/raw-records/test-map-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-map-array.rb
@@ -310,6 +310,15 @@ module RawRecordsMapArrayTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [{"key1" => 1, "key2" => nil}],
+      [nil],
+    ]
+    target = build(:month_interval, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_list
     records = [
       [{"key1" => [true, nil, false], "key2" => nil}],

--- a/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
@@ -349,6 +349,15 @@ module RawRecordsSparseUnionArrayTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [{"0" => 1}],
+      [{"1" => nil}],
+    ]
+    target = build(:month_interval, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_list
     records = [
       [{"0" => [true, nil, false]}],

--- a/ruby/red-arrow/test/raw-records/test-struct-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-struct-array.rb
@@ -344,6 +344,16 @@ module RawRecordsStructArrayTests
     assert_equal(records, target.raw_records)
   end
 
+  def test_month_interval
+    records = [
+      [{"field" => 1}],
+      [nil],
+      [{"field" => nil}],
+    ]
+    target = build(:month_interval, records)
+    assert_equal(records, target.raw_records)
+  end
+
   def test_list
     records = [
       [{"field" => [true, nil, false]}],


### PR DESCRIPTION
Implement #raw_records method of month interval type to red arrow.