### PR TITLE
MINOR: [Python] Make ARROW_DEBUG_MEMORY_POOL test more robust

### DIFF
--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -191,6 +191,10 @@ def run_debug_memory_pool(pool_factory, env_value):
 
         pool = pa.{pool_factory}()
         buf = pa.allocate_buffer(64, memory_pool=pool)
+        # Allocate another buffer which will hopefully be laid out
+        # contiguously after `buf` (so that writing out of bounds to `buf`
+        # doesn't crash the process).
+        buf2 = pa.allocate_buffer(64, memory_pool=pool)
 
         # Write memory out of bounds
         ptr = ctypes.cast(buf.address, ctypes.POINTER(ctypes.c_ubyte))


### PR DESCRIPTION
When writing out of bounds and ARROW_DEBUG_MEMORY_POOL isn't set, the test subprocess may crash depending on the underlying allocator.