### PR TITLE
ARROW-15918: [Ruby] Add support for DayTimeIntervalArray.new([{day:, millisecond:}, ...])

### DIFF
--- a/ruby/red-arrow/lib/arrow/day-time-interval-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/day-time-interval-array-builder.rb
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class DayTimeIntervalArrayBuilder
+    private
+    def convert_to_arrow_value(value)
+      if value.is_a?(Hash)
+        Arrow::DayMillisecond.new(value[:day], value[:millisecond])
+      else
+        value
+      end
+    end
+  end
+end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -59,6 +59,7 @@ module Arrow
       require "arrow/date64-array"
       require "arrow/date64-array-builder"
       require "arrow/datum"
+      require "arrow/day-time-interval-array-builder"
       require "arrow/decimal128"
       require "arrow/decimal128-array"
       require "arrow/decimal128-array-builder"

--- a/ruby/red-arrow/test/values/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/values/test-basic-arrays.rb
@@ -293,12 +293,7 @@ module ValuesBasicArraysTests
       nil,
       {day: 2, millisecond: 300},
     ]
-    inputs = [
-      Arrow::DayMillisecond.new(1, 100),
-      nil,
-      Arrow::DayMillisecond.new(2, 300),
-    ]
-    target = build(Arrow::DayTimeIntervalArray.new(inputs))
+    target = build(Arrow::DayTimeIntervalArray.new(values))
     assert_equal(values, target.values)
   end
 end

--- a/ruby/red-arrow/test/values/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/values/test-dense-union-array.rb
@@ -361,11 +361,7 @@ module ValuesDenseUnionArrayTests
       {"0" => {day: 1, millisecond: 100}},
       {"1" => nil},
     ]
-    inputs = [
-      {"0" => Arrow::DayMillisecond.new(1, 100)},
-      {"1" => nil},
-    ]
-    target = build(:day_time_interval, inputs)
+    target = build(:day_time_interval, values)
     assert_equal(values, target.values)
   end
 

--- a/ruby/red-arrow/test/values/test-list-array.rb
+++ b/ruby/red-arrow/test/values/test-list-array.rb
@@ -394,15 +394,7 @@ module ValuesListArrayTests
       ],
       nil,
     ]
-    inputs = [
-      [
-        Arrow::DayMillisecond.new(1, 100),
-        nil,
-        Arrow::DayMillisecond.new(2, 300),
-      ],
-      nil,
-    ]
-    target = build(:day_time_interval, inputs)
+    target = build(:day_time_interval, values)
     assert_equal(values, target.values)
   end
 

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -319,14 +319,7 @@ module ValuesMapArrayTests
       },
       nil,
     ]
-    inputs = [
-      {
-        "key1" => Arrow::DayMillisecond.new(1, 100),
-        "key2" => nil,
-      },
-      nil,
-    ]
-    target = build(:day_time_interval, inputs)
+    target = build(:day_time_interval, values)
     assert_equal(values, target.values)
   end
 

--- a/ruby/red-arrow/test/values/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/values/test-sparse-union-array.rb
@@ -338,11 +338,7 @@ module ValuesSparseUnionArrayTests
       {"0" => {day: 1, millisecond: 100}},
       {"1" => nil},
     ]
-    inputs = [
-      {"0" => Arrow::DayMillisecond.new(1, 100)},
-      {"1" => nil},
-    ]
-    target = build(:day_time_interval, inputs)
+    target = build(:day_time_interval, values)
     assert_equal(values, target.values)
   end
 

--- a/ruby/red-arrow/test/values/test-struct-array.rb
+++ b/ruby/red-arrow/test/values/test-struct-array.rb
@@ -357,12 +357,7 @@ module ValuesStructArrayTests
       nil,
       {"field" => nil},
     ]
-    inputs = [
-      {"field" => Arrow::DayMillisecond.new(1, 100)},
-      nil,
-      {"field" => nil},
-    ]
-    target = build(:day_time_interval, inputs)
+    target = build(:day_time_interval, values)
     assert_equal(values, target.values)
   end
 


### PR DESCRIPTION
Ref: https://github.com/apache/arrow/pull/12593#discussion_r824526692