### PR TITLE
ARROW-14823: [R] Implement bindings for lubridate::leap_year

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -157,8 +157,7 @@ register_bindings_datetime <- function() {
   })
 
   register_binding("leap_year", function(date) {
-    year <- Expression$create("year", date)
-    (year %% 4 == 0) & ((year %% 100 != 0) | (year %% 400 == 0))
+    Expression$create("is_leap_year", date)
   })
 
   register_binding("am", function(x) {


### PR DESCRIPTION
updates the binding for `lubridate::leap_year` to call `is_leap_year` directly now that it is available