### PR TITLE
ARROW-15587: [C++] Add support for all options specified by substrait::ReadRel::LocalFiles::FileOrFiles

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -168,7 +168,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
                     std::back_inserter(files));
         } else {
           ARROW_ASSIGN_OR_RAISE(auto discovered_files,
-                                fs::internal::GetGlobFiles(filesystem, path));
+                                fs::internal::GlobFiles(filesystem, path));
           std::move(discovered_files.begin(), discovered_files.end(),
                     std::back_inserter(files));
         }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -210,8 +210,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         }
         if (item.path_type_case() ==
             substrait::ReadRel_LocalFiles_FileOrFiles::kUriFile) {
-          ARROW_ASSIGN_OR_RAISE(auto file, filesystem->GetFileInfo(path));
-          files.push_back(std::move(file));
+          files.emplace_back(path, fs::FileType::File);
         } else if (item.path_type_case() ==
                    substrait::ReadRel_LocalFiles_FileOrFiles::kUriFolder) {
           fs::FileSelector selector;

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -94,7 +94,9 @@ Result<fs::FileInfoVector> GetGlobFiles(const std::shared_ptr<fs::FileSystem>& f
 
   if (!cur.empty()) {
     for (size_t i = 0; i < results.size(); i++) {
-      results[i].set_path(fs::internal::ConcatAbstractPath(results[i].path(), cur));
+      ARROW_ASSIGN_OR_RAISE(
+          results[i], filesystem->GetFileInfo(
+                          fs::internal::ConcatAbstractPath(results[i].path(), cur)));
     }
   }
 
@@ -208,7 +210,8 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         }
         if (item.path_type_case() ==
             substrait::ReadRel_LocalFiles_FileOrFiles::kUriFile) {
-          files.emplace_back(std::move(path), fs::FileType::File);
+          ARROW_ASSIGN_OR_RAISE(auto file, filesystem->GetFileInfo(path));
+          files.push_back(std::move(file));
         } else if (item.path_type_case() ==
                    substrait::ReadRel_LocalFiles_FileOrFiles::kUriFolder) {
           fs::FileSelector selector;

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -628,11 +628,7 @@ TEST(Substrait, ReadRel) {
       "local_files": {
         "items": [
           {
-            "uri_file": "file:///tmp/dat1.parquet",
-            "format": "FILE_FORMAT_PARQUET"
-          },
-          {
-            "uri_file": "file:///tmp/dat2.parquet",
+            "uri_path_glob": "file:///tmp/dat*.parquet",
             "format": "FILE_FORMAT_PARQUET"
           }
         ]
@@ -654,7 +650,9 @@ TEST(Substrait, ReadRel) {
   ASSERT_EQ(scan_node_options.dataset->type_name(), "filesystem");
   const auto& dataset =
       checked_cast<const dataset::FileSystemDataset&>(*scan_node_options.dataset);
-  EXPECT_THAT(dataset.files(), ElementsAre("/tmp/dat1.parquet", "/tmp/dat2.parquet"));
+  auto files = dataset.files();
+  std::sort(files.begin(), files.end());
+  EXPECT_THAT(files, ElementsAre("/tmp/dat1.parquet", "/tmp/dat2.parquet"));
   EXPECT_EQ(dataset.format()->type_name(), "parquet");
   EXPECT_EQ(*dataset.schema(), Schema({field("i", int64()), field("b", boolean())}));
 }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -628,7 +628,11 @@ TEST(Substrait, ReadRel) {
       "local_files": {
         "items": [
           {
-            "uri_path_glob": "file:///tmp/dat*.parquet",
+            "uri_file": "file:///tmp/dat1.parquet",
+            "format": "FILE_FORMAT_PARQUET"
+          },
+          {
+            "uri_file": "file:///tmp/dat2.parquet",
             "format": "FILE_FORMAT_PARQUET"
           }
         ]

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -33,6 +33,7 @@
 using testing::ElementsAre;
 using testing::Eq;
 using testing::HasSubstr;
+using testing::UnorderedElementsAre;
 
 namespace arrow {
 
@@ -654,9 +655,8 @@ TEST(Substrait, ReadRel) {
   ASSERT_EQ(scan_node_options.dataset->type_name(), "filesystem");
   const auto& dataset =
       checked_cast<const dataset::FileSystemDataset&>(*scan_node_options.dataset);
-  auto files = dataset.files();
-  std::sort(files.begin(), files.end());
-  EXPECT_THAT(files, ElementsAre("/tmp/dat1.parquet", "/tmp/dat2.parquet"));
+  EXPECT_THAT(dataset.files(),
+              UnorderedElementsAre("/tmp/dat1.parquet", "/tmp/dat2.parquet"));
   EXPECT_EQ(dataset.format()->type_name(), "parquet");
   EXPECT_EQ(*dataset.schema(), Schema({field("i", int64()), field("b", boolean())}));
 }

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -266,9 +266,18 @@ TEST(PathUtil, ToSlashes) {
 }
 
 TEST(PathUtil, Globber) {
+  Globber empty("");
+  ASSERT_FALSE(empty.Matches("/1.txt"));
+
+  Globber star("/*");
+  ASSERT_TRUE(star.Matches("/a.txt"));
+  ASSERT_TRUE(star.Matches("/b.csv"));
+  ASSERT_FALSE(star.Matches("/foo/c.parquet"));
+
   Globber localfs_linux("/f?o/bar/a?/1*.txt");
   ASSERT_TRUE(localfs_linux.Matches("/foo/bar/a1/1.txt"));
   ASSERT_TRUE(localfs_linux.Matches("/f#o/bar/ab/1000.txt"));
+  ASSERT_FALSE(localfs_linux.Matches("/f#o/bar/ab/1/23.txt"));
 
   Globber localfs_windows("C:/f?o/bar/a?/1*.txt");
   ASSERT_TRUE(localfs_windows.Matches("C:/f_o/bar/ac/1000.txt"));

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -277,6 +277,10 @@ TEST(PathUtil, Globber) {
   ASSERT_TRUE(remotefs.Matches("remote://my|bucket(#0)/foo{}/[?]bar~/b&z/a: -c.txt"));
   ASSERT_TRUE(
       remotefs.Matches("remote://my|bucket(#%)/foo{abc}/[_]bar~/b&z/a: ab-c.txt"));
+
+  Globber wildcards("remote://bucket?/f\\?o/\\*/*.parquet");
+  ASSERT_TRUE(wildcards.Matches("remote://bucket0/f?o/*/abc.parquet"));
+  ASSERT_FALSE(wildcards.Matches("remote://bucket0/foo/ab/a.parquet"));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -265,6 +265,20 @@ TEST(PathUtil, ToSlashes) {
 #endif
 }
 
+TEST(PathUtil, Globber) {
+  Globber localfs_linux("/f?o/bar/a?/1*.txt");
+  ASSERT_TRUE(localfs_linux.Matches("/foo/bar/a1/1.txt"));
+  ASSERT_TRUE(localfs_linux.Matches("/f#o/bar/ab/1000.txt"));
+
+  Globber localfs_windows("C:/f?o/bar/a?/1*.txt");
+  ASSERT_TRUE(localfs_windows.Matches("C:/f_o/bar/ac/1000.txt"));
+
+  Globber remotefs("remote://my|bucket(#?)/foo{*}/[?]bar~/b&z/a: *-c.txt");
+  ASSERT_TRUE(remotefs.Matches("remote://my|bucket(#0)/foo{}/[?]bar~/b&z/a: -c.txt"));
+  ASSERT_TRUE(
+      remotefs.Matches("remote://my|bucket(#%)/foo{abc}/[_]bar~/b&z/a: ab-c.txt"));
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Generic MockFileSystem tests
 

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -274,6 +274,10 @@ TEST(PathUtil, Globber) {
   ASSERT_TRUE(star.Matches("/b.csv"));
   ASSERT_FALSE(star.Matches("/foo/c.parquet"));
 
+  Globber question("/a?b");
+  ASSERT_TRUE(question.Matches("/acb"));
+  ASSERT_FALSE(question.Matches("/a/b"));
+
   Globber localfs_linux("/f?o/bar/a?/1*.txt");
   ASSERT_TRUE(localfs_linux.Matches("/foo/bar/a1/1.txt"));
   ASSERT_TRUE(localfs_linux.Matches("/f#o/bar/ab/1000.txt"));

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -398,33 +398,6 @@ TYPED_TEST(TestLocalFS, FileMTime) {
   AssertDurationBetween(t2 - infos[1].mtime(), -kTimeSlack, kTimeSlack);
 }
 
-TYPED_TEST(TestLocalFS, GetGlobFiles) {
-  auto check_entries = [](const std::vector<FileInfo>& infos,
-                          std::vector<std::string> expected) -> void {
-    std::vector<std::string> actual(infos.size());
-    std::transform(infos.begin(), infos.end(), actual.begin(),
-                   [](const FileInfo& file) { return file.path(); });
-    std::sort(actual.begin(), actual.end());
-    ASSERT_EQ(actual, expected);
-  };
-
-  ASSERT_OK(this->fs_->CreateDir("A/CD"));
-  ASSERT_OK(this->fs_->CreateDir("AB/CD"));
-  ASSERT_OK(this->fs_->CreateDir("AB/CD/ab"));
-  CreateFile(this->fs_.get(), "A/CD/ab.txt", "data");
-  CreateFile(this->fs_.get(), "AB/CD/a.txt", "data");
-  CreateFile(this->fs_.get(), "AB/CD/abc.txt", "data");
-  CreateFile(this->fs_.get(), "AB/CD/ab/c.txt", "data");
-
-  std::vector<FileInfo> infos;
-  ASSERT_OK_AND_ASSIGN(infos, GetGlobFiles(this->fs_, "A*/CD/?b*.txt"));
-  ASSERT_EQ(infos.size(), 2);
-  check_entries(infos, {"A/CD/ab.txt", "AB/CD/abc.txt"});
-
-  ASSERT_OK_AND_ASSIGN(infos, GetGlobFiles(this->fs_, "A*/CD/?/b*.txt"));
-  ASSERT_EQ(infos.size(), 0);
-}
-
 // TODO Should we test backslash paths on Windows?
 // SubTreeFileSystem isn't compatible with them.
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -291,21 +291,19 @@ bool IsLikelyUri(util::string_view v) {
 struct Globber::Impl {
   std::regex pattern_;
 
-  explicit Impl(std::string p) : pattern_(std::regex(std::move(transform(p)))) {}
+  explicit Impl(const std::string& p) : pattern_(std::regex(PatternToRegex(p))) {}
 
-  std::string transform(std::string p) {
+  std::string PatternToRegex(const std::string& p) {
+    std::string special_chars_ = "()[]{}+-|^$\\.&~# \t\n\r\v\f";
     std::string transformed;
     for (char c : p) {
       if (c == '*') {
         transformed += ".*";
       } else if (c == '?') {
         transformed += ".";
-      } else if (c == '.') {
-        transformed += "\\.";
-      } else if (c == '[') {
-        transformed += "\\[";
-      } else if (c == ']') {
-        transformed += "\\]";
+      } else if (special_chars_.find(c) != std::string::npos) {
+        transformed += "\\";
+        transformed += c;
       } else {
         transformed += c;
       }

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -298,9 +298,15 @@ struct Globber::Impl {
     std::string transformed;
     for (char c : p) {
       if (c == '*') {
-        transformed += ".*";
+        if (transformed.back() != '\\')
+          transformed += ".*";
+        else
+          transformed.back() = c;
       } else if (c == '?') {
-        transformed += ".";
+        if (transformed.back() != '\\')
+          transformed += ".";
+        else
+          transformed.back() = c;
       } else if (special_chars_.find(c) != std::string::npos) {
         transformed += "\\";
         transformed += c;

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -128,6 +128,17 @@ bool IsEmptyPath(util::string_view s);
 ARROW_EXPORT
 bool IsLikelyUri(util::string_view s);
 
+class ARROW_EXPORT Globber {
+ public:
+  ~Globber();
+  explicit Globber(std::string pattern);
+  bool Matches(std::string path);
+
+ protected:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -132,7 +132,7 @@ class ARROW_EXPORT Globber {
  public:
   ~Globber();
   explicit Globber(std::string pattern);
-  bool Matches(std::string path);
+  bool Matches(const std::string& path);
 
  protected:
   struct Impl;

--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -20,6 +20,7 @@
 #include <cerrno>
 
 #include "arrow/buffer.h"
+#include "arrow/filesystem/path_util.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/io_util.h"
@@ -73,6 +74,61 @@ Status InvalidDeleteDirContents(const std::string& path) {
   return Status::Invalid(
       "DeleteDirContents called on invalid path '", path, "'. ",
       "If you wish to delete the root directory's contents, call DeleteRootDirContents.");
+}
+
+Result<FileInfoVector> GetGlobFiles(const std::shared_ptr<FileSystem>& filesystem,
+                                    const std::string& glob) {
+  FileInfoVector results, temp;
+  FileSelector selector;
+  std::string cur;
+
+  auto split_path = SplitAbstractPath(glob, '/');
+  ARROW_ASSIGN_OR_RAISE(auto file, filesystem->GetFileInfo("/"));
+  results.push_back(std::move(file));
+
+  for (size_t i = 0; i < split_path.size(); i++) {
+    if (split_path[i].find_first_of("*?") == std::string::npos) {
+      if (cur.empty())
+        cur = split_path[i];
+      else
+        cur = ConcatAbstractPath(cur, split_path[i]);
+      continue;
+    } else {
+      for (auto res : results) {
+        if (res.type() != FileType::Directory) continue;
+        if (cur.empty())
+          selector.base_dir = res.path();
+        else
+          selector.base_dir = ConcatAbstractPath(res.path(), cur);
+        ARROW_ASSIGN_OR_RAISE(auto entries, filesystem->GetFileInfo(selector));
+        Globber globber(ConcatAbstractPath(selector.base_dir, split_path[i]));
+        for (auto entry : entries) {
+          if (globber.Matches(entry.path())) {
+            temp.push_back(std::move(entry));
+          }
+        }
+      }
+      results = std::move(temp);
+      cur.clear();
+    }
+  }
+
+  if (!cur.empty()) {
+    std::vector<std::string> paths;
+    for (size_t i = 0; i < results.size(); i++) {
+      paths.push_back(ConcatAbstractPath(results[i].path(), cur));
+    }
+    ARROW_ASSIGN_OR_RAISE(results, filesystem->GetFileInfo(paths));
+  }
+
+  std::vector<FileInfo> out;
+  for (const auto& file : results) {
+    if (file.type() != FileType::NotFound) {
+      out.push_back(std::move(file));
+    }
+  }
+
+  return out;
 }
 
 FileSystemGlobalOptions global_options;

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -49,6 +49,10 @@ Status NotAFile(const std::string& path);
 ARROW_EXPORT
 Status InvalidDeleteDirContents(const std::string& path);
 
+ARROW_EXPORT
+Result<FileInfoVector> GetGlobFiles(const std::shared_ptr<FileSystem>& filesystem,
+                                    const std::string& glob);
+
 extern FileSystemGlobalOptions global_options;
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -49,6 +49,9 @@ Status NotAFile(const std::string& path);
 ARROW_EXPORT
 Status InvalidDeleteDirContents(const std::string& path);
 
+// Glob patters should be absolute paths.
+// For example a valid glob is: file://*.parquet
+// And an invalid glob is: *.parquet
 ARROW_EXPORT
 Result<FileInfoVector> GetGlobFiles(const std::shared_ptr<FileSystem>& filesystem,
                                     const std::string& glob);

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -49,9 +49,11 @@ Status NotAFile(const std::string& path);
 ARROW_EXPORT
 Status InvalidDeleteDirContents(const std::string& path);
 
-// Glob patters should be absolute paths.
-// For example a valid glob is: file://*.parquet
-// And an invalid glob is: *.parquet
+/// \brief Return files matching the glob pattern
+///
+/// Currently, glob patterns must be absolute paths.
+/// For example, a valid glob is: /*.parquet
+/// and an invalid glob is: *.parquet
 ARROW_EXPORT
 Result<FileInfoVector> GetGlobFiles(const std::shared_ptr<FileSystem>& filesystem,
                                     const std::string& glob);

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -49,14 +49,12 @@ Status NotAFile(const std::string& path);
 ARROW_EXPORT
 Status InvalidDeleteDirContents(const std::string& path);
 
-/// \brief Return files matching the glob pattern
+/// \brief Return files matching the glob pattern on the filesystem
 ///
-/// Currently, glob patterns must be absolute paths.
-/// For example, a valid glob is: /*.parquet
-/// and an invalid glob is: *.parquet
+/// Globbing starts from the root of the filesystem.
 ARROW_EXPORT
-Result<FileInfoVector> GetGlobFiles(const std::shared_ptr<FileSystem>& filesystem,
-                                    const std::string& glob);
+Result<FileInfoVector> GlobFiles(const std::shared_ptr<FileSystem>& filesystem,
+                                 const std::string& glob);
 
 extern FileSystemGlobalOptions global_options;
 


### PR DESCRIPTION
The Substrait read operator defines files with LocalFiles::FileOrFiles. These elements can take one of several forms:

- uri_path (can be a file or a folder)
- uri_path_glob (a glob expression)
- uri_file (file only)
- uri_folder (folder only)

The C++ Substrait consumer currently only supports uri_file. This PR adds support for the other options.

- [x] uri_path (can be a file or a folder)
- [x] uri_path_glob (a glob expression)
- [x] uri_folder (folder only)