### PR TITLE
ARROW-15875: [R] Expose ReadMetadata for input streams

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1276,6 +1276,10 @@ io___RandomAccessFile__ReadAt <- function(x, position, nbytes) {
   .Call(`_arrow_io___RandomAccessFile__ReadAt`, x, position, nbytes)
 }
 
+io___RandomAccessFile__ReadMetadata <- function(x) {
+  .Call(`_arrow_io___RandomAccessFile__ReadMetadata`, x)
+}
+
 io___MemoryMappedFile__Create <- function(path, size) {
   .Call(`_arrow_io___MemoryMappedFile__Create`, path, size)
 }

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -163,6 +163,9 @@ RandomAccessFile <- R6Class("RandomAccessFile",
         nbytes <- self$GetSize() - position
       }
       io___RandomAccessFile__ReadAt(self, position, nbytes)
+    },
+    ReadMetadata = function() {
+      as.list(io___RandomAccessFile__ReadMetadata(self))
     }
   )
 )

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -5013,6 +5013,21 @@ extern "C" SEXP _arrow_io___RandomAccessFile__ReadAt(SEXP x_sexp, SEXP position_
 
 // io.cpp
 #if defined(ARROW_R_WITH_ARROW)
+cpp11::strings io___RandomAccessFile__ReadMetadata(const std::shared_ptr<arrow::io::RandomAccessFile>& x);
+extern "C" SEXP _arrow_io___RandomAccessFile__ReadMetadata(SEXP x_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<arrow::io::RandomAccessFile>&>::type x(x_sexp);
+	return cpp11::as_sexp(io___RandomAccessFile__ReadMetadata(x));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_io___RandomAccessFile__ReadMetadata(SEXP x_sexp){
+	Rf_error("Cannot call io___RandomAccessFile__ReadMetadata(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// io.cpp
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::io::MemoryMappedFile> io___MemoryMappedFile__Create(const std::string& path, int64_t size);
 extern "C" SEXP _arrow_io___MemoryMappedFile__Create(SEXP path_sexp, SEXP size_sexp){
 BEGIN_CPP11
@@ -7619,11 +7634,11 @@ return Rf_ScalarLogical(
 );
 }
 static const R_CallMethodDef CallEntries[] = {
-{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
-{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
-{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
-{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
-{ "_json_available", (DL_FUNC)& _json_available, 0 },
+		{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
+		{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
+		{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
+		{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
+		{ "_json_available", (DL_FUNC)& _json_available, 0 },
 		{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
 		{ "_arrow_is_arrow_altrep", (DL_FUNC) &_arrow_is_arrow_altrep, 1}, 
 		{ "_arrow_Array__Slice1", (DL_FUNC) &_arrow_Array__Slice1, 2}, 
@@ -7943,6 +7958,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_io___RandomAccessFile__Tell", (DL_FUNC) &_arrow_io___RandomAccessFile__Tell, 1}, 
 		{ "_arrow_io___RandomAccessFile__Read0", (DL_FUNC) &_arrow_io___RandomAccessFile__Read0, 1}, 
 		{ "_arrow_io___RandomAccessFile__ReadAt", (DL_FUNC) &_arrow_io___RandomAccessFile__ReadAt, 3}, 
+		{ "_arrow_io___RandomAccessFile__ReadMetadata", (DL_FUNC) &_arrow_io___RandomAccessFile__ReadMetadata, 1}, 
 		{ "_arrow_io___MemoryMappedFile__Create", (DL_FUNC) &_arrow_io___MemoryMappedFile__Create, 2}, 
 		{ "_arrow_io___MemoryMappedFile__Open", (DL_FUNC) &_arrow_io___MemoryMappedFile__Open, 2}, 
 		{ "_arrow_io___MemoryMappedFile__Resize", (DL_FUNC) &_arrow_io___MemoryMappedFile__Resize, 2}, 

--- a/r/src/io.cpp
+++ b/r/src/io.cpp
@@ -25,6 +25,7 @@
 #include <arrow/io/file.h>
 #include <arrow/io/memory.h>
 #include <arrow/io/transform.h>
+#include <arrow/util/key_value_metadata.h>
 
 // ------ arrow::io::Readable
 
@@ -89,6 +90,29 @@ std::shared_ptr<arrow::Buffer> io___RandomAccessFile__ReadAt(
     const std::shared_ptr<arrow::io::RandomAccessFile>& x, int64_t position,
     int64_t nbytes) {
   return ValueOrStop(x->ReadAt(position, nbytes));
+}
+
+// [[arrow::export]]
+cpp11::strings io___RandomAccessFile__ReadMetadata(
+    const std::shared_ptr<arrow::io::RandomAccessFile>& x) {
+  std::shared_ptr<const arrow::KeyValueMetadata> metadata =
+      ValueOrStop(x->ReadMetadata());
+  if (metadata.get() == nullptr) {
+    return cpp11::writable::strings();
+  }
+
+  cpp11::writable::strings metadata_r;
+  cpp11::writable::strings metadata_r_names;
+  metadata_r.reserve(metadata->size());
+  metadata_r_names.reserve(metadata->size());
+
+  for (int64_t i = 0; i < metadata->size(); i++) {
+    metadata_r.push_back(metadata->value(i));
+    metadata_r_names.push_back(metadata->key(i));
+  }
+
+  metadata_r.names() = metadata_r_names;
+  return metadata_r;
 }
 
 // ------ arrow::io::MemoryMappedFile

--- a/r/tests/testthat/test-io.R
+++ b/r/tests/testthat/test-io.R
@@ -15,6 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+test_that("RandomAccessFile$ReadMetadata() works for LocalFileSystem", {
+  fs <- LocalFileSystem$create()
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write("abcdefg", tf)
+
+  expect_identical(
+    fs$OpenInputFile(tf)$ReadMetadata(),
+    list()
+  )
+})
+
 test_that("reencoding input stream works for windows-1252", {
   string <- "province_name\nQu\u00e9bec"
   bytes_windows1252 <- iconv(

--- a/r/tests/testthat/test-s3.R
+++ b/r/tests/testthat/test-s3.R
@@ -52,4 +52,11 @@ if (run_these) {
     write_parquet(example_data, bucket_uri(now, "test.parquet"))
     expect_identical(read_parquet(bucket_uri(now, "test.parquet")), example_data)
   })
+
+  test_that("RandomAccessFile$ReadMetadata() works for S3FileSystem", {
+    file <- bucket$OpenInputFile(paste0(now, "/", "test.parquet"))
+    metadata <- file$ReadMetadata()
+    expect_true(is.list(metadata))
+    expect_true("ETag" %in% names(metadata))
+  })
 }


### PR DESCRIPTION
This PR exposes `RandomAccessFile::GetFileInfo()`, which is particularly useful for S3 files which carry some extra information that is useful to know without reading the whole file.

``` r
# remotes::install_github("paleolimbot/arrow/r@r-file-metadata")
library(arrow, warn.conflicts = FALSE)

bucket <- s3_bucket("ursa-labs-taxi-data")
file <- bucket$OpenInputFile("2019/06/data.parquet")
file$ReadMetadata()
#> $`Content-Length`
#> [1] "120790979"
#> 
#> $`Content-Type`
#> [1] "application/x-www-form-urlencoded; charset=utf-8"
#> 
#> $ETag
#> [1] "\"f1efd5d76cb82861e1542117bfa52b90-8\""
#> 
#> $`Last-Modified`
#> [1] "2020-01-17T16:26:28Z"
```