### PR TITLE
ARROW-15898: [CI] Clean old conda nightlies more thoroughly

### DIFF
--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -23,6 +23,6 @@ jobs:
       {% endif %}
       eval "$(conda shell.bash hook)"
       conda activate base
-      python3 arrow/dev/tasks/conda-recipes/clean.py FORCE
+      python3 arrow/dev/tasks/conda-recipes/clean.py {% if arrow.branch == 'master' %}FORCE{% endif %}
     displayName: Delete outdated packages
 

--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -23,6 +23,6 @@ jobs:
       {% endif %}
       eval "$(conda shell.bash hook)"
       conda activate base
-      python3 arrow/dev/tasks/conda-recipes/clean.py {% if arrow.branch == 'master' %}FORCE{% endif %}
+      python3 arrow/dev/tasks/conda-recipes/clean.py FORCE
     displayName: Delete outdated packages
 

--- a/dev/tasks/conda-recipes/clean.py
+++ b/dev/tasks/conda-recipes/clean.py
@@ -1,8 +1,7 @@
 from subprocess import check_output, check_call
-from typing import List, Set
+from typing import Set
 
 import json
-import os
 import pandas as pd
 import sys
 
@@ -80,5 +79,5 @@ if __name__ == "__main__":
         print(f"- {name}")
 
     if "FORCE" in sys.argv:
-        print(f"Deleting ...")
+        print("Deleting ...")
         check_call(["anaconda", "remove", "-f"] + to_delete)

--- a/dev/tasks/conda-recipes/clean.py
+++ b/dev/tasks/conda-recipes/clean.py
@@ -1,5 +1,5 @@
 from subprocess import check_output, check_call
-from typing import List
+from typing import List, Set
 
 import json
 import os
@@ -10,26 +10,18 @@ from packaging.version import Version
 
 
 VERSIONS_TO_KEEP = 5
-PACKAGES = [
-    "arrow-cpp",
-    "arrow-cpp-proc",
-    "parquet-cpp",
-    "pyarrow",
-    "pyarrow-tests",
-    "r-arrow",
-]
+DELETE_BEFORE = pd.Timestamp.now() - pd.Timedelta(days=30)
+
 PLATFORMS = [
     "linux-64",
     "linux-aarch64",
     "osx-64",
+    "osx-arm64",
     "win-64",
 ]
-EXCLUDED_PATTERNS = [
-    ["r-arrow", "linux-aarch64"],
-]
 
 
-def packages_to_delete(package_name: str, platform: str) -> List[str]:
+def packages_to_delete(platform: str, to_delete: Set[str]):
     env = os.environ.copy()
     env["CONDA_SUBDIR"] = platform
     pkgs_json = check_output(
@@ -40,41 +32,50 @@ def packages_to_delete(package_name: str, platform: str) -> List[str]:
             "-c",
             "arrow-nightlies",
             "--override-channels",
-            package_name,
         ],
         env=env,
     )
-    pkgs = pd.DataFrame(json.loads(pkgs_json)[package_name])
-    pkgs["version"] = pkgs["version"].map(Version)
-    pkgs["py_version"] = pkgs["build"].str.slice(0, 4)
+    pkgs = json.loads(pkgs_json)
 
-    to_delete = []
+    for package_name, builds in pkgs.items():
+        builds = pd.DataFrame(builds)
+        builds["version"] = builds["version"].map(Version)
+        # May be NaN if package doesn't depend on Python
+        builds["py_version"] = builds["build"].str.extract(r'(py\d+)')
+        builds["timestamp"] = pd.to_datetime(builds['timestamp'], unit='ms')
+        builds["stale"] = builds["timestamp"]< DELETE_BEFORE
 
-    for (subdir, python), group in pkgs.groupby(["subdir", "py_version"]):
-        group = group.sort_values(by="version", ascending=False)
+        for (subdir, python, stale), group in builds.groupby(
+                ["subdir", "py_version", "stale"]):
+            if stale:
+                del_candidates = group
+            else:
+                group = group.sort_values(by="version", ascending=False)
+                if len(group) > VERSIONS_TO_KEEP:
+                    del_candidates = group[VERSIONS_TO_KEEP:]
 
-        if len(group) > VERSIONS_TO_KEEP:
-            del_candidates = group[VERSIONS_TO_KEEP:]
-            to_delete += (
+            to_delete.update(
                 f"arrow-nightlies/{package_name}/"
                 + del_candidates["version"].astype(str)
                 + del_candidates["url"].str.replace(
-                    "https://conda.anaconda.org/arrow-nightlies", ""
+                    "https://conda.anaconda.org/arrow-nightlies", "",
+                    regex=False
                 )
-            ).to_list()
+            )
 
     return to_delete
 
 
 if __name__ == "__main__":
-    to_delete = []
-    for package in PACKAGES:
-        for platform in PLATFORMS:
-            if [package, platform] in EXCLUDED_PATTERNS:
-                continue
-            to_delete += packages_to_delete(package, platform)
+    to_delete = set()
+    for platform in PLATFORMS:
+        packages_to_delete(platform, to_delete)
 
-    for name in to_delete:
+    to_delete = sorted(to_delete)
+
+    print(f"{len(to_delete)} packages may be deleted")
+    for name in sorted(to_delete):
         print(f"Deleting {name} …")
-        if "FORCE" in sys.argv:
-            check_call(["anaconda", "remove", "-f", name])
+
+    if "FORCE" in sys.argv:
+        check_call(["anaconda", "remove", "-f"] + to_delete)


### PR DESCRIPTION
1. The "osx-arm64" architecture was not handled
2. Some old builds were left behind if the corresponding configuration (e.g. Python 3.6) was obsolete