### PR TITLE
ARROW-15885 [Ruby] Add support for #values of DayTime Interval Type

### DIFF
--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -36,6 +36,11 @@ namespace red_arrow {
   ID id_jd;
   ID id_new;
   ID id_to_datetime;
+
+  namespace symbols {
+    VALUE day;
+    VALUE millisecond;
+  }
 }
 
 extern "C" void Init_arrow() {
@@ -81,4 +86,7 @@ extern "C" void Init_arrow() {
   red_arrow::id_to_datetime = rb_intern("to_datetime");
 
   red_arrow::memory_view::init(mArrow);
+
+  red_arrow::symbols::day = ID2SYM(rb_intern("day"));
+  red_arrow::symbols::millisecond = ID2SYM(rb_intern("millisecond"));
 }

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -207,6 +207,21 @@ namespace red_arrow {
       return INT2NUM(array.Value(i));
     }
 
+    inline VALUE convert(const arrow::DayTimeIntervalArray& array,
+                         const int64_t i) {
+
+      auto value = rb_hash_new();
+      auto arrow_value = array.Value(i);
+      rb_hash_aset(value,
+                   red_arrow::symbols::day,
+                   INT2NUM(arrow_value.days));
+      rb_hash_aset(value,
+                   red_arrow::symbols::millisecond,
+                   INT2NUM(arrow_value.milliseconds));
+
+      return value;
+    }
+
     VALUE convert(const arrow::ListArray& array,
                   const int64_t i);
 
@@ -306,6 +321,7 @@ namespace red_arrow {
     // TODO
     // VISIT(Interval)
     VISIT(MonthInterval)
+    VISIT(DayTimeInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -413,6 +429,7 @@ namespace red_arrow {
     // TODO
     // VISIT(Interval)
     VISIT(MonthInterval)
+    VISIT(DayTimeInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -516,6 +533,7 @@ namespace red_arrow {
     // TODO
     // VISIT(Interval)
     VISIT(MonthInterval)
+    VISIT(DayTimeInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)
@@ -620,6 +638,7 @@ namespace red_arrow {
     // TODO
     // VISIT(Interval)
     VISIT(MonthInterval)
+    VISIT(DayTimeInterval)
     VISIT(List)
     VISIT(Struct)
     VISIT(Map)

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -209,7 +209,6 @@ namespace red_arrow {
 
     inline VALUE convert(const arrow::DayTimeIntervalArray& array,
                          const int64_t i) {
-
       auto value = rb_hash_new();
       auto arrow_value = array.Value(i);
       rb_hash_aset(value,

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -217,7 +217,6 @@ namespace red_arrow {
       rb_hash_aset(value,
                    red_arrow::symbols::millisecond,
                    INT2NUM(arrow_value.milliseconds));
-
       return value;
     }
 

--- a/ruby/red-arrow/ext/arrow/red-arrow.hpp
+++ b/ruby/red-arrow/ext/arrow/red-arrow.hpp
@@ -47,6 +47,11 @@ namespace red_arrow {
   extern ID id_new;
   extern ID id_to_datetime;
 
+  namespace symbols {
+    extern VALUE day;
+    extern VALUE millisecond;
+  }
+
   VALUE array_values(VALUE obj);
   VALUE chunked_array_values(VALUE obj);
 

--- a/ruby/red-arrow/ext/arrow/values.cpp
+++ b/ruby/red-arrow/ext/arrow/values.cpp
@@ -80,6 +80,7 @@ namespace red_arrow {
       // TODO
       // VISIT(Interval)
       VISIT(MonthInterval)
+      VISIT(DayTimeInterval)
       VISIT(List)
       VISIT(Struct)
       VISIT(Map)

--- a/ruby/red-arrow/test/values/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/values/test-basic-arrays.rb
@@ -286,6 +286,21 @@ module ValuesBasicArraysTests
     target = build(Arrow::MonthIntervalArray.new(values))
     assert_equal(values, target.values)
   end
+
+  def test_day_time_interval
+    values = [
+      {day: 1, millisecond: 100},
+      nil,
+      {day: 2, millisecond: 300},
+    ]
+    inputs = [
+      Arrow::DayMillisecond.new(1, 100),
+      nil,
+      Arrow::DayMillisecond.new(2, 300),
+    ]
+    target = build(Arrow::DayTimeIntervalArray.new(inputs))
+    assert_equal(values, target.values)
+  end
 end
 
 class ValuesArrayBasicArraysTest < Test::Unit::TestCase

--- a/ruby/red-arrow/test/values/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/values/test-dense-union-array.rb
@@ -356,6 +356,19 @@ module ValuesDenseUnionArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_day_time_interval
+    values = [
+      {"0" => {day: 1, millisecond: 100}},
+      {"1" => nil},
+    ]
+    inputs = [
+      {"0" => Arrow::DayMillisecond.new(1, 100)},
+      {"1" => nil},
+    ]
+    target = build(:day_time_interval, inputs)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"0" => [true, nil, false]},

--- a/ruby/red-arrow/test/values/test-list-array.rb
+++ b/ruby/red-arrow/test/values/test-list-array.rb
@@ -385,6 +385,27 @@ module ValuesListArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_day_time_interval
+    values = [
+      [
+        {day: 1, millisecond: 100},
+        nil,
+        {day: 2, millisecond: 300},
+      ],
+      nil,
+    ]
+    inputs = [
+      [
+        Arrow::DayMillisecond.new(1, 100),
+        nil,
+        Arrow::DayMillisecond.new(2, 300),
+      ],
+      nil,
+    ]
+    target = build(:day_time_interval, inputs)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       [

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -311,6 +311,25 @@ module ValuesMapArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_day_time_interval
+    values = [
+      {
+        "key1" => {day: 1, millisecond: 100},
+        "key2" => nil,
+      },
+      nil,
+    ]
+    inputs = [
+      {
+        "key1" => Arrow::DayMillisecond.new(1, 100),
+        "key2" => nil,
+      },
+      nil,
+    ]
+    target = build(:day_time_interval, inputs)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"key1" => [true, nil, false], "key2" => nil},

--- a/ruby/red-arrow/test/values/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/values/test-sparse-union-array.rb
@@ -333,6 +333,19 @@ module ValuesSparseUnionArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_day_time_interval
+    values = [
+      {"0" => {day: 1, millisecond: 100}},
+      {"1" => nil},
+    ]
+    inputs = [
+      {"0" => Arrow::DayMillisecond.new(1, 100)},
+      {"1" => nil},
+    ]
+    target = build(:day_time_interval, inputs)
+    assert_equal(values, target.values)
+  end
+
   def test_decimal256
     values = [
       {"0" => BigDecimal("92.92")},

--- a/ruby/red-arrow/test/values/test-struct-array.rb
+++ b/ruby/red-arrow/test/values/test-struct-array.rb
@@ -351,6 +351,21 @@ module ValuesStructArrayTests
     assert_equal(values, target.values)
   end
 
+  def test_day_time_interval
+    values = [
+      {"field" => {day: 1, millisecond: 100}},
+      nil,
+      {"field" => nil},
+    ]
+    inputs = [
+      {"field" => Arrow::DayMillisecond.new(1, 100)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:day_time_interval, inputs)
+    assert_equal(values, target.values)
+  end
+
   def test_list
     values = [
       {"field" => [true, nil, false]},


### PR DESCRIPTION
Implement #values method of day time interval type to red arrow.