### PR TITLE
ARROW-15869: [C++] Fix Valgrind failure (uninitialized value)

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -18,6 +18,7 @@
 #include "arrow/scalar.h"
 
 #include <memory>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1025,4 +1025,6 @@ Result<std::shared_ptr<Scalar>> Scalar::CastTo(std::shared_ptr<DataType> to) con
   return out;
 }
 
+void PrintTo(const Scalar& scalar, std::ostream* os) { *os << scalar.ToString(); }
+
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <utility>

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -100,6 +100,8 @@ struct ARROW_EXPORT Scalar : public util::EqualityComparable<Scalar> {
   // TODO(bkietz) add compute::CastOptions
   Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to) const;
 
+  ARROW_EXPORT friend void PrintTo(const Scalar& scalar, std::ostream* os);
+
  protected:
   Scalar(std::shared_ptr<DataType> type, bool is_valid)
       : type(std::move(type)), is_valid(is_valid) {}


### PR DESCRIPTION
Fix Valgrind failure (uninitialized value) in `hash_one` kernel tests in the arrow-compute-aggregate-test by adding `PrintTo()` to Scalar to be used by GTEST.