### PR TITLE
ARROW-15823: [C++][Python] Add a method to convert a Table to a RecordBatchReader

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -590,8 +590,8 @@ Result<std::shared_ptr<RecordBatch>> Table::CombineChunksToBatch(MemoryPool* poo
 // Convert a table to a sequence of record batches
 
 TableBatchReader::TableBatchReader(const Table& table)
-    : table_(table),
-      owned_table_(nullptr),
+    : owned_table_(nullptr),
+      table_(table),
       column_data_(table.num_columns()),
       chunk_numbers_(table.num_columns(), 0),
       chunk_offsets_(table.num_columns(), 0),
@@ -603,15 +603,15 @@ TableBatchReader::TableBatchReader(const Table& table)
 }
 
 TableBatchReader::TableBatchReader(std::shared_ptr<Table> table)
-    : table_(*table.get()),
-      owned_table_(std::move(table)),
-      column_data_(table.get()->num_columns()),
-      chunk_numbers_(table.get()->num_columns(), 0),
-      chunk_offsets_(table.get()->num_columns(), 0),
+    : owned_table_(std::move(table)),
+      table_(*owned_table_),
+      column_data_(owned_table_->num_columns()),
+      chunk_numbers_(owned_table_->num_columns(), 0),
+      chunk_offsets_(owned_table_->num_columns(), 0),
       absolute_row_position_(0),
       max_chunksize_(std::numeric_limits<int64_t>::max()) {
-  for (int i = 0; i < table.get()->num_columns(); ++i) {
-    column_data_[i] = table.get()->column(i).get();
+  for (int i = 0; i < owned_table_->num_columns(); ++i) {
+    column_data_[i] = owned_table_->column(i).get();
   }
 }
 

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -591,6 +591,7 @@ Result<std::shared_ptr<RecordBatch>> Table::CombineChunksToBatch(MemoryPool* poo
 
 TableBatchReader::TableBatchReader(const Table& table)
     : table_(table),
+      owned_table_(nullptr),
       column_data_(table.num_columns()),
       chunk_numbers_(table.num_columns(), 0),
       chunk_offsets_(table.num_columns(), 0),
@@ -598,6 +599,19 @@ TableBatchReader::TableBatchReader(const Table& table)
       max_chunksize_(std::numeric_limits<int64_t>::max()) {
   for (int i = 0; i < table.num_columns(); ++i) {
     column_data_[i] = table.column(i).get();
+  }
+}
+
+TableBatchReader::TableBatchReader(std::shared_ptr<Table> table)
+    : table_(*table.get()),
+      owned_table_(std::move(table)),
+      column_data_(table.get()->num_columns()),
+      chunk_numbers_(table.get()->num_columns(), 0),
+      chunk_offsets_(table.get()->num_columns(), 0),
+      absolute_row_position_(0),
+      max_chunksize_(std::numeric_limits<int64_t>::max()) {
+  for (int i = 0; i < table.get()->num_columns(); ++i) {
+    column_data_[i] = table.get()->column(i).get();
   }
 }
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -245,6 +245,7 @@ class ARROW_EXPORT TableBatchReader : public RecordBatchReader {
  public:
   /// \brief Construct a TableBatchReader for the given table
   explicit TableBatchReader(const Table& table);
+  explicit TableBatchReader(std::shared_ptr<Table> table);
 
   std::shared_ptr<Schema> schema() const override;
 
@@ -258,6 +259,7 @@ class ARROW_EXPORT TableBatchReader : public RecordBatchReader {
 
  private:
   const Table& table_;
+  std::shared_ptr<Table> owned_table_;
   std::vector<ChunkedArray*> column_data_;
   std::vector<int> chunk_numbers_;
   std::vector<int64_t> chunk_offsets_;

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -258,8 +258,8 @@ class ARROW_EXPORT TableBatchReader : public RecordBatchReader {
   void set_chunksize(int64_t chunksize);
 
  private:
-  const Table& table_;
   std::shared_ptr<Table> owned_table_;
+  const Table& table_;
   std::vector<ChunkedArray*> column_data_;
   std::vector<int> chunk_numbers_;
   std::vector<int64_t> chunk_offsets_;

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -789,4 +789,24 @@ TEST_F(TestTableBatchReader, NoColumns) {
   ASSERT_EQ(nullptr, batch);
 }
 
+TEST_F(TestTableBatchReader, OwnedTableNoColumns) {
+  std::shared_ptr<Table> table =
+      Table::Make(schema({}), std::vector<std::shared_ptr<Array>>{}, 100);
+  TableBatchReader reader(table);
+  table.reset();
+  reader.set_chunksize(80);
+
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_OK(batch->ValidateFull());
+  ASSERT_EQ(80, batch->num_rows());
+
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_OK(batch->ValidateFull());
+  ASSERT_EQ(20, batch->num_rows());
+
+  ASSERT_OK(reader.ReadNext(&batch));
+  ASSERT_EQ(nullptr, batch);
+}
+
 }  // namespace arrow

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -856,7 +856,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass TableBatchReader(CRecordBatchReader):
         TableBatchReader(const CTable& table)
-        TableBatchReader(CTable *)
+        TableBatchReader(shared_ptr[CTable] table)
         void set_chunksize(int64_t chunksize)
 
     cdef cppclass CTensor" arrow::Tensor":

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -856,6 +856,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass TableBatchReader(CRecordBatchReader):
         TableBatchReader(const CTable& table)
+        TableBatchReader(CTable *)
         void set_chunksize(int64_t chunksize)
 
     cdef cppclass CTensor" arrow::Tensor":

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -20,6 +20,7 @@
 from cpython cimport PyObject
 from libcpp cimport nullptr
 from libcpp.cast cimport dynamic_cast
+from libcpp.memory cimport dynamic_pointer_cast
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2020,8 +2020,13 @@ cdef class Table(_PandasConvertible):
         """
         cdef:
              shared_ptr[CRecordBatchReader] c_reader
-        c_reader.reset(new TableBatchReader(make_shared[CTable](self.table)))
-        return RecordBatchReader(c_reader)
+             RecordBatchReader reader
+             shared_ptr[TableBatchReader] t_reader
+        t_reader = make_shared[TableBatchReader](self.sp_table)
+        c_reader = dynamic_pointer_cast[CRecordBatchReader, TableBatchReader](t_reader)
+        reader = RecordBatchReader.__new__(RecordBatchReader)
+        reader.reader = c_reader
+        return reader
 
     def _to_pandas(self, options, categories=None, ignore_metadata=False,
                    types_mapper=None):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2032,7 +2032,6 @@ cdef class Table(_PandasConvertible):
         reader.reader = c_reader
         return reader
 
-
     def _to_pandas(self, options, categories=None, ignore_metadata=False,
                    types_mapper=None):
         from pyarrow.pandas_compat import table_to_blockmanager

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2010,10 +2010,9 @@ cdef class Table(_PandasConvertible):
 
         return result
 
-    def to_reader(self, max_chunksize=None, **kwargs):
+    def to_reader(self, max_chunksize=None):
         """
         Convert a Table to RecordBatchReader
-
         Returns
         -------
         RecordBatchReader        
@@ -2024,22 +2023,15 @@ cdef class Table(_PandasConvertible):
             shared_ptr[TableBatchReader] t_reader
         t_reader = make_shared[TableBatchReader](self.sp_table)
 
-        if 'chunksize' in kwargs:
-            max_chunksize = kwargs['chunksize']
-            msg = ('The parameter chunksize is deprecated for '
-                   'pyarrow.Table.to_batches as of 0.15, please use '
-                   'the parameter max_chunksize instead')
-            warnings.warn(msg, FutureWarning)
-
         if max_chunksize is not None:
-            c_max_chunksize = max_chunksize
-            t_reader.get().set_chunksize(c_max_chunksize)
+            t_reader.get().set_chunksize(max_chunksize)
 
         c_reader = dynamic_pointer_cast[CRecordBatchReader, TableBatchReader](
             t_reader)
         reader = RecordBatchReader.__new__(RecordBatchReader)
         reader.reader = c_reader
         return reader
+
 
     def _to_pandas(self, options, categories=None, ignore_metadata=False,
                    types_mapper=None):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2009,6 +2009,19 @@ cdef class Table(_PandasConvertible):
             result.append(pyarrow_wrap_batch(batch))
 
         return result
+    
+    def to_reader(self):
+        """
+        Convert a Table to RecordBatchReader
+        
+        Returns
+        -------
+        RecordBatchReader        
+        """
+        cdef:
+            shared_ptr[CRecordBatchReader] c_reader
+        c_reader.reset(new CRecordBatchReader(self.table))
+        return RecordBatchReader(c_reader)
 
     def _to_pandas(self, options, categories=None, ignore_metadata=False,
                    types_mapper=None):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2019,8 +2019,8 @@ cdef class Table(_PandasConvertible):
         RecordBatchReader        
         """
         cdef:
-            shared_ptr[CRecordBatchReader] c_reader
-        c_reader.reset(new CRecordBatchReader(self.table))
+             shared_ptr[CRecordBatchReader] c_reader
+        c_reader.reset(new TableBatchReader(make_shared[CTable](self.table)))
         return RecordBatchReader(c_reader)
 
     def _to_pandas(self, options, categories=None, ignore_metadata=False,

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2032,3 +2032,10 @@ def test_table_sort_by():
         "keys": ["c", "b", "b", "a", "a"],
         "values": [5, 4, 3, 2, 1]
     }
+
+
+def test_table_to_recordbatchreader():
+    table = pa.Table.from_pydict({'x': [1, 2, 3]})
+    reader = table.to_reader()
+    assert table.schema == reader.schema
+    assert table == reader.read_all()

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2039,3 +2039,7 @@ def test_table_to_recordbatchreader():
     reader = table.to_reader()
     assert table.schema == reader.schema
     assert table == reader.read_all()
+
+    reader = table.to_reader(max_chunksize=2)
+    assert reader.read_next_batch().num_rows == 2
+    assert reader.read_next_batch().num_rows == 1


### PR DESCRIPTION
This PR adds an owning version of Table in TableBatchReader and implements a `to_reader()` method to convert a table to RecordBatchReader in PyArrow