### PR TITLE
ARROW-15919: [C++] Add function not commutative with timestamps & duration maths

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal_test.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal_test.cc
@@ -182,6 +182,8 @@ TEST(TestDispatchBest, CommonTemporalResolution) {
   ASSERT_EQ(TimeUnit::MILLI, CommonTemporalResolution(args.data(), args.size()));
   args = {duration(TimeUnit::SECOND), time32(TimeUnit::SECOND)};
   ASSERT_EQ(TimeUnit::SECOND, CommonTemporalResolution(args.data(), args.size()));
+  args = {duration(TimeUnit::SECOND), time64(TimeUnit::NANO)};
+  ASSERT_EQ(TimeUnit::NANO, CommonTemporalResolution(args.data(), args.size()));
   args = {time64(TimeUnit::MICRO), duration(TimeUnit::NANO)};
   ASSERT_EQ(TimeUnit::NANO, CommonTemporalResolution(args.data(), args.size()));
   args = {timestamp(TimeUnit::SECOND, tz), timestamp(TimeUnit::MICRO)};
@@ -204,6 +206,8 @@ TEST(TestDispatchBest, CommonTemporalResolution) {
   ASSERT_EQ(TimeUnit::NANO, CommonTemporalResolution(args.data(), args.size()));
   args = {duration(TimeUnit::SECOND), int64()};
   ASSERT_EQ(TimeUnit::SECOND, CommonTemporalResolution(args.data(), args.size()));
+  args = {duration(TimeUnit::MILLI), timestamp(TimeUnit::SECOND, tz)};
+  ASSERT_EQ(TimeUnit::MILLI, CommonTemporalResolution(args.data(), args.size()));
 }
 
 TEST(TestDispatchBest, ReplaceTemporalTypes) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -2609,12 +2609,9 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // Add add(timestamp, duration) -> timestamp
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::TimestampTypeUnit(unit));
-    auto exec1 = ScalarBinary<Int64Type, Int64Type, Int64Type, Add>::Exec;
-    DCHECK_OK(add->AddKernel({in_type, duration(unit)}, OutputType(FirstType),
-                             std::move(exec1)));
-    auto exec2 = ScalarBinary<Int64Type, Int64Type, Int64Type, Add>::Exec;
-    DCHECK_OK(add->AddKernel({duration(unit), in_type}, OutputType(LastType),
-                             std::move(exec2)));
+    auto exec = ScalarBinary<Int64Type, Int64Type, Int64Type, Add>::Exec;
+    DCHECK_OK(add->AddKernel({in_type, duration(unit)}, OutputType(FirstType), exec));
+    DCHECK_OK(add->AddKernel({duration(unit), in_type}, OutputType(LastType), exec));
   }
 
   // Add add(duration, duration) -> duration
@@ -2637,12 +2634,11 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // Add add_checked(timestamp, duration) -> timestamp
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::TimestampTypeUnit(unit));
-    auto exec1 = ScalarBinary<Int64Type, Int64Type, Int64Type, AddChecked>::Exec;
-    DCHECK_OK(add_checked->AddKernel({in_type, duration(unit)}, OutputType(FirstType),
-                                     std::move(exec1)));
-    auto exec2 = ScalarBinary<Int64Type, Int64Type, Int64Type, AddChecked>::Exec;
-    DCHECK_OK(add_checked->AddKernel({duration(unit), in_type}, OutputType(LastType),
-                                     std::move(exec2)));
+    auto exec = ScalarBinary<Int64Type, Int64Type, Int64Type, AddChecked>::Exec;
+    DCHECK_OK(
+        add_checked->AddKernel({in_type, duration(unit)}, OutputType(FirstType), exec));
+    DCHECK_OK(
+        add_checked->AddKernel({duration(unit), in_type}, OutputType(LastType), exec));
   }
 
   // Add add(duration, duration) -> duration
@@ -2788,12 +2784,9 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
 
   // Add multiply(duration, int64) -> duration
   for (auto unit : TimeUnit::values()) {
-    auto exec1 = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Multiply>(Type::DURATION);
-    DCHECK_OK(
-        multiply->AddKernel({duration(unit), int64()}, duration(unit), std::move(exec1)));
-    auto exec2 = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Multiply>(Type::DURATION);
-    DCHECK_OK(
-        multiply->AddKernel({int64(), duration(unit)}, duration(unit), std::move(exec2)));
+    auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Multiply>(Type::DURATION);
+    DCHECK_OK(multiply->AddKernel({duration(unit), int64()}, duration(unit), exec));
+    DCHECK_OK(multiply->AddKernel({int64(), duration(unit)}, duration(unit), exec));
   }
 
   DCHECK_OK(registry->AddFunction(std::move(multiply)));
@@ -2805,14 +2798,12 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
 
   // Add multiply_checked(duration, int64) -> duration
   for (auto unit : TimeUnit::values()) {
-    auto exec1 =
+    auto exec =
         ArithmeticExecFromOp<ScalarBinaryEqualTypes, MultiplyChecked>(Type::DURATION);
-    DCHECK_OK(multiply_checked->AddKernel({duration(unit), int64()}, duration(unit),
-                                          std::move(exec1)));
-    auto exec2 =
-        ArithmeticExecFromOp<ScalarBinaryEqualTypes, MultiplyChecked>(Type::DURATION);
-    DCHECK_OK(multiply_checked->AddKernel({int64(), duration(unit)}, duration(unit),
-                                          std::move(exec2)));
+    DCHECK_OK(
+        multiply_checked->AddKernel({duration(unit), int64()}, duration(unit), exec));
+    DCHECK_OK(
+        multiply_checked->AddKernel({int64(), duration(unit)}, duration(unit), exec));
   }
 
   DCHECK_OK(registry->AddFunction(std::move(multiply_checked)));

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -243,31 +243,9 @@ struct SubtractCheckedDate32 {
 template <bool left_is_32bit, int64_t multiple>
 struct AddTimeDuration {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(!std::is_same<Arg0, Arg1>::value && left_is_32bit), T> Call(
-      KernelContext*, Arg0 left, Arg1 right, Status* st) {
-    T result = arrow::internal::SafeSignedAdd(left, static_cast<T>(right));
-    if (result < 0 || multiple <= result) {
-      *st = Status::Invalid(result, " is not within the acceptable range of ", "[0, ",
-                            multiple, ") s");
-    }
-    return result;
-  }
-
-  template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(!std::is_same<Arg0, Arg1>::value && !left_is_32bit), T> Call(
-      KernelContext*, Arg0 left, Arg1 right, Status* st) {
-    T result = arrow::internal::SafeSignedAdd(static_cast<T>(left), right);
-    if (result < 0 || multiple <= result) {
-      *st = Status::Invalid(result, " is not within the acceptable range of ", "[0, ",
-                            multiple, ") s");
-    }
-    return result;
-  }
-
-  template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(std::is_same<Arg0, Arg1>::value), T> Call(KernelContext*, Arg0 left,
-                                                                Arg1 right, Status* st) {
-    T result = arrow::internal::SafeSignedAdd(left, right);
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
+    T result =
+        arrow::internal::SafeSignedAdd(static_cast<T>(left), static_cast<T>(right));
     if (result < 0 || multiple <= result) {
       *st = Status::Invalid(result, " is not within the acceptable range of ", "[0, ",
                             multiple, ") s");
@@ -279,38 +257,10 @@ struct AddTimeDuration {
 template <bool left_is_32bit, int64_t multiple>
 struct AddTimeDurationChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(!std::is_same<Arg0, Arg1>::value && left_is_32bit), T> Call(
-      KernelContext*, Arg0 left, Arg1 right, Status* st) {
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     T result = 0;
-    if (ARROW_PREDICT_FALSE(AddWithOverflow(left, static_cast<T>(right), &result))) {
-      *st = Status::Invalid("overflow");
-    }
-    if (result < 0 || multiple <= result) {
-      *st = Status::Invalid(result, " is not within the acceptable range of ", "[0, ",
-                            multiple, ") s");
-    }
-    return result;
-  }
-
-  template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(!std::is_same<Arg0, Arg1>::value && !left_is_32bit), T> Call(
-      KernelContext*, Arg0 left, Arg1 right, Status* st) {
-    T result = 0;
-    if (ARROW_PREDICT_FALSE(AddWithOverflow(static_cast<T>(left), right, &result))) {
-      *st = Status::Invalid("overflow");
-    }
-    if (result < 0 || multiple <= result) {
-      *st = Status::Invalid(result, " is not within the acceptable range of ", "[0, ",
-                            multiple, ") s");
-    }
-    return result;
-  }
-
-  template <typename T, typename Arg0, typename Arg1>
-  static enable_if_t<(std::is_same<Arg0, Arg1>::value), T> Call(KernelContext*, Arg0 left,
-                                                                Arg1 right, Status* st) {
-    T result = 0;
-    if (ARROW_PREDICT_FALSE(AddWithOverflow(left, right, &result))) {
+    if (ARROW_PREDICT_FALSE(
+            AddWithOverflow(static_cast<T>(left), static_cast<T>(right), &result))) {
       *st = Status::Invalid("overflow");
     }
     if (result < 0 || multiple <= result) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1070,6 +1070,9 @@ TEST_F(ScalarTemporalTest, TestTemporalAddDateAndDuration) {
         ArrayFromJSON(timestamp(TimeUnit::MICRO), times_seconds_precision);
     CheckScalarBinary(op, dates32, durations_us, timestamps_us);
     CheckScalarBinary(op, dates64, durations_us, timestamps_us);
+
+    CheckScalarBinary(op, durations_us, dates32, timestamps_us);
+    CheckScalarBinary(op, durations_us, dates64, timestamps_us);
   }
 }
 
@@ -1153,6 +1156,10 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimestampAndDuration) {
                         ArrayFromJSON(timestamp_unit_us, times_seconds_precision2));
       CheckScalarBinary(op, ArrayFromJSON(timestamp_unit_ns, times_seconds_precision),
                         ArrayFromJSON(duration_unit_ns, nanoseconds_between),
+                        ArrayFromJSON(timestamp_unit_ns, times_seconds_precision2));
+
+      CheckScalarBinary(op, ArrayFromJSON(duration_unit_ns, nanoseconds_between),
+                        ArrayFromJSON(timestamp_unit_ns, times_seconds_precision),
                         ArrayFromJSON(timestamp_unit_ns, times_seconds_precision2));
     }
 
@@ -1341,6 +1348,9 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimeAndDuration) {
     CheckScalarBinary(op, arr_ns,
                       ArrayFromJSON(duration(TimeUnit::NANO), nanoseconds_between_time),
                       arr_ns2);
+    CheckScalarBinary(op,
+                      ArrayFromJSON(duration(TimeUnit::NANO), nanoseconds_between_time),
+                      arr_ns, arr_ns2);
 
     auto seconds_1 = ArrayFromJSON(time32(TimeUnit::SECOND), R"([1, null])");
     auto milliseconds_2k = ArrayFromJSON(duration(TimeUnit::MILLI), R"([2000, null])");
@@ -1352,6 +1362,10 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimeAndDuration) {
     CheckScalarBinary(op, seconds_1, milliseconds_2k, milliseconds_3k);
     CheckScalarBinary(op, nanoseconds_1G, microseconds_2M, nanoseconds_3M);
     CheckScalarBinary(op, seconds_1, microseconds_2M, microseconds_3M);
+
+    CheckScalarBinary(op, milliseconds_2k, seconds_1, milliseconds_3k);
+    CheckScalarBinary(op, microseconds_2M, nanoseconds_1G, nanoseconds_3M);
+    CheckScalarBinary(op, microseconds_2M, seconds_1, microseconds_3M);
 
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid,

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1061,18 +1061,15 @@ TEST_F(ScalarTemporalTest, TestTemporalAddDateAndDuration) {
         ArrayFromJSON(duration(TimeUnit::MILLI), milliseconds_between_date_and_time);
     auto timestamps_ms =
         ArrayFromJSON(timestamp(TimeUnit::MILLI), times_seconds_precision);
-    CheckScalarBinary(op, dates32, durations_ms, timestamps_ms);
-    CheckScalarBinary(op, dates64, durations_ms, timestamps_ms);
+    CheckScalarBinaryCommutative(op, dates32, durations_ms, timestamps_ms);
+    CheckScalarBinaryCommutative(op, dates64, durations_ms, timestamps_ms);
 
     auto durations_us =
         ArrayFromJSON(duration(TimeUnit::MICRO), microseconds_between_date_and_time);
     auto timestamps_us =
         ArrayFromJSON(timestamp(TimeUnit::MICRO), times_seconds_precision);
-    CheckScalarBinary(op, dates32, durations_us, timestamps_us);
-    CheckScalarBinary(op, dates64, durations_us, timestamps_us);
-
-    CheckScalarBinary(op, durations_us, dates32, timestamps_us);
-    CheckScalarBinary(op, durations_us, dates64, timestamps_us);
+    CheckScalarBinaryCommutative(op, dates32, durations_us, timestamps_us);
+    CheckScalarBinaryCommutative(op, dates64, durations_us, timestamps_us);
   }
 }
 
@@ -1145,33 +1142,33 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimestampAndDuration) {
       auto timestamp_unit_ns = timestamp(TimeUnit::NANO, tz);
       auto duration_unit_ns = duration(TimeUnit::NANO);
 
-      CheckScalarBinary(op, ArrayFromJSON(timestamp_unit_s, times_seconds_precision),
-                        ArrayFromJSON(duration_unit_s, seconds_between),
-                        ArrayFromJSON(timestamp_unit_s, times_seconds_precision2));
-      CheckScalarBinary(op, ArrayFromJSON(timestamp_unit_ms, times_seconds_precision),
-                        ArrayFromJSON(duration_unit_ms, milliseconds_between),
-                        ArrayFromJSON(timestamp_unit_ms, times_seconds_precision2));
-      CheckScalarBinary(op, ArrayFromJSON(timestamp_unit_us, times_seconds_precision),
-                        ArrayFromJSON(duration_unit_us, microseconds_between),
-                        ArrayFromJSON(timestamp_unit_us, times_seconds_precision2));
-      CheckScalarBinary(op, ArrayFromJSON(timestamp_unit_ns, times_seconds_precision),
-                        ArrayFromJSON(duration_unit_ns, nanoseconds_between),
-                        ArrayFromJSON(timestamp_unit_ns, times_seconds_precision2));
-
-      CheckScalarBinary(op, ArrayFromJSON(duration_unit_ns, nanoseconds_between),
-                        ArrayFromJSON(timestamp_unit_ns, times_seconds_precision),
-                        ArrayFromJSON(timestamp_unit_ns, times_seconds_precision2));
+      CheckScalarBinaryCommutative(
+          op, ArrayFromJSON(timestamp_unit_s, times_seconds_precision),
+          ArrayFromJSON(duration_unit_s, seconds_between),
+          ArrayFromJSON(timestamp_unit_s, times_seconds_precision2));
+      CheckScalarBinaryCommutative(
+          op, ArrayFromJSON(timestamp_unit_ms, times_seconds_precision),
+          ArrayFromJSON(duration_unit_ms, milliseconds_between),
+          ArrayFromJSON(timestamp_unit_ms, times_seconds_precision2));
+      CheckScalarBinaryCommutative(
+          op, ArrayFromJSON(timestamp_unit_us, times_seconds_precision),
+          ArrayFromJSON(duration_unit_us, microseconds_between),
+          ArrayFromJSON(timestamp_unit_us, times_seconds_precision2));
+      CheckScalarBinaryCommutative(
+          op, ArrayFromJSON(timestamp_unit_ns, times_seconds_precision),
+          ArrayFromJSON(duration_unit_ns, nanoseconds_between),
+          ArrayFromJSON(timestamp_unit_ns, times_seconds_precision2));
     }
 
     auto seconds_1 = ArrayFromJSON(timestamp(TimeUnit::SECOND), R"([1, null])");
     auto milliseconds_2k = ArrayFromJSON(duration(TimeUnit::MILLI), R"([2000, null])");
     auto milliseconds_3k = ArrayFromJSON(timestamp(TimeUnit::MILLI), R"([3000, null])");
-    CheckScalarBinary(op, seconds_1, milliseconds_2k, milliseconds_3k);
+    CheckScalarBinaryCommutative(op, seconds_1, milliseconds_2k, milliseconds_3k);
 
     auto seconds_1_tz = ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), R"([1, null])");
     auto milliseconds_3k_tz =
         ArrayFromJSON(timestamp(TimeUnit::MILLI, "UTC"), R"([3000, null])");
-    CheckScalarBinary(op, seconds_1_tz, milliseconds_2k, milliseconds_3k_tz);
+    CheckScalarBinaryCommutative(op, seconds_1_tz, milliseconds_2k, milliseconds_3k_tz);
   }
 }
 
@@ -1336,21 +1333,18 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimeAndDuration) {
     auto arr_ns = ArrayFromJSON(time64(TimeUnit::NANO), times_ns);
     auto arr_ns2 = ArrayFromJSON(time64(TimeUnit::NANO), times_ns2);
 
-    CheckScalarBinary(op, arr_s,
-                      ArrayFromJSON(duration(TimeUnit::SECOND), seconds_between_time),
-                      arr_s2);
-    CheckScalarBinary(op, arr_ms,
-                      ArrayFromJSON(duration(TimeUnit::MILLI), milliseconds_between_time),
-                      arr_ms2);
-    CheckScalarBinary(op, arr_us,
-                      ArrayFromJSON(duration(TimeUnit::MICRO), microseconds_between_time),
-                      arr_us2);
-    CheckScalarBinary(op, arr_ns,
-                      ArrayFromJSON(duration(TimeUnit::NANO), nanoseconds_between_time),
-                      arr_ns2);
-    CheckScalarBinary(op,
-                      ArrayFromJSON(duration(TimeUnit::NANO), nanoseconds_between_time),
-                      arr_ns, arr_ns2);
+    CheckScalarBinaryCommutative(
+        op, arr_s, ArrayFromJSON(duration(TimeUnit::SECOND), seconds_between_time),
+        arr_s2);
+    CheckScalarBinaryCommutative(
+        op, arr_ms, ArrayFromJSON(duration(TimeUnit::MILLI), milliseconds_between_time),
+        arr_ms2);
+    CheckScalarBinaryCommutative(
+        op, arr_us, ArrayFromJSON(duration(TimeUnit::MICRO), microseconds_between_time),
+        arr_us2);
+    CheckScalarBinaryCommutative(
+        op, arr_ns, ArrayFromJSON(duration(TimeUnit::NANO), nanoseconds_between_time),
+        arr_ns2);
 
     auto seconds_1 = ArrayFromJSON(time32(TimeUnit::SECOND), R"([1, null])");
     auto milliseconds_2k = ArrayFromJSON(duration(TimeUnit::MILLI), R"([2000, null])");
@@ -1359,13 +1353,9 @@ TEST_F(ScalarTemporalTest, TestTemporalAddTimeAndDuration) {
     auto microseconds_2M = ArrayFromJSON(duration(TimeUnit::MICRO), R"([2000000, null])");
     auto nanoseconds_3M = ArrayFromJSON(time64(TimeUnit::NANO), R"([3000000000, null])");
     auto microseconds_3M = ArrayFromJSON(time64(TimeUnit::MICRO), R"([3000000, null])");
-    CheckScalarBinary(op, seconds_1, milliseconds_2k, milliseconds_3k);
-    CheckScalarBinary(op, nanoseconds_1G, microseconds_2M, nanoseconds_3M);
-    CheckScalarBinary(op, seconds_1, microseconds_2M, microseconds_3M);
-
-    CheckScalarBinary(op, milliseconds_2k, seconds_1, milliseconds_3k);
-    CheckScalarBinary(op, microseconds_2M, nanoseconds_1G, nanoseconds_3M);
-    CheckScalarBinary(op, microseconds_2M, seconds_1, microseconds_3M);
+    CheckScalarBinaryCommutative(op, seconds_1, milliseconds_2k, milliseconds_3k);
+    CheckScalarBinaryCommutative(op, nanoseconds_1G, microseconds_2M, nanoseconds_3M);
+    CheckScalarBinaryCommutative(op, seconds_1, microseconds_2M, microseconds_3M);
 
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid,
@@ -1486,10 +1476,10 @@ TEST_F(ScalarTemporalTest, TestTemporalMultiplyDuration) {
     auto multipliers = ArrayFromJSON(int64(), R"([0, 3, 2, 7, null])");
     auto durations_multiplied = ArrayFromJSON(unit, R"([0, -3, 4, 42, null])");
 
-    CheckScalarBinary("multiply", durations, multipliers, durations_multiplied);
-    CheckScalarBinary("multiply", multipliers, durations, durations_multiplied);
-    CheckScalarBinary("multiply_checked", durations, multipliers, durations_multiplied);
-    CheckScalarBinary("multiply_checked", multipliers, durations, durations_multiplied);
+    CheckScalarBinaryCommutative("multiply", durations, multipliers,
+                                 durations_multiplied);
+    CheckScalarBinaryCommutative("multiply_checked", durations, multipliers,
+                                 durations_multiplied);
 
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr("Invalid: overflow"),

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -273,6 +273,13 @@ void CheckScalarBinary(std::string func_name, Datum left_input, Datum right_inpu
   CheckScalar(std::move(func_name), {left_input, right_input}, expected, options);
 }
 
+void CheckScalarBinaryCommutative(std::string func_name, Datum left_input,
+                                  Datum right_input, Datum expected,
+                                  const FunctionOptions* options) {
+  CheckScalar(func_name, {left_input, right_input}, expected, options);
+  CheckScalar(func_name, {right_input, left_input}, expected, options);
+}
+
 namespace {
 
 void ValidateOutput(const ArrayData& output) {

--- a/cpp/src/arrow/compute/kernels/test_util.h
+++ b/cpp/src/arrow/compute/kernels/test_util.h
@@ -124,6 +124,10 @@ void CheckScalarUnary(std::string func_name, Datum input, Datum expected,
 void CheckScalarBinary(std::string func_name, Datum left_input, Datum right_input,
                        Datum expected, const FunctionOptions* options = nullptr);
 
+void CheckScalarBinaryCommutative(std::string func_name, Datum left_input,
+                                  Datum right_input, Datum expected,
+                                  const FunctionOptions* options = nullptr);
+
 void CheckVectorUnary(std::string func_name, Datum input, Datum expected,
                       const FunctionOptions* options = nullptr);
 


### PR DESCRIPTION
This is to resolve [ARROW-15919](https://issues.apache.org/jira/browse/ARROW-15919).

It adds commutativity to kernels:
* `add/add_checked(timestamp, duration)->timestamp`
* `add/add_checked(time32/64, duration)->time32/64`
* `add/add_checked(date32/64, duration)->date32/64`